### PR TITLE
Fix Dropbox for ARM Devices

### DIFF
--- a/packages/dropbox.rb
+++ b/packages/dropbox.rb
@@ -12,7 +12,7 @@ class Dropbox < Package
     source_url 'https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-28.4.14.tar.gz'
     source_sha1 '40f4f37b64394d42f4fa3d6b3d53553f854587e4'
   else
-    abort 'Unable to install dropboxd.  Supported architectures include x86 and x86_64 only.'.lightred
+    'Unable to install dropboxd.  Supported architectures include x86 and x86_64 only.'.lightred
   end
 
   depends_on 'python'


### PR DESCRIPTION
Recently submitted Dropbox package "breaks" `crew search` for the ARM devices by aborting before search is completed. Simple fix allows search to continue on ARM. 