### PR TITLE
Need some modification to install ffcall.

### DIFF
--- a/packages/ffcall.rb
+++ b/packages/ffcall.rb
@@ -12,6 +12,10 @@ class Ffcall < Package
 
   def self.install
     system "make check"
+
+    # ffcall's `make install` doesn't create intermediate directory, so prepare for it here.
+    system "mkdir", "-p", "#{CREW_DEST_DIR}/usr/local"
+
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 end


### PR DESCRIPTION
When I try `crew install ffcall`, it fails because its makefile doesn't create intermediate directory to copy several files in `ffcall` package.  I add `mkdir -p #{CREW_DEST_DIR}/usr/local` to fix the problem.

Tested on X86_64.
`ffcall` itself has problems on ARM, so it is not tested on ARM.  