### PR TITLE
Update curl to 7.54.0

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -1,17 +1,25 @@
 require 'package'
 
 class Curl < Package
-  version '7.32.0'
-  binary_url ({
-    aarch64: 'https://dl.dropboxusercontent.com/s/vvs612glzxrnjva/curl-7.32.0-chromeos-armv7l.tar.xz',
-    armv7l:  'https://dl.dropboxusercontent.com/s/vvs612glzxrnjva/curl-7.32.0-chromeos-armv7l.tar.xz',
-    i686:    'https://dl.dropboxusercontent.com/s/h3x2iiy5ibi97vr/curl-7.32.0-chromeos-i686.tar.gz?token_hash=AAETu-MnNyBTCHQbkh4O817QbNK3wRLbAP_gQhjgNyFGtw&dl=1',
-    x86_64:  'https://dl.dropboxusercontent.com/s/u2hmmd6wfz25qnn/curl-7.32.0-chromeos-x86_64.tar.gz?token_hash=AAGHjx6ATIsDW-Xi4pNUbCMknfWUa6GGQbAquWDkH1xzgg&dl=1',
-  })
-  binary_sha1 ({
-    aarch64: '5d974555b12b54ec47f044dc1cfe7a8ed31bb7e7',
-    armv7l:  '5d974555b12b54ec47f044dc1cfe7a8ed31bb7e7',
-    i686:    'af3abbae663884ed367c5b6b467ebb310052f53f',
-    x86_64:  '94766f554b195583040e31ce8e85846d8271ac11',
-  })
+  version '7.52.1'
+  source_url 'https://curl.haxx.se/download/curl-7.52.1.tar.bz2'
+  source_sha1 'aa9f2300096d806c68c7ba8c50771853d1b43eb4'
+
+  depends_on 'openssl' => :build
+  depends_on 'zlibpkg' => :build
+  depends_on 'libssh2'
+  depends_on 'groff' => :build
+
+  def self.build
+    system "./configure", "--disable-static"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make test"
+  end
 end

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -16,7 +16,10 @@ class Curl < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+
+    # strip debug symbol from library
+    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/libcurl.so.*"
   end
 
   def self.check

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Curl < Package
-  version '7.52.1'
-  source_url 'https://curl.haxx.se/download/curl-7.52.1.tar.bz2'
-  source_sha1 'aa9f2300096d806c68c7ba8c50771853d1b43eb4'
+  version '7.54.0'
+  source_url 'https://curl.haxx.se/download/curl-7.54.0.tar.bz2'
+  source_sha1 'e1cc251508e98bc5a8b9d5c40d8a4f6e48465d1c'
 
   depends_on 'openssl' => :build
   depends_on 'zlibpkg' => :build
@@ -20,6 +20,6 @@ class Curl < Package
   end
 
   def self.check
-    system "make test"
+    system "make", "test"
   end
 end


### PR DESCRIPTION
It is not need to distribute binary packages, so I add source compile methods.

Tested on armv7l.
And passed all curl test cases (it is possible to perform them by `crew build curl`)
```
TESTDONE: 905 tests out of 905 reported OK: 100%
TESTDONE: 1082 tests were considered during 416 seconds.
```