### PR TITLE
(UPDATE/FIX) JDK8

### DIFF
--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Jdk8 < Package
-  version '1.8.0-112'
+  version '8_112'
   binary_url ({
     i686: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-i686.tar.gz",
     x86_64: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-x86_64.tar.gz"

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -3,11 +3,11 @@ require 'package'
 class Jdk8 < Package
   version '1.8.0-112'
   binary_url ({
-    i686: "https://www.dropbox.com/s/d1omw087ilkh5oq/jdk1.8.0_25_i686.tar.gz?dl=0",
+    i686: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk1.8.0_112-i686.tar.gz",
     x86_64: "https://www.dropbox.com/s/ykw2jt797cpghfy/jdk1.8.0_65_x86_64.tar.gz?dl=0"
   })
   binary_sha1 ({
-    i686: "2f6fabc6e7b86fa2f21d19f9617d2641c5862a30",
+    i686: "65de377470bdd42e4f3e158b16917166ebe47a02",
     x86_64: "7701c06a704722b73bf8468a9d7819693e6d4be0"
   })
 end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,10 +4,10 @@ class Jdk8 < Package
   version '1.8.0-112'
   binary_url ({
     i686: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk1.8.0_112-i686.tar.gz",
-    x86_64: "https://www.dropbox.com/s/ykw2jt797cpghfy/jdk1.8.0_65_x86_64.tar.gz?dl=0"
+    x86_64: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk1.8.0_112-x86_64.tar.gz"
   })
   binary_sha1 ({
     i686: "65de377470bdd42e4f3e158b16917166ebe47a02",
-    x86_64: "7701c06a704722b73bf8468a9d7819693e6d4be0"
+    x86_64: "9a009b3b33cbb82ec70e7b0061973b09308c7fed"
   })
 end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Jdk8 < Package
-  version '8.0.25'
+  version '1.8.0-112'
   binary_url ({
     i686: "https://www.dropbox.com/s/d1omw087ilkh5oq/jdk1.8.0_25_i686.tar.gz?dl=0",
     x86_64: "https://www.dropbox.com/s/ykw2jt797cpghfy/jdk1.8.0_65_x86_64.tar.gz?dl=0"

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Jdk8 < Package
-  version '8_112'
+  version '8u112'
   binary_url ({
     i686: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-i686.tar.gz",
     x86_64: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-x86_64.tar.gz"

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -3,8 +3,8 @@ require 'package'
 class Jdk8 < Package
   version '1.8.0-112'
   binary_url ({
-    i686: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk1.8.0_112-i686.tar.gz",
-    x86_64: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk1.8.0_112-x86_64.tar.gz"
+    i686: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-i686.tar.gz",
+    x86_64: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-x86_64.tar.gz"
   })
   binary_sha1 ({
     i686: "65de377470bdd42e4f3e158b16917166ebe47a02",


### PR DESCRIPTION
Summary:
- Updated JDK8 to 8u112
- Updates SHA1s to match
- Fixed so it actually installs (there were directory structuring issues before)
- Changed crew package version number to 1.8.0-112 from 8.0.25

Enjoy your classes
-bfayers