### PR TITLE
Change to use xz and specify xz compression option in create_package.sh

### DIFF
--- a/create_package.sh
+++ b/create_package.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 DIRNAME=${PWD##*/}
 
+XZ_OPT=${XZ_OPT-"-7e"}
+export XZ_OPT
+
 echo creating file list
 find . -type f > ../filelist && find . -type l >> ../filelist && cut -c2- ../filelist > filelist
 
@@ -11,8 +14,8 @@ echo removing temporary files
 rm dlistcut ../dlist ../filelist
 
 echo building binary package
-tar -czf ../$DIRNAME.tar.gz *
-sha1sum ../$DIRNAME.tar.gz > ../$DIRNAME.tar.gz.sha1
+tar -cJf ../$DIRNAME.tar.xz *
+sha1sum ../$DIRNAME.tar.xz > ../$DIRNAME.tar.xz.sha1
 
 echo finished
-cat ../$DIRNAME.tar.gz.sha1
+cat ../$DIRNAME.tar.xz.sha1


### PR DESCRIPTION
Change create_package.sh to use xz for better compression.  For the extraction, no modification is needed since tar automatically detect tar file format.  This also specifies the default compression level for better compression.