### PR TITLE
Change node.rb to modify the way of configuration

### DIFF
--- a/packages/node.rb
+++ b/packages/node.rb
@@ -11,7 +11,12 @@ class Node < Package
   depends_on 'python27'
 
   def self.build
-    system "CC='gcc -m64' python2.7 ./configure --without-snapshot"
+    case ARCH
+    when "x86_64"
+      system "CC='gcc -m64' python2.7 ./configure --without-snapshot"
+    else
+      system "CC='gcc' python2.7 ./configure --without-snapshot"
+    end
     system "make"
   end
 


### PR DESCRIPTION
This time, I modified only the way of configuration by following the way in node_current.  This is required to compile node on arm.

Tested on arm, x86_64 and i686.