### PR TITLE
Update toolchains

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,7 @@ echo '}' >> device.json
 
 #download git and its dependencies .rb package files
 cd $CREW_PACKAGES_PATH
-for file in git zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make mpc mpfr gmp glibc linuxheaders pkgconfig; do
+for file in git zlibpkg libssh2 perl curl expat gettext python readline ruby buildessential gcc binutils make isl cloog mpc mpfr gmp glibc linuxheaders pkgconfig; do
   wget -N -c $URL/packages/$file.rb
 done
 

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -1,15 +1,15 @@
 require 'package'
 
 class Binutils < Package
-  version '2.23.2'
+  version '2.25'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/jkaqtj356gmh5un/binutils-2.25-chromeos-armv7l.tar.xz",
-    i686: 'https://dl.dropboxusercontent.com/s/u3cp7mpdyfx99ij/binutils-2.23.2-chromeos-i686.tar.gz?token_hash=AAGsFB9HXNb5tSAm_Wd2GyIUL59BkZYgMTHkj4CkHLxggg&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/mnu21v101rdbm8k/binutils-2.23.2-chromeos-x86_64.tar.gz?token_hash=AAEn4ngAJs-fpRUz1n1Q_2WKxQvQnPMwlgcEHBDKyLOpoA&dl=1'
+    armv7l: "https://dl.dropboxusercontent.com/s/5pbtdh0l4wfl1jv/binutils-2.25-chromeos-armv7l.tar.xz",
+    i686: "https://dl.dropboxusercontent.com/s/lufy9gv15q2ut5i/binutils-2.25-chromeos-i686.tar.xz",
+    x86_64: "https://dl.dropboxusercontent.com/s/4p9cmf7wapd8l8m/binutils-2.25-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
-    armv7l: "60d855c14c2ffb6fd9a486a6284c1b888cbe04ab",
-    i686: 'a7edc9bdaf9fc72112fe6b370f158a9a1aee87ac',
-    x86_64: '1c13b8f261e419a66b87f09653f3fbaf8449efe1'
+    armv7l: "d4b42e13b4e4ed87c0f7a449b067b5f42345b7d8",
+    i686: "bc686fd29b9e9588a6f4f37c619dba217afb9bc3",
+    x86_64: "3ca5e6940c47385456f96861b169f925543f08b3",
   })
 end

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,9 +3,9 @@ require 'package'
 class Binutils < Package
   version '2.25'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/5pbtdh0l4wfl1jv/binutils-2.25-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/lufy9gv15q2ut5i/binutils-2.25-chromeos-i686.tar.xz",
-    x86_64: "https://dl.dropboxusercontent.com/s/4p9cmf7wapd8l8m/binutils-2.25-chromeos-x86_64.tar.xz",
+    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-chromeos-armv7l.tar.xz",
+    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-chromeos-i686.tar.xz",
+    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
     armv7l: "d4b42e13b4e4ed87c0f7a449b067b5f42345b7d8",

--- a/packages/cloog.rb
+++ b/packages/cloog.rb
@@ -1,0 +1,15 @@
+require 'package'
+
+class Cloog < Package
+  version "0.18.4"
+  binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/0p5izfn5efelsap/cloog-0.18.4-chromeos-armv7l.tar.xz",
+    i686: "https://dl.dropboxusercontent.com/s/s0sggb68zz0xbpd/cloog-0.18.4-chromeos-i686.tar.xz",
+    x86_64: "https://dl.dropboxusercontent.com/s/hsdct4dbn9ck5q7/cloog-0.18.4-chromeos-x86_64.tar.xz",
+  })
+  binary_sha1 ({
+    armv7l: "919798d4329b96aa33374fe460d95e6e485b00c2",
+    i686: "7f37371de5d5f7eeaf13fe93fc664ecd6daadb25",
+    x86_64: "33d18076f6ca5b5c56e7908368b87d137355696a",
+  })
+end

--- a/packages/cloog.rb
+++ b/packages/cloog.rb
@@ -3,9 +3,9 @@ require 'package'
 class Cloog < Package
   version "0.18.4"
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/0p5izfn5efelsap/cloog-0.18.4-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/s0sggb68zz0xbpd/cloog-0.18.4-chromeos-i686.tar.xz",
-    x86_64: "https://dl.dropboxusercontent.com/s/hsdct4dbn9ck5q7/cloog-0.18.4-chromeos-x86_64.tar.xz",
+    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-armv7l.tar.xz",
+    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-i686.tar.xz",
+    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
     armv7l: "919798d4329b96aa33374fe460d95e6e485b00c2",

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -4,9 +4,9 @@ class Gcc < Package
   version '4.9.x'
 
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/2hrsqpcjb2u4u7p/gcc-4.9.x-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/stk2hrehuhd3uki/gcc-4.9.x-chromeos-i686.tar.xz",
-    x86_64: "https://dl.dropboxusercontent.com/s/386g6diaxdkfm96/gcc-4.9.x-chromeos-x86_64.tar.xz",
+    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-armv7l.tar.xz",
+    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-i686.tar.xz",
+    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
     armv7l: "267d2d6647af07805a7a8f5dabbb88ec31ff8db0",

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -1,22 +1,24 @@
 require 'package'
 
 class Gcc < Package
-  version '4.8.1-baseline'
+  version '4.9.x'
 
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/b0zmlefc40ddgvn/gcc-4.9.x-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/c06pcge8ogsqfcd/gcc-4.8.1-baseline-chromeos-i686.tar.gz?token_hash=AAFLnE_8iL_lAnGtAAVM5G_sYqejA44jGW8D9r0a8xCjrQ&dl=1",
-    x86_64: "https://dl.dropboxusercontent.com/s/kk52ic170je87fc/gcc-4.8.1-baseline-chromeos-x86_64.tar.gz?token_hash=AAGcQBSj1y8OfHXUhsayxlFfvk4LRszY07ehx_Z6UoyNEg&dl=1"
+    armv7l: "https://dl.dropboxusercontent.com/s/2hrsqpcjb2u4u7p/gcc-4.9.x-chromeos-armv7l.tar.xz",
+    i686: "https://dl.dropboxusercontent.com/s/stk2hrehuhd3uki/gcc-4.9.x-chromeos-i686.tar.xz",
+    x86_64: "https://dl.dropboxusercontent.com/s/386g6diaxdkfm96/gcc-4.9.x-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
-    armv7l: "a3c0465b7664057f132f6fd5d65c4dcd75590b57",
-    i686: "d720c9a804d26728d730b93748072ffa6df7ee3d",
-    x86_64: "59932a73cd149ae82b4b5c277b734788c1efab44"
+    armv7l: "267d2d6647af07805a7a8f5dabbb88ec31ff8db0",
+    i686: "904b4666a326505bd7546231a9273a4aa47e30f0",
+    x86_64: "c044e84073b2457079e611e2f27fd54b5e502e9a",
   })
 
   depends_on 'binutils'
   depends_on 'gmp'
-  depends_on 'mpc'
   depends_on 'mpfr'
+  depends_on 'mpc'
+  depends_on 'isl'
+  depends_on 'cloog'
   depends_on 'glibc'
 end

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -1,15 +1,15 @@
 require 'package'
 
 class Glibc < Package
-  version '2.17.90-baseline'
+  version '2.19'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/18kk32dzt17mxnu/glibc-2.19-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/dic47f8eqxhpf89/glibc-2.17.90-baseline-chromeos-i686.tar.gz?token_hash=AAHx_77YtWLLnkjCJRaCJt7RsdKrfkT6lgKS9BZc4O-0Pg&dl=1",
-    x86_64: "https://dl.dropboxusercontent.com/s/x3tu160i7pmn6tp/glibc-2.17-baseline-chromeos-x86_64.tar.gz?token_hash=AAG794JG65HjzHMcAyAysQUbEPMUci1bZJPREj3ztCtnBg&dl=1"
+    armv7l: "https://dl.dropboxusercontent.com/s/mtql9jcvct11tsi/glibc-2.19-chromeos-armv7l.tar.xz",
+    i686: "https://dl.dropboxusercontent.com/s/fr8msjl41euauyp/glibc-2.19-chromeos-i686.tar.xz",
+    x86_64: "https://dl.dropboxusercontent.com/s/ow8hg6zuww1n7s2/glibc-2.19-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
-    armv7l: "fd1ce2302b806a7ebdb4147bc89e0a29bcd90325",
-    i686: "3c3a0b86ed4591ec59daeb24d2dcda139574de1b",
-    x86_64: "d818775f74d91692828f12321044cd95fc649cf0"
+    armv7l: "c4da258eacf411833494bbe6903918909fb5629c",
+    i686: "7d7f4e8e137bbb96dea2b2792dc12a7e61c729d9",
+    x86_64: "073545bf8aa4b29fbf9084d31848b40f1df1b4ef",
   })
 end

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -3,9 +3,9 @@ require 'package'
 class Glibc < Package
   version '2.19'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/mtql9jcvct11tsi/glibc-2.19-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/fr8msjl41euauyp/glibc-2.19-chromeos-i686.tar.xz",
-    x86_64: "https://dl.dropboxusercontent.com/s/ow8hg6zuww1n7s2/glibc-2.19-chromeos-x86_64.tar.xz",
+    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-armv7l.tar.xz",
+    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-i686.tar.xz",
+    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
     armv7l: "c4da258eacf411833494bbe6903918909fb5629c",

--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -1,15 +1,15 @@
 require 'package'
 
 class Gmp < Package
-  version "5.1.2"
+  version "6.1.2"
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/zk1odzu8wxtffxm/gmp-5.1.2-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/9cwila1kaomsyl2/gmp-5.1.2-chromeos-i686.tar.gz?token_hash=AAHO9VxBpvXU2GPWBwimsp4hL8DADIItfNnIaFbfcyynMg&dl=1",
-    x86_64: "https://dl.dropboxusercontent.com/s/zp1mw0l93jcg35e/gmp-5.1.3-chromeos-x86_64.tar.gz?token_hash=AAHa75_Uu5zFQlbQUbse19d_vhIAmEnZ8bYpshE6giSXGw&dl=1"
+    armv7l: "https://dl.dropboxusercontent.com/s/lsysc6fka01fdb9/gmp-6.1.2-chromeos-armv7l.tar.xz",
+    i686: "https://dl.dropboxusercontent.com/s/skficanyik0fo4q/gmp-6.1.2-chromeos-i686.tar.xz",
+    x86_64: "https://dl.dropboxusercontent.com/s/dnfc1eqnqx6qg1m/gmp-6.1.2-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
-    armv7l: "daa46fe9c7a02542b58d9baeebdfafdbc7596e96",
-    i686: "b03b9508463588bfe9d09303c0725068cddd8810",
-    x86_64: "2aee1fee1e4b98261127a4c73f3f88670f1c8162"
+    armv7l: "ef330045d0eb7b33015e31cd1ac8428caacaf026",
+    i686: "a26eeac034966b50ca70d43b23768a078ca4dd14",
+    x86_64: "0ada7fbc26b2b5567df516daaf61edc4129ae1b5",
   })
 end

--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -3,9 +3,9 @@ require 'package'
 class Gmp < Package
   version "6.1.2"
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/lsysc6fka01fdb9/gmp-6.1.2-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/skficanyik0fo4q/gmp-6.1.2-chromeos-i686.tar.xz",
-    x86_64: "https://dl.dropboxusercontent.com/s/dnfc1eqnqx6qg1m/gmp-6.1.2-chromeos-x86_64.tar.xz",
+    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-armv7l.tar.xz",
+    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-i686.tar.xz",
+    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
     armv7l: "ef330045d0eb7b33015e31cd1ac8428caacaf026",

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -1,0 +1,15 @@
+require 'package'
+
+class Isl < Package
+  version "0.14.1"
+  binary_url ({
+    armv7l: "https://dl.dropboxusercontent.com/s/69o9prvyr1sh2o0/isl-0.14.1-chromeos-armv7l.tar.xz",
+    i686: "https://dl.dropboxusercontent.com/s/et5zpqxg4vrvk5c/isl-0.14.1-chromeos-i686.tar.xz",
+    x86_64: "https://dl.dropboxusercontent.com/s/u7rbyj43jkc855n/isl-0.14.1-chromeos-x86_64.tar.xz",
+  })
+  binary_sha1 ({
+    armv7l: "c151cbe2601eda6cd391da165ad940aa7fa666bc",
+    i686: "cc2d07411dbfcfd03afe0953bce8cef8d7bb8307",
+    x86_64: "3fa612198955e3d6e8201c05ef486d1462c76462",
+  })
+end

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -3,9 +3,9 @@ require 'package'
 class Isl < Package
   version "0.14.1"
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/69o9prvyr1sh2o0/isl-0.14.1-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/et5zpqxg4vrvk5c/isl-0.14.1-chromeos-i686.tar.xz",
-    x86_64: "https://dl.dropboxusercontent.com/s/u7rbyj43jkc855n/isl-0.14.1-chromeos-x86_64.tar.xz",
+    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-armv7l.tar.xz",
+    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-i686.tar.xz",
+    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
     armv7l: "c151cbe2601eda6cd391da165ad940aa7fa666bc",

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -1,15 +1,15 @@
 require 'package'
 
 class Linuxheaders < Package
-  version '3.4.0'
+  version '3.18'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/fvyzy5qpouj819z/linux-headers-3.14-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/mdzdoyq7dtnz682/linux-headers-3.4.0-chromeos-i686.tar.gz?token_hash=AAE4yw5oH_SfZ3lAx02mFP603rnjmoB9Gp4vqTY14NsA-A&dl=1",
-    x86_64: "https://dl.dropboxusercontent.com/s/3ec3fjpls0t2iqn/linuxheaders-3.8.11-chromeos-x86_64.tar.gz?token_hash=AAFl1_1I3FtwGdoGvGJuGrGUqzaDkhumPzsGJMX5pYhZyQ&dl=1"
+    armv7l: "https://dl.dropboxusercontent.com/s/cjmfim8igfz3eij/linux-headers-3.18-chromeos-armv7l.tar.xz",
+    i686: "https://dl.dropboxusercontent.com/s/1i73uc7x27q3dkf/linux-headers-3.18-chromeos-i686.tar.xz",
+    x86_64: "https://dl.dropboxusercontent.com/s/5j7df4rsjknc506/linux-headers-3.18-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
-    armv7l: "1d9103909d0f7108ecff9202933bd5870b3d0fb8",
-    i686: "31c933f3a4e82fd9310b0f5b32d79c9a51514fee",
-    x86_64: "c113e16d72147429f774ba6678d72a221b19a5bc"
+    armv7l: "fad98da3de461b0b08298c5a1ec07cca53eed008",
+    i686: "4142a609534383c99123fb43016745746589922b",
+    x86_64: "716f50b255d6bd3c4039a92cbd20d4e887e25bb7",
   })
 end

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -3,9 +3,9 @@ require 'package'
 class Linuxheaders < Package
   version '3.18'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/cjmfim8igfz3eij/linux-headers-3.18-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/1i73uc7x27q3dkf/linux-headers-3.18-chromeos-i686.tar.xz",
-    x86_64: "https://dl.dropboxusercontent.com/s/5j7df4rsjknc506/linux-headers-3.18-chromeos-x86_64.tar.xz",
+    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-armv7l.tar.xz",
+    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-i686.tar.xz",
+    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
     armv7l: "fad98da3de461b0b08298c5a1ec07cca53eed008",

--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -1,15 +1,15 @@
 require 'package'
 
 class Mpc < Package
-  version '1.0.1'
+  version '1.0.3'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/l302ru0xdq9qtsu/mpc-1.0.1-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/3o6uc8n4uy3oved/mpc-1.0.1-chromeos-i686.tar.gz?token_hash=AAH_OlvQWGUF7lyFhV3DXXgYRM1fupgKoHIwyiVmmVyWUQ&dl=1",
-    x86_64: "https://dl.dropboxusercontent.com/s/qr1x2fr1z0af26o/mpc-1.0.1-chromeos-x86_64.tar.gz?token_hash=AAFGK8OM8sm4k02lBAudZg8olgKxs_HmieFFqU6MZZONOA&dl=1"
+    armv7l: "https://dl.dropboxusercontent.com/s/v86dgj7tut6wnty/mpc-1.0.3-chromeos-armv7l.tar.xz",
+    i686: "https://dl.dropboxusercontent.com/s/oewxjj9cx5f879m/mpc-1.0.3-chromeos-i686.tar.xz",
+    x86_64: "https://dl.dropboxusercontent.com/s/vk1qr1t0yisgqt6/mpc-1.0.3-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
-    armv7l: "861960c75696ff613a410e3a1ab406c7128a790c",
-    i686: "f11c6e74e9059bf400b0978e6e05fe67c7f3dfe9",
-    x86_64: "24c4be4ea026d2d6e432a0aa9edb6dd27cf3e7df"
+    armv7l: "2a05a536cc6fd4da7d948c4732722c5d430ee010",
+    i686: "f10689f81749d65d1741f801387e9970eea988d7",
+    x86_64: "659123c6bf218d60837579e1fe50dd86f24d487f",
   })
 end

--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -3,9 +3,9 @@ require 'package'
 class Mpc < Package
   version '1.0.3'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/v86dgj7tut6wnty/mpc-1.0.3-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/oewxjj9cx5f879m/mpc-1.0.3-chromeos-i686.tar.xz",
-    x86_64: "https://dl.dropboxusercontent.com/s/vk1qr1t0yisgqt6/mpc-1.0.3-chromeos-x86_64.tar.xz",
+    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-armv7l.tar.xz",
+    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-i686.tar.xz",
+    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
     armv7l: "2a05a536cc6fd4da7d948c4732722c5d430ee010",

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -1,15 +1,15 @@
 require 'package'
 
 class Mpfr < Package
-  version '3.1.2'
+  version '3.1.5'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/56np7jwgybpcel8/mpfr-3.1.2-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/lo9ks3g7ar3zpfu/mpfr-3.1.2-chromeos-i686.tar.gz?token_hash=AAH1GlLfYtUs4uxl1ayeGTBe8RJ5uTXzOAsXgSlv8G5rrA&dl=1",
-    x86_64: "https://dl.dropboxusercontent.com/s/ev2a1yha3gm1hwy/mpfr-3.1.2-chromeos-x86_64.tar.gz?token_hash=AAErYQPCHkhALqnX4Y0LjATZITtD2qoKNbkdn67LOmRVRQ&dl=1"
+    armv7l: "https://dl.dropboxusercontent.com/s/gqd8pzck4p7nl1k/mpfr-3.1.5-chromeos-armv7l.tar.xz",
+    i686: "https://dl.dropboxusercontent.com/s/xiw4vjtew4zujmd/mpfr-3.1.5-chromeos-i686.tar.xz",
+    x86_64: "https://dl.dropboxusercontent.com/s/n8ygddm4ir8ihbg/mpfr-3.1.5-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
-    armv7l: "cad1a1d66f52199733d84638b7cb4178069efdb9",
-    i686: "eb81b9bb83ebb43b94ab33e43293f1df3bcbad7c",
-    x86_64: "a80c48bee7e6e8ddcd1771c4fd7708d89f2abb9c"
+    armv7l: "8ace66e438f6593affc460cc8a45f2a7df0ac1ca",
+    i686: "1a3e4833cbdf002e5fd62135b5113c37c2700362",
+    x86_64: "0028523daf1b3935bad21d3706e39fb248a8f0f2",
   })
 end

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -3,9 +3,9 @@ require 'package'
 class Mpfr < Package
   version '3.1.5'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/gqd8pzck4p7nl1k/mpfr-3.1.5-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/xiw4vjtew4zujmd/mpfr-3.1.5-chromeos-i686.tar.xz",
-    x86_64: "https://dl.dropboxusercontent.com/s/n8ygddm4ir8ihbg/mpfr-3.1.5-chromeos-x86_64.tar.xz",
+    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-armv7l.tar.xz",
+    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-i686.tar.xz",
+    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-x86_64.tar.xz",
   })
   binary_sha1 ({
     armv7l: "8ace66e438f6593affc460cc8a45f2a7df0ac1ca",


### PR DESCRIPTION
This is what I told in #338.  Newly cross-compiled toolchains.  I was using it on ARM and X86_64 for 4 weeks without any problems.  This time, I also tested it on X86 cloudready.  I wished if someone could volunteer to test this on real X86 chromebook, tho.

Anyway, I believe this new toolchains is good to merge now after above tests.  So, making this PR.

P.S. This toolschains are easy to build on recent 64 bit linux.  I made cross compiling scripts and publish them at https://github.com/jam7/chrome-cross.  So, even if we find a problem, it's easy to fix it now.