### PR TITLE
Add package for newLISP programming language

### DIFF
--- a/newlisp.rb
+++ b/newlisp.rb
@@ -1,0 +1,29 @@
+require 'package'
+
+class Newlisp < Package
+  version '10.7.0'
+  source_url 'http://www.newlisp.org/downloads/newlisp-10.7.0.tgz'
+  source_sha1 '8c256d134e4879d97f83087585cfe90d462def22'
+
+  #depends_on 'readline'
+  #depends_on 'libffi'
+
+  def self.build
+    # This works but readline and ffi are disabled. When using the
+    #  standard ./configure it's looking in the wrong place for ffi.h
+    #  and readline isn't linked against libtermcap/ncurses.
+    #
+    # Looks like the readline issue is the system libreadline vs the
+    #  one shipped with bash.
+    #
+    # Ideally I'll figure out how to get it building properly as follows:
+    # system "./configure --prefix=/usr/local --enable-readline --enable-ffi"
+    system "./configure-alt --prefix=/usr/local"
+    system "make"
+    system "make", "check"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
This adds the newLISP (10.7.0) programming language. newLISP is a general-purpose, Lisp-like scripting language. Currently has readline and ffi support disabled. Things work correctly but adding support for these two things in eventually would be nice.

Tested sucessfully on Samsung Chromebook 3 (XE500C13-K01US).