### PR TITLE
Update Python from 2.7.12 to 2.7.13

### DIFF
--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -1,16 +1,16 @@
 require 'package'
 
 class Python27 < Package
-  version '2.7.12'
-  source_url 'https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz' # software source tarball url
-  source_sha1 '05360b8ade117b35e266b2004a7f1f11250c6dcd'                     # source tarball sha1 sum
+  version '2.7.13'
+  source_url 'https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tar.xz' # software source tarball url
+  source_sha1 '18a8f30a0356c751b8d0ea6f76e764cab13ee046'                     # source tarball sha1 sum
 
   depends_on 'bz2'
   depends_on 'ncurses'
   depends_on 'openssl'
 
   def self.build                                                  # self.build contains commands needed to build the software from source
-    system "./configure --prefix=/usr/local CPPFLAGS=\"-I/usr/local/include -I/usr/local/include/ncurses\" LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\" -fPIC\""
+    system "./configure --prefix=/usr/local CPPFLAGS=\"-I/usr/local/include -I/usr/local/include/ncurses\" LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\" -fPIC\" --with-ensure-pip=install"
     system "make"                                                 # ordered chronologically
   end
 


### PR DESCRIPTION
Update to 2.7.13 and also ensure that the pip module is being installed. This is suppoed to be default behavior when installing from either source or binary and for some reason wasn't happening.

Tested as working properly on Samsung XE50013-K01US.