### PR TITLE
Add package for ScrollZ IRC client

### DIFF
--- a/packages/scrollz.rb
+++ b/packages/scrollz.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Scrollz < Package
+  version '2.3'
+  source_url 'http://www.scrollz.info/download/ScrollZ-2.3.tar.gz' # Software source tarball url  
+  source_sha1 '991e6acfdf95d84ca159a37336c2d45a624d432f'
+
+  depends_on 'buildessential'
+  depends_on 'ncurses'
+  
+  def self.build                                                  # self.build contains commands needed to build the software from source
+    system "./configure" 
+    system "make"                                                 # ordered chronologically
+  end
+  
+  def self.install                                                # self.install contains commands needed to install the software on the target system
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
+  end         
+end


### PR DESCRIPTION
This adds ScrollZ 2.3 as a package. There's currently no IRC client package available for Chromebrew, and while e.g. EPIC may be more popular, ScrollZ has been a favorite since the 90s. This latest version 2.3 has been released earlier this year. Tested successfully on a Samsung Series 3 (ARM) Chromebook.