### PR TITLE
[mandb] Update post-installation message to include missing step

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -24,6 +24,8 @@ class Mandb < Package
     puts ""
     puts "You will have to change the default PAGER env variable to be able to use mandb:"
     puts "echo \"export PAGER=/usr/local/bin/less\" >> ~/.bashrc && . ~/.bashrc"
+    puts ""
+    puts "You will also have to set the MANPATH env variable:"
+    puts "echo \"export MANPATH/usr/local/man:$MANPATH\" >> ~/.bashrc && ~/.bashrc"
   end
-
 end


### PR DESCRIPTION
Quite a few packages install manpages into /usr/local/man/ which is not
included in the default MANPATH. Users will need to update their
environment to include this in the search path after installing the
mandb package.