### PR TITLE
Change to load pkgconfig.rb in the startup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,7 @@ echo '}' >> device.json
 
 #download git and its dependencies .rb package files
 cd $CREW_PACKAGES_PATH
-for file in git zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders; do
+for file in git zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders pkgconfig; do
   wget -N -c $URL/packages/$file.rb
 done
 


### PR DESCRIPTION
#354 caused problem in nstall.sh.  pkgconfig is now required to install buildessential, but I forget to pre-load pkgconfig in install.sh.