### PR TITLE
Discuss: Installation errors can leave chromebrew in an inconsistent state

### DIFF
--- a/crew
+++ b/crew
@@ -156,7 +156,7 @@ def resolveDependenciesAndInstall
     search origin
     install
   rescue InstallError => e 
-    puts "install error: #{e.to_s}"
+    puts "#{@pkg.name} failed to install: #{e.to_s}"
   ensure
     #cleanup
     unless ARGV[2] == 'keep'

--- a/crew
+++ b/crew
@@ -148,18 +148,22 @@ def download
 end
 
 def resolveDependenciesAndInstall
-  origin = @pkg.name
+  begin
+    origin = @pkg.name
 
-  resolveDependencies
+    resolveDependencies
   
-  search origin
-  install
-
-  #cleanup
-  unless ARGV[2] == 'keep'
-    Dir.chdir CREW_BREW_DIR do
-      system "rm -rf *"
-      system "mkdir dest" #this is a little ugly, feel free to find a better way
+    search origin
+    install
+  rescue InstallError => e 
+    puts "install error: #{e.to_s}"
+  ensure
+    #cleanup
+    unless ARGV[2] == 'keep'
+      Dir.chdir CREW_BREW_DIR do
+        system "rm -rf *"
+        system "mkdir dest" #this is a little ugly, feel free to find a better way
+      end
     end
   end
 end
@@ -183,7 +187,7 @@ def resolveDependencies
   return if @dependencies.empty?
 
   puts "Following packages also need to be installed: "
-  @dependencies.flatten!.each do |dep|
+  @dependencies.flatten!.uniq!.each do |dep|
     print dep + " "
   end
   puts ""

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -26,4 +26,10 @@ class Package
   def self.build
     
   end
+
+  def self.system(*args)
+    Kernel.system(*args)
+    exitstatus = $?.exitstatus
+    raise InstallError.new("`#{args.join(" ")}` exited with #{exitstatus}") unless exitstatus == 0
+  end
 end

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -1,3 +1,5 @@
+class InstallError < RuntimeError; end
+
 def property(*properties)
   properties.each do |prop|
     self.class_eval("def self.#{prop}(#{prop} = nil); @#{prop} = #{prop} if #{prop}; @#{prop}; end")


### PR DESCRIPTION
Chromebrew currently ignores `build` and `install` errors returned from `Kernel.system`. This is an issue, because it tells the user that the package has installed successfully. However, when the user tries to use the package they will see that installation failed, but not know where to look.

This commit adds some error checking around `Kernel.system`. It was the simplest solution I could come up with. I can rename `Package.system` to `Package.system!` if you want it to be a little clearer. I can also replace `system` everywhere so errors outside of `Package.build` and `Package.install` will raise errors. Or I can do something completely different. Let me know.