### PR TITLE
(UPDATE) JDK8 armv7l binary.

### DIFF
--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,10 +4,12 @@ class Jdk8 < Package
   version '8u112'
   binary_url ({
     i686: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-i686.tar.gz",
-    x86_64: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-x86_64.tar.gz"
+    x86_64: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-x86_64.tar.gz",
+    armv7l: "https://www.dropbox.com/s/bfu14nhbeoi8tdo/jdk8u111-armv7l.tar.gz?dl=1"
   })
   binary_sha1 ({
     i686: "65de377470bdd42e4f3e158b16917166ebe47a02",
-    x86_64: "9a009b3b33cbb82ec70e7b0061973b09308c7fed"
+    x86_64: "9a009b3b33cbb82ec70e7b0061973b09308c7fed",
+    armv7l: "913adb900bf0d9d42452a4591c1a9093076ed4b6"
   })
 end


### PR DESCRIPTION
Summary:
- Added a binary to jdk8 for armv7l
- Added sha1sum for that binary.

Known Bugs:
- It is verson 8u111 whereas the other 2 binaries are 8u112, this is because I can't find a 8u112 binary for arm on oracle's site.