### PR TITLE
Fix python34.rb to symlink /usr/local/bin/python

### DIFF
--- a/packages/python34.rb
+++ b/packages/python34.rb
@@ -6,13 +6,15 @@ class Python34 < Package
   source_sha1 'e8c1bd575a6ccc2a75f79d9d094a6a29d3802f5d'          	# source tarball sha1 sum
 
   depends_on 'openssl'
-  
+
   def self.build                                                  # self.build contains commands needed to build the software from source
     system "./configure"
     system "make"                                                 # ordered chronologically
   end
-  
+
   def self.install                                                # self.install contains commands needed to install the software on the target system
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"          # remember to include DESTDIR set to CREW_DEST_DIR - needed to keep track of changes made to system
-  end         
+    system "rm /usr/local/bin/python"
+    system "ln -s /usr/local/bin/python3.4 /usr/local/bin/python" # set the python executable to version 3.4
+  end
 end


### PR DESCRIPTION
If I `crew install python34`, the `which python` command returns version 2.7.13 instead of 3.4.1 as expected.  This PR recreates the symlink to `/usr/local/bin/python` to reference `/usr/local/bin/python3.4` instead.