### PR TITLE
Fixing diskscan and imagemagick

### DIFF
--- a/packages/diskscan.rb
+++ b/packages/diskscan.rb
@@ -7,7 +7,7 @@ class Diskscan < Package
   source_url 'https://github.com/baruch/diskscan/archive/0.19.tar.gz'
   source_sha256 '92a7298af99043e1e584e4343040b6574b9229f44c122e1cbcb90ba478d928d1'
 
-  depends_on 'cmake'
+  depends_on 'cmake' => :build
   depends_on 'termcap'
 
   def self.build
@@ -17,9 +17,5 @@ class Diskscan < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-  end
-
-  def self.check
-    system "make", "check"
   end
 end

--- a/packages/diskscan.rb
+++ b/packages/diskscan.rb
@@ -3,7 +3,7 @@ require 'package'
 class Diskscan < Package
   description 'diskscan is intended to find sectors of a storage medium (hard disk, flash drive or pendrive, etc.) which are bad or in the process of going bad.'
   homepage 'http://blog.disksurvey.org/proj/diskscan/'
-  version '0.19'
+  version '0.19-1'
   source_url 'https://github.com/baruch/diskscan/archive/0.19.tar.gz'
   source_sha256 '92a7298af99043e1e584e4343040b6574b9229f44c122e1cbcb90ba478d928d1'
 

--- a/packages/imagemagick.rb
+++ b/packages/imagemagick.rb
@@ -3,11 +3,11 @@ require 'package'
 class Imagemagick < Package
   description 'Use ImageMagick to create, edit, compose, or convert bitmap images.'
   homepage 'http://www.imagemagick.org/script/index.php'
-  version '7.0.6-4'
-  source_url 'https://www.imagemagick.org/download/releases/ImageMagick-7.0.6-4.tar.xz'
-  source_sha256 '5fe1ce7d78befb5c8aa7f8ae69710d0f78063d2e3a35c656521a3ce468ea733b'
+  version '7.0.6-7'
+  source_url 'https://www.imagemagick.org/download/releases/ImageMagick-7.0.6-7.tar.xz'
+  source_sha256 '732332a76cb62f067d680a90d85dd05a2f2592e0017af83becb639d05681106d'
 
-  depends_on 'pkgconfig'
+  depends_on 'buildessential' => :build
 
   def self.build
     system "./configure CFLAGS=\" -fPIC\" --without-python"


### PR DESCRIPTION
Diskscan did `make check` and there was no check target.
ImageMagick had the wrong link.
Relates to #1051 