### PR TITLE
Add libpcap (1.8.1) package

### DIFF
--- a/packages/libpcap.rb
+++ b/packages/libpcap.rb
@@ -6,6 +6,8 @@ class Libpcap < Package
   source_sha1 '32d7526dde8f8a2f75baf40c01670602aeef7e39'
 
   depends_on "buildessential"
+  depends_on "bison"
+  depends_on "flex"
 
   def self.build
     system "./configure --prefix=/usr/local"

--- a/packages/libpcap.rb
+++ b/packages/libpcap.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Libpcap < Package
+  version '1.8.1'
+  source_url 'http://www.tcpdump.org/release/libpcap-1.8.1.tar.gz'
+  source_sha1 '32d7526dde8f8a2f75baf40c01670602aeef7e39'
+
+  depends_on "buildessential"
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
libpcap provides functions for user-level packet capture, used in low-level network monitoring.

Tested as working properly on Samsung XE50013-K01US.