### PR TITLE
Change to use -j option in make to reduce the compile time

### DIFF
--- a/crew
+++ b/crew
@@ -15,6 +15,13 @@ CREW_CONFIG_PATH = CREW_PREFIX + '/etc/crew/'
 CREW_BREW_DIR = CREW_PREFIX + '/tmp/crew/'
 CREW_DEST_DIR = CREW_BREW_DIR + '/dest'
 
+# Set CREW_NPROC from environment variable or `nproc`
+if ENV["CREW_NPROC"].to_s == ''
+  CREW_NPROC = `nproc`.strip
+else
+  CREW_NPROC = ENV["CREW_NPROC"]
+end
+
 ARCH = `uname -m`.strip
 #SHORTARCH = `getconf LONG_BIT`.strip # will refactor this line in the future
 case ARCH

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -33,6 +33,14 @@ class Package
       args = args.map {|s| s.gsub("-m32", "")}
       args = args.map {|s| s.gsub("lib32", "lib")}
     end
+    # add "-j#{CREW_NPROC}" argument to "make"
+    if args[0] == "make"
+      # modify ["make", "args", ...] into ["make", "-j#{CREW_NPROC}", "args", ...]
+      args.insert(1, "-j#{CREW_NPROC}")
+    elsif args.length == 1
+      # modify ["make args..."] into ["make -j#{CREW_NPROC} args..."]
+      args[0].gsub!(/^make /, "make -j#{CREW_NPROC} ")
+    end
     Kernel.system(*args)
     exitstatus = $?.exitstatus
     raise InstallError.new("`#{args.join(" ")}` exited with #{exitstatus}") unless exitstatus == 0


### PR DESCRIPTION
Discussed in #362.  Php7 compile time is only 16 min after applying this.  It took 30 min before.

Users can specify their own usage of multiple cores by CREW_NPROC environment variable.  If a user sets it 2, crew uses only 2 cores.