### PR TITLE
Fixed go package to correctly build and uninstall

### DIFF
--- a/packages/go.rb
+++ b/packages/go.rb
@@ -6,10 +6,16 @@ class Go < Package
   source_sha1 'c7a683e8d39b835e333199d68d0c0baefcd24a68'
 
   def self.build
-    system "sudo cp -r ../go /usr/local/lib/"
-    system "./usr/local/lib/go/all.bash"
+    FileUtils.cd('src') do
+      system "./all.bash"
+    end
   end
+
   def self.install
+    dest = "#{CREW_DEST_DIR}/usr/local/lib/"
+    system "mkdir", "-p", dest
+    FileUtils.mv Dir.pwd, dest
+
     puts "--------"
     puts "Installed Go for linux/amd64 in /usr/local/lib/go"
     puts "Make sure to set go environment variables."


### PR DESCRIPTION
The previous version tried to run `all.bash` from a directory where it didn't exist. I fixed that and also moved the build directory into `dest` so that the filelist and directorylist would be built for correct package removal.

The only thing I wasn't able to fix was getting the build to not run all the tests. If there was a flag for it, I missed it. They all fail due to permissions, but don't take too long.