### PR TITLE
Update expat to 2.2.0

### DIFF
--- a/packages/expat.rb
+++ b/packages/expat.rb
@@ -12,6 +12,10 @@ class Expat < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+
+    # strip binary and library
+    system "strip #{CREW_DEST_DIR}/usr/local/bin/xmlwf"
+    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/libexpat.so.*"
   end
 
   def self.check

--- a/packages/expat.rb
+++ b/packages/expat.rb
@@ -1,17 +1,20 @@
 require 'package'
 
 class Expat < Package
-  version '2.1.0'
-  binary_url ({
-    aarch64: 'https://dl.dropboxusercontent.com/s/0wq0gbbg1cf5uub/expat-2.1.0-chromeos-armv7l.tar.xz',
-    armv7l:  'https://dl.dropboxusercontent.com/s/0wq0gbbg1cf5uub/expat-2.1.0-chromeos-armv7l.tar.xz',
-    i686:    'https://dl.dropboxusercontent.com/s/jh5uw42elm40t9a/expat-2.1.0-chromeos-i686.tar.gz?token_hash=AAGYckE0KoTPsydZGG85KTkpr7Nt5U1OUs0egJ1K0iJ1mg&dl=1',
-    x86_64:  'https://dl.dropboxusercontent.com/s/k89o1x1a3fwoamu/expat-2.1.0-chromeos-x86_64.tar.gz?token_hash=AAGBLOil45Zg7G2RlFlfDUxKfeDyTP3uUWjfBvGQrOjAYA&dl=1',
-  })
-  binary_sha1 ({
-    aarch64: '42ddf5b8e5db3bd7898bbc43997c95f488799ba8',
-    armv7l:  '42ddf5b8e5db3bd7898bbc43997c95f488799ba8',
-    i686:    '9ab42ec03d06cc64d5d9944cb4cc7eaa61a0af84',
-    x86_64:  '3ac96a0e02c1117718d15bcd4976ef4bcef1a9ac',
-  })
+  version '2.2.0'
+  source_url 'https://sourceforge.net/projects/expat/files/expat/2.2.0/expat-2.2.0.tar.bz2/download'
+  source_sha1 '8453bc52324be4c796fd38742ec48470eef358b3'
+
+  def self.build
+    system "./configure", "--enable-shared", "--disable-static", "--with-pic"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
+  end
 end


### PR DESCRIPTION
It is not need to distribute binary packages, so I'm adding source compile methods.

Tested on armv7l.