### PR TITLE
Add npth (1.3) package

### DIFF
--- a/packages/npth.rb
+++ b/packages/npth.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Npth < Package
+  version '1.3'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/npth/npth-1.3.tar.bz2'
+  source_sha1 '1b21507cfa3f58bdd19ef2f6800ab4cb67729972'
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
nPth is a library to provide the GNU Pth API and thus a non-preemptive
threads implementation.

Tested as working on Samsung XE50013-K01US (x86_64). All tests passing.
https://gist.github.com/cstrouse/080899dc9f67fb118c9dca8cfae39428