### PR TITLE
make ruby_latest depend on openssl and add the include directory

### DIFF
--- a/packages/ruby_latest.rb
+++ b/packages/ruby_latest.rb
@@ -10,7 +10,7 @@ class Ruby_latest < Package
   depends_on 'openssl'
 
   def self.build
-    system "CC='gcc' CPPFLAGS=-I/usr/local/include/openssl ./configure"
+    system "CC='gcc' ./configure"
     system "make"
   end
 

--- a/packages/ruby_latest.rb
+++ b/packages/ruby_latest.rb
@@ -7,9 +7,10 @@ class Ruby_latest < Package
 
   depends_on 'readline'
   depends_on 'zlibpkg'
+  depends_on 'openssl'
 
   def self.build
-    system "CC='gcc' ./configure"
+    system "CC='gcc' CPPFLAGS=-I/usr/local/include/openssl ./configure"
     system "make"
   end
 


### PR DESCRIPTION
without openssl at compile time ruby will be unable to install gems from an https source