### PR TITLE
Add new experimental package named glibc223 to support glibc-2.23

### DIFF
--- a/packages/glibc223.rb
+++ b/packages/glibc223.rb
@@ -1,0 +1,15 @@
+require 'package'
+
+class Glibc223 < Package
+  version '2.23'
+  binary_url ({
+    armv7l: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-armv7l.tar.xz',
+    i686:   'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-i686.tar.xz',
+    x86_64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-x86_64.tar.xz',
+  })
+  binary_sha1 ({
+    armv7l: '4cac7d5d3d97f147c9ac9ad0c1deb1ac9b967450',
+    i686:   '434adb6dd1c3dcc30a25e3700f425a081888a28a',
+    x86_64: '9b4ae8c6ccc081f7d9d169cd0b3eb74ae736e79f',
+  })
+end


### PR DESCRIPTION
Chromebook dev channel and beta channel is using glibc-2.23 now.  This new glibc requires libmvec_nonshared.a for x86_64 at compile-time, but chromebook doesn't have these .a files.  So, having glibc-2.23 may cause new problems like #517 and https://github.com/jam7/chromebrew/issues/2 describe.

It will be available in a month or two in stable channel.  So, I just made glibc223.rb to prepare for it.

How to use: perform `crew install glibc223`.  This overwrites existing `glibc`.
It is also possible to perform `sudo crew remove glibc` then `crew install glibc223` if you want.

How much test: Not tested enough yet.  I don't want to use dev/beta channel for daily purpose.  Tested little on x86_64.  Not tested yet on armv7l nor i686.  This is independent and experimental package glibc223.rb, so I think it is OK.

How to build your own glibc: Methods are available at https://github.com/jam7/chrome-cross.