### PR TITLE
Fix wrong homepage resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       </div>
 
       <div class="row marketing">
-        <div class="col-lg-6">
+        <div class="col-6">
           <div class="bs-example bs-example-type">
             <h4>Chromebrew installs what you need with its dependencies:</h4>
           </div>
@@ -80,7 +80,7 @@
       </div>
 
       <div class="row marketing">
-        <div class="col-lg-6">
+        <div class="col-6">
           <div class="bs-example bs-example-type">
             <h4>Install Chromebrew (along with Ruby and Git).</h4>
             <h5>Available on aarch64, armv7l, i686 and x86_64.</h5>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       </div>
 
       <div class="row marketing">
-        <div class="col-6">
+        <div class="col-12">
           <div class="bs-example bs-example-type">
             <h4>Chromebrew installs what you need with its dependencies:</h4>
           </div>
@@ -80,7 +80,7 @@
       </div>
 
       <div class="row marketing">
-        <div class="col-6">
+        <div class="col-12">
           <div class="bs-example bs-example-type">
             <h4>Install Chromebrew (along with Ruby and Git).</h4>
             <h5>Available on aarch64, armv7l, i686 and x86_64.</h5>


### PR DESCRIPTION
Just changed the type of Bootstrap columns. You can check the fixes by applying the same changes in your DevTools' inspector.
Fixes #819.