### PR TITLE
Add git_lfs package

### DIFF
--- a/packages/git_lfs.rb
+++ b/packages/git_lfs.rb
@@ -10,6 +10,7 @@ class Git_lfs < Package
   depends_on 'go'
 
   def self.build
+    ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
     system 'script/bootstrap'
   end
 

--- a/packages/git_lfs.rb
+++ b/packages/git_lfs.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Git_lfs < Package
+  description 'Git extension for versioning large files'
+  homepage 'https://git-lfs.github.com/'
+  version '2.2.1'
+  source_url 'https://github.com/git-lfs/git-lfs/archive/v2.2.1.tar.gz'
+  source_sha256 'fede2b31b0539fd4a580f831867caac1b5d5dc4405e938c4ee0bfeacfb78ad7a'
+
+  depends_on 'go'
+
+  def self.build
+    system 'script/bootstrap'
+  end
+
+  def self.install
+    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
+    system "cp -r bin/ #{CREW_DEST_PREFIX}"
+  end
+end


### PR DESCRIPTION
An open source Git extension for versioning large files

Git Large File Storage (LFS) replaces large files such as audio samples, videos, datasets, and graphics with text pointers inside Git, while storing the file contents on a remote server like GitHub.com or GitHub Enterprise.

See https://git-lfs.github.com/.