### PR TITLE
Add libslz (1.1.0) package

### DIFF
--- a/packages/libslz.rb
+++ b/packages/libslz.rb
@@ -1,0 +1,15 @@
+require 'package'
+
+class Libslz < Package
+  version '1.1.0'
+  source_url 'http://git.1wt.eu/web?p=libslz.git;a=snapshot;h=afa04ae1f976957cf36287cc5370998d0559bc63;sf=tbz2'
+  source_sha1 '20d8a90c6a0949bfb15547ead0636e416366ac44'
+
+  def self.build
+    system "make PREFIX=/usr/local"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" 
+  end
+end


### PR DESCRIPTION
libslz is a lightweight alternative to zlib often used to increase the
performance of the HAProxy load balancer.

Tested on Samsung XE50013-K01US (x86_64).