### PR TITLE
Change crew to abort just after errors

### DIFF
--- a/crew
+++ b/crew
@@ -266,7 +266,7 @@ def resolveDependenciesAndInstall
     search origin
     install
   rescue InstallError => e 
-    puts "#{@pkg.name} failed to install: #{e.to_s}"
+    abort "#{@pkg.name} failed to install: #{e.to_s}"
   ensure
     #cleanup
     unless ARGV[2] == 'keep'


### PR DESCRIPTION
`crew upgrade` is continuously trying to install multiple packages even if errors are caused.  This solves such problems.

Clean-up codes in `ensure` section is executed even if abort is called.