### PR TITLE
Support "depends_on name => :build" style dependencies

### DIFF
--- a/crew
+++ b/crew
@@ -295,17 +295,22 @@ def resolveDependencies
   @source_package = 0
 
   def pushDeps
-    if @pkg.binary_url && @pkg.binary_url.has_key?(@device[:architecture])
-      @check_deps = @pkg.dependencies
+    if @pkg.is_binary?(@device[:architecture])
+      # retrieve name of dependencies that doesn't contain :build tag
+      @check_deps = @pkg.dependencies.select {|k, v| !v.include?(:build)}.map {|k, v| k}
+    elsif @pkg.is_fake?
+      # retrieve name of all dependencies
+      @check_deps = @pkg.dependencies.map {|k, v| k}
     else
-      # Use source dependencies
-      @check_deps = @pkg.dependencies
+      # retrieve name of all dependencies
+      @check_deps = @pkg.dependencies.map {|k, v| k}
+      # count the number of source packages to add buildessential into dependencies later
       @source_package += 1
     end
     if @check_deps && !@check_deps.empty?
       @dependencies.unshift @check_deps
-      
-      @pkg.dependencies.each do |dep|
+
+      @check_deps.each do |dep|
         search dep, true
         pushDeps
       end

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -2,15 +2,35 @@ require 'package_helpers'
 
 class Package
   property :version, :binary_url, :binary_sha1, :source_url, :source_sha1, :is_fake
-  
+
   class << self
-    attr_reader :dependencies, :is_fake
+    attr_reader :is_fake
     attr_accessor :name, :in_build, :build_from_source
   end
+
+  def self.dependencies
+    # Not sure how to initialize instance variable of not constructed class.
+    # Therefore, initialize it in reader function.
+    @dependencies = Hash.new unless @dependencies
+    @dependencies
+  end
+
   def self.depends_on (dependency = nil)
-    @dependencies = [] unless @dependencies
+    @dependencies = Hash.new unless @dependencies
     if dependency
-      @dependencies << dependency
+      # add element in "[ name, [ tag1, tag2, ... ] ]" format
+      if dependency.is_a?(Hash)
+        if dependency.first[1].is_a?(Array)
+          # parse "depends_on name => [ tag1, tag2 ]"
+          @dependencies.store(dependency.first[0], dependency.first[1])
+        else
+          # parse "depends_on name => tag"
+          @dependencies.store(dependency.first[0], [ dependency.first[1] ])
+        end
+      else
+        # parse "depends_on name"
+        @dependencies.store(dependency, [])
+      end
     end
     @dependencies
   end


### PR DESCRIPTION
This PR adds feature described in #487.

With this PR, we can say for example git requires only `libssh2` to install it from binary package.  Therefore, crew install only `libssh2` and `git` if a binary package of git is distributed.  Otherwise, crew install all and compile git from source code.
```
  depends_on 'zlibpkg' => :build
  depends_on 'libssh2'
  depends_on 'openssl' => :build
  depends_on 'perl' => :build
  depends_on 'curl' => :build
  depends_on 'expat' => :build
  depends_on 'gettext' => :build
  depends_on 'python27'  => :build    # requires python2
```
This reduces the amount of installation time if binary packages are distributed enough.

Prerequisites: need to apply #573 first.