### PR TITLE
Add github_release package

### DIFF
--- a/packages/github_release.rb
+++ b/packages/github_release.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Github_release < Package
+  description 'Commandline app to create and edit releases on Github (and upload artifacts)'
+  homepage 'https://github.com/aktau/github-release'
+  version '0.7.2'
+  source_url 'https://github.com/aktau/github-release/archive/v0.7.2.tar.gz'
+  source_sha256 '057d57b01cd45d0316e2d32b7593ff0f4bb493d4767b5701b21b54301d74ff48'
+
+  depends_on 'go'
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
+    system "cp github-release #{CREW_DEST_DIR}/usr/local/bin"
+  end
+end


### PR DESCRIPTION
Commandline app to create and edit releases on Github (and upload artifacts).  See https://github.com/aktau/github-release.  I couldn't install via `go get github.com/aktau/github-release` but I could with this package. :)