### PR TITLE
Remove --without-debug from ncurses configure options

### DIFF
--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -10,7 +10,6 @@ class Ncurses < Package
   def self.build
     system './configure ' \
 	    'CFLAGS=" -fPIC" ' \
-	    '--without-debug ' \
 	    '--prefix=/usr/local ' \
 	    '--with-shared ' \
 	    '--with-cxx-shared ' \


### PR DESCRIPTION
  Symbols needed for goaccess package.