### PR TITLE
Add libtool (2.4.6) package

### DIFF
--- a/packages/libtool.rb
+++ b/packages/libtool.rb
@@ -8,7 +8,7 @@ class Libtool < Package
   depends_on 'buildessential'
 
   def self.build
-    system "./configure"
+    system "./configure --prefix=/usr/local"
     system "make"
   end
 

--- a/packages/libtool.rb
+++ b/packages/libtool.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Libtool < Package
+  version '2.4.6'
+  source_url 'https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz'
+  source_sha1 '25b6931265230a06f0fc2146df64c04e5ae6ec33'
+
+  depends_on 'buildessential'
+
+  def self.build
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
This adds GNU libtool as a package in preparation for a libusb package.

Tested as working properly on Samsung XE50013-K01US.