### PR TITLE
Add nodebrew 0.9.7

### DIFF
--- a/packages/nodebrew.rb
+++ b/packages/nodebrew.rb
@@ -21,7 +21,7 @@ class Nodebrew < Package
 
     puts ""
     puts "Please set PATH environment variable."
-    puts "\texport PATH=$HOME/.nodebrew:$PATH"
+    puts "\texport PATH=$HOME/.nodebrew/current/bin:$PATH"
     puts ""
     puts "To install the latest node, please execute:"
     puts "\tnodebrew install-binary latest"

--- a/packages/nodebrew.rb
+++ b/packages/nodebrew.rb
@@ -16,6 +16,8 @@ class Nodebrew < Package
     system "mkdir -p #{CREW_DEST_DIR}#{CREW_PREFIX}/bin"
     system "ln -s #{CREW_LIB_PREFIX}/nodebrew/nodebrew #{CREW_DEST_DIR}#{CREW_PREFIX}/bin/"
     system "ln -s #{CREW_LIB_PREFIX}/nodebrew/current/bin/node #{CREW_DEST_DIR}#{CREW_PREFIX}/bin/"
+    system "ln -s #{CREW_LIB_PREFIX}/nodebrew/current/bin/npm #{CREW_DEST_DIR}#{CREW_PREFIX}/bin/"
+    system "ln -s #{CREW_LIB_PREFIX}/nodebrew/current/bin/npx #{CREW_DEST_DIR}#{CREW_PREFIX}/bin/"
 
     system "ln -s #{CREW_LIB_PREFIX}/nodebrew $HOME/.nodebrew"
 

--- a/packages/nodebrew.rb
+++ b/packages/nodebrew.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Nodebrew < Package
+  description 'Node.js version manager'
+  homepage 'https://github.com/hokaccha/nodebrew'
+  version 'v0.9.7'
+  source_url 'https://github.com/hokaccha/nodebrew/archive/v0.9.7.tar.gz'
+  source_sha256 '3aa8b0cf30024d105f1ac6921aadf0440bc95bcae43df9d6ec58fc9de8cd352e'
+
+  depends_on 'perl'
+
+  def self.install
+    system "mkdir -p #{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/nodebrew"
+    system "NODEBREW_ROOT=#{CREW_DEST_DIR}#{CREW_LIB_PREFIX}/nodebrew perl nodebrew setup > /dev/null"
+
+    system "mkdir -p #{CREW_DEST_DIR}#{CREW_PREFIX}/bin"
+    system "ln -s #{CREW_LIB_PREFIX}/nodebrew/nodebrew #{CREW_DEST_DIR}#{CREW_PREFIX}/bin/"
+    system "ln -s #{CREW_LIB_PREFIX}/nodebrew/current/bin/node #{CREW_DEST_DIR}#{CREW_PREFIX}/bin/"
+
+    system "ln -s #{CREW_LIB_PREFIX}/nodebrew $HOME/.nodebrew"
+
+    puts ""
+    puts "Please set PATH environment variable."
+    puts "\texport PATH=$HOME/.nodebrew:$PATH"
+    puts ""
+    puts "To install the latest node, please execute:"
+    puts "\tnodebrew install-binary latest"
+    puts "\tnodebrew use latest"
+    puts ""
+  end
+end


### PR DESCRIPTION
This PR adds nodebrew 0.9.7, another `node` version manager similar to `nvm`.

Once installed nodebrew, use can install their favorite version of `node` like:
```
$ nodebrew install-binary latest
Fetching: https://nodejs.org/dist/v8.2.1/node-v8.2.1-linux-armv7l.tar.gz
######################################################################## 100.0%
Installed successfully
$ nodebrew use latest
use v8.2.1
```

Tested on armv7l and x86_64.