### PR TITLE
Update mongodb to 3.2.15.  Add method to compile it from source.

### DIFF
--- a/packages/mongodb.rb
+++ b/packages/mongodb.rb
@@ -3,13 +3,64 @@ require 'package'
 class Mongodb < Package
   description 'MongoDB is the next-generation database that lets you create applications never before possible.'
   homepage 'https://www.mongodb.com/'
-  version '3.0.8'
-  binary_url ({
-    i686: 'https://www.dropbox.com/s/n32v3h34jswxhg7/mongodb-linux-i686-3.0.8.tar.gz?dl=0',
-    x86_64: 'https://www.dropbox.com/s/two0chqyim5eo4a/mongodb-linux-x86_64-3.0.8.tar.gz?dl=0'
-  })
-  binary_sha256 ({
-    i686: 'e4b837c7213d08b528c675710dbd3fb3d5cf761929d0d89d27232fe7609549a3',
-    x86_64: '0cacc59ab09d7031ebafc3ff008ff2e9305d9fafc590f1a0e52848342033197a'
-  })
+  # We use 3.2 branch here since:
+  #  - 3.2 branch works well with gcc-4.9.4
+  #  - master 3.4 branch requires gcc-5.4.0
+  version '3.2.15'
+  source_url 'https://fastdl.mongodb.org/src/mongodb-src-r3.2.15.tar.gz'
+  source_sha256 '6726634f86d5887f9a8f9ae5e9e57d5d27ef219b6154280782d95ab81a2e43d7'
+
+  depends_on 'openssl' => :build
+  depends_on 'libpcap' => :build
+  depends_on 'python27' => :build
+  depends_on 'scons' => :build
+  depends_on 'go' => :build
+  depends_on 'git' => :build
+  case ARCH
+  when 'armv7l', 'aarch64'
+    depends_on 'perl' => :build         # gen-config.sh uses perl
+  end
+
+  def self.build
+    # prepare mongo-tools
+    system "git clone https://github.com/mongodb/mongo-tools"
+    system "cd mongo-tools; ./build.sh ssl || echo '***YOU NEED TO SET UP GO ENVIRONMENT IN ORDER TO COMPILE MONGO-TOOLS***'"
+    system "mkdir src/mongo-tools"
+    system "cp mongo-tools/bin/* src/mongo-tools/"
+    system "rm -rf mongo-tools"
+  end
+
+  def self.install
+    # build mongo and install it at once
+    case ARCH
+    when 'x86_64'
+      system "scons -j#{CREW_NPROC} install --ssl --prefix=#{CREW_DEST_DIR}#{CREW_PREFIX} --use-new-tools"
+    when 'i686'
+      system "scons -j#{CREW_NPROC} install --ssl --wiredtiger=off --prefix=#{CREW_DEST_DIR}#{CREW_PREFIX} --use-new-tools"
+    when 'armv7l'
+      # Arm 32 bit architecture is not supported officaially.
+      # Please read https://groups.google.com/forum/#!msg/mongodb-dev/G-kGjZEEam0/VSVB9fYCBAAJ for details
+      system "cd src/third_party/mozjs-38/; ./get_sources.sh"
+      system "cd src/third_party/mozjs-38/; ./gen-config.sh arm linux"
+      system "cd src/third_party/mozjs-38/; rm -rf firefix* mozilla-release"
+      system "scons -j#{CREW_NPROC} install --ssl --wiredtiger=off --mmapv1=on --prefix=#{CREW_DEST_DIR}#{CREW_PREFIX} --use-new-tools"
+    when 'aarch64'
+      # Arm 64 bit architecture is supported, but Chrome OS aarch64 is 32 bit.
+      # So, it is required to pretend it is armv7l.
+      system "cd src/third_party/mozjs-38/; ./get_sources.sh"
+      system "cd src/third_party/mozjs-38/; ./gen-config.sh arm linux"
+      system "cd src/third_party/mozjs-38/; rm -rf firefix* mozilla-release"
+      # Not sure how to pretend it under scons
+      system "scons -j#{CREW_NPROC} install --ssl --wiredtiger=off --mmapv1=on --prefix=#{CREW_DEST_DIR}#{CREW_PREFIX} --use-new-tools"
+    end
+
+    # guide messages
+    puts "type `mkdir #{CREW_PREFIX}/lib/mongodb` to create directory for database"
+    case ARCH
+    when 'x86_64'
+      puts "type `mongod --dbpath=#{CREW_PREFIX}/lib/mongodb` to start server"
+    when 'i686','armv7l', 'aarch64'
+      puts "type `mongod --dbpath=#{CREW_PREFIX}/lib/mongodb --storageEngine=mmapv1` to start server"
+    end
+  end
 end


### PR DESCRIPTION
Update mongodb to 3.2.15.  Add source compile methods, so this will solve #622.  Compiling it requires several GB disk space.

Mongodb has 3.4 branch also, but it requires gcc 5.4.0 and won't support 32 bit.  So, I use 3.2 branch here.  Even with 3.2, mongodb default storage engine named wiredTiger doesn't support 32 bit, so need to use mmapv1 engine.

How to start server:
 - make your db at somewhere under `/usr/local`.  Just type `mkdir /usr/local/your-favorite-path`.
 - x86_64: `mongod --dbpath your-db-path`
 - armv7l, i686, aarch64: `mongod --dbpath your-db-path --storageEngine mmapv1`

Tested on armv7l, i686 and x86_64.  I don't know whether it is possible to compile on aarch64.