### PR TITLE
Change crew to use same logic for zip and tar

### DIFF
--- a/crew
+++ b/crew
@@ -13,7 +13,7 @@ CREW_PREFIX = '/usr/local'
 CREW_LIB_PATH = CREW_PREFIX + '/lib/crew/'
 CREW_CONFIG_PATH = CREW_PREFIX + '/etc/crew/'
 CREW_BREW_DIR = CREW_PREFIX + '/tmp/crew/'
-CREW_DEST_DIR = CREW_BREW_DIR + '/dest'
+CREW_DEST_DIR = CREW_BREW_DIR + 'dest'
 
 # Set CREW_NPROC from environment variable or `nproc`
 if ENV["CREW_NPROC"].to_s == ''
@@ -185,6 +185,76 @@ def download
   return {source: source, filename: filename}
 end
 
+def unpack (meta)
+  extract_dir = "#{meta[:filename]}.dir"
+  target_dir = nil
+  Dir.chdir CREW_BREW_DIR do
+    puts "Unpacking archive, this may take a while..."
+    Dir.mkdir("#{extract_dir}") unless Dir.exist?("#{extract_dir}")
+    if meta[:filename][-4,4] == ".zip"
+      system "unzip", "-qq", "-d", "#{extract_dir}", meta[:filename]
+    else
+      system "tar", "xf", meta[:filename], "-C", "#{extract_dir}"
+    end
+    if meta[:source] == true
+      # Check the number of directories in the archive
+      entries=Dir["#{extract_dir}/*/"]
+      if entries.length == 1
+        # Use `extract_dir/dir_in_archive` if there is only one directory.
+        #  FIXME: need to support archives having Makefile and one src directory.
+        target_dir = entries.first
+      else
+        # Use `extract_dir` otherwise
+        target_dir = extract_dir
+      end
+    else
+      # Use `extract_dir` for binary distribution
+      target_dir = extract_dir
+    end
+  end
+  return CREW_BREW_DIR + target_dir
+end
+
+def build_and_preconfigure (target_dir)
+  Dir.chdir target_dir do
+    puts "Building from source, this may take a while..."
+    @pkg.build
+    system "rm -rf", CREW_DEST_DIR + "/*" #wipe crew destdir
+    puts "Preconfiguring package..."
+    @pkg.install
+  end
+end
+
+def prepare_packaging (destdir)
+  Dir.chdir destdir do
+    #create directory list
+    system "find . -type f > ../filelist"
+    system "find . -type l >> ../filelist"
+    system "cut -c2- ../filelist > filelist"
+    #create file list
+    system "find . -type d > ../dlist"
+    system "cut -c2- ../dlist > dlistcut"
+    system "tail -n +2 dlistcut > dlist"
+    #remove temporary files
+    system "rm dlistcut ../dlist ../filelist"
+  end
+end
+
+def pkg_install (pkgdir)
+  Dir.chdir pkgdir do
+    FileUtils.mv 'dlist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.directorylist"
+    FileUtils.mv 'filelist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.filelist"
+
+    File.open(CREW_CONFIG_PATH + "meta/#{@pkg.name}.directorylist").each_line do |line|
+      system "sudo", "mkdir", "-p", line.chomp
+    end
+
+    File.open(CREW_CONFIG_PATH + "meta/#{@pkg.name}.filelist").each_line do |line|
+      system "sudo", "mv", pkgdir + line.chomp, line.chomp
+    end
+  end
+end
+
 def resolveDependenciesAndInstall
   begin
     origin = @pkg.name
@@ -261,81 +331,27 @@ def install
 
   unless @pkg.is_fake?
     meta = download
-    topdir = ""
-    Dir.chdir CREW_BREW_DIR do
-      puts "Unpacking archive, this may take a while..."
-      if meta[:filename][-4,4] == ".zip"
-        system "unzip", "-qq", "-d", "tmpzip", meta[:filename]
-      else
-        system "tar", "xf", meta[:filename]
-      end
-      if meta[:source] == true
-        abort "You don't have a working C compiler. Run 'crew install buildessential' to get one and try again." unless system("gcc", "--version")
-        if meta[:filename][-4,4] == ".zip"
-          Dir.chdir "tmpzip" do
-            entries=Dir["*"]
-            if entries.length == 0
-              abort "empty zip archive: #{meta[:filename]}"
-            elsif entries.length == 1
-              topdir = "tmpzip/" + entries.first
-            else 
-              topdir = "tmpzip/"
-            end
-          end
-        else
-          topdir = `tar -tf #{meta[:filename]} | sed -e 's@/.*@@' | uniq`.chomp!
-        end
-        Dir.chdir CREW_BREW_DIR + topdir do
-          puts "Building from source, this may take a while..."
-          @pkg.build
-          system "rm -rf", CREW_DEST_DIR + "/*" #wipe crew destdir
-          puts "Preconfiguring package..."
-          @pkg.install
-        end
+    target_dir = unpack meta
+    if meta[:source] == true
+      abort "You don't have a working C compiler. Run 'crew install buildessential' to get one and try again." unless system("gcc", "--version")
 
-        Dir.chdir CREW_DEST_DIR do
-          #create directory list
-          system "find . -type f > ../filelist"
-          system "find . -type l >> ../filelist"
-          system "cut -c2- ../filelist > filelist"
-          #create file list
-          system "find . -type d > ../dlist"
-          system "cut -c2- ../dlist > dlistcut"
-          system "tail -n +2 dlistcut > dlist"
-          #remove temporary files
-          system "rm dlistcut ../dlist ../filelist"
-          
-          #create resulting folders list
-          directories = []
-          Dir.glob('*').select do |fn|
-            if File.directory?(fn)
-              directories.push(fn)
-            end
-          end
+      # build from source and place binaries at CREW_DEST_DIR
+      # CREW_DEST_DIR contains usr/local/... hierarchy
+      build_and_preconfigure target_dir
 
-          #wipe directories with the same name in brew dir to avoid conflicts
-          directories.each do |dir|
-            system "rm -rf ../" + dir.chomp
-          end
+      # prepare filelist and dlist at CREW_DEST_DIR
+      prepare_packaging CREW_DEST_DIR
 
-          #move result files and directories to brew dir
-          system "mv * ../"
-        end
-      end
-
-      puts "Installing..."
-
-      FileUtils.mv 'dlist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.directorylist"
-      FileUtils.mv 'filelist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.filelist"
- 
-      File.open(CREW_CONFIG_PATH + "meta/#{@pkg.name}.directorylist").each_line do |line|
-        system "sudo", "mkdir", "-p", line.chomp
-      end
-
-      File.open(CREW_CONFIG_PATH + "meta/#{@pkg.name}.filelist").each_line do |line|
-        system "sudo", "mv", CREW_BREW_DIR + line.chomp, line.chomp
-      end
+      # use CREW_DEST_DIR
+      dest_dir = CREW_DEST_DIR
+    else
+      # use extracted binary directory
+      dest_dir = target_dir
     end
+
+    # install filelist, dlist and binary files
+    puts "Installing..."
+    pkg_install dest_dir
   end
   
   #add to installed packages

--- a/crew
+++ b/crew
@@ -225,7 +225,7 @@ def build_and_preconfigure (target_dir)
   end
 end
 
-def prepare_packaging (destdir)
+def prepare_package (destdir)
   Dir.chdir destdir do
     #create directory list
     system "find . -type f > ../filelist"
@@ -240,7 +240,7 @@ def prepare_packaging (destdir)
   end
 end
 
-def pkg_install (pkgdir)
+def install_package (pkgdir)
   Dir.chdir pkgdir do
     FileUtils.mv 'dlist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.directorylist"
     FileUtils.mv 'filelist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.filelist"
@@ -340,7 +340,7 @@ def install
       build_and_preconfigure target_dir
 
       # prepare filelist and dlist at CREW_DEST_DIR
-      prepare_packaging CREW_DEST_DIR
+      prepare_package CREW_DEST_DIR
 
       # use CREW_DEST_DIR
       dest_dir = CREW_DEST_DIR
@@ -351,7 +351,7 @@ def install
 
     # install filelist, dlist and binary files
     puts "Installing..."
-    pkg_install dest_dir
+    install_package dest_dir
   end
   
   #add to installed packages

--- a/crew
+++ b/crew
@@ -130,7 +130,6 @@ def upgrade
     end
     
     if currentVersion != @pkg.version
-      search @pkg.name
       puts "Updating #{@pkg.name}..."
       remove @pkg.name
       resolveDependenciesAndInstall

--- a/crew
+++ b/crew
@@ -198,10 +198,11 @@ def unpack (meta)
     end
     if meta[:source] == true
       # Check the number of directories in the archive
-      entries=Dir["#{extract_dir}/*/"]
-      if entries.length == 1
+      entries=Dir["#{extract_dir}/*"]
+      if entries.length == 0
+        abort "empty archive: #{meta[:filename]}"
+      elsif entries.length == 1 && File.directory?(entries.first)
         # Use `extract_dir/dir_in_archive` if there is only one directory.
-        #  FIXME: need to support archives having Makefile and one src directory.
         target_dir = entries.first
       else
         # Use `extract_dir` otherwise

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -10,14 +10,14 @@ class Llvm < Package
 
   def self.build
     system "mkdir mybuilddir"
-    Dir.chdir CREW_BREW_DIR+"llvm-"+version+".src/mybuilddir" do
+    Dir.chdir "mybuilddir" do
  	system "cmake .."
     	system "cmake --build ."
     end
   end
 
   def self.install
-    Dir.chdir CREW_BREW_DIR+"llvm-"+version+".src/mybuilddir" do
+    Dir.chdir "mybuilddir" do
        system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_DIR}/usr/local -P cmake_install.cmake"
     end  
   end

--- a/packages/nethack4.rb
+++ b/packages/nethack4.rb
@@ -14,7 +14,7 @@ class Nethack4 < Package
 
   
   def self.build
-    target=CREW_BREW_DIR+"nethack4-4.3-beta2/build"
+    target="build"
     system "mkdir -p " + target
     Dir.chdir target  do
       #build with rpath pointing at /usr/local
@@ -24,7 +24,7 @@ class Nethack4 < Package
   end
   
   def self.install
-    target=CREW_BREW_DIR+"nethack4-4.3-beta2/build"
+    target="build"
     Dir.chdir target  do
       #install in destdir so package manager can keep track
       system "/usr/local/bin/perl ../aimake --install-only -i #{CREW_DEST_DIR}/usr/local/ --directory-layout=prefix --without=gui"  


### PR DESCRIPTION
This PR is originally created to compile lshw #400 as we discussed in #394.  This PR will replace #399.

This PR has relations to #276 and #284 also.  I refactor crew carefully, so I think I'm not breaking #276.  But who knows, please test this PR carefully.  Thanks.

I tested on X86_64 using following scenarios.

- lshw #400, as a test of tar file containing files at top  (EDIT: need modification after https://github.com/skycocker/chromebrew/pull/443/commits/0c435ec6dd56fae1df3ffbf3086415e7ed723b66)
- perl, as a test of binary package
- automake and m4 as a test of multiple package installation at once
- Makefile.zip #276 as a test of zip file without directories inside
- a.zip #276 as a test of zip file with top directory