### PR TITLE
Add figlet (2.2.5) package

### DIFF
--- a/packages/figlet.rb
+++ b/packages/figlet.rb
@@ -1,0 +1,15 @@
+require 'package'
+
+class Figlet < Package
+  version '2.2.5'
+  source_url 'ftp://ftp.figlet.org/pub/figlet/program/unix/figlet-2.2.5.tar.gz'
+  source_sha1 'dda696958c161bd71d6590152c94c4f705415727'
+
+  def self.build
+    system "make", "PREFIX=/usr/local"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
FIGlet is a program for making large letters out of ordinary text.

Tested as working on Samsung XE50013-K01US.

All tests pass.
https://gist.github.com/cstrouse/fe0c07877dfa06ed4c5594acc276b04f