### PR TITLE
Add dstat (0.7.3) package

### DIFF
--- a/packages/dstat.rb
+++ b/packages/dstat.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Dstat < Package
+  version '0.7.3'
+  source_url 'https://github.com/dagwieers/dstat/archive/0.7.3.tar.gz'
+  source_sha1 '1e410412a1f53b7be5292354e815785f480fd0e5'
+
+  depends_on "python27"
+
+  def self.build
+  end
+
+  def self.install
+    system "make", "prefix=/usr/local", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
Dstat is a versatile replacement for vmstat, iostat, netstat and ifstat.
Dstat overcomes some of their limitations and adds some extra features,
more counters and flexibility. Dstat is handy for monitoring systems
during performance tuning tests, benchmarks or troubleshooting.

Tested as working on Samsung XE50013-K01US.