### PR TITLE
Dart version bump, arch update, update binary source, fix #780

### DIFF
--- a/packages/dart.rb
+++ b/packages/dart.rb
@@ -1,6 +1,5 @@
 require 'package'
 
-depends_on 'unzip'
 
 class Dart < Package
   description 'The Dart SDK is a set of tools and libraries for the Dart programming language.  You can find information about Dart online at dartlang.org.'
@@ -27,6 +26,9 @@ class Dart < Package
 #  else
 #    abort 'Unable to install dart sdk.  Architecture not supported.'.lightred
   end
+
+  depends_on 'unzip'
+
   def self.install
     system "mkdir -p #{CREW_DEST_DIR}/usr/local"
     system "cp -r bin/ #{CREW_DEST_DIR}/usr/local"

--- a/packages/dart.rb
+++ b/packages/dart.rb
@@ -1,5 +1,7 @@
 require 'package'
 
+depends_on 'unzip'
+
 class Dart < Package
   description 'The Dart SDK is a set of tools and libraries for the Dart programming language.  You can find information about Dart online at dartlang.org.'
   homepage 'https://www.dartlang.org'

--- a/packages/dart.rb
+++ b/packages/dart.rb
@@ -17,8 +17,13 @@ class Dart < Package
   when 'aarch64'
     source_url 'https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.2/sdk/dartsdk-linux-arm64-release.zip'
     source_sha1 'cf6b96eb5b88b1865bf357c2c9fd7ad8d64f763f'
-  else
-    abort 'Unable to install dart sdk.  Architecture not supported.'.lightred
+#  
+#  comment out abort per discussion in #798
+#  https://github.com/skycocker/chromebrew/pull/798
+#  we have all current archs covered here anyway, i believe
+#
+#  else
+#    abort 'Unable to install dart sdk.  Architecture not supported.'.lightred
   end
   def self.install
     system "mkdir -p #{CREW_DEST_DIR}/usr/local"

--- a/packages/dart.rb
+++ b/packages/dart.rb
@@ -29,6 +29,6 @@ class Dart < Package
     system "mkdir -p #{CREW_DEST_DIR}/usr/local"
     system "cp -r bin/ #{CREW_DEST_DIR}/usr/local"
     system "cp -r lib/ #{CREW_DEST_DIR}/usr/local"
-    system "cp -r man/ #{CREW_DEST_DIR}/usr/local"
+    system "cp -r include/ #{CREW_DEST_DIR}/usr/local"
   end
 end

--- a/packages/dart.rb
+++ b/packages/dart.rb
@@ -1,16 +1,29 @@
 require 'package'
 
 class Dart < Package
-  version '1.22.0'
-
-  binary_url ({
-    armv7l: "https://www.dropbox.com/s/3w9kvs3yross3lw/dart-1.22.0-arm.tgz",
-    i686: "https://www.dropbox.com/s/p3ib8qx32j70qwi/dart-1.22.0-ia32.tgz",
-    x86_64: "https://www.dropbox.com/s/i8r0kzqd5r7iunz/dart-1.22.0-x64.tgz"
-  })
-  binary_sha1 ({
-    armv7l: "7d8d9cb9e92d72853eb7c536fd5af6183973958d",
-    i686: "0dc1c5de8f0802ff64ba111d60432191d8e852de",
-    x86_64: "472c6364d4afac21337fcd89c3001c04fa63bb4d"
-  })
+  description 'The Dart SDK is a set of tools and libraries for the Dart programming language.  You can find information about Dart online at dartlang.org.'
+  homepage 'https://www.dartlang.org'
+  version '1.24.2'
+  case ARCH
+  when 'i686'
+    source_url 'https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.2/sdk/dartsdk-linux-ia32-release.zip'
+    source_sha1 '24d132e12d7982ae0c7f41bf78e7e45aaae303cb'
+  when 'x86_64'
+    source_url 'https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.2/sdk/dartsdk-linux-x64-release.zip'
+    source_sha1 'c2ff2a1c499b1dd3f8e547d7f012fabf46e06108'
+  when 'armv7l'
+    source_url 'https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.2/sdk/dartsdk-linux-arm-release.zip'
+    source_sha1 'c14d211981c405a754963941d3c8be6d0da22a8c'
+  when 'aarch64'
+    source_url 'https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.2/sdk/dartsdk-linux-arm64-release.zip'
+    source_sha1 'cf6b96eb5b88b1865bf357c2c9fd7ad8d64f763f'
+  else
+    abort 'Unable to install dart sdk.  Architecture not supported.'.lightred
+  end
+  def self.install
+    system "mkdir -p #{CREW_DEST_DIR}/usr/local"
+    system "cp -r bin/ #{CREW_DEST_DIR}/usr/local"
+    system "cp -r lib/ #{CREW_DEST_DIR}/usr/local"
+    system "cp -r man/ #{CREW_DEST_DIR}/usr/local"
+  end
 end


### PR DESCRIPTION
Dart version bump to current.  Add arm7 architecture.  Download from official repositories. Fix directory install location issues  (#780). 