### PR TITLE
Change crew to not automatically install buildessential

### DIFF
--- a/crew
+++ b/crew
@@ -476,9 +476,6 @@ end
 def expand_dependencies
   @dependencies = []
 
-  # check source packages existance
-  @source_package = 0
-
   def push_dependencies
     if @pkg.is_binary?(@device[:architecture]) ||
        (!@pkg.in_upgrade && !@pkg.build_from_source && @device[:installed_packages].any? { |pkg| pkg[:name] == @pkg.name })
@@ -490,8 +487,6 @@ def expand_dependencies
     else
       # retrieve name of all dependencies
       check_deps = @pkg.dependencies.map {|k, v| k}
-      # count the number of source packages to add buildessential into dependencies later
-      @source_package += 1
     end
 
     # remove a dependent package which is equal to the target
@@ -509,12 +504,6 @@ def expand_dependencies
 
   push_dependencies
 
-  # Add buildessential's dependencies if any of dependent
-  # packages are made from source
-  if @source_package > 0
-    search 'buildessential', true
-    push_dependencies
-  end
   @dependencies.uniq
 end
 


### PR DESCRIPTION
Once I modified to crew to automatically install `buildessential` if users try to compile package from source, but this behavior causes #797 problem because `crew install make` tries to install `pkgconfig` as a part of `buildessential` although `make` is required to compile `pkgconfig`.

This PR solves this problem by modifying `crew` to simply not install `buildessential` automatically.  Even with this PR, `crew` still shows error message to ask users to install `buildessential` when users try to install source packages.  So, this PR won't break anything.

Tested on x86_64.