### PR TITLE
Change to abort if no precompiled binary nor source is available

### DIFF
--- a/crew
+++ b/crew
@@ -171,7 +171,9 @@ def download
   url = @pkg.get_url(@device[:architecture])
   source = @pkg.is_source?(@device[:architecture])
 
-  if !source
+  if !url
+    abort "No precompiled binary for #{@device[:architecture]} nor source is available."
+  elsif !source
     puts "Precompiled binary available, downloading..."
   elsif @pkg.build_from_source
     puts "Downloading source..."


### PR DESCRIPTION
#622 shows `crew` crashes if no pre-compiled binary nor source is available.  This PR fixes it.  Tested on armv7l.