### PR TITLE
Add m4 dependency to libtool

### DIFF
--- a/packages/libtool.rb
+++ b/packages/libtool.rb
@@ -3,11 +3,12 @@ require 'package'
 class Libtool < Package
   description 'GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries behind a consistent, portable interface.'
   homepage 'https://www.gnu.org/software/libtool/'
-  version '2.4.6'
+  version '2.4.6-1'
   source_url 'https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz'
   source_sha256 'e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3'
 
   depends_on 'buildessential'
+  depends_on 'm4'
 
   def self.build
     system "./configure --prefix=/usr/local"


### PR DESCRIPTION
Resolves:
```
Building from source, this may take a while...
## ------------------------- ##
## Configuring libtool 2.4.6 ##
## ------------------------- ##

checking for GNU M4 that supports accurate traces... configure: error: no acceptable m4 could be found in $PATH.
GNU M4 1.4.6 or later is required; 1.4.16 or newer is recommended.
GNU M4 1.4.15 uses a buggy replacement strstr on some systems.
Glibc 2.9 - 2.12 and GNU M4 1.4.11 - 1.4.15 have another strstr bug.
```