### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/packages/tmux.rb
+++ b/packages/tmux.rb
@@ -7,8 +7,6 @@ class Tmux < Package                                            	# name the pack
   
   depends_on 'readline'                                            # software dependencies
   depends_on 'libevent'
-  # does this really depend on openssl?  or just on libevent that depends on openssl
-  depends_on 'openssl'
   depends_on 'ncurses'
   
   def self.build                                                  # self.build contains commands needed to build the software from source


### PR DESCRIPTION
Libevent pulls openssl in so openssl is not necessary as a dependency.

Tested as working on Samsung XE50013-K01US (x86_64).