### PR TITLE
Change crew to support both sha1 and sha256.

### DIFF
--- a/crew
+++ b/crew
@@ -363,12 +363,16 @@ def download
   filename = File.basename(uri.path)
   if source
     sha1sum = @pkg.source_sha1
+    sha256sum = @pkg.source_sha256
   else
     sha1sum = @pkg.binary_sha1[@device[:architecture]]
+    sha256sum = @pkg.binary_sha256[@device[:architecture]]
   end
   Dir.chdir CREW_BREW_DIR do
     system('wget', '--continue', '--no-check-certificate', url, '-O', filename)
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA1.hexdigest( File.read("./#{filename}") ) == sha1sum
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless
+      Digest::SHA1.hexdigest( File.read("./#{filename}") ) == sha1sum or
+      Digest::SHA256.hexdigest( File.read("./#{filename}") ) == sha256sum
   end
   puts "Archive downloaded".lightgreen
   return {source: source, filename: filename}
@@ -658,6 +662,7 @@ def archive_package (pwd)
   end
   Dir.chdir pwd do
     system "sha1sum #{pkg_name} > #{pkg_name}.sha1"
+    system "sha256sum #{pkg_name} > #{pkg_name}.sha256"
   end
   puts "#{pkg_name} is built!".lightgreen
 end

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -1,7 +1,7 @@
 require 'package_helpers'
 
 class Package
-  property :description, :homepage, :version, :binary_url, :binary_sha1, :source_url, :source_sha1, :is_fake
+  property :description, :homepage, :version, :binary_url, :binary_sha1, :binary_sha256, :source_url, :source_sha1, :source_sha256, :is_fake
 
   class << self
     attr_reader :is_fake

--- a/packages/compressdoc.rb
+++ b/packages/compressdoc.rb
@@ -4,10 +4,20 @@ class Compressdoc < Package
   description 'Compress (with bzip2 or gzip) all man pages in a hierarchy and update symlinks'
   homepage 'https://github.com/ojab/BLFS/blob/master/auxfiles/compressdoc'
   version '9b2b12'
-  source_url 'https://github.com/ojab/BLFS/archive/9b2b12c0d809e287e1ea3fa4790a73a71feffbe4.zip'
-  source_sha1 'dd55e750128972ffd1022808b1b26cff2de242b1'
-
-  depends_on 'unzip'
+  source_url 'https://github.com/ojab/BLFS/archive/9b2b12c0d809e287e1ea3fa4790a73a71feffbe4.tar.gz'
+  source_sha256 '6ebe4a9bbef5d0e84a36e56ac6fb1f0a2cfa86cb00c49628a0d3151d37f5d2f1'
+  binary_url ({
+    aarch64: 'https://github.com/jam7/chromebrew/releases/download/binaries/compressdoc-9b2b12-chromeos-x86_64.tar.xz',
+    armv7l:  'https://github.com/jam7/chromebrew/releases/download/binaries/compressdoc-9b2b12-chromeos-x86_64.tar.xz',
+    i686:    'https://github.com/jam7/chromebrew/releases/download/binaries/compressdoc-9b2b12-chromeos-x86_64.tar.xz',
+    x86_64:  'https://github.com/jam7/chromebrew/releases/download/binaries/compressdoc-9b2b12-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '4743bfb71bf851cb659dce71465e034fae19250e72f97aa7a50d6d8298f03347',
+    armv7l:  '4743bfb71bf851cb659dce71465e034fae19250e72f97aa7a50d6d8298f03347',
+    i686:    '4743bfb71bf851cb659dce71465e034fae19250e72f97aa7a50d6d8298f03347',
+    x86_64:  '4743bfb71bf851cb659dce71465e034fae19250e72f97aa7a50d6d8298f03347',
+  })
 
   def self.install
     system "chmod +x auxfiles/compressdoc"


### PR DESCRIPTION
This PR follows the discussion in #808.

I modify crew to support both.  I also modify compressdoc to demonstrate how to write sha256 in package files.  I also modify compressdoc for the ease of use.

Tested on x86_64.