### PR TITLE
Remove sha1 related stuff

### DIFF
--- a/crew
+++ b/crew
@@ -2,7 +2,7 @@
 require 'find'
 require 'net/http'
 require 'uri'
-require 'digest/sha1'
+require 'digest/sha2'
 require 'json'
 require 'fileutils'
 
@@ -365,16 +365,13 @@ def download
   uri = URI.parse url
   filename = File.basename(uri.path)
   if source
-    sha1sum = @pkg.source_sha1
     sha256sum = @pkg.source_sha256
   else
-    sha1sum = @pkg.binary_sha1[@device[:architecture]] if @pkg.binary_sha1
-    sha256sum = @pkg.binary_sha256[@device[:architecture]] if @pkg.binary_sha256
+    sha256sum = @pkg.binary_sha256[@device[:architecture]]
   end
   Dir.chdir CREW_BREW_DIR do
     system('wget', '--continue', '--no-check-certificate', url, '-O', filename)
     abort 'Checksum mismatch. :/ Try again.'.lightred unless
-      Digest::SHA1.hexdigest( File.read("./#{filename}") ) == sha1sum or
       Digest::SHA256.hexdigest( File.read("./#{filename}") ) == sha256sum
   end
   puts "Archive downloaded".lightgreen
@@ -688,7 +685,6 @@ def archive_package (pwd)
     system "tar cJf #{pwd}/#{pkg_name} *"
   end
   Dir.chdir pwd do
-    system "sha1sum #{pkg_name} > #{pkg_name}.sha1"
     system "sha256sum #{pkg_name} > #{pkg_name}.sha256"
   end
   puts "#{pkg_name} is built!".lightgreen

--- a/packages/heroku.rb
+++ b/packages/heroku.rb
@@ -9,9 +9,9 @@ class Heroku < Package
     i686: "https://drive.google.com/uc?export=download&id=0ByCixsDmZPzxd3NULTRkMWlHQTA",
     x86_64: "https://drive.google.com/uc?export=download&id=0ByCixsDmZPzxLURkMktpREpDZk0"
   })
-  binary_sha1 ({
-    armv7l: "b48f2f52d11cee4ca6a1878fdf2608a4b10ea53d",
-    i686: "1b0a736797c9293431b7db0055861fc73657a3fe",
-    x86_64: "9524fbc86c0a19f84f8bbb77c56ce2439d929a92"
+  binary_sha256 ({
+    armv7l: "b7fab53d3c8cfd42d41c1b07db069c9fd5f7261fcea48fd99114981cf1a293d7",
+    i686: "1e73fbff3a10c0c95dd1aa1cf68952a95a330634fa410765962df0396315a42c",
+    x86_64: "9259cd8b5d7aaeb9172142b5956ad767a3d4f1bcf126e51a7f4a8c055e53c068"
   })
 end


### PR DESCRIPTION
This PR is a final step toward to #808 direction.  This PR removes several methods related to sha1.  Leaving sha1 means making security hole, so I think we need to remove them to achieve #808.

However, there is only one package still using sha1, `heroku.rb`.  I guess @uberhacker didn't update it since he introduces #829 discussion.  I agree with him, but for now I just need to update heroku to use sha256 in order to remove sha1 stuff.  Please remove heroku later after #829 discussion.

Tested on armv7l.

Thank you @uberhacker to update every package files.  Thank you @lyxell to show this problem.