### PR TITLE
Change to not only overwrite device.json but also update it if it exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,28 +81,30 @@ sudo ln -s `pwd`/crew $CREW_PREFIX/bin
 mkdir $CREW_LIB_PATH/lib && cd $CREW_LIB_PATH/lib
 wget -N -c $URL/lib/package.rb
 wget -N -c $URL/lib/package_helpers.rb
-#create the device.json file
+
+#create or update the device.json file
+ruby_version='2.0.0p247'
 cd $CREW_CONFIG_PATH
 if [ ! -f device.json ]; then
-  echo "Creating device.json newly..."
+  echo "Creating new device.json..."
   echo '{' > device.json
   echo '  "architecture": "'$architecture'",' >> device.json
   echo '  "installed_packages": [' >> device.json
   echo '    {' >> device.json
   echo '      "name": "ruby",' >> device.json
-  echo '      "version": "2.0.0p247"' >> device.json
+  echo '      "version": "'$ruby_version'"' >> device.json
   echo '    }' >> device.json
   echo '  ]' >> device.json
   echo '}' >> device.json
 elif grep '"name": "ruby"' device.json > /dev/null; then
   echo "Updating version number of existing information in device.json..."
-  sed -i device.json -e '/"name": "ruby"/N;//s/"version": ".*"/"version": "2.0.0p247"/'
+  sed -i device.json -e '/"name": "ruby"/N;//s/"version": ".*"/"version": "'$ruby_version'"/'
 else
   echo "Adding new information to device.json..."
   sed -i device.json -e '/    }$/s/$/,\
     {\
       "name": "ruby",\
-      "version": "2.0.0p247"\
+      "version": "'$ruby_version'"\
     }/'
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -83,15 +83,28 @@ wget -N -c $URL/lib/package.rb
 wget -N -c $URL/lib/package_helpers.rb
 #create the device.json file
 cd $CREW_CONFIG_PATH
-echo '{' > device.json
-echo '  "architecture": "'$architecture'",' >> device.json
-echo '  "installed_packages": [' >> device.json
-echo '    {' >> device.json
-echo '      "name": "ruby",' >> device.json
-echo '      "version": "2.0.0p247"' >> device.json
-echo '    }' >> device.json
-echo '  ]' >> device.json
-echo '}' >> device.json
+if [ ! -f device.json ]; then
+  echo "Creating device.json newly..."
+  echo '{' > device.json
+  echo '  "architecture": "'$architecture'",' >> device.json
+  echo '  "installed_packages": [' >> device.json
+  echo '    {' >> device.json
+  echo '      "name": "ruby",' >> device.json
+  echo '      "version": "2.0.0p247"' >> device.json
+  echo '    }' >> device.json
+  echo '  ]' >> device.json
+  echo '}' >> device.json
+elif grep '"name": "ruby"' device.json > /dev/null; then
+  echo "Updating version number of existing information in device.json..."
+  sed -i device.json -e '/"name": "ruby"/N;//s/"version": ".*"/"version": "2.0.0p247"/'
+else
+  echo "Adding new information to device.json..."
+  sed -i device.json -e '/    }$/s/$/,\
+    {\
+      "name": "ruby",\
+      "version": "2.0.0p247"\
+    }/'
+fi
 
 #download git and its dependencies .rb package files
 cd $CREW_PACKAGES_PATH


### PR DESCRIPTION
`install.sh` overwrites existing device.json, so we need to install everything again if we executes it accidentally.  Moreover, as described in #236, if we remove `ruby` accidentally, we also need to install everything again from scratch.

This PR fixes it.  New `install.sh` creates device.json if it doesn't exist or update it if it exists.

Tested on flip (ARM).