### PR TITLE
DEBUG_SYMBOLS modification

### DIFF
--- a/lib/package.rb
+++ b/lib/package.rb
@@ -9,6 +9,8 @@ class Package
     attr_accessor :in_upgrade
   end
 
+  @@debug_symbol = ENV['CREW_DEBUG_SYMBOL'] || false
+
   def self.dependencies
     # Not sure how to initialize instance variable of not constructed class.
     # Therefore, initialize it in reader function.


### PR DESCRIPTION
This solves issue #711.  I needed to make this PR first.

It is great to remove debug information from binaries and libraries to save disk space.  However, we rarely need it for debugging purpose.  This PR make user be able to decide it (need to modify packages to check this new variable though).

Currently, only python27.rb check this variable.  If user define `CREW_DEBUG_SYMBOL` environment variable at install time, `crew` leaves debug symbols for python.  If user doesn't define it, `crew` strip debug symbols.

Tested on armv7l and x86_64.