### PR TITLE
Change all toolcain to use stripped binaries and libraries

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -1,17 +1,17 @@
 require 'package'
 
 class Binutils < Package
-  version '2.25-1'
+  version '2.25-cc1.3'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/binutils-2.25-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/binutils-2.25-cc1.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/binutils-2.25-cc1.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/binutils-2.25-cc1.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/binutils-2.25-cc1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '5a4b3c8ddcac5d1b3fdc2f6aee8c9ec64f2d23ea',
-    armv7l:  '5a4b3c8ddcac5d1b3fdc2f6aee8c9ec64f2d23ea',
-    i686:    '9d8d586e5e44badbe1f2058f53c183c019353a0e',
-    x86_64:  '94d246a14efc080a398aefe9e192331a4ffaed46',
+    aarch64: '926b6aeab6d9c33435eefb856e4cb5263753387c',
+    armv7l:  '926b6aeab6d9c33435eefb856e4cb5263753387c',
+    i686:    'ebf66128ca99fa81c26b49b20163ea77eeb1e204',
+    x86_64:  '5427ba83960d0b7866aec8de63415720595ffe4a',
   })
 end

--- a/packages/cloog.rb
+++ b/packages/cloog.rb
@@ -1,17 +1,17 @@
 require 'package'
 
 class Cloog < Package
-  version "0.18.4"
+  version "0.18.4-cc1.3"
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/cloog-0.18.4-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/cloog-0.18.4-cc1.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/cloog-0.18.4-cc1.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/cloog-0.18.4-cc1.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/cloog-0.18.4-cc1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '919798d4329b96aa33374fe460d95e6e485b00c2',
-    armv7l:  '919798d4329b96aa33374fe460d95e6e485b00c2',
-    i686:    '7f37371de5d5f7eeaf13fe93fc664ecd6daadb25',
-    x86_64:  '33d18076f6ca5b5c56e7908368b87d137355696a',
+    aarch64: 'e54784816f181c185dbd0eddc1b0c9f898db2caa',
+    armv7l:  'e54784816f181c185dbd0eddc1b0c9f898db2caa',
+    i686:    '3409f9c55e187533308f4febee39651833f592ad',
+    x86_64:  'cb29abf230eff44903a9a727f901903cba8bd1c7',
   })
 end

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -1,19 +1,19 @@
 require 'package'
 
 class Gcc < Package
-  version '4.9.x'
+  version '4.9.x-cc1.3'
 
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gcc-4.9.x-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/gcc-4.9.x-cc1.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/gcc-4.9.x-cc1.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/gcc-4.9.x-cc1.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/gcc-4.9.x-cc1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '267d2d6647af07805a7a8f5dabbb88ec31ff8db0',
-    armv7l:  '267d2d6647af07805a7a8f5dabbb88ec31ff8db0',
-    i686:    '904b4666a326505bd7546231a9273a4aa47e30f0',
-    x86_64:  'c044e84073b2457079e611e2f27fd54b5e502e9a',
+    aarch64: 'b71b4f64ff0ab9d32ed15714889046a329b1019c',
+    armv7l:  'b71b4f64ff0ab9d32ed15714889046a329b1019c',
+    i686:    'a8f9d270d89ba8d9afb4478bf2df1f73ba2878a7',
+    x86_64:  'a7da1611b35280117acb0fa86d7d91e0ff6a5e01',
   })
 
   depends_on 'binutils'

--- a/packages/glibc223.rb
+++ b/packages/glibc223.rb
@@ -1,17 +1,17 @@
 require 'package'
 
 class Glibc223 < Package
-  version '2.23'
+  version '2.23-cc1.3'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.23-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/glibc-2.23-cc1.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/glibc-2.23-cc1.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/glibc-2.23-cc1.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/glibc-2.23-cc1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '4cac7d5d3d97f147c9ac9ad0c1deb1ac9b967450',
-    armv7l:  '4cac7d5d3d97f147c9ac9ad0c1deb1ac9b967450',
-    i686:    '434adb6dd1c3dcc30a25e3700f425a081888a28a',
-    x86_64:  '9b4ae8c6ccc081f7d9d169cd0b3eb74ae736e79f',
+    aarch64: '09cac401b8d6821c4ea2f349f0a348fcef9e07b2',
+    armv7l:  '09cac401b8d6821c4ea2f349f0a348fcef9e07b2',
+    i686:    '66096f5bf50ab19f17f8d9356589ea6dc809f8d9',
+    x86_64:  '1807e449919fff8d3473d97d43d184961a65a323',
   })
 end

--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -1,17 +1,17 @@
 require 'package'
 
 class Gmp < Package
-  version "6.1.2"
+  version "6.1.2-cc1.3"
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/gmp-6.1.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/gmp-6.1.2-cc1.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/gmp-6.1.2-cc1.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/gmp-6.1.2-cc1.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/gmp-6.1.2-cc1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: 'ef330045d0eb7b33015e31cd1ac8428caacaf026',
-    armv7l:  'ef330045d0eb7b33015e31cd1ac8428caacaf026',
-    i686:    'a26eeac034966b50ca70d43b23768a078ca4dd14',
-    x86_64:  '0ada7fbc26b2b5567df516daaf61edc4129ae1b5',
+    aarch64: '16c62caf6da5971ddb4e4985d5905ce43a40f2f8',
+    armv7l:  '16c62caf6da5971ddb4e4985d5905ce43a40f2f8',
+    i686:    'eadba1eb5fcc25bdafd1f868045984d726a26d08',
+    x86_64:  '706ca2c87011f5ee12324f03ae286fb95a532cec',
   })
 end

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -1,17 +1,17 @@
 require 'package'
 
 class Isl < Package
-  version "0.14.1"
+  version "0.14.1-cc1.3"
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/isl-0.14.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/isl-0.14.1-cc1.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/isl-0.14.1-cc1.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/isl-0.14.1-cc1.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/isl-0.14.1-cc1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: 'c151cbe2601eda6cd391da165ad940aa7fa666bc',
-    armv7l:  'c151cbe2601eda6cd391da165ad940aa7fa666bc',
-    i686:    'cc2d07411dbfcfd03afe0953bce8cef8d7bb8307',
-    x86_64:  '3fa612198955e3d6e8201c05ef486d1462c76462',
+    aarch64: '749bf7d0a09c1578ce2de20a21ce7f7d6a575756',
+    armv7l:  '749bf7d0a09c1578ce2de20a21ce7f7d6a575756',
+    i686:    '306c249734107ac29e7951a44a000cfcbb523a35',
+    x86_64:  '7e0dcb1c65a99be666c4369abb649ad27f88ade1',
   })
 end

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -1,17 +1,17 @@
 require 'package'
 
 class Linuxheaders < Package
-  version '3.18'
+  version '3.18-cc1.3'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/linux-headers-3.18-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/linux-headers-3.18-cc1.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/linux-headers-3.18-cc1.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/linux-headers-3.18-cc1.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/linux-headers-3.18-cc1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: 'fad98da3de461b0b08298c5a1ec07cca53eed008',
-    armv7l:  'fad98da3de461b0b08298c5a1ec07cca53eed008',
-    i686:    '4142a609534383c99123fb43016745746589922b',
-    x86_64:  '716f50b255d6bd3c4039a92cbd20d4e887e25bb7',
+    aarch64: '4f7c1df409b416735d8d2bfbbc62cb57f3ca5d80',
+    armv7l:  '4f7c1df409b416735d8d2bfbbc62cb57f3ca5d80',
+    i686:    '0c8190aa192db06772a6d125c1e22ef2ec11e996',
+    x86_64:  'aee9c675d1f51268c16273d3ba3bd73334783072',
   })
 end

--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -1,17 +1,17 @@
 require 'package'
 
 class Mpc < Package
-  version '1.0.3'
+  version '1.0.3-cc1.3'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpc-1.0.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpc-1.0.3-cc1.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpc-1.0.3-cc1.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpc-1.0.3-cc1.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpc-1.0.3-cc1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '2a05a536cc6fd4da7d948c4732722c5d430ee010',
-    armv7l:  '2a05a536cc6fd4da7d948c4732722c5d430ee010',
-    i686:    'f10689f81749d65d1741f801387e9970eea988d7',
-    x86_64:  '659123c6bf218d60837579e1fe50dd86f24d487f',
+    aarch64: 'd1f6e5d521f1807accca245cecf2ccc56c29c96d',
+    armv7l:  'd1f6e5d521f1807accca245cecf2ccc56c29c96d',
+    i686:    'd7fcd41e92b637220208e136207d1095237f3ac1',
+    x86_64:  'fcc7bc8f7a4f9956f801af84e4104e565dd8b285',
   })
 end

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -1,17 +1,17 @@
 require 'package'
 
 class Mpfr < Package
-  version '3.1.5'
+  version '3.1.5-cc1.3'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/mpfr-3.1.5-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpfr-3.1.5-cc1.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpfr-3.1.5-cc1.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpfr-3.1.5-cc1.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpfr-3.1.5-cc1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '8ace66e438f6593affc460cc8a45f2a7df0ac1ca',
-    armv7l:  '8ace66e438f6593affc460cc8a45f2a7df0ac1ca',
-    i686:    '1a3e4833cbdf002e5fd62135b5113c37c2700362',
-    x86_64:  '0028523daf1b3935bad21d3706e39fb248a8f0f2',
+    aarch64: 'd201c3e9c7fa3d483e93cb967e9ae78b4578868b',
+    armv7l:  'd201c3e9c7fa3d483e93cb967e9ae78b4578868b',
+    i686:    '71569b4f88e852d0a6734b2be8e200f52248a7fe',
+    x86_64:  '7d434ebe762b004d9f822f5baa21b9c9f37452b0',
   })
 end


### PR DESCRIPTION
All toolchaiins are compiled by using https://github.com/jam7/chrome-cross as previous one was.  This time, I stripped all unnecessary symbols from binaries and libraries as suggested by @lyxell in https://github.com/jam7/chrome-cross/issues/2.

Reducing file size introduces more disk space, more performance, less battery usage.  :)

Tested on armv7 and x86_64.