### PR TITLE
Update newlisp to 10.7.1

### DIFF
--- a/packages/newlisp.rb
+++ b/packages/newlisp.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Newlisp < Package
-  version '10.7.0'
+  version '10.7.1'
   source_url 'http://www.newlisp.org/downloads/newlisp-10.7.1.tgz'
   source_sha1 '724e7fd1c0512a4236fde022825dfd7ef859ca96'
 

--- a/packages/newlisp.rb
+++ b/packages/newlisp.rb
@@ -2,8 +2,8 @@ require 'package'
 
 class Newlisp < Package
   version '10.7.0'
-  source_url 'http://www.newlisp.org/downloads/newlisp-10.7.0.tgz'
-  source_sha1 '8c256d134e4879d97f83087585cfe90d462def22'
+  source_url 'http://www.newlisp.org/downloads/newlisp-10.7.1.tgz'
+  source_sha1 '724e7fd1c0512a4236fde022825dfd7ef859ca96'
 
   #depends_on 'readline'
   #depends_on 'libffi'

--- a/packages/newlisp.rb
+++ b/packages/newlisp.rb
@@ -2,8 +2,8 @@ require 'package'
 
 class Newlisp < Package
   version '10.7.1'
-  source_url 'http://www.newlisp.org/downloads/newlisp-10.7.1.tgz'
-  source_sha1 '724e7fd1c0512a4236fde022825dfd7ef859ca96'
+  source_url 'https://github.com/kosh04/newlisp/archive/10.7.1.tar.gz'
+  source_sha1 '258d88a6c52ecea73da1a7774fa4f53a265da073'
 
   #depends_on 'readline'
   #depends_on 'libffi'


### PR DESCRIPTION
Update newlisp to 10.7.1, 10.7.0 is not available for download anymore.
Tested on armv7l

### Release notes:
This stable release adds new functionality to existing functions, adds one new function and fixes bugs.

**Additions and changes**
The now function on MS Windows, reports the type of daylight savings used in the GMT offset field.
The new history functions reports the call history of a function.
The maximum length of a symbol has been extended to 1022 characters from 255.
When creating symbols with a hash functor an error message will be thrown on symbol strings longer 1022 characters.
**Bug fixes**
The GMT offset field in the now function would report the wrong value when not in daylight savings time. This bug was introduced in 10.7.0 and did not exist before.
On some platforms file positions went out of sync when using search, seek and read-line.
mat with a scalar second argument was broken on 64-bit versions when the scalar parameter was not a float.
fixed a problem in --, ++ when passing a nil argument which was not content of a symbol.
**Compatibility with previous versions**
This version is compatible with the previous version 10.7.0.