### PR TITLE
Add tcpstat (1.5) package

### DIFF
--- a/packages/tcpstat.rb
+++ b/packages/tcpstat.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Tcpstat < Package
+  version '1.5' 
+  source_url 'http://www.frenchfries.net/paul/tcpstat/tcpstat-1.5.tar.gz' 
+  source_sha1 '3881edafe2a45c807a6f197792251036c599ec50'
+
+  def self.build
+    system "./configure", "--prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
tcpstat reports certain network interface statistics much like vmstat does for system statistics. tcpstat gets its information by either monitoring a specific interface, or by reading previously saved tcpdump data from a file. All features/commands except for `tcpprof` are enabled and working properly. `tcpprof` is disabled due to Oracle's licensing for Berkeley DB.

Tested as working properly on Samsung XE50013-K01US.