### PR TITLE
Update pkgconfig and correct default search paths

### DIFF
--- a/packages/pkgconfig.rb
+++ b/packages/pkgconfig.rb
@@ -1,14 +1,15 @@
 require 'package'
 
 class Pkgconfig < Package
-  version '0.28'
-  source_url 'http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz'
-  source_sha1 '71853779b12f958777bffcb8ca6d849b4d3bed46'
+  version '0.29.1'
+  source_url 'http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.1.tar.gz'
+  source_sha1 '271ce928f6d673cc16cbced2bfd14a5f2e5d3d37'
 
   depends_on 'buildessential'
 
   def self.build
-      system "./configure --with-internal-glib --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+      # check lib64 on any architectures since it is not a problem to not exist lib64 directory.
+      system "./configure --with-internal-glib --with-pc-path=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:/usr/local/share/pkgconfig CFLAGS=\" -fPIC\""
       system "make"
   end
 


### PR DESCRIPTION
Now pkg-config searches all /usr/local/lib, /usr/local/lib64, /usr/local/share without PKG_CONFIG_PATH environment variable.  This searches lib64 on any architectures, but it will be not a problem since armv7l and i686 just ignore it.

Tested on both armv7 and x86_64, not on i686 (don't own).

I didn't know there are two identical package with different name until I read #328.  Only pkgconfig was depended by others, so I've just modified it.