### PR TITLE
Change crew version to match release tag

### DIFF
--- a/crew
+++ b/crew
@@ -428,7 +428,7 @@ when "remove"
   abort 'Removing actions must be ran with sudo.' unless USER == 'root'
   remove @pkgName
 when nil
-  puts "Chromebrew, version 0.2.2"
+  puts "Chromebrew, version 0.4"
   puts "Usage: crew [command] [package]"
   puts "Available commands: search, download, install, remove, whatprovides"
 else

--- a/crew
+++ b/crew
@@ -428,7 +428,7 @@ when "remove"
   abort 'Removing actions must be ran with sudo.' unless USER == 'root'
   remove @pkgName
 when nil
-  puts "Chromebrew, version 0.4"
+  puts "Chromebrew, version 0.4.1"
   puts "Usage: crew [command] [package]"
   puts "Available commands: search, download, install, remove, whatprovides"
 else


### PR DESCRIPTION
How about tagging another release tag of 0.4.1 so it matches what the crew command outputs? :)

After merging this PR, of course!