### PR TITLE
github release management tools

### DIFF
--- a/create_sha_list.sh
+++ b/create_sha_list.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Create SHA1/SHA256 list of binary files from packages/* and install.sh
+#
+# You can test SHA1/SHA256 by using 'sha1sum -c sha-file' or 'sha256sum -c sha-file'
+
+case x$1 in
+x|x-h)
+  echo "Usage: $0 [options] > output_file
+Options:
+  -h: help
+  -a: show all SHA1/SHA256
+
+Create SHA1/SHA256 list of binary files from packages/*.rb files and install.sh.
+It is possible to check SHA1/SHA256 by using 'sha1sum -c file' or 'sha256sum -c file'"
+  exit 0;;
+x-a)
+  ;;
+esac
+
+grep -h '\(link=\|sha256=\)' install.sh |
+  sed -e 's/link=//' \
+      -e 's/sha256=//'\
+      -e 's/^[ \t]*["'"'"']//' \
+      -e 's/[\?&].*["'"'"'].*$//' \
+      -e 's/["'"'"'].*$//' \
+      -e 's/\(http\|https\|ftp\):.*\///' | \
+  sed -ne 'N;s/\(.*\)\n\(.*\)/\2 \1/;p'
+
+for f in packages/*.rb; do 
+  grep -h '\(armv7l\|i686\|x86_64\):' $f | \
+    sort | \
+    sed -e 's:/www\.dropbox\.com/:/dl.dropboxusercontent.com/:' \
+        -e 's/\(armv7l\|i686\|x86_64\)://' \
+        -e 's/^[ \t]*["'"'"']//' \
+        -e 's/[\?&].*["'"'"'].*$//' \
+        -e 's/["'"'"'].*$//' \
+        -e 's/\(http\|https\|ftp\):.*\///' | \
+  sed -ne 'N;s/\n/ /;p'
+done

--- a/create_sha_list.sh
+++ b/create_sha_list.sh
@@ -27,7 +27,7 @@ grep -h '\(link=\|sha256=\)' install.sh |
       -e 's/\(http\|https\|ftp\):.*\///' | \
   sed -ne 'N;s/\(.*\)\n\(.*\)/\2 \1/;p'
 
-for f in packages/*.rb; do 
+for f in packages/*.rb; do
   grep -h '\(armv7l\|i686\|x86_64\):' $f | \
     sort | \
     sed -e 's:/www\.dropbox\.com/:/dl.dropboxusercontent.com/:' \

--- a/create_url_list.sh
+++ b/create_url_list.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Create URL list of binary URLs from packages/*
+#
+# You can download all of them by using 'wget -P output_dir -i output_file' command
+
+case x$1 in
+x|x-h)
+  echo "Usage: $0 [options] > output_file
+Options:
+  -h: help
+  -s: show URLs      (ignore github URL)
+  -a: show all URLs  (include github URL)
+
+Create URL list of binary URLs from packages/*.rb files.
+It is possible to download them all using 'wget -P output_dir -i output_file'"
+  exit 0;;
+x-s)
+  EXCLUDE_GITHUB_URL="grep -v 'github\.com'";;
+x-a)
+  EXCLUDE_GITHUB_URL="cat";;
+esac
+
+grep -h '\(armv7l\|i686\|x86_64\):.*\(http\|https\|ftp\):' packages/*.rb | \
+  eval $EXCLUDE_GITHUB_URL | \
+  sed -e 's:/www\.dropbox\.com/:/dl.dropboxusercontent.com/:' \
+      -e 's/\(armv7l\|i686\|x86_64\)://' \
+      -e 's/^[ \t]*["'"'"']//' \
+      -e 's/[\?&].*["'"'"'].*$//' \
+      -e 's/["'"'"'].*$//' \

--- a/create_url_list.sh
+++ b/create_url_list.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Create URL list of binary URLs from packages/*
+# Create URL list of binary URLs from packages/* and install.sh
 #
-# You can download all of them by using 'wget -P output_dir -i output_file' command
+# You can download all of them by using 'wget -N -P output_dir -i output_file' command
 
 case x$1 in
 x|x-h)
@@ -12,8 +12,8 @@ Options:
   -s: show URLs      (ignore github URL)
   -a: show all URLs  (include github URL)
 
-Create URL list of binary URLs from packages/*.rb files.
-It is possible to download them all using 'wget -P output_dir -i output_file'"
+Create URL list of binary URLs from packages/*.rb files and install.sh.
+It is possible to download them all using 'wget -N -P output_dir -i output_file'"
   exit 0;;
 x-s)
   EXCLUDE_GITHUB_URL="grep -v 'github\.com'";;
@@ -21,10 +21,18 @@ x-a)
   EXCLUDE_GITHUB_URL="cat";;
 esac
 
+grep -h 'link=.*\(http\|https\|ftp\):' install.sh | \
+  eval $EXCLUDE_GITHUB_URL | \
+  sed -e 's:/www\.dropbox\.com/:/dl.dropboxusercontent.com/:' \
+      -e 's/link=//' \
+      -e 's/^[ \t]*["'"'"']//' \
+      -e 's/[\?&].*["'"'"'].*$//' \
+      -e 's/["'"'"'].*$//'
+
 grep -h '\(armv7l\|i686\|x86_64\):.*\(http\|https\|ftp\):' packages/*.rb | \
   eval $EXCLUDE_GITHUB_URL | \
   sed -e 's:/www\.dropbox\.com/:/dl.dropboxusercontent.com/:' \
       -e 's/\(armv7l\|i686\|x86_64\)://' \
       -e 's/^[ \t]*["'"'"']//' \
       -e 's/[\?&].*["'"'"'].*$//' \
-      -e 's/["'"'"'].*$//' \
+      -e 's/["'"'"'].*$//'

--- a/upload_github_release.sh
+++ b/upload_github_release.sh
@@ -36,4 +36,3 @@ for file in "$@"; do
   name=$(basename $file)
   github-release upload -u "$owner" -r "$repo" -t "$tag" -n "$name" -f "$file"
 done
-  

--- a/upload_github_release.sh
+++ b/upload_github_release.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Script to upload binary files to github release page.
+#
+# Prerequirement:
+#   github-release  (https://github.com/aktau/github-release)
+#   golang
+
+owner=skycocker
+repo=chromebrew
+
+case x$1 in
+x|x-h)
+  echo "Usage: $0 [options] tag files...
+Options:
+  -h: help
+  -d: dump status of repository
+
+Upload files to tagged release page of http://github.com/$owner/$repo"
+  exit 0;;
+x-d)
+  github-release info -u "$owner" -r "$repo"
+  exit 0;;
+*)
+  tag=$1
+  shift;;
+esac
+
+case x$GITHUB_TOKEN in
+x)
+  echo "It is required to set your public_repo token to GITHUB_TOKEN environment variable to upload"
+  exit 1;;
+esac
+
+for file in "$@"; do
+  name=$(basename $file)
+  github-release upload -u "$owner" -r "$repo" -t "$tag" -n "$name" -f "$file"
+done
+  


### PR DESCRIPTION
I've made two scripts to make binary release page maintenance easy.

It is discussed at #268.

I made test page at https://github.com/jam7/chromebrew/releases which contains all binary files refered by newgcc branch.  This page is made by following steps with two newly created scripts.  Isn't it easy?  :)
```
<<create release page first and give it a TAG>>
$ sh create_url_list.sh -s > url_list
$ wget -P bin -i url_list
$ sh upload_github_release.sh TAG bin/*
```