### PR TITLE
Allow for SHA-256, update ruby_latest and Oracle JDK8

### DIFF
--- a/create_package.sh
+++ b/create_package.sh
@@ -12,7 +12,7 @@ rm dlistcut ../dlist ../filelist
 
 echo building binary package
 tar -czf ../$DIRNAME.tar.gz *
-sha1sum ../$DIRNAME.tar.gz > ../$DIRNAME.tar.gz.sha1
+sha256sum ../$DIRNAME.tar.gz > ../$DIRNAME.tar.gz.sha256
 
 echo finished
-cat ../$DIRNAME.tar.gz.sha1
+cat ../$DIRNAME.tar.gz.sha256

--- a/crew
+++ b/crew
@@ -142,14 +142,15 @@ def download
   filename = File.basename(uri.path)
   if source
     sha1sum = @pkg.source_sha1
-    sha256sum = @pkg.source_sha256
+    sha256sum = @pkg.source_sha2
   else
     sha1sum = @pkg.binary_sha1[@device[:architecture]]
-    sha256sum = @pkg.binary_sha256[@device[:architecture]]
+    sha256sum = @pkg.binary_sha2[@device[:architecture]]
   end
   Dir.chdir CREW_BREW_DIR do
     system('wget', '--continue', '--no-check-certificate', url, '-O', filename)
-    abort 'Checksum mismatch :/ try again' unless Digest::SHA1.hexdigest( File.read("./#{filename}") ) == sha1sum
+    abort 'Checksum mismatch :/ try again' unless Digest::SHA1.hexdigest( File.read("./#{filename}") ) == sha1sum || 
+      Digest::SHA2.hexdigest( File.read("./#{filename}") ) == sha256sum
   end
   puts "Archive downloaded"
   return {source: source, filename: filename}

--- a/crew
+++ b/crew
@@ -142,8 +142,10 @@ def download
   filename = File.basename(uri.path)
   if source
     sha1sum = @pkg.source_sha1
+    sha256sum = @pkg.source_sha256
   else
     sha1sum = @pkg.binary_sha1[@device[:architecture]]
+    sha256sum = @pkg.binary_sha256[@device[:architecture]]
   end
   Dir.chdir CREW_BREW_DIR do
     system('wget', '--continue', '--no-check-certificate', url, '-O', filename)

--- a/crew
+++ b/crew
@@ -3,6 +3,7 @@ require 'find'
 require 'net/http'
 require 'uri'
 require 'digest/sha1'
+require 'digest/sha2'
 require 'json'
 require 'fileutils'
 

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -1,7 +1,7 @@
 require 'package_helpers'
 
 class Package
-  property :version, :binary_url, :binary_sha1, :source_url, :source_sha1, :is_fake
+  property :version, :binary_url, :binary_sha1, :binary_sha2, :source_url, :source_sha1, :source_sha2, :is_fake
   
   class << self
     attr_reader :dependencies, :is_fake

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -1,13 +1,13 @@
 require 'package'
 
 class Jdk8 < Package
-  version '8.0.25'
+  version '8.0.91'
   binary_url ({
-    i686: "https://www.dropbox.com/s/d1omw087ilkh5oq/jdk1.8.0_25_i686.tar.gz?dl=0",
-    x86_64: "https://www.dropbox.com/s/ykw2jt797cpghfy/jdk1.8.0_65_x86_64.tar.gz?dl=0"
+    i686: "http://download.oracle.com/otn-pub/java/jdk/8u91-b14/jdk-8u91-linux-i586.tar.gz",
+    x86_64: "http://download.oracle.com/otn-pub/java/jdk/8u91-b14/jdk-8u91-linux-x64.tar.gz"
   })
-  binary_sha1 ({
-    i686: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30",
-    x86_64: "7701c06a704722b73bf8468a9d7819693e6d4be0"
+  binary_sha2 ({
+    i686: "5ecd05b5e566cbe688fc1e3159f04004ccad14d4faa3f50d15ffba1d50b4cd52",
+    x86_64: "6f9b516addfc22907787896517e400a62f35e0de4a7b4d864b26b61dbe1b7552"
   })
 end

--- a/packages/ruby_latest.rb
+++ b/packages/ruby_latest.rb
@@ -3,7 +3,7 @@ require 'package'
 class Ruby_latest < Package
   version '2.3.1'
   source_url 'https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz'
-  source_sha256 'b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd'
+  source_sha2 'b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd'
 
   depends_on 'readline'
   depends_on 'zlibpkg'


### PR DESCRIPTION
Brought the more secure SHA-2 class to crew, allowing new packages to be verified with sha-256 and old packages to be migrated. Updated ruby_latest the the newest stable version of Ruby 2.3 and added Oracle's JDK 8u91,
