### PR TITLE
Remove .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store


### PR DESCRIPTION
.gitignore contains ".DS_Store".  It may work on Mac but doesn't on others.  Commit log says:
```
commit 8b773b1b46d7a2b8b404f591f1768f022c7aa51d
    Add --no-check-certificate for wget in install script
```
So, I guess this file is added accidentally.

Personally, I like to not have project-wide .gitignore, since without it, I can write whatever there without considering commit or accidental removal when switching between branches.  So, if collaborators don't mind, please merge this PR.  Thanks. 