### PR TITLE
Add dependencies to make sure pkgconfig is installed prior to source code compilations

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -8,4 +8,5 @@ class Buildessential < Package
   depends_on 'gcc'
   depends_on 'make'
   depends_on 'linuxheaders'
+  depends_on 'pkgconfig'
 end

--- a/packages/pkgconfig.rb
+++ b/packages/pkgconfig.rb
@@ -5,7 +5,7 @@ class Pkgconfig < Package
   source_url 'http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.1.tar.gz'
   source_sha1 '271ce928f6d673cc16cbced2bfd14a5f2e5d3d37'
 
-  # It is not possible to write buildessential here since it depends on build essential too.
+  # It is not possible to write buildessential here since it causes dependency loop.
   #   depends_on 'buildessential'
   # Write dependency to gcc make linuxheaders instead.
   depends_on 'gcc'

--- a/packages/pkgconfig.rb
+++ b/packages/pkgconfig.rb
@@ -5,7 +5,12 @@ class Pkgconfig < Package
   source_url 'http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.1.tar.gz'
   source_sha1 '271ce928f6d673cc16cbced2bfd14a5f2e5d3d37'
 
-  depends_on 'buildessential'
+  # It is not possible to write buildessential here since it depends on build essential too.
+  #   depends_on 'buildessential'
+  # Write dependency to gcc make linuxheaders instead.
+  depends_on 'gcc'
+  depends_on 'make'
+  depends_on 'linuxheaders'
 
   def self.build
       # check lib64 on any architectures since it is not a problem to not exist lib64 directory.


### PR DESCRIPTION
This is my solution to @lyxell's question, https://github.com/skycocker/chromebrew/pull/347#issuecomment-271432465.

**Problem**: x86_64 really needs `pkgconfig` to figure out library path and others, but it's really really easy to forget adding dependency to `pkgconfig` since other architectures don't need it.

**Solution**: add `pkgconfig` as a part of `buildessential`.  This won't break other architectures since having pkgconfig helps configure process on not only x86_64 but also arm and i686.

Some packages forget to add `buildessential` dependency, so this PR doesn't solve problems on all packages.  Once #260 is merged and `buildessential` dependency is hardcoded, this will work correctly with all packages.