### PR TITLE
Add tcpdump (4.8.1) package

### DIFF
--- a/packages/tcpdump.rb
+++ b/packages/tcpdump.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Tcpdump < Package
+  version '4.8.1' 
+  source_url 'http://www.tcpdump.org/release/tcpdump-4.8.1.tar.gz'
+  source_sha1 '364c8a60b637d1b122769fdeae79bcd300d5bd5c'
+
+  depends_on 'libpcap'
+  depends_on 'openssl'
+
+  def self.build
+    system "./configure --prefix=/usr/local --with-user=chronos"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Tcpdump prints out a description of the contents of packets on a network interface.

Tested as working properly on Samsung XE50013-K01US. I was able to capture USB traffic as expected and all tests in their test suite passed.