### PR TITLE
Add "no-asm" option for the case of aarch64

### DIFF
--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -10,7 +10,11 @@ class Openssl < Package
   depends_on 'zlibpkg'
 
   def self.build
-    system "./config", "--prefix=/usr/local", "--openssldir=/etc/ssl", "shared", "zlib-dynamic"
+    options="shared zlib-dynamic"
+    if `uname -m`.strip == 'aarch64'
+      options = options + " no-asm"
+    end
+    system "./config --prefix=/usr/local --openssldir=/etc/ssl #{options}"
     system "make"
   end
 


### PR DESCRIPTION
Add mechanism to add "no-asm" option for only the case of aarch64.
This will solve #577.  @ksunden  please let me know if this solves your problem.

This works well on x86_64 and armv7l.