### PR TITLE
Add NcFTP (client) package

### DIFF
--- a/packages/ncftp.rb
+++ b/packages/ncftp.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Ncftp < Package
+  version '3.2.6'
+  source_url 'ftp://ftp.ncftp.com/ncftp/ncftp-3.2.6-src.tar.gz' # Software source tarball url  
+  source_sha1 'e2351802b40db18d6cbab2537a9644cd858b934d'
+
+  depends_on 'buildessential'
+  
+  def self.build                                                  # self.build contains commands needed to build the software from source
+    system "./configure" 
+    system "make"                                                 # ordered chronologically
+  end
+  
+  def self.install                                                # self.install contains commands needed to install the software on the target system
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
+  end         
+end


### PR DESCRIPTION
This adds NcFTP client 3.2.6 as a package. This is useful, since we don't have any standard FTP console client on ChromeOS. If the user has ncurses or openssl libraries installed, then the client can be run via an ncurses or with encryption respectively, but this is optional and therefore not defined in the dependencies. Tested the package successfully on a Samsung Series 3 (ARM) Chromebook.