### PR TITLE
Update from 4.11.0 to 4.12.0

### DIFF
--- a/packages/chicken.rb
+++ b/packages/chicken.rb
@@ -3,9 +3,9 @@ require 'package'
 class Chicken < Package
   description 'CHICKEN is practical and portable scheme system.'
   homepage 'https://code.call-cc.org/'
-  version '4.11.0'
-  source_url 'https://code.call-cc.org/releases/4.11.0/chicken-4.11.0.tar.gz'
-  source_sha1 'b8b1e8b741a5ea5b318c449c3bf8a42f8de8ba69'
+  version '4.12.0'
+  source_url 'https://code.call-cc.org/releases/4.12.0/chicken-4.12.0.tar.gz'
+  source_sha1 'f128b57d42ce6f1d4a56a372916e9e538ae1ceab'
 
   def self.build
     system "make", "PLATFORM=linux"


### PR DESCRIPTION
This is a security release addressing CVE-2016-6830, CVE-2016-6831, and
CVE-2016-9954. Numerous other bugfixes and enhancements are included in
this revision as well.

It's recommended that all users install this update.