### PR TITLE
Fix package being broken on ARM due to asm error

### DIFF
--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -22,7 +22,11 @@ class Unzip < Package
 
   def self.build
     self.patch
-    system "make -f unix/Makefile linux_noasm"
+    if ARCH == "armv7l"
+      system "make -f unix/Makefile linux_noasm"
+    else
+      system "make -f unix/Makefile generic"
+    end
   end
 
   def self.install

--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -22,7 +22,7 @@ class Unzip < Package
 
   def self.build
     self.patch
-    system "make -f unix/Makefile generic"
+    system "make -f unix/Makefile linux_noasm"
   end
 
   def self.install


### PR DESCRIPTION
If you execute "crew install unzip", it will fail on ARM, due to an assembler related error (I assume that the unzip sources only contain x86 assembler, but no ARM asm). The error output looks like this:

________________
[ ... some more stuff ...]
cc -c -I. -Ibzip2 -DUNIX -O3 -DLARGE_FILE_SUPPORT -DUNICODE_SUPPORT -DUNICODE_WCHAR -DUNICODE_SUPPORT -DUTF8_MAYBE_NATIVE -DNO_LCHMOD -DHAVE_DIRENT_H -DHAVE_TERMIOS_H -D_MBCS  process.c
/tmp/ccRacqej.s: Assembler messages:
/tmp/ccRacqej.s:301: Error: offset out of range
/tmp/ccRacqej.s:302: Error: offset out of range
make[1]: *** [process.o] Error 1
make[1]: Leaving directory `/usr/local/tmp/crew/unzip60'
make: *** [generic] Error 2
unzip failed to install: `make -f unix/Makefile generic` exited with 2
chronos@localhost ~ $
________________

I have therefore downloaded the Unzip sources myself from ftp://ftp.info-zip.org/pub/infozip/src/unzip60.zip , deflated it, copied the unix/Makefile over into the sources root directory and used:

make linux_noasm

The resulting build was successful, with no asm related errors.

The relevant line is line 25 in https://github.com/skycocker/chromebrew/blob/master/packages/unzip.rb :

Currently is reads:
system "make -f unix/Makefile generic"
But in order to fix the error, it would have to be:
system "make -f unix/Makefile linux_noasm"

This has been implemented via this commit.