### PR TITLE
Update aws package so it doesn't rely on the awscli-bundle.zip installer checksum

### DIFF
--- a/packages/aws.rb
+++ b/packages/aws.rb
@@ -3,15 +3,17 @@ require 'package'
 class Aws < Package
   description 'The AWS CLI is an open source tool built on top of the AWS SDK for Python (Boto) that provides commands for interacting with AWS services.'
   homepage 'https://aws.amazon.com/documentation/cli/'
-  version 'latest'
-  source_url 'https://s3.amazonaws.com/aws-cli/awscli-bundle.zip'
-  source_sha1 'af083a1e5455a8e040aaeda46e7b634b6510a8af'
+  version '1.11.110'
+  source_url 'https://github.com/aws/aws-cli/archive/1.11.110.tar.gz'
+  source_sha1 'a30e4f23951c06bb4ab9ffaa9ac42188fae6d6ba'
 
-  depends_on 'python'
+  depends_on 'python' unless File.exists? '/usr/local/bin/python'
   depends_on 'unzip'
 
   def self.install
-    system "#{CREW_BREW_DIR}/awscli-bundle.zip.dir/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws"
+    system "wget https://s3.amazonaws.com/aws-cli/awscli-bundle.zip"
+    system "unzip awscli-bundle.zip"
+    system "awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws"
     system "chmod +x /usr/local/bin/aws"
     system "mkdir -p #{CREW_DEST_DIR}/usr/local/aws"
     system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"


### PR DESCRIPTION
  - The awscli-bundle.zip installer is not versioned so it remains
    a moving target regarding checksums
  - Only require the python package if python isn't already installed