### PR TITLE
Remove git dependencies

### DIFF
--- a/crew
+++ b/crew
@@ -177,6 +177,12 @@ end
 def resolveDependencies
   @dependencies = []
 
+  #add buildessential as dependency if we're building from source
+  if !@pkg.binary_url || !@pkg.binary_url.has_key?(@device[:architecture])
+    @dependencies.unshift 'buildessential'
+    search 'buildessential', true
+  end
+
   def pushDeps
     if @pkg.dependencies
       @dependencies.unshift @pkg.dependencies

--- a/install.sh
+++ b/install.sh
@@ -93,15 +93,16 @@ echo '    }' >> device.json
 echo '  ]' >> device.json
 echo '}' >> device.json
 
-#download git and its dependencies .rb package files
+#download git package file
 cd $CREW_PACKAGES_PATH
-for file in git zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders; do
-  wget -N -c $URL/packages/$file.rb
-done
+wget -N -c $URL/packages/git.rb
 
 #install gcc on arm only.  It requires special treatments
-case "$architecture" in
-"armv7l")
+if [ "$architecture" == "armv7l" ]; then
+  cd $CREW_PACKAGES_PATH
+  for file in buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders; do
+    wget -N -c $URL/packages/$file.rb
+  done
   echo y | crew install gcc
   if [ ! -d $HOME/Downloads/tools ]; then
     mkdir $HOME/Downloads/tools
@@ -117,11 +118,8 @@ case "$architecture" in
     ln -s /usr/local/lib/gcc $HOME/Downloads/tools/lib
     ln -s /usr/local/libexec/gcc $HOME/Downloads/tools/libexec
     ln -s /usr/local/share/bison $HOME/Downloads/tools/share
-  fi;;
-esac
-
-#install readline for ruby
-echo y | crew install readline
+  fi
+fi
 
 #install git
 echo y | crew install git

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -12,12 +12,4 @@ class Git < Package
     i686: '8c1bf4bcffb0e9c17bf20dd05981e86ea34d5d65',
     x86_64: '067cb6c36616ac30999ab97e85f3dc0e9d1d57f4'
   })
-
-  depends_on 'zlibpkg'
-  depends_on 'libssh2'
-  depends_on 'perl'
-  depends_on 'curl'
-  depends_on 'expat'
-  depends_on 'gettext'
-  depends_on 'python'
 end


### PR DESCRIPTION
Remove the unnecessary dependencies for Git. In essence; if the user only wants Git and, lets say, a binary package, nothing else needs to be downloaded or installed. Earlier discussed in #167 

Tested on ARM, needs testing on x86.