### PR TITLE
Add texinfo package

### DIFF
--- a/packages/texinfo.rb
+++ b/packages/texinfo.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Texinfo < Package
+  version '6.3'
+  source_url 'http://ftp.gnu.org/gnu/texinfo/texinfo-6.3.tar.gz' # software source tarball url
+  source_sha1 '29b16c646c7bc9cd351b2f1d8dafdce70e5377f6'                  # source tarball sha1 sum
+
+  def self.build                                                  # self.build contains commands needed to build the software from source
+    system "./configure"
+    system "make"                                                 # ordered chronologically
+  end
+
+  def self.install                                                # self.install contains commands needed to install the software on the target system
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
+  end
+end


### PR DESCRIPTION
> Texinfo uses a single source file to produce output in a number of formats, both online and printed (dvi, html, info, pdf, xml, etc.). This means that instead of writing different documents for online information and another for a printed manual, you need write only one document. And when the work is revised, you need revise only that one document. - GNU.org

I have come across a couple packages that required it and though that I may aswell make a package out of it.