### PR TITLE
add file command since chromeos doesn't have it

### DIFF
--- a/packages/file.rb
+++ b/packages/file.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Filecmd < Package
+  version '5.25'
+  source_url 'ftp://ftp.astron.com/pub/file/file-5.25.tar.gz'
+  source_sha1 'fea78106dd0b7a09a61714cdbe545135563e84bd'
+
+  def self.build
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Filecmd < Package
+  version '5.25'
+  source_url 'ftp://ftp.astron.com/pub/file/file-5.25.tar.gz'
+  source_sha1 'fea78106dd0b7a09a61714cdbe545135563e84bd'
+
+  def self.build
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Chromeos is missing the 'file' command which I seem to miss using more than I thought I did.

This installs both libmagic and the file command as a set (unlike brew and linuxbrew which have 
2 formulas for them).