### PR TITLE
Update libgd from 2.0.33-1 to 2.2.4

### DIFF
--- a/packages/libgd.rb
+++ b/packages/libgd.rb
@@ -1,21 +1,23 @@
 require 'package'
 
 class Libgd < Package
-  version '2.0.33-1'
-  source_url 'https://github.com/libgd/libgd/archive/GD_2_0_33.tar.gz'
-  source_sha1 '489e25f18d3fc9d7f8b0e4889f98f5aa25363c3e'
+  version '2.2.4'
+  source_url 'https://github.com/libgd/libgd/archive/gd-2.2.4.tar.gz'
+  source_sha1 '630daec16fe06e4e916fd0fa8499c8fa5c0dcbca'
 
+  depends_on 'cmake'
   depends_on 'libpng'
 
   def self.build
-    FileUtils.cd('src') do
-      system "./configure CFLAGS=\" -fPIC\""
+    FileUtils.mkdir('build')
+    FileUtils.cd('build') do
+      system "cmake -DCMAKE_INCLUDE_PATH=/usr/local/include -DCMAKE_INSTALL_PREFIX=/usr/local .."
       system "make"
     end
   end
 
   def self.install
-    FileUtils.cd('src') do
+    FileUtils.cd('build') do
       system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     end
   end


### PR DESCRIPTION
This release addresses a security issue in regards to loading external
resource. It's recommended that all users of this library update to this
version. The project has also transitioned to cmake.

Refs CVE-2016-9317 and CVE-2016-6912.

Tested as working on Samung XE50013-K01US (x86_64). Test harness does
not build.