### PR TITLE
calculate SHORTARCH from ARCH - fix for missing getconf

### DIFF
--- a/crew
+++ b/crew
@@ -17,6 +17,16 @@ CREW_DEST_DIR = CREW_BREW_DIR + '/dest'
 
 ARCH = `uname -m`.strip
 #SHORTARCH = `getconf LONG_BIT`.strip # commenting for now since it doesn't work.
+case ARCH
+  when "i686"
+    SHORTARCH="32"
+  when "x86_64"
+    SHORTARCH="64"
+  when "arm7l"
+    SHORTARCH="32"
+  else  
+    SHORTARCH="32"
+end
 
 
 $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"

--- a/crew
+++ b/crew
@@ -16,7 +16,7 @@ CREW_BREW_DIR = CREW_PREFIX + '/tmp/crew/'
 CREW_DEST_DIR = CREW_BREW_DIR + '/dest'
 
 ARCH = `uname -m`.strip
-#SHORTARCH = `getconf LONG_BIT`.strip # commenting for now since it doesn't work.
+#SHORTARCH = `getconf LONG_BIT`.strip # will refactor this line in the future
 case ARCH
   when "i686"
     SHORTARCH="32"


### PR DESCRIPTION
remove getconf as a dependency for install, case statement to figure out long size from arch.