### PR TITLE
Fixed the broken JDK8 packge URK for x64 bit computers

### DIFF
--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,14 +4,10 @@ class Jdk8 < Package
   version '8.0.25'
   binary_url ({
     i686: "https://www.dropbox.com/s/d1omw087ilkh5oq/jdk1.8.0_25_i686.tar.gz?dl=0",
-    x86_64: "https://www.dropbox.com/s/2zohwl033i6rol2/jdk1.8.0_25_x86_64.tar.gz?dl=0"
+    x86_64: "https://www.dropbox.com/s/j1p2fbof5ms2wob/jdk1.8.0_25_i686.tar.gz?dl=0"
   })
   binary_sha1 ({
     i686: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30",
-    x86_64: "601ab66006ade8bbac8dad465cf71aefe5266744"
+    x86_64: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30"
   })
 end
-
-
-
-

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,10 +4,10 @@ class Jdk8 < Package
   version '8.0.25'
   binary_url ({
     i686: "https://www.dropbox.com/s/d1omw087ilkh5oq/jdk1.8.0_25_i686.tar.gz?dl=0",
-    x86_64: "https://www.dropbox.com/s/j1p2fbof5ms2wob/jdk1.8.0_25_i686.tar.gz?dl=0"
+    x86_64: "https://www.dropbox.com/s/my0ztzdngrjbsfh/jdk1.8.0_65_x86_64.tar.gz?dl=0"
   })
   binary_sha1 ({
     i686: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30",
-    x86_64: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30"
+    x86_64: "7701c06a704722b73bf8468a9d7819693e6d4be0"
   })
 end


### PR DESCRIPTION
The old URL would do a 404 so I simply went to the official download page and downloaded the latest JDK

I think we should move to openJDK. MUCH easier to clone