### PR TITLE
Fix the usage of CREW_DEST_DIR in mono.rb.

### DIFF
--- a/packages/mono.rb
+++ b/packages/mono.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Mono < Package
-  version '4.4.0.148'
+  version '4.4.0.148-1'
   source_url 'http://download.mono-project.com/sources/mono/mono-4.4.0.148.tar.bz2'
   source_sha1 '8da7726b7c09df97856b55eda062356666928d35'
 

--- a/packages/mono.rb
+++ b/packages/mono.rb
@@ -6,11 +6,11 @@ class Mono < Package
   source_sha1 '8da7726b7c09df97856b55eda062356666928d35'
 
   def self.build
-    system "./configure","--disable-dependency-tracking","--disable-silent-rules","--enable-nls=no","prefix=#{CREW_DEST_DIR}/usr/local"
+    system "./configure","--disable-dependency-tracking","--disable-silent-rules","--enable-nls=no","--prefix=/usr/local"
     system "make"
   end
 
   def self.install
-    system "make", "PREFIX=#{CREW_DEST_DIR}/usr/local", "install"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 end


### PR DESCRIPTION
Similar to #321.  I modified two lines.

- `./configure` line, prefix argument is ignored since it doesn't start with `--`, so it is configured by default value, `/usr/local`, anyway.  Add `--` and fix the path.
- insall line, wrong variable name doesn't modify the install directory, so everything were being copied to configured directory, /usr/local, directly.  Modify variable name and fix the path.

