### PR TITLE
Clear up python's zlib dependency

### DIFF
--- a/packages/mercurial.rb
+++ b/packages/mercurial.rb
@@ -9,7 +9,6 @@ class Mercurial < Package
 
   # what's the best route for adding a minimum version symbol as a constraint?
   depends_on "python27"
-  depends_on "zlibpkg"
 
   def self.build
     # would be great to avoid even downloading the source tarball if this dependency wasn't met

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -12,6 +12,7 @@ class Python27 < Package
   depends_on 'openssl' => :build
   depends_on 'sqlite' => :build
   depends_on 'gdbm' => :build
+  depends_on 'zlibpkg'
 
   def self.build
     # python requires to use /usr/local/lib, so leave as is but specify -rpath

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -12,6 +12,7 @@ class Python3 < Package
   depends_on 'ncurses'
   depends_on 'openssl' => :build
   depends_on 'sqlite' => :build
+  depends_on 'zlibpkg'
 
   def self.build
     # python requires to use /usr/local/lib, so leave as is but specify -rpath


### PR DESCRIPTION
This will add the `zlib` dependency to `python27` and `python3` packages, to fix #869, `python` package does not need `zlib`.
Therefor `zlib` is removed from `mercurial`, as a previous fix from #869.