### PR TITLE
Fix include path for ncurses-dependent packages

### DIFF
--- a/packages/iftop.rb
+++ b/packages/iftop.rb
@@ -9,7 +9,11 @@ class Iftop < Package
   depends_on "ncurses"
 
   def self.build
-    system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncurses"'
+    if Dir.exist? '/usr/local/include/ncursesw'
+      system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncursesw"'
+    else
+      system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncurses"'
+    end
     system 'make'
   end
 

--- a/packages/libedit.rb
+++ b/packages/libedit.rb
@@ -6,7 +6,11 @@ class Libedit < Package
   source_sha1 '55e327ee4661b13d20ebb411d790f2bb258271cf'
 
   def self.build
-    system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncurses"'
+    if Dir.exist? '/usr/local/include/ncursesw'
+      system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncursesw"'
+    else
+      system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncurses"'
+    end
     system "make"
   end
 

--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -9,7 +9,11 @@ class Nano < Package
   depends_on 'ncurses' 
   
   def self.build                                                  # self.build contains commands needed to build the software from source
-    system "./configure CPPFLAGS=\"-I/usr/local/include/ncurses\""
+    if Dir.exist? '/usr/local/include/ncursesw'
+      system "./configure CPPFLAGS=\"-I/usr/local/include/ncursesw\""
+    else
+      system "./configure CPPFLAGS=\"-I/usr/local/include/ncurses\""
+    end
     system "make"                                                 # ordered chronologically
   end
   

--- a/packages/ncdu.rb
+++ b/packages/ncdu.rb
@@ -5,10 +5,14 @@ class Ncdu < Package
   source_url 'https://dev.yorhel.nl/download/ncdu-1.12.tar.gz'
   source_sha1 'b79b1c44784f334dca74d89a49f49274f14cfeef'
 
-  depends_on "ncurses_so"
+  depends_on "ncurses"
 
   def self.build
-    system "./configure --prefix=/usr/local CPPFLAGS=-I/usr/local/include/ncurses"
+    if Dir.exist? '/usr/local/include/ncursesw'
+      system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncursesw"'
+    else
+      system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncurses"'
+    end
     system "make"
   end
 

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -10,7 +10,11 @@ class Python27 < Package
   depends_on 'openssl'
 
   def self.build                                                  # self.build contains commands needed to build the software from source
-    system "./configure --prefix=/usr/local CPPFLAGS=\"-I/usr/local/include -I/usr/local/include/ncurses\" LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\" -fPIC\" --with-ensure-pip=install"
+    if Dir.exist? '/usr/local/include/ncursesw'
+      system "./configure --prefix=/usr/local CPPFLAGS=\"-I/usr/local/include -I/usr/local/include/ncursesw\" LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\" -fPIC\" --with-ensure-pip=install"
+    else
+      system "./configure --prefix=/usr/local CPPFLAGS=\"-I/usr/local/include -I/usr/local/include/ncurses\" LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\" -fPIC\" --with-ensure-pip=install"
+    end
     system "make"                                                 # ordered chronologically
   end
 

--- a/packages/tmux.rb
+++ b/packages/tmux.rb
@@ -12,7 +12,11 @@ class Tmux < Package                                            	# name the pack
   depends_on 'ncurses'
   
   def self.build                                                  # self.build contains commands needed to build the software from source
-    system "CPPFLAGS=-I/usr/local/include/ncurses ./configure"
+    if Dir.exist? '/usr/local/include/ncursesw'
+      system "CPPFLAGS=-I/usr/local/include/ncurses ./configure"
+    else
+      system "CPPFLAGS=-I/usr/local/include/ncurses ./configure"
+    end
     system "make"                                                 # ordered chronologically
   end
   


### PR DESCRIPTION
This is a temporary fix until it's safe to assume everyone's using the
updated ncurses 6.0 with utf-8 support.

The other option would be to create a symlink from /usr/local/include/ncurses to /usr/local/include/ncursesw and leave the packages alone.