### PR TITLE
Correct dependency problems

### DIFF
--- a/crew
+++ b/crew
@@ -299,8 +299,25 @@ def upgrade
       puts "#{@pkg.name} is already up to date.".lightgreen
     end
   else
-    toBeUpdated = []
+    # Make a installed packages list belong to the dependency order
+    dependencies = []
     @device[:installed_packages].each do |package|
+      # skip package if it is dependent other packages previously checked
+      next if dependencies.include? package[:name]
+      # add package itself
+      dependencies = [ package[:name] ].concat(dependencies)
+      # expand depencencies and add it to the dependencies list
+      search package[:name], true
+      exp_dep = expand_dependencies
+      dependencies = exp_dep.concat(dependencies)
+    end
+    dependencies.uniq!
+
+    # Check version number of installed package and make a target list
+    toBeUpdated = []
+    dependencies.each do |dep|
+      package = @device[:installed_packages].find {|pkg| pkg[:name] == dep}
+      next unless package
       search package[:name], true
       if package[:version] != @pkg.version
         toBeUpdated.push(package[:name])

--- a/crew
+++ b/crew
@@ -465,7 +465,7 @@ def expand_dependencies
 
   def push_dependencies
     if @pkg.is_binary?(@device[:architecture]) ||
-       (!@pkg.in_upgrade && @device[:installed_packages].any? { |pkg| pkg[:name] == @pkg.name })
+       (!@pkg.in_upgrade && !@pkg.build_from_source && @device[:installed_packages].any? { |pkg| pkg[:name] == @pkg.name })
       # retrieve name of dependencies that doesn't contain :build tag
       check_deps = @pkg.dependencies.select {|k, v| !v.include?(:build)}.map {|k, v| k}
     elsif @pkg.is_fake?


### PR DESCRIPTION
This solves #790 problem, but this makes `crew upgrade` little slow if you install a lot of packages.  :(

This also solves a problem that :build tagged packages are not installed automatically when `crew build target` if the target is already installed.

Tested on armv7l and x86_64.