### PR TITLE
Add gpgme (1.8.0) package

### DIFF
--- a/packages/gpgme.rb
+++ b/packages/gpgme.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Gpgme < Package
+  version '1.8.0'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.8.0.tar.bz2'
+  source_sha1 'efa043064dbf675fd713228c6fcfcc4116feb221'
+
+  depends_on "libgpgerror"
+  depends_on "libassuan"
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG
easier for applications. It provides a High-Level Crypto API for
encryption, decryption, signing, signature verification and key
management.

Tested as working on Samsung XE50013-K01US (x86_64).

***NOTE:*** Requires #469 and #470.