### PR TITLE
Update bacon to version 3.5.3

### DIFF
--- a/packages/bacon.rb
+++ b/packages/bacon.rb
@@ -1,12 +1,12 @@
 require 'package'
 
 class Bacon < Package
-  version '3.5.1'
-  source_url 'http://www.basic-converter.org/stable/bacon-3.5.1.tar.gz'
-  source_sha1 '13a90fa76a07edf36e4a4e5b242b60479a0eccc3'
+  version '3.5.3'
+  source_url 'http://www.basic-converter.org/stable/bacon-3.5.3.tar.gz'
+  source_sha1 'd88cc452d0580309e106f692639293ef2c249f58'
 
   def self.build
-    system "./configure --prefix=/usr/local --without-gui"
+    system "./configure --prefix=/usr/local --disable-gui"
     system 'sed -i "45s,/usr/share,/usr/local/share," Makefile'
     system 'sed -i "46s,/usr/share,/usr/local/share," Makefile'
 


### PR DESCRIPTION
Update bacon to version 3.5.3, and use correct `configure` parameter to disable the gui.

### Release notes:
- New: UTF8$ to print character from Unicode value, UCS to get code, ISASCII to detect ascii (all versions)
- New: ULEN/BYTELEN to determine length of UTF8 string and substring (all versions)
- Imp: string comparison should treat NULL and empty string as the same thing (all versions)
- Imp: added check for Windows file type, now also in INCLUDE statement (all versions)
- Fix: long standing issue with floating expressions sometimes producing integer (all versions)
- Fix: DELIM$ could crash in case new delimiter has bigger size (all versions)
- Fix: regression in JOIN (all versions)
- Imp: small improvement in the autoconf macros (all versions)
- Imp: SAVE/APPEND should read / execute string only once (all versions)
- Imp: adapted BaConGUI help to new framed format (BaConGUI version)
- Imp: changed the name of the temporary Makefile to avoid conflict with other Makefiles (all versions)
- Imp: added '-q' command line option to suppress line counting during conversion (Shell and BaCon version)
- Imp: code cleaning related to internal string checking as consequence of CASE bug (all versions)
- Imp: SPLIT should return 0 elements with numeric argument 0 (all versions)
- Fix: GUI version exits unexpectedly when canceling save action (BaConGUI version)
- Fix: adapt to newer GCC versions which generate more elaborate error logging (all versions)
- Fix: JOIN did not calculate size of resulting string correctly (all versions)
- Fix: strndup is not recognized by certain platforms, replaced with propriety (all versions)
- Fix: nested functions in RETURN statement could crash (all versions)
- Fix: CASE did not detect string members in RECORDS correctly (all versions)
- Fix: SORT worked partially in case OPTION BASE was set (all versions)
- Fix: TOKEN$ returned last token instead of empty string in case index > total (all versions)
- Fix: SPLIT crashed with numeric argument and string length 1 (all versions)
- Fix: implementation of TYPEOF$ calculated wrong offset after occurrence (BaCon and BaConGUI version)
- Fix: COPY and BSAVE needed proper cast for memory address (all versions)