### PR TITLE
Removing curl dependency from perl

### DIFF
--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -8,7 +8,6 @@ class Perl < Package
   source_sha256 'e6c185c9b09bdb3f1b13f678999050c639859a7ef39c8cad418448075f5918af'
 
   depends_on 'patch' => :build
-  depends_on 'curl'
 
   def self.build
     # Use system zlib and bzip2


### PR DESCRIPTION
This should close issue #956, and will work because curl is already installed by default.