### PR TITLE
Update bacon to 3.5.1

### DIFF
--- a/packages/bacon.rb
+++ b/packages/bacon.rb
@@ -1,12 +1,14 @@
 require 'package'
 
 class Bacon < Package
-  version '3.5'
-  source_url 'http://www.basic-converter.org/stable/bacon-3.5.tar.gz'
-  source_sha1 '878da51d1f8bef9baea6523be8f09d8a616f8e9f'
+  version '3.5.1'
+  source_url 'http://www.basic-converter.org/stable/bacon-3.5.1.tar.gz'
+  source_sha1 '13a90fa76a07edf36e4a4e5b242b60479a0eccc3'
 
   def self.build
-    system "./configure --prefix=/usr/local"
+    system "./configure --prefix=/usr/local --without-gui"
+    system 'sed -i "45s,/usr/share,/usr/local/share," Makefile'
+    system 'sed -i "46s,/usr/share,/usr/local/share," Makefile'
     system "make"
   end
 


### PR DESCRIPTION
This also disables the unnecessary GUI builder and fixes a problem with
the syntax highlighter.

Tested as working on Samsung XE50013-K01US.