### PR TITLE
Change go.rb to set pre-defined GOROOT

### DIFF
--- a/packages/go.rb
+++ b/packages/go.rb
@@ -3,7 +3,7 @@ require 'package'
 class Go < Package
   description 'Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.'
   homepage 'https://golang.org/'
-  version '1.8.3'
+  version '1.8.3-1'
   source_url 'https://storage.googleapis.com/golang/go1.8.3.src.tar.gz'
   source_sha256 '5f5dea2447e7dcfdc50fa6b94c512e58bfba5673c039259fd843f68829d99fa6'
 
@@ -20,10 +20,13 @@ class Go < Package
       unless File.exist? "#{CREW_PREFIX}/lib/go/bin/go"
         system "GOROOT_BOOTSTRAP=#{CREW_PREFIX}/lib/go_bootstrap/go \
                 TMPDIR=#{CREW_PREFIX}/tmp \
+                GOROOT_FINAL=#{CREW_PREFIX}/lib/go \
                 ./make.bash"
       else
         system "GOROOT_BOOTSTRAP=#{CREW_PREFIX}/lib/go \
-                TMPDIR=#{CREW_PREFIX}/tmp ./make.bash"
+                TMPDIR=#{CREW_PREFIX}/tmp \
+                GOROOT_FINAL=#{CREW_PREFIX}/lib/go \
+                ./make.bash"
       end
     end
   end
@@ -33,30 +36,28 @@ class Go < Package
     system "mkdir", "-p", dest
     FileUtils.cp_r Dir.pwd, dest
 
+    # make a symbolic link for /usr/local/bin/{go,gofmt}
+    system "mkdir", "-p", "#{CREW_DEST_DIR}#{CREW_PREFIX}/bin"
+    system "ln", "-s", "#{CREW_PREFIX}/lib/go/bin/go", "#{CREW_DEST_DIR}#{CREW_PREFIX}/bin"
+    system "ln", "-s", "#{CREW_PREFIX}/lib/go/bin/gofmt", "#{CREW_DEST_DIR}#{CREW_PREFIX}/bin"
+
     puts "--------"
     puts "Installed Go for #{ARCH} in #{CREW_PREFIX}/lib/go"
-    puts ""
-    puts "Make sure to set go environment variables."
-    puts ""
-    puts "Minimal:"
-    puts "\texport GOROOT=#{CREW_PREFIX}/lib/go"
-    puts "\texport PATH=$PATH:$GOROOT/bin"
     puts ""
     puts "To use `go run`:"
     puts "\texport TMPDIR=#{CREW_PREFIX}/tmp"
     puts ""
-    puts "To add environment variables, execute the following:".lightblue
-    puts ""
-    puts "echo 'export GOROOT=/usr/local/lib/go' >> ~/.bashrc".lightblue
-    puts "echo 'export PATH=$PATH:$GOROOT/bin' >> ~/.bashrc".lightblue
-    puts "echo 'export TMPDIR=/usr/local/tmp' >> ~/.bashrc".lightblue
-    puts "source ~/.bashrc".lightblue
+    puts "To develop with `go`:"
+    puts "\tmkdir -p /usr/local/work/go"
+    puts "\tln -s /usr/local/work/go $HOME/go"
+    puts "\texport PATH=\"$HOME/go/bin:$PATH\""
+    puts "\texport TMPDIR=#{CREW_PREFIX}/tmp"
     puts ""
   end
 
   def self.check
     FileUtils.cd('src') do
-      system "PATH=\"#{Dir.pwd}/../bin:$PATH\" TMPDIR=\"#{CREW_PREFIX}/tmp\" go tool dist test"
+      system "PATH=\"#{Dir.pwd}/../bin:$PATH\" GOROOT=\"#{Dir.pwd}/..\" TMPDIR=\"#{CREW_PREFIX}/tmp\" go tool dist test"
     end
   end
 end

--- a/packages/go.rb
+++ b/packages/go.rb
@@ -8,10 +8,10 @@ class Go < Package
   source_sha256 '5f5dea2447e7dcfdc50fa6b94c512e58bfba5673c039259fd843f68829d99fa6'
 
   # Tests requires perl
-  depends_on 'perl'
+  depends_on 'perl' => :build
   # go is required to build versions of go > 1.4
   unless File.exist? "#{CREW_PREFIX}/lib/go/bin/go"
-    depends_on 'go_bootstrap'
+    depends_on 'go_bootstrap' => :build
   end
 
   def self.build


### PR DESCRIPTION
This PR solves problems related to user setting GOROOT/GOPATH environment variable by setting them by default in go binary file.  Compiled binaries will have following pre-defined variables.
```
$ go env GOROOT
/usr/local/lib/go
$ go env GOPATH
/home/chronos/user/go
```
This PR also creates a symbolic link from `/usr/local/bin/go` for the ease of use.

As a result, we do not need to define any environment variable specially for go in order use go from other package files.

We still need some configuration to use go for development, though (TMPDIR and putting GOPATH directory to under `/usr/local` for execution).