### PR TITLE
(UPDATE/FIX) Change the "only supported on i686 and x86_64" line on the website.

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         <div class="col-lg-6">
           <div class="bs-example bs-example-type">
             <h4>Install Chromebrew (along with Ruby and Git)</h4>
-            <h5>currently only i686 and x86_64 Chromebooks supported</h5>
+            <h5>avaliable on arm, i686 and x86_64</h5>
           </div>
           <div class="highlight">
             <pre><code>wget -q -O - https://raw.github.com/skycocker/chromebrew/master/install.sh | bash</code></pre>


### PR DESCRIPTION
Summary:
- Changed "only supported on i686 and x86_64" line on the website to "avaliable on arm, i686 and x86_64"

-bfayers