### PR TITLE
fix empty openssl library problem on flip c100pa

### DIFF
--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -15,7 +15,8 @@ class Openssl < Package
   end
 
   def self.install
-    system "make", "INSTALL_PREFIX=#{CREW_DEST_DIR}", "install"
+    # installing using multi cores may cause empty libssl.so.1.0.0 or libcrypto.so.1.0.0 problem
+    system "make", "-j1", "INSTALL_PREFIX=#{CREW_DEST_DIR}", "install"
 
     # remove all files pretended to install /etc/ssl (use system's /etc/ssl as is)
     system "rm", "-rf", "#{CREW_DEST_DIR}/etc"


### PR DESCRIPTION
`crew install openssl` does not work after #430 on particular machine, flip c100pa.  This is just remedy to avoid the situation.  Please read #362 and discuss there for the solution.  Thanks.