### PR TITLE
Add openssl 1.0.2k binaries

### DIFF
--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -5,6 +5,16 @@ class Openssl < Package
 
   source_url 'ftp://openssl.org/source/openssl-1.0.2k.tar.gz'
   source_sha1 '5f26a624479c51847ebd2f22bb9f84b3b44dcb44'
+  binary_url ({
+    armv7l: 'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2k-chromeos-armv7l.tar.xz',
+    i686:   'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2k-chromeos-i686.tar.xz',
+    x86_64: 'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2k-chromeos-x86_64.tar.xz',
+  })
+  binary_sha1 ({
+    armv7l: '3993fab089b11f215ae554f2dec27c7bb5c28a09',
+    i686:   'ea4fbca401f62f75ff5ad758e52f54d595dd949b',
+    x86_64: 'c32d211c0033380144527aaf00c6e04dd3dbc20a',
+  })
 
   depends_on 'perl'
   depends_on 'zlibpkg'
@@ -15,11 +25,9 @@ class Openssl < Package
   end
 
   def self.install
-    # installing using multi cores may cause empty libssl.so.1.0.0 or libcrypto.so.1.0.0 problem
-    system "make", "-j1", "INSTALL_PREFIX=#{CREW_DEST_DIR}", "install"
+    system "make", "INSTALL_PREFIX=#{CREW_DEST_DIR}", "install"
 
     # remove all files pretended to install /etc/ssl (use system's /etc/ssl as is)
     system "rm", "-rf", "#{CREW_DEST_DIR}/etc"
   end
-
 end


### PR DESCRIPTION
Provides openssl 1.0.2k binaries.

Tested on armv7l and x86_64 using chromebook.  Tested on i686 using cloudready.  Passed `make test` on all architectures.