### PR TITLE
Add aspell package

### DIFF
--- a/packages/aspell.rb
+++ b/packages/aspell.rb
@@ -5,8 +5,7 @@ class Aspell < Package
   homepage 'http://aspell.net/'
   version '0.60.7-rc1'
   source_url 'ftp://alpha.gnu.org/gnu/aspell/aspell-0.60.7-rc1.tar.gz'
-  source_sha1 '65d4bd8c2e9f8455344d22805d6e135706a69bdd'
-  #source_sha256 '86b5662f24316142f70c5890787bdc5596625ca3604dfe85926ee61f27f2365e'
+  source_sha256 '86b5662f24316142f70c5890787bdc5596625ca3604dfe85926ee61f27f2365e'
 
   depends_on 'ruby' unless File.exists? '/usr/local/bin/ruby'
 

--- a/packages/aspell.rb
+++ b/packages/aspell.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Aspell < Package
+  description 'GNU Aspell is a Free and Open Source spell checker designed to eventually replace Ispell.'
+  homepage 'http://aspell.net/'
+  version '0.60.7-rc1'
+  source_url 'ftp://alpha.gnu.org/gnu/aspell/aspell-0.60.7-rc1.tar.gz'
+  source_sha1 '65d4bd8c2e9f8455344d22805d6e135706a69bdd'
+  #source_sha256 '86b5662f24316142f70c5890787bdc5596625ca3604dfe85926ee61f27f2365e'
+
+  depends_on 'ruby' unless File.exists? '/usr/local/bin/ruby'
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
GNU Aspell is a Free and Open Source spell checker designed to eventually replace Ispell. It can either be used as a library or as an independent spell checker. Its main feature is that it does a superior job of suggesting possible replacements for a misspelled word than just about any other spell checker out there for the English language.  See http://aspell.net/.