### PR TITLE
Add patchutils package

### DIFF
--- a/packages/patchutils.rb
+++ b/packages/patchutils.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Patchutils < Package
+  version '0.3.4'
+  source_url 'http://cyberelk.net/tim/data/patchutils/stable/patchutils-0.3.4.tar.xz'
+  source_sha1 'b1d91eb1e2213450eae666a4701b3f917625dea3'
+
+  def self.build
+    system './configure --prefix=/usr/local'
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
+  end
+end


### PR DESCRIPTION
Tools for manipulating patch files

Patchutils contains the following tools for manipulating patch files: interdiff, combinediff, filterdiff, fixcvsdiff, rediff, lsdiff, and splitdiff. You can use

interdiff- creates an incremental patch from two patches against a common source
combinediff- creates a single patch from two incremental patches
filterdiff- selects patches based on files matching shell wildcards
lsdiff- lists modified files in a patch
rediff- corrects hand-edited patches
fixcvsdiff- corrects the output of 'cvs diff'
splitdiff- separates patches so that each new file alters a given file only once

See http://cyberelk.net/tim/patchutils/.