### PR TITLE
Add moreutils package

### DIFF
--- a/packages/moreutils.rb
+++ b/packages/moreutils.rb
@@ -1,0 +1,22 @@
+require 'package'
+
+class Moreutils < Package
+  description 'moreutils is a growing collection of the unix tools that nobody thought to write long ago when unix was young.'
+  homepage 'https://joeyh.name/code/moreutils/'
+  version '0.60'
+  source_url 'http://http.debian.net/debian/pool/main/m/moreutils/moreutils_0.60.orig.tar.xz'
+  source_sha1 '3af60490f763ece48b2fcba968903673c3e63495'
+
+  depends_on 'docbook'
+
+  def self.build
+    system "sed -i 's,PREFIX?=/usr,PREFIX?=/usr/local,' Makefile"
+    system "sed -i 's,DOCBOOKXSL?=/usr/share/xml/docbook/stylesheet/docbook-xsl,DOCBOOKXSL?=/usr/local/docbook,' Makefile"
+    system "sed -i 's,share/man,man,g' Makefile"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
moreutils is a growing collection of the unix tools that nobody thought to write long ago when unix was young.

chronic: runs a command quietly unless it fails
combine: combine the lines in two files using boolean operations
errno: look up errno names and descriptions
ifdata: get network interface info without parsing ifconfig output
ifne: run a program if the standard input is not empty
isutf8: check if a file or standard input is utf-8
lckdo: execute a program with a lock held
mispipe: pipe two commands, returning the exit status of the first
parallel: run multiple jobs at once
pee: tee standard input to pipes
sponge: soak up standard input and write to a file
ts: timestamp standard input
vidir: edit a directory in your text editor
vipe: insert a text editor into a pipe
zrun: automatically uncompress arguments to command

See https://joeyh.name/code/moreutils/.