### PR TITLE
Add libassuan (2.4.3) package

### DIFF
--- a/packages/libassuan.rb
+++ b/packages/libassuan.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Libassuan < Package
+  version '2.4.3'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.4.3.tar.bz2'
+  source_sha1 '27391cf4a820b5350ea789c30661830c9a271518'
+
+  def self.build
+    system './configure --prefix=/usr/local'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
The libassuan package contains an inter process communication library
used by some of the other GnuPG related packages. libassuan's primary
use is to allow a client to interact with a non-persistent server.
libassuan is not, however, limited to use with GnuPG servers and
clients. It was designed to be flexible enough to meet the demands of
many transaction based environments with non-persistent servers.

Tested as working on Samsung XE50013-K01US. All tests passing.
https://gist.github.com/cstrouse/c7ef8478ca5381ca141bf7f2cebfe4d8