### PR TITLE
Change openssl to pass `make test` on armv7l

### DIFF
--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,7 +3,7 @@ require 'package'
 class Openssl < Package
   description 'OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.'
   homepage 'https://www.openssl.org/'
-  version '1.0.2l'
+  version '1.0.2l-1'
   source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2l.tar.gz'
   source_sha256 'a3d3a7c03c90ba370405b2d12791598addfcafb1a77ef483c02a317a56c08485'
 
@@ -14,9 +14,21 @@ class Openssl < Package
 
   def self.build
     options="shared zlib-dynamic"
+
+    # Change default optimization level for armv7l from -O3 to -O2 because
+    # gcc-4.9.4 -O3 for armv7l cause `evp_test` problem like below.
+    #
+    #   Testing cipher CAMELLIA-256-OFB(decrypt)
+    #   Key
+    #   0000 60 3d eb 10 15 ca 71 be 2b 73 ae f0 85 7Decrypt failed
+    #   d 77 81
+    #   0010 1f 35 2c 07 3b 61 08 d7 2d 98 10 a3 09 14 df f4
+    #
+    system "sed -e '/linux-armv4/s/-O3/-O2/' -i Configure"
+
+    # Specify armv7 for aarch64 since Chrome OS aarch64 uses armv7 binaries as its userland.
     case `uname -m`.strip
     when "aarch64"
-      # Specify armv7 since aarch64 uses armv7 as its user land.
       system "./Configure --prefix=/usr/local --openssldir=/etc/ssl #{options} linux-armv4 -march=armv7-a"
     else
       system "./config --prefix=/usr/local --openssldir=/etc/ssl #{options}"
@@ -31,7 +43,7 @@ class Openssl < Package
     # move man to /usr/local/man
     system "mv", "#{CREW_DEST_DIR}/etc/ssl/man", "#{CREW_DEST_DIR}/usr/local/man"
 
-    # remove all files pretended to install /etc/ssl (use system's /etc/ssl as is)
+    # remove all files under /etc/ssl (use system's /etc/ssl as is)
     system "rm", "-rf", "#{CREW_DEST_DIR}/etc"
   end
 

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -8,6 +8,8 @@ class Openssl < Package
   source_sha256 'a3d3a7c03c90ba370405b2d12791598addfcafb1a77ef483c02a317a56c08485'
 
   depends_on 'perl' => :build
+  depends_on 'bc' => :build             # required for `make test`
+  depends_on 'diffutils' => :build      # required for `make test`
   depends_on 'zlibpkg' => :build
 
   def self.build

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -4,27 +4,21 @@ class Openssl < Package
   description 'OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.'
   homepage 'https://www.openssl.org/'
   version '1.0.2l'
-
   source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2l.tar.gz'
   source_sha256 'a3d3a7c03c90ba370405b2d12791598addfcafb1a77ef483c02a317a56c08485'
-  binary_url ({
-    aarch64: 'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2l-chromeos-armv7l.tar.xz',
-    armv7l:  'https://github.com/jam7/chromebrew/releases/download/binaries/openssl-1.0.2l-chromeos-armv7l.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '4af16174aa6a9f565a5895fedea89daf0c8fb66b8f26b0c8416f5456aa440ea5',
-    armv7l:  '4af16174aa6a9f565a5895fedea89daf0c8fb66b8f26b0c8416f5456aa440ea5',
-  })
 
   depends_on 'perl' => :build
   depends_on 'zlibpkg' => :build
 
   def self.build
     options="shared zlib-dynamic"
-    if `uname -m`.strip == 'aarch64'
-      options = options + " no-asm"
+    case `uname -m`.strip
+    when "aarch64"
+      # Specify armv7 since aarch64 uses armv7 as its user land.
+      system "./Configure --prefix=/usr/local --openssldir=/etc/ssl #{options} linux-armv4 -march=armv7-a"
+    else
+      system "./config --prefix=/usr/local --openssldir=/etc/ssl #{options}"
     end
-    system "./config --prefix=/usr/local --openssldir=/etc/ssl #{options}"
     system "make"
   end
 


### PR DESCRIPTION
Change the optimization level for armv7l from `-O3` to `-O2` since test shows a few failures.  This PR is also changed to support source compile on aarch64.

Tested on armv7l, i686 and x86_64.  I've not tested this on aarch64 yet, so I appreciate if someone test this on aarch64.  Thanks.