### PR TITLE
Set GOROOT_BOOTSTRAP to existing go installation

### DIFF
--- a/packages/go.rb
+++ b/packages/go.rb
@@ -18,7 +18,8 @@ class Go < Package
                 TMPDIR=/usr/local/tmp \
                 ./make.bash"
       else
-        system "TMPDIR=/usr/local/tmp ./make.bash"
+        system "GOROOT_BOOTSTRAP=/usr/local/lib/go \
+                TMPDIR=/usr/local/tmp ./make.bash"
       end
     end
   end


### PR DESCRIPTION
#479 If GOROOT_BOOTSTRAP is not passed in, make.bash will look for/prefer Go 1.4 to access the go compiler. 