### PR TITLE
Add lshw (B.02.18) package

### DIFF
--- a/packages/lshw.rb
+++ b/packages/lshw.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Lshw < Package
+  version 'B.02.18' 
+  source_url 'http://www.ezix.org/software/files/lshw-B.02.18.tar.gz'
+  source_sha1 'c0240f5e53cf40769d52e316719e8010ea6bdea3'
+
+  def self.build
+    FileUtils.chdir("src") do
+      system "PREFIX=/usr/local make"
+    end
+  end
+
+  def self.install
+    FileUtils.chdir("src") do
+      system "PREFIX=/usr/local make DESTDIR=#{CREW_DEST_DIR} install"
+    end
+  end
+end


### PR DESCRIPTION
lshw is a small tool to extract detailed information on the hardware configuration of the machine.

Tested as working properly on Samsung XE50013-K01US.

**NOTE:** Requires merge of #399 before it will build and install.