### PR TITLE
Add glib-2.0 library

### DIFF
--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Glib2 < Package
+class Glib < Package
   version '2.0.7'
   source_url 'https://ftp.gnome.org/pub/gnome/sources/glib/2.0/glib-2.0.7.tar.gz'
   source_sha1 '02401937a5e06d8797d966b06d9a191425cbec6f'

--- a/packages/glib2.rb
+++ b/packages/glib2.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Glib2 < Package
+  version '2.0.7'
+  source_url 'https://ftp.gnome.org/pub/gnome/sources/glib/2.0/glib-2.0.7.tar.gz'
+  source_sha1 '02401937a5e06d8797d966b06d9a191425cbec6f'
+
+  depends_on 'libffi'
+
+  def self.build
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
GLib provides the core application building blocks for libraries and applications written in C. It provides the core object system used in GNOME, the main loop implementation, and a large set of utility functions for strings and common data structures.  This is also a dependency of the sshfs command.