### PR TITLE
Update libpng from 1.6.26-1 to 1.6.28

### DIFF
--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Libpng < Package
-  version '1.6.26-1'
-  source_url 'http://prdownloads.sourceforge.net/libpng/libpng-1.6.26.tar.gz'
-  source_sha1 '3b2652f89b8fdcb6c29e9ed7642dfcfc0bbcf17e'
+  version '1.6.28'
+  source_url 'http://prdownloads.sourceforge.net/libpng/libpng-1.6.28.tar.gz'
+  source_sha1 '004556d65f21baed83755f8e094112711e39ebae'
 
   def self.build
       system "./configure CFLAGS=\" -fPIC\""


### PR DESCRIPTION
This is a maintenance release primarily addressing issues with their
cmake build files.

Tested as working on Samung XE50013-K01US (x86_64).