### PR TITLE
Changed to use #{CREW_DEST_DIR} in libffi.rb

### DIFF
--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -13,6 +13,6 @@ class Libffi < Package
   end
 
   def self.install
-    system "make", "install"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 end

--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Libffi < Package
-  version '3.0.13'
+  version '3.0.13-1'
   source_url 'ftp://sourceware.org/pub/libffi/libffi-3.0.13.tar.gz'
   source_sha1 'f5230890dc0be42fb5c58fbf793da253155de106'
 


### PR DESCRIPTION
libffi was not using CREW_DEST_DIR.  As a result, it didn't make a file list correctly in /usr/local/etc/crew/meta/libffi.filelist.  By this modification, the problem will be solved.