### PR TITLE
Openssl_devel  - headers to allow building against system openssl

### DIFF
--- a/packages/libevent.rb
+++ b/packages/libevent.rb
@@ -4,6 +4,8 @@ class Libevent < Package                                            	# name the 
   version '2.0.21'                                               	                                      # software version
   source_url 'https://github.com/downloads/libevent/libevent/libevent-2.0.21-stable.tar.gz'     # software source tarball url
   source_sha1 '3e6674772eb77de24908c6267c698146420ab699'          	# source tarball sha1 sum
+
+  depends_on 'openssl_devel'
   
   def self.build                                                  # self.build contains commands needed to build the software from source
     system "./configure"

--- a/packages/openssl_devel.rb
+++ b/packages/openssl_devel.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+#Installs JUST the headers to match the chromeos supplied libraries so that you can build things 
+# that link with openssl. Needs to be kept version-synced with chromeos releases
+# Could detect current version and grab one of many different packages, compare to saved
+# hashes and support multiple versions if needed
+
+#grumble - package names in crew must conform to ruby variable name restrictions. For instance '-' is disallowed
+class Openssl_devel < Package
+  version '1.0.2f'
+
+#  chromeos wget can't do proper ssl negotiation with this server
+#  source_url 'https://www.openssl.org/source/old/1.0.2/openssl-1.0.2f.tar.gz'
+#  so use their ftp server.  
+  source_url 'ftp://ftp.openssl.org/source/old/1.0.2/openssl-1.0.2f.tar.gz'
+  source_sha1 '2047c592a6e5a42bd37970bdb4a931428110a927'
+
+  depends_on 'perl'
+
+  def self.build
+    # only need to run config to get the headers set up right
+    system './config'
+  end
+
+  def self.install
+    out = "#{CREW_DEST_DIR}/usr/local/include/openssl"
+    system "mkdir -p #{out}"
+
+    `ls ./include/openssl`.split(' ').each do |header|
+      system "cp", "./include/openssl/#{header}", out
+    end
+
+    #system "cp", "./include/openssl/*", "#{out}"
+  end
+
+end

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -7,7 +7,7 @@ class Python27 < Package
 
   depends_on 'bz2'
   depends_on 'ncurses'
-  depends_on 'openssl-devel'
+  depends_on 'openssl_devel'
 
   def self.build                                                  # self.build contains commands needed to build the software from source
     system "./configure --prefix=/usr/local CPPFLAGS=\"-I/usr/local/include -I/usr/local/include/ncurses\" LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\" -fPIC\""

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -7,6 +7,7 @@ class Python27 < Package
 
   depends_on 'bz2'
   depends_on 'ncurses'
+  depends_on 'openssl-devel'
 
   def self.build                                                  # self.build contains commands needed to build the software from source
     system "./configure --prefix=/usr/local CPPFLAGS=\"-I/usr/local/include -I/usr/local/include/ncurses\" LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\" -fPIC\""

--- a/packages/python34.rb
+++ b/packages/python34.rb
@@ -5,7 +5,7 @@ class Python34 < Package
   source_url 'https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz'     # software source tarball url
   source_sha1 'e8c1bd575a6ccc2a75f79d9d094a6a29d3802f5d'          	# source tarball sha1 sum
 
-  depends_on 'openssl-devel'
+  depends_on 'openssl_devel'
   
   def self.build                                                  # self.build contains commands needed to build the software from source
     system "./configure"

--- a/packages/python34.rb
+++ b/packages/python34.rb
@@ -4,6 +4,8 @@ class Python34 < Package
   version '3.4.1'
   source_url 'https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz'     # software source tarball url
   source_sha1 'e8c1bd575a6ccc2a75f79d9d094a6a29d3802f5d'          	# source tarball sha1 sum
+
+  depends_on 'openssl-devel'
   
   def self.build                                                  # self.build contains commands needed to build the software from source
     system "./configure"

--- a/packages/tmux.rb
+++ b/packages/tmux.rb
@@ -7,7 +7,8 @@ class Tmux < Package                                            	# name the pack
   
   depends_on 'readline'                                            # software dependencies
   depends_on 'libevent'
-  depends_on 'openssl'
+  # does this really depend on openssl?  or just on libevent that depends on openssl
+  depends_on 'openssl_devel'
   depends_on 'ncurses'
   
   def self.build                                                  # self.build contains commands needed to build the software from source


### PR DESCRIPTION
Installs JUST the headers to match the chromeos supplied libraries so that you can build things 
that link with openssl. Needs to be kept version-synced with chromeos releases
Could detect current version and grab one of many different packages, compare to saved
hashes and support multiple versions  maybe - call it a TODO

update the two 'from-source' python pacakges and libevent to depend on openssl_devel
