### PR TITLE
Add `crew build` command to build binary archives

### DIFF
--- a/crew
+++ b/crew
@@ -22,6 +22,14 @@ else
   CREW_NPROC = ENV["CREW_NPROC"]
 end
 
+# Set XZ_OPT environment variable for build command.
+# If CREW_XZ_OPT is defined, use it by default.  Use `-7e`, otherwise.
+if ENV["CREW_XZ_OPT"].to_s == ''
+  ENV["XZ_OPT"] = "-7e"
+else
+  ENV["XZ_OPT"] = ENV["CREW_XZ_OPT"]
+end
+
 ARCH = `uname -m`.strip
 
 $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"
@@ -160,15 +168,17 @@ def upgrade
 end
 
 def download
-  if @pkg.binary_url && @pkg.binary_url.has_key?(@device[:architecture])
-    url = @pkg.binary_url[@device[:architecture]]
-    source = false
+  url = @pkg.get_url(@device[:architecture])
+  source = @pkg.working_on_source?(@device[:architecture])
+
+  if !source
     puts "Precompiled binary available, downloading..."
+  elsif @pkg.build_from_source
+    puts "Downloading source..."
   else
-    url = @pkg.source_url
-    source = true
     puts "No precompiled binary available for your platform, downloading source..."
   end
+
   uri = URI.parse url
   filename = File.basename(uri.path)
   if source
@@ -383,6 +393,69 @@ def install
   puts "#{@pkg.name.capitalize} installed!"
 end
 
+def resolve_dependencies_and_build
+  begin
+    origin = @pkg.name
+
+    # mark current package as which is required to compile from source
+    @pkg.build_from_source = true
+    resolveDependencies
+
+    search origin, true
+    build_package Dir.pwd
+  rescue InstallError => e
+    abort "#{@pkg.name} failed to build: #{e.to_s}"
+  ensure
+    #cleanup
+    unless ARGV[2] == 'keep'
+      Dir.chdir CREW_BREW_DIR do
+        system "rm -rf *"
+        system "mkdir dest" #this is a little ugly, feel free to find a better way
+      end
+    end
+  end
+end
+
+def build_package (pwd)
+  abort "It is not possible to build fake package" if @pkg.is_fake?
+  abort "It is not possible to build binary package" if !@pkg.source_url
+  abort "You don't have a working C compiler. Run 'crew install buildessential' to get one and try again." unless system("gcc", "--version")
+
+  # download source codes and unpack it
+  meta = download_source
+  target_dir = unpack meta
+
+  # build from source and place binaries at CREW_DEST_DIR
+  build_and_preconfigure target_dir
+
+  # call check method here.  this check method is called by this function only,
+  # therefore it is possible place time consuming tests in the check method.
+  if Dir.exist? target_dir
+    Dir.chdir target_dir do
+      puts "Checking..."
+      @pkg.check
+    end
+  end
+
+  # prepare filelist and dlist at CREW_DEST_DIR
+  prepare_package CREW_DEST_DIR
+
+  # build package from filelist, dlist and binary files in CREW_DEST_DIR
+  puts "Archiving..."
+  archive_package pwd
+end
+
+def archive_package (pwd)
+  pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
+  Dir.chdir CREW_DEST_DIR do
+    system "tar cJf #{pwd}/#{pkg_name} *"
+  end
+  Dir.chdir pwd do
+    system "sha1sum #{pkg_name} > #{pkg_name}.sha1"
+  end
+  puts "#{pkg_name} is built!"
+end
+
 def remove (pkgName)
 
   #make sure the package is actually installed
@@ -456,14 +529,17 @@ when "upgrade"
 when "install"
   search @pkgName
   resolveDependenciesAndInstall
+when "build"
+  search @pkgName
+  resolve_dependencies_and_build
 when "remove"
   abort 'Removing actions must be ran with sudo.' unless USER == 'root'
   remove @pkgName
 when nil
   puts "Chromebrew, version 0.4.1"
   puts "Usage: crew [command] [package]"
-  puts "Available commands: download, install, remove, search, update, upgrade, whatprovides"
+  puts "Available commands: build, download, install, remove, search, update, upgrade, whatprovides"
 else
   puts "I have no idea how to do #{@command} :("
-  puts "Available commands: download, install, remove, search, update, upgrade, whatprovides"
+  puts "Available commands: build, download, install, remove, search, update, upgrade, whatprovides"
 end

--- a/crew
+++ b/crew
@@ -418,11 +418,10 @@ end
 
 def build_package (pwd)
   abort "It is not possible to build fake package" if @pkg.is_fake?
-  abort "It is not possible to build binary package" if !@pkg.source_url
-  abort "You don't have a working C compiler. Run 'crew install buildessential' to get one and try again." unless system("gcc", "--version")
+  abort "It is not possible to build without source" if !@pkg.working_on_source?(@device[:architecture])
 
   # download source codes and unpack it
-  meta = download_source
+  meta = download
   target_dir = unpack meta
 
   # build from source and place binaries at CREW_DEST_DIR

--- a/crew
+++ b/crew
@@ -169,7 +169,7 @@ end
 
 def download
   url = @pkg.get_url(@device[:architecture])
-  source = @pkg.working_on_source?(@device[:architecture])
+  source = @pkg.is_source?(@device[:architecture])
 
   if !source
     puts "Precompiled binary available, downloading..."
@@ -418,7 +418,7 @@ end
 
 def build_package (pwd)
   abort "It is not possible to build fake package" if @pkg.is_fake?
-  abort "It is not possible to build without source" if !@pkg.working_on_source?(@device[:architecture])
+  abort "It is not possible to build without source" if !@pkg.is_source?(@device[:architecture])
 
   # download source codes and unpack it
   meta = download

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -23,8 +23,16 @@ class Package
     end
   end
 
-  def self.working_on_source? (architecture)
+  def self.is_binary? (architecture)
     if !@build_from_source && @binary_url && @binary_url.has_key?(architecture)
+      return true
+    else
+      return false
+    end
+  end
+
+  def self.is_source? (architecture)
+    if is_binary?(architecture) || is_fake?
       return false
     else
       return true
@@ -34,13 +42,13 @@ class Package
   def self.is_fake
     @is_fake = true
   end
-  
+
   def self.is_fake?
     @is_fake
   end
 
   def self.build
-    
+
   end
 
   def self.check

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -5,7 +5,7 @@ class Package
   
   class << self
     attr_reader :dependencies, :is_fake
-    attr_accessor :name, :in_build
+    attr_accessor :name, :in_build, :build_from_source
   end
   def self.depends_on (dependency = nil)
     @dependencies = [] unless @dependencies
@@ -14,7 +14,23 @@ class Package
     end
     @dependencies
   end
-  
+
+  def self.get_url (architecture)
+    if !@build_from_source && @binary_url && @binary_url.has_key?(architecture)
+      return @binary_url[architecture]
+    else
+      return @source_url
+    end
+  end
+
+  def self.working_on_source? (architecture)
+    if !@build_from_source && @binary_url && @binary_url.has_key?(architecture)
+      return false
+    else
+      return true
+    end
+  end
+
   def self.is_fake
     @is_fake = true
   end
@@ -25,6 +41,10 @@ class Package
 
   def self.build
     
+  end
+
+  def self.check
+
   end
 
   def self.system(*args)


### PR DESCRIPTION
This PR adds feature described in #552.

If a user types `crew build package-name`, crew compile it from source as described in `package.rb` file and leave binary package and sha1 file at the current working directory like below.
```
$ crew build git
...
$ ls
git-2.11.0-chromeos-armv7l.tar.xz
git-2.11.0-chromeos-armv7l.tar.xz.sha1
``` 

There are two additional features.

 - Developer can specify the level of compression by `CREW_XZ_OPT` environment variable.  See xz manual for details.  Use "-7e" by default.
 - Developer can add aggressive test in the check method in each package.  This check method is executed only in this build mode.  So, we can add any kind of time consuming test cases here.  Even if it takes 2 days, regular `crew install` will be finished quick.

In order to add latter check method, need to modify `.rb` files.  For example, we can add python check method like below.  This test takes long time, but only users who use `crew build python` gets affected.
```
  def self.check
    system "TMPDIR=/usr/local/tmp http_proxy= https_proxy= ftp_proxy= make test"
  end
```