### PR TITLE
Update goaccess from 1.1.1 to 1.2

### DIFF
--- a/packages/goaccess.rb
+++ b/packages/goaccess.rb
@@ -3,9 +3,9 @@ require 'package'
 class Goaccess < Package
   description 'GoAccess is an open source real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems or through your browser.'
   homepage 'https://goaccess.io/'
-  version '1.1.1'
-  source_url 'http://tar.goaccess.io/goaccess-1.1.1.tar.gz'
-  source_sha1 '8f79d90ea3e423f85aadf45528340a6547ab83f0'
+  version '1.2'
+  source_url 'http://tar.goaccess.io/goaccess-1.2.tar.gz'
+  source_sha1 '4c12796ff5afd14f359b1f638fc51c4007db1e3c'
 
   depends_on 'openssl'
   depends_on 'geoip'
@@ -13,7 +13,7 @@ class Goaccess < Package
 
   def self.build
     system './configure \
-              --enable-geoip \
+              --enable-geoip=legacy \
               --enable-utf8 \
               --with-getline \
               --with-openssl'


### PR DESCRIPTION
GoAccess v1.2 is a major release that gives the ability to parse multiple log files in real-time. It also adds the ability to pipe data in w/o closing the pipe and thus allowing a great amount of flexibility such as the ability to use tail -f and still have real-time stats. In addition to GeoIP2 support and other features and fixes.