### PR TITLE
Add powerstat (0.02.11) package

### DIFF
--- a/packages/powerstat.rb
+++ b/packages/powerstat.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Powerstat < Package
+  version '0.02.11'
+  source_url 'http://kernel.ubuntu.com/~cking/tarballs/powerstat/powerstat-0.02.11.tar.gz'
+  source_sha1 '729c5f8f4509ab13134278c8afe04cf2244d928c'
+
+  def self.build
+    system "sed -i 's,/usr,/usr/local,g' Makefile"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Powerstat measures the power consumption of a laptop using the ACPI battery information. The output is like vmstat but also shows power consumption statistics. At the end of a run, powerstat will calculate the average, standard deviation and min/max of the gathered data.

Tested as working properly on Samsung XE50013-K01US.