### PR TITLE
Add nanomsg (1.0.0) package

### DIFF
--- a/packages/nanomsg.rb
+++ b/packages/nanomsg.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Nanomsg < Package
+  version '1.0,0'
+  source_url 'https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz'
+  source_sha1 '57f90778a9bb7b95a7fd73910fd41894f3ee9cab'
+
+  depends_on 'cmake'
+
+  def self.build
+    system "./configure --prefix=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
nanomsg is a socket library that provides several common communication
patterns. It aims to make the networking layer fast, scalable, and easy
to use.

Tested as working on Samsung XE50013-K01US (x86_64).

All tests passing.
https://gist.github.com/cstrouse/9d2cc4cb0937f4c5d827abb41852c07e