### PR TITLE
update libxml2.rb to avoid compile error later

### DIFF
--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,12 +3,14 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.4'
+  version '2.9.4-1'
   source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz'
   source_sha256 'ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c'
 
   def self.build
-    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic", "--without-python"
+    system "./configure", "--libdir=#{CREW_LIB_PREFIX}",
+      "--enable-shared", "--disable-static", "--with-pic", "--without-python",
+      "--without-lzma", "--without-zlib"
     system "make"
   end
 


### PR DESCRIPTION
If libxml2 uses zlibpkg or xzutils (lzma) for it's binary programs, entire library requires to install both of them.  It widens dependencies.  So, disabling them here.  libxml2 has a lot of such unnecessary dependencies.  This time, I only disabled above two, but it may be good to disable other options too.

Tested on armv7l and x86_64. 