### PR TITLE
Update gdb from 7.31.0 to 8.0

### DIFF
--- a/packages/gdb.rb
+++ b/packages/gdb.rb
@@ -3,9 +3,9 @@ require 'package'
 class Gdb < Package
   description 'GDB, the GNU Project debugger, allows you to see what is going on \'inside\' another program while it executes -- or what another program was doing at the moment it crashed.'
   homepage 'https://www.gnu.org/software/gdb/'
-  version '7.12.1.' 
-  source_url 'https://ftp.gnu.org/gnu/gdb/gdb-7.12.1.tar.xz'
-  source_sha1 'ef77c5345d6f9fdcdf7a5d8503301242b701936e'
+  version '8.0' 
+  source_url 'http://ftp.gnu.org/gnu/gdb/gdb-8.0.tar.xz'
+  source_sha1 '148c8e783ebf9b281241d0566db59961191ec64d'
 
   depends_on "buildessential"
   depends_on "ncurses"


### PR DESCRIPTION
This is a general maintenance and bugfix release.

Tested as working on Samsung XE500C13-K01US.