### PR TITLE
Add buildessential as dependency if we're building from source

### DIFF
--- a/crew
+++ b/crew
@@ -279,9 +279,19 @@ end
 def resolveDependencies
   @dependencies = []
 
+  # check source packages existance
+  @source_package = 0
+
   def pushDeps
-    if @pkg.dependencies
-      @dependencies.unshift @pkg.dependencies
+    if @pkg.binary_url && @pkg.binary_url.has_key?(@device[:architecture])
+      @check_deps = @pkg.dependencies
+    else
+      # Use source dependencies
+      @check_deps = @pkg.dependencies
+      @source_package += 1
+    end
+    if @check_deps && !@check_deps.empty?
+      @dependencies.unshift @check_deps
       
       @pkg.dependencies.each do |dep|
         search dep, true
@@ -290,6 +300,14 @@ def resolveDependencies
     end
   end
   
+  pushDeps
+
+  # Add buildessential and solve its dependencies if any of dependent
+  # packages are made from source
+  if @source_package > 0
+    @dependencies.unshift 'buildessential'
+    search 'buildessential', true
+  end
   pushDeps
   
   return if @dependencies.empty?


### PR DESCRIPTION
Currently, chromebrew doesn't install buildessential by default.  It is required to install it if we want to compile from source.  However, almost all packages don't have such dependencies.

This PR modifies crew command to automatically add buildessential dependency if not only target but also any of dependet packages of the target are build from source.

Tested on ARM and X64.  Tested on X86 also with Cloudready.