### PR TITLE
add packages/yasm.rb

### DIFF
--- a/packages/yasm.rb
+++ b/packages/yasm.rb
@@ -1,0 +1,15 @@
+require 'package'
+class Yasm < Package
+  version '1.3.0'
+  source_url 'http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz'
+  source_sha1 'b7574e9f0826bedef975d64d3825f75fbaeef55e'
+
+  def self.build
+    system './configure --prefix=/usr/local'
+    system 'make'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} make install"
+  end
+end


### PR DESCRIPTION
Hey.
Before I say anything about the pull request, I should say: Thanks :)
"chromebrew" has been very useful so far!

yasm appears to be a default dependency of mplayer, which I am in the process of trying to compile. 
yasm homepage: http://yasm.tortall.net/

I could add a source tarball for mplayer next (in the process of running `make`) but if you could offer some guidance, maybe a static mplayer binary could work, I'm really not too sure about how the process for that works in chromebrew.

Cheers.