### PR TITLE
Add libedit (3.1) package

### DIFF
--- a/packages/libedit.rb
+++ b/packages/libedit.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Libedit < Package
+  version '3.1'
+  source_url 'http://thrysoee.dk/editline/libedit-20160903-3.1.tar.gz'
+  source_sha1 '55e327ee4661b13d20ebb411d790f2bb258271cf'
+
+  def self.build
+    system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncurses"'
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
This is an autotool- and libtoolized port of the NetBSD Editline library
(libedit). This Berkeley-style licensed command line editor library
provides generic line editing, history, and tokenization functions,
similar to those found in GNU Readline.

Tested as working on Samsung XE50013-K01US. No tests for libedit.