### PR TITLE
Change to perform `make` in sequential on packages not working in parallel

### DIFF
--- a/packages/bacon.rb
+++ b/packages/bacon.rb
@@ -9,7 +9,9 @@ class Bacon < Package
     system "./configure --prefix=/usr/local --without-gui"
     system 'sed -i "45s,/usr/share,/usr/local/share," Makefile'
     system 'sed -i "46s,/usr/share,/usr/local/share," Makefile'
-    system "make"
+
+    # force to compile in sequential since bacon Makefile doesn't work in parallel
+    system "make", "-j1"
   end
 
   def self.install

--- a/packages/ffcall.rb
+++ b/packages/ffcall.rb
@@ -7,7 +7,9 @@ class Ffcall < Package
 
   def self.build
     system "./configure --prefix=/usr/local CFLAGS=\" -fPIC\""
-    system "make"
+
+    # force to compile in sequential since ffcall Makefile doesn't work in parallel
+    system "make", "-j1"
   end
 
   def self.install

--- a/packages/groff.rb
+++ b/packages/groff.rb
@@ -7,7 +7,9 @@ class Groff < Package
   
   def self.build
     system './configure'
-    system 'make'
+
+    # force to compile in sequential since groff Makefile doesn't work in parallel
+    system 'make', '-j1'
   end
   
   def self.install

--- a/packages/slang.rb
+++ b/packages/slang.rb
@@ -7,7 +7,9 @@ class Slang < Package
 
   def self.build
     system "./configure", "--prefix=/usr/local", "--without-x"
-    system "make"
+
+    # force to compile in sequential since slang Makefile doesn't work in parallel
+    system "make", "-j1"
   end
 
   def self.install

--- a/packages/unrar.rb
+++ b/packages/unrar.rb
@@ -8,8 +8,10 @@ class Unrar < Package
   def self.build
     system "sed -i '145s,$,/libunrar.so,' makefile" # fix naming mistake
     system "sed -i '145s,install,install -D,' makefile" # create directory
-    system "make", "all"
-    system "make", "lib"
+
+    # force to compile in sequential since unrar Makefile doesn't work in parallel
+    system "make", "-j1", "all"
+    system "make", "-j1", "lib"
   end
 
   def self.install


### PR DESCRIPTION
As explained in #362, I've noticed several packages have problem in parallel make execution.  Add "-j1" flag to force them to compile program in sequential.

Please merge #488 also.