### PR TITLE
Add readline7.rb to install readline 7.0p3

### DIFF
--- a/packages/readline7.rb
+++ b/packages/readline7.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Readline7 < Package
+  version '7.0p3'
+  source_url 'ftp://ftp.gnu.org/gnu/readline/readline-7.0.tar.gz'
+  source_sha1 'd9095fa14a812495052357e1d678b3f2ac635463'
+
+  depends_on 'buildessential' => :build
+  depends_on 'patch' => :build
+  depends_on 'ncurses'
+
+  def self.build
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-7.0-patches -P readline-7.0-patches"
+    # system "for i in readline-7.0-patches/*.sig; do gpg $i; done"
+    system "for i in readline-7.0-patches/readline70-???; do patch < $i; done"
+
+    system "CC='gcc' ./configure --disable-static --with-curses"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
readline 7.0 has different ABI, so I'm adding it as readline7.rb.

Tested on armv7l and x86_64.