### PR TITLE
Update libsigsegv to 2.11

### DIFF
--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -1,12 +1,23 @@
 require 'package'
 
 class Libsigsegv < Package
-  version '2.10-1'
-  source_url 'ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.10.tar.gz'
-  source_sha1 'b75a647a9ebda70e7a3b33583efdd550e0eac094'
+  version '2.11'
+  source_url 'ftp://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.11.tar.gz'
+  source_sha1 '186dea8ae788395476bd7cbaf38c17ebe82e1777'
+
+  # Not duplicating armv7l as aarch64 for the safe since libsigsegv traces stack.
+  # I'm not sure differences between armv7l stack and aarch64 stack.
+  binary_url ({
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/binaries/libsigsegv-2.11-chromeos-armv7l.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/binaries/libsigsegv-2.11-chromeos-x86_64.tar.xz',
+  })
+  binary_sha1 ({
+    armv7l:  '49ac940d93c9c174194a96444ac4006d8ebd6d53',
+    x86_64:  '3fdafd698589fffabc215dea2b559dacf94b4500',
+  })
 
   def self.build
-    system "./configure CFLAGS=\" -fPIC\""
+    system "./configure", "--enable-shared", "--disable-static", "--with-pic"
     system "make"
   end
 


### PR DESCRIPTION
Change to use libsigsegv 2.11
Change configure options to make only shared library
Add binaries for some architectures

This will fix #576.

In addition, this time, I'm not duplicating aarmv7l binary packages for aarch64 since I'm not sure whether armv7l binary work correctly on aarch64 or not for this case.  Libsigsegv traces stack frame.  I guess 64 bits aarm64 stack frame may be different from 32 bits armv7l's one.