### PR TITLE
Symlink ncursesw (utf-8 version) to ncurses

### DIFF
--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -20,5 +20,6 @@ class Ncurses < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    FileUtils.ln_s '/usr/local/include/ncursesw', '/usr/local/include/ncurses'
   end
 end


### PR DESCRIPTION
Many packages which rely on ncurses have trouble finding the library
headers with the utf-8 version (/usr/local/include/ncursesw) so rather
than edit a ton of packages we create a symlink after ncurses has been
installed.