### PR TITLE
Add yarn

### DIFF
--- a/packages/yarn.rb
+++ b/packages/yarn.rb
@@ -1,0 +1,17 @@
+require 'package'
+
+class Yarn < Package
+  version '0.25.3'
+  source_url 'https://github.com/yarnpkg/yarn/releases/download/v0.25.3/yarn-v0.25.3.tar.gz'
+  source_sha1 'a25d2eba9d40479a795422a23af8db9e950f36d0'
+
+  depends_on 'node'
+
+  def self.build
+    system "sudo bash chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
+  end
+
+  def self.install
+    system "npm install -g"
+  end
+end

--- a/packages/yarn.rb
+++ b/packages/yarn.rb
@@ -2,7 +2,7 @@ require 'package'
 
 class Yarn < Package
   version '0.25.4'
-  source_url 'https://github.com/yarnpkg/yarn/releases/download/v0.25.3/yarn-v0.25.3.tar.gz'
+  source_url 'https://github.com/yarnpkg/yarn/releases/download/v0.25.4/yarn-v0.25.4.tar.gz'
   source_sha1 '94b08478cf06652a337aef5742cf32472c767924'
 
   depends_on 'node'

--- a/packages/yarn.rb
+++ b/packages/yarn.rb
@@ -8,7 +8,7 @@ class Yarn < Package
   depends_on 'node'
 
   def self.build
-    system "sudo bash chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
+    system "npm install"
   end
 
   def self.install

--- a/packages/yarn.rb
+++ b/packages/yarn.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Yarn < Package
-  version '0.25.3'
+  version '0.25.4'
   source_url 'https://github.com/yarnpkg/yarn/releases/download/v0.25.3/yarn-v0.25.3.tar.gz'
-  source_sha1 'a25d2eba9d40479a795422a23af8db9e950f36d0'
+  source_sha1 '94b08478cf06652a337aef5742cf32472c767924'
 
   depends_on 'node'
 


### PR DESCRIPTION
Automatically chown's the npm directories (for `-g` installs). I think we should consider doing this aswell in the node package rather than telling the user to do so.