### PR TITLE
Add aarch64 binary packages by duplicating existing armv7l packages.

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,13 +3,15 @@ require 'package'
 class Binutils < Package
   version '2.25-1'
   binary_url ({
-    armv7l: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-armv7l.tar.xz',
-    i686:   'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-i686.tar.xz',
-    x86_64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: '5a4b3c8ddcac5d1b3fdc2f6aee8c9ec64f2d23ea',
-    i686:   '9d8d586e5e44badbe1f2058f53c183c019353a0e',
-    x86_64: '94d246a14efc080a398aefe9e192331a4ffaed46',
+    aarch64: '5a4b3c8ddcac5d1b3fdc2f6aee8c9ec64f2d23ea',
+    armv7l:  '5a4b3c8ddcac5d1b3fdc2f6aee8c9ec64f2d23ea',
+    i686:    '9d8d586e5e44badbe1f2058f53c183c019353a0e',
+    x86_64:  '94d246a14efc080a398aefe9e192331a4ffaed46',
   })
 end

--- a/packages/cloog.rb
+++ b/packages/cloog.rb
@@ -3,13 +3,15 @@ require 'package'
 class Cloog < Package
   version "0.18.4"
   binary_url ({
-    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-armv7l.tar.xz",
-    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-i686.tar.xz",
-    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-x86_64.tar.xz",
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: "919798d4329b96aa33374fe460d95e6e485b00c2",
-    i686: "7f37371de5d5f7eeaf13fe93fc664ecd6daadb25",
-    x86_64: "33d18076f6ca5b5c56e7908368b87d137355696a",
+    aarch64: '919798d4329b96aa33374fe460d95e6e485b00c2',
+    armv7l:  '919798d4329b96aa33374fe460d95e6e485b00c2',
+    i686:    '7f37371de5d5f7eeaf13fe93fc664ecd6daadb25',
+    x86_64:  '33d18076f6ca5b5c56e7908368b87d137355696a',
   })
 end

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,13 +3,15 @@ require 'package'
 class Curl < Package
   version '7.32.0'
   binary_url ({
-    armv7l: 'https://dl.dropboxusercontent.com/s/vvs612glzxrnjva/curl-7.32.0-chromeos-armv7l.tar.xz',
-    i686: 'https://dl.dropboxusercontent.com/s/h3x2iiy5ibi97vr/curl-7.32.0-chromeos-i686.tar.gz?token_hash=AAETu-MnNyBTCHQbkh4O817QbNK3wRLbAP_gQhjgNyFGtw&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/u2hmmd6wfz25qnn/curl-7.32.0-chromeos-x86_64.tar.gz?token_hash=AAGHjx6ATIsDW-Xi4pNUbCMknfWUa6GGQbAquWDkH1xzgg&dl=1'
+    aarch64: 'https://dl.dropboxusercontent.com/s/vvs612glzxrnjva/curl-7.32.0-chromeos-armv7l.tar.xz',
+    armv7l:  'https://dl.dropboxusercontent.com/s/vvs612glzxrnjva/curl-7.32.0-chromeos-armv7l.tar.xz',
+    i686:    'https://dl.dropboxusercontent.com/s/h3x2iiy5ibi97vr/curl-7.32.0-chromeos-i686.tar.gz?token_hash=AAETu-MnNyBTCHQbkh4O817QbNK3wRLbAP_gQhjgNyFGtw&dl=1',
+    x86_64:  'https://dl.dropboxusercontent.com/s/u2hmmd6wfz25qnn/curl-7.32.0-chromeos-x86_64.tar.gz?token_hash=AAGHjx6ATIsDW-Xi4pNUbCMknfWUa6GGQbAquWDkH1xzgg&dl=1',
   })
   binary_sha1 ({
-    armv7l: '5d974555b12b54ec47f044dc1cfe7a8ed31bb7e7',
-    i686: 'af3abbae663884ed367c5b6b467ebb310052f53f',
-    x86_64: '94766f554b195583040e31ce8e85846d8271ac11'
+    aarch64: '5d974555b12b54ec47f044dc1cfe7a8ed31bb7e7',
+    armv7l:  '5d974555b12b54ec47f044dc1cfe7a8ed31bb7e7',
+    i686:    'af3abbae663884ed367c5b6b467ebb310052f53f',
+    x86_64:  '94766f554b195583040e31ce8e85846d8271ac11',
   })
 end

--- a/packages/expat.rb
+++ b/packages/expat.rb
@@ -3,13 +3,15 @@ require 'package'
 class Expat < Package
   version '2.1.0'
   binary_url ({
-    armv7l: 'https://dl.dropboxusercontent.com/s/0wq0gbbg1cf5uub/expat-2.1.0-chromeos-armv7l.tar.xz',
-    i686: 'https://dl.dropboxusercontent.com/s/jh5uw42elm40t9a/expat-2.1.0-chromeos-i686.tar.gz?token_hash=AAGYckE0KoTPsydZGG85KTkpr7Nt5U1OUs0egJ1K0iJ1mg&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/k89o1x1a3fwoamu/expat-2.1.0-chromeos-x86_64.tar.gz?token_hash=AAGBLOil45Zg7G2RlFlfDUxKfeDyTP3uUWjfBvGQrOjAYA&dl=1'
+    aarch64: 'https://dl.dropboxusercontent.com/s/0wq0gbbg1cf5uub/expat-2.1.0-chromeos-armv7l.tar.xz',
+    armv7l:  'https://dl.dropboxusercontent.com/s/0wq0gbbg1cf5uub/expat-2.1.0-chromeos-armv7l.tar.xz',
+    i686:    'https://dl.dropboxusercontent.com/s/jh5uw42elm40t9a/expat-2.1.0-chromeos-i686.tar.gz?token_hash=AAGYckE0KoTPsydZGG85KTkpr7Nt5U1OUs0egJ1K0iJ1mg&dl=1',
+    x86_64:  'https://dl.dropboxusercontent.com/s/k89o1x1a3fwoamu/expat-2.1.0-chromeos-x86_64.tar.gz?token_hash=AAGBLOil45Zg7G2RlFlfDUxKfeDyTP3uUWjfBvGQrOjAYA&dl=1',
   })
   binary_sha1 ({
-    armv7l: '42ddf5b8e5db3bd7898bbc43997c95f488799ba8',
-    i686: '9ab42ec03d06cc64d5d9944cb4cc7eaa61a0af84',
-    x86_64: '3ac96a0e02c1117718d15bcd4976ef4bcef1a9ac'
+    aarch64: '42ddf5b8e5db3bd7898bbc43997c95f488799ba8',
+    armv7l:  '42ddf5b8e5db3bd7898bbc43997c95f488799ba8',
+    i686:    '9ab42ec03d06cc64d5d9944cb4cc7eaa61a0af84',
+    x86_64:  '3ac96a0e02c1117718d15bcd4976ef4bcef1a9ac',
   })
 end

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -4,14 +4,16 @@ class Gcc < Package
   version '4.9.x'
 
   binary_url ({
-    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-armv7l.tar.xz",
-    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-i686.tar.xz",
-    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-x86_64.tar.xz",
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: "267d2d6647af07805a7a8f5dabbb88ec31ff8db0",
-    i686: "904b4666a326505bd7546231a9273a4aa47e30f0",
-    x86_64: "c044e84073b2457079e611e2f27fd54b5e502e9a",
+    aarch64: '267d2d6647af07805a7a8f5dabbb88ec31ff8db0',
+    armv7l:  '267d2d6647af07805a7a8f5dabbb88ec31ff8db0',
+    i686:    '904b4666a326505bd7546231a9273a4aa47e30f0',
+    x86_64:  'c044e84073b2457079e611e2f27fd54b5e502e9a',
   })
 
   depends_on 'binutils'

--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -3,13 +3,15 @@ require 'package'
 class Gettext < Package
   version '0.18.3.1'
   binary_url ({
-    armv7l: 'https://dl.dropboxusercontent.com/s/wmfctz7x8bj6cwe/gettext-0.18.3.1-chromeos-armv7l.tar.xz',
-    i686: 'https://dl.dropboxusercontent.com/s/xmsfr7q9r99dhcs/gettext-0.18.3.1-chromeos-i686.tar.gz?token_hash=AAGJo0pqudCOkGU3NHOcBuFG2zLwWpapNXLX-zUJLcS3aA&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/nidj0ehxwserhz6/gettext-0.18.3.1-chromeos-x86_64.tar.gz?token_hash=AAFn-kdXlB23HDVDCKTn9n_U-i9LFNCIB6HU0jSUiJTctA&dl=1'
+    aarch64: 'https://dl.dropboxusercontent.com/s/wmfctz7x8bj6cwe/gettext-0.18.3.1-chromeos-armv7l.tar.xz',
+    armv7l:  'https://dl.dropboxusercontent.com/s/wmfctz7x8bj6cwe/gettext-0.18.3.1-chromeos-armv7l.tar.xz',
+    i686:    'https://dl.dropboxusercontent.com/s/xmsfr7q9r99dhcs/gettext-0.18.3.1-chromeos-i686.tar.gz?token_hash=AAGJo0pqudCOkGU3NHOcBuFG2zLwWpapNXLX-zUJLcS3aA&dl=1',
+    x86_64:  'https://dl.dropboxusercontent.com/s/nidj0ehxwserhz6/gettext-0.18.3.1-chromeos-x86_64.tar.gz?token_hash=AAFn-kdXlB23HDVDCKTn9n_U-i9LFNCIB6HU0jSUiJTctA&dl=1',
   })
   binary_sha1 ({
-    armv7l: '5224004048dd80bb523cd0091ad577b21448790b',
-    i686: '1ecbff59d6134c7f8804bcf18fb2b1b7a9a6d4c0',
-    x86_64: '22174347defa4f034a360078c248a61710c5f854'
+    aarch64: '5224004048dd80bb523cd0091ad577b21448790b',
+    armv7l:  '5224004048dd80bb523cd0091ad577b21448790b',
+    i686:    '1ecbff59d6134c7f8804bcf18fb2b1b7a9a6d4c0',
+    x86_64:  '22174347defa4f034a360078c248a61710c5f854',
   })
 end

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,14 +3,16 @@ require 'package'
 class Git < Package
   version '1.8.4'
   binary_url ({
-    armv7l: 'https://dl.dropboxusercontent.com/s/lnz5hmjv48d14f2/git-1.8.4-chromeos-armv7l.tar.xz',
-    i686: 'https://dl.dropboxusercontent.com/s/g3binxopw5nfky1/git-1.8.4-chromeos-i686.tar.gz?token_hash=AAEWnMNBfozSIzLD1unbYGJzT4FGkEfJmLFQ-3uzydfT_A&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/i7vs9wfk94tsrzt/git-1.8.4-chromeos-x86_64.tar.gz?token_hash=AAHyvjayN7THoxlryZaxQ2Ejm9xyD6bZCqXZM81hYRC8iQ&dl=1'
+    aarch64: 'https://dl.dropboxusercontent.com/s/lnz5hmjv48d14f2/git-1.8.4-chromeos-armv7l.tar.xz',
+    armv7l:  'https://dl.dropboxusercontent.com/s/lnz5hmjv48d14f2/git-1.8.4-chromeos-armv7l.tar.xz',
+    i686:    'https://dl.dropboxusercontent.com/s/g3binxopw5nfky1/git-1.8.4-chromeos-i686.tar.gz?token_hash=AAEWnMNBfozSIzLD1unbYGJzT4FGkEfJmLFQ-3uzydfT_A&dl=1',
+    x86_64:  'https://dl.dropboxusercontent.com/s/i7vs9wfk94tsrzt/git-1.8.4-chromeos-x86_64.tar.gz?token_hash=AAHyvjayN7THoxlryZaxQ2Ejm9xyD6bZCqXZM81hYRC8iQ&dl=1',
   })
   binary_sha1 ({
-    armv7l: '084a3b9bb90c572e7c5b12aae485715f145053e5',
-    i686: '8c1bf4bcffb0e9c17bf20dd05981e86ea34d5d65',
-    x86_64: '067cb6c36616ac30999ab97e85f3dc0e9d1d57f4'
+    aarch64: '084a3b9bb90c572e7c5b12aae485715f145053e5',
+    armv7l:  '084a3b9bb90c572e7c5b12aae485715f145053e5',
+    i686:    '8c1bf4bcffb0e9c17bf20dd05981e86ea34d5d65',
+    x86_64:  '067cb6c36616ac30999ab97e85f3dc0e9d1d57f4',
   })
 
   depends_on 'zlibpkg'

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -3,13 +3,15 @@ require 'package'
 class Glibc < Package
   version '2.19'
   binary_url ({
-    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-armv7l.tar.xz",
-    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-i686.tar.xz",
-    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-x86_64.tar.xz",
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: "c4da258eacf411833494bbe6903918909fb5629c",
-    i686: "7d7f4e8e137bbb96dea2b2792dc12a7e61c729d9",
-    x86_64: "073545bf8aa4b29fbf9084d31848b40f1df1b4ef",
+    aarch64: 'c4da258eacf411833494bbe6903918909fb5629c',
+    armv7l:  'c4da258eacf411833494bbe6903918909fb5629c',
+    i686:    '7d7f4e8e137bbb96dea2b2792dc12a7e61c729d9',
+    x86_64:  '073545bf8aa4b29fbf9084d31848b40f1df1b4ef',
   })
 end

--- a/packages/glibc223.rb
+++ b/packages/glibc223.rb
@@ -3,13 +3,15 @@ require 'package'
 class Glibc223 < Package
   version '2.23'
   binary_url ({
-    armv7l: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-armv7l.tar.xz',
-    i686:   'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-i686.tar.xz',
-    x86_64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: '4cac7d5d3d97f147c9ac9ad0c1deb1ac9b967450',
-    i686:   '434adb6dd1c3dcc30a25e3700f425a081888a28a',
-    x86_64: '9b4ae8c6ccc081f7d9d169cd0b3eb74ae736e79f',
+    aarch64: '4cac7d5d3d97f147c9ac9ad0c1deb1ac9b967450',
+    armv7l:  '4cac7d5d3d97f147c9ac9ad0c1deb1ac9b967450',
+    i686:    '434adb6dd1c3dcc30a25e3700f425a081888a28a',
+    x86_64:  '9b4ae8c6ccc081f7d9d169cd0b3eb74ae736e79f',
   })
 end

--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -3,13 +3,15 @@ require 'package'
 class Gmp < Package
   version "6.1.2"
   binary_url ({
-    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-armv7l.tar.xz",
-    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-i686.tar.xz",
-    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-x86_64.tar.xz",
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: "ef330045d0eb7b33015e31cd1ac8428caacaf026",
-    i686: "a26eeac034966b50ca70d43b23768a078ca4dd14",
-    x86_64: "0ada7fbc26b2b5567df516daaf61edc4129ae1b5",
+    aarch64: 'ef330045d0eb7b33015e31cd1ac8428caacaf026',
+    armv7l:  'ef330045d0eb7b33015e31cd1ac8428caacaf026',
+    i686:    'a26eeac034966b50ca70d43b23768a078ca4dd14',
+    x86_64:  '0ada7fbc26b2b5567df516daaf61edc4129ae1b5',
   })
 end

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -3,13 +3,15 @@ require 'package'
 class Isl < Package
   version "0.14.1"
   binary_url ({
-    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-armv7l.tar.xz",
-    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-i686.tar.xz",
-    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-x86_64.tar.xz",
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: "c151cbe2601eda6cd391da165ad940aa7fa666bc",
-    i686: "cc2d07411dbfcfd03afe0953bce8cef8d7bb8307",
-    x86_64: "3fa612198955e3d6e8201c05ef486d1462c76462",
+    aarch64: 'c151cbe2601eda6cd391da165ad940aa7fa666bc',
+    armv7l:  'c151cbe2601eda6cd391da165ad940aa7fa666bc',
+    i686:    'cc2d07411dbfcfd03afe0953bce8cef8d7bb8307',
+    x86_64:  '3fa612198955e3d6e8201c05ef486d1462c76462',
   })
 end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -3,13 +3,15 @@ require 'package'
 class Jdk8 < Package
   version '8u112'
   binary_url ({
-    i686: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-i686.tar.gz",
-    x86_64: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-x86_64.tar.gz",
-    armv7l: "https://www.dropbox.com/s/bfu14nhbeoi8tdo/jdk8u111-armv7l.tar.gz?dl=1"
+    aarch64: 'https://www.dropbox.com/s/bfu14nhbeoi8tdo/jdk8u111-armv7l.tar.gz?dl=1',
+    armv7l:  'https://www.dropbox.com/s/bfu14nhbeoi8tdo/jdk8u111-armv7l.tar.gz?dl=1',
+    i686:    'https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-i686.tar.gz',
+    x86_64:  'https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-x86_64.tar.gz',
   })
   binary_sha1 ({
-    i686: "65de377470bdd42e4f3e158b16917166ebe47a02",
-    x86_64: "9a009b3b33cbb82ec70e7b0061973b09308c7fed",
-    armv7l: "913adb900bf0d9d42452a4591c1a9093076ed4b6"
+    aarch64: '913adb900bf0d9d42452a4591c1a9093076ed4b6',
+    armv7l:  '913adb900bf0d9d42452a4591c1a9093076ed4b6',
+    i686:    '65de377470bdd42e4f3e158b16917166ebe47a02',
+    x86_64:  '9a009b3b33cbb82ec70e7b0061973b09308c7fed',
   })
 end

--- a/packages/libssh2.rb
+++ b/packages/libssh2.rb
@@ -3,13 +3,15 @@ require 'package'
 class Libssh2 < Package
   version '1.4.3'
   binary_url ({
-    armv7l: 'https://dl.dropboxusercontent.com/s/fq23kj42gsifcvi/libssh2-1.4.3-chromeos-armv7l.tar.xz',
-    i686: 'https://dl.dropboxusercontent.com/s/zjnild1c2i10h53/libssh2-1.4.3-chromeos-i686.tar.gz?token_hash=AAG_aZ7_dPKOiOMCMUiW2g3mLkz8UKHnGn5jLcDAGcNCIA&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/frzkbbnf35ie6ns/libssh2-1.4.3-chromeos-x86_64.tar.gz?token_hash=AAEk26mEOXT0MX05nM9gG6yNDPkL6KmLazRxKqQCR6qs8Q&dl=1'
+    aarch64: 'https://dl.dropboxusercontent.com/s/fq23kj42gsifcvi/libssh2-1.4.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://dl.dropboxusercontent.com/s/fq23kj42gsifcvi/libssh2-1.4.3-chromeos-armv7l.tar.xz',
+    i686:    'https://dl.dropboxusercontent.com/s/zjnild1c2i10h53/libssh2-1.4.3-chromeos-i686.tar.gz?token_hash=AAG_aZ7_dPKOiOMCMUiW2g3mLkz8UKHnGn5jLcDAGcNCIA&dl=1',
+    x86_64:  'https://dl.dropboxusercontent.com/s/frzkbbnf35ie6ns/libssh2-1.4.3-chromeos-x86_64.tar.gz?token_hash=AAEk26mEOXT0MX05nM9gG6yNDPkL6KmLazRxKqQCR6qs8Q&dl=1',
   })
   binary_sha1 ({
-    armv7l: '559f37b727f181ad0b623dba352a9efd0facf51a',
-    i686: '21b4b1a9608b12c0b3d1e6f0b6615f4a4152acb3',
-    x86_64: '903aae8255c47c6052003837be132ff39582422b'
+    aarch64: '559f37b727f181ad0b623dba352a9efd0facf51a',
+    armv7l:  '559f37b727f181ad0b623dba352a9efd0facf51a',
+    i686:    '21b4b1a9608b12c0b3d1e6f0b6615f4a4152acb3',
+    x86_64:  '903aae8255c47c6052003837be132ff39582422b',
   })
 end

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -3,13 +3,15 @@ require 'package'
 class Linuxheaders < Package
   version '3.18'
   binary_url ({
-    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-armv7l.tar.xz",
-    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-i686.tar.xz",
-    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-x86_64.tar.xz",
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: "fad98da3de461b0b08298c5a1ec07cca53eed008",
-    i686: "4142a609534383c99123fb43016745746589922b",
-    x86_64: "716f50b255d6bd3c4039a92cbd20d4e887e25bb7",
+    aarch64: 'fad98da3de461b0b08298c5a1ec07cca53eed008',
+    armv7l:  'fad98da3de461b0b08298c5a1ec07cca53eed008',
+    i686:    '4142a609534383c99123fb43016745746589922b',
+    x86_64:  '716f50b255d6bd3c4039a92cbd20d4e887e25bb7',
   })
 end

--- a/packages/make.rb
+++ b/packages/make.rb
@@ -3,13 +3,15 @@ require 'package'
 class Make < Package
   version '3.82'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/2s68lllqlsix15i/make-3.82-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/f6pg4bkg6m3vn7q/make-3.82-chromeos-i686.tar.gz?token_hash=AAHP__I3leN8BCLdP0pLbkNopoFGGhDuKX0sN-I6Zx4JYg&dl=1",
-    x86_64: "https://dl.dropboxusercontent.com/s/t818zxgixti6wvl/make-3.82-chromeos-x86_64.tar.gz?token_hash=AAGLBxpwv2mZj7dAgnzdmfFcO8G28wbCfb0lPM8_qwRtSA&dl=1"
+    aarch64: 'https://dl.dropboxusercontent.com/s/2s68lllqlsix15i/make-3.82-chromeos-armv7l.tar.xz',
+    armv7l:  'https://dl.dropboxusercontent.com/s/2s68lllqlsix15i/make-3.82-chromeos-armv7l.tar.xz',
+    i686:    'https://dl.dropboxusercontent.com/s/f6pg4bkg6m3vn7q/make-3.82-chromeos-i686.tar.gz?token_hash=AAHP__I3leN8BCLdP0pLbkNopoFGGhDuKX0sN-I6Zx4JYg&dl=1',
+    x86_64:  'https://dl.dropboxusercontent.com/s/t818zxgixti6wvl/make-3.82-chromeos-x86_64.tar.gz?token_hash=AAGLBxpwv2mZj7dAgnzdmfFcO8G28wbCfb0lPM8_qwRtSA&dl=1',
   })
   binary_sha1 ({
-    armv7l: "eb98493bf26f8ce670c12005b6a6f3c93f9a634d",
-    i686: "ccb01c7358e5abdf8b06305eb31b1969b8b174f7",
-    x86_64: "2bab91837440d101eb55129f41a7837101249b46"
+    aarch64: 'eb98493bf26f8ce670c12005b6a6f3c93f9a634d',
+    armv7l:  'eb98493bf26f8ce670c12005b6a6f3c93f9a634d',
+    i686:    'ccb01c7358e5abdf8b06305eb31b1969b8b174f7',
+    x86_64:  '2bab91837440d101eb55129f41a7837101249b46',
   })
 end

--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -3,13 +3,15 @@ require 'package'
 class Mpc < Package
   version '1.0.3'
   binary_url ({
-    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-armv7l.tar.xz",
-    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-i686.tar.xz",
-    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-x86_64.tar.xz",
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: "2a05a536cc6fd4da7d948c4732722c5d430ee010",
-    i686: "f10689f81749d65d1741f801387e9970eea988d7",
-    x86_64: "659123c6bf218d60837579e1fe50dd86f24d487f",
+    aarch64: '2a05a536cc6fd4da7d948c4732722c5d430ee010',
+    armv7l:  '2a05a536cc6fd4da7d948c4732722c5d430ee010',
+    i686:    'f10689f81749d65d1741f801387e9970eea988d7',
+    x86_64:  '659123c6bf218d60837579e1fe50dd86f24d487f',
   })
 end

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -3,13 +3,15 @@ require 'package'
 class Mpfr < Package
   version '3.1.5'
   binary_url ({
-    armv7l: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-armv7l.tar.xz",
-    i686: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-i686.tar.xz",
-    x86_64: "https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-x86_64.tar.xz",
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: "8ace66e438f6593affc460cc8a45f2a7df0ac1ca",
-    i686: "1a3e4833cbdf002e5fd62135b5113c37c2700362",
-    x86_64: "0028523daf1b3935bad21d3706e39fb248a8f0f2",
+    aarch64: '8ace66e438f6593affc460cc8a45f2a7df0ac1ca',
+    armv7l:  '8ace66e438f6593affc460cc8a45f2a7df0ac1ca',
+    i686:    '1a3e4833cbdf002e5fd62135b5113c37c2700362',
+    x86_64:  '0028523daf1b3935bad21d3706e39fb248a8f0f2',
   })
 end

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -5,13 +5,15 @@ class Perl < Package
   source_url 'http://www.cpan.org/src/5.0/perl-5.24.1.tar.gz'
   source_sha1 '19b218bbc3a63a8408ed56b93928fd9a4c1b5c83'
   binary_url ({
-    armv7l: 'https://github.com/jam7/chromebrew/releases/download/binaries/perl-5.24.1-chromeos-armv7l.tar.xz',
-    i686:   'https://github.com/jam7/chromebrew/releases/download/binaries/perl-5.24.1-chromeos-i686.tar.xz',
-    x86_64: 'https://github.com/jam7/chromebrew/releases/download/binaries/perl-5.24.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/binaries/perl-5.24.1-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/binaries/perl-5.24.1-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/binaries/perl-5.24.1-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/binaries/perl-5.24.1-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    armv7l: '3352e1cb829062bf91da51802304b702aaa072d8',
-    i686:   '2929f609a1d4d098eef649432af7feb2b8762e4f',
-    x86_64: '5406a1b1a2d32392e44de48e9a7ea17d76918389',
+    aarch64: '3352e1cb829062bf91da51802304b702aaa072d8',
+    armv7l:  '3352e1cb829062bf91da51802304b702aaa072d8',
+    i686:    '2929f609a1d4d098eef649432af7feb2b8762e4f',
+    x86_64:  '5406a1b1a2d32392e44de48e9a7ea17d76918389',
   })
 end

--- a/packages/python.rb
+++ b/packages/python.rb
@@ -3,13 +3,15 @@ require 'package'
 class Python < Package
   version '3.3.2'
   binary_url ({
-    armv7l: 'https://dl.dropboxusercontent.com/s/xsu18iggr51ewqh/python-3.3.2-chromeos-armv7l.tar.xz',
-    i686: 'https://dl.dropboxusercontent.com/s/mxgfmq992hhiawk/python-3.3.2-chromeos-i686.tar.gz?token_hash=AAFA2YzFp293uyV3zYfP70iwCk8oH9HCLKMTrK0dtMU8GQ&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/r1zvmza51hrr87q/python-3.3.2-chromeos-x86_64.tar.gz?token_hash=AAHIdz6pWcOrfty7C8ACuRcLDq0d0ERYs0jCgOPLn5USUQ&dl=1'
+    aarch64: 'https://dl.dropboxusercontent.com/s/xsu18iggr51ewqh/python-3.3.2-chromeos-armv7l.tar.xz',
+    armv7l:  'https://dl.dropboxusercontent.com/s/xsu18iggr51ewqh/python-3.3.2-chromeos-armv7l.tar.xz',
+    i686:    'https://dl.dropboxusercontent.com/s/mxgfmq992hhiawk/python-3.3.2-chromeos-i686.tar.gz?token_hash=AAFA2YzFp293uyV3zYfP70iwCk8oH9HCLKMTrK0dtMU8GQ&dl=1',
+    x86_64:  'https://dl.dropboxusercontent.com/s/r1zvmza51hrr87q/python-3.3.2-chromeos-x86_64.tar.gz?token_hash=AAHIdz6pWcOrfty7C8ACuRcLDq0d0ERYs0jCgOPLn5USUQ&dl=1',
   })
   binary_sha1 ({
-    armv7l: 'b32ee2db9c14d7e2d1df6d43836312521a3ece91',
-    i686: 'a985a4bba243b4fa701db302dc2fa554aef76f1c',
-    x86_64: 'fbfe0946c2f9191bd6110705994d459e373a8b09'
+    aarch64: 'b32ee2db9c14d7e2d1df6d43836312521a3ece91',
+    armv7l:  'b32ee2db9c14d7e2d1df6d43836312521a3ece91',
+    i686:    'a985a4bba243b4fa701db302dc2fa554aef76f1c',
+    x86_64:  'fbfe0946c2f9191bd6110705994d459e373a8b09',
   })
 end

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -3,14 +3,16 @@ require 'package'
 class Ruby < Package
   version '2.0.0p247-chromeos1'
   binary_url ({
-    armv7l: "https://dl.dropboxusercontent.com/s/02afb4qm4ugl0os/ruby-2.0.0p247-chromeos-armv7l.tar.xz",
-    i686: "https://dl.dropboxusercontent.com/s/tufbuqcn80ubypx/ruby-2.0.0p247-chromeos-i686.tar.gz&dl=1",
-    x86_64: "https://www.dropbox.com/s/x3jt0z5i1r4afyv/ruby-2.0.0p247-chromeos-x86_64.tar.gz?dl=1"
+    aarch64: 'https://dl.dropboxusercontent.com/s/02afb4qm4ugl0os/ruby-2.0.0p247-chromeos-armv7l.tar.xz',
+    armv7l:  'https://dl.dropboxusercontent.com/s/02afb4qm4ugl0os/ruby-2.0.0p247-chromeos-armv7l.tar.xz',
+    i686:    'https://dl.dropboxusercontent.com/s/tufbuqcn80ubypx/ruby-2.0.0p247-chromeos-i686.tar.gz&dl=1',
+    x86_64:  'https://www.dropbox.com/s/x3jt0z5i1r4afyv/ruby-2.0.0p247-chromeos-x86_64.tar.gz?dl=1',
   })
   binary_sha1 ({
-    armv7l: "f575e27e9b20cbb6f1c77cdd87270748e83cf6b2",
-    i686: "49eeba5d542e4c3e6aa3686f215485e0946fb99a",
-    x86_64: "f1de1ef5ed690c3b78f4e40208a4fb93e227c4ed"
+    aarch64: 'f575e27e9b20cbb6f1c77cdd87270748e83cf6b2',
+    armv7l:  'f575e27e9b20cbb6f1c77cdd87270748e83cf6b2',
+    i686:    '49eeba5d542e4c3e6aa3686f215485e0946fb99a',
+    x86_64:  'f1de1ef5ed690c3b78f4e40208a4fb93e227c4ed',
   })
 
   depends_on 'readline'

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -3,13 +3,15 @@ require 'package'
 class Zlibpkg < Package
   version '1.2.8'
   binary_url ({
-    armv7l: 'https://dl.dropboxusercontent.com/s/7y34bh0wph4iipa/zlibpkg-1.2.8-chromeos-armv7l.tar.xz',
-    i686: 'https://dl.dropboxusercontent.com/s/ljhhvr12u1izayj/zlib-1.2.8-chromeos-i686.tar.gz?token_hash=AAEABTatYkxOOybZGoCj3Kg_DKEbFbSfolzZklfHwCsP_A&dl=1',
-    x86_64: 'https://dl.dropboxusercontent.com/s/h4lqj0rnand0jqu/zlib-1.2.8-chromeos-x86_64.tar.gz?token_hash=AAGabAMhX4CGpzhpkcuKMmmWPxFZDiNOC-r9B0o7x4D7eQ&dl=1'
+    aarch64: 'https://dl.dropboxusercontent.com/s/7y34bh0wph4iipa/zlibpkg-1.2.8-chromeos-armv7l.tar.xz',
+    armv7l:  'https://dl.dropboxusercontent.com/s/7y34bh0wph4iipa/zlibpkg-1.2.8-chromeos-armv7l.tar.xz',
+    i686:    'https://dl.dropboxusercontent.com/s/ljhhvr12u1izayj/zlib-1.2.8-chromeos-i686.tar.gz?token_hash=AAEABTatYkxOOybZGoCj3Kg_DKEbFbSfolzZklfHwCsP_A&dl=1',
+    x86_64:  'https://dl.dropboxusercontent.com/s/h4lqj0rnand0jqu/zlib-1.2.8-chromeos-x86_64.tar.gz?token_hash=AAGabAMhX4CGpzhpkcuKMmmWPxFZDiNOC-r9B0o7x4D7eQ&dl=1',
   })
   binary_sha1 ({
-    armv7l: '85980c0e6765e6264b191db1fa4c58508e663d3f',
-    i686: 'e02974780bfb3bf46940183043d15897a765ab4e',
-    x86_64: 'cb764e22b68b7e2884372708b5b585d11efca972'
+    aarch64: '85980c0e6765e6264b191db1fa4c58508e663d3f',
+    armv7l:  '85980c0e6765e6264b191db1fa4c58508e663d3f',
+    i686:    'e02974780bfb3bf46940183043d15897a765ab4e',
+    x86_64:  'cb764e22b68b7e2884372708b5b585d11efca972',
   })
 end


### PR DESCRIPTION
This is additional PR to #547.  The combination of this and #547 will fix problem described in #555.

This PR duplicates all armv7l binaries as aarch64 binaries to solve problem after the installation.  I don't own aarch64 machine, so I've not tested this on the real machine though.