### PR TITLE
Add /usr/lib64 to VPATH to make traceroute compilable on x86_64.

### DIFF
--- a/packages/traceroute.rb
+++ b/packages/traceroute.rb
@@ -6,6 +6,8 @@ class Traceroute < Package
   source_sha1 'bc5c6c8022187511be5665b3818d919be5987dcc'
 
   def self.build
+    # add /usr/lib64 to vpath to check /usr/lib64/libm.so
+    system "sed", "-i", "Make.rules", "-e", "/vpath lib%.so/s:$: /usr/lib64:"
     system "make"
   end
 


### PR DESCRIPTION
This is small patch to make traceroute compilable on x86_64.

Without this patch, `crew isntall traceroute` on x86_64 causes following error:
```
make[1]: *** No rule to make target '-lm', needed by 'traceroute'.  Stop.
```
With this patch, `crew install traceroute` works fine on x86_64.