### PR TITLE
Update node to latest lts (6.9.2)

### DIFF
--- a/packages/node_current.rb
+++ b/packages/node_current.rb
@@ -2,8 +2,8 @@ require 'package'
 
 class Node_current < Package
   version '6.2.2'
-  source_url 'https://nodejs.org/dist/v6.2.2/node-v6.2.2.tar.xz'
-  source_sha1 '5014800813fa3682b8053637518b37a119c26e93'
+  source_url 'https://nodejs.org/dist/v6.9.2/node-v6.9.2.tar.gz'
+  source_sha1 '6b33b9fac28785b8317dfa5f2402aff2df3e2d5a'
 
   depends_on 'buildessential'
   depends_on 'python27'

--- a/packages/node_stable.rb
+++ b/packages/node_stable.rb
@@ -3,7 +3,7 @@ require 'package'
 class Node_stable < Package
   version '6.2.2'
   source_url 'https://nodejs.org/dist/v6.2.2/node-v6.2.2.tar.xz'
-  source_sha1 '5014800813FA3682B8053637518B37A119C26E93'
+  source_sha1 '5014800813fa3682b8053637518b37a119c26e93'
 
   depends_on 'buildessential'
   depends_on 'python27'

--- a/packages/node_stable.rb
+++ b/packages/node_stable.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Node_stable < Package
-  version '6.2.2'
-  source_url 'https://nodejs.org/dist/v6.2.2/node-v6.2.2.tar.xz'
-  source_sha1 '5014800813fa3682b8053637518b37a119c26e93'
+  version '6.9.2'
+  source_url 'https://nodejs.org/dist/v6.9.2/node-v6.9.2.tar.gz'
+  source_sha1 '6b33b9fac28785b8317dfa5f2402aff2df3e2d5a'
 
   depends_on 'buildessential'
   depends_on 'python27'


### PR DESCRIPTION
I would also like to raise the question for having node_current and node_stable if they're the same?