### PR TITLE
[tree] Fix missing package meta

### DIFF
--- a/packages/tree.rb
+++ b/packages/tree.rb
@@ -7,6 +7,8 @@ class Tree < Package
 
   def self.build
     system "sed -i 's,/usr,/usr/local,g' Makefile"
+    system "sed -i '25s,=,=$(DESTDIR),' Makefile"
+    system "sed -i '27s,=,=$(DESTDIR),' Makefile"
     system "make"
   end
 


### PR DESCRIPTION
The Makefile was not honoring DEST_DIR resulting in empty .filelist and
.directorylist metadata files.