### PR TITLE
Change crew to compress manual files at install time

### DIFF
--- a/crew
+++ b/crew
@@ -28,7 +28,7 @@ else
 end
 
 # Set CREW_NOT_COMPRESS from environment variable
-CREW_NOT_COMPRESS = `bash -c "type compressdoc 2> /dev/null"`.empty? || ENV["CREW_NOT_COMPRESS"]
+CREW_NOT_COMPRESS = ENV["CREW_NOT_COMPRESS"]
 
 # Set CREW_NOT_STRIP from environment variable
 CREW_NOT_STRIP = ENV["CREW_NOT_STRIP"]
@@ -425,13 +425,23 @@ def build_and_preconfigure (target_dir)
   end
 end
 
+def compress_doc (dir)
+  # check whether crew should compress
+  return if CREW_NOT_COMPRESS || !File.exist?("#{CREW_PREFIX}/bin/compressdoc")
+
+  if Dir.exist? dir
+    system "find #{dir} -type f ! -perm -200 | xargs -r chmod u+w"
+    system "compressdoc --gzip -9 #{dir}"
+  end
+end
+
 def prepare_package (destdir)
   Dir.chdir destdir do
     # compress manual files
-    system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/man > /dev/null" unless CREW_NOT_COMPRESS
-    system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/info > /dev/null" unless CREW_NOT_COMPRESS
-    system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/share/man > /dev/null" unless CREW_NOT_COMPRESS
-    system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/share/info > /dev/null" unless CREW_NOT_COMPRESS
+    compress_doc "#{destdir}#{CREW_PREFIX}/man"
+    compress_doc "#{destdir}#{CREW_PREFIX}/info"
+    compress_doc "#{destdir}#{CREW_PREFIX}/share/man"
+    compress_doc "#{destdir}#{CREW_PREFIX}/share/info"
 
     # create directory list
     system "find . -type f > ../filelist"

--- a/crew
+++ b/crew
@@ -28,7 +28,7 @@ else
 end
 
 # Set CREW_NOT_COMPRESS from environment variable
-CREW_NOT_COMPRESS = ENV["CREW_NOT_COMPRESS"]
+CREW_NOT_COMPRESS = `bash -c "type compressdoc 2> /dev/null"`.empty? || ENV["CREW_NOT_COMPRESS"]
 
 # Set CREW_NOT_STRIP from environment variable
 CREW_NOT_STRIP = ENV["CREW_NOT_STRIP"]
@@ -428,8 +428,8 @@ end
 def prepare_package (destdir)
   Dir.chdir destdir do
     # compress manual files
-    system "find usr/local/man -type f -print | xargs gzip -9 2>/dev/null" unless CREW_NOT_COMPRESS
-    system "find usr/local/share/man -type f -print | xargs gzip -9 2>/dev/null" unless CREW_NOT_COMPRESS
+    system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/man > /dev/null" unless CREW_NOT_COMPRESS
+    system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/share/man > /dev/null" unless CREW_NOT_COMPRESS
 
     # create directory list
     system "find . -type f > ../filelist"

--- a/crew
+++ b/crew
@@ -429,7 +429,9 @@ def prepare_package (destdir)
   Dir.chdir destdir do
     # compress manual files
     system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/man > /dev/null" unless CREW_NOT_COMPRESS
+    system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/info > /dev/null" unless CREW_NOT_COMPRESS
     system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/share/man > /dev/null" unless CREW_NOT_COMPRESS
+    system "compressdoc --gzip -9 #{destdir}#{CREW_PREFIX}/share/info > /dev/null" unless CREW_NOT_COMPRESS
 
     # create directory list
     system "find . -type f > ../filelist"

--- a/crew
+++ b/crew
@@ -27,6 +27,9 @@ else
   CREW_NPROC = ENV["CREW_NPROC"]
 end
 
+# Set CREW_NOT_COMPRESS from environment variable
+CREW_NOT_COMPRESS = ENV["CREW_NOT_COMPRESS"]
+
 # Set CREW_NOT_STRIP from environment variable
 CREW_NOT_STRIP = ENV["CREW_NOT_STRIP"]
 
@@ -424,15 +427,21 @@ end
 
 def prepare_package (destdir)
   Dir.chdir destdir do
-    #create directory list
+    # compress manual files
+    system "find usr/local/man -type f -print | xargs gzip -9 2>/dev/null" unless CREW_NOT_COMPRESS
+    system "find usr/local/share/man -type f -print | xargs gzip -9 2>/dev/null" unless CREW_NOT_COMPRESS
+
+    # create directory list
     system "find . -type f > ../filelist"
     system "find . -type l >> ../filelist"
     system "cut -c2- ../filelist > filelist"
-    #create file list
+
+    # create file list
     system "find . -type d > ../dlist"
     system "cut -c2- ../dlist > dlistcut"
     system "tail -n +2 dlistcut > dlist"
-    #remove temporary files
+
+    # remove temporary files
     system "rm dlistcut ../dlist ../filelist"
   end
 end


### PR DESCRIPTION
I was looking for a way to install `compressdoc`.  Thank you @uberhacker to make it as a package.  This PR change crew to use `compressdoc` at install time if `compressdoc` is available and `CREW_NOT_COMPRESS` environment variable is not defined.

Tested on x86_64.