### PR TITLE
Add dmidecode package

### DIFF
--- a/packages/dmidecode.rb
+++ b/packages/dmidecode.rb
@@ -8,6 +8,10 @@ class Dmidecode < Package
   source_sha256 'd766ce9b25548c59b1e7e930505b4cad9a7bb0b904a1a391fbb604d529781ac0'
 
   def self.build
+    case ARCH
+    when 'aarch64', 'armv7l'
+      abort "#{ARCH} architecture not supported.".lightred
+    end
     system 'make'
   end
 

--- a/packages/dmidecode.rb
+++ b/packages/dmidecode.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Dmidecode < Package
+  description "Dmidecode reports information about your system's hardware as described in your system BIOS according to the SMBIOS/DMI standard (see a sample output)."
+  homepage 'http://www.nongnu.org/dmidecode/'
+  version '3.1'
+  source_url 'http://download.savannah.gnu.org/releases/dmidecode/dmidecode-3.1.tar.xz'
+  source_sha256 'd766ce9b25548c59b1e7e930505b4cad9a7bb0b904a1a391fbb604d529781ac0'
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    puts ""
+    puts "To complete the installation, execute the following:".lightblue
+    puts "echo 'export PATH=$PATH:/usr/local/sbin' >> ~/.bashrc && source ~/.bashrc".lightblue
+    puts ""
+  end
+end

--- a/packages/dmidecode.rb
+++ b/packages/dmidecode.rb
@@ -9,17 +9,21 @@ class Dmidecode < Package
 
   def self.build
     case ARCH
-    when 'aarch64', 'armv7l'
-      abort "#{ARCH} architecture not supported.".lightred
+    when 'i686', 'x86_64'
+      system 'make'
+    else
+      puts "#{ARCH} architecture not supported.".lightred
     end
-    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    puts ""
-    puts "To complete the installation, execute the following:".lightblue
-    puts "echo 'export PATH=$PATH:/usr/local/sbin' >> ~/.bashrc && source ~/.bashrc".lightblue
-    puts ""
+    case ARCH
+    when 'i686', 'x86_64'
+      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+      puts ""
+      puts "To complete the installation, execute the following:".lightblue
+      puts "echo 'export PATH=$PATH:/usr/local/sbin' >> ~/.bashrc && source ~/.bashrc".lightblue
+      puts ""
+    end
   end
 end


### PR DESCRIPTION
Dmidecode reports information about your system's hardware as described in your system BIOS according to the SMBIOS/DMI standard (see a sample output). This information typically includes system manufacturer, model name, serial number, BIOS version, asset tag as well as a lot of other details of varying level of interest and reliability depending on the manufacturer. This will often include usage status for the CPU sockets, expansion slots (e.g. AGP, PCI, ISA) and memory module slots, and the list of I/O ports (e.g. serial, parallel, USB).  See http://www.nongnu.org/dmidecode/.