### PR TITLE
flex requires yacc or bison.

### DIFF
--- a/packages/flex.rb
+++ b/packages/flex.rb
@@ -6,6 +6,7 @@ class Flex < Package
   source_sha1 'cfe10b5de4893ced356adc437e78018e715818c3'
 
   depends_on 'm4'
+  depends_on 'bison'
 
   def self.build
     system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""


### PR DESCRIPTION
When I try `crew install flex`, it fails because no `yacc` is installed.  There is no `yacc` in chromebrew, but there is `bison` -- something  of `GNU yacc`.  If I install `bison`, `crew install flex` is worked well.  So, I added dependency to `bison`.

Tested on ARM and X86_64.