### PR TITLE
Refactor search logic to support regex

### DIFF
--- a/crew
+++ b/crew
@@ -157,7 +157,7 @@ def regexp_search(pkg_name)
   results = Dir["#{CREW_LIB_PATH}packages/*.rb"] \
 	  .select  { |f| File.basename(f, '.rb') =~ Regexp.new(pkg_name, true) } \
 	  .collect { |f| File.basename(f, '.rb') } \
-	  .each    { |f| set_package(f) }
+	  .each    { |f| print_package(f, ARGV[2] == "extra") }
   abort "Package not found :(" unless results.length > 0
 end
 

--- a/crew
+++ b/crew
@@ -153,6 +153,14 @@ def search (pkgName, silent = false)
   abort "Package #{pkgName} not found. :(".lightred
 end
 
+def regexp_search(pkg_name)
+  results = Dir["#{CREW_LIB_PATH}packages/*.rb"] \
+	  .select  { |f| File.basename(f, '.rb') =~ Regexp.new(pkg_name, true) } \
+	  .collect { |f| File.basename(f, '.rb') } \
+	  .each    { |f| set_package(f) }
+  abort "Package not found :(" unless results.length > 0
+end
+
 def help (pkgName)
   case pkgName
   when "build"
@@ -663,7 +671,7 @@ when "help"
   end
 when "search"
   if @pkgName
-    print_package @pkgName, true
+    regexp_search @pkgName
   else
     list_packages
   end


### PR DESCRIPTION
This is revised version of #403.

I modified @cstrouse PR to match the latest upstream/master and change to add new `regexp_search` function instead of modifying existing `search` function.  I also add `extra` option.  So, it is possible to use this like below now.
```
$ crew search vi
(i) vim: Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.
(i) vidstab: Transcode video stabilization plugin.
vifm: Vifm is an ncurses based file manager with vi like keybindings/modes/options/commands/configuration, which also borrows some useful ideas from mutt.
(i) libxvid: The free video codec that is strong in compression and quality.
neovim: Neovim is a refactor, and sometimes redactor, in the tradition of Vim (which itself derives from Stevie).
$ crew search ^vim$ extra
(i) vim: Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.
http://www.vim.org/
version 8.0-1
```