### PR TITLE
Update toolcahin binary packages to use compressed manual/info

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,17 +3,17 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'http://www.gnu.org/software/binutils/'
-  version '2.25-2'
+  version '2.25-3'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/binutils-2.25-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/binutils-2.25-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/binutils-2.25-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/binutils-2.25-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/binutils-2.25-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/binutils-2.25-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/binutils-2.25-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/binutils-2.25-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'a6edb738fa8b65374b0ad087537fa0649ba59af6bb7ddc83eca06d504f1c2a45',
-    armv7l:  'a6edb738fa8b65374b0ad087537fa0649ba59af6bb7ddc83eca06d504f1c2a45',
-    i686:    '214ae25a910f56ff379620933defd497697f37f693c5b54dd34fb3b8b4f286dc',
-    x86_64:  '1c00d036d95a5255dd35dfdb9c934f2b9ae2d73f6788831e60a3ab12e5c1f354',
+    aarch64: '1bacd0d559775a5e8c444ccb51e75158abc4b997a206756bee2414d83f60381d',
+    armv7l:  '1bacd0d559775a5e8c444ccb51e75158abc4b997a206756bee2414d83f60381d',
+    i686:    '0e633732a1b4c4ca0eb7d5e7bdb69e3dc027c398caa1ad940b0bceb5a067a371',
+    x86_64:  '98f6862f011ba38d192c8dac80f45af667832b850dc85f73959548a2a251bd44',
   })
 end

--- a/packages/cloog.rb
+++ b/packages/cloog.rb
@@ -3,17 +3,17 @@ require 'package'
 class Cloog < Package
   description 'Chunky Loop Generator which is used to perform optimization in gcc'
   homepage 'https://www.cloog.org/'
-  version '0.18.4-1'
+  version '0.18.4-2'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/cloog-0.18.4-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/cloog-0.18.4-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/cloog-0.18.4-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/cloog-0.18.4-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/cloog-0.18.4-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/cloog-0.18.4-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/cloog-0.18.4-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/cloog-0.18.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5c0d563960076a50f332cf484d5ceb7043045ae6f647e74d86a141158b4fa621',
-    armv7l:  '5c0d563960076a50f332cf484d5ceb7043045ae6f647e74d86a141158b4fa621',
-    i686:    'b82930b14f6b1a506150c3b367f455d8fd78b20a1dacbd53a18b369e32552512',
-    x86_64:  '092a6621231b76f4cd331cdac356281185dcff3a8d62d982baee58f20f1aaec8',
+    aarch64: 'f79bede55ba092c133a26b03c79b71a4d9e7f46c7118308f9d182f3a2ed3f2c0',
+    armv7l:  'f79bede55ba092c133a26b03c79b71a4d9e7f46c7118308f9d182f3a2ed3f2c0',
+    i686:    '7bf5c2b4eb9b0d27fe10c4da4315ffb767f22dcc0281803e1f38bfbf6cbb6c74',
+    x86_64:  'e5f20db359ef15b7881f0b15f25851a462fc06ccd5e17f23cfc420a6b29b79f6',
   })
 end

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -3,19 +3,19 @@ require 'package'
 class Gcc < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '4.9.4'
+  version '4.9.4-1'
 
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/gcc-4.9.4-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/gcc-4.9.4-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/gcc-4.9.4-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/gcc-4.9.4-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/gcc-4.9.4-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/gcc-4.9.4-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/gcc-4.9.4-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/gcc-4.9.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'e0bf0855f30aa2084e86b0d382c99b6d15bbc1937f4ea6a993ab06ca1a80bd70',
-    armv7l:  'e0bf0855f30aa2084e86b0d382c99b6d15bbc1937f4ea6a993ab06ca1a80bd70',
-    i686:    '66a6f4f1b08c1f0f09bc58ccb65b35e48912bf529d1de8452e3e8faeff75bc0c',
-    x86_64:  '78cd2fd1a95aee25a9804371118adad78265237718068ed86d90d82e41ca02ce',
+    aarch64: 'ecb047a9f52ea6b24313d4329b00236b6880e12df684e52e34e9664127d447c6',
+    armv7l:  'ecb047a9f52ea6b24313d4329b00236b6880e12df684e52e34e9664127d447c6',
+    i686:    '9a8b20b58a564c9557c74b2b2769ddc68c110211588356b71c533aac6d54431b',
+    x86_64:  '1ae1f58ca4b9fee3b0f68856e5d49b2feeb90e259e8d885f339c9aa8091f27c8',
   })
 
   depends_on 'binutils'

--- a/packages/glibc219.rb
+++ b/packages/glibc219.rb
@@ -3,17 +3,17 @@ require 'package'
 class Glibc219 < Package
   description 'GNU C Library'
   homepage 'https://www.gnu.org/software/libc/'
-  version '2.19-1'
+  version '2.19-2'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.19-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.19-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.19-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.19-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/glibc-2.19-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/glibc-2.19-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/glibc-2.19-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/glibc-2.19-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '7524d818571059970caece1b4616d947c4937a591383ed5644636c45d9c16bdd',
-    armv7l:  '7524d818571059970caece1b4616d947c4937a591383ed5644636c45d9c16bdd',
-    i686:    'b9eb79ec3bfe59c85b7520673cbd5eb24414a176e040fca9a5fb57e82e4dd28e',
-    x86_64:  '173200b006598bc46c964531a87ffde6cae1656759d5f96c54bc73b322e0af46',
+    aarch64: 'df5fb603d658438489bc1d54de317bf8901e2cd3d80a4f3c3379e93cf8539c3c',
+    armv7l:  'df5fb603d658438489bc1d54de317bf8901e2cd3d80a4f3c3379e93cf8539c3c',
+    i686:    'a7e09144668734a08c660093b4f9ef7b6660c89c027d16eb9db1426f61660d85',
+    x86_64:  'bd8a5e69ca2994884bb7cf006887754331faa90e59e6165a693c4392968ccca3',
   })
 end

--- a/packages/glibc223.rb
+++ b/packages/glibc223.rb
@@ -3,17 +3,17 @@ require 'package'
 class Glibc223 < Package
   description 'GNU C Library'
   homepage 'https://www.gnu.org/software/libc/'
-  version '2.23-1'
+  version '2.23-2'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.23-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.23-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.23-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/glibc-2.23-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/glibc-2.23-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/glibc-2.23-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/glibc-2.23-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/glibc-2.23-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '54cfc66b712bb3a0f5619a90e82db98c34c949e93902cfeb6140da38ed73a19d',
-    armv7l:  '54cfc66b712bb3a0f5619a90e82db98c34c949e93902cfeb6140da38ed73a19d',
-    i686:    '9a51fe1485eb84b13d4c0fe03839fd9534a48e81c6cb22e845db17a6e711106d',
-    x86_64:  '28fd0a4aa514081e1ae098421e47d0172e818e4435b1a2ffd447d4f7cb6799e4',
+    aarch64: '34755443a25fbe74da7fd4c0d67f758aaf7078db76c45dfa36fdab86a3842266',
+    armv7l:  '34755443a25fbe74da7fd4c0d67f758aaf7078db76c45dfa36fdab86a3842266',
+    i686:    '14ce3a27fb989a7d26713ebe1c374b9c5f603f6570d99b015dc603223d055f63',
+    x86_64:  '151470a91581b26c6b1eaf18aa085c2665aa16eccafb1435040983e1dd8acba0',
   })
 end

--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -3,17 +3,17 @@ require 'package'
 class Gmp < Package
   description 'GMP is a free library for arbitrary precision arithmetic, operating on signed integers, rational numbers, and floating-point numbers.'
   homepage 'https://gmplib.org/'
-  version '6.1.2-1'
+  version '6.1.2-2'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/gmp-6.1.2-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/gmp-6.1.2-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/gmp-6.1.2-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/gmp-6.1.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/gmp-6.1.2-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/gmp-6.1.2-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/gmp-6.1.2-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/gmp-6.1.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '74c06e1c7fa3b6be68613ba72167416141674a70044452706b9612f6dd4d4267',
-    armv7l:  '74c06e1c7fa3b6be68613ba72167416141674a70044452706b9612f6dd4d4267',
-    i686:    'd9c8f4c0102d30d17e75c753491c527138ead8238681368e265a58edc8b3ae40',
-    x86_64:  '09e6e4a1575da39471e0ae713e54d62dfcb347d913afc3f7f2d49e8489c8d54a',
+    aarch64: '3ec9dd786c7fd0eaf5d2f539ca47d5b050a221e341c3ba23fbbbeedcab437a03',
+    armv7l:  '3ec9dd786c7fd0eaf5d2f539ca47d5b050a221e341c3ba23fbbbeedcab437a03',
+    i686:    '3b670ac470d2b1d7724f903fde93766ae8c4780b1b61cd4de0a50ec3780529d4',
+    x86_64:  'b7cbf53d56f7bb0a3ed36adcafbc340409d2da375560ceaf17102ea4413cebb4',
   })
 end

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -3,17 +3,17 @@ require 'package'
 class Isl < Package
   description 'Integer Set Library for manipulating sets and relations of integer points bounded by linear constraints'
   homepage 'http://isl.gforge.inria.fr/'
-  version '0.18'
+  version '0.18-1'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/isl-0.18-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/isl-0.18-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/isl-0.18-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/isl-0.18-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/isl-0.18-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/isl-0.18-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/isl-0.18-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/isl-0.18-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f792f6c917c12e8319f00b7a536f974b7040276ded9a00045b91a7cbe0ac61f1',
-    armv7l:  'f792f6c917c12e8319f00b7a536f974b7040276ded9a00045b91a7cbe0ac61f1',
-    i686:    'eaeb4f965f2e171fd729a111b5525ef31e2a58f67d5cdc68fc5252f1965127ea',
-    x86_64:  'a2732f63f643e64c5e75de026c8ef2e339717f249875a762765b750f4691d760',
+    aarch64: '34ab13258b490e96932dc8cb79fd3f7f6ec1e724aba829011cc5f2b16644c28e',
+    armv7l:  '34ab13258b490e96932dc8cb79fd3f7f6ec1e724aba829011cc5f2b16644c28e',
+    i686:    '513b04781a6759ffff0481151090711b19a29bc636a9839e9b571b1cb4276ac7',
+    x86_64:  'dbab5361321ea49a310e8d6507464438f227dff149223d68a797d4479ae1c173',
   })
 end

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -3,17 +3,17 @@ require 'package'
 class Linuxheaders < Package
   description 'Linux headers for Chrome OS.'
   homepage ''
-  version '3.18-1'
+  version '3.18-2'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/linux-headers-3.18-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/linux-headers-3.18-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/linux-headers-3.18-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/linux-headers-3.18-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/linux-headers-3.18-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/linux-headers-3.18-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/linux-headers-3.18-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/linux-headers-3.18-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd36e27d2edd0819e37b7b95b7d77d42e3f256e7b4bb845325f394b28d6487b4f',
-    armv7l:  'd36e27d2edd0819e37b7b95b7d77d42e3f256e7b4bb845325f394b28d6487b4f',
-    i686:    'fd44ecb2f021cf8ced4e46b1579a0f1a27bc553f41a077745394056afaa3d808',
-    x86_64:  'cf8f4db6a406ef2d59701902d5981dd864a834ced50e9832d6856174e4271f7d',
+    aarch64: '811e1bfa4d83e866ac7625c6970d7289b8768bf30b18af8a3b79c0760dfa42af',
+    armv7l:  '811e1bfa4d83e866ac7625c6970d7289b8768bf30b18af8a3b79c0760dfa42af',
+    i686:    '8ee5c68467cb5e7994993cddf163d59cb61a5f7d70f5bc595cb3fe288131ae59',
+    x86_64:  '830b18e54ebd6a2c8701c5ea1efd883e345719770de34ad0ece2f7cfb904df6f',
   })
 end

--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -3,17 +3,17 @@ require 'package'
 class Mpc < Package
   description 'Gnu Mpc is a C library for the arithmetic of complex numbers with arbitrarily high precision and correct rounding of the result.'
   homepage 'http://www.multiprecision.org/'
-  version '1.0.3-1'
+  version '1.0.3-2'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpc-1.0.3-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpc-1.0.3-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpc-1.0.3-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpc-1.0.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/mpc-1.0.3-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/mpc-1.0.3-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/mpc-1.0.3-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/mpc-1.0.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '58518e1b1a26d4c48e101bea2d42c640b9dccdd0300fbda9cce9635dbdbfa4ba',
-    armv7l:  '58518e1b1a26d4c48e101bea2d42c640b9dccdd0300fbda9cce9635dbdbfa4ba',
-    i686:    'ac2789b514e0b581c619a197d8e7cecae1bfc3c5251a9a9bb857d4a78d03ca1e',
-    x86_64:  '6c39fe899b348b693736a662bd19168ffea70718533942b35491d7df0a4a2d35',
+    aarch64: '49795b457852098b34964c768bc4f5fa852c2c40e72f4e856437301f36edb3fd',
+    armv7l:  '49795b457852098b34964c768bc4f5fa852c2c40e72f4e856437301f36edb3fd',
+    i686:    'efec8e5ab8dac926546dabda0ff8b32fe30d85ff2a7c1ab44bdb3d58ad49d19b',
+    x86_64:  'b9b26abf315efce1b826f58e70795493d7ed503652486bc3766ac54dfa5d0a35',
   })
 end

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -3,17 +3,17 @@ require 'package'
 class Mpfr < Package
   description 'The MPFR library is a C library for multiple-precision floating-point computations with correct rounding.'
   homepage 'http://www.mpfr.org/'
-  version '3.1.5-1'
+  version '3.1.5-2'
   binary_url ({
-    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpfr-3.1.5-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpfr-3.1.5-chromeos-armv7l.tar.xz',
-    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpfr-3.1.5-chromeos-i686.tar.xz',
-    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.7/mpfr-3.1.5-chromeos-x86_64.tar.xz',
+    aarch64: 'https://github.com/jam7/chrome-cross/releases/download/v1.8/mpfr-3.1.5-chromeos-armv7l.tar.xz',
+    armv7l:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/mpfr-3.1.5-chromeos-armv7l.tar.xz',
+    i686:    'https://github.com/jam7/chrome-cross/releases/download/v1.8/mpfr-3.1.5-chromeos-i686.tar.xz',
+    x86_64:  'https://github.com/jam7/chrome-cross/releases/download/v1.8/mpfr-3.1.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '8a2f8a0059ae27778c51bb949f07b7920bc1e3a5942889c9809558a021296329',
-    armv7l:  '8a2f8a0059ae27778c51bb949f07b7920bc1e3a5942889c9809558a021296329',
-    i686:    'c30a5f8c45262529953de89309ac6d65546ef3fa57e79a03aaa98f037d18db75',
-    x86_64:  '60ce5bb3d89a917aae7fe1e753e221687eb7f7eb28ea2bf05c5cd4a766a510c8',
+    aarch64: '41170f3c49ea226df739d90bb633895dc0479d855acece2cd96d1bb24818202a',
+    armv7l:  '41170f3c49ea226df739d90bb633895dc0479d855acece2cd96d1bb24818202a',
+    i686:    '341e8109fbfc376883e5eeb649561897958a8cbf92ba3dc73ca7da5e52fa7e63',
+    x86_64:  '5e9fe71170cc82e1d789ee9aecf568b70f4f9694f2c945a6c04ae573bf0509a2',
   })
 end


### PR DESCRIPTION
This PR updates toolchain binary packages to use compressed man/info files.

Tested on x86_64 and armv7l.  Tested i686 on clooudready.

All packages are cross-compiled on x86_64 ubuntu by using https://github.com/jam7/chrome-cross.