### PR TITLE
Add attr (2.4.47) package

### DIFF
--- a/packages/attr.rb
+++ b/packages/attr.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Attr < Package
+  version '2.4.47'
+  source_url 'http://download.savannah.gnu.org/releases/attr/attr-2.4.47.src.tar.gz'
+  source_sha1 '5060f0062baee6439f41a433325b8b3671f8d2d8'
+
+  def self.build
+    system "./configure --prefix=/usr/local --disable-static"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-dev"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-lib"
+  end
+end


### PR DESCRIPTION
The attr package contains utilities to administer the extended
attributes on filesystem objects.

Tested as working properly on Samsung XE50013-K01US.