### PR TITLE
(FIX/UPDATE) Remove i686/x86_64 only from the website.

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,14 +114,9 @@
           The idea is that you may be on a weak internet connection and cannot download too much data, but you don't have Crouton and need just some few small packages. Also, you may be on a good internet connection and need just some few small packages. Also, why not to use Chrome OS as a normal operating system?
         </p>
 
-        <h3>Why does it currently only work on i686 and x86_64?</h3>
-        <p>
-          Because it needs Ruby, Git, GNU Make and GCC to work, and I only have an i686/x86_64 Acer C7 Chromebook, so I can't port this software to other architectures. If Chromebrew will be widely used, I'm planning to raise money on Kickstarter to buy other Chromebooks and make Chromebrew work also on them.
-        </p>
-
         <h3 id="howcanihelp">How can I help?</h3>
         <p>
-          If you have a compatibile (i686 or x86_64) Chromebook, you can fork my Github repo and add some new packages to its <code>packages</code> directory if you managed to build them from source successfully on your device. Package recipes are simple Ruby files - here is an example:
+          If you have a compatibile (arm, i686 or x86_64) Chromebook, you can fork my Github repo and add some new packages to its <code>packages</code> directory if you managed to build them from source successfully on your device. Package recipes are simple Ruby files - here is an example:
         </p>
         <p>
           <script src="https://gist.github.com/skycocker/6747775.js"></script>


### PR DESCRIPTION
Summary:

- Remove anything that says it will only work on i686 and x86_64

:) Hopefully this will clear things up if people are only visiting the page.
