### PR TITLE
Add libgpg-error (1.13) package

### DIFF
--- a/packages/libgpgerror.rb
+++ b/packages/libgpgerror.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Libgpgerror < Package
+  version '1.26'
+  source_url 'ftp://ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.26.tar.bz2'
+  source_sha1 '9a926e7ee6309e539313443555535d49a2a5c9f1'
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
The libgpg-error package contains a library that defines common error
values for all GnuPG components.

Tested as working on Samsung XE50013-K01US. All tests passing.

https://gist.github.com/cstrouse/4fc05bcedefc44d80c699115683f1ab1