### PR TITLE
Remove abort line from packages

### DIFF
--- a/packages/dropbox.rb
+++ b/packages/dropbox.rb
@@ -11,11 +11,9 @@ class Dropbox < Package
   when 'x86_64'
     source_url 'https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-28.4.14.tar.gz'
     source_sha1 '40f4f37b64394d42f4fa3d6b3d53553f854587e4'
-  else
-    abort 'Unable to install dropboxd.  Supported architectures include x86 and x86_64 only.'.lightred
   end
 
-  depends_on 'python'
+  depends_on 'python' unless File.exists? '/usr/local/bin/python'
 
   def self.install
     system "wget https://linux.dropbox.com/packages/dropbox.py"

--- a/packages/gdrive.rb
+++ b/packages/gdrive.rb
@@ -27,8 +27,6 @@ class Gdrive < Package
       system "wget -L -O #{CREW_DEST_DIR}/usr/local/bin/gdrive https://docs.google.com/uc?id=0B3X9GlR6EmbnS09XMzhfRXBnUzA&export=download"
       system "sleep 10"
       abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA1.hexdigest( File.read("#{CREW_DEST_DIR}/usr/local/bin/gdrive") ) == '70a1ac5be9ba819da5cf7a8dbd513805a26509ac'
-    else
-      abort 'Unable to install gdrive.  Architecture not supported.'.lightred
     end
     system "chmod +x #{CREW_DEST_DIR}/usr/local/bin/gdrive"
   end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -17,8 +17,6 @@ class Jdk8 < Package
   when 'aarch64'
     source_url 'https://www.dropbox.com/s/vcejuitboafaxib/jdk8u22-armv7l.tar.gz'
     source_sha1 '913adb900bf0d9d42452a4591c1a9093076ed4b6'
-  else
-    abort 'Unable to install jdk8.  Architecture not supported.'.lightred
   end
   def self.install
     system "mkdir -p #{CREW_DEST_DIR}/usr/local"

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -19,8 +19,6 @@ class Wine < Package
       system "./configure --without-x"
     when "x86_64" || "aarch64"
       system "./configure --without-x --enable-win64"
-    else
-      abort "Error getting your device configuration."
     end
     system "make"
   end


### PR DESCRIPTION
  - Fix dropbox package to depend on python only if not installed yet
This also fixes the issue as discussed in PR #798.