### PR TITLE
Add gc (7.2g) package

### DIFF
--- a/packages/gc.rb
+++ b/packages/gc.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Gc < Package
+  version '7.2g'
+  source_url 'http://www.hboehm.info/gc/gc_source/gc-7.2g.tar.gz'
+  source_sha1 'd470f6c0dcb55f8a4f26199731edf006eba5b85c'
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
gc is also known as the Boehm-Demers-Weiser conservative garbage
collector. This is a dependency for multiple developer tools that I am
creating packages for.

Tested as working properly on Samsung XE50013-K01US.