### PR TITLE
(ADD) pip Package

### DIFF
--- a/packages/pip.rb
+++ b/packages/pip.rb
@@ -1,0 +1,17 @@
+require 'package'
+
+class Pip < Package # the name of the package
+  version '1.0' # the current version of the package
+  source_url 'https://dl.dropboxusercontent.com/u/14799278/crew/get-pip.tar.gz' # the source files for the package
+  source_sha1 'b6d86af835532c0225b4297be9502e15b43ba638'
+
+  depends_on 'python27'
+
+  def self.build
+    system "sudo python get-pip.py"
+  end
+
+  def self.install
+    system "echo PIP Installed!"
+  end
+end


### PR DESCRIPTION
Summary:
- Added pip package
- Set version number to 1.0 as get-pip.py always gets the latest anyway

Known Issues:
- ```sudo crew remove pip``` doesn't work as pip has its own install script (get-pip.py) to uninstall ```sudo pip uninstall pip setuptools``` must be run
- To update ```sudo pip install -U pip``` must be run cannot use crew upgrade.
- Will require #246 to be merged too