### PR TITLE
Add bashdb package

### DIFF
--- a/packages/bashdb.rb
+++ b/packages/bashdb.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Bashdb < Package
+  version '4.4-0.92'
+  source_url 'https://downloads.sourceforge.net/project/bashdb/bashdb/4.2-0.92/bashdb-4.4-0.92.tar.gz'
+  source_sha1 '918c7d576c476c4b7d768e1fccda6150cf5ca62d'
+
+  def self.build
+    system "./configure \
+            --bindir=/usr/local/bin \
+            --datadir=/usr/local \
+            --infodir=/usr/local \
+            --mandir=/usr/local"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/bashdb.rb
+++ b/packages/bashdb.rb
@@ -8,9 +8,9 @@ class Bashdb < Package
   def self.build
     system "./configure \
             --bindir=/usr/local/bin \
-            --datadir=/usr/local \
-            --infodir=/usr/local \
-            --mandir=/usr/local"
+            --datadir=/usr/local/share \
+            --infodir=/usr/local/info \
+            --mandir=/usr/local/man"
     system "make"
   end
 


### PR DESCRIPTION
The Bash Debugger Project is a source-code debugger for bash that follows the gdb command syntax.  If you create bash shell scripts often, this is an excellent command to have in your tool set.  See http://bashdb.sourceforge.net/.