### PR TITLE
ARM support (tested on c100pa)

### DIFF
--- a/crew
+++ b/crew
@@ -15,6 +15,7 @@ CREW_CONFIG_PATH = CREW_PREFIX + '/etc/crew/'
 CREW_BREW_DIR = CREW_PREFIX + '/tmp/crew/'
 CREW_DEST_DIR = CREW_BREW_DIR + '/dest'
 
+ARCH = `uname -m | tr -d '\n\r'`
 SHORTARCH = `getconf LONG_BIT | tr -d '\n\r'`
 
 $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"

--- a/install.sh
+++ b/install.sh
@@ -92,8 +92,20 @@ done
 case "$architecture" in
 "armv7l")
   echo y | crew install gcc
-  if [ ! -L $HOME/Downloads/tools ]; then
-    ln -s /usr/local $HOME/Downloads/tools
+  if [ ! -d $HOME/Downloads/tools ]; then
+    mkdir $HOME/Downloads/tools
+    mkdir $HOME/Downloads/tools/bin
+    mkdir $HOME/Downloads/tools/lib
+    mkdir $HOME/Downloads/tools/libexec
+    mkdir $HOME/Downloads/tools/share
+    ln -s /usr/local/armv7a-cros-linux-gnueabi $HOME/Downloads/tools
+    ln -s /usr/local/bin/as $HOME/Downloads/tools/bin
+    ln -s /usr/local/bin/bison $HOME/Downloads/tools/bin
+    ln -s /usr/local/bin/ld $HOME/Downloads/tools/bin
+    ln -s /usr/local/bin/m4 $HOME/Downloads/tools/bin
+    ln -s /usr/local/lib/gcc $HOME/Downloads/tools/lib
+    ln -s /usr/local/libexec/gcc $HOME/Downloads/tools/libexec
+    ln -s /usr/local/share/bison $HOME/Downloads/tools/share
   fi;;
 esac
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #chromebrew directories
-OWNER="jam7"
+OWNER="skycocker"
 REPO="chromebrew"
 BRANCH="master"
 URL="https://raw.githubusercontent.com/$OWNER/$REPO/$BRANCH"

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #chromebrew directories
-OWNER="skycocker"
+OWNER="jam7"
 REPO="chromebrew"
 BRANCH="master"
 URL="https://raw.githubusercontent.com/$OWNER/$REPO/$BRANCH"
@@ -17,10 +17,13 @@ if [ $EUID -eq 0 ]; then
   exit 1;
 fi
 
-if [ $architecture != "i686" ] && [ $architecture != "x86_64" ]; then
+case "$architecture" in
+"i686"|"x86_64"|"armv7l")
+  ;;
+*)
   echo 'Your device is not supported by Chromebrew yet.'
-  exit 1;
-fi
+  exit 1;;
+esac
 
 #prepare directories
 for dir in $CREW_LIB_PATH $CREW_CONFIG_PATH $CREW_CONFIG_PATH/meta $CREW_BREW_DIR $CREW_DEST_DIR $CREW_PACKAGES_PATH; do
@@ -34,6 +37,10 @@ cd $CREW_BREW_DIR
 echo "Downloading ruby..."
 
 case "$architecture" in
+"armv7l")
+  link='https://dl.dropboxusercontent.com/s/w4y8b0an136fk3i/ruby-2.0.0p247-chromeos-armv7l.tar.xz'
+  tarname='ruby-2.0.0p247-chromeos-'$architecture'.tar.gz'
+  ;;
 "i686")
   link='https://dl.dropboxusercontent.com/s/tufbuqcn80ubypx/ruby-2.0.0p247-chromeos-i686.tar.gz'
   tarname='ruby-2.0.0p247-chromeos-'$architecture'.tar.gz'
@@ -80,6 +87,15 @@ cd $CREW_PACKAGES_PATH
 for file in git zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders; do
   wget -N -c $URL/packages/$file.rb
 done
+
+#install gcc on arm only.  It requires special treatments
+case "$architecture" in
+"armv7l")
+  echo y | crew install gcc
+  if [ ! -L $HOME/Downloads/tools ]; then
+    ln -s /usr/local $HOME/Downloads/tools
+  fi;;
+esac
 
 #install readline for ruby
 echo y | crew install readline

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -32,7 +32,6 @@ class Package
     if ARCH == "armv7l"
       args = args.map {|s| s.gsub("-m32", "")}
       args = args.map {|s| s.gsub("lib32", "lib")}
-      puts *args
     end
     Kernel.system(*args)
     exitstatus = $?.exitstatus

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -28,6 +28,12 @@ class Package
   end
 
   def self.system(*args)
+    # strip -m32 option and convert lib32 to lib for the case of ARM to avoid SHORTARCH flood
+    if ARCH == "armv7l"
+      args = args.map {|s| s.gsub("-m32", "")}
+      args = args.map {|s| s.gsub("lib32", "lib")}
+      puts *args
+    end
     Kernel.system(*args)
     exitstatus = $?.exitstatus
     raise InstallError.new("`#{args.join(" ")}` exited with #{exitstatus}") unless exitstatus == 0

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,10 +3,12 @@ require 'package'
 class Binutils < Package
   version '2.23.2'
   binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/kut6emhlda9pbc9/dummy-1.0.0-chromeos-armv7l.tar.gz",
     i686: 'https://dl.dropboxusercontent.com/s/u3cp7mpdyfx99ij/binutils-2.23.2-chromeos-i686.tar.gz?token_hash=AAGsFB9HXNb5tSAm_Wd2GyIUL59BkZYgMTHkj4CkHLxggg&dl=1',
     x86_64: 'https://dl.dropboxusercontent.com/s/mnu21v101rdbm8k/binutils-2.23.2-chromeos-x86_64.tar.gz?token_hash=AAEn4ngAJs-fpRUz1n1Q_2WKxQvQnPMwlgcEHBDKyLOpoA&dl=1'
   })
   binary_sha1 ({
+    armv7l: "049db60338a74d798e72afabe05097f3a4c4f7cd",
     i686: 'a7edc9bdaf9fc72112fe6b370f158a9a1aee87ac',
     x86_64: '1c13b8f261e419a66b87f09653f3fbaf8449efe1'
   })

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,10 +3,12 @@ require 'package'
 class Curl < Package
   version '7.32.0'
   binary_url ({
+    armv7l: 'https://dl.dropboxusercontent.com/s/lvs0o30t4u9zjre/curl-7.32.0-chromeos-armv7l.tar.xz',
     i686: 'https://dl.dropboxusercontent.com/s/h3x2iiy5ibi97vr/curl-7.32.0-chromeos-i686.tar.gz?token_hash=AAETu-MnNyBTCHQbkh4O817QbNK3wRLbAP_gQhjgNyFGtw&dl=1',
     x86_64: 'https://dl.dropboxusercontent.com/s/u2hmmd6wfz25qnn/curl-7.32.0-chromeos-x86_64.tar.gz?token_hash=AAGHjx6ATIsDW-Xi4pNUbCMknfWUa6GGQbAquWDkH1xzgg&dl=1'
   })
   binary_sha1 ({
+    armv7l: '0ee487342dc4e2cb10aa088a39b04b449b410e7c',
     i686: 'af3abbae663884ed367c5b6b467ebb310052f53f',
     x86_64: '94766f554b195583040e31ce8e85846d8271ac11'
   })

--- a/packages/diffutils.rb
+++ b/packages/diffutils.rb
@@ -5,6 +5,14 @@ class Diffutils < Package
   source_url 'ftp://ftp.gnu.org/gnu/diffutils/diffutils-3.3.tar.xz'
   source_sha1 '6463cce7d3eb73489996baefd0e4425928ecd61e'
 
+  # arm has 3.3 diffutils in system, so leave it as is
+  binary_url({
+    armv7l: "https://dl.dropboxusercontent.com/s/kut6emhlda9pbc9/dummy-1.0.0-chromeos-armv7l.tar.gz",
+  })
+  binary_sha1({
+    armv7l: "049db60338a74d798e72afabe05097f3a4c4f7cd",
+  })
+
   depends_on "libsigsegv"
 
   def self.build

--- a/packages/expat.rb
+++ b/packages/expat.rb
@@ -3,10 +3,12 @@ require 'package'
 class Expat < Package
   version '2.1.0'
   binary_url ({
+    armv7l: 'https://dl.dropboxusercontent.com/s/iwa36x4jjekcrnp/expat-2.1.0-chromeos-armv7l.tar.xz',
     i686: 'https://dl.dropboxusercontent.com/s/jh5uw42elm40t9a/expat-2.1.0-chromeos-i686.tar.gz?token_hash=AAGYckE0KoTPsydZGG85KTkpr7Nt5U1OUs0egJ1K0iJ1mg&dl=1',
     x86_64: 'https://dl.dropboxusercontent.com/s/k89o1x1a3fwoamu/expat-2.1.0-chromeos-x86_64.tar.gz?token_hash=AAGBLOil45Zg7G2RlFlfDUxKfeDyTP3uUWjfBvGQrOjAYA&dl=1'
   })
   binary_sha1 ({
+    armv7l: '5d12c1fae84601735a803f9ed10cc4e113f47ab7',
     i686: '9ab42ec03d06cc64d5d9944cb4cc7eaa61a0af84',
     x86_64: '3ac96a0e02c1117718d15bcd4976ef4bcef1a9ac'
   })

--- a/packages/gawk.rb
+++ b/packages/gawk.rb
@@ -4,6 +4,12 @@ class Gawk < Package
   version '4.1.1'
   source_url 'http://ftp.gnu.org/gnu/gawk/gawk-4.1.1.tar.gz'
   source_sha1 '0480d23fffbf04bfd0d4ede4c1c3d57eb81cc771'
+  binary_url({
+    armv7l: "https://dl.dropboxusercontent.com/s/b7w6l92az4dmitf/gawk-4.1.1-chromeos-armv7l.tar.xz",
+  })
+  binary_sha1({
+    armv7l: "470c7f9360d563d88031d793f7bbe39a972e2209",
+  })
 
   def self.build
     system './configure --prefix=/usr/local'

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -2,11 +2,15 @@ require 'package'
 
 class Gcc < Package
   version '4.8.1-baseline'
+
+  # GCC for ARM is taken from http://davy.nyacom.net/cros-arm-dev.html and modified little to fit crew package.
   binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/fajmnew33ah8k34/gcc-4.9.x-google-20150123-chromeos-armv7l.tar.xz",
     i686: "https://dl.dropboxusercontent.com/s/c06pcge8ogsqfcd/gcc-4.8.1-baseline-chromeos-i686.tar.gz?token_hash=AAFLnE_8iL_lAnGtAAVM5G_sYqejA44jGW8D9r0a8xCjrQ&dl=1",
     x86_64: "https://dl.dropboxusercontent.com/s/kk52ic170je87fc/gcc-4.8.1-baseline-chromeos-x86_64.tar.gz?token_hash=AAGcQBSj1y8OfHXUhsayxlFfvk4LRszY07ehx_Z6UoyNEg&dl=1"
   })
   binary_sha1 ({
+    armv7l: "f1a50672bb0d21496ae494f07da4d298773d146e",
     i686: "d720c9a804d26728d730b93748072ffa6df7ee3d",
     x86_64: "59932a73cd149ae82b4b5c277b734788c1efab44"
   })

--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -3,10 +3,12 @@ require 'package'
 class Gettext < Package
   version '0.18.3.1'
   binary_url ({
+    armv7l: 'https://dl.dropboxusercontent.com/s/c6pqmdrvl6epblv/gettext-0.18.3.1-chromeos-armv7l.tar.xz',
     i686: 'https://dl.dropboxusercontent.com/s/xmsfr7q9r99dhcs/gettext-0.18.3.1-chromeos-i686.tar.gz?token_hash=AAGJo0pqudCOkGU3NHOcBuFG2zLwWpapNXLX-zUJLcS3aA&dl=1',
     x86_64: 'https://dl.dropboxusercontent.com/s/nidj0ehxwserhz6/gettext-0.18.3.1-chromeos-x86_64.tar.gz?token_hash=AAFn-kdXlB23HDVDCKTn9n_U-i9LFNCIB6HU0jSUiJTctA&dl=1'
   })
   binary_sha1 ({
+    armv7l: '985fb8b666289b8abb3a820423a10860fa35e8ef',
     i686: '1ecbff59d6134c7f8804bcf18fb2b1b7a9a6d4c0',
     x86_64: '22174347defa4f034a360078c248a61710c5f854'
   })

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,10 +3,12 @@ require 'package'
 class Git < Package
   version '1.8.4'
   binary_url ({
+    armv7l: 'https://dl.dropboxusercontent.com/s/axzamdiwfl1cbnq/git-1.8.4-chromeos-armv7l.tar.xz',
     i686: 'https://dl.dropboxusercontent.com/s/g3binxopw5nfky1/git-1.8.4-chromeos-i686.tar.gz?token_hash=AAEWnMNBfozSIzLD1unbYGJzT4FGkEfJmLFQ-3uzydfT_A&dl=1',
     x86_64: 'https://dl.dropboxusercontent.com/s/i7vs9wfk94tsrzt/git-1.8.4-chromeos-x86_64.tar.gz?token_hash=AAHyvjayN7THoxlryZaxQ2Ejm9xyD6bZCqXZM81hYRC8iQ&dl=1'
   })
   binary_sha1 ({
+    armv7l: '6dafe06d2c430f492eba939982419e167e7e4e26',
     i686: '8c1bf4bcffb0e9c17bf20dd05981e86ea34d5d65',
     x86_64: '067cb6c36616ac30999ab97e85f3dc0e9d1d57f4'
   })

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -2,11 +2,14 @@ require 'package'
 
 class Glibc < Package
   version '2.17.90-baseline'
+  # arm use 2.19 by system, so 2.19 here also
   binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/nxyjvbea59nwwdi/glibc-2.19-minimum-chromeos-armv7l.tar.xz",
     i686: "https://dl.dropboxusercontent.com/s/dic47f8eqxhpf89/glibc-2.17.90-baseline-chromeos-i686.tar.gz?token_hash=AAHx_77YtWLLnkjCJRaCJt7RsdKrfkT6lgKS9BZc4O-0Pg&dl=1",
     x86_64: "https://dl.dropboxusercontent.com/s/x3tu160i7pmn6tp/glibc-2.17-baseline-chromeos-x86_64.tar.gz?token_hash=AAG794JG65HjzHMcAyAysQUbEPMUci1bZJPREj3ztCtnBg&dl=1"
   })
   binary_sha1 ({
+    armv7l: "ad342eb260c78d2951b3aaf3f6f1f4519ceb8dd4",
     i686: "3c3a0b86ed4591ec59daeb24d2dcda139574de1b",
     x86_64: "d818775f74d91692828f12321044cd95fc649cf0"
   })

--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -3,10 +3,12 @@ require 'package'
 class Gmp < Package
   version "5.1.2"
   binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/kut6emhlda9pbc9/dummy-1.0.0-chromeos-armv7l.tar.gz",
     i686: "https://dl.dropboxusercontent.com/s/9cwila1kaomsyl2/gmp-5.1.2-chromeos-i686.tar.gz?token_hash=AAHO9VxBpvXU2GPWBwimsp4hL8DADIItfNnIaFbfcyynMg&dl=1",
     x86_64: "https://dl.dropboxusercontent.com/s/zp1mw0l93jcg35e/gmp-5.1.3-chromeos-x86_64.tar.gz?token_hash=AAHa75_Uu5zFQlbQUbse19d_vhIAmEnZ8bYpshE6giSXGw&dl=1"
   })
   binary_sha1 ({
+    armv7l: "049db60338a74d798e72afabe05097f3a4c4f7cd",
     i686: "b03b9508463588bfe9d09303c0725068cddd8810",
     x86_64: "2aee1fee1e4b98261127a4c73f3f88670f1c8162"
   })

--- a/packages/less.rb
+++ b/packages/less.rb
@@ -4,6 +4,12 @@ class Less < Package
   version '451'
   source_url 'ftp://ftp.gnu.org/gnu/less/less-451.tar.gz'
   source_sha1 'ee95be670e8fcc97ac87d02dd1980209130423d0'
+  binary_url({
+    armv7l: "https://dl.dropboxusercontent.com/s/tsyva5iweqp2blq/less-451-chromeos-armv7l.tar.xz",
+  })
+  binary_sha1({
+    armv7l: "c36725933672985b649073b0a6345e68c6bea96d",
+  })
 
   depends_on 'buildessential'
   depends_on 'ncurses' 

--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -5,6 +5,14 @@ class Libsigsegv < Package
   source_url 'ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.10.tar.gz'
   source_sha1 'b75a647a9ebda70e7a3b33583efdd550e0eac094'
 
+  # arm compiler doesn't recognize -m32 option, so I made binary for the ease of use
+  binary_url({
+    armv7l: "https://dl.dropboxusercontent.com/s/8tcvv9s16mmtdgs/libsigsegv-2.10-chromeos-armv7l.tar.xz",
+  })
+  binary_sha1({
+    armv7l: "004a4c6500946c7585c6ef782c912e36a056d8df",
+  })
+
   def self.build
     system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
     system "make"

--- a/packages/libssh2.rb
+++ b/packages/libssh2.rb
@@ -3,10 +3,12 @@ require 'package'
 class Libssh2 < Package
   version '1.4.3'
   binary_url ({
+    armv7l: 'https://dl.dropboxusercontent.com/s/rm6ww0r2afbsdvz/libssh2-1.4.3-chromeos-armv7l.tar.xz',
     i686: 'https://dl.dropboxusercontent.com/s/zjnild1c2i10h53/libssh2-1.4.3-chromeos-i686.tar.gz?token_hash=AAG_aZ7_dPKOiOMCMUiW2g3mLkz8UKHnGn5jLcDAGcNCIA&dl=1',
     x86_64: 'https://dl.dropboxusercontent.com/s/frzkbbnf35ie6ns/libssh2-1.4.3-chromeos-x86_64.tar.gz?token_hash=AAEk26mEOXT0MX05nM9gG6yNDPkL6KmLazRxKqQCR6qs8Q&dl=1'
   })
   binary_sha1 ({
+    armv7l: '1f2554b8199dba88d0f4fee5c9b3284da6657c24',
     i686: '21b4b1a9608b12c0b3d1e6f0b6615f4a4152acb3',
     x86_64: '903aae8255c47c6052003837be132ff39582422b'
   })

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -3,10 +3,12 @@ require 'package'
 class Linuxheaders < Package
   version '3.4.0'
   binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/kut6emhlda9pbc9/dummy-1.0.0-chromeos-armv7l.tar.gz",
     i686: "https://dl.dropboxusercontent.com/s/mdzdoyq7dtnz682/linux-headers-3.4.0-chromeos-i686.tar.gz?token_hash=AAE4yw5oH_SfZ3lAx02mFP603rnjmoB9Gp4vqTY14NsA-A&dl=1",
     x86_64: "https://dl.dropboxusercontent.com/s/3ec3fjpls0t2iqn/linuxheaders-3.8.11-chromeos-x86_64.tar.gz?token_hash=AAFl1_1I3FtwGdoGvGJuGrGUqzaDkhumPzsGJMX5pYhZyQ&dl=1"
   })
   binary_sha1 ({
+    armv7l: "049db60338a74d798e72afabe05097f3a4c4f7cd",
     i686: "31c933f3a4e82fd9310b0f5b32d79c9a51514fee",
     x86_64: "c113e16d72147429f774ba6678d72a221b19a5bc"
   })

--- a/packages/make.rb
+++ b/packages/make.rb
@@ -3,10 +3,12 @@ require 'package'
 class Make < Package
   version '3.82'
   binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/zadlpkkj73m10an/make-3.82-chromeos-armv7l.tar.xz",
     i686: "https://dl.dropboxusercontent.com/s/f6pg4bkg6m3vn7q/make-3.82-chromeos-i686.tar.gz?token_hash=AAHP__I3leN8BCLdP0pLbkNopoFGGhDuKX0sN-I6Zx4JYg&dl=1",
     x86_64: "https://dl.dropboxusercontent.com/s/t818zxgixti6wvl/make-3.82-chromeos-x86_64.tar.gz?token_hash=AAGLBxpwv2mZj7dAgnzdmfFcO8G28wbCfb0lPM8_qwRtSA&dl=1"
   })
   binary_sha1 ({
+    armv7l: "b25e550b11ce3344744c26dad4089bfbc19a0fdb",
     i686: "ccb01c7358e5abdf8b06305eb31b1969b8b174f7",
     x86_64: "2bab91837440d101eb55129f41a7837101249b46"
   })

--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -3,10 +3,12 @@ require 'package'
 class Mpc < Package
   version '1.0.1'
   binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/kut6emhlda9pbc9/dummy-1.0.0-chromeos-armv7l.tar.gz",
     i686: "https://dl.dropboxusercontent.com/s/3o6uc8n4uy3oved/mpc-1.0.1-chromeos-i686.tar.gz?token_hash=AAH_OlvQWGUF7lyFhV3DXXgYRM1fupgKoHIwyiVmmVyWUQ&dl=1",
     x86_64: "https://dl.dropboxusercontent.com/s/qr1x2fr1z0af26o/mpc-1.0.1-chromeos-x86_64.tar.gz?token_hash=AAFGK8OM8sm4k02lBAudZg8olgKxs_HmieFFqU6MZZONOA&dl=1"
   })
   binary_sha1 ({
+    armv7l: "049db60338a74d798e72afabe05097f3a4c4f7cd",
     i686: "f11c6e74e9059bf400b0978e6e05fe67c7f3dfe9",
     x86_64: "24c4be4ea026d2d6e432a0aa9edb6dd27cf3e7df"
   })

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -3,10 +3,12 @@ require 'package'
 class Mpfr < Package
   version '3.1.2'
   binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/kut6emhlda9pbc9/dummy-1.0.0-chromeos-armv7l.tar.gz",
     i686: "https://dl.dropboxusercontent.com/s/lo9ks3g7ar3zpfu/mpfr-3.1.2-chromeos-i686.tar.gz?token_hash=AAH1GlLfYtUs4uxl1ayeGTBe8RJ5uTXzOAsXgSlv8G5rrA&dl=1",
     x86_64: "https://dl.dropboxusercontent.com/s/ev2a1yha3gm1hwy/mpfr-3.1.2-chromeos-x86_64.tar.gz?token_hash=AAErYQPCHkhALqnX4Y0LjATZITtD2qoKNbkdn67LOmRVRQ&dl=1"
   })
   binary_sha1 ({
+    armv7l: "049db60338a74d798e72afabe05097f3a4c4f7cd",
     i686: "eb81b9bb83ebb43b94ab33e43293f1df3bcbad7c",
     x86_64: "a80c48bee7e6e8ddcd1771c4fd7708d89f2abb9c"
   })

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -5,6 +5,14 @@ class Ncurses < Package
   source_url 'ftp://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz'
   source_sha1 '3e042e5f2c7223bffdaac9646a533b8c758b65b5'
 
+  # arm has 5.9 ncurses library in system, so leave it as is
+  binary_url({
+    armv7l: "https://dl.dropboxusercontent.com/s/kut6emhlda9pbc9/dummy-1.0.0-chromeos-armv7l.tar.gz",
+  })
+  binary_sha1({
+    armv7l: "049db60338a74d798e72afabe05097f3a4c4f7cd",
+  })
+
   depends_on "diffutils"
 
   def self.build

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -3,10 +3,12 @@ require 'package'
 class Perl < Package
   version '5.16.3'
   binary_url ({
+    armv7l: 'https://dl.dropboxusercontent.com/s/84esb5d5638plvn/perl-5.16.3-chromeos-armv7l.tar.xz',
     i686: 'https://dl.dropboxusercontent.com/s/qwbwhvqed0yyv3l/perl-5.16.3-chromeos-i686.tar.gz?token_hash=AAHjq1OrZ3iNYerA9y6QIPtsn3fOnW5QeIFbYlBbBN-OkA&dl=1',
     x86_64: 'https://dl.dropboxusercontent.com/s/gg2q9tsvy2ybf80/perl-5.18.1-chromeos-x86_64.tar.gz?token_hash=AAFbAeYB604esg7FRBM_TeBh2hiDg2Bw8eZfPHFH8zCdHw&dl=1'
   })
   binary_sha1 ({
+    armv7l: '4ce1cbeea2cd79610f8a681a9c094370590c981f',
     i686: 'e2a8c5280b8a4abec70256f41d5e5b04253d6796',
     x86_64: '5bf7c1762499a40f2ce8684be6f5699c6a4658e1'
   })

--- a/packages/python.rb
+++ b/packages/python.rb
@@ -3,10 +3,12 @@ require 'package'
 class Python < Package
   version '3.3.2'
   binary_url ({
+    armv7l: 'https://dl.dropboxusercontent.com/s/1uwhvkteeqwxy38/python-3.3.2-chromeos-armv7l.tar.xz',
     i686: 'https://dl.dropboxusercontent.com/s/mxgfmq992hhiawk/python-3.3.2-chromeos-i686.tar.gz?token_hash=AAFA2YzFp293uyV3zYfP70iwCk8oH9HCLKMTrK0dtMU8GQ&dl=1',
     x86_64: 'https://dl.dropboxusercontent.com/s/r1zvmza51hrr87q/python-3.3.2-chromeos-x86_64.tar.gz?token_hash=AAHIdz6pWcOrfty7C8ACuRcLDq0d0ERYs0jCgOPLn5USUQ&dl=1'
   })
   binary_sha1 ({
+    armv7l: '0bca057b1ce5c368fa8a80353b5b9f0e6eedfb89',
     i686: 'a985a4bba243b4fa701db302dc2fa554aef76f1c',
     x86_64: 'fbfe0946c2f9191bd6110705994d459e373a8b09'
   })

--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -3,10 +3,13 @@ require 'package'
 class Readline < Package
   version '6.2'
 
+  # arm has 6.3 readline library in system, so leave it as is
   binary_url({
+    armv7l: "https://dl.dropboxusercontent.com/s/kut6emhlda9pbc9/dummy-1.0.0-chromeos-armv7l.tar.gz",
     x86_64: "https://dl.dropboxusercontent.com/s/v8xva6e4u3tvkaw/readline-6.2-chromeos-x86_64.tar.gz?token_hash=AAHOv1kLiv7xzDkYEZCSB_3ShK0n_7B4m2dNGHPnn2fZIg&dl=1"
   })
   binary_sha1({
+    armv7l: "049db60338a74d798e72afabe05097f3a4c4f7cd",
     x86_64: '621c2538b452be33cca507110ccfd4144c61edd2'
   })
   

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -3,10 +3,12 @@ require 'package'
 class Ruby < Package
   version '2.0.0p247-chromeos1'
   binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/w4y8b0an136fk3i/ruby-2.0.0p247-chromeos-armv7l.tar.xz",
     i686: "https://dl.dropboxusercontent.com/s/tufbuqcn80ubypx/ruby-2.0.0p247-chromeos-i686.tar.gz&dl=1",
     x86_64: "https://www.dropbox.com/s/x3jt0z5i1r4afyv/ruby-2.0.0p247-chromeos-x86_64.tar.gz?dl=1"
   })
   binary_sha1 ({
+    armv7l: "0340b0dfd35e94d634a3f4a5647e13d496aea4e0",
     i686: "49eeba5d542e4c3e6aa3686f215485e0946fb99a",
     x86_64: "f1de1ef5ed690c3b78f4e40208a4fb93e227c4ed"
   })

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -3,10 +3,12 @@ require 'package'
 class Zlibpkg < Package
   version '1.2.8'
   binary_url ({
+    armv7l: 'https://dl.dropboxusercontent.com/s/0abbkyzj6unp5lz/zlibpkg-1.2.8-chromeos-armv7l.tar.xz',
     i686: 'https://dl.dropboxusercontent.com/s/ljhhvr12u1izayj/zlib-1.2.8-chromeos-i686.tar.gz?token_hash=AAEABTatYkxOOybZGoCj3Kg_DKEbFbSfolzZklfHwCsP_A&dl=1',
     x86_64: 'https://dl.dropboxusercontent.com/s/h4lqj0rnand0jqu/zlib-1.2.8-chromeos-x86_64.tar.gz?token_hash=AAGabAMhX4CGpzhpkcuKMmmWPxFZDiNOC-r9B0o7x4D7eQ&dl=1'
   })
   binary_sha1 ({
+    armv7l: 'ff64005a9e5c953a1d4b05cfa3a1a5d36006f969',
     i686: 'e02974780bfb3bf46940183043d15897a765ab4e',
     x86_64: 'cb764e22b68b7e2884372708b5b585d11efca972'
   })


### PR DESCRIPTION
Hi, this is a pull request for full ARM support including gcc, glibc, ruby, python, git, etc.
I'm using pre-compiled gcc taken from http://davy.nyacom.net/cros-arm-dev.html under author's permission.
Others are compiled by myself using this gcc. 

All of above are available on https://github.com/jam7/chromebrew also for the ease of access.

In addion, regarding to recent discuss on the board.  I know #185, but I haven't had time to test it.  I modified package.rb to avoid SHORTARCH conflicts, so I hope almost all source compile packages work on ARM too.

Have a fun.  And thank you for the great effort to release and update chrombrew.  👍 