### PR TITLE
Revert to source build for powerline fonts

### DIFF
--- a/packages/powerline_fonts.rb
+++ b/packages/powerline_fonts.rb
@@ -1,19 +1,33 @@
 require 'package'
 
 class Powerline_fonts < Package
-  version '1'
-  binary_url ({
-    i686: "https://www.dropbox.com/s/lkrnw3hu7yb88vt/powerline_fonts.tar.gz?dl=0",
-    x86_64: "https://www.dropbox.com/s/lkrnw3hu7yb88vt/powerline_fonts.tar.gz?dl=0"
-  })
-  binary_sha1 ({
-    i686: "c5bcd35c94feed9cb48bb821c2d08f3ddc36dc64",
-    x86_64: "c5bcd35c94feed9cb48bb821c2d08f3ddc36dc64"
-  })
-  
-  puts "\nFonts will be available after restart or chrome:inducebrowsercrashforrealz"
-  puts "To change the font in crosh, enable developer tools in extensions and execute:"
-  puts "\tterm_.prefs_.set(\"font-family\", \"DejaVu Sans Mono for Powerline\")" 
-  puts "in the Javascript Console to change the font to DejaVu Sans Mono, for example\n\n"
-  
+  version '1.1'
+  source_url 'https://codeload.github.com/powerline/fonts/tar.gz/2015-12-04?dummy=/'
+  source_sha1 '4ffe9a28b842ba4ef052b3ffa8cc58db1dbecc64'
+
+  def self.install
+    fonts = "#{CREW_DEST_DIR}/usr/local/share/fonts"
+    FileUtils.mkdir_p(fonts)
+
+    Dir.glob('*').each do |f| 
+      FileUtils.mv(f, fonts) unless ["README.rst", "install.sh"].include? f
+    end
+
+    home = "#{CREW_DEST_DIR}/home/chronos/user"
+    FileUtils.mkdir_p(home)
+    FileUtils.cd(home) do
+      File.open('.font.conf','w') do |f|
+        f.puts "<?xml version=\"1.0\"?>"
+        f.puts "<!DOCTYPE fontconfig SYSTEM \"fonts.dtd\">"
+        f.puts "<fontconfig>"
+        f.puts "\t<dir>/usr/local/share/fonts</dir>"
+        f.puts "</fontconfig>"
+      end
+
+      puts "\nFonts will be available after restart or chrome:inducebrowsercrashforrealz"
+      puts "To change the font in crosh, enable developer tools in extensions and execute:"
+      puts "\tterm_.prefs_.set(\"font-family\", \"DejaVu Sans Mono for Powerline\")" 
+      puts "in the Javascript Console to change the font to DejaVu Sans Mono, for example\n\n"
+    end
+  end
 end


### PR DESCRIPTION
This is due to the binary package no longer being available. Closes #467.