### PR TITLE
Add txt2man package

### DIFF
--- a/packages/txt2man.rb
+++ b/packages/txt2man.rb
@@ -1,0 +1,14 @@
+require 'package'
+
+class Txt2man < Package
+  version '1.5.6'
+  source_url 'http://mvertes.free.fr/download/txt2man-1.5.6.tar.gz'
+  source_sha1 'ef1392785333ea88f7e01f4f4c519ecfbdd498bd'
+
+  depends_on 'gawk'
+  depends_on 'mandb'
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Txt2man converts flat ASCII text into the man page format. This allows man pages to be authored without knowledge of nroff macros. It is a shell script that uses GNU awk, and it should run on any Unix-like system.  See https://directory.fsf.org/wiki/Txt2man.