### PR TITLE
Support lib64 installation on x86_64 part 2

### DIFF
--- a/packages/bison.rb
+++ b/packages/bison.rb
@@ -14,8 +14,8 @@ class Bison < Package
   # depends_on 'flex' => :build
 
   def self.build
-    system './configure --prefix=/usr/local'
-    system 'make'
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "make"
   end
 
   def self.install

--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -8,7 +8,7 @@ class Filecmd < Package
   source_sha256 '09c588dac9cff4baa054f51a36141793bcf64926edc909594111ceae60fce4ee'
 
   def self.build
-    system "./configure"
+    system "./configure --libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 

--- a/packages/flex.rb
+++ b/packages/flex.rb
@@ -11,7 +11,7 @@ class Flex < Package
   depends_on 'bison' => :build
 
   def self.build
-    system "./configure", "--with-pic", "--disable-static", "--enable-shared"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--with-pic", "--disable-static", "--enable-shared"
     system "make"
   end
 

--- a/packages/gawk.rb
+++ b/packages/gawk.rb
@@ -14,7 +14,7 @@ class Gawk < Package
   depends_on 'gmp'
 
   def self.build
-    system './configure', '--prefix=/usr/local'
+    system './configure', "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 

--- a/packages/gdbm.rb
+++ b/packages/gdbm.rb
@@ -10,7 +10,7 @@ class Gdbm < Package
   depends_on 'readline'
 
   def self.build
-    system './configure', '--disable-static', '--enable-shared', '--with-pic'
+    system './configure', "--libdir=#{CREW_LIB_PREFIX}", '--disable-static', '--enable-shared', '--with-pic'
     system 'make'
   end
 

--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -12,7 +12,7 @@ class Gettext < Package
   depends_on 'libxml2'
 
   def self.build
-    system "./configure", "--enable-shared", "--disable-static", "--with-pic"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic"
     system "make"
   end
 

--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -8,7 +8,7 @@ class Libffi < Package
   source_sha1 '280c265b789e041c02e5c97815793dfc283fb1e6'
 
   def self.build
-    system "./configure", "--enable-shared", "--disable-static", "--with-pic", "--disable-debug", "--disable-dependency-tracking"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic", "--disable-debug", "--disable-dependency-tracking"
     system "make"
   end
 

--- a/packages/libpipeline.rb
+++ b/packages/libpipeline.rb
@@ -8,7 +8,7 @@ class Libpipeline < Package
   source_sha1 'b31cc955f22b1aa4545dc8d00ddbde831936594f'
   
   def self.build
-    system './configure', '--disable-static', '--enable-shared', '--with-pic'
+    system './configure', "--libdir=#{CREW_LIB_PREFIX}", '--disable-static', '--enable-shared', '--with-pic'
     system 'make'
   end
   

--- a/packages/libssh2.rb
+++ b/packages/libssh2.rb
@@ -11,8 +11,9 @@ class Libssh2 < Package
   depends_on 'zlibpkg' => :build
 
   def self.build
-    system "./configure", "--with-zlib", "--with-openssl", "--with-pic", "--disable-static"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--with-zlib", "--with-openssl", "--with-pic", "--disable-static"
     system "make"
+    system "find . -name '*.so.*' -print | xargs strip -S"
   end
 
   def self.install

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -13,7 +13,7 @@ class Libunbound < Package
   depends_on 'expat'
 
   def self.build
-    system "./configure", "--enable-shared", "--disable-static", "--with-pic"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic"
 
     # flex 2.6.3 requires -P option to rename yylex and other funcions
     system "sed", "-i", "Makefile", "-e", '/$(LEX) -t $(srcdir)\/util\/configlexer.lex/s:-t:-t -Pub_c_:'

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -8,7 +8,7 @@ class Libxml2 < Package
   source_sha1 '958ae70baf186263a4bd801a81dd5d682aedd1db'
 
   def self.build
-    system "./configure", "--enable-shared", "--disable-static", "--with-pic", "--without-python"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic", "--without-python"
     system "make"
   end
 

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -14,7 +14,9 @@ class Python3 < Package
   depends_on 'sqlite' => :build
 
   def self.build
+    # python requires to use /usr/local/lib, so leave as is but specify -rpath
     system "./configure", "CPPFLAGS=-I/usr/local/include/ncurses -I/usr/local/include/ncursesw",
+      "LDFLAGS=-Wl,-rpath,#{CREW_PREFIX}/lib",
       "--with-ensurepip=install", "--enable-shared"
     system "make"
   end
@@ -23,7 +25,13 @@ class Python3 < Package
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
 
     # remove static library
-    system "find #{CREW_DEST_DIR}/usr/local -name 'libpython*.a' -print | xargs rm"
+    system "find #{CREW_DEST_DIR}/usr/local -name 'libpython*.a' -print | xargs -r rm"
+
+    # create symbolic links in lib64 for other applications which use libpython
+    unless Dir.exist? "#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}"
+      system "mkdir -p #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}"
+      system "cd #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}; ln -s ../lib/libpython*.so* ."
+    end
   end
 
   def self.check

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -14,7 +14,7 @@ class Ruby < Package
   # at run-time, system's gmp, openssl, readline and zlibpkg are possible to use
 
   def self.build
-    system "CC='gcc' ./configure"
+    system "CC='gcc' ./configure --libdir=#{CREW_LIB_PREFIX} --enable-shared"
     system "make"
   end
 

--- a/packages/sqlite.rb
+++ b/packages/sqlite.rb
@@ -8,7 +8,7 @@ class Sqlite < Package
   source_sha1 '74559194e1dd9b9d577cac001c0e9d370856671b'
 
   def self.build
-    system "./configure", "--disable-static", "--enable-shared", "--with-pic"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--disable-static", "--enable-shared", "--with-pic"
     system "make"
   end
   

--- a/packages/tcl.rb
+++ b/packages/tcl.rb
@@ -10,9 +10,9 @@ class Tcl < Package
   def self.build
     FileUtils.chdir("unix") do
       if `uname -m`.strip == "x86_64"
-        system "./configure --prefix=/usr/local --enable-64bit"
+        system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --enable-64bit"
       else
-	system "./configure --prefix=/usr/local"
+        system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
       end
       system "make"
     end


### PR DESCRIPTION
This PR is part 2 of #794 PR.  Changing several packages to install their libraries into lib64 on x86_64.

For the cause of python27 and python3, they are not possible to install lib64 without modifying setup scripts a lot.  So, this time I leave them as is but add -rpath option at compile-time.  Also I modified to create symbolic links for other applications which use libpython.so like vim.

This PR follows the direction what the latest ChromeOS on x86_64 takes. However, this PR won't break anything. We still can choose use only lib64 or both lib64 and lib as we are discussing in #689. This PR just shows the possibility that we can use only lib64 way as what ChromeOS is choosing.

Tested on x86_64.


