### PR TITLE
Add libuv (1.9.1) package

### DIFF
--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Libuv < Package
+  version '1.9.1'
+  source_url 'http://dist.libuv.org/dist/v1.9.1/libuv-v1.9.1.tar.gz'
+  source_sha1 '668d636372e3276aecc6082082a86f86ddb67877'
+
+  depends_on 'glibc'
+
+  def self.build
+    system './autogen.sh'
+    system './configure --prefix=/usr/local'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
libuv is a multi-platform support library with a focus on asynchronous
I/O.

Tested as working on Samsung XE50013-K01US.

`make check` had a few failures but they seem mostly from CrOS not having some of the features that the tests were exercising. Library appears to function properly in all aspects.

https://gist.github.com/cstrouse/a67b1d0a27f3cb8c11058240cc058ab2