### PR TITLE
Corrected URL for JDK8 x64 version

### DIFF
--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,14 +4,10 @@ class Jdk8 < Package
   version '8.0.25'
   binary_url ({
     i686: "https://www.dropbox.com/s/d1omw087ilkh5oq/jdk1.8.0_25_i686.tar.gz?dl=0",
-    x86_64: "https://www.dropbox.com/s/2zohwl033i6rol2/jdk1.8.0_25_x86_64.tar.gz?dl=0"
+    x86_64: "https://www.dropbox.com/s/j1p2fbof5ms2wob/jdk1.8.0_25_i686.tar.gz?dl=0"
   })
   binary_sha1 ({
     i686: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30",
-    x86_64: "601ab66006ade8bbac8dad465cf71aefe5266744"
+    x86_64: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30"
   })
 end
-
-
-
-

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,10 +4,10 @@ class Jdk8 < Package
   version '8.0.25'
   binary_url ({
     i686: "https://www.dropbox.com/s/d1omw087ilkh5oq/jdk1.8.0_25_i686.tar.gz?dl=0",
-    x86_64: "https://www.dropbox.com/s/j1p2fbof5ms2wob/jdk1.8.0_25_i686.tar.gz?dl=0"
+    x86_64: "https://www.dropbox.com/s/my0ztzdngrjbsfh/jdk1.8.0_65_x86_64.tar.gz?dl=0"
   })
   binary_sha1 ({
     i686: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30",
-    x86_64: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30"
+    x86_64: "7701c06a704722b73bf8468a9d7819693e6d4be0"
   })
 end


### PR DESCRIPTION
Saw that the original dropbox url was a 404 error.
Downloaded the package. Removed the /usr/local/opt/java contents, and added the x64 content from the official jdk8_65 then repackaged it.

installed it myself to test and I have java on my chromebook pixel (Amazing!) 

I'm contributing back this package. Feel free to host the dropbox package yourself.

I'd also suggest to moving to openJDK (safer then the official JDK)

thank you.
