### PR TITLE
Change to instal both ncurses ncursesw

### DIFF
--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -6,6 +6,7 @@ class Ncurses < Package
   source_sha1 'acd606135a5124905da770803c05f1f20dd3b21c'
 
   depends_on "diffutils"
+  depends_on "ncursesw"
 
   def self.build
     system './configure ' \

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Ncurses < Package
-  version '6.0'
+  version '6.0-1'
   source_url 'ftp://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz'
   source_sha1 'acd606135a5124905da770803c05f1f20dd3b21c'
 

--- a/packages/ncursesw.rb
+++ b/packages/ncursesw.rb
@@ -8,6 +8,16 @@ class Ncursesw < Package
   depends_on "diffutils"
 
   def self.build
+    # Check ncurses doesn't conflict with ncrusesw
+    if File.exist? CREW_CONFIG_PATH + "meta/ncurses.filelist"
+      if `grep include/ncursesw #{CREW_CONFIG_PATH}meta/ncurses.filelist` != ''
+	puts
+	puts "PLEASE PERFORMS `crew upgrade ncurses` OR `sudo crew remove ncurses` FIRST"
+	puts
+	exit 1
+      end
+    end
+    # Build ncursesw
     system './configure ' \
 	    'CFLAGS=" -fPIC" ' \
 	    '--without-debug ' \

--- a/packages/ncursesw.rb
+++ b/packages/ncursesw.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Ncurses < Package
+class Ncursesw < Package
   version '6.0'
   source_url 'ftp://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz'
   source_sha1 'acd606135a5124905da770803c05f1f20dd3b21c'
@@ -13,7 +13,8 @@ class Ncurses < Package
 	    '--without-debug ' \
 	    '--prefix=/usr/local ' \
 	    '--with-shared ' \
-	    '--with-cxx-shared '
+	    '--with-cxx-shared ' \
+	    '--enable-widec'
     system "make"
   end
 


### PR DESCRIPTION
This is a PR to fix ncurses problem.  This PR has conflicts to #477.  I was waiting for @cstrouse to modify his PR, but not.  So, I've just decided to submit it by myself.

I think this PR solves ncurses and ncrusesw problem.

What I did:
- This reverts ncurses.rb to install ncurses similar to previous ncurses.
- This add ncursesw.rb to install wide character ncurses for user who want it.
- This add dependency so `depends_on ncurses` requires both ncurses and ncursesw now.
- Incresed the version number of ncurses to force to reinstall it.

3rd modification is for the ease of development.  For example, less works well even if there is only ncurses but it choose ncursesw if both are installed.  It is difficult to decide which we should install.  Therefore, 3rd modification forces to install both if developers simply write `dependes_on ncurses`.  Then, each applications configuration script will choose what they want.

Problem:
- ncurses and ncursesw writes several identical files like man files.  So, removing one of them may cause problem.

Other options:
- It is also possible to use `--enable-widec` and `--disable-suffix`, but I'm not sure whether that works well or not.