### PR TITLE
Update tig to 2.2.1

### DIFF
--- a/packages/tig.rb
+++ b/packages/tig.rb
@@ -1,15 +1,16 @@
 require 'package'                                                      	# include package class file
  
 class Tig < Package                                            	# name the package and make it a Package class instance
-  version '1.9a'                                               	                                      # software version
-  source_url 'http://jonas.nitro.dk/tig/releases/tig-2.0.2.tar.gz'     # software source tarball url
-  source_sha1 'de01c3a52952172e42ae642d97a55505d7e09efd'          	# source tarball sha1 sum
+  version '2.2.1'                                               	                                      # software version
+  source_url 'https://github.com/jonas/tig/archive/tig-2.2.1.tar.gz'     # software source tarball url
+  source_sha1 '704e35ad3f54024d7ce14dade4294aacc0744b3d'          	# source tarball sha1 sum
   
   depends_on 'readline'                                            # software dependencies
   depends_on 'ncurses'
   
   def self.build                                                  # self.build contains commands needed to build the software from source
-    system "CPPFLAGS=-I/usr/local/include/ncurses ./configure"
+    system "./autogen.sh"
+    system "./configure", "--prefix=/usr/local"
     system "make"                                                 # ordered chronologically
   end
   


### PR DESCRIPTION
Now uses autogen.sh and correctly finds ncurses without explictly
passing an include path to CPPFLAGS.

Tested as working on Samsung XE50013-K01US.

All tests passing.
https://gist.github.com/cstrouse/bb84f4f4d1405d4c990261ce0ff04a5e