### PR TITLE
Change to use tar for the performance

### DIFF
--- a/crew
+++ b/crew
@@ -304,13 +304,7 @@ def install_package (pkgdir)
     FileUtils.mv 'dlist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.directorylist"
     FileUtils.mv 'filelist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.filelist"
 
-    File.open(CREW_CONFIG_PATH + "meta/#{@pkg.name}.directorylist").each_line do |line|
-      system "mkdir", "-p", line.chomp
-    end
-
-    File.open(CREW_CONFIG_PATH + "meta/#{@pkg.name}.filelist").each_line do |line|
-      system "mv", pkgdir + line.chomp, line.chomp
-    end
+    system "tar cf - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
   end
 end
 


### PR DESCRIPTION
Modify crew to use `"tar cf - | tar xf -"` style to reduce the installation time, twice or several times faster.

This mechanism is used in install.sh and I was testing this for several months on armv7l and x86_64.  Please check it out. :)