### PR TITLE
Add ascii package

### DIFF
--- a/packages/ascii.rb
+++ b/packages/ascii.rb
@@ -1,0 +1,19 @@
+require "package"
+
+class Ascii < Package
+  description 'List ASCII idiomatic names and octal/decimal code-point forms.'
+  homepage 'http://www.catb.org/~esr/ascii/'
+  version "3.15"
+  source_url "http://www.catb.org/~esr/ascii/ascii-3.15.tar.gz"
+  source_sha1 "94ac41d8ef89daf148ebfd30333c07f6e64d4dec"
+
+  def self.build
+    system "make"
+  end
+
+  def self.install
+    system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
+    system "cp ascii #{CREW_DEST_DIR}/usr/local/bin"
+  end
+end
+


### PR DESCRIPTION
List ASCII idiomatic names and octal/decimal code-point forms.

Provides easy conversion between various byte representations and the American Standard Code for Information Interchange (ASCII) character table. It knows about a wide variety of hex, binary, octal, Teletype mnemonic, ISO/ECMA code point, slang names, XML entity names, and other representations. Given any one on the command line, it will try to display all others. Called with no arguments it displays a handy small ASCII chart.

See http://www.catb.org/~esr/ascii/.