### PR TITLE
Add nmap package

### DIFF
--- a/packages/nmap.rb
+++ b/packages/nmap.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Nmap < Package
+  version '7.31'
+  source_url 'https://nmap.org/dist/nmap-7.31.tgz' # Software source tarball url  
+  source_sha1 'ccf1bb34463f39a645d9a924ce9e3c9e15eefbbf'
+
+  depends_on 'buildessential'
+  
+  def self.build                                                  # self.build contains commands needed to build the software from source
+    system "./configure" 
+    system "make"                                                 # ordered chronologically
+  end
+  
+  def self.install                                                # self.install contains commands needed to install the software on the target system
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
+  end         
+end


### PR DESCRIPTION
This adds nmap 7.31 as a package. I have tested the package on a Samsung Series 3 (ARM) machine and everything compiles successfully. The resulting binary works without issues. I did not add "openssl" as a dependency - this is on purpose. For a few corner cases, nmap can use some SSL functionality, but it works perfectly without. However, if the user has "openssl" installed at the time this package is being installed, then nmap will use this.