### PR TITLE
Update Imagemagick to v7.0.5-4

### DIFF
--- a/packages/imagemagick.rb
+++ b/packages/imagemagick.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Imagemagick < Package
-  version '7.0.4-7'
-  source_url 'http://www.imagemagick.org/download/releases/ImageMagick-7.0.4-7.tar.xz'
-  source_sha1 'a0811b4ea76892a2ef2ac8a7e82b314c32f8ec42'
+  version '7.0.5-4'
+  source_url 'https://www.imagemagick.org/download/ImageMagick-7.0.5-4.tar.xz'
+  source_sha1 '118b2d1753cf5eb0761ea8dac068e24217b8e32b'
   
   depends_on 'pkgconfig'
 


### PR DESCRIPTION
Update to v7.0.5-4 because the v7.0.4-7 archive was moved.