### PR TITLE
Add libarchive (3.2.2) package

### DIFF
--- a/packages/libarchive.rb
+++ b/packages/libarchive.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Libarchive < Package
+  version '3.2.2'
+  source_url 'http://www.libarchive.org/downloads/libarchive-3.2.2.tar.gz'
+  source_sha1 'ccf14e3b4ec7c6b242cf07062dd40e82a17485a5'
+
+  depends_on "acl"
+  depends_on "attr"
+  depends_on "lz4"
+
+  def self.build
+    system "./configure --prefix=/usr/local --disable-static"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
Add libarchive (3.2.2) package

The libarchive library provides a single interface for reading/writing
various compression formats.

Tested as working properly on Samsung XE50013-K01US.

```bash
  PASS: libarchive_test
  PASS: bsdtar_test
  PASS: bsdcpio_test
  PASS: bsdcat_test
  ============================================================================
  Testsuite summary for libarchive 3.2.2
  ============================================================================
  # TOTAL: 4
  # PASS:  4
  # SKIP:  0
  # XFAIL: 0
  # FAIL:  0
  # XPASS: 0
  # ERROR: 0
  ============================================================================
  make[3]: Leaving directory `/usr/local/tmp/libarchive-3.2.2'
  make[2]: Leaving directory `/usr/local/tmp/libarchive-3.2.2'
  make[1]: Leaving directory `/usr/local/tmp/libarchive-3.2.2'
```

***NOTE:*** This requires #426, #423 and #422 to build and install.