### PR TITLE
removed unnecessary dependencies related to git

### DIFF
--- a/crew
+++ b/crew
@@ -241,12 +241,12 @@ def resolveDependencies
   
   pushDeps
 
-  #add buildessential as dependency if we're building from source
+  # Add buildessential and solve its dependencies if any of dependent
+  # packages are made from source
   if @source_package > 0
     @dependencies.unshift 'buildessential'
     search 'buildessential', true
   end
-
   pushDeps
   
   return if @dependencies.empty?

--- a/crew
+++ b/crew
@@ -214,10 +214,21 @@ def resolveDependencies
   @dependencies = []
 
   def pushDeps
-    if @pkg.dependencies
-      @dependencies.unshift @pkg.dependencies
+    if @pkg.binary_url && @pkg.binary_url.has_key?(@device[:architecture])
+      # Use binary dependencies if it exists, use source dependencies otherwise
+      if @pkg.rdependencies
+        @check_deps = @pkg.rdependencies
+      else
+        @check_deps = @pkg.dependencies
+      end
+    else
+      # Use only source dependencies
+      @check_deps = @pkg.dependencies
+    end
+    if @check_deps && !@check_deps.empty?
+      @dependencies.unshift @check_deps
       
-      @pkg.dependencies.each do |dep|
+      @check_deps.each do |dep|
         search dep, true
         pushDeps
       end

--- a/crew
+++ b/crew
@@ -213,6 +213,9 @@ end
 def resolveDependencies
   @dependencies = []
 
+  # check source packages existance
+  @source_package = 0
+
   def pushDeps
     if @pkg.binary_url && @pkg.binary_url.has_key?(@device[:architecture])
       # Use binary dependencies if it exists, use source dependencies otherwise
@@ -222,8 +225,9 @@ def resolveDependencies
         @check_deps = @pkg.dependencies
       end
     else
-      # Use only source dependencies
+      # Use source dependencies
       @check_deps = @pkg.dependencies
+      @source_package += 1
     end
     if @check_deps && !@check_deps.empty?
       @dependencies.unshift @check_deps
@@ -235,6 +239,14 @@ def resolveDependencies
     end
   end
   
+  pushDeps
+
+  #add buildessential as dependency if we're building from source
+  if @source_package > 0
+    @dependencies.unshift 'buildessential'
+    search 'buildessential', true
+  end
+
   pushDeps
   
   return if @dependencies.empty?

--- a/install.sh
+++ b/install.sh
@@ -74,13 +74,13 @@ mv ./filelist $CREW_CONFIG_PATH/meta/ruby.filelist
 
 #download, prepare and install chromebrew
 cd $CREW_LIB_PATH
-wget -N -c $URL/crew
+wget -N $URL/crew
 chmod +x crew
 sudo ln -s `pwd`/crew $CREW_PREFIX/bin
 #install crew library
 mkdir $CREW_LIB_PATH/lib && cd $CREW_LIB_PATH/lib
-wget -N -c $URL/lib/package.rb
-wget -N -c $URL/lib/package_helpers.rb
+wget -N $URL/lib/package.rb
+wget -N $URL/lib/package_helpers.rb
 #create the device.json file
 cd $CREW_CONFIG_PATH
 echo '{' > device.json
@@ -97,7 +97,7 @@ echo '}' >> device.json
 cd $CREW_PACKAGES_PATH
 
 #first, download only git package
-wget -N -c $URL/packages/git.rb
+wget -N $URL/packages/git.rb
 
 #check whether git provides binary package or not
 #if not, prepare to compile git from source
@@ -106,7 +106,7 @@ case .$GIT_BINARY_URL in
 .)
   #download git and its dependencies .rb package files to compile git from source
   for file in zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders pkgconfig openssl; do
-    wget -N -c $URL/packages/$file.rb
+    wget -N $URL/packages/$file.rb
   done
 
   #install readline for ruby

--- a/install.sh
+++ b/install.sh
@@ -93,14 +93,26 @@ echo '    }' >> device.json
 echo '  ]' >> device.json
 echo '}' >> device.json
 
-#download git and its dependencies .rb package files
+#download packages
 cd $CREW_PACKAGES_PATH
-for file in git zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders pkgconfig; do
-  wget -N -c $URL/packages/$file.rb
-done
 
-#install readline for ruby
-echo y | crew install readline
+#first, download only git package
+wget -N -c $URL/packages/git.rb
+
+#check whether git provides binary package or not
+#if not, prepare to compile git from source
+GIT_BINARY_URL=`sed -e 's/#.*$//' $CREW_PACKAGES_PATH/git.rb | grep ".*$architecture:.*\(http\|https\|ftp\)://"`
+case .$GIT_BINARY_URL in
+.)
+  #download git and its dependencies .rb package files to compile git from source
+  for file in zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders pkgconfig; do
+    wget -N -c $URL/packages/$file.rb
+  done
+
+  #install readline for ruby
+  echo y | crew install readline
+  ;;
+esac
 
 #install git
 echo y | crew install git

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ GIT_BINARY_URL=`sed -e 's/#.*$//' $CREW_PACKAGES_PATH/git.rb | grep ".*$architec
 case .$GIT_BINARY_URL in
 .)
   #download git and its dependencies .rb package files to compile git from source
-  for file in zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders pkgconfig; do
+  for file in zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders pkgconfig openssl; do
     wget -N -c $URL/packages/$file.rb
   done
 

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -4,7 +4,7 @@ class Package
   property :version, :binary_url, :binary_sha1, :source_url, :source_sha1, :is_fake
   
   class << self
-    attr_reader :dependencies, :is_fake
+    attr_reader :dependencies, :rdependencies, :is_fake
     attr_accessor :name
   end
   def self.depends_on (dependency = nil)
@@ -13,6 +13,14 @@ class Package
       @dependencies << dependency
     end
     @dependencies
+  end
+
+  def self.rdepends_on (dependency = nil)
+    @rdependencies = [] unless @rdependencies
+    if dependency
+      @rdependencies << dependency
+    end
+    @rdependencies
   end
   
   def self.is_fake

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -1,11 +1,13 @@
 require 'package'
 
 class Git < Package
-  version '1.8.4'
+  version '2.11.0'
+  source_url 'https://github.com/git/git/archive/v2.11.0.tar.gz'
+  source_sha1 'ca1187843b7dd2bb3b1c5e275f04c17fa70e7100'
   binary_url ({
-    armv7l: 'https://dl.dropboxusercontent.com/s/lnz5hmjv48d14f2/git-1.8.4-chromeos-armv7l.tar.xz',
-    i686: 'https://dl.dropboxusercontent.com/s/g3binxopw5nfky1/git-1.8.4-chromeos-i686.tar.gz?token_hash=AAEWnMNBfozSIzLD1unbYGJzT4FGkEfJmLFQ-3uzydfT_A&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/i7vs9wfk94tsrzt/git-1.8.4-chromeos-x86_64.tar.gz?token_hash=AAHyvjayN7THoxlryZaxQ2Ejm9xyD6bZCqXZM81hYRC8iQ&dl=1'
+#    armv7l: 'https://dl.dropboxusercontent.com/s/lnz5hmjv48d14f2/git-1.8.4-chromeos-armv7l.tar.xz',
+#    i686: 'https://dl.dropboxusercontent.com/s/g3binxopw5nfky1/git-1.8.4-chromeos-i686.tar.gz?token_hash=AAEWnMNBfozSIzLD1unbYGJzT4FGkEfJmLFQ-3uzydfT_A&dl=1',
+#    x86_64: 'https://dl.dropboxusercontent.com/s/i7vs9wfk94tsrzt/git-1.8.4-chromeos-x86_64.tar.gz?token_hash=AAHyvjayN7THoxlryZaxQ2Ejm9xyD6bZCqXZM81hYRC8iQ&dl=1'
   })
   binary_sha1 ({
     armv7l: '084a3b9bb90c572e7c5b12aae485715f145053e5',
@@ -16,6 +18,7 @@ class Git < Package
   # compile-time dependencies
   depends_on 'zlibpkg'
   depends_on 'libssh2'
+  depends_on 'openssl'
   depends_on 'perl'
   depends_on 'curl'
   depends_on 'expat'
@@ -24,4 +27,12 @@ class Git < Package
 
   # no run-time dependency (need empty line)
   rdepends_on
+
+  def self.build
+    system "make", "prefix=/usr/local", "CC=gcc", "PERL_PATH=perl", "PYTHON_PATH=python3", "all"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "prefix=/usr/local", "CC=gcc", "PERL_PATH=perl", "PYTHON_PATH=python3", "install"
+  end
 end

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -5,14 +5,12 @@ class Git < Package
   source_url 'https://github.com/git/git/archive/v2.11.0.tar.gz'
   source_sha1 'ca1187843b7dd2bb3b1c5e275f04c17fa70e7100'
   binary_url ({
-#    armv7l: 'https://dl.dropboxusercontent.com/s/lnz5hmjv48d14f2/git-1.8.4-chromeos-armv7l.tar.xz',
-#    i686: 'https://dl.dropboxusercontent.com/s/g3binxopw5nfky1/git-1.8.4-chromeos-i686.tar.gz?token_hash=AAEWnMNBfozSIzLD1unbYGJzT4FGkEfJmLFQ-3uzydfT_A&dl=1',
-#    x86_64: 'https://dl.dropboxusercontent.com/s/i7vs9wfk94tsrzt/git-1.8.4-chromeos-x86_64.tar.gz?token_hash=AAHyvjayN7THoxlryZaxQ2Ejm9xyD6bZCqXZM81hYRC8iQ&dl=1'
+    armv7l: 'https://dl.dropboxusercontent.com/s/l6evyt7uvu8pcyb/git-2.11.0-chromeos-armv7l.tar.xz',
+    x86_64: 'https://dl.dropboxusercontent.com/s/71m9oldde6hq8f1/git-2.11.0-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: '084a3b9bb90c572e7c5b12aae485715f145053e5',
-    i686: '8c1bf4bcffb0e9c17bf20dd05981e86ea34d5d65',
-    x86_64: '067cb6c36616ac30999ab97e85f3dc0e9d1d57f4'
+    armv7l: 'd4b9da420c2e411767332b6d65cfacf1ad4e5a94',
+    x86_64: '0e2e495096c683f38bac334b4d4eb5d6381163bb',
   })
 
   # compile-time dependencies

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -13,6 +13,7 @@ class Git < Package
     x86_64: '067cb6c36616ac30999ab97e85f3dc0e9d1d57f4'
   })
 
+  # compile-time dependencies
   depends_on 'zlibpkg'
   depends_on 'libssh2'
   depends_on 'perl'
@@ -20,4 +21,7 @@ class Git < Package
   depends_on 'expat'
   depends_on 'gettext'
   depends_on 'python'
+
+  # no run-time dependency (need empty line)
+  rdepends_on
 end


### PR DESCRIPTION
This is originally promoted by @lyxell at #260.

Git itself is distributed as binary form on all architectures and it depends on several run time libraries but all of them are available on chromeos out of the box.  So, all of them required at compile time is not necessary to use it.