### PR TITLE
Libevent and tmux fixes

### DIFF
--- a/crew
+++ b/crew
@@ -142,7 +142,7 @@ def download
     sha1sum = @pkg.binary_sha1[@device[:architecture]]
   end
   Dir.chdir CREW_BREW_DIR do
-    system('wget', '--continue', '--content-disposition', '--no-check-certificate', '-N', url, '-O', filename)
+    system('wget', '--continue', '--no-check-certificate', url, '-O', filename)
     abort 'Checksum mismatch :/ try again' unless Digest::SHA1.hexdigest( File.read("./#{filename}") ) == sha1sum
   end
   puts "Archive downloaded"

--- a/packages/libevent.rb
+++ b/packages/libevent.rb
@@ -1,12 +1,12 @@
 require 'package'                                                      	# include package class file
  
 class Libevent < Package                                            	# name the package and make it a Package class instance
-  version '2.0.21'                                               	                                      # software version
-  source_url 'https://github.com/downloads/libevent/libevent/libevent-2.0.21-stable.tar.gz'     # software source tarball url
-  source_sha1 '3e6674772eb77de24908c6267c698146420ab699'          	# source tarball sha1 sum
+  version '2.0.22'                                               	                                      # software version
+  source_url 'https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz'     # software source tarball url
+  source_sha1 'a586882bc93a208318c70fc7077ed8fca9862864'          	# source tarball sha1 sum
   
   def self.build                                                  # self.build contains commands needed to build the software from source
-    system "./configure"
+    system "./configure --disable-openssl"
     system "make"                                                 # ordered chronologically
   end
   

--- a/packages/tmux.rb
+++ b/packages/tmux.rb
@@ -1,13 +1,12 @@
 require 'package'                                                      	# include package class file
  
 class Tmux < Package                                            	# name the package and make it a Package class instance
-  version '1.9a'                                               	                                      # software version
-  source_url 'http://downloads.sourceforge.net/tmux/tmux-1.9a.tar.gz'     # software source tarball url
-  source_sha1 '815264268e63c6c85fe8784e06a840883fcfc6a2'          	# source tarball sha1 sum
+  version '2.2'                                               	                                      # software version
+  source_url 'https://github.com/tmux/tmux/releases/download/2.2/tmux-2.2.tar.gz'     # software source tarball url
+  source_sha1 '5ed1430bc7ef44c227e64e9401c686573dd0791a'          	# source tarball sha1 sum
   
   depends_on 'readline'                                            # software dependencies
   depends_on 'libevent'
-  depends_on 'openssl'
   depends_on 'ncurses'
   
   def self.build                                                  # self.build contains commands needed to build the software from source


### PR DESCRIPTION
update tmux, fix libevent build, fix crew wget

fixes #69 
fixes #164 #152 #163

    3 changes to get tmux to work:

    update tmux to latest release

    remove openssl dependency for libevent (partly because openssl forumla
    on chromebrew is broken right now, partly because we dont need it.) 

    change command line options for wget in crew script:
    man page says -N is incompatible with -O (and wget complains every run)
    --content-disposition not needed since we specify -O and big files on
    github (which are backed by aws) can not be retrieved with this flag,
    probably because AWS doesn't support HEAD requests for those files