### PR TITLE
Update bc to 1.07.1 and add new related packages

### DIFF
--- a/packages/bc.rb
+++ b/packages/bc.rb
@@ -1,14 +1,16 @@
 require 'package'
 
 class Bc < Package
-  version '1.06-1'
-  source_url 'http://ftp.gnu.org/gnu/bc/bc-1.06.tar.gz'
-  source_sha1 'c8f258a7355b40a485007c40865480349c157292'
+  version '1.07.1'
+  source_url 'https://ftp.gnu.org/gnu/bc/bc-1.07.1.tar.gz'
+  source_sha1 'b4475c6d66590a5911d30f9747361db47231640a'
 
+  depends_on 'readline'
   depends_on 'flex'
+  depends_on 'ed'
 
   def self.build
-    system "./configure"
+    system "./configure", "--with-readline"
     system "make"
   end
 

--- a/packages/ed.rb
+++ b/packages/ed.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Ed < Package
+  version '1.14.2'
+  source_url 'http://ftpmirror.gnu.org/ed/ed-1.14.2.tar.lz'
+  source_sha1 '3e8aa331ffbc929884107ff3f8fbd76d01252277'
+
+  # only lz archive is available for ed and it requires lzip.
+  depends_on 'lzip'
+
+  def self.build
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
+  end
+end

--- a/packages/lzip.rb
+++ b/packages/lzip.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Lzip < Package
+  version '1.19'
+  source_url 'http://download.savannah.gnu.org/releases/lzip/lzip-1.19.tar.gz'
+  source_sha1 'c6042a786b69e3209112fa991806e2e7e0ba5f07'
+
+  def self.build
+    # default -O2 cause run-time segmentation fault on armv7l
+    system "./configure", "CXXFLAGS=-Wall -W -O1"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
+  end
+end


### PR DESCRIPTION
This PR updates bc to 1.07.1 and enables readline library option.

New bc solves problems like segmentation fault in `bc -l` and conflicts with readline library.  However, in order to compile 1.07.1, ed and lzip commands are required.  So, I add them too.

Tested on armv7l.