### PR TITLE
JDK to u131 -  Node to 6.11.0 - Node_Current to 8.1.0 - Inetutils Package (for telnet, BBS TIME!) added

### DIFF
--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -1,20 +1,29 @@
 require 'package'
 
 class Inetutils < Package
-  description 'Inetutils - GNU network utilities is a collection of common network programs.'
+  description 'The Inetutils package contains programs for basic networking. Such as dnsdomainname, ftp, hostname, ifconfig, ping, 
+ping6, talk, telnet, tftp, traceroute'
   homepage 'https://www.gnu.org/software/inetutils/'
   version '1.9.4'
-  source_url 'http://ftp.gnu.org/gnu/inetutils/inetutils-1.9.4.tar.gz'
-  source_sha1 'defae98a27c0e9516c4ef2321a374a3645adb3b9'
+  source_url 'https://ftp.gnu.org/gnu/inetutils/inetutils-1.9.4.tar.xz'
+  source_sha1 '5e515cc9da142cb73bb1beda137b4c2dcf2b528c'
 
   depends_on 'buildessential'
-  
+
   def self.build
-    system "./configure"
+    system "./configure --prefix=/usr/local        \
+            --localstatedir=/usr/var \
+            --disable-logger     \
+            --disable-whois      \
+            --disable-rcp        \
+            --disable-rexec      \
+            --disable-rlogin     \
+            --disable-rsh        \
+            --disable-servers"
     system "make"
   end
-  
+
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-  end         
+  end
 end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -3,16 +3,16 @@ require 'package'
 class Jdk8 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html'
-  version '8u111'
+  version '8u131'
   binary_url ({
-    i686: "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=216422",
-    x86_64: "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=216424",
+    i686: "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=220303_d54c1d3a095b4ff2b6607d096fa80163",
+    x86_64: "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=220305_d54c1d3a095b4ff2b6607d096fa80163",
     armv7l: "https://www.dropbox.com/s/vcejuitboafaxib/jdk8u22-armv7l.tar.gz",
     aarch64: "https://www.dropbox.com/s/vcejuitboafaxib/jdk8u22-armv7l.tar.gz"
   })
   binary_sha1 ({
-    i686:    '37556a34403cb6d76c6e51471627c9e07727ea2d',
-    x86_64:  'd09fa2b77b6cf05ba835377a00ef495e6deebe1b',
+    i686:    '20d1a77783a01a592d9bcf3597256caee2ccfce0',
+    x86_64:  '9303d3a8e8fc2d2eda014887fd92a6f5883f0170',
     aarch64: '913adb900bf0d9d42452a4591c1a9093076ed4b6',
     armv7l:  '913adb900bf0d9d42452a4591c1a9093076ed4b6'
   })

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -3,17 +3,17 @@ require 'package'
 class Jdk8 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html'
-  version '8u112'
+  version '8u111'
   binary_url ({
-    i686: "https://www.dropbox.com/s/0c9yratmcf5fdpq/jdk8u112-i686.tar.gz",
-    x86_64: "https://www.dropbox.com/s/efa747g7or3294u/jdk8u112-x86_64.tar.gz",
+    i686: "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=216422",
+    x86_64: "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=216424",
     armv7l: "https://www.dropbox.com/s/vcejuitboafaxib/jdk8u22-armv7l.tar.gz",
     aarch64: "https://www.dropbox.com/s/vcejuitboafaxib/jdk8u22-armv7l.tar.gz"
   })
   binary_sha1 ({
+    i686:    '37556a34403cb6d76c6e51471627c9e07727ea2d',
+    x86_64:  'd09fa2b77b6cf05ba835377a00ef495e6deebe1b',
     aarch64: '913adb900bf0d9d42452a4591c1a9093076ed4b6',
-    armv7l:  '913adb900bf0d9d42452a4591c1a9093076ed4b6',
-    i686:    '65de377470bdd42e4f3e158b16917166ebe47a02',
-    x86_64:  '9a009b3b33cbb82ec70e7b0061973b09308c7fed',
+    armv7l:  '913adb900bf0d9d42452a4591c1a9093076ed4b6'
   })
 end

--- a/packages/node.rb
+++ b/packages/node.rb
@@ -12,7 +12,7 @@ class Node < Package
 
   def self.build
     case ARCH
-    when "x86_64" || "aarch64"
+    when "x86_64"
       system "CC='gcc -m64' python2.7 ./configure --without-snapshot"
     else
       system "CC='gcc' python2.7 ./configure --without-snapshot"

--- a/packages/node.rb
+++ b/packages/node.rb
@@ -3,26 +3,27 @@ require 'package'
 class Node < Package
   description 'As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications.'
   homepage 'https://nodejs.org/en/'
-  version '6.9.4'
-  source_url 'https://nodejs.org/dist/v6.9.4/node-v6.9.4.tar.xz'
-  source_sha1 '3b798acf7af4cd3f0efdb86bea009794492129ba'
+  version '6.11.0'
+  source_url 'https://nodejs.org/dist/v6.11.0/node-v6.11.0.tar.xz'
+  source_sha1 '1e408d9981606c5a01f46b4b6c93c0b30fa49d8c'
 
   depends_on 'buildessential'
   depends_on 'python27'
 
   def self.build
-    system "CC='gcc' python2.7 ./configure --without-snapshot"
+    system "CC='gcc -m64' python2.7 ./configure --without-snapshot"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     #Fix Permissiongs for -g installs of node packages
-    puts  "************************************************************"
-    puts "Now run:"
-    puts "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
-    puts "To be able to do"
-    puts "npm install -g"
-    puts "without being SUDO"
+    #puts  "************************************************************"
+    #puts "Now run:"
+    #puts "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
+    #puts "To be able to do"
+    #puts "npm install -g"
+    #puts "without being SUDO"
+    system "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
   end
 end

--- a/packages/node.rb
+++ b/packages/node.rb
@@ -11,18 +11,15 @@ class Node < Package
   depends_on 'python27'
 
   def self.build
-    case ARCH
-    when "x86_64"
-      system "CC='gcc -m64' python2.7 ./configure --without-snapshot"
-    else
-      system "CC='gcc' python2.7 ./configure --without-snapshot"
-    end
+    system "CC='gcc -m64' python2.7 ./configure --without-snapshot"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     #Fix Permissiongs for -g installs of node packages
-    system "sudo chown -R chronos /usr/local/{lib/node_modules,bin,share}"
+    system "sudo chown -R chronos /usr/local/lib/node_modules"
+    system "sudo chown -R chronos /usr/local/bin"
+    system "sudo chown -R chronos /usr/local/share"
   end
 end

--- a/packages/node.rb
+++ b/packages/node.rb
@@ -18,12 +18,6 @@ class Node < Package
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     #Fix Permissiongs for -g installs of node packages
-    #puts  "************************************************************"
-    #puts "Now run:"
-    #puts "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
-    #puts "To be able to do"
-    #puts "npm install -g"
-    #puts "without being SUDO"
-    system "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
+    system "sudo chown -R chronos /usr/local/{lib/node_modules,bin,share}"
   end
 end

--- a/packages/node_current.rb
+++ b/packages/node_current.rb
@@ -1,28 +1,29 @@
 require 'package'
 
-class Node_current < Package
-  description 'As an asynchronous event driven JavaScript runtime, Node current is designed to build scalable network applications.'
+class Node < Package
+  description 'As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications.'
   homepage 'https://nodejs.org/en/'
-  version '7.4.0'
-  source_url 'https://nodejs.org/dist/v7.4.0/node-v7.4.0.tar.xz'
-  source_sha1 'e31d4d67a6f39ccce2db66dcfa0e6c11851c1375'
+  version '8.1.0'
+  source_url 'https://nodejs.org/dist/v8.1.0/node-v8.1.0.tar.xz'
+  source_sha1 '13ed221ed55577beac5203c3c8bfec61af3cad97'
 
   depends_on 'buildessential'
   depends_on 'python27'
 
   def self.build
-    system "CC='gcc' python2.7 ./configure --without-snapshot"
+    system "CC='gcc -m64' python2.7 ./configure --without-snapshot"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     #Fix Permissiongs for -g installs of node packages
-    puts  "************************************************************"
-    puts "Now run:"
-    puts "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
-    puts "To be able to do"
-    puts "npm install -g"
-    puts "without being SUDO"
+    #puts  "************************************************************"
+    #puts "Now run:"
+    #puts "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
+    #puts "To be able to do"
+    #puts "npm install -g"
+    #puts "without being SUDO"
+    system "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
   end
 end

--- a/packages/node_current.rb
+++ b/packages/node_current.rb
@@ -23,6 +23,8 @@ class Node_current < Package
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     #Fix Permissiongs for -g installs of node packages
-    system "sudo chown -R chronos /usr/local/{lib/node_modules,bin,share}"
+    system "sudo chown -R chronos /usr/local/lib/node_modules"
+    system "sudo chown -R chronos /usr/local/bin"
+    system "sudo chown -R chronos /usr/local/share"
   end
 end

--- a/packages/node_current.rb
+++ b/packages/node_current.rb
@@ -11,7 +11,12 @@ class Node_current < Package
   depends_on 'python27'
 
   def self.build
-    system "CC='gcc -m64' python2.7 ./configure --without-snapshot"
+    case ARCH
+    when "x86_64"
+      system "CC='gcc -m64' python2.7 ./configure --without-snapshot"
+    else
+      system "CC='gcc' python2.7 ./configure --without-snapshot"
+    end
     system "make"
   end
 

--- a/packages/node_current.rb
+++ b/packages/node_current.rb
@@ -18,12 +18,6 @@ class Node < Package
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     #Fix Permissiongs for -g installs of node packages
-    #puts  "************************************************************"
-    #puts "Now run:"
-    #puts "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
-    #puts "To be able to do"
-    #puts "npm install -g"
-    #puts "without being SUDO"
-    system "sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}"
+    system "sudo chown -R chronos /usr/local/{lib/node_modules,bin,share}"
   end
 end

--- a/packages/node_current.rb
+++ b/packages/node_current.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Node < Package
+class Node_current < Package
   description 'As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications.'
   homepage 'https://nodejs.org/en/'
   version '8.1.0'

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -18,14 +18,14 @@ class Python27 < Package
     system "make"
 
     # strip debug symbols from library
-    system "find . -name '*.so' -print | xargs strip -S" unless @@debug_symbol
+    system "find . -name '*.so' -print | xargs strip -S" #unless @@debug_symbol
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
 
     # strip binary
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/python2" unless @@debug_symbol
+    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/python2" #unless @@debug_symbol
 
     # remove static library
     system "find #{CREW_DEST_DIR}/usr/local -name 'libpython*.a' -print | xargs rm"


### PR DESCRIPTION
Just updating Java, and Node to all the current versions.

NOTE: In Java I was able to find the x86 and 64x official links from oracle (instead of dropbox) but I couldn't find the ones for arm, so actually arm is back at 8u22 until I can find the links.