### PR TITLE
Added bin heroku 4.28.3

### DIFF
--- a/packages/heroku.rb
+++ b/packages/heroku.rb
@@ -1,0 +1,15 @@
+require 'package'
+
+class Heroku < Package
+  version '4.28.3'
+  binary_url ({
+    armv7l: "https://drive.google.com/uc?export=download&id=0ByCixsDmZPzxOHFIMzQyNHNFUWc",
+    i686: "https://drive.google.com/uc?export=download&id=0ByCixsDmZPzxd3NULTRkMWlHQTA",
+    x86_64: "https://drive.google.com/uc?export=download&id=0ByCixsDmZPzxLURkMktpREpDZk0"
+  })
+  binary_sha1 ({
+    armv7l: "b48f2f52d11cee4ca6a1878fdf2608a4b10ea53d",
+    i686: "1b0a736797c9293431b7db0055861fc73657a3fe",
+    x86_64: "9524fbc86c0a19f84f8bbb77c56ce2439d929a92"
+  })
+end


### PR DESCRIPTION
Yes, I know the current stable version is 5.7.3 (35ab144) and not 4.28.3. I just couldn't find a proper binary download for that version. ( I inspected https://cli-assets.heroku.com/ to determine the most recent version I could download ).

When starting the binary, it will automatically update itself to 5.7.3.

I was only able to test this on x86_64.