### PR TITLE
Package.tar.gz to directoryname.tar.gz

### DIFF
--- a/create_package.sh
+++ b/create_package.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+DIRNAME=${PWD##*/}
 
 echo creating file list
 find . -type f > ../filelist && find . -type l >> ../filelist && cut -c2- ../filelist > filelist
@@ -10,8 +11,8 @@ echo removing temporary files
 rm dlistcut ../dlist ../filelist
 
 echo building binary package
-tar -czf ../package.tar.gz *
-sha1sum ../package.tar.gz > ../package.tar.gz.sha1
+tar -czf ../$DIRNAME.tar.gz *
+sha1sum ../$DIRNAME.tar.gz > ../$DIRNAME.tar.gz.sha1
 
 echo finished
-cat ../package.tar.gz.sha1
+cat ../$DIRNAME.tar.gz.sha1


### PR DESCRIPTION
So you don't have to rename the package.tar.gz when building multiple packages.