### PR TITLE
Add optipng (0.7.6) package

### DIFF
--- a/packages/optipng.rb
+++ b/packages/optipng.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Optipng < Package
+  version '0.7.6'
+  source_url 'http://prdownloads.sourceforge.net/optipng/optipng-0.7.6.tar.gz'
+  source_sha1 '3b3e31430e735589470c4af204354d38823f4989'
+
+  # NOTE: uses libpng and zlib but uses its own versions of those libraries
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
The OptiPNG program shall attempt to optimize PNG files, i.e. reduce
theiz size to a minimum, without losing semantic information. In addi-
tion, this program shall perform a suite of auxiliary functions like
integrity checks, metadata recovery and pixmap-to-PNG conversion.

Tested as working on Samsung XE50013-K01US.

All tests passed.
https://gist.github.com/cstrouse/bb6a59a0f59348a45721f389bcd9ee53