### PR TITLE
Fix build problems on armv7l for optipng

### DIFF
--- a/packages/optipng.rb
+++ b/packages/optipng.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Optipng < Package
-  version '0.7.6'
+  version '0.7.6-1'
   source_url 'http://prdownloads.sourceforge.net/optipng/optipng-0.7.6.tar.gz'
   source_sha1 '3b3e31430e735589470c4af204354d38823f4989'
   

--- a/packages/optipng.rb
+++ b/packages/optipng.rb
@@ -4,11 +4,12 @@ class Optipng < Package
   version '0.7.6'
   source_url 'http://prdownloads.sourceforge.net/optipng/optipng-0.7.6.tar.gz'
   source_sha1 '3b3e31430e735589470c4af204354d38823f4989'
-
-  # NOTE: uses libpng and zlib but uses its own versions of those libraries
+  
+  depends_on 'libpng'
+  depends_on 'zlibpkg'
 
   def self.build
-    system "./configure --prefix=/usr/local"
+    system "./configure --prefix=/usr/local --with-system-libpng" # Bundled libpng doesn't work on armv7l
     system "make"
   end
 


### PR DESCRIPTION
The bundled version of libpng is outdated, and does not build on armv7l.