### PR TITLE
Disallow sudo

### DIFF
--- a/crew
+++ b/crew
@@ -21,6 +21,9 @@ $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"
 
 USER = `whoami`.chomp
 
+#disallow sudo
+abort "Chromebrew should not be run as root." if Process.uid == 0
+
 @device = JSON.parse(File.read(CREW_CONFIG_PATH + 'device.json'), symbolize_names: true)
 #symbolize also values
 @device.each do |key, elem|

--- a/crew
+++ b/crew
@@ -22,7 +22,7 @@ $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"
 USER = `whoami`.chomp
 
 #disallow sudo
-abort "Chromebrew should not be run as root." if Process.uid == 0
+abort "Chromebrew should not be run as root." if Process.uid == 0 && @command != "remove"
 
 @device = JSON.parse(File.read(CREW_CONFIG_PATH + 'device.json'), symbolize_names: true)
 #symbolize also values

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,11 @@ CREW_PACKAGES_PATH=$CREW_LIB_PATH/packages
 user=$(whoami)
 architecture=$(uname -m)
 
+if [ $EUID -eq 0 ]; then
+  echo 'Chromebrew should not be run as root.'
+  exit 1;
+fi
+
 if [ $architecture != "i686" ] && [ $architecture != "x86_64" ]; then
   echo 'Your device is not supported by Chromebrew yet.'
   exit 1;


### PR DESCRIPTION
A common cause of various errors is running the install script or the crew executable as the root user, this may introduce undefined behaviour which may be hard to reproduce.

See issues #143 #13 #79 #56 #159 #149 to name a few.

This pull request enforces that the `install.sh` script and the `crew` executable is not run with sudo or as the root user.