### PR TITLE
Fix clisp

### DIFF
--- a/packages/clisp.rb
+++ b/packages/clisp.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Clisp < Package
-  version '2.49-1'
+  version '2.49-2'
   source_url 'ftp://ftp.gnu.org/pub/gnu/clisp/release/2.49/clisp-2.49.tar.bz2'
   source_sha1 '7e8d585ef8d0d6349ffe581d1ac08681e6e670d4'
 
@@ -9,10 +9,14 @@ class Clisp < Package
   depends_on 'ffcall'
 
   def self.build
-    system "./configure CFLAGS=\" -fPIC\""
+    system "./configure", "--disable-static", "--enable-static", "--with-pic"
     FileUtils.cd('src') do
-      system "ulimit -s 16384"
-      system "make"
+      # disable unavailable "-R" option
+      # modifying configure options doesn't work for this
+      system "sed", "-i", "Makefile", "-e", "s:-R/usr/local/lib ::"
+
+      # force to compile in sequential since clisp Makefile doesn't work in parallel
+      system "make", "-j1"
     end
   end
 


### PR DESCRIPTION
Similar to #526, but clisp requires Makefile modifications to compile it correctly.  Tested on chromebook x86_64 and cloudready i686.  This is not tested on armv7l since ffcall required by clisp doesn't work on armv7l.

 - Correct Makefile
 - Change to not install static library
 - Change to install shared library
 - Force to compile in sequential