### PR TITLE
(FIX) Make nano depend on filecmd (Only a problem for ChromiumOS?)

### DIFF
--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -6,7 +6,8 @@ class Nano < Package
   source_sha1 '7dd39f21bbb1ab176158e0292fd61c47ef681f6d'
 
   depends_on 'buildessential'
-  depends_on 'ncurses' 
+  depends_on 'ncurses'
+  depends_on 'filecmd'
   
   def self.build                                                  # self.build contains commands needed to build the software from source
     system "./configure CPPFLAGS=\"-I/usr/local/include/ncurses\""


### PR DESCRIPTION
I've seen reports of nano being a pain. in #131 @Kriskras99 suggested a fix, that worked, which was to install file. Now that we have file (package name filecmd) I've made nano depend on it. I'm aware @thedamian has confirmed it isn't need on 32bit however I ran into the issue upon installing it on x64, admittedly on chromiumos but I think quite a few people may be using chromiumos and want nano.