### PR TITLE
Add ghostscript package

### DIFF
--- a/packages/ghostscript.rb
+++ b/packages/ghostscript.rb
@@ -5,7 +5,7 @@ class Ghostscript < Package
   homepage 'https://www.gnu.org/software/ghostscript/'
   version '9.14.1'
   source_url 'ftp://ftp.gnu.org/gnu/ghostscript/gnu-ghostscript-9.14.1.tar.xz'
-  source_sha1 'd2ac2229ee53b6f8594980da3c6a0819c99ecfa0'
+  source_sha256 '424a4ff333a594fdd397cd8adc4249bad7d74a6ae653f840dee72b27f1bf1da0'
 
   depends_on 'lcms'
   depends_on 'libjpeg'

--- a/packages/ghostscript.rb
+++ b/packages/ghostscript.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Ghostscript < Package
+  description 'Ghostscript is the name of a set of software that provides an interpreter for the PostScript language and the PDF file format.'
+  homepage 'https://www.gnu.org/software/ghostscript/'
+  version '9.14.1'
+  source_url 'ftp://ftp.gnu.org/gnu/ghostscript/gnu-ghostscript-9.14.1.tar.xz'
+  source_sha1 'd2ac2229ee53b6f8594980da3c6a0819c99ecfa0'
+
+  depends_on 'lcms'
+  depends_on 'libjpeg'
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Ghostscript is the name of a set of software that provides:

- An interpreter for the PostScript language and the PDF file format,
- A set of C procedures (the Ghostscript library) that implement the graphics capabilities that appear as
- primitive operations in the PostScript language, and
- A wide variety of output drivers for various file formats and printers.

See https://www.gnu.org/software/ghostscript/.