### PR TITLE
Add pip package

### DIFF
--- a/packages/pip.rb
+++ b/packages/pip.rb
@@ -7,12 +7,16 @@ class Pip < Package
   source_url 'https://github.com/pypa/pip/archive/9.0.1.tar.gz'
   source_sha256 'd03fabbc4fbf2fbfc2f97307960aef2b3ca4c880ecda993dcc35957e33d7cd76'
 
+  # Don't overwrite the currently installed version.
+  abort 'pip is already installed.'.lightgreen if File.exists? '/usr/local/bin/pip'
+
+  # Install python if not found.
   depends_on 'python' unless File.exists? '/usr/local/bin/python'
 
   def self.install
     system "wget https://bootstrap.pypa.io/get-pip.py"
     system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
     system "python get-pip.py -I -b #{CREW_DEST_DIR}/usr/local"
-    system "cp /usr/local/bin/pip* #{CREW_DEST_DIR}/usr/local/bin"
+    system "cp /usr/local/bin/pip #{CREW_DEST_DIR}/usr/local/bin"
   end
 end

--- a/packages/pip.rb
+++ b/packages/pip.rb
@@ -5,7 +5,7 @@ class Pip < Package
   homepage 'https://pip.pypa.io/'
   version '9.0.1'
   source_url 'https://github.com/pypa/pip/archive/9.0.1.tar.gz'
-  source_sha1 '39b5840f6a9e6888d56a78beb447a064aeaf1592'
+  source_sha256 'd03fabbc4fbf2fbfc2f97307960aef2b3ca4c880ecda993dcc35957e33d7cd76'
 
   depends_on 'python' unless File.exists? '/usr/local/bin/python'
 

--- a/packages/pip.rb
+++ b/packages/pip.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Pip < Package
+  description 'The PyPA recommended tool for installing Python packages.'
+  homepage 'https://pip.pypa.io/'
+  version '9.0.1'
+  source_url 'https://github.com/pypa/pip/archive/9.0.1.tar.gz'
+  source_sha1 '39b5840f6a9e6888d56a78beb447a064aeaf1592'
+
+  depends_on 'python' unless File.exists? '/usr/local/bin/python'
+
+  def self.install
+    system "wget https://bootstrap.pypa.io/get-pip.py"
+    system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
+    system "mkdir -p #{CREW_DEST_DIR}/usr/local/pip"
+    system "python get-pip.py -I -b #{CREW_DEST_DIR}/usr/local"
+    system "cp /usr/local/bin/pip* #{CREW_DEST_DIR}/usr/local/bin"
+  end
+end

--- a/packages/pip.rb
+++ b/packages/pip.rb
@@ -7,13 +7,12 @@ class Pip < Package
   source_url 'https://github.com/pypa/pip/archive/9.0.1.tar.gz'
   source_sha256 'd03fabbc4fbf2fbfc2f97307960aef2b3ca4c880ecda993dcc35957e33d7cd76'
 
-  # Don't overwrite the currently installed version.
-  abort 'pip is already installed.'.lightgreen if File.exists? '/usr/local/bin/pip'
-
-  # Install python if not found.
+  # Install python only if not found.
   depends_on 'python' unless File.exists? '/usr/local/bin/python'
 
   def self.install
+    # Don't overwrite the currently installed version.
+    abort 'Package pip is already installed, skipping...'.lightgreen if File.exists? '/usr/local/bin/pip'
     system "wget https://bootstrap.pypa.io/get-pip.py"
     system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
     system "python get-pip.py -I -b #{CREW_DEST_DIR}/usr/local"

--- a/packages/pip.rb
+++ b/packages/pip.rb
@@ -12,7 +12,7 @@ class Pip < Package
 
   def self.install
     # Don't overwrite the currently installed version.
-    abort 'Package pip is already installed, skipping...'.lightgreen if File.exists? '/usr/local/bin/pip'
+    abort 'pip is already installed, skipping...'.lightgreen if File.exists? '/usr/local/bin/pip'
     system "wget https://bootstrap.pypa.io/get-pip.py"
     system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
     system "python get-pip.py -I -b #{CREW_DEST_DIR}/usr/local"

--- a/packages/pip.rb
+++ b/packages/pip.rb
@@ -12,7 +12,6 @@ class Pip < Package
   def self.install
     system "wget https://bootstrap.pypa.io/get-pip.py"
     system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
-    system "mkdir -p #{CREW_DEST_DIR}/usr/local/pip"
     system "python get-pip.py -I -b #{CREW_DEST_DIR}/usr/local"
     system "cp /usr/local/bin/pip* #{CREW_DEST_DIR}/usr/local/bin"
   end


### PR DESCRIPTION
Unless you install the python27 package, pip is unavailable even if the python and/or python3 packages are installed.  Sometimes you need python version 3 which justifies having this package available.