### PR TITLE
Add cbase package

### DIFF
--- a/packages/cbase.rb
+++ b/packages/cbase.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Cbase < Package
+  description 'cbase is a C library of useful functions that simplify systems software development on System V UNIX.'
+  homepage 'http://www.hyperrealm.com/main.php?s=misctools'
+  version '1.3.7'
+  source_url 'http://www.hyperrealm.com/cbase/cbase-1.3.7.tar.gz'
+  source_sha256 'c4d155686ac2e9d1480319de311967fadad745a6ab6971d53d495d9a9e52dc47'
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/cbase.rb
+++ b/packages/cbase.rb
@@ -2,7 +2,7 @@ require 'package'
 
 class Cbase < Package
   description 'cbase is a C library of useful functions that simplify systems software development on System V UNIX.'
-  homepage 'http://www.hyperrealm.com/main.php?s=misctools'
+  homepage 'http://www.hyperrealm.com/main.php?s=cbase'
   version '1.3.7'
   source_url 'http://www.hyperrealm.com/cbase/cbase-1.3.7.tar.gz'
   source_sha256 'c4d155686ac2e9d1480319de311967fadad745a6ab6971d53d495d9a9e52dc47'


### PR DESCRIPTION
cbase is a C library of useful functions that simplify systems software development on System V UNIX. The library includes routines for memory management, string parsing, filesystem traversal, subprocess execution, I/O, as well as implementations of common data structures such as linked lists, hash tables, stacks, and queues. The library also includes a high-level interface to Berkeley sockets, and an implementation of a scheduler which has functionality very similar to that of the cron daemon. Note: cbase was formerly known as CFL.  See http://www.hyperrealm.com/main.php?s=cbase.