### PR TITLE
Add crew whatprovides command

### DIFF
--- a/crew
+++ b/crew
@@ -67,40 +67,12 @@ end
 
 def whatprovides (pkgName)
   fileArray = []
-  op = '*'
-  search = pkgName.dup
-  if search[/\*/]
-    search = search.gsub! '*', ''
-  end
-  abort if not search
-  if search[0] == '^'
-    op = '^'
-    search = search[1..search.length - 1]
-  end
-  if search[-1] == '$'
-    if op == '^'
-      op = '^$'
-    else
-      op = '$'
-    end
-    search = search[0..search.length - 2]
-  end
   Find.find (CREW_CONFIG_PATH + 'meta/') do |packageList|
     if File.file? packageList
       if packageList[/\.filelist$/]
         packageName = File.basename packageList, '.filelist'
         File.readlines(packageList).each do |line|
-          found = nil
-          case op
-          when '*'
-            found = line[/#{Regexp.quote(search)}/]
-          when '^'
-            found = line[/^#{Regexp.quote(search)}/]
-          when '$'
-            found = line[/#{Regexp.quote(search)}$/]
-          when '^$'
-            found = line[/^#{Regexp.quote(search)}$/]
-          end
+          found = line[/#{Regexp.new(pkgName)}/]
           if found
             fileLine = packageName + ': ' + line
             if not fileArray.include? fileLine

--- a/crew
+++ b/crew
@@ -70,18 +70,15 @@ def whatprovides (pkgName, silent = false)
   packageName = ''
   fileName = pkgName + "\n"
   Find.find (CREW_LIB_PATH + 'packages') do |filename|
-    Find.find (CREW_CONFIG_PATH + 'meta/') do |packageList|
-      packageName = File.basename filename, '.rb'
-      fileList = CREW_CONFIG_PATH + 'meta/' + packageName + '.filelist'
-      if File.file?(fileList)
-        File.readlines(fileList).each do |line|
-          if line == fileName
-            found = true
-            break
-          end
+    packageName = File.basename filename, '.rb'
+    fileList = CREW_CONFIG_PATH + 'meta/' + packageName + '.filelist'
+    if File.file?(fileList)
+      File.readlines(fileList).each do |line|
+        if line == fileName
+          found = true
+          break
         end
       end
-      break if found
     end
     break if found
   end
@@ -414,7 +411,7 @@ when "remove"
   search @pkgName
   remove
 when nil
-  puts "Chromebrew, version 0.2.1"
+  puts "Chromebrew, version 0.2.2"
   puts "Usage: crew [command] [package]"
   puts "Available commands: search, download, install, remove, whatprovides"
 else

--- a/crew
+++ b/crew
@@ -65,24 +65,51 @@ def search (pkgName, silent = false)
   abort "package #{pkgName} not found :("
 end
 
-def whatprovides (pkgName, silent = false)
-  found = nil
-  packageName = ''
-  fileName = pkgName + "\n"
-  Find.find (CREW_LIB_PATH + 'packages') do |filename|
-    packageName = File.basename filename, '.rb'
-    fileList = CREW_CONFIG_PATH + 'meta/' + packageName + '.filelist'
-    if File.file?(fileList)
-      File.readlines(fileList).each do |line|
-        if line == fileName
-          found = true
-          break
+def whatprovides (pkgName)
+  fileArray = []
+  arg = ARGV[1].dup
+  op = '*'
+  search = arg
+  if arg[0] == '^'
+    op = '^'
+    search = arg[1..arg.length - 1]
+  end
+  if arg[-1] == '$'
+    op = '$'
+    search = arg[0..arg.length - 2]
+  end
+  Find.find (CREW_CONFIG_PATH + 'meta/') do |packageList|
+    if File.file? packageList
+      if packageList[/\.filelist$/]
+        packageName = File.basename packageList, '.filelist'
+        File.readlines(packageList).each do |line|
+          found = nil
+          case op
+          when '*'
+            found = line[/#{Regexp.quote(search)}/]
+          when '^'
+            found = line[/^#{Regexp.quote(search)}/]
+          when '$'
+            found = line[/#{Regexp.quote(search)}$/]
+          end
+          if found
+            fileLine = packageName + ': ' + line
+            if not fileArray.include? fileLine
+              fileArray.push(fileLine)
+            end
+          end
         end
       end
     end
-    break if found
   end
-  puts packageName + ': ' + fileName if found
+  if not fileArray.empty?
+    fileCount = 0
+    fileArray.sort.each do |item|
+      puts item
+      fileCount += 1
+    end
+    puts "\nTotal found: #{fileCount}"
+  end
 end
 
 def update
@@ -394,7 +421,7 @@ when "whatprovides"
   if @pkgName
     whatprovides @pkgName
   else
-    puts "Usage: crew whatprovides [filepath]"
+    puts "Usage: crew whatprovides [pattern]"
   end
 when "download"
   search @pkgName

--- a/crew
+++ b/crew
@@ -28,7 +28,6 @@ case ARCH
     SHORTARCH="32"
 end
 
-
 $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"
 
 USER = `whoami`.chomp
@@ -52,8 +51,8 @@ end
 def list_packages
   Find.find (CREW_LIB_PATH + 'packages') do |filename|
     Find.find(CREW_CONFIG_PATH + 'meta/') do |packageList|
-        packageName = File.basename filename, '.rb'
-        print '(i) ' if packageList == CREW_CONFIG_PATH + 'meta/' + packageName + '.filelist' 
+      packageName = File.basename filename, '.rb'
+      print '(i) ' if packageList == CREW_CONFIG_PATH + 'meta/' + packageName + '.filelist'
     end
     puts File.basename filename, '.rb' if File.extname(filename) == '.rb'
   end
@@ -64,6 +63,29 @@ def search (pkgName, silent = false)
     return setPkg(pkgName, silent) if filename == CREW_LIB_PATH + 'packages/' + pkgName + '.rb'
   end
   abort "package #{pkgName} not found :("
+end
+
+def whatprovides (pkgName, silent = false)
+  found = nil
+  packageName = ''
+  fileName = pkgName + "\n"
+  Find.find (CREW_LIB_PATH + 'packages') do |filename|
+    Find.find (CREW_CONFIG_PATH + 'meta/') do |packageList|
+      packageName = File.basename filename, '.rb'
+      fileList = CREW_CONFIG_PATH + 'meta/' + packageName + '.filelist'
+      if File.file?(fileList)
+        File.readlines(fileList).each do |line|
+          if line == fileName
+            found = true
+            break
+          end
+        end
+      end
+      break if found
+    end
+    break if found
+  end
+  puts packageName + ': ' + fileName if found
 end
 
 def update
@@ -371,6 +393,12 @@ when "search"
   else
     list_packages
   end
+when "whatprovides"
+  if @pkgName
+    whatprovides @pkgName
+  else
+    puts "Usage: crew whatprovides [filepath]"
+  end
 when "download"
   search @pkgName
   download
@@ -388,8 +416,8 @@ when "remove"
 when nil
   puts "Chromebrew, version 0.2.1"
   puts "Usage: crew [command] [package]"
-  puts "Available commands: search, download, install, remove"
+  puts "Available commands: search, download, install, remove, whatprovides"
 else
   puts "I have no idea how to do #{@command} :("
-  puts "Available commands: search, download, install, remove"
+  puts "Available commands: search, download, install, remove, whatprovides"
 end

--- a/crew
+++ b/crew
@@ -67,16 +67,23 @@ end
 
 def whatprovides (pkgName)
   fileArray = []
-  arg = ARGV[1].dup
   op = '*'
-  search = arg
-  if arg[0] == '^'
-    op = '^'
-    search = arg[1..arg.length - 1]
+  search = pkgName.dup
+  if search[/\*/]
+    search = search.gsub! '*', ''
   end
-  if arg[-1] == '$'
-    op = '$'
-    search = arg[0..arg.length - 2]
+  abort if not search
+  if search[0] == '^'
+    op = '^'
+    search = search[1..search.length - 1]
+  end
+  if search[-1] == '$'
+    if op == '^'
+      op = '^$'
+    else
+      op = '$'
+    end
+    search = search[0..search.length - 2]
   end
   Find.find (CREW_CONFIG_PATH + 'meta/') do |packageList|
     if File.file? packageList
@@ -91,6 +98,8 @@ def whatprovides (pkgName)
             found = line[/^#{Regexp.quote(search)}/]
           when '$'
             found = line[/#{Regexp.quote(search)}$/]
+          when '^$'
+            found = line[/^#{Regexp.quote(search)}$/]
           end
           if found
             fileLine = packageName + ': ' + line
@@ -103,12 +112,10 @@ def whatprovides (pkgName)
     end
   end
   if not fileArray.empty?
-    fileCount = 0
     fileArray.sort.each do |item|
       puts item
-      fileCount += 1
     end
-    puts "\nTotal found: #{fileCount}"
+    puts "\nTotal found: #{fileArray.length}"
   end
 end
 


### PR DESCRIPTION
This is basically the equivalent of `grep <pattern> /usr/local/etc/crew/meta/*` when you want to find out which package includes &lt;pattern&gt;.
```
Usage: crew whatprovides [pattern]
```
Essentially, this is the same concept as `dpkg -S <filepath>` on Debian-based or `rpm -qf <filepath>` on RedHat-based Linux distributions when you want to find out which package contains a certain file on the system.

Changed from `crew source` to `crew whatprovides` per @minektur's preference.  He was the loudest so he wins. :)