### PR TITLE
Fixed a typo in crew script

### DIFF
--- a/crew
+++ b/crew
@@ -22,7 +22,7 @@ case ARCH
     SHORTARCH="32"
   when "x86_64"
     SHORTARCH="64"
-  when "arm7l"
+  when "armv7l"
     SHORTARCH="32"
   else  
     SHORTARCH="32"


### PR DESCRIPTION
uname -m returns armv7l instead of arm7l.
This doesn't cause failure since default value is 32 but it's good to fix.