### PR TITLE
Add `rdepends_on` rule to specify run-time dependencies.

### DIFF
--- a/crew
+++ b/crew
@@ -286,16 +286,21 @@ def resolveDependencies
 
   def pushDeps
     if @pkg.binary_url && @pkg.binary_url.has_key?(@device[:architecture])
-      @check_deps = @pkg.dependencies
+      # Use binary dependencies if it exists, use source dependencies otherwise
+      if @pkg.rdependencies
+        @check_deps = @pkg.rdependencies
+      else
+        @check_deps = @pkg.dependencies
+      end
     else
-      # Use source dependencies
+      # Use only source dependencies
       @check_deps = @pkg.dependencies
       @source_package += 1
     end
     if @check_deps && !@check_deps.empty?
       @dependencies.unshift @check_deps
       
-      @pkg.dependencies.each do |dep|
+      @check_deps.each do |dep|
         search dep, true
         pushDeps
       end

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -4,7 +4,7 @@ class Package
   property :version, :binary_url, :binary_sha1, :source_url, :source_sha1, :is_fake
   
   class << self
-    attr_reader :dependencies, :is_fake
+    attr_reader :dependencies, :rdependencies, :is_fake
     attr_accessor :name, :in_build
   end
   def self.depends_on (dependency = nil)
@@ -13,6 +13,14 @@ class Package
       @dependencies << dependency
     end
     @dependencies
+  end
+
+  def self.rdepends_on (dependency = nil)
+    @rdependencies = [] unless @rdependencies
+    if dependency
+      @rdependencies << dependency
+    end
+    @rdependencies
   end
   
   def self.is_fake


### PR DESCRIPTION
Implemented `rdepends_on` described in #487.

After this PR, we can say for example git depends on only `libssh2` at run-time as below.
```
  # compile-time dependencies
  depends_on 'zlibpkg'
  depends_on 'libssh2'
  depends_on 'openssl'
  depends_on 'perl'
  depends_on 'curl'
  depends_on 'expat'
  depends_on 'gettext'
  depends_on 'python27'     # requires python2

  # run-time dependencies
  # use system zlibpkg, openssl, curl, expat
  rdepends_on 'libssh2'
```

Algorithm this PR takes:
 - For binary installation, modified crew checks rdepends_on instead of depends_on.
 - For the ease of maintenance, new crew also checks depends_on if rdepends_on is not specified.
 - For source installation, new crew checks depends_on as old one is.