### PR TITLE
Add unbound to gnutls

### DIFF
--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -1,24 +1,34 @@
 require 'package'
 
 class Gnutls < Package
-  version '3.5.8'
-  source_url 'ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-3.5.8.tar.xz'
-  source_sha1 '238d5e62f9bb078101131dd2f4c7f2c1ac13e813'
+  version '3.5.9'
+  source_url 'ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-3.5.9.tar.xz'
+  source_sha1 'f3f184a92f128af1c2fb29b29a4d325af65694a5'
 
-  depends_on 'buildessential'
+  depends_on 'buildessential' => :build
+  depends_on 'zlibpkg' => :build
+  depends_on 'libunistring'
+  depends_on 'gmp'
   depends_on 'nettle'
-  depends_on 'pkgconfig'
+  depends_on 'pkgconfig' => :build
   depends_on 'libtasn1'
   depends_on 'trousers'
   depends_on 'p11kit'
-  depends_on 'libunistring'
+  depends_on 'libffi'
+  depends_on 'libunbound'
 
   def self.build
-    system "./configure"
+    system "./configure", "--enable-shared", "--disable-static", "--with-pic",
+      "--with-system-priority-file=#{CREW_PREFIX}/etc/gnutls/default-priorities",
+      "--with-unbound-root-key-file=#{CREW_PREFIX}/etc/unbound/root.key"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make check"
   end
 end

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Gnutls < Package
-  version '3.5.9'
-  source_url 'ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-3.5.9.tar.xz'
-  source_sha1 'f3f184a92f128af1c2fb29b29a4d325af65694a5'
+  version '3.5.11'
+  source_url 'ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-3.5.11.tar.xz'
+  source_sha1 'bcdc68233590a99b8d4234270fe8a946d9a2abeb'
 
   depends_on 'buildessential' => :build
   depends_on 'zlibpkg' => :build

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -1,9 +1,9 @@
 require 'package'
 
 class Gnutls < Package
-  version '3.5.11'
-  source_url 'ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-3.5.11.tar.xz'
-  source_sha1 'bcdc68233590a99b8d4234270fe8a946d9a2abeb'
+  version '3.5.12'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.12.tar.xz'
+  source_sha1 '9f453686bc6b1e6ebc04197158a2bc123c0272df'
 
   depends_on 'buildessential' => :build
   depends_on 'zlibpkg' => :build

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -17,6 +17,8 @@ class Libunbound < Package
     system "sed", "-i", "Makefile", "-e", '/$(LEX) -t $(srcdir)\/util\/configlexer.lex/s:-t:-t -Pub_c_:'
 
     system "make"
+    system "make", "strip"
+    system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end
 
   def self.install

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -1,0 +1,29 @@
+require 'package'
+
+class Libunbound < Package
+  version '1.6.2'
+  source_url 'https://www.unbound.net/downloads/unbound-1.6.2.tar.gz'
+  source_sha1 'de370b1ac8e260db9c4c1504453752713dd8818f'
+
+  depends_on 'flex' => :build
+  depends_on 'bison' => :build
+  depends_on 'gawk' => :build
+  depends_on 'expat'
+
+  def self.build
+    system "./configure", "--enable-shared", "--disable-static", "--with-pic"
+
+    # flex 2.6.3 requires -P option to rename yylex and other funcions
+    system "sed", "-i", "Makefile", "-e", '/$(LEX) -t $(srcdir)\/util\/configlexer.lex/s:-t:-t -Pub_c_:'
+
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "test"
+  end
+end


### PR DESCRIPTION
Add libunbound package and add dependency to `libunbound` to `gnutls`.
This add DNSSEC option to gnutls to protect it from cache poisoning.

I also update gnutls to the latest 3.5.12 and add configure options.

Tested on armv7l and x86_64.  Passed `make check` also.