### PR TITLE
Update subversion to 1.9.7 and correct the install method of serf

### DIFF
--- a/packages/serf.rb
+++ b/packages/serf.rb
@@ -3,7 +3,7 @@ require 'package'
 class Serf < Package
   description 'The serf library is a high performance C-based HTTP client library built upon the Apache Portable Runtime (APR) library.'
   homepage 'https://serf.apache.org/'
-  version '1.3.9-1'
+  version '1.3.9-2'
   source_url 'https://www.apache.org/dist/serf/serf-1.3.9.tar.bz2'
   source_sha256 '549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc'
 
@@ -11,8 +11,11 @@ class Serf < Package
   depends_on 'aprutil'
   depends_on 'openssl'
 
+  def self.build
+    system "scons APR=/usr/local APU=/usr/local OPENSSL=/usr/local/include/openssl PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
+  end
+
   def self.install
-    system "mkdir -p #{CREW_DEST_DIR}/usr/local"
-    system "scons APR=/usr/local APU=/usr/local OPENSSL=/usr/local/include/openssl PREFIX=#{CREW_DEST_DIR}/usr/local install"
+    system "scons install --install-sandbox=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/serf.rb
+++ b/packages/serf.rb
@@ -12,7 +12,7 @@ class Serf < Package
   depends_on 'openssl'
 
   def self.build
-    system "scons APR=/usr/local APU=/usr/local OPENSSL=/usr/local/include/openssl PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
+    system "scons APR=#{CREW_PREFIX} APU=#{CREW_PREFIX} OPENSSL=#{CREW_PREFIX}/include/openssl PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
   end
 
   def self.install

--- a/packages/subversion.rb
+++ b/packages/subversion.rb
@@ -3,21 +3,19 @@ require 'package'
 class Subversion < Package
   description 'Subversion is an open source version control system.'
   homepage 'https://subversion.apache.org/'
-  version '1.9.6-1'
-  source_url 'http://apache.mirrors.ionfish.org/subversion/subversion-1.9.6.tar.bz2'
-  source_sha256 'dbcbc51fb634082f009121f2cb64350ce32146612787ffb0f7ced351aacaae19'
+  version '1.9.7'
+  source_url 'http://www-us.apache.org/dist/subversion/subversion-1.9.7.tar.bz2'
+  source_sha256 'c3b118333ce12e501d509e66bb0a47bcc34d053990acab45559431ac3e491623'
 
   depends_on 'aprutil'
   depends_on 'autoconf'
   depends_on 'libtool'
   depends_on 'serf'
   depends_on 'sqlite'
+  depends_on 'zlibpkg'
 
   def self.build
-    system "sed -i 's,<serf.h>,</usr/local/include/serf-1/serf.h>,' subversion/libsvn_ra_serf/*"
-    system "sed -i 's,<serf_bucket_util.h>,</usr/local/include/serf-1/serf_bucket_util.h>,' subversion/libsvn_ra_serf/*.c"
-    system "sed -i 's,<serf_bucket_types.h>,</usr/local/include/serf-1/serf_bucket_types.h>,' subversion/libsvn_ra_serf/*.c"
-    system './configure'
+    system './configure', '--disable-static', "--libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 


### PR DESCRIPTION
This PR updates `subversion` to 1.9.7.

While I was trying to install it, I noticed `serf` is installed into `/usr/local/tmp/crew/dest/usr/local` directly instead of the combination of compiling it for `/usr/local` and installing it to `/usr/local/tmp/crew/dest/usr/local`.  So, I fixed it.  Once I fixed it, several hacks to `subversion` are not needed anymore, so I removed them also.

When I check `get-dep.sh` script, I notice we don't have `zlibpkg` dependency.  So, I add that one too.

Tested on armv7l and x86_64.