### PR TITLE
Change perl.rb to install manual files correctly

### DIFF
--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -12,7 +12,8 @@ class Perl < Package
   def self.build
     # Use system zlib and bzip2
     # Create shared library
-    system "BUILD_ZLIB=False BUILD_BZIP2=0 ./Configure -de -Duseshrplib"
+    # Install manual files into /usr/local/share/man/man* even if groff is not installed.
+    system "BUILD_ZLIB=False BUILD_BZIP2=0 ./Configure -de -Duseshrplib -Dman1dir=#{CREW_PREFIX}/share/man/man1 -Dman3dir=#{CREW_PREFIX}/share/man/man3"
     system "make"
   end
 


### PR DESCRIPTION
This PR forces perl configure script to install manual correctly even if nroff is not installed.  Perl's configure script checks the existence of nroff and not install manual files sometimes.  This PR fix such problem.  BTW, nroff is a part of groff package.

Tested on armv7l and x86_64.

