### PR TITLE
Add tinycc (0.9.26) package

### DIFF
--- a/packages/tinycc.rb
+++ b/packages/tinycc.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Tinycc < Package
+  version '0.9.26'
+  source_url 'http://download.savannah.gnu.org/releases/tinycc/tcc-0.9.26.tar.bz2'
+  source_sha1 '7110354d3637d0e05f43a006364c897248aed5d0'
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
TinyCC (aka TCC) is a small but hyper fast C compiler.

Tested as working properly on Samsung XE50013-K01US.