### PR TITLE
Update leveldb from 1.15 to 1.19

### DIFF
--- a/packages/leveldb.rb
+++ b/packages/leveldb.rb
@@ -1,9 +1,9 @@
 require 'package'                                                      	# include package class file
  
 class Leveldb < Package                                            	# name the package and make it a Package class instance
-  version '1.15.0'                                               	                                      # software version
-  source_url 'https://leveldb.googlecode.com/files/leveldb-1.15.0.tar.gz'     # software source tarball url
-  source_sha1 '74b70a1156d91807d8d84bfdd026e0bb5acbbf23'          	# source tarball sha1 sum
+  version '1.19.0'                                               	                                      # software version
+  source_url 'https://github.com/google/leveldb/archive/v1.19.tar.gz'     # software source tarball url
+  source_sha1 '864b45b4a8d1ad400b9115ff6d3c9fb1f79be82b'          	# source tarball sha1 sum
   
   def self.build                                                  # self.build contains commands needed to build the software from source
     system "make"                                                 # ordered chronologically
@@ -13,9 +13,9 @@ class Leveldb < Package                                            	# name the p
     system "mkdir", "-p", "#{CREW_DEST_DIR}/usr/local/include"
     system "mkdir", "-p", "#{CREW_DEST_DIR}/usr/local/lib"
     system "cp", "-R", "include/leveldb", "#{CREW_DEST_DIR}/usr/local/include"
-    system "cp", "libleveldb.a", "#{CREW_DEST_DIR}/usr/local/lib"
-    system "cp", "libleveldb.so.1.15", "#{CREW_DEST_DIR}/usr/local/lib"
-    system "cp", "-P", "libleveldb.so.1", "#{CREW_DEST_DIR}/usr/local/lib"
-    system "cp", "-P", "libleveldb.so", "#{CREW_DEST_DIR}/usr/local/lib"
+    system "cp", "out-static/libleveldb.a", "#{CREW_DEST_DIR}/usr/local/lib"
+    system "cp", "out-shared/libleveldb.so.1.19", "#{CREW_DEST_DIR}/usr/local/lib"
+    system "cp", "-P", "out-shared/libleveldb.so.1", "#{CREW_DEST_DIR}/usr/local/lib"
+    system "cp", "-P", "out-shared/libleveldb.so", "#{CREW_DEST_DIR}/usr/local/lib"
   end                                                             # during installation
 end


### PR DESCRIPTION
This is a bugfix/general maintenance release.

Tested as working on Samsung XE50013-K01US (x86_64).