### PR TITLE
Update git to 2.11.0 with binaries

### DIFF
--- a/packages/git.rb
+++ b/packages/git.rb
@@ -1,23 +1,36 @@
 require 'package'
 
 class Git < Package
-  version '1.8.4'
+  version '2.11.0'
+  source_url 'https://github.com/git/git/archive/v2.11.0.tar.gz'
+  source_sha1 'ca1187843b7dd2bb3b1c5e275f04c17fa70e7100'
   binary_url ({
-    armv7l: 'https://dl.dropboxusercontent.com/s/lnz5hmjv48d14f2/git-1.8.4-chromeos-armv7l.tar.xz',
-    i686: 'https://dl.dropboxusercontent.com/s/g3binxopw5nfky1/git-1.8.4-chromeos-i686.tar.gz?token_hash=AAEWnMNBfozSIzLD1unbYGJzT4FGkEfJmLFQ-3uzydfT_A&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/i7vs9wfk94tsrzt/git-1.8.4-chromeos-x86_64.tar.gz?token_hash=AAHyvjayN7THoxlryZaxQ2Ejm9xyD6bZCqXZM81hYRC8iQ&dl=1'
+    armv7l: 'https://github.com/jam7/chromebrew/releases/download/binaries/git-2.11.0-chromeos-armv7l.tar.xz',
+    i686:   'https://github.com/jam7/chromebrew/releases/download/binaries/git-2.11.0-chromeos-i686.tar.xz',
+    x86_64: 'https://github.com/jam7/chromebrew/releases/download/binaries/git-2.11.0-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: '084a3b9bb90c572e7c5b12aae485715f145053e5',
-    i686: '8c1bf4bcffb0e9c17bf20dd05981e86ea34d5d65',
-    x86_64: '067cb6c36616ac30999ab97e85f3dc0e9d1d57f4'
+    armv7l: '1d04e232826fcbeff7a20da6a3b0ab3b823d2cd2',
+    i686:   '7dd3b08c9b1e2a219494b6c77efc1b6773ef08f4',
+    x86_64: 'd8345b00742cadf4f34585f61cf49da5d5f7a695',
   })
 
+  # compile-time dependencies
   depends_on 'zlibpkg'
   depends_on 'libssh2'
+  depends_on 'openssl'
   depends_on 'perl'
   depends_on 'curl'
   depends_on 'expat'
   depends_on 'gettext'
-  depends_on 'python'
+  depends_on 'python27'     # git requires python2
+
+  def self.build
+    # need to build using single core
+    system "make", "-j1", "prefix=/usr/local", "CC=gcc", "PERL_PATH=perl", "PYTHON_PATH=python2", "all"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "prefix=/usr/local", "CC=gcc", "PERL_PATH=perl", "PYTHON_PATH=python2", "install"
+  end
 end


### PR DESCRIPTION
Update git to 2.11.0.  Need to apply #529 first, since applying only this PR affects install.sh behavior.

This PR also provides binaries for all architectures.

Tested on armv7l and x86_64 using chromebook and i686 using cloudready.