### PR TITLE
Add expect (5.45) package

### DIFF
--- a/packages/expect.rb
+++ b/packages/expect.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Expect < Package
+  version '5.45'
+  source_url 'http://prdownloads.sourceforge.net/expect/expect5.45.tar.gz'
+  source_sha1 'e634992cab35b7c6931e1f21fbb8f74d464bd496'
+
+  depends_on "tcl"
+
+  def self.build
+    system "./configure", "--prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Expect is a tool for automating interactive applications such as telnet,
ftp, passwd, fsck, rlogin, tip, etc. Expect really makes this stuff
trivial. Expect is also useful for testing these same applications.

Tested as working properly on Samsung XE50013-K01US.

***NOTE:*** Requires the merge of #411 to build.