### PR TITLE
Fix nano

### DIFF
--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -9,7 +9,7 @@ class Nano < Package
   depends_on 'ncurses' 
   
   def self.build                                                  # self.build contains commands needed to build the software from source
-    system "./configure CPPFLAGS=\"-I/usr/local/include/ncurses\""
+    system "./configure CPPFLAGS=\"-I/usr/local/include/ncursesw\""
     system "make"                                                 # ordered chronologically
   end
   


### PR DESCRIPTION
It looked like ncurses installs in /usr/local/include/ncursesw instead of /usr/local/include/ncurses. Fixed this case