### PR TITLE
Correct scrollz

### DIFF
--- a/packages/scrollz.rb
+++ b/packages/scrollz.rb
@@ -9,13 +9,13 @@ class Scrollz < Package
 
   depends_on 'buildessential'
   depends_on 'ncurses'
-  
+
   def self.build
-    system "./configure" 
+    system "CFLAGS=-I/usr/local/include/ncurses ./configure"
     system "make"
   end
-  
+
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-  end         
+  end
 end


### PR DESCRIPTION
It was not possible to compile scrollz with following error since it doesn't know where ncurses is.
```
gcc -I../include -g -O2 -DHAVE_CONFIG_H   -c edit5.c
edit5.c:113:40: fatal error: term.h: No such file or directory
 #include <term.h>     /* for tparm() */
                                        ^
```

This PR fixes it.  Tested on armv7l and x86_64.