### PR TITLE
Change to use gcc-4.9.4.

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,17 +3,17 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'http://www.gnu.org/software/binutils/'
-  version '2.25-cc1.3'
+  version '2.25-2'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/binutils-2.25-cc1.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/binutils-2.25-cc1.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/binutils-2.25-cc1.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/binutils-2.25-cc1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/binutils-2.25-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/binutils-2.25-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/binutils-2.25-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/binutils-2.25-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '926b6aeab6d9c33435eefb856e4cb5263753387c',
-    armv7l:  '926b6aeab6d9c33435eefb856e4cb5263753387c',
-    i686:    'ebf66128ca99fa81c26b49b20163ea77eeb1e204',
-    x86_64:  '5427ba83960d0b7866aec8de63415720595ffe4a',
+    aarch64: '575c926920389cb4aff2b593a833097f85cee2fe',
+    armv7l:  '575c926920389cb4aff2b593a833097f85cee2fe',
+    i686:    'bb24463e862fd812a8ccbac5b5e2920f54fecacd',
+    x86_64:  'e02063609a97e1f061df96b68299910ff7be59d4',
   })
 end

--- a/packages/cloog.rb
+++ b/packages/cloog.rb
@@ -3,17 +3,17 @@ require 'package'
 class Cloog < Package
   description 'Chunky Loop Generator which is used to perform optimization in gcc'
   homepage 'https://www.cloog.org/'
-  version "0.18.4-cc1.3"
+  version '0.18.4-1'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/cloog-0.18.4-cc1.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/cloog-0.18.4-cc1.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/cloog-0.18.4-cc1.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/cloog-0.18.4-cc1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/cloog-0.18.4-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/cloog-0.18.4-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/cloog-0.18.4-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/cloog-0.18.4-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: 'e54784816f181c185dbd0eddc1b0c9f898db2caa',
-    armv7l:  'e54784816f181c185dbd0eddc1b0c9f898db2caa',
-    i686:    '3409f9c55e187533308f4febee39651833f592ad',
-    x86_64:  'cb29abf230eff44903a9a727f901903cba8bd1c7',
+    aarch64: 'f4a3af2c427944f30b4149428af1215a0200ff57',
+    armv7l:  'f4a3af2c427944f30b4149428af1215a0200ff57',
+    i686:    'fa62fb428bb6d211c6896bbb9912caa170db0590',
+    x86_64:  '5ffdb93347874dbd06916a50cba7876299f29ba2',
   })
 end

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -3,19 +3,19 @@ require 'package'
 class Gcc < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '4.9.x-cc1.3'
+  version '4.9.4'
 
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/gcc-4.9.x-cc1.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/gcc-4.9.x-cc1.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/gcc-4.9.x-cc1.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/gcc-4.9.x-cc1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/gcc-4.9.4-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/gcc-4.9.4-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/gcc-4.9.4-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/gcc-4.9.4-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: 'b71b4f64ff0ab9d32ed15714889046a329b1019c',
-    armv7l:  'b71b4f64ff0ab9d32ed15714889046a329b1019c',
-    i686:    'a8f9d270d89ba8d9afb4478bf2df1f73ba2878a7',
-    x86_64:  'a7da1611b35280117acb0fa86d7d91e0ff6a5e01',
+    aarch64: 'b34938c0ec56dc7bf7c03d4d5596232dede65c53',
+    armv7l:  'b34938c0ec56dc7bf7c03d4d5596232dede65c53',
+    i686:    '2f18ba781298d4275dd54a339ea415764a4d6fee',
+    x86_64:  '4e8e609fafab6ebb527cad7ecabce481c1b419e4',
   })
 
   depends_on 'binutils'

--- a/packages/glibc219.rb
+++ b/packages/glibc219.rb
@@ -3,17 +3,17 @@ require 'package'
 class Glibc219 < Package
   description 'GNU C Library'
   homepage 'https://www.gnu.org/software/libc/'
-  version '2.19'
+  version '2.19-1'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chromebrew/releases/download/newtoolchains/glibc-2.19-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.19-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.19-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.19-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.19-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: 'c4da258eacf411833494bbe6903918909fb5629c',
-    armv7l:  'c4da258eacf411833494bbe6903918909fb5629c',
-    i686:    '7d7f4e8e137bbb96dea2b2792dc12a7e61c729d9',
-    x86_64:  '073545bf8aa4b29fbf9084d31848b40f1df1b4ef',
+    aarch64: '4e318b8250d90a52d0f19963be60de41a8eccba4',
+    armv7l:  '4e318b8250d90a52d0f19963be60de41a8eccba4',
+    i686:    '156c2b7bcb0ed9f8604d0a91908871648c55e260',
+    x86_64:  'e094f717ec2f5add484994a8537903fa0d07d7f8',
   })
 end

--- a/packages/glibc223.rb
+++ b/packages/glibc223.rb
@@ -3,17 +3,17 @@ require 'package'
 class Glibc223 < Package
   description 'GNU C Library'
   homepage 'https://www.gnu.org/software/libc/'
-  version '2.23-cc1.3'
+  version '2.23-1'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/glibc-2.23-cc1.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/glibc-2.23-cc1.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/glibc-2.23-cc1.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/glibc-2.23-cc1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.23-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.23-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.23-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.23-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '09cac401b8d6821c4ea2f349f0a348fcef9e07b2',
-    armv7l:  '09cac401b8d6821c4ea2f349f0a348fcef9e07b2',
-    i686:    '66096f5bf50ab19f17f8d9356589ea6dc809f8d9',
-    x86_64:  '1807e449919fff8d3473d97d43d184961a65a323',
+    aarch64: '0fecd72cda0d24833750553015e88fb6624e62a3',
+    armv7l:  '0fecd72cda0d24833750553015e88fb6624e62a3',
+    i686:    '5260ed2243ca382c5fd780f3833a0d39b519f1fc',
+    x86_64:  '57e08745e97f79a49283847c92ac5164072db14c',
   })
 end

--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -3,17 +3,17 @@ require 'package'
 class Gmp < Package
   description 'GMP is a free library for arbitrary precision arithmetic, operating on signed integers, rational numbers, and floating-point numbers.'
   homepage 'https://gmplib.org/'
-  version "6.1.2-cc1.3"
+  version '6.1.2-1'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/gmp-6.1.2-cc1.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/gmp-6.1.2-cc1.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/gmp-6.1.2-cc1.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/gmp-6.1.2-cc1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/gmp-6.1.2-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/gmp-6.1.2-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/gmp-6.1.2-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/gmp-6.1.2-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '16c62caf6da5971ddb4e4985d5905ce43a40f2f8',
-    armv7l:  '16c62caf6da5971ddb4e4985d5905ce43a40f2f8',
-    i686:    'eadba1eb5fcc25bdafd1f868045984d726a26d08',
-    x86_64:  '706ca2c87011f5ee12324f03ae286fb95a532cec',
+    aarch64: '63b9465ad81d2ad68f6b328f1dada69337c4f71e',
+    armv7l:  '63b9465ad81d2ad68f6b328f1dada69337c4f71e',
+    i686:    '51d647a9a3bd14d0d5f8acbd6f4baf4401e155b4',
+    x86_64:  'a69e303b879264de36ca3e075dd3601f77538163',
   })
 end

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -3,17 +3,17 @@ require 'package'
 class Isl < Package
   description 'Integer Set Library for manipulating sets and relations of integer points bounded by linear constraints'
   homepage 'http://isl.gforge.inria.fr/'
-  version "0.14.1-cc1.3"
+  version '0.18'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/isl-0.14.1-cc1.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/isl-0.14.1-cc1.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/isl-0.14.1-cc1.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/isl-0.14.1-cc1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/isl-0.18-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/isl-0.18-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/isl-0.18-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/isl-0.18-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '749bf7d0a09c1578ce2de20a21ce7f7d6a575756',
-    armv7l:  '749bf7d0a09c1578ce2de20a21ce7f7d6a575756',
-    i686:    '306c249734107ac29e7951a44a000cfcbb523a35',
-    x86_64:  '7e0dcb1c65a99be666c4369abb649ad27f88ade1',
+    aarch64: 'c954cc42a2129cd179ec1554c8c0bb66ea1ff242',
+    armv7l:  'c954cc42a2129cd179ec1554c8c0bb66ea1ff242',
+    i686:    'ffd99eb6b19cd83856a58c10bbc55a634c37e520',
+    x86_64:  '56e335db9d66b91d0943fe1597b20eb23d05bc94',
   })
 end

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -3,17 +3,17 @@ require 'package'
 class Linuxheaders < Package
   description 'Linux headers for Chrome OS.'
   homepage ''
-  version '3.18-cc1.3'
+  version '3.18-1'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/linux-headers-3.18-cc1.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/linux-headers-3.18-cc1.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/linux-headers-3.18-cc1.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/linux-headers-3.18-cc1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/linux-headers-3.18-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/linux-headers-3.18-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/linux-headers-3.18-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/linux-headers-3.18-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: '4f7c1df409b416735d8d2bfbbc62cb57f3ca5d80',
-    armv7l:  '4f7c1df409b416735d8d2bfbbc62cb57f3ca5d80',
-    i686:    '0c8190aa192db06772a6d125c1e22ef2ec11e996',
-    x86_64:  'aee9c675d1f51268c16273d3ba3bd73334783072',
+    aarch64: '783acca9a3afe6c77ecd93f10930c779c3d625a5',
+    armv7l:  '783acca9a3afe6c77ecd93f10930c779c3d625a5',
+    i686:    '965234573d99c99926feb759cdf6e4a70e97c6a0',
+    x86_64:  '87a6f22e6f92614279eba518d6e00432c09d8671',
   })
 end

--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -3,17 +3,17 @@ require 'package'
 class Mpc < Package
   description 'Gnu Mpc is a C library for the arithmetic of complex numbers with arbitrarily high precision and correct rounding of the result.'
   homepage 'http://www.multiprecision.org/'
-  version '1.0.3-cc1.3'
+  version '1.0.3-1'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpc-1.0.3-cc1.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpc-1.0.3-cc1.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpc-1.0.3-cc1.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpc-1.0.3-cc1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpc-1.0.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpc-1.0.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpc-1.0.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpc-1.0.3-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: 'd1f6e5d521f1807accca245cecf2ccc56c29c96d',
-    armv7l:  'd1f6e5d521f1807accca245cecf2ccc56c29c96d',
-    i686:    'd7fcd41e92b637220208e136207d1095237f3ac1',
-    x86_64:  'fcc7bc8f7a4f9956f801af84e4104e565dd8b285',
+    aarch64: '275fdba883722c3a0c8dbc92e3fc7d7a5a88bc57',
+    armv7l:  '275fdba883722c3a0c8dbc92e3fc7d7a5a88bc57',
+    i686:    '19ac6cf905c86c71a4be7773882f742e9786ead9',
+    x86_64:  '25586540bc6be6bfa9814ac65b3ee633c452c1b0',
   })
 end

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -3,17 +3,17 @@ require 'package'
 class Mpfr < Package
   description 'The MPFR library is a C library for multiple-precision floating-point computations with correct rounding.'
   homepage 'http://www.mpfr.org/'
-  version '3.1.5-cc1.3'
+  version '3.1.5-1'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpfr-3.1.5-cc1.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpfr-3.1.5-cc1.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpfr-3.1.5-cc1.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.3/mpfr-3.1.5-cc1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpfr-3.1.5-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpfr-3.1.5-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpfr-3.1.5-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpfr-3.1.5-chromeos-x86_64.tar.xz',
   })
   binary_sha1 ({
-    aarch64: 'd201c3e9c7fa3d483e93cb967e9ae78b4578868b',
-    armv7l:  'd201c3e9c7fa3d483e93cb967e9ae78b4578868b',
-    i686:    '71569b4f88e852d0a6734b2be8e200f52248a7fe',
-    x86_64:  '7d434ebe762b004d9f822f5baa21b9c9f37452b0',
+    aarch64: 'e388055aa9652e2c0c580f0e0cc26509d8c17f39',
+    armv7l:  'e388055aa9652e2c0c580f0e0cc26509d8c17f39',
+    i686:    '87630dd77fbdad79f0382e64a9ddb82453d21a46',
+    x86_64:  '6e137ee58ceca44fbc9bd0f35a2039993f7a0cc1',
   })
 end


### PR DESCRIPTION
Change toolchains to use gcc-4.9.4 instead of google internal gcc-4.9.x.  This may solve the problem #697.  This time I also modify binutils to install stuff into `/usr/local/lib64` on x86_64 to not cause any problems like #689.  So, this toolchains work flawlessly on ChromeOS 60 x86_64 out of the box.

Tested on armv7l and x86_64.  Not tested on i686 nor aarch64, but I hope it works well since we used to use these cross-compiled toolchains on them.