### PR TITLE
Add coreutils package

### DIFF
--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -4,7 +4,7 @@ class Coreutils < Package
   description 'The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system.'
   homepage 'http://www.gnu.org/software/coreutils/coreutils.html'
   version '8.27'
-  source_url 'http://ftpmirror.gnu.org/coreutils/coreutils-8.27.tar.xz'
+  source_url 'https://ftpmirror.gnu.org/coreutils/coreutils-8.27.tar.xz'
   source_sha256 '8891d349ee87b9ff7870f52b6d9312a9db672d2439d289bc57084771ca21656b'
 
   def self.build

--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -5,7 +5,7 @@ class Coreutils < Package
   homepage 'http://www.gnu.org/software/coreutils/coreutils.html'
   version '8.27'
   source_url 'http://ftp.gnu.org/gnu/coreutils/coreutils-8.27.tar.xz'
-  source_sha1 'ee054c8a4c0c924de49e4f03266733f27f986fbb'
+  source_sha256 '8891d349ee87b9ff7870f52b6d9312a9db672d2439d289bc57084771ca21656b'
 
   def self.build
     system './configure'

--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -4,7 +4,7 @@ class Coreutils < Package
   description 'The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system.'
   homepage 'http://www.gnu.org/software/coreutils/coreutils.html'
   version '8.27'
-  source_url 'http://ftp.gnu.org/gnu/coreutils/coreutils-8.27.tar.xz'
+  source_url 'http://ftpmirror.gnu.org/coreutils/coreutils-8.27.tar.xz'
   source_sha256 '8891d349ee87b9ff7870f52b6d9312a9db672d2439d289bc57084771ca21656b'
 
   def self.build

--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Coreutils < Package
+  description 'The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system.'
+  homepage 'http://www.gnu.org/software/coreutils/coreutils.html'
+  version '8.27'
+  source_url 'http://ftp.gnu.org/gnu/coreutils/coreutils-8.27.tar.xz'
+  source_sha1 'ee054c8a4c0c924de49e4f03266733f27f986fbb'
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system.  See http://www.gnu.org/software/coreutils/coreutils.html.  This package updates the core GNU commands to the newer versions and will use the commands in `/usr/local/bin` instead of their `/bin`, `/usr/bin`, `/sbin` or `/usr/sbin` counterparts.  Why do this?  Why not?