### PR TITLE
Update nmap from 7.31 to 7.50

### DIFF
--- a/packages/nmap.rb
+++ b/packages/nmap.rb
@@ -3,9 +3,9 @@ require 'package'
 class Nmap < Package
   description 'Nmap (\'Network Mapper\') is a free and open source (license) utility for network discovery and security auditing.'
   homepage 'https://nmap.org/'
-  version '7.31'
-  source_url 'https://nmap.org/dist/nmap-7.31.tgz'
-  source_sha1 'ccf1bb34463f39a645d9a924ce9e3c9e15eefbbf'
+  version '7.50'
+  source_url 'https://nmap.org/dist/nmap-7.50.tgz'
+  source_sha1 '9e77da9079489e86db9634e87efbd88500de9c65'
 
   depends_on 'buildessential'
   


### PR DESCRIPTION
This updates nmap from 7.31 to 7.50. The 7.50 release contains mostly
improvements to the signature database and nse scripts.

My chromebook is currently in a problematic state due to some firmware shenanigans so I was only able to test this under a cloudready machine I had handy running 56.3.82 stable channel. Everything works as expected.