### PR TITLE
Add byobu package

### DIFF
--- a/packages/byobu.rb
+++ b/packages/byobu.rb
@@ -7,6 +7,8 @@ class Byobu < Package
   source_url 'https://launchpadlibrarian.net/322131788/byobu_5.119.orig.tar.gz'
   source_sha1 '1d8d07da4c94c4adeb662a7f8b33fe02482d9839'
 
+  depends_on 'gawk'
+
   def self.build
     system './configure'
     system 'make'

--- a/packages/byobu.rb
+++ b/packages/byobu.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Byobu < Package
+  description 'Byobu is a GPLv3 open source text-based window manager and terminal multiplexer.'
+  homepage 'http://byobu.org/'
+  version '5.119'
+  source_url 'https://launchpadlibrarian.net/322131788/byobu_5.119.orig.tar.gz'
+  source_sha1 '1d8d07da4c94c4adeb662a7f8b33fe02482d9839'
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Byobu is a Japanese term for decorative, multi-panel screens that serve as folding room dividers. As an open source software project, Byobu is an elegant enhancement of the otherwise functional, plain, practical GNU Screen. Byobu includes an enhanced profile, configuration utilities, and system status notifications for the GNU screen window manager as well as the Tmux terminal multiplexer. Byobu is developed and released as free software under the GPLv3.  See http://byobu.org/about.html.