### PR TITLE
Fix broken dependency

### DIFF
--- a/packages/ncdu.rb
+++ b/packages/ncdu.rb
@@ -5,7 +5,7 @@ class Ncdu < Package
   source_url 'https://dev.yorhel.nl/download/ncdu-1.12.tar.gz'
   source_sha1 'b79b1c44784f334dca74d89a49f49274f14cfeef'
 
-  depends_on "ncurses_so"
+  depends_on "ncurses"
 
   def self.build
     system "./configure --prefix=/usr/local CPPFLAGS=-I/usr/local/include/ncurses"


### PR DESCRIPTION
The recent update to ncurses built the shared libraries deprecating the
ncurses_so package which ncdu was dependent on. This changes the
dependency to use the current ncurses package.

Tested as working on Samsung XE50013-K01US (x86_64).