### PR TITLE
Update libevent from 2.0.22 to 2.1.8

### DIFF
--- a/packages/libevent.rb
+++ b/packages/libevent.rb
@@ -1,9 +1,9 @@
 require 'package'                                                      	# include package class file
  
 class Libevent < Package                                            	# name the package and make it a Package class instance
-  version '2.0.22'                                               	                                      # software version
-  source_url 'https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz'     # software source tarball url
-  source_sha1 'a586882bc93a208318c70fc7077ed8fca9862864'          	# source tarball sha1 sum
+  version '2.1.8'                                               	                                      # software version
+  source_url 'https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz'     # software source tarball url
+  source_sha1 '2a1b8bb7a262d3fd0ed6a080a20991a6eed675ec'          	# source tarball sha1 sum
   depends_on 'openssl'
   
   def self.build                                                  # self.build contains commands needed to build the software from source


### PR DESCRIPTION
This is a general bugfix/maintenance release. Key updates include
performance tweaks and fixes for OpenSSL bugs.

Tested as working on Samsung XE50013-K01US (x86_64). Test harness is
currently broken and enters a loop.