### PR TITLE
Add package for bacon (BASIC-to-C converter) tool

### DIFF
--- a/packages/bacon.rb
+++ b/packages/bacon.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Bacon < Package
+  version '3.5'
+  source_url 'http://www.basic-converter.org/stable/bacon-3.5.tar.gz'
+  source_sha1 '878da51d1f8bef9baea6523be8f09d8a616f8e9f'
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
This adds the BaCon BASIC-to-C converter (3.5). BaCon allows one to write programs using a modern BASIC dialect and generate C code and and binaries as output. The final step of the installation script fails to create a directory containing a sample source file but the tool itself works properly. Will address the example creation step in the future as time permits.

Tested sucessfully on Samsung Chromebook 3 (XE500C13-K01US).