### PR TITLE
Update php7 package dependencies

### DIFF
--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -5,10 +5,12 @@ class Php7 < Package
   source_url 'http://php.net/distributions/php-7.1.0.tar.xz'   # software source tarball url
   source_sha1 'c74c920256b9c6873bae696fbb0ec14a02dc8495'       # source tarball sha1 sum
 
-  depends_on 'curl'
+  depends_on 'pkgconfig'
+  depends_on 'zlibpkg'
   depends_on 'libpng'
   depends_on 'libxml2'
   depends_on 'openssl'
+  depends_on 'curl'
   depends_on 'pcre'
 
   def self.build                                               # self.build contains commands needed to build the software from source


### PR DESCRIPTION
@lyxell, @thedamian: This PR should fix #344.  I noticed since we made so many changes to the packages lately, it appears some installs that worked previously no longer work now, including this one.  So I have to agree with @thedamian about this package.  I decided to remove every package that was even remotely related to the dependencies of this package including `openssl_devel` and `pkg_config`.  After a few unsuccessful installation attempts, I was finally able to figure out how to perform a fresh install correctly.  One thing I found out about the dependencies is that order matters!  Apparently, I needed `pkgconfig` before `zlibpkg` and `zlibpkg` before `libpng` and `libxml2`.  In any event, I had success after nearly an hour of compiling all the dependencies from scratch.  Please test this out when you get a chance and hopefully, you will be reporting success stories. :) Thanks