### PR TITLE
Add di (disk information) package

### DIFF
--- a/packages/di.rb
+++ b/packages/di.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Di < Package
+  version '4.43'
+  source_url 'http://gentoo.com/di/di-4.43.tar.gz'
+  source_sha1 'ddced0d59d29ccdcbc4282bc7464a925d14955e1'
+
+  def self.build
+    system "CC=gcc prefix=/usr/local make -e"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "-e", "install"
+  end
+end


### PR DESCRIPTION
This adds the disk information utility as a package. 'di' is a disk information utility, displaying everything (and more) that your 'df' command does. It features the ability to display your disk usage in whatever format you prefer. It also checks the user and group quotas, so that the user sees the space available for their use, not the system wide disk space.

Tested as working properly on Samsung XE50013-K01US.