### PR TITLE
Fix url in installation to avoid 301 redirects

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 OWNER="skycocker"
 REPO="chromebrew"
 BRANCH="master"
-URL="https://raw.github.com/$OWNER/$REPO/$BRANCH"
+URL="https://raw.githubusercontent.com/$OWNER/$REPO/$BRANCH"
 CREW_PREFIX=/usr/local
 CREW_LIB_PATH=$CREW_PREFIX/lib/crew/
 CREW_CONFIG_PATH=$CREW_PREFIX/etc/crew/


### PR DESCRIPTION
Right now every file downloaded from github goes through a 301 redirect, this pull request speeds up install.sh by using the correct url for downloading.