### PR TITLE
Add manpages

### DIFF
--- a/packages/gdbm.rb
+++ b/packages/gdbm.rb
@@ -1,0 +1,16 @@
+require 'package'
+ 
+class Gdbm < Package
+  version '1.12'
+  source_url 'ftp://ftp.gnu.org/gnu/gdbm/gdbm-1.12.tar.gz'
+  source_sha1 '86513e8871bb376bc014e9e5a2d18a8e0a8ea2f5'
+  
+  def self.build
+    system './configure'
+    system 'make'
+  end
+  
+  def self.install
+    system 'make', 'install'
+  end
+end

--- a/packages/groff.rb
+++ b/packages/groff.rb
@@ -1,0 +1,16 @@
+require 'package'
+ 
+class Groff < Package
+  version '1.22.3'
+  source_url 'http://ftp.gnu.org/gnu/groff/groff-1.22.3.tar.gz'
+  source_sha1 '61a6808ea1ef715df9fa8e9b424e1f6b9fa8c091'
+  
+  def self.build
+    system './configure'
+    system 'make'
+  end
+  
+  def self.install
+    system 'make', 'install'
+  end
+end

--- a/packages/libpipeline.rb
+++ b/packages/libpipeline.rb
@@ -1,0 +1,16 @@
+require 'package'
+ 
+class Libpipeline < Package
+  version '1.4.1'
+  source_url 'https://download.savannah.gnu.org/releases/libpipeline/libpipeline-1.4.1.tar.gz'
+  source_sha1 'b31cc955f22b1aa4545dc8d00ddbde831936594f'
+  
+  def self.build
+    system './configure'
+    system 'make'
+  end
+  
+  def self.install
+    system 'make install'
+  end
+end

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Mandb < Package
+  version '2.7.6'
+  source_url 'https://download.savannah.gnu.org/releases/man-db/man-db-2.7.6.tar.xz'
+  source_sha1 '35a10f80d5cf6411d5c73376fcddcec1539e788a'
+  
+  def self.build
+    system './configure',
+      '--with-systemdtmpfilesdir=/usr/local/lib/tmpfiles.d',  # we can't write to /usr/lib/tmpfiles.d
+      '--disable-cache-owner',                                # we can't create the user 'man'
+      '--with-pager=/usr/local/bin/less'                      # the pager is not at the default location
+    system 'make'
+  end
+  
+  def self.install
+    system 'make', 'install'
+  end
+
+  depends_on 'libpipeline'
+  depends_on 'pkgconfig'
+  depends_on 'gdbm'
+  depends_on 'groff'
+  depends_on 'less'
+
+end

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -4,7 +4,7 @@ class Mandb < Package
   version '2.7.6'
   source_url 'https://download.savannah.gnu.org/releases/man-db/man-db-2.7.6.tar.xz'
   source_sha1 '35a10f80d5cf6411d5c73376fcddcec1539e788a'
-  
+
   def self.build
     system './configure',
       '--with-systemdtmpfilesdir=/usr/local/lib/tmpfiles.d',  # we can't write to /usr/lib/tmpfiles.d
@@ -12,9 +12,12 @@ class Mandb < Package
       '--with-pager=/usr/local/bin/less'                      # the pager is not at the default location
     system 'make'
   end
-  
+
   def self.install
     system 'make', 'install'
+    puts ""
+    puts "You will have to change the default PAGER env variable to be able to use mandb:"
+    puts "echo \"export PAGER=/usr/local/bin/less\" >> ~/.bashrc && . ~/.bashrc"
   end
 
   depends_on 'libpipeline'


### PR DESCRIPTION
This pull request adds support for `man`, however, chromeos has some environment variables set per default, among them is `PAGER=/usr/bin/less`, so, in order to use the `man` command, one first has to `unset PAGER`. I'm not sure whether there is a way to solve this.

Fixes #27 