### PR TITLE
Update Go version to 1.8

### DIFF
--- a/packages/go.rb
+++ b/packages/go.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Go < Package
-  version '1.7.5'
-  source_url 'https://storage.googleapis.com/golang/go1.7.5.src.tar.gz'
-  source_sha1 '4a36ad56b11579a8d534817b70a9baf754e5369a'
+  version '1.8.0'
+  source_url 'https://storage.googleapis.com/golang/go1.8.src.tar.gz'
+  source_sha1 '37945c372140c3a46c2c5b4b9ce382b6c8d88811'
   
   # go is required to build versions of go > 1.4
   if `which go` == ''


### PR DESCRIPTION
Updates go version to latest 1.8 release as of this time.

Tested working on Acer c720 w/ Chrome 55.0.2883.105, Platform 8872.76.0