### PR TITLE
Fix libpng url

### DIFF
--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Libpng < Package
-  version '1.6.24'
-  source_url 'http://downloads.sourceforge.net/project/libpng/libpng16/1.6.24/libpng-1.6.24.tar.xz'
-  source_sha1 'b8fa86449bebd7b1cda71e0ed2cd417b6596ce78'
+  version '1.6.26'
+  source_url 'http://prdownloads.sourceforge.net/libpng/libpng-1.6.26.tar.gz'
+  source_sha1 '3b2652f89b8fdcb6c29e9ed7642dfcfc0bbcf17e'
 
   def self.build
       system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""


### PR DESCRIPTION
There's a checksum mismatch for the current url of libpng.
This pr updates libpng to version 1.6.24 and resolves the mismatch.

Fixes #199 