### PR TITLE
Need gettext to compile attr

### DIFF
--- a/packages/attr.rb
+++ b/packages/attr.rb
@@ -5,6 +5,8 @@ class Attr < Package
   source_url 'http://download.savannah.gnu.org/releases/attr/attr-2.4.47.src.tar.gz'
   source_sha1 '5060f0062baee6439f41a433325b8b3671f8d2d8'
 
+  depends_on 'gettext'
+
   def self.build
     system "./configure --prefix=/usr/local --disable-static"
     system "make"


### PR DESCRIPTION
Discovered gettext is a dependency for attr while attempting to install.