### PR TITLE
Add termcap package

### DIFF
--- a/packages/termcap.rb
+++ b/packages/termcap.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Termcap < Package
+  description 'A library for sending terminal control codes.'
+  homepage 'https://www.gnu.org/software/termutils/'
+  version '1.3.1'
+  source_url 'https://ftp.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz'
+  source_sha1 '42dd1e6beee04f336c884f96314f0c96cc2578be'
+
+  def self.build
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
A library for sending terminal control codes

This package provides a library for using terminals in programs not depending on the terminal type, and a database of known terminal types.

See https://directory.fsf.org/wiki/Termcap.