### PR TITLE
Add dependency to healthcheck package

### DIFF
--- a/packages/healthcheck.rb
+++ b/packages/healthcheck.rb
@@ -8,6 +8,7 @@ class Healthcheck < Package
   source_sha256 '4f40995614da68da7422e2ba8e01815c569e3c1a268122a5e13a007899092630'
 
   depends_on 'lsb_release'
+  depends_on 'dmidecode'
   depends_on 'sysstat'
 
   def self.install
@@ -15,5 +16,9 @@ class Healthcheck < Package
     system "sed -i 's,usr/bin,usr/local/bin,' health-check.sh"
     system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
     system "cp health-check.sh #{CREW_DEST_DIR}/usr/local/bin/healthcheck"
+    puts ""
+    puts "To execute, enter the following:".lightblue
+    puts "sudo healthcheck".lightblue
+    puts ""
   end
 end


### PR DESCRIPTION
Resolves the following:
```
/usr/local/bin/healthcheck: line 154: dmidecode: command not found
```