### PR TITLE
Adding manpages package

### DIFF
--- a/packages/manpages.rb
+++ b/packages/manpages.rb
@@ -1,0 +1,14 @@
+require 'package'
+
+class Manpages < Package
+  description 'The Linux man-pages project documents the Linux kernel and C library interfaces that are employed by user-space programs.'
+  homepage 'https://www.kernel.org/doc/man-pages/'
+  version '4.12'
+  source_url 'https://www.kernel.org/pub/linux/docs/man-pages/man-pages-4.12.tar.xz'
+  source_sha256 '6f6d79d991fed04e16e7c7a15705304b0b9d51de772c51c57428555039fbe093'
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "prefix=/usr/local", "install"
+    puts "Try 'man printf' to see if it works. You should have package 'mandb' installed.".lightblue
+  end
+end


### PR DESCRIPTION
I wasn't sure if I should put `mandb` as a dependency, so I decided to not do it and put a friendly text for the following reasons:
1. It really doesn't need `mandb` to be installed, just used.
1. If someone installed this package directly, the helper text in the end of the `mandb` installation (that shows how to configure it) would be lost in the installation text.

Feel free to change it, though.