### PR TITLE
Add mtools package

### DIFF
--- a/packages/mtools.rb
+++ b/packages/mtools.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Mtools < Package
+  description 'Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting them.'
+  homepage 'https://www.gnu.org/software/mtools/'
+  version '4.0.18'
+  source_url 'https://ftp.gnu.org/gnu/mtools/mtools-4.0.18.tar.bz2'
+  source_sha256 '59e9cf80885399c4f229e5d87e49c0c2bfeec044e1386d59fcd0b0aead6b2f85'
+
+  def self.build
+    system './configure --without-x'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting them. It supports Win'95 style long file names, OS/2 Xdf disks and 2m disks (store up to 1992k on a high density 3 1/2 disk). In addition to file access, it supports many FAT-specific features: volume labels, FAT-specific file attributes (hidden, system, ...), "bad block" map maintenance, access to remote floppy drives, Iomega ZIP disk protection, "secure" erase, display of file's on-disk layout, etc.  See https://www.gnu.org/software/mtools/.