### PR TITLE
Switch to ```all.bash``` for existing go

### DIFF
--- a/packages/go.rb
+++ b/packages/go.rb
@@ -18,7 +18,7 @@ class Go < Package
                 TMPDIR=/usr/local/tmp \
                 ./make.bash"
       else
-        system "TMPDIR=/usr/local/tmp ./make.bash"
+        system "TMPDIR=/usr/local/tmp ./all.bash"
       end
     end
   end


### PR DESCRIPTION
Regarding #479: For building go using go, we ```all.bash``` is used instead of ```make.bash```.