### PR TITLE
Update fish from 2.3.0 to 2.5.0

### DIFF
--- a/packages/fish.rb
+++ b/packages/fish.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Fish < Package
-  version '2.3.0'
-  source_url 'https://github.com/fish-shell/fish-shell/releases/download/2.3.0/fish-2.3.0.tar.gz'
-  source_sha1 'afc6e9ea4cbd1ade63e9af41280b1f08bff23bba'
+  version '2.5.0'
+  source_url 'https://github.com/fish-shell/fish-shell/releases/download/2.5.0/fish-2.5.0.tar.gz'
+  source_sha1 'ec52debe0a829b9df29f658697523af7c18ee778'
 
   depends_on 'ncurses'
 


### PR DESCRIPTION
This is a bugfix/general maintenance release. Completions for a lot more
programs were added and performance improvements were made.

Tested as working on Samsung XE50013-K01US (x86_64).