### PR TITLE
Add slang (2.3.1a) package

### DIFF
--- a/packages/slang.rb
+++ b/packages/slang.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Slang < Package
+  version '2.3.1a'
+  source_url 'http://www.jedsoft.org/releases/slang/slang-2.3.1a.tar.bz2'
+  source_sha1 'a8ea7f1b5736160a94efb67b137a0f5b9916bdf2'
+
+  def self.build
+    system "./configure", "--prefix=/usr/local", "--without-x"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
S-Lang (slang) is an interpreted language that may be embedded into an
application to make the application extensible. It provides facilities
required by interactive applications such as display/screen management,
keyboard input and keymaps.

Tested as working on Samsung XE50013-K01US.