### PR TITLE
Change aircrack_ng to make it configure itself correctly.

### DIFF
--- a/packages/aircrack_ng.rb
+++ b/packages/aircrack_ng.rb
@@ -3,7 +3,7 @@ require 'package'
 class Aircrack_ng < Package
   description 'Key cracker for the 802.11 WEP and WPA-PSK protocols.'
   homepage 'https://www.aircrack-ng.org'
-  version '1.2-rc4'
+  version '1.2-rc4-1'
   source_url 'http://download.aircrack-ng.org/aircrack-ng-1.2-rc4.tar.gz'
   source_sha256 'd93ac16aade5b4d37ab8cdf6ce4b855835096ccf83deb65ffdeff6d666eaff36'
 
@@ -16,9 +16,8 @@ class Aircrack_ng < Package
   depends_on "rfkill"
 
   def self.build
-    system "make",
-      "sqlite=true",
-      "experimental=true"
+    # Need to specify TMPDIR to run automatic configuration tool correctly
+    system "TMPDIR=/usr/local/tmp make sqlite=true experimental=true"
   end
 
   def self.install


### PR DESCRIPTION
Compiling aircrack_ng on i686 causes errors related to SIMD instructions.  The source of problem is that aircrack_ng is not configured well because it expects exec permission on /tmp.  Therefore, this PR add `TMPDIR=/usr/local/tmp` to make it run correctly.

This solves compile error on i686.

Tested on armv7l, i686 and x86_64.