### PR TITLE
Add package for pv (1.6.0)

### DIFF
--- a/packages/pv.rb
+++ b/packages/pv.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Pv < Package
+  version '1.6.0'
+  source_url 'http://www.ivarch.com/programs/sources/pv-1.6.0.tar.gz'
+  source_sha1 '395ce62f4f3e035b86c77038f04b96c5aa233595'
+
+  def self.build
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
This adds pv (pipe viewer) version 1.6.0. The pv command allows you to monitor the progress of data as is passes through command pipelines.

Tested as working properly on Samsung XE50013-K01US. All tests pass when running `make test`.