### PR TITLE
Add unrar (5.4.5) package

### DIFF
--- a/packages/unrar.rb
+++ b/packages/unrar.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Unrar < Package
+  version '5.4.5'
+  source_url 'http://www.rarlab.com/rar/unrarsrc-5.4.5.tar.gz'
+  source_sha1 '1590aec535792def68710dad7b73d5522e50c971'
+
+  def self.build
+    system "sed -i '145s,$,/libunrar.so,' makefile" # fix naming mistake
+    system "sed -i '145s,install,install -D,' makefile" # create directory
+    system "make", "all"
+    system "make", "lib"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-lib"
+  end
+end


### PR DESCRIPTION
The UnRar package contains a RAR extraction utility used for extracting
files from RAR archives. RAR archives are usually created with WinRAR,
primarily in a Windows environment.

Tested as working on Samsung XE50013-K01US. No test suite exists for
unrar.