### PR TITLE
(FIX) Update URLs for java jdk8 since dropbox has changed the public folders to private.

### DIFF
--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -3,9 +3,9 @@ require 'package'
 class Jdk8 < Package
   version '8u112'
   binary_url ({
-    i686: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-i686.tar.gz",
-    x86_64: "https://dl.dropboxusercontent.com/u/14799278/crew/jdk8u112-x86_64.tar.gz",
-    armv7l: "https://www.dropbox.com/s/bfu14nhbeoi8tdo/jdk8u111-armv7l.tar.gz?dl=1"
+    i686: "https://www.dropbox.com/s/0c9yratmcf5fdpq/jdk8u112-i686.tar.gz",
+    x86_64: "https://www.dropbox.com/s/ojtv2phawxzg6wr/jdk8u112-x86_64.tar.gz",
+    armv7l: "https://www.dropbox.com/s/vcejuitboafaxib/jdk8u22-armv7l.tar.gz"
   })
   binary_sha1 ({
     i686: "65de377470bdd42e4f3e158b16917166ebe47a02",

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,7 +4,7 @@ class Jdk8 < Package
   version '8u112'
   binary_url ({
     i686: "https://www.dropbox.com/s/0c9yratmcf5fdpq/jdk8u112-i686.tar.gz",
-    x86_64: "https://www.dropbox.com/s/ojtv2phawxzg6wr/jdk8u112-x86_64.tar.gz",
+    x86_64: "https://www.dropbox.com/s/efa747g7or3294u/jdk8u112-x86_64.tar.gz",
     armv7l: "https://www.dropbox.com/s/vcejuitboafaxib/jdk8u22-armv7l.tar.gz"
   })
   binary_sha1 ({


### PR DESCRIPTION
Changelog:
- Change url to new ones as i needed to reshare on dropbox and the urls are different.
- Check sha1sums (all good)

Resolves:
#568 
I've made a small guide in #268 for how to reshare.