### PR TITLE
(UPDATE) HTOP to 2.0.2

### DIFF
--- a/packages/htop.rb
+++ b/packages/htop.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Htop < Package
-  version '1.0.3'
-  source_url 'http://hisham.hm/htop/releases/1.0.3/htop-1.0.3.tar.gz' # software source tarball url
-  source_sha1 '261492274ff4e741e72db1ae904af5766fc14ef4'
+  version '2.0.2'
+  source_url 'http://hisham.hm/htop/releases/2.0.2/htop-2.0.2.tar.gz' # software source tarball url
+  source_sha1 '201f793f13dce2448e36047079875b9bd5bba75a'
 
   depends_on 'buildessential'
   depends_on 'ncurses'


### PR DESCRIPTION
Summary:
- Changed url to v2.0.2
- Changed sha1 to match
- Changed crew package version number to 2.0.2