### PR TITLE
Fix install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,12 +19,12 @@ if [ $architecture != "i686" ] && [ $architecture != "x86_64" ]; then
 fi
 
 #prepare directories
-sudo mkdir -p $CREW_LIB_PATH && sudo chown -R $user:$user $CREW_LIB_PATH
-sudo mkdir -p $CREW_CONFIG_PATH && sudo chown -R $user:$user $CREW_CONFIG_PATH
-sudo mkdir -p $CREW_CONFIG_PATH/meta && sudo chown -R $user:$user $CREW_CONFIG_PATH/meta
-sudo mkdir -p $CREW_BREW_DIR && sudo chown -R $user:$user $CREW_BREW_DIR
-sudo mkdir -p $CREW_DEST_DIR && sudo chown -R $user:$user $CREW_DEST_DIR
-sudo mkdir -p $CREW_PACKAGES_PATH && sudo chown -R $user:$user $CREW_PACKAGES_PATH
+sudo mkdir -p $CREW_LIB_PATH && sudo chown -R $USER:$USER $CREW_LIB_PATH
+sudo mkdir -p $CREW_CONFIG_PATH && sudo chown -R $USER:$USER $CREW_CONFIG_PATH
+sudo mkdir -p $CREW_CONFIG_PATH/meta && sudo chown -R $USER:$USER $CREW_CONFIG_PATH/meta
+sudo mkdir -p $CREW_BREW_DIR && sudo chown -R $USER:$USER $CREW_BREW_DIR
+sudo mkdir -p $CREW_DEST_DIR && sudo chown -R $USER:$USER $CREW_DEST_DIR
+sudo mkdir -p $CREW_PACKAGES_PATH && sudo chown -R $USER:$USER $CREW_PACKAGES_PATH
 
 #cd into the brew directory, everything will happen there
 cd $CREW_BREW_DIR

--- a/packages/nodejs.rb
+++ b/packages/nodejs.rb
@@ -3,7 +3,7 @@ require 'package'
 class Nodejs < Package
   version '0.12.0'
   source_url 'http://nodejs.org/dist/v0.12.0/node-v0.12.0.tar.gz'
-  source_sha1 'd08810034d170c19759cb38bfc9442ab6b0ebc7a'
+  source_sha1 'a969f17a0a6c9238584f8946d96e8d39be8eb957'
 
   depends_on 'buildessential'
   depends_on 'python27'


### PR DESCRIPTION
Install.sh is using $user:$user to set permissions. This is failing as linux doesn't understand how these. The proper variable should be $USER:$USER in caps.