### PR TITLE
Add cdrkit package

### DIFF
--- a/packages/cdrkit.rb
+++ b/packages/cdrkit.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Cdrkit < Package
+  version '1.1.11'
+  source_url 'https://downloads.sourceforge.net/project/wodim/cdrkit/cdrkit_1.1.11.orig.tar.gz'
+  source_sha1 '3f7ddc06db0272942e1a4cd98c3c96462df77387'
+
+  depends_on 'cmake'
+  depends_on 'libcap'
+
+  def self.build
+    system 'make clean'
+    system 'make CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
The cdrkit package includes a suite of tools to manage cd/dvd recording.  Most Chromebooks do not have a cd/dvd burner included but an external usb drive can easily be attached.

This package contains the following software:

- cdda2wav (an digital CD audio extraction program)
  By Heiko Eißfeldt <heiko@hexco.de>

- wodim (a CD recording program). Originaly based on
  cdrecord by Jörg Schilling <schilling@fokus.fhg.de> but
  developed independently now.

- genisoimage (an ISO-9660 filesystem image creator)
  By Eric Youngdale <eric@andante.org>, Jörg Schilling
  <schilling@fokus.fhg.de>, James Pearson
  <jcpearso@ge.ucl.ac.uk> and other contributors.

- mkhybrid (an ISO-9660/HFS filesystem image creator)
  Link to genisoimage

- several diagnostic programs for ISO-9660, originally from
  cdrtools (by Jörg Schilling), 

        -       devdump dump a device or file in hex

        -       isodump dump a device or file based on ISO-9660

        -       isoinfo analyze or list an ISO-9660 image

        -       isovfy verify an ISO-9660 image

- readcd (a stripped down version of usalskeleton)
  By Jörg Schilling schilling@fokus.fhg.de and
  may be used to read data CD's, to write to DVD-RAM
  and to copy Solaris boot CD's

- usalcheck (a program to validate the correct behavior
  By Jörg Schilling schilling@fokus.fhg.de and
  of the low level libusal code and the SCSI transport
  code of the underlying OS).

- libusal (a highly portable SCSI transport library)
  By Jörg Schilling schilling@fokus.fhg.de