### PR TITLE
Add libgcrypt (1.7.6) package

### DIFF
--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Libgcrypt < Package
+  version '1.7.6'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.7.6.tar.bz2'
+  source_sha1 'd2b9e0f413064cfc67188f80d3cbda887c755a62'
+
+  depends_on "libgpgerror"
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
Libgcrypt is a general purpose cryptographic library originally based on
code from GnuPG. It provides functions for various cryptograhic building
blocks.

Tested as working on Samsung XE50013-K01US (x86_64). All tests passing.
https://gist.github.com/cstrouse/8cb016eed7c026ff403ed36880c7e199

***NOTE:*** Requires #469.