### PR TITLE
cmake requires ncurses, otherwise bootstrap fails

### DIFF
--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -7,6 +7,7 @@ class Cmake < Package
 
   depends_on 'buildessential'
   depends_on 'openssl'
+  depends_on 'ncurses'
 
   def self.build
     system "./bootstrap"


### PR DESCRIPTION
When I try `crew install cmake` to check #384, I've just noticed ncurses is also required to build cmake.  So, adding dependency for it.

Tested on ARM.