### PR TITLE
Add package for jq

### DIFF
--- a/packages/jq.rb
+++ b/packages/jq.rb
@@ -6,7 +6,10 @@ class Jq < Package
   source_sha1 '6eef3705ac0a322e8aa0521c57ce339671838277' 
 
   def self.build
-    system "./configure --prefix=/usr/local --disable-maintainer-mode"
+    system "./configure",
+      "--prefix=/usr/local",
+      "--disable-maintainer-mode", # disable make rules and dependencies not useful
+      "--disable-docs"             # there's no support for manpages
     system "make"
   end
 

--- a/packages/jq.rb
+++ b/packages/jq.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Jq < Package
+  version '1.5' 
+  source_url 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-1.5.tar.gz' 
+  source_sha1 '6eef3705ac0a322e8aa0521c57ce339671838277' 
+
+  def self.build
+    system "./configure --prefix=/usr/local --disable-maintainer-mode"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
This adds jq (1.5) which is a command line filter for processing JSON. Configure warns about missing Ruby dependencies which I'm ignoring since we don't have proper manpage support yet and I don't see a need for bringing in additional bloat when disk space is limited for us to begin with. Also, regex support requires oniguruma which will come shortly.

Tested sucessfully on Samsung Chromebook 3 (XE500C13-K01US).