### PR TITLE
Add misctools package

### DIFF
--- a/packages/misctools.rb
+++ b/packages/misctools.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Misctools < Package
+  description 'The misctools package is a collection of small but useful utilities.'
+  homepage 'http://www.hyperrealm.com/main.php?s=misctools'
+  version '2.5.5'
+  source_url 'http://www.hyperrealm.com/misctools/misctools-2.5.5.tar.bz2'
+  source_sha256 '4eb5913566da3e243ebd9cab499f927a2d46a2191baa51b810214f83eebb3ae9'
+
+  depends_on 'cbase'
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
The misctools package is a collection of small but useful utilities. Though they are small and trivial, I've found these programs to be indispensable. The utilities are:

- basecvt : A simple program for converting numeric values from one base to another.
- bat : A binary dump program; similar to the UNIX od command, but produces output in a much more useful format.
- cpmod : A program to copy file permissions.
- dirstack  : A curses-based directory browser/selector.
- dirtree : A program that generates a hierarchical list of filenames for a given directory tree.
- djinn : A wrapper program that allows a Java program to run as a true UNIX daemon.
- ftrunc  : A program that truncates files to specified lengths.
- man2pdf : A script that converts manpages into PDF files.
- man2ps  : A script that converts manpages into PostScript files.
- pascii  : A program that reads characters from the keyboard and displays their : ASCII codes in various formats.
- pfortune  : A program that prints out random fortunes.
- pkgenv  : A simple shell environment manager for software packages.
- psprint : A script that formats and prints various types of files to a PostScript printer.
- ps2pdf  : A script that converts PostScript files into PDF files.
- ranline : A program that reads a line at random from standard input or a file.
- stat  : A program that prints out information about a file.
- texi2pdf  : A script that converts Texinfo files into PDF files.
- texi2ps : A script that converts Texinfo files into PostScript files.
- textlock  : A password-protection program like xlock for use on text terminals.
- watcherd  : A program that watches the size of a file and invokes another program when the file size increases.
- wrap  : A program that reformats text, wrapping words as necessary, to fit within a specified number of columns.

See http://www.hyperrealm.com/main.php?s=misctools.