### PR TITLE
fix tmpdir because chromeos /tmp is mounted noexec

### DIFF
--- a/packages/go.rb
+++ b/packages/go.rb
@@ -7,7 +7,7 @@ class Go < Package
 
   def self.build
     FileUtils.cd('src') do
-      system "./all.bash"
+      system "TMPDIR=/usr/local/tmp ./make.bash"
     end
   end
 


### PR DESCRIPTION
also skip tests because at least one test wants to write to /


This makes go build/install successfully for me.