### PR TITLE
Support lib64 installation on x86_64

### DIFF
--- a/crew
+++ b/crew
@@ -9,7 +9,12 @@ require 'fileutils'
 @command = ARGV[0]
 @pkgName = ARGV[1]
 
+ARCH = `uname -m`.strip
+ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
+
 CREW_PREFIX = '/usr/local'
+CREW_LIB_PREFIX = CREW_PREFIX + '/' + ARCH_LIB
+
 CREW_LIB_PATH = CREW_PREFIX + '/lib/crew/'
 CREW_CONFIG_PATH = CREW_PREFIX + '/etc/crew/'
 CREW_BREW_DIR = CREW_PREFIX + '/tmp/crew/'
@@ -29,8 +34,6 @@ if ENV["CREW_XZ_OPT"].to_s == ''
 else
   ENV["XZ_OPT"] = ENV["CREW_XZ_OPT"]
 end
-
-ARCH = `uname -m`.strip
 
 $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"
 

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -34,13 +34,13 @@ class Bz2 < Package
     system "ln", "-sf", "bzip2", "#{CREW_DEST_DIR}/usr/local/bin/bzcat"
 
     # Install shared library by hand
-    system "cp", "-p", "libbz2.so.1.0.6", "#{CREW_DEST_DIR}/usr/local/lib"
-    system "ln", "-s", "libbz2.so.1.0.6", "#{CREW_DEST_DIR}/usr/local/lib/libbz2.so.1.0"
+    system "cp", "-p", "libbz2.so.1.0.6", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}"
+    system "ln", "-s", "libbz2.so.1.0.6", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libbz2.so.1.0"
 
     # Strip binaries and libraries
     system "strip #{CREW_DEST_DIR}/usr/local/bin/bzip2"
     system "strip #{CREW_DEST_DIR}/usr/local/bin/bzip2recover"
-    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/*"
+    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/*"
   end
 
   def self.check

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -34,6 +34,7 @@ class Bz2 < Package
     system "ln", "-sf", "bzip2", "#{CREW_DEST_DIR}/usr/local/bin/bzcat"
 
     # Install shared library by hand
+    system "mkdir", "-p", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}"
     system "cp", "-p", "libbz2.so.1.0.6", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}"
     system "ln", "-s", "libbz2.so.1.0.6", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libbz2.so.1.0"
 

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -13,7 +13,7 @@ class Curl < Package
   depends_on 'groff' => :build
 
   def self.build
-    system "./configure", "--disable-static"
+    system "./configure", "--lidir=#{CREW_LIB_PREFIX}", "--disable-static"
     system "make"
   end
 
@@ -21,7 +21,7 @@ class Curl < Package
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
 
     # strip debug symbol from library
-    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/libcurl.so.*"
+    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libcurl.so.*"
   end
 
   def self.check

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -13,7 +13,7 @@ class Curl < Package
   depends_on 'groff' => :build
 
   def self.build
-    system "./configure", "--lidir=#{CREW_LIB_PREFIX}", "--disable-static"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--disable-static"
     system "make"
   end
 

--- a/packages/expat.rb
+++ b/packages/expat.rb
@@ -8,7 +8,7 @@ class Expat < Package
   source_sha1 '8453bc52324be4c796fd38742ec48470eef358b3'
 
   def self.build
-    system "./configure", "--enable-shared", "--disable-static", "--with-pic"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic"
     system "make"
   end
 
@@ -17,7 +17,7 @@ class Expat < Package
 
     # strip binary and library
     system "strip #{CREW_DEST_DIR}/usr/local/bin/xmlwf"
-    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/libexpat.so.*"
+    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libexpat.so.*"
   end
 
   def self.check

--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -7,19 +7,8 @@ class Libsigsegv < Package
   source_url 'ftp://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.11.tar.gz'
   source_sha1 '186dea8ae788395476bd7cbaf38c17ebe82e1777'
 
-  # Not duplicating armv7l as aarch64 for the safe since libsigsegv traces stack.
-  # I'm not sure differences between armv7l stack and aarch64 stack.
-  binary_url ({
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/binaries/libsigsegv-2.11-chromeos-armv7l.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/binaries/libsigsegv-2.11-chromeos-x86_64.tar.xz',
-  })
-  binary_sha1 ({
-    armv7l:  '49ac940d93c9c174194a96444ac4006d8ebd6d53',
-    x86_64:  '3fdafd698589fffabc215dea2b559dacf94b4500',
-  })
-
   def self.build
-    system "./configure", "--enable-shared", "--disable-static", "--with-pic"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic"
     system "make"
   end
 

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -13,6 +13,7 @@ class Ncurses < Package
   def self.build
     system './configure',
 	    '--prefix=/usr/local',
+	    "--libdir=#{CREW_LIB_PREFIX}",
 	    '--without-normal',
 	    '--with-shared',
 	    '--with-cxx-shared',
@@ -33,6 +34,6 @@ class Ncurses < Package
     system "strip", "#{CREW_DEST_DIR}/usr/local/bin/toe"
 
     # strip libraries here since `make install` re-link libraries again
-    system "find #{CREW_DEST_DIR}/usr/local -name 'lib*.so.*' -print | xargs strip -S"
+    system "find #{CREW_DEST_DIR}#{CREW_LIB_PREFIX} -name 'lib*.so.*' -print | xargs strip -S"
   end
 end

--- a/packages/ncursesw.rb
+++ b/packages/ncursesw.rb
@@ -22,6 +22,7 @@ class Ncursesw < Package
     # Build ncursesw
     system './configure',
 	    '--prefix=/usr/local',
+	    "--libdir=#{CREW_LIB_PREFIX}",
 	    '--without-normal',
 	    '--with-shared',
 	    '--with-cxx-shared',
@@ -43,6 +44,6 @@ class Ncursesw < Package
     system "rm", "#{CREW_DEST_DIR}/usr/local/bin/toe"
 
     # strip libraries here since `make install` re-link libraries again
-    system "find #{CREW_DEST_DIR}/usr/local -name 'lib*.so.*' -print | xargs strip -S"
+    system "find #{CREW_DEST_DIR}#{CREW_LIB_PREFIX} -name 'lib*.so.*' -print | xargs strip -S"
   end
 end

--- a/packages/pcre.rb
+++ b/packages/pcre.rb
@@ -8,13 +8,13 @@ class Pcre < Package
   source_sha1 '12f338719b8b028a2eecbf9192fcc00a13fc04f6'
   
   def self.build
-    system "./configure", "--enable-shared", "--disable-static", "--with-pic", "--enable-utf"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic", "--enable-utf"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
-    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/lib*.so.*"
+    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/lib*.so.*"
   end
 
   def self.check

--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -12,11 +12,18 @@ class Readline < Package
   depends_on 'ncurses'
 
   def self.build
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches -P readline-6.3-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-001 -P readline-6.3-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-002 -P readline-6.3-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-003 -P readline-6.3-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-004 -P readline-6.3-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-005 -P readline-6.3-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-006 -P readline-6.3-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-007 -P readline-6.3-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-008 -P readline-6.3-patches"
     # system "for i in readline-6.3-patches/*.sig; do gpg $i; done"
     system "for i in readline-6.3-patches/readline63-???; do patch < $i; done"
 
-    system "CC='gcc' ./configure --disable-static --with-curses"
+    system "CC='gcc' ./configure --libdir=#{CREW_LIB_PREFIX} --disable-static --with-curses"
     system "make"
     system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end

--- a/packages/readline7.rb
+++ b/packages/readline7.rb
@@ -12,11 +12,13 @@ class Readline7 < Package
   depends_on 'ncurses'
 
   def self.build
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-7.0-patches -P readline-7.0-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-7.0-patches/readline70-001 -P readline-7.0-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-7.0-patches/readline70-002 -P readline-7.0-patches"
+    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-7.0-patches/readline70-003 -P readline-7.0-patches"
     # system "for i in readline-7.0-patches/*.sig; do gpg $i; done"
     system "for i in readline-7.0-patches/readline70-???; do patch < $i; done"
 
-    system "CC='gcc' ./configure --disable-static --with-curses"
+    system "CC='gcc' ./configure --libdir=#{CREW_LIB_PREFIX} --disable-static --with-curses"
     system "make"
   end
 

--- a/packages/xzutils.rb
+++ b/packages/xzutils.rb
@@ -8,7 +8,8 @@ class Xzutils < Package
   source_sha1 '529638eec3597e429cc54c74551ac0a89169e841'
 
   def self.build
-    system "./configure", "--prefix=/usr/local", "--disable-docs", "--enable-shared", "--disable-static", "--with-pic"
+    system "./configure", "--prefix=/usr/local", "--libdir=#{CREW_LIB_PREFIX}",
+      "--disable-docs", "--enable-shared", "--disable-static", "--with-pic"
     system "make"
   end
 
@@ -16,7 +17,7 @@ class Xzutils < Package
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
 
     # strip debug symbol from library
-    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/liblzma.so.*"
+    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/liblzma.so.*"
   end
 
   def self.check

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -8,7 +8,7 @@ class Zlibpkg < Package
   source_sha1 'e6d119755acdf9104d7ba236b1242696940ed6dd'
 
   def self.build
-    system "./configure"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 
@@ -16,10 +16,10 @@ class Zlibpkg < Package
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
 
     # remove static library since there is no configuration option to not create it.
-    system "rm", "#{CREW_DEST_DIR}/usr/local/lib/libz.a"
+    system "rm", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libz.a"
 
     # strip library
-    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/libz.so.*"
+    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libz.so.*"
   end
 
   def self.check


### PR DESCRIPTION
This PR modify `crew` to add `CREW_LIB_PREFIX` constant as described in #689.  This also modify several packages to demonstrate how to use it.  By applying this PR, some packanges start to install their libraries into `/usr/local/lib64` instead of `/usr/local/lib` on x86_64.

This PR follows the direction what the latest ChromeOS on x86_64 takes.  However, this PR won't break anything.  We still can choose use only lib64 or both lib64 and lib as we are discussing in #689.  This PR just shows the possibility that we can use only lib64 way as what ChromeOS is choosing.

Tested on armv7l and x86_64.