### PR TITLE
Fix wrong option in cmatrix.rb

### DIFF
--- a/packages/cmatrix.rb
+++ b/packages/cmatrix.rb
@@ -11,7 +11,7 @@ class Cmatrix < Package
   depends_on 'ncurses'
 
   def self.build
-    system './configure --prefix=/usr/local CPPFLAGS="-I/usr/local/include/ncurses"'
+    system 'CPPFLAGS=-I/usr/local/include/ncurses ./configure --prefix=/usr/local'
     system "make"
   end
 

--- a/packages/cmatrix.rb
+++ b/packages/cmatrix.rb
@@ -3,7 +3,7 @@ require 'package'
 class Cmatrix < Package
   description "CMatrix is a program to see the cool scrolling lines from 'The Matrix' movie."
   homepage 'http://www.asty.org/cmatrix/'
-  version '1.2a'
+  version '1.2a-1'
   source_url 'http://www.asty.org/cmatrix/dist/cmatrix-1.2a.tar.gz'
   source_sha256 '1fa6e6caea254b6fe70a492efddc1b40ad7ccb950a5adfd80df75b640577064c'
 

--- a/packages/cmatrix.rb
+++ b/packages/cmatrix.rb
@@ -11,7 +11,7 @@ class Cmatrix < Package
   depends_on 'ncurses'
 
   def self.build
-    system 'CPPFLAGS=-I/usr/local/include/ncurses ./configure --prefix=/usr/local'
+    system "CPPFLAGS=-I#{CREW_PREFIX}/include/ncurses ./configure --prefix=#{CREW_PREFIX}"
     system "make"
   end
 


### PR DESCRIPTION
I cannot compile cmatrix with original package file.  I needed to change the way to set environment variable like this PR.

Tested on armv7l and x86_64.