### PR TITLE
add imagemagick 6 package

### DIFF
--- a/packages/imagemagick6.rb
+++ b/packages/imagemagick6.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Imagemagick6 < Package
+  description 'Use ImageMagick to create, edit, compose, or convert bitmap images.'
+  homepage 'http://www.imagemagick.org/script/index.php'
+  version '6.9.8.10'
+  source_url 'https://www.imagemagick.org/download/ImageMagick-6.9.8-10.tar.xz'
+  source_sha256 '8fc268f6e1bc514b41620e0f3f6c5dd33bfc5169db679e9a5c0455c6edd11810'
+
+  depends_on 'pkgconfig'
+  depends_on "libjpeg"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "freetype"
+
+  def self.build
+    system "./configure CFLAGS=\" -fPIC\" --without-python"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Homebrew has an equivalent formula called [imagemagick@6 ](https://github.com/Homebrew/homebrew-core/blob/master/Formula/imagemagick%406.rb)which is used because the latest rmagick gem is not compatible with ImageMagick 7. If anyone is using chromebrew to do ruby development this may come in handy. See[ this thread](https://stackoverflow.com/questions/41647979/imagemagick-7-with-rmagick-2-16-on-macos-sierra-cant-find-magickwand-h) on Stackoverflow for more info.