### PR TITLE
Update openssl to 1.0.2l and distribute with pre-built arm binaries

### DIFF
--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -8,8 +8,8 @@ class Openssl < Package
   source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2l.tar.gz'
   source_sha1 '5bea0957b371627e8ebbee5bef221519e94d547c'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2l-1-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2l-1-chromeos-armv7l.tar.xz',
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2l-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2l-chromeos-armv7l.tar.xz',
   })
   binary_sha1 ({
     aarch64: '4c9eb37df898e9495a8f53e3aa7f6058063fa8ce',

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -7,6 +7,14 @@ class Openssl < Package
 
   source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2l.tar.gz'
   source_sha1 '5bea0957b371627e8ebbee5bef221519e94d547c'
+  binary_url ({
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2l-1-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2l-1-chromeos-armv7l.tar.xz',
+  })
+  binary_sha1 ({
+    aarch64: '4c9eb37df898e9495a8f53e3aa7f6058063fa8ce',
+    armv7l:  '4c9eb37df898e9495a8f53e3aa7f6058063fa8ce',
+  })
 
   depends_on 'perl' => :build
   depends_on 'zlibpkg' => :build


### PR DESCRIPTION
This avoids the aarch64 openssl problem.  This doesn't fix it since we are not sure the source of problem.  At least we know armv7l binary works fine on aarch64, so I'm distributing it.  Also update the version of openssl.

I'm using official github distribution instead of official http distribution, since later removes old version at every release.

Tested on armv7l and x86_64.  Also tested on aarch64 as described in https://github.com/skycocker/chromebrew/issues/665#issuecomment-306335119.

This will fix problems in #665, #614, #577.