### PR TITLE
OpenConnect VPN client

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #chromebrew directories
-OWNER="skycocker"
+OWNER="titpetric"
 REPO="chromebrew"
 BRANCH="master"
 URL="https://raw.github.com/$OWNER/$REPO/$BRANCH"

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -7,6 +7,7 @@ class Gnutls < Package
 
 	depends_on 'buildessential'
 	depends_on 'nettle'
+	depends_on 'pkgconfig'
 
 	def self.build
 		system "./configure"

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Gnutls < Package
+	version '3.3.15'
+	source_url 'ftp://ftp.gnutls.org/gcrypt/gnutls/v3.3/gnutls-3.3.15.tar.xz'
+	source_sha1 'd7f66b0aeaf48ff8621cc1913230635ef672f0a4'
+
+	depends_on 'buildessential'
+	depends_on 'nettle'
+
+	def self.build
+		system "./configure"
+		system "make"
+	end
+
+	def self.install
+		system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+	end
+end

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Libxml2 < Package
+	version '2.9.2'
+	source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.2.tar.gz'
+	source_sha1 'f46a37ea6d869f702e03f393c376760f3cbee673'
+
+	def self.build
+		system "./configure"
+		system "make"
+	end
+
+	def self.install
+		system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+	end
+end

--- a/packages/nettle.rb
+++ b/packages/nettle.rb
@@ -9,7 +9,7 @@ class Nettle < Package
 	depends_on 'm4'
 
 	def self.build
-		system "./configure"
+		system "./configure --libdir=/usr/local/lib"
 		system "make"
 	end
 

--- a/packages/nettle.rb
+++ b/packages/nettle.rb
@@ -1,11 +1,12 @@
 require 'package'
 
-class Libxml2 < Package
-	version '2.9.2'
-	source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.2.tar.gz'
-	source_sha1 'f46a37ea6d869f702e03f393c376760f3cbee673'
+class Nettle < Package
+	version '2.7.1'
+	source_url 'https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz'
+	source_sha1 'e7477df5f66e650c4c4738ec8e01c2efdb5d1211'
 
 	depends_on 'buildessential'
+	depends_on 'm4'
 
 	def self.build
 		system "./configure"

--- a/packages/openconnect.rb
+++ b/packages/openconnect.rb
@@ -1,0 +1,46 @@
+require 'package'
+
+# @todo: provide vpnc-script (standalone), instructions for manual install:
+#
+# sudo su -
+# mkdir /usr/local/etc/vpnc
+# cd /usr/local/etc/vpnc
+# wget http://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/HEAD:/vpnc-script
+# chmod a+x vpnc-script
+# exit
+
+# @todo: provide start-vpn script, instructions for manual connect:
+
+# Usage (as root - run 'sudo su -'):
+#
+# Create 'tun0' tunnel interface:
+#
+# > ip tuntap add mode tun tun0
+#
+# Run openconnect on tun0 interface
+#
+# > openconnect -i tun0 vpn.monotek.net
+# (Press Ctrl+C to exit)
+#
+# Shut down tun0 interface
+#
+# > ip tuntap del mode tun tun0
+
+class Openconnect < Package
+  version '7.06'
+  source_url 'ftp://ftp.infradead.org/pub/openconnect/openconnect-7.06.tar.gz' # software source tarball url  
+  source_sha1 '2351408693aab0c6bc97d37e68b4a869fbb217ed'
+
+  depends_on 'buildessential'
+  depends_on 'libxml2'
+  depends_on 'gnutls'
+  
+  def self.build                                                  # self.build contains commands needed to build the software from source
+    system "./configure --with-vpnc-script=/usr/local/etc/vpnc/vpnc-script"
+    system "make"                                                 # ordered chronologically
+  end
+  
+  def self.install                                                # self.install contains commands needed to install the software on the target system
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
+  end         
+end

--- a/packages/pkgconfig.rb
+++ b/packages/pkgconfig.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Pkgconfig < Package
+  version '0.28'
+  source_url 'http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz' # software source tarball url  
+  source_sha1 '71853779b12f958777bffcb8ca6d849b4d3bed46'
+
+  depends_on 'buildessential'
+  
+  def self.build                                                  # self.build contains commands needed to build the software from source
+    system "./configure --with-internal-glib"
+    system "make"                                                 # ordered chronologically
+  end
+  
+  def self.install                                                # self.install contains commands needed to install the software on the target system
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
+  end         
+end


### PR DESCRIPTION
I wrote a few package definitions to install the openconnect VPN client as a local Chromebook app (avoiding crouton). The included openssl lib has a bug which means I had to use the prefered gnutls library and dependencies (m4, pkg-config, libxml2, nettle).

A bit of the procedure is still manual (see packages/openconnect.rb for details).