### PR TITLE
Add json-c (0.12.1-nodoc) package

### DIFF
--- a/packages/jsonc.rb
+++ b/packages/jsonc.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Jsonc < Package
+  version '0.12.1-nodoc'
+  source_url 'https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12.1-nodoc.tar.gz'
+  source_sha1 'ffb24acc03110703a88657a64507cc055373f252'
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
JSON-C implements a reference counting object model that allows you to
easily construct JSON objects in C, output them as JSON formatted
strings and parse JSON formatted strings back into the C representation
of JSON objects. It aims to conform to RFC 7159.

Tested as working properly on Samsung XE50013-K01US.