### PR TITLE
Remove all SHORTARCH related stuff

### DIFF
--- a/crew
+++ b/crew
@@ -23,17 +23,6 @@ else
 end
 
 ARCH = `uname -m`.strip
-#SHORTARCH = `getconf LONG_BIT`.strip # will refactor this line in the future
-case ARCH
-  when "i686"
-    SHORTARCH="32"
-  when "x86_64"
-    SHORTARCH="64"
-  when "armv7l"
-    SHORTARCH="32"
-  else  
-    SHORTARCH="32"
-end
 
 $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"
 

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -28,11 +28,6 @@ class Package
   end
 
   def self.system(*args)
-    # strip -m32 option and convert lib32 to lib for the case of ARM to avoid SHORTARCH flood
-    if ARCH == "armv7l"
-      args = args.map {|s| s.gsub("-m32", "")}
-      args = args.map {|s| s.gsub("lib32", "lib")}
-    end
     # add "-j#{CREW_NPROC}" argument to "make"
     if args[0] == "make"
       # modify ["make", "args", ...] into ["make", "-j#{CREW_NPROC}", "args", ...]

--- a/packages/bc.rb
+++ b/packages/bc.rb
@@ -1,14 +1,14 @@
 require 'package'
 
 class Bc < Package
-  version '1.06'
+  version '1.06-1'
   source_url 'http://ftp.gnu.org/gnu/bc/bc-1.06.tar.gz'
   source_sha1 'c8f258a7355b40a485007c40865480349c157292'
 
   depends_on 'flex'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/"
+    system "./configure"
     system "make"
   end
 

--- a/packages/clisp.rb
+++ b/packages/clisp.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Clisp < Package
-  version '2.49'
+  version '2.49-1'
   source_url 'ftp://ftp.gnu.org/pub/gnu/clisp/release/2.49/clisp-2.49.tar.bz2'
   source_sha1 '7e8d585ef8d0d6349ffe581d1ac08681e6e670d4'
 
@@ -9,7 +9,7 @@ class Clisp < Package
   depends_on 'ffcall'
 
   def self.build
-    system "./configure CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+    system "./configure CFLAGS=\" -fPIC\""
     FileUtils.cd('src') do
       system "ulimit -s 16384"
       system "make"

--- a/packages/ffcall.rb
+++ b/packages/ffcall.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Ffcall < Package
-  version '1.10'
+  version '1.10-1'
   source_url 'http://www.haible.de/bruno/gnu/ffcall-1.10.tar.gz'
   source_sha1 '6b4fdc7bd38b434bbf3d65508a3d117fc8b349f3'
 
   def self.build
-    system "./configure --prefix=/usr/local --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+    system "./configure --prefix=/usr/local CFLAGS=\" -fPIC\""
     system "make"
   end
 

--- a/packages/flex.rb
+++ b/packages/flex.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Flex < Package
-  version '2.5.39'
+  version '2.5.39-1'
   source_url 'http://fossies.org/linux/misc/flex-2.6.0.tar.gz'
   source_sha1 'cfe10b5de4893ced356adc437e78018e715818c3'
 
@@ -9,7 +9,7 @@ class Flex < Package
   depends_on 'bison'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+    system "./configure CFLAGS=\" -fPIC\""
     system "make"
   end
 

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Fontconfig < Package
-  version '2.11.94'
+  version '2.11.94-1'
   source_url 'http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.94.tar.gz'
   source_sha1 '3748d8a2b9cf8052dbd003f524d829157f1ead83'
 
@@ -9,7 +9,7 @@ class Fontconfig < Package
   depends_on 'freetype'
 
   def self.build
-      system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+      system "./configure CFLAGS=\" -fPIC\""
       system "make"
   end
 

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Freetype < Package
-  version '2.6'
+  version '2.6-1'
   source_url 'http://download.savannah.gnu.org/releases/freetype/freetype-2.6.tar.gz'
   source_sha1 '12dd3267af62cccc32045ed99984f3d8a8ddbf90'
 
   def self.build
-      system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+      system "./configure CFLAGS=\" -fPIC\""
       system "make"
   end
 

--- a/packages/gdal.rb
+++ b/packages/gdal.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Gdal < Package
-  version '1.11.2'
+  version '1.11.2-1'
   source_url 'http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz'
   source_sha1 '6f3ccbe5643805784812072a33c25be0bbff00db'
 
@@ -12,7 +12,7 @@ class Gdal < Package
   depends_on 'libxml2'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\" --with-png=internal --with-libtiff=internal --with-geotiff=internal --with-jpeg=internal --with-gif=internal --with-curl=/usr/local/bin/curl-config --with-geos=/usr/local/bin/geos-config --with-static-proj4=/usr/local/share/proj --with-python"
+    system "./configure CFLAGS=\" -fPIC\" --with-png=internal --with-libtiff=internal --with-geotiff=internal --with-jpeg=internal --with-gif=internal --with-curl=/usr/local/bin/curl-config --with-geos=/usr/local/bin/geos-config --with-static-proj4=/usr/local/share/proj --with-python"
     system "make"
   end
 

--- a/packages/geos.rb
+++ b/packages/geos.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Geos < Package
-  version '3.4.2'
+  version '3.4.2-1'
   source_url 'http://download.osgeo.org/geos/geos-3.4.2.tar.bz2'
   source_sha1 'b8aceab04dd09f4113864f2d12015231bb318e9a'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+    system "./configure CFLAGS=\" -fPIC\""
     system "make"
   end
 

--- a/packages/imagemagick.rb
+++ b/packages/imagemagick.rb
@@ -1,14 +1,14 @@
 require 'package'
 
 class Imagemagick < Package
-  version '6.9.2-10'
+  version '6.9.2-10-1'
   source_url 'http://www.imagemagick.org/download/releases/ImageMagick-6.9.2-10.tar.xz'
   source_sha1 'd0b3fdf8f25856bf0058716703f7bf989560d2ce'
   
   depends_on 'pkgconfig'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\" --without-python"
+    system "./configure CFLAGS=\" -fPIC\" --without-python"
     system "make"
   end
 

--- a/packages/libgd.rb
+++ b/packages/libgd.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Libgd < Package
-  version '2.0.33'
+  version '2.0.33-1'
   source_url 'https://github.com/libgd/libgd/archive/GD_2_0_33.tar.gz'
   source_sha1 '489e25f18d3fc9d7f8b0e4889f98f5aa25363c3e'
 
@@ -9,7 +9,7 @@ class Libgd < Package
 
   def self.build
     FileUtils.cd('src') do
-      system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+      system "./configure CFLAGS=\" -fPIC\""
       system "make"
     end
   end

--- a/packages/libjpeg.rb
+++ b/packages/libjpeg.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Libjpeg < Package
-  version '9.1'
+  version '9.1-1'
   source_url 'http://www.ijg.org/files/jpegsrc.v9a.tar.gz'
   source_sha1 'd65ed6f88d318f7380a3a5f75d578744e732daca'
 
   def self.build
-    system "./configure --includedir=/usr/local/include --libdir=/usr/local/lib#{SHORTARCH} CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+    system "./configure --includedir=/usr/local/include CFLAGS=\" -fPIC\""
     system "make"
   end
 

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Libpng < Package
-  version '1.6.26'
+  version '1.6.26-1'
   source_url 'http://prdownloads.sourceforge.net/libpng/libpng-1.6.26.tar.gz'
   source_sha1 '3b2652f89b8fdcb6c29e9ed7642dfcfc0bbcf17e'
 
   def self.build
-      system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+      system "./configure CFLAGS=\" -fPIC\""
       system "make"
   end
 

--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Libsigsegv < Package
-  version '2.10'
+  version '2.10-1'
   source_url 'ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.10.tar.gz'
   source_sha1 'b75a647a9ebda70e7a3b33583efdd550e0eac094'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+    system "./configure CFLAGS=\" -fPIC\""
     system "make"
   end
 

--- a/packages/libtiff.rb
+++ b/packages/libtiff.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Libtiff < Package
-  version '4.0.7'
+  version '4.0.7-1'
   source_url 'ftp://download.osgeo.org/libtiff/tiff-4.0.7.tar.gz'
   source_sha1 '2c1b64478e88f93522a42dd5271214a0e5eae648'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+    system "./configure CFLAGS=\" -fPIC\""
     system "make"
   end
 

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Libxml2 < Package
-  version '2.9.2'
+  version '2.9.2-1'
   source_url 'http://xmlsoft.org/sources/libxml2-2.9.2.tar.gz'
   source_sha1 'f46a37ea6d869f702e03f393c376760f3cbee673'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\" --without-python"
+    system "./configure CFLAGS=\" -fPIC\" --without-python"
     system "make"
   end
 

--- a/packages/libxslt.rb
+++ b/packages/libxslt.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Libxslt < Package
-  version '1.1.28'
+  version '1.1.28-1'
   source_url 'http://xmlsoft.org/sources/libxslt-1.1.28.tar.gz'
   source_sha1 '4df177de629b2653db322bfb891afa3c0d1fa221'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\" --without-python"
+    system "./configure CFLAGS=\" -fPIC\" --without-python"
     system "make"
   end
 

--- a/packages/mapserver.rb
+++ b/packages/mapserver.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Mapserver < Package
-  version '5.6.9'
+  version '5.6.9-1'
   source_url 'http://download.osgeo.org/mapserver/mapserver-5.6.9.tar.gz'
   source_sha1 '3f05bf6c9a32b34408e36ddd32f61d68d65cf01c'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\" --with-gdal=/usr/local/bin/gdal-config --with-ogr --with-png --with-jpeg --without-pdf --with-agg --with-proj --with-threads --with-geos=/usr/local/bin/geos-config --with-tiff --with-wfs --with-wmsclient --with-wfsclient --with-curl-config=/usr/local/bin/curl-config --with-xml2-config=/usr/local/bin/xml2-config"
+    system "./configure CFLAGS=\" -fPIC\" --with-gdal=/usr/local/bin/gdal-config --with-ogr --with-png --with-jpeg --without-pdf --with-agg --with-proj --with-threads --with-geos=/usr/local/bin/geos-config --with-tiff --with-wfs --with-wmsclient --with-wfsclient --with-curl-config=/usr/local/bin/curl-config --with-xml2-config=/usr/local/bin/xml2-config"
     system "make"
   end
 

--- a/packages/openconnect.rb
+++ b/packages/openconnect.rb
@@ -27,7 +27,7 @@ require 'package'
 # > ip tuntap del mode tun tun0
 
 class Openconnect < Package
-  version '7.06'
+  version '7.06-1'
   source_url 'ftp://ftp.infradead.org/pub/openconnect/openconnect-7.06.tar.gz'
   source_sha1 '2351408693aab0c6bc97d37e68b4a869fbb217ed'
 
@@ -36,7 +36,7 @@ class Openconnect < Package
   depends_on 'gnutls'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\" --with-vpnc-script=/usr/local/etc/vpnc/vpnc-script"
+    system "./configure CFLAGS=\" -fPIC\" --with-vpnc-script=/usr/local/etc/vpnc/vpnc-script"
     system "make"
   end
 

--- a/packages/proj4.rb
+++ b/packages/proj4.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Proj4 < Package
-  version '4.9.1'
+  version '4.9.1-1'
   source_url 'http://download.osgeo.org/proj/proj-4.9.1.tar.gz'
   source_sha1 '0bc63a41f1bdcff600d076c056f796007abf3f2f'
 
   def self.build
-    system "./configure --libdir=/usr/local/lib#{SHORTARCH}/ CC=\"gcc -m#{SHORTARCH}\" CFLAGS=\" -fPIC\""
+    system "./configure CFLAGS=\" -fPIC\""
     system "make"
   end
 


### PR DESCRIPTION
Removing SHORTARCH variable from crew as discussed/described in #337.

This modifies bc, clisp, ffcall, flex, fontconfig, freetype, gdal, geos, imagemagick, libgd, libjpeg, libpng, libsigsegv, libtiff, libxml2, libxslt, mapserver, openconnect and proj4.

I tested them all and all other packages depend on them on X86_64.  I also tested all except ffcal and clisp on ARM (those two are not compilable on ARM) 