### PR TITLE
Update curl from 7.54.0 to 7.54.1

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,9 +3,9 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.haxx.se/'
-  version '7.54.0'
-  source_url 'https://curl.haxx.se/download/curl-7.54.0.tar.bz2'
-  source_sha1 'e1cc251508e98bc5a8b9d5c40d8a4f6e48465d1c'
+  version '7.54.1'
+  source_url 'https://curl.haxx.se/download/curl-7.54.1.tar.bz2'
+  source_sha1 'f5193316e4b5ff23505cb09bc946763d35d02cd6'
 
   depends_on 'openssl' => :build
   depends_on 'zlibpkg' => :build


### PR DESCRIPTION
This is a security and general bugfix release. CVE-2017-9502 is
addressed.