### PR TITLE
Add screenfetch (3.7.0) package

### DIFF
--- a/packages/screenfetch.rb
+++ b/packages/screenfetch.rb
@@ -1,0 +1,15 @@
+require 'package'
+
+class Screenfetch < Package
+  version '3.7.0'
+  source_url 'https://github.com/KittyKatt/screenFetch/archive/v3.7.0.tar.gz'
+  source_sha1 '5a3702504e154335e372df56e4cb621840dc5506'
+
+  def self.build
+  end
+
+  def self.install
+    system "install -D screenfetch-dev #{CREW_DEST_DIR}/usr/local/bin/screenfetch"
+    system "install -D screenfetch.1 #{CREW_DEST_DIR}/usr/local/man/man1/screenfetch.1"
+  end
+end


### PR DESCRIPTION
screenFetch is a "Bash Screenshot Information Tool".

Tested as working on Samsung XE50013-K01US.

They haven't tagged a release in a while but I have an issue opened for a new release and it's been assigned to someone. Also, I just had a [PR merged ](https://github.com/KittyKatt/screenFetch/pull/435)a few minutes ago that adds proper support for CrOS with Chromebrew installed.

Output looks as such on 3.7.0:
https://drive.google.com/open?id=0ByyabEwPOsBLNGpYcG43S1F6QzA

Output will look as such when 3.7.1 is tagged:
https://drive.google.com/open?id=0ByyabEwPOsBLZGNJT3RYa25LNTA