### PR TITLE
Correct dependency of ncdu package

### DIFF
--- a/packages/ncdu.rb
+++ b/packages/ncdu.rb
@@ -5,7 +5,7 @@ class Ncdu < Package
   source_url 'https://dev.yorhel.nl/download/ncdu-1.12.tar.gz'
   source_sha1 'b79b1c44784f334dca74d89a49f49274f14cfeef'
 
-  depends_on "ncurses_so"
+  depends_on "ncurses"
 
   def self.build
     system "./configure --prefix=/usr/local CPPFLAGS=-I/usr/local/include/ncurses"


### PR DESCRIPTION
Ncdu package file was using old ncurses_so dependency.  This correct it.

Tested on x86_64.