### PR TITLE
Add acl (2.2.52) package

### DIFF
--- a/packages/acl.rb
+++ b/packages/acl.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Acl < Package
+  version '2.2.52'
+  source_url 'http://download.savannah.gnu.org/releases/acl/acl-2.2.52.src.tar.gz'
+  source_sha1 '537dddc0ee7b6aa67960a3de2d36f1e2ff2059d9'
+
+  depends_on "attr"
+
+  def self.build
+    system "./configure --prefix=/usr/local --libexecdir=/usr/local/lib --disable-static"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-dev"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-lib"
+  end
+end


### PR DESCRIPTION
The acl package contains utilities to administer Access Control Lists, which
are used to define more fine-grained discretionary access rights for
files and directories.

Tested as working properly on Samsung XE50013-K01US.

***NOTE***: Requires merge of #422 to build and install.