### PR TITLE
Fix a bug not removing CREW_DEST_DIR/* before the preconfiguration

### DIFF
--- a/crew
+++ b/crew
@@ -221,7 +221,7 @@ def build_and_preconfigure (target_dir)
     @pkg.in_build = true
     @pkg.build
     @pkg.in_build = false
-    system "rm -rf", CREW_DEST_DIR + "/*" #wipe crew destdir
+    system "rm -rf #{CREW_DEST_DIR}/*" #wipe crew destdir
     puts "Preconfiguring package..."
     @pkg.install
   end


### PR DESCRIPTION
Crew is trying to remove `/usr/local/tmp/crew/dest/*` before copying files there as a part of install process.  However,
```
system "rm -rf", CREW_DEST_DIR + "/*" #wipe crew destdir
```
doesn't perform that since ruby uses execv for array style arguments.  Execv doesn't call shell, so `*` is not expanded.  You can see this problem if you install several source packages with `keep` option like:
```
$ crew install PACKAGE_A keep
$ crew install PACKAGE_B keep   # PACKAGE_B metafile will contain few directories for PACKAGE_A
```

This PR changes it to use shell to expand `*` by changing an array of arguments to single string argument.

Tested on ARM and X64.  Tested on X86 with Cloudready.