### PR TITLE
Change unzip.rb to correctly install binary and manual files

### DIFF
--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -33,9 +33,7 @@ class Unzip < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "MANDIR=/usr/local/tmp/unzip-man", "-f", "unix/Makefile", "install"
-    #remove the man pages we couldn't install
-    system "rm -r -f /usr/local/tmp/unzip-man"
+    system "make", "BINDIR=#{CREW_DEST_DIR}#{CREW_PREFIX}/bin", "MANDIR=#{CREW_DEST_DIR}#{CREW_PREFIX}/share/man", "-f", "unix/Makefile", "install"
   end
 
 end


### PR DESCRIPTION
Fix following problems:
 - install binary files directly
 - not install manual files

Tested on armv7l, i686 and x86_64.