### PR TITLE
Add place holder for openssl_devel.rb

### DIFF
--- a/packages/openssl_devel.rb
+++ b/packages/openssl_devel.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+# We are going to use openssl only instead of openssl_devel for the
+# ease of maintenance.  Removing package file is not easy, so leaving
+# place holder here.  PH needs to have source_url unfortunately.
+
+class Openssl_devel < Package
+  version 'removed'
+
+  source_url 'ftp://ftp.openssl.org/source/old/1.0.2/openssl-1.0.2f.tar.gz'
+  source_sha1 '2047c592a6e5a42bd37970bdb4a931428110a927'
+
+  def self.build
+  end
+
+  def self.install
+  end
+end


### PR DESCRIPTION
This is a remedy of the #335.  Need some kind of concrete fix for that, but need to avoid the problem too.

I've checked situation below.

- For a user having previous openssl_devel installed and performs `crew update` and fails `crew upgrade`, it works fine both once this PR is merged to master.

Few more tests are good to do, but I don't imagine others.