### PR TITLE
Don't redownload tarballs every time.

### DIFF
--- a/crew
+++ b/crew
@@ -153,7 +153,7 @@ def download
     sha1sum = @pkg.binary_sha1[@device[:architecture]]
   end
   Dir.chdir CREW_BREW_DIR do
-    system('wget', '-N', '--continue', '--content-disposition', '--no-check-certificate', '-N', url, '-O', filename)
+    system('wget', '--continue', '--content-disposition', '--no-check-certificate', '-N', url, '-O', filename)
     abort 'Checksum mismatch :/ try again' unless Digest::SHA1.hexdigest( File.read("./#{filename}") ) == sha1sum
   end
   puts "Archive downloaded"

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ case "$architecture" in
   ;;
 esac
 
-wget -N --continue --no-check-certificate --content-disposition $link -O $tarname
+wget --continue --no-check-certificate --content-disposition $link -O $tarname
 
 #extract and install ruby
 echo "Extracting ruby (this may take a while)..."


### PR DESCRIPTION
If the `crew` or `install.sh` exits prematurely, it allows the downloads to finish where they left off.

This saved me so much time! After `install.sh` failed due to lack of internet connection, I ran this and it whipped through the downloads up until the point it had failed.
