### PR TITLE
Update php5 from 5.6.29 to 5.6.30

### DIFF
--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Php5 < Package
-  version '5.6.29'
-  source_url 'http://php.net/distributions/php-5.6.29.tar.xz'  # software source tarball url
-  source_sha1 'df3301d11d56fbeabd8f6336e9c8f4c47af45562'       # source tarball sha1 sum
+  version '5.6.30'
+  source_url 'http://php.net/distributions/php-5.6.30.tar.xz'  # software source tarball url
+  source_sha1 '1bca4a340e6aaf82a3e940b0f2de3f36518238e4'       # source tarball sha1 sum
 
   depends_on 'pkgconfig'                                       # add package dependencies
   depends_on 'zlibpkg'

--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -12,6 +12,7 @@ class Php5 < Package
   depends_on 'openssl'
   depends_on 'curl'
   depends_on 'pcre'
+  depends_on 'readline'
 
   def self.build                                               # self.build contains commands needed to build the software from source
     system './configure \
@@ -21,6 +22,7 @@ class Php5 < Package
       --enable-mbstring \
       --with-openssl \
       --with-pcre-regex \
+      --with-readline \
       --with-zlib'
     system 'make'                                              # ordered chronologically
   end


### PR DESCRIPTION
Add `--with-readline` configure option to enable interactive shell.
 
Test with `$ php -a`:

```
Interactive shell

php > echo 'test';
test
php > exit
```

http://www.php.net/ChangeLog-5.php#5.6.30