### PR TITLE
Add aspell dictionaries

### DIFF
--- a/packages/aspell_en.rb
+++ b/packages/aspell_en.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Aspell_en < Package
+  description 'English Aspell Dictionary'
+  homepage 'ftp://ftp.gnu.org/gnu/aspell/dict/0index.html'
+  version '2017.01.22-0'
+  source_url 'ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2'
+  source_sha1 '05f5123d7c043446c385d4fb77fa3d796f2356ab'
+  #source_sha256 '93c73fae3eab5ea3ca6db3cea8770715a820f1b7d6ea2b932dd66a17f8fd55e1'
+
+  depends_on 'aspell'
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/aspell_en.rb
+++ b/packages/aspell_en.rb
@@ -5,8 +5,7 @@ class Aspell_en < Package
   homepage 'ftp://ftp.gnu.org/gnu/aspell/dict/0index.html'
   version '2017.01.22-0'
   source_url 'ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2017.01.22-0.tar.bz2'
-  source_sha1 '05f5123d7c043446c385d4fb77fa3d796f2356ab'
-  #source_sha256 '93c73fae3eab5ea3ca6db3cea8770715a820f1b7d6ea2b932dd66a17f8fd55e1'
+  source_sha256 '93c73fae3eab5ea3ca6db3cea8770715a820f1b7d6ea2b932dd66a17f8fd55e1'
 
   depends_on 'aspell'
 

--- a/packages/aspell_es.rb
+++ b/packages/aspell_es.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Aspell_es < Package
+  description 'Spanish Aspell Dictionary'
+  homepage 'ftp://ftp.gnu.org/gnu/aspell/dict/0index.html'
+  version '1.11-2'
+  source_url 'ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2'
+  source_sha1 '18acfa4bc08433e920bb015b158e43643e5125cf'
+  #source_sha256 'ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc'
+
+  depends_on 'aspell'
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/aspell_es.rb
+++ b/packages/aspell_es.rb
@@ -5,8 +5,7 @@ class Aspell_es < Package
   homepage 'ftp://ftp.gnu.org/gnu/aspell/dict/0index.html'
   version '1.11-2'
   source_url 'ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2'
-  source_sha1 '18acfa4bc08433e920bb015b158e43643e5125cf'
-  #source_sha256 'ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc'
+  source_sha256 'ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc'
 
   depends_on 'aspell'
 


### PR DESCRIPTION
This PR adds the English and Spanish aspell dictionaries which complement the aspell package.  See ftp://ftp.gnu.org/gnu/aspell/dict/0index.html.