### PR TITLE
Add libxslt dependency

### DIFF
--- a/packages/moreutils.rb
+++ b/packages/moreutils.rb
@@ -8,6 +8,7 @@ class Moreutils < Package
   source_sha1 '3af60490f763ece48b2fcba968903673c3e63495'
 
   depends_on 'docbook'
+  depends_on 'libxslt'
 
   def self.build
     system "sed -i 's,PREFIX?=/usr,PREFIX?=/usr/local,' Makefile"


### PR DESCRIPTION
Fixes error:
```
make: xsltproc: Command not found
make: *** [sponge.1] Error 127
moreutils failed to install: make -j4 exited with 2
```
Reference #758.