### PR TITLE
Add masscan package

### DIFF
--- a/packages/masscan.rb
+++ b/packages/masscan.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Masscan < Package
+  description 'TCP port scanner, spews SYN packets asynchronously, scanning entire
+Internet in under 5 minutes.'
+  homepage 'https://github.com/robertdavidgraham/masscan'
+  version '1.0.4'
+  source_url 'https://github.com/robertdavidgraham/masscan/archive/1.0.4.tar.gz'
+  source_sha256 '51de345f677f46595fc3bd747bfb61bc9ff130adcbec48f3401f8057c8702af9'
+
+  depends_on 'libpcap'
+
+  def self.build
+    system "make"
+  end
+
+  def self.install
+    system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
+    system "cp bin/masscan #{CREW_DEST_DIR}/usr/local/bin"
+  end
+end


### PR DESCRIPTION
masscan is a utility that can scan a large range of hosts very quickly. It installed fine (and ran correctly with `masscan --help`). But it wouldn't scan properly on my own Samsung Chromebook 2 (ARM), but I figured it should work for other chromebooks that have proper wifi adapters.

Here is the error it spits out for me:

```
chronos@localhost ~ $ masscan -p80 192.168.2.0/24
FAIL: live packet capture not supported on this system
adapter[mlan0].init: failed
chronos@localhost ~ $ 
```