### PR TITLE
Change crew to strip binaries and libraries at install time

### DIFF
--- a/crew
+++ b/crew
@@ -27,6 +27,9 @@ else
   CREW_NPROC = ENV["CREW_NPROC"]
 end
 
+# Set CREW_NOT_STRIP from environment variable
+CREW_NOT_STRIP = ENV["CREW_NOT_STRIP"]
+
 # Set XZ_OPT environment variable for build command.
 # If CREW_XZ_OPT is defined, use it by default.  Use `-7e`, otherwise.
 if ENV["CREW_XZ_OPT"].to_s == ''
@@ -434,6 +437,16 @@ def install_package (pkgdir)
   Dir.chdir pkgdir do
     FileUtils.mv 'dlist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.directorylist"
     FileUtils.mv 'filelist', CREW_CONFIG_PATH + "meta/#{@pkg.name}.filelist"
+
+    # Strip libraries with -S
+    system "find . -name 'lib*.a' -print | xargs chmod u+w 2>/dev/null" unless CREW_NOT_STRIP
+    system "find . -name 'lib*.a' -print | xargs strip -S 2>/dev/null" unless CREW_NOT_STRIP
+    system "find . -name 'lib*.so*' -print | xargs chmod u+w 2>/dev/null" unless CREW_NOT_STRIP
+    system "find . -name 'lib*.so*' -print | xargs strip -S 2>/dev/null" unless CREW_NOT_STRIP
+
+    # Strip binaries
+    system "find . -type f -perm /111 -print | sed -e '/lib.*\.a$/d' -e '/lib.*\.so/d' | xargs chmod u+w 2>/dev/null" unless CREW_NOT_STRIP
+    system "find . -type f -perm /111 -print | sed -e '/lib.*\.a$/d' -e '/lib.*\.so/d' | xargs strip 2>/dev/null" unless CREW_NOT_STRIP
 
     system "tar cf - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
   end

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -9,8 +9,6 @@ class Package
     attr_accessor :in_upgrade
   end
 
-  @@debug_symbol = ENV['CREW_DEBUG_SYMBOL'] || false
-
   def self.dependencies
     # We need instance variable in derived class, so not define it here,
     # base class.  Instead of define it, we initialize it in a function

--- a/packages/bison.rb
+++ b/packages/bison.rb
@@ -16,11 +16,10 @@ class Bison < Package
   def self.build
     system './configure --prefix=/usr/local'
     system "make"
-    system "find . -name '*.a' -print | xargs strip -S"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -37,11 +37,6 @@ class Bz2 < Package
     system "mkdir", "-p", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}"
     system "cp", "-p", "libbz2.so.1.0.6", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}"
     system "ln", "-s", "libbz2.so.1.0.6", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libbz2.so.1.0"
-
-    # Strip binaries and libraries
-    system "strip #{CREW_DEST_DIR}/usr/local/bin/bzip2"
-    system "strip #{CREW_DEST_DIR}/usr/local/bin/bzip2recover"
-    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/*"
   end
 
   def self.check

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -18,10 +18,7 @@ class Curl < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
-
-    # strip debug symbol from library
-    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libcurl.so.*"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/diffutils.rb
+++ b/packages/diffutils.rb
@@ -15,7 +15,7 @@ class Diffutils < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/dos2unix.rb
+++ b/packages/dos2unix.rb
@@ -9,7 +9,6 @@ class Dos2unix < Package
 
   def self.build
     system 'make'
-    system 'make strip'
   end
 
   def self.install

--- a/packages/ed.rb
+++ b/packages/ed.rb
@@ -16,7 +16,7 @@ class Ed < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/expat.rb
+++ b/packages/expat.rb
@@ -14,10 +14,6 @@ class Expat < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-
-    # strip binary and library
-    system "strip #{CREW_DEST_DIR}/usr/local/bin/xmlwf"
-    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libexpat.so.*"
   end
 
   def self.check

--- a/packages/expect.rb
+++ b/packages/expect.rb
@@ -12,8 +12,6 @@ class Expect < Package
   def self.build
     system "./configure", "--prefix=/usr/local"
     system "make"
-    system "find . -name '*.so' -print | xargs strip -S"
-    system "strip expect"
   end
 
   def self.install

--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -10,11 +10,10 @@ class Filecmd < Package
   def self.build
     system "./configure"
     system "make"
-    system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/flex.rb
+++ b/packages/flex.rb
@@ -13,11 +13,10 @@ class Flex < Package
   def self.build
     system "./configure", "--with-pic", "--disable-static", "--enable-shared"
     system "make"
-    system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/gawk.rb
+++ b/packages/gawk.rb
@@ -16,11 +16,10 @@ class Gawk < Package
   def self.build
     system './configure', '--prefix=/usr/local'
     system 'make'
-    system "find . -name '*.so' -print | xargs strip -S"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/gdbm.rb
+++ b/packages/gdbm.rb
@@ -12,11 +12,10 @@ class Gdbm < Package
   def self.build
     system './configure', '--disable-static', '--enable-shared', '--with-pic'
     system 'make'
-    system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end
   
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -14,11 +14,10 @@ class Gettext < Package
   def self.build
     system "./configure", "--enable-shared", "--disable-static", "--with-pic"
     system "make"
-    system "find . -name '*.so.*' -print | xargs strip -S"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -22,7 +22,6 @@ class Git < Package
 
   def self.build
     system "#{@make_cmd} all"
-    system "#{@make_cmd} strip"
   end
 
   def self.install

--- a/packages/less.rb
+++ b/packages/less.rb
@@ -16,7 +16,7 @@ class Less < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -10,11 +10,10 @@ class Libffi < Package
   def self.build
     system "./configure", "--enable-shared", "--disable-static", "--with-pic", "--disable-debug", "--disable-dependency-tracking"
     system "make"
-    system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/libpipeline.rb
+++ b/packages/libpipeline.rb
@@ -10,11 +10,10 @@ class Libpipeline < Package
   def self.build
     system './configure', '--disable-static', '--enable-shared', '--with-pic'
     system 'make'
-    system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end
   
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/libssh2.rb
+++ b/packages/libssh2.rb
@@ -17,9 +17,6 @@ class Libssh2 < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-
-    # strip debug symbol from library
-    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/libssh2.so.*"
   end
 
   def self.check

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -19,8 +19,6 @@ class Libunbound < Package
     system "sed", "-i", "Makefile", "-e", '/$(LEX) -t $(srcdir)\/util\/configlexer.lex/s:-t:-t -Pub_c_:'
 
     system "make"
-    system "make", "strip"
-    system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end
 
   def self.install

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -13,10 +13,7 @@ class Libxml2 < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
-
-    # strip debug symbol from library
-    system "strip -S #{CREW_DEST_DIR}/usr/local/lib/libxml2.so.*"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/lzip.rb
+++ b/packages/lzip.rb
@@ -14,7 +14,7 @@ class Lzip < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/m4.rb
+++ b/packages/m4.rb
@@ -15,7 +15,7 @@ class M4 < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/make.rb
+++ b/packages/make.rb
@@ -16,7 +16,7 @@ class Make < Package
   end
 
   def self.install
-    system "./make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "./make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -20,11 +20,10 @@ class Mandb < Package
       '--disable-cache-owner',                                # we can't create the user 'man'
       '--with-pager=/usr/local/bin/less'                      # the pager is not at the default location
     system 'make'
-    system "find . -name 'lib*.so*' -print | xargs strip -S"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     puts ""
     puts "You will have to change the default PAGER environment variable to be able to use mandb:"
     puts "echo \"export PAGER=/usr/local/bin/less\" >> ~/.bashrc && . ~/.bashrc"

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -23,17 +23,5 @@ class Ncurses < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-
-    # strip binaries
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/clear"
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/infocmp"
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/tabs"
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/tic"
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/tput"
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/tset"
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/toe"
-
-    # strip libraries here since `make install` re-link libraries again
-    system "find #{CREW_DEST_DIR}#{CREW_LIB_PREFIX} -name 'lib*.so.*' -print | xargs strip -S"
   end
 end

--- a/packages/ncursesw.rb
+++ b/packages/ncursesw.rb
@@ -42,8 +42,5 @@ class Ncursesw < Package
     system "rm", "#{CREW_DEST_DIR}/usr/local/bin/tput"
     system "rm", "#{CREW_DEST_DIR}/usr/local/bin/tset"
     system "rm", "#{CREW_DEST_DIR}/usr/local/bin/toe"
-
-    # strip libraries here since `make install` re-link libraries again
-    system "find #{CREW_DEST_DIR}#{CREW_LIB_PREFIX} -name 'lib*.so.*' -print | xargs strip -S"
   end
 end

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -26,13 +26,10 @@ class Openssl < Package
     end
     system "./config --prefix=/usr/local --openssldir=/etc/ssl #{options}"
     system "make"
-    system "find . -name '*.so' -print | xargs strip -S"
-    system "find . -name '*.so.*' -print | xargs strip -S"
   end
 
   def self.install
     system "make", "INSTALL_PREFIX=#{CREW_DEST_DIR}", "install"
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/openssl"
     system "find #{CREW_DEST_DIR}/usr/local -name 'lib*.a' -print | xargs rm"
 
     # move man to /usr/local/man

--- a/packages/patch.rb
+++ b/packages/patch.rb
@@ -13,7 +13,7 @@ class Patch < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/pcre.rb
+++ b/packages/pcre.rb
@@ -13,8 +13,7 @@ class Pcre < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
-    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/lib*.so.*"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -14,11 +14,10 @@ class Perl < Package
     # Create shared library
     system "BUILD_ZLIB=False BUILD_BZIP2=0 ./Configure -de -Duseshrplib"
     system "make"
-    system "find . -name '*.so' -print | xargs strip -S"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/pkgconfig.rb
+++ b/packages/pkgconfig.rb
@@ -21,7 +21,7 @@ class Pkgconfig < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -16,22 +16,13 @@ class Python27 < Package
   def self.build
     system "./configure", "CPPFLAGS=-I/usr/local/include/ncurses -I/usr/local/include/ncursesw", "--with-ensurepip=install", "--enable-shared"
     system "make"
-
-    # strip debug symbols from library
-    system "find . -name '*.so' -print | xargs strip -S" unless @@debug_symbol
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
 
-    # strip binary
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/python2" unless @@debug_symbol
-
     # remove static library
     system "find #{CREW_DEST_DIR}/usr/local -name 'libpython*.a' -print | xargs rm"
-
-    # remove cache (byte-code) files from install package
-    system "find #{CREW_DEST_DIR}/usr/local -name '*.pyc' -o -name '*.pyo' | xargs rm"
   end
 
   def self.check

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -17,22 +17,13 @@ class Python3 < Package
     system "./configure", "CPPFLAGS=-I/usr/local/include/ncurses -I/usr/local/include/ncursesw",
       "--with-ensurepip=install", "--enable-shared"
     system "make"
-
-    # strip debug symbols from library
-    system "find . -name '*.so' -print | xargs strip -S" unless @@debug_symbol
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
 
-    # strip binary
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/python3" unless @@debug_symbol
-
     # remove static library
     system "find #{CREW_DEST_DIR}/usr/local -name 'libpython*.a' -print | xargs rm"
-
-    # remove cache (byte-code) files from install package
-    system "find #{CREW_DEST_DIR}/usr/local -name '__pycache__' -print | xargs rm -rf"
   end
 
   def self.check
@@ -53,10 +44,6 @@ class Python3 < Package
         "-e", '/test_logincapa_with_client_ssl_context/i\ \ \ \ @unittest.skipIf(True,\
                      "bpo-30175: FIXME: cyrus.andrew.cmu.edu doesn\'t accept "\
                      "our randomly generated client x509 certificate anymore")'
-
-    # skip gdb test since we are stripping debug symbols
-    system "sed", "-i", "Lib/test/test_gdb.py",
-        "-e", '/get_gdb_version/iraise unittest.SkipTest("only for python install with debug symbols")' unless @@debug_symbol
 
     # Using /tmp breaks test_distutils, test_subprocess
     # Proxy setting breaks test_httpservers, test_ssl,

--- a/packages/r.rb
+++ b/packages/r.rb
@@ -24,7 +24,7 @@ class R < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -25,7 +25,6 @@ class Readline < Package
 
     system "CC='gcc' ./configure --libdir=#{CREW_LIB_PREFIX} --disable-static --with-curses"
     system "make"
-    system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end
 
   def self.install

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -16,12 +16,10 @@ class Ruby < Package
   def self.build
     system "CC='gcc' ./configure"
     system "make"
-    system "find . -name '*.so' | xargs strip -S"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    system "strip #{CREW_DEST_DIR}/usr/local/bin/ruby"
   end
 
   def self.check

--- a/packages/sqlite.rb
+++ b/packages/sqlite.rb
@@ -10,10 +10,9 @@ class Sqlite < Package
   def self.build
     system "./configure", "--disable-static", "--enable-shared", "--with-pic"
     system "make"
-    system "find . -name 'lib*.so.*' -print | xargs strip -S"
   end
   
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 end

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -20,7 +20,6 @@ class Vim < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    system "strip", "#{CREW_DEST_DIR}/usr/local/bin/vim"
 
     puts "\nMake sure to put your .vim directory in a subdirectory of /usr/local so it has execute permissions"
     puts "You can then symlink to your home directory so vim can see it"

--- a/packages/xzutils.rb
+++ b/packages/xzutils.rb
@@ -14,10 +14,7 @@ class Xzutils < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
-
-    # strip debug symbol from library
-    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/liblzma.so.*"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
   def self.check

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -17,9 +17,6 @@ class Zlibpkg < Package
 
     # remove static library since there is no configuration option to not create it.
     system "rm", "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libz.a"
-
-    # strip library
-    system "strip -S #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/libz.so.*"
   end
 
   def self.check


### PR DESCRIPTION
This PR modifies `crew` to strip binaries and libraries at install time unless `CREW_NOT_STRIP` environment variable is defined.

I modified several packages to do so, but it makes those files complicated and difficult to understand.  Therefore, I was looking for different method to strip them without modifying package files.  This PR is it.

I also reverted package files modified to strip binaries and libraries by themselves.

Tested on armv7l and x86_64.