### PR TITLE
Refactor search logic to support regex

### DIFF
--- a/crew
+++ b/crew
@@ -62,7 +62,7 @@ def search(pkg_name, silent = false)
   results = Dir["#{CREW_LIB_PATH}packages/*.rb"] \
 	  .select  { |f| File.basename(f, '.rb') =~ Regexp.new(pkg_name, true) } \
 	  .collect { |f| File.basename(f, '.rb') } \
-	  .each    { |f| set_pkg(f) }
+	  .each    { |f| set_pkg(f, silent) }
   abort "Package not found :(" unless results.length > 0
 end
 
@@ -108,7 +108,7 @@ def update
 
   canBeUpdated = 0
   @device[:installed_packages].each do |package|
-    search package[:name], true
+    search("^#{package[:name]}$", true)
     if package[:version] != @pkg.version
       canBeUpdated += 1
       puts @pkg.name + " could be updated from " + package[:version] + " to " + @pkg.version
@@ -125,7 +125,7 @@ end
 
 def upgrade
   if @pkgName
-    search @pkgName
+    search("^#{@pkgName}$")
 
     currentVersion = nil
     @device[:installed_packages].each do |package|
@@ -135,7 +135,7 @@ def upgrade
     end
     
     if currentVersion != @pkg.version
-      search @pkg.name
+      search("^#{@pkg.name}$")
       puts "Updating #{@pkg.name}..."
       remove @pkg.name
       resolveDependenciesAndInstall
@@ -145,7 +145,7 @@ def upgrade
   else
     toBeUpdated = []
     @device[:installed_packages].each do |package|
-      search package[:name], true
+      search("^#{package[:name]}$", true)
       if package[:version] != @pkg.version
         toBeUpdated.push(package[:name])
       end
@@ -154,7 +154,7 @@ def upgrade
     if toBeUpdated.length > 0
       puts "Updating packages..."
       toBeUpdated.each do |package|
-        search package
+        search("^#{package}$")
         remove @pkg.name
         resolveDependenciesAndInstall
       end
@@ -196,7 +196,7 @@ def resolveDependenciesAndInstall
 
     resolveDependencies
   
-    search origin
+    search("^#{origin}$")
     install
   rescue InstallError => e 
     puts "#{@pkg.name} failed to install: #{e.to_s}"
@@ -219,7 +219,7 @@ def resolveDependencies
       @dependencies.unshift @pkg.dependencies
       
       @pkg.dependencies.each do |dep|
-        search dep, true
+        search("^#{dep}$", true)
         pushDeps
       end
     end
@@ -252,7 +252,7 @@ def resolveDependencies
 
   if proceed
     @dependencies.each do |dep|
-      search dep
+      search("^#{dep}$")
       install
     end
   end
@@ -405,7 +405,7 @@ end
 case @command
 when "search"
   if @pkgName
-    search @pkgName
+    search("^#{@pkgName}$")
   else
     list_packages
   end
@@ -416,14 +416,14 @@ when "whatprovides"
     puts "Usage: crew whatprovides [pattern]"
   end
 when "download"
-  search @pkgName
+  search("^#{@pkgName}$")
   download
 when "update"
   update
 when "upgrade"
   upgrade
 when "install"
-  search @pkgName
+  search("^#{@pkgName}$")
   resolveDependenciesAndInstall
 when "remove"
   abort 'Removing actions must be ran with sudo.' unless USER == 'root'

--- a/crew
+++ b/crew
@@ -41,11 +41,11 @@ abort "Chromebrew should not be run as root." if Process.uid == 0 && @command !=
   @device[key] = @device[key].to_sym rescue @device[key]
 end
 
-def setPkg (pkgName, silent = false)
-  require CREW_LIB_PATH + 'packages/' + pkgName
-  @pkg = Object.const_get(pkgName.capitalize)
-  @pkg.name = pkgName
-  puts "Found #{pkgName}, version #{@pkg.version}" unless silent
+def set_pkg(pkg_name, silent = false)
+  require CREW_LIB_PATH + 'packages/' + pkg_name
+  @pkg = Object.const_get(pkg_name.capitalize)
+  @pkg.name = pkg_name
+  puts "Found #{pkg_name}, version #{@pkg.version}" unless silent
 end
 
 def list_packages
@@ -58,11 +58,12 @@ def list_packages
   end
 end
 
-def search (pkgName, silent = false)
-  Find.find (CREW_LIB_PATH + 'packages') do |filename|
-    return setPkg(pkgName, silent) if filename == CREW_LIB_PATH + 'packages/' + pkgName + '.rb'
-  end
-  abort "package #{pkgName} not found :("
+def search(pkg_name, silent = false)
+  results = Dir["#{CREW_LIB_PATH}packages/*.rb"] \
+	  .select  { |f| File.basename(f, '.rb') =~ Regexp.new(pkg_name, true) } \
+	  .collect { |f| File.basename(f, '.rb') } \
+	  .each    { |f| set_pkg(f) }
+  abort "Package not found :(" unless results.length > 0
 end
 
 def whatprovides (pkgName)


### PR DESCRIPTION
`crew search` use to only return a single result if your query string
matched a package name exactly.

`crew search` now supports regex.

```bash
chronos@localhost / $ crew search ^lib
Found libpcap, version 1.8.1
Found libjpeg, version 9.1
Found libunwind, version 1.1
Found libxslt, version 1.1.28
Found libffi, version 3.0.13-1
Found libssh2, version 1.4.3
Found libtool, version 2.4.6
Found libpipeline, version 1.4.1
Found libevent, version 2.0.22
Found libxml2, version 2.9.2
Found libgd, version 2.0.33
Found libtiff, version 4.0.7
Found libpng, version 1.6.26
Found libsigsegv, version 2.10
```

Also includes some minor cleanup to make things more idiomatic.