### PR TITLE
Add iftop (0.17) package

### DIFF
--- a/packages/iftop.rb
+++ b/packages/iftop.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Iftop < Package
+  version '0.17'
+  source_url 'http://www.ex-parrot.com/pdw/iftop/download/iftop-0.17.tar.gz'
+  source_sha1 '75ce6afc8c0bf851278b0a15e66f523af90cfda9'
+
+  depends_on "libpcap"
+  depends_on "ncurses"
+
+  def self.build
+    system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncurses"'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
iftop does for network usage what top(1) does for CPU usage. It listens
to network traffic on a named interface and displays a table of current
bandwidth usage by pairs of hosts. Handy for answering the question "why
is our ADSL link so slow?".

Tested as working on Samsung XE50013-K01US. No test suite for iftop.