### PR TITLE
Change install.sh to check LD_LIBRARY_PATH and show guide message.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -182,3 +182,14 @@ echo crew >> .git/info/sparse-checkout
 git fetch origin master
 git reset --hard origin/master
 echo "Chromebrew installed successfully and package lists updated."
+
+#check LD_LIBRARY_PATH on x86_64
+case "$architecture" in
+"x86_64")
+  (echo $LD_LIBRARY_PATH | grep '/usr/local/lib[^6]\|/usr/local/lib$' > /dev/null) || cat << EOF
+
+Several packages may install their libraries into $CREW_PREFIX/lib, so adding below to your ~/.bash_profile is recommended.
+  export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib
+EOF
+  ;;
+esac


### PR DESCRIPTION
This PR does what @flyingP0tat0 said in https://github.com/skycocker/chromebrew/issues/689#issuecomment-309211334.

I tried to modify several packages to install libraries into lib64 on x86_64.  It works.  However, it is not perfect, since anyone can possible to add new package and install libraries into lib by accident.

Therefore, I made this PR.  Tested on x86_64 and arvm7l.  install.sh shows following message on x86_64 after this PR.
```
Chromebrew installed successfully and package lists updated.

Several packages may install their libraries into /usr/local/lib, so adding below to your ~/.bash_profile is recommended.
  export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib
$
```