### PR TITLE
Add check routine before hash references to fix problem caused by #817

### DIFF
--- a/crew
+++ b/crew
@@ -365,8 +365,8 @@ def download
     sha1sum = @pkg.source_sha1
     sha256sum = @pkg.source_sha256
   else
-    sha1sum = @pkg.binary_sha1[@device[:architecture]]
-    sha256sum = @pkg.binary_sha256[@device[:architecture]]
+    sha1sum = @pkg.binary_sha1[@device[:architecture]] if @pkg.binary_sha1
+    sha256sum = @pkg.binary_sha256[@device[:architecture]] if @pkg.binary_sha256
   end
   Dir.chdir CREW_BREW_DIR do
     system('wget', '--continue', '--no-check-certificate', url, '-O', filename)


### PR DESCRIPTION
Sorry for inconvinience.  This PR fix a problem caused by #817 like below.
```
$ crew install compressdoc
compressdoc: Compress (with bzip2 or gzip) all man pages in a hierarchy and update symlinks
https://github.com/ojab/BLFS/blob/master/auxfiles/compressdoc
version 9b2b12
Precompiled binary available, downloading...
/usr/local/bin/crew:368:in `download': undefined method `[]' for nil:NilClass (NoMethodError)
        from /usr/local/bin/crew:568:in `install'
        from /usr/local/bin/crew:466:in `resolve_dependencies_and_install'
        from /usr/local/bin/crew:754:in `<main>'
```
#817 was working last night, but now it's not working.  I guess that I was dozing instead of testing it.  :(

Tested on armv7l and x86_64 this time really.