### PR TITLE
(UPDATE) NGINX Change stopnginx to run "sudo nginx -s quit" instead of "sudo pkill nginx"

### DIFF
--- a/packages/nginx.rb
+++ b/packages/nginx.rb
@@ -14,7 +14,7 @@ class Nginx < Package
 
   def self.install                                                # self.install contains commands needed to install the software on the target system
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
-    system "sudo ln -s /usr/local/nginx/sbin/nginx /usr/local/bin/nginx"
+    system "sudo ln -sf /usr/local/nginx/sbin/nginx /usr/local/bin/nginx"
     system "echo all NGINX things are in /usr/local/nginx"
     system "echo pages are in /usr/local/nginx/html"
     system "echo adding bash aliases so you can easily start/stop nginx"

--- a/packages/nginx.rb
+++ b/packages/nginx.rb
@@ -20,6 +20,6 @@ class Nginx < Package
     system "echo adding bash aliases so you can easily start/stop nginx"
     system "echo startnginx starts nginx and stopnginx stops nginx"
     system "sed -i '$ a alias startnginx=\"sudo nginx\"' ~/.bashrc"
-    system "sed -i '$ a alias stopnginx=\"sudo pkill nginx\"' ~/.bashrc"
+    system "sed -i '$ a alias stopnginx=\"sudo nginx -s quit\"' ~/.bashrc"
   end
 end

--- a/packages/nginx.rb
+++ b/packages/nginx.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Nginx < Package
-  version '1.11.6'
+  version '1.11.6-1'
   source_url 'http://nginx.org/download/nginx-1.11.6.tar.gz' # software source tarball url
   source_sha1 '51903b721a5ee721568fc59f0a243df5356a98de'  # source tarball sha1 sum
   
@@ -19,6 +19,8 @@ class Nginx < Package
     system "echo pages are in /usr/local/nginx/html"
     system "echo adding bash aliases so you can easily start/stop nginx"
     system "echo startnginx starts nginx and stopnginx stops nginx"
+    system "sed -i \'/^alias startnginx/d\' ~/.bashrc"
+    system "sed -i \'/^alias stopnginx/d\' ~/.bashrc"
     system "sed -i '$ a alias startnginx=\"sudo nginx\"' ~/.bashrc"
     system "sed -i '$ a alias stopnginx=\"sudo nginx -s quit\"' ~/.bashrc"
   end


### PR DESCRIPTION
Summary:
- Change sed line so that ```stopnginx``` is ```sudo nginx -s quit``` instead of ```sudo pkill nginx```
- Add sed line to remove old ```stopnginx``` & ```startnginx``` alias
- Change crew version number to 1.11.6-1 so that crew upgrade can perform these changes

enjoy oiling the wheels
-bfayers