### PR TITLE
Refactor dependency expansion

### DIFF
--- a/crew
+++ b/crew
@@ -336,7 +336,8 @@ def resolveDependencies
   @source_package = 0
 
   def push_dependencies
-    if @pkg.is_binary?(@device[:architecture])
+    if @pkg.is_binary?(@device[:architecture]) ||
+       (!@pkg.in_upgrade && @device[:installed_packages].any? { |pkg| pkg[:name] == @pkg.name })
       # retrieve name of dependencies that doesn't contain :build tag
       @check_deps = @pkg.dependencies.select {|k, v| !v.include?(:build)}.map {|k, v| k}
     elsif @pkg.is_fake?
@@ -348,13 +349,17 @@ def resolveDependencies
       # count the number of source packages to add buildessential into dependencies later
       @source_package += 1
     end
-    if @check_deps && !@check_deps.empty?
-      @dependencies.unshift @check_deps
 
-      @check_deps.each do |dep|
-        search dep, true
-        push_dependencies
-      end
+    # remove a dependent package which is equal to the target
+    @check_deps.select! {|name| @pkgName != name}
+
+    # insert only not installed packages into dependencies
+    @dependencies = @check_deps.select {|name| @device[:installed_packages].none? {|pkg| pkg[:name] == name}}.concat(@dependencies)
+
+    # check all dependencies recursively
+    @check_deps.each do |dep|
+      search dep, true
+      push_dependencies
     end
   end
 
@@ -363,16 +368,15 @@ def resolveDependencies
   # Add buildessential and solve its dependencies if any of dependent
   # packages are made from source
   if @source_package > 0
-    @dependencies.unshift 'buildessential'
     search 'buildessential', true
+    push_dependencies
   end
-  push_dependencies
 
   return if @dependencies.empty?
 
   puts "Following packages also need to be installed: "
 
-  @dependencies.flatten!.uniq!
+  @dependencies.uniq!
   @dependencies.each do |dep|
     print dep + " "
   end

--- a/crew
+++ b/crew
@@ -312,7 +312,7 @@ def resolve_dependencies_and_install
   begin
     origin = @pkg.name
 
-    resolveDependencies
+    resolve_dependencies
 
     search origin, true
     install
@@ -329,7 +329,7 @@ def resolve_dependencies_and_install
   end
 end
 
-def resolveDependencies
+def expand_dependencies
   @dependencies = []
 
   # check source packages existance
@@ -339,25 +339,25 @@ def resolveDependencies
     if @pkg.is_binary?(@device[:architecture]) ||
        (!@pkg.in_upgrade && @device[:installed_packages].any? { |pkg| pkg[:name] == @pkg.name })
       # retrieve name of dependencies that doesn't contain :build tag
-      @check_deps = @pkg.dependencies.select {|k, v| !v.include?(:build)}.map {|k, v| k}
+      check_deps = @pkg.dependencies.select {|k, v| !v.include?(:build)}.map {|k, v| k}
     elsif @pkg.is_fake?
       # retrieve name of all dependencies
-      @check_deps = @pkg.dependencies.map {|k, v| k}
+      check_deps = @pkg.dependencies.map {|k, v| k}
     else
       # retrieve name of all dependencies
-      @check_deps = @pkg.dependencies.map {|k, v| k}
+      check_deps = @pkg.dependencies.map {|k, v| k}
       # count the number of source packages to add buildessential into dependencies later
       @source_package += 1
     end
 
     # remove a dependent package which is equal to the target
-    @check_deps.select! {|name| @pkgName != name}
+    check_deps.select! {|name| @pkgName != name}
 
-    # insert only not installed packages into dependencies
-    @dependencies = @check_deps.select {|name| @device[:installed_packages].none? {|pkg| pkg[:name] == name}}.concat(@dependencies)
+    # add new dependencies at the beginning of array
+    @dependencies = check_deps.clone.concat(@dependencies)
 
     # check all dependencies recursively
-    @check_deps.each do |dep|
+    check_deps.each do |dep|
       search dep, true
       push_dependencies
     end
@@ -365,19 +365,26 @@ def resolveDependencies
 
   push_dependencies
 
-  # Add buildessential and solve its dependencies if any of dependent
+  # Add buildessential's dependencies if any of dependent
   # packages are made from source
   if @source_package > 0
     search 'buildessential', true
     push_dependencies
   end
+  @dependencies.uniq
+end
 
-  return if @dependencies.empty?
+def resolve_dependencies
+  dependencies = expand_dependencies
+
+  # leave only not installed packages in dependencies
+  dependencies.select! {|name| @device[:installed_packages].none? {|pkg| pkg[:name] == name}}
+
+  return if dependencies.empty?
 
   puts "Following packages also need to be installed: "
 
-  @dependencies.uniq!
-  @dependencies.each do |dep|
+  dependencies.each do |dep|
     print dep + " "
   end
 
@@ -396,7 +403,7 @@ def resolveDependencies
   end
 
   if proceed
-    @dependencies.each do |dep|
+    dependencies.each do |dep|
       search dep
       install
     end
@@ -455,7 +462,7 @@ def resolve_dependencies_and_build
 
     # mark current package as which is required to compile from source
     @pkg.build_from_source = true
-    resolveDependencies
+    resolve_dependencies
 
     search origin, true
     build_package Dir.pwd

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -12,8 +12,9 @@ class Package
   @@debug_symbol = ENV['CREW_DEBUG_SYMBOL'] || false
 
   def self.dependencies
-    # Not sure how to initialize instance variable of not constructed class.
-    # Therefore, initialize it in reader function.
+    # We need instance variable in derived class, so not define it here,
+    # base class.  Instead of define it, we initialize it in a function
+    # called from derived classees.
     @dependencies = Hash.new unless @dependencies
     @dependencies
   end


### PR DESCRIPTION
Change crew to remove already installed packages from dependencies, so it won't show something like following messages if toolchains are already installed.  :)
```
$ crew install xzutils
Found xzutils, version 5.2.3-2
Following packages also need to be installed: 
glibc223 binutils gmp mpfr mpc isl cloog glibc gcc linuxheaders make pkgconfig 
Do you agree? [Y/n]
```
Also modified following stuff.
 - Change to check only run-time dependencies if a target is already installed
 - Change to remove unnecessary push_dependency call

Tested on armv7l and x86_64.