### PR TITLE
Add inetutils package

### DIFF
--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Inetutils < Package
+  version '1.9.4'
+  source_url 'http://ftp.gnu.org/gnu/inetutils/inetutils-1.9.4.tar.gz' # Software source tarball url  
+  source_sha1 'defae98a27c0e9516c4ef2321a374a3645adb3b9'
+
+  depends_on 'buildessential'
+  
+  def self.build                                                  # self.build contains commands needed to build the software from source
+    system "./configure" 
+    system "make"                                                 # ordered chronologically
+  end
+  
+  def self.install                                                # self.install contains commands needed to install the software on the target system
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
+  end         
+end


### PR DESCRIPTION
This package adds GNU Inetutils 1.9.4, i.e. the standard telnet, ftp and related tools that are missing on ChromeOS. Website: https://www.gnu.org/software/inetutils/ . Tested and confirmed working on Samsung Series 3 ARM Chromebook.