### PR TITLE
(UPDATE/FIX) Python27 SSL Stuff

### DIFF
--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -7,6 +7,7 @@ class Python27 < Package
 
   depends_on 'bz2'
   depends_on 'ncurses'
+  depends_on 'openssl_devel'
 
   def self.build                                                  # self.build contains commands needed to build the software from source
     system "./configure --prefix=/usr/local CPPFLAGS=\"-I/usr/local/include -I/usr/local/include/ncurses\" LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\" -fPIC\""

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -17,7 +17,7 @@ class Python27 < Package
   def self.install                                                # self.install contains commands needed to install the software on the target system
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
     system "wget https://bootstrap.pypa.io/get-pip.py"
-    system "The sudo bit here is for python-pip to be installed"
+    system "echo The sudo bit here is for python-pip to be installed"
     system "sudo python get-pip.py"
   end
 end

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Python27 < Package
-  version '2.7.12'
-  source_url 'https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz' # software source tarball url
-  source_sha1 '1e80b781eacc6b7e243bd277e5002426aa56d0f1'                  # source tarball sha1 sum
+  version '2.7.12-1'
+  source_url 'https://dl.dropboxusercontent.com/u/14799278/crew/Python-2.7.12-SSLFIX.tar.gz' # software source tarball url
+  source_sha1 '27a91c877773c5440f65d35d05c0bf398d0ce540'                  # source tarball sha1 sum
 
   depends_on 'bz2'
   depends_on 'ncurses'

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -16,8 +16,5 @@ class Python27 < Package
 
   def self.install                                                # self.install contains commands needed to install the software on the target system
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
-    system "wget https://bootstrap.pypa.io/get-pip.py"
-    system "echo The sudo bit here is for python-pip to be installed"
-    system "sudo python get-pip.py"
   end
 end

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -16,5 +16,8 @@ class Python27 < Package
 
   def self.install                                                # self.install contains commands needed to install the software on the target system
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
+    system "wget https://bootstrap.pypa.io/get-pip.py"
+    system "The sudo bit here is for python-pip to be installed"
+    system "sudo python get-pip.py"
   end
 end


### PR DESCRIPTION
Quick rundown of changes.
- Add openssl_devel as a dependency
- Change source_url to a **slightly** modified source so Python27 builds with SSL support
- Changed source_sha1 to match the new source_url
- Added installation of pip at the end.
- Changed version number (in crew) to 2.7.12-1 so people can just run crew update

pip For All!
Enjoy
-bfayers