### PR TITLE
Add individual package files to install perl modules.

### DIFF
--- a/packages/perl_locale_messages.rb
+++ b/packages/perl_locale_messages.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Perl_locale_messages < Package
+  description 'Perl Locale::Messages - Gettext Like Message Retrieval.'
+  homepage 'https://metacpan.org/pod/Locale::Messages'
+  version '1.27'
+  source_url 'https://cpan.metacpan.org/authors/id/G/GU/GUIDO/libintl-perl-1.27.tar.gz'
+  source_sha256 '46de373e84e8a178353990b87eeacf9ef4f5c72650248eb20ed9772a65817c6a'
+
+  depends_on 'perl'
+
+  def self.build
+  end
+
+  def self.install
+    # install files to build directory
+    system 'cpanm', '-l', "build", '--self-contained', '.'
+
+    # install lib
+    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+
+    # install man
+    mandir = "#{CREW_PREFIX}/share/man"
+    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+  end
+
+  def self.check
+  end
+end

--- a/packages/perl_text_unidecode.rb
+++ b/packages/perl_text_unidecode.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Perl_text_unidecode < Package
+  description 'Perl Text::Unidecode -- plain ASCII transliterations of Unicode text.'
+  homepage 'https://metacpan.org/pod/Text::Unidecode'
+  version '1.30'
+  source_url 'https://cpan.metacpan.org/authors/id/S/SB/SBURKE/Text-Unidecode-1.30.tar.gz'
+  source_sha256 '6c24f14ddc1d20e26161c207b73ca184eed2ef57f08b5fb2ee196e6e2e88b1c6'
+
+  depends_on 'perl'
+
+  def self.build
+  end
+
+  def self.install
+    # install files to build directory
+    system 'cpanm', '-l', "build", '--self-contained', '.'
+
+    # install lib
+    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+
+    # install man
+    mandir = "#{CREW_PREFIX}/share/man"
+    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+  end
+
+  def self.check
+  end
+end

--- a/packages/perl_unicode_eastasianwidth.rb
+++ b/packages/perl_unicode_eastasianwidth.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Perl_unicode_eastasianwidth < Package
+  description 'Perl Unicode::EastAsianWidth - East Asian Width properties.'
+  homepage 'https://metacpan.org/pod/Unicode::EastAsianWidth'
+  version '1.33'
+  source_url 'https://cpan.metacpan.org/authors/id/A/AU/AUDREYT/Unicode-EastAsianWidth-1.33.tar.gz'
+  source_sha256 '41c9f0b50c45dd806a97de73f9fe93516b6c63255e2a5174e5fb2d89635c7797'
+
+  depends_on 'perl'
+
+  def self.build
+  end
+
+  def self.install
+    # install files to build directory
+    system 'cpanm', '-l', "build", '--self-contained', '.'
+
+    # install lib
+    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+
+    # install man
+    mandir = "#{CREW_PREFIX}/share/man"
+    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+  end
+
+  def self.check
+  end
+end

--- a/packages/texinfo.rb
+++ b/packages/texinfo.rb
@@ -3,18 +3,18 @@ require 'package'
 class Texinfo < Package
   description 'Texinfo is the official documentation format of the GNU project.'
   homepage 'https://www.gnu.org/software/texinfo/'
-  version '6.4'
+  version '6.4-1'
   source_url 'http://ftpmirror.gnu.org/texinfo/texinfo-6.4.tar.xz'
   source_sha256 '6ae2e61d87c6310f9af7c6f2426bd0470f251d1a6deb61fba83a3b3baff32c3a'
 
   depends_on 'gettext' => :build
   depends_on 'perl'
+  depends_on 'perl_locale_messages'
+  depends_on 'perl_text_unidecode'
+  depends_on 'perl_unicode_eastasianwidth'
   depends_on 'ncurses'
 
   def self.build
-    # installing necessary perl modules
-    system 'cpan', 'install', 'CPAN', 'Locale::Messages', 'Text::Unidecode', 'Unicode::EastAsianWidth'
-
     # configure and make
     system './configure',
         '--with-external-Text-Unidecode',


### PR DESCRIPTION
Texinfo performs something like below in the middle of `build` function.  But, this doesn't install stuff through CREW_DEST_DIR and it cause problem in pre-compiled binary format.
```
  def self.build
    # installing necessary perl modules
    system 'cpan', 'install', 'CPAN', 'Locale::Messages', 'Text::Unidecode', 'Unicode::EastAsianWidth'

    # configure and make
    system './configure',
        '--with-external-Text-Unidecode',
        '--with-external-Unicode-EastAsianWidth'
    system "make"
  end
```
This PR separates those perl modules into individual packages and also changes texinfo.rb to use those packages instead of calling `cpan`.

These individual packages for perl modules are also good example to add more perl modules later.

Tested on armv7l, i686 and x86_64.