### PR TITLE
Add package for xz-utils (5.2.3)

### DIFF
--- a/packages/xzutils.rb
+++ b/packages/xzutils.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Xzutils < Package
+  version '5.2.3' 
+  source_url 'http://tukaani.org/xz/xz-5.2.3.tar.gz' 
+  source_sha1 '529638eec3597e429cc54c74551ac0a89169e841' 
+
+  def self.build
+    system "./configure",
+      "--prefix=/usr/local",
+      "--disable-docs"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Adds xz-utils (5.2.3). CrOS dev tools provides these tools primarily for reducing the size of image files to preserve what little disk space we have available on our tiny eMMC drives. For those who don't wish to run dev_install this will allow you to work with xz archives.

Tested as working properly on Samsung XE50013-K01US.