### PR TITLE
[binutils] add gold-linker

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -1,15 +1,15 @@
 require 'package'
 
 class Binutils < Package
-  version '2.25'
+  version '2.25-1'
   binary_url ({
-    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-chromeos-armv7l.tar.xz",
-    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-chromeos-i686.tar.xz",
-    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-chromeos-x86_64.tar.xz",
+    armv7l: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-armv7l.tar.xz',
+    i686:   'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-i686.tar.xz',
+    x86_64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: "d4b42e13b4e4ed87c0f7a449b067b5f42345b7d8",
-    i686: "bc686fd29b9e9588a6f4f37c619dba217afb9bc3",
-    x86_64: "3ca5e6940c47385456f96861b169f925543f08b3",
+    armv7l: '5a4b3c8ddcac5d1b3fdc2f6aee8c9ec64f2d23ea',
+    i686:   '9d8d586e5e44badbe1f2058f53c183c019353a0e',
+    x86_64: '94d246a14efc080a398aefe9e192331a4ffaed46',
   })
 end


### PR DESCRIPTION
Add gold-liinker as a part of binutils.

 - traditional linker: ld, ld.bfd (alias)
 - gold liker: ld.gold

The gold linker is required to use cgo with shared library on armv7l.  It is not required on x86_64 nor i686, but it helps link speed if you are using c++ a lot.  Check https://en.wikipedia.org/wiki/Gold_(linker) for details.

I also updated https://github.com/jam7/chrome-cross if you have an interest on source.