### PR TITLE
Add package for libffi

### DIFF
--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Libffi < Package
+  version '3.0.13'
+  source_url 'ftp://sourceware.org/pub/libffi/libffi-3.0.13.tar.gz'
+  source_sha1 'f5230890dc0be42fb5c58fbf793da253155de106'
+
+  depends_on 'autoconf'
+  depends_on 'automake'
+
+  def self.build
+    system "./configure", "--disable-debug", "--disable-dependency-tracking"
+  end
+
+  def self.install
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
This adds libffi (3.0.13) which provides a portable foreign-function interface library. I'm adding this in preparation for an update to the newLISP package adding ffi and proper readline support which will enhance usability of the REPL and allow use of the GUI library if you install Oracle's JRE.

Tested sucessfully on Samsung Chromebook 3 (XE500C13-K01US).