### PR TITLE
libgd requires libpng and `cd src`

### DIFF
--- a/packages/libgd.rb
+++ b/packages/libgd.rb
@@ -5,6 +5,8 @@ class Libgd < Package
   source_url 'https://github.com/libgd/libgd/archive/GD_2_0_33.tar.gz'
   source_sha1 '489e25f18d3fc9d7f8b0e4889f98f5aa25363c3e'
 
+  depends_on 'libpng'
+
   def self.build
     FileUtils.cd('src') do
       system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
@@ -13,6 +15,8 @@ class Libgd < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    FileUtils.cd('src') do
+      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    end
   end
 end


### PR DESCRIPTION
When I try `crew install libgd`, it fails because of several problems.

First, it requires `libpng`, so I added dependency.
Second, it has `makefile` and all other files under `src` directory, so I added `cd src` just before the installation process.

Tested on ARM and X86_64.