### PR TITLE
Replace mlocate download url

### DIFF
--- a/packages/mlocate.rb
+++ b/packages/mlocate.rb
@@ -1,8 +1,8 @@
 require 'package'
 
 class Mlocate < Package
-  version '0.26'
-  source_url 'https://fedorahosted.org/releases/m/l/mlocate/mlocate-0.26.tar.xz' # software source tarball url
+  version '0.26-1'
+  source_url 'https://releases.pagure.org/mlocate/mlocate-0.26.tar.xz' # software source tarball url
   source_sha1 'c6e6d81b25359c51c545f4b8ba0f3b469227fcbc'                         # source tarball sha1 sum
   
   def self.build                                                                 # self.build contains commands needed to build the software from source


### PR DESCRIPTION
fedorahosted is being shutdown, replaced the url with the new official site, pagure.io
Fixes #564 