### PR TITLE
Bootstrap Go

### DIFF
--- a/packages/go.rb
+++ b/packages/go.rb
@@ -33,6 +33,6 @@ class Go < Package
     puts "Make sure to set go environment variables."
     puts "Minimal:"
     puts "\texport GOROOT=/usr/local/lib/go"
-    puts "\texport PATH=$GOROOT/bin"
+    puts "\texport PATH=$PATH:$GOROOT/bin"
   end
 end

--- a/packages/go.rb
+++ b/packages/go.rb
@@ -29,7 +29,7 @@ class Go < Package
     FileUtils.mv Dir.pwd, dest
 
     puts "--------"
-    puts "Installed Go for linux/amd64 in /usr/local/lib/go"
+    puts "Installed Go for #{ARCH} in /usr/local/lib/go"
     puts "Make sure to set go environment variables."
     puts "Minimal:"
     puts "\texport GOROOT=/usr/local/lib/go"

--- a/packages/go.rb
+++ b/packages/go.rb
@@ -4,10 +4,22 @@ class Go < Package
   version '1.7.4'
   source_url 'https://storage.googleapis.com/golang/go1.7.4.src.tar.gz'
   source_sha1 '0fb305c827c8794cfda7e437befa6101a2d06b2e'
+  
+  # go is required to build versions of go > 1.4
+  if `which go` == ''
+    depends_on 'go_bootstrap'
+  end
 
   def self.build
     FileUtils.cd('src') do
-      system "TMPDIR=/usr/local/tmp ./make.bash"
+      # install with go_bootstrap if go is not in the path
+      if `which go` == ''
+        system "GOROOT_BOOTSTRAP=/usr/local/lib/go_bootstrap/go \
+                TMPDIR=/usr/local/tmp \
+                ./make.bash"
+      else
+        system "TMPDIR=/usr/local/tmp ./make.bash"
+      end
     end
   end
 

--- a/packages/go_bootstrap.rb
+++ b/packages/go_bootstrap.rb
@@ -17,6 +17,6 @@ class Go_bootstrap < Package
     FileUtils.mv Dir.pwd, dest
     
     puts "--------"
-    puts "Installed Go_bootstrap for linux/amd64 in /usr/local/lib/go_bootstrap"
+    puts "Installed Go_bootstrap for #{ARCH} in /usr/local/lib/go_bootstrap"
   end
 end

--- a/packages/go_bootstrap.rb
+++ b/packages/go_bootstrap.rb
@@ -1,0 +1,22 @@
+require 'package'
+
+class Go_bootstrap < Package
+  version '1.4'
+  source_url 'https://storage.googleapis.com/golang/go1.4-bootstrap-20161024.tar.gz'
+  source_sha1 '47e02e41aa99dea899b65ebf7b50ec706141be8c'
+
+  def self.build
+    FileUtils.cd('src') do
+      system "TMPDIR=/usr/local/tmp ./make.bash"
+    end
+  end
+
+  def self.install
+    dest = "#{CREW_DEST_DIR}/usr/local/lib/go_bootstrap"
+    system "mkdir", "-p", dest
+    FileUtils.mv Dir.pwd, dest
+    
+    puts "--------"
+    puts "Installed Go_bootstrap for linux/amd64 in /usr/local/lib/go_bootstrap"
+  end
+end


### PR DESCRIPTION
Satisfies #290 

Building any version of go > 1.4 requires go itself. This PR allows compilation of the latest go package for systems without an existing go binary by requiring a dependency, go_bootstrap (essentially go v1.4, which has the ability to be built with gcc).