### PR TITLE
Add SDL2 (libsdl2) and fix libtheora

### DIFF
--- a/packages/libsdl2.rb
+++ b/packages/libsdl2.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Libsdl2 < Package
+  description 'Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.'
+  homepage 'http://www.libsdl.org/'
+  version '2.0.5'
+  source_url 'https://www.libsdl.org/release/SDL2-2.0.5.tar.gz'
+  source_sha256 '442038cf55965969f2ff06d976031813de643af9c9edc9e331bd761c242e8785'
+
+  def self.build
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/libtheora.rb
+++ b/packages/libtheora.rb
@@ -8,7 +8,7 @@ class Libtheora < Package
   source_sha256 'b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc'
 
   depends_on 'libvorbis'
-  depends_on 'libsdl'
+  depends_on 'libsdl2'
 
   def self.build
     system "sed -i 's/png_sizeof/sizeof/g' ./examples/png2theora.c"


### PR DESCRIPTION
Cleares up my mistake from #905. Also fixes `libtheora`, which caused an error before.