### PR TITLE
Fix gdrive package to include only supported architectures

### DIFF
--- a/packages/gdrive.rb
+++ b/packages/gdrive.rb
@@ -12,25 +12,21 @@ class Gdrive < Package
     system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
     case ARCH
     when 'aarch64'
-      system "wget -L -O #{CREW_DEST_DIR}/usr/local/bin/gdrive https://docs.google.com/uc?id=0B3X9GlR6EmbnamliN0Rld01oRVk&export=download"
+      system "wget -L -O #{CREW_DEST_DIR}/usr/local/bin/gdrive https://docs.google.com/uc?id=0B3X9GlR6EmbnRjBaMVVLalN4cTA&export=download"
       system "sleep 10"
-      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("#{CREW_DEST_DIR}/usr/local/bin/gdrive") ) == '83cfcad8e1f39d3b7ae9407d34a624d1951d616cadb89841613b588cac468fa8'
+      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("#{CREW_DEST_DIR}/usr/local/bin/gdrive") ) == '25eb74f892785bfd7c93ec22e63dfce04fd68298d8449ea1473bdbf90e3aaf35'
     when 'armv7l'
-      system "wget -L -O #{CREW_DEST_DIR}/usr/local/bin/gdrive https://docs.google.com/uc?id=0B3X9GlR6EmbnamliN0Rld01oRVk&export=download"
+      system "wget -L -O #{CREW_DEST_DIR}/usr/local/bin/gdrive https://docs.google.com/uc?id=0B3X9GlR6EmbnRjBaMVVLalN4cTA&export=download"
       system "sleep 10"
-      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("#{CREW_DEST_DIR}/usr/local/bin/gdrive") ) == '83cfcad8e1f39d3b7ae9407d34a624d1951d616cadb89841613b588cac468fa8'
+      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("#{CREW_DEST_DIR}/usr/local/bin/gdrive") ) == '25eb74f892785bfd7c93ec22e63dfce04fd68298d8449ea1473bdbf90e3aaf35'
+    when 'i686'
+      system "wget -L -O #{CREW_DEST_DIR}/usr/local/bin/gdrive https://docs.google.com/uc?id=0B3X9GlR6EmbnLV92dHBpTkFhTEU&export=download"
+      system "sleep 10"
+      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("#{CREW_DEST_DIR}/usr/local/bin/gdrive") ) == '768103053ebe56d5b6e17396ac208db85a3b1968d19e9cac9172fe56b6b8cad2'
     when 'x86_64'
       system "wget -L -O #{CREW_DEST_DIR}/usr/local/bin/gdrive https://docs.google.com/uc?id=0B3X9GlR6EmbnQ0FtZmJJUXEyRTA&export=download"
       system "sleep 10"
       abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("#{CREW_DEST_DIR}/usr/local/bin/gdrive") ) == 'f31b441c5cdb835ee69849a62856e35c17954fd5b600f6de8a6f5d7bd7bf0420'
-    when 'mips64'
-      system "wget -L -O #{CREW_DEST_DIR}/usr/local/bin/gdrive https://docs.google.com/uc?id=0B3X9GlR6Embna2lzdEJ6blFzSzQ&export=download"
-      system "sleep 10"
-      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("#{CREW_DEST_DIR}/usr/local/bin/gdrive") ) == 'df9fc86b782bb313a65633b90294e1167993bf7527e9d1aecdbb8937571bdb20'
-    when 'ppc64'
-      system "wget -L -O #{CREW_DEST_DIR}/usr/local/bin/gdrive https://docs.google.com/uc?id=0B3X9GlR6EmbnS09XMzhfRXBnUzA&export=download"
-      system "sleep 10"
-      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("#{CREW_DEST_DIR}/usr/local/bin/gdrive") ) == '3560ef4971cb9fc02785fa652bb9d3525253b853a744540cc717e578c329bfe4'
     end
     system "chmod +x #{CREW_DEST_DIR}/usr/local/bin/gdrive"
   end


### PR DESCRIPTION
- Change aarch64 and armv7l to use arm 32-bit instead of arm 64-bit archive.
- Remove mips64 and ppc64 architecture support
- Add i686 architecture support
