### PR TITLE
specify ncurses so nano will build

### DIFF
--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -9,7 +9,7 @@ class Nano < Package
   depends_on 'ncurses' 
   
   def self.build                                                  # self.build contains commands needed to build the software from source
-    system "./configure"
+    system "./configure CPPFLAGS=\"-I/usr/local/include/ncurses\""
     system "make"                                                 # ordered chronologically
   end
   


### PR DESCRIPTION
Nano won't build becauses it can't find `curses.h`. I specify with `CPPFLAGS` now it works.
