### PR TITLE
Add ncdu (1.12) package

### DIFF
--- a/packages/ncdu.rb
+++ b/packages/ncdu.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Ncdu < Package
+  version '1.12'
+  source_url 'https://dev.yorhel.nl/download/ncdu-1.12.tar.gz'
+  source_sha1 'b79b1c44784f334dca74d89a49f49274f14cfeef'
+
+  depends_on "ncurses_so"
+
+  def self.build
+    system "./configure --prefix=/usr/local CPPFLAGS=-I/usr/local/include/ncurses"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
ncdu (NCurses Disk Usage) is a curses-based version of the well-known
'du', and provides a fast way to see what directories are using your
disk space.

Tested as working properly on Samsung XE50013-K01US.