### PR TITLE
Add pciutils (3.5.2) package

### DIFF
--- a/packages/pciutils.rb
+++ b/packages/pciutils.rb
@@ -6,7 +6,7 @@ class Pciutils < Package
   source_sha1 '29d9a75ce2a2d92721b6e92c7c89236b4c91041f'
 
   def self.build
-    system "make", "PREFIX=/usr/local"
+    system "make", "PREFIX=/usr/local", "SHARED=yes"
   end
 
   def self.install

--- a/packages/pciutils.rb
+++ b/packages/pciutils.rb
@@ -1,0 +1,15 @@
+require 'package'
+
+class Pciutils < Package
+  version '3.5.2'
+  source_url 'https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.5.2.tar.xz'
+  source_sha1 '29d9a75ce2a2d92721b6e92c7c89236b4c91041f'
+
+  def self.build
+    system "make", "PREFIX=/usr/local"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
The PCI Utils package contains a set of programs for listing PCI
devices, inspecting their status and setting their configuration
registers.

Tested as working properly on Samsung XE50013-K01US.