### PR TITLE
Add Libtasn1

### DIFF
--- a/packages/Libtasn1.rb
+++ b/packages/Libtasn1.rb
@@ -5,8 +5,6 @@ class Libtasn1 < Package
   source_url 'https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.10.tar.gz'
   source_sha1 'c7b36fa50866bbc889f7503c7fd1e9f9d7c52a64'
   
-  depends_on 'buildessential'
-  depends_on 'pkgconfig'
   
   def self.build
     system "make"

--- a/packages/Libtasn1.rb
+++ b/packages/Libtasn1.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Libtasn1 < Package
+  version '4.10'
+  source_url 'https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.10.tar.gz'
+  source_sha1 'c7b36fa50866bbc889f7503c7fd1e9f9d7c52a64'
+  
+  depends_on 'buildessential'
+  depends_on 'pkgconfig'
+  
+  def self.build
+    system "make"
+    
+    end
+    
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+  
+end


### PR DESCRIPTION
This is required to install GnuTLS since it was unbundled in the newer versions of that package.

I did not test this, just wrote it really quickly to get us moving in the right direction. We might need to change it up a little bit if needed for it to install correctly.