### PR TITLE
Changes to use lib64 on x86_64

### DIFF
--- a/packages/aspell.rb
+++ b/packages/aspell.rb
@@ -3,14 +3,14 @@ require 'package'
 class Aspell < Package
   description 'GNU Aspell is a Free and Open Source spell checker designed to eventually replace Ispell.'
   homepage 'http://aspell.net/'
-  version '0.60.7-rc1'
+  version '0.60.7-rc1-1'
   source_url 'ftp://alpha.gnu.org/gnu/aspell/aspell-0.60.7-rc1.tar.gz'
   source_sha256 '86b5662f24316142f70c5890787bdc5596625ca3604dfe85926ee61f27f2365e'
 
   depends_on 'ruby' unless File.exists? '/usr/local/bin/ruby'
 
   def self.build
-    system './configure'
+    system "./configure --libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 

--- a/packages/expect.rb
+++ b/packages/expect.rb
@@ -10,7 +10,7 @@ class Expect < Package
   depends_on "tcl"
 
   def self.build
-    system "./configure", "--prefix=/usr/local"
+    system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 

--- a/packages/finch.rb
+++ b/packages/finch.rb
@@ -3,34 +3,38 @@ require 'package'
 class Finch < Package
   description 'Finch is a chat program which lets you log in to accounts on multiple chat networks simultaneously.'
   homepage 'http://pidgin.im/'
-  version '2.12.0'
+  version '2.12.0-1'
   source_url 'https://downloads.sourceforge.net/project/pidgin/Pidgin/2.12.0/pidgin-2.12.0.tar.bz2'
   source_sha256 '8c3d3536d6d3c971bd433ff9946678af70a0f6aa4e6969cc2a83bb357015b7f8'
 
   depends_on 'glib'
   depends_on 'ncursesw'
   depends_on 'tcl'
+  depends_on 'perl'
+  depends_on 'gnutls'
 
   def self.build
     system "sed -i 's,/usr/include,/usr/local/include,g' configure"
-    system './configure \
-            --disable-avahi \
-            --disable-dbus \
-            --disable-gtkui \
-            --disable-nls \
-            --disable-gstreamer \
-            --disable-gstreamer-video \
-            --disable-gstreamer-interfaces \
-            --disable-idn \
-            --disable-meanwhile \
-            --disable-screensaver \
-            --disable-sm \
-            --disable-tk \
-            --disable-vv \
-            --enable-consoleui=yes \
-            --includedir=/usr/local/include \
-            --oldincludedir=/usr/local/include \
-            --without-x'
+    system './configure',
+      '--disable-avahi',
+      '--disable-dbus',
+      '--disable-gtkui',
+      '--disable-nls',
+      '--disable-gstreamer',
+      '--disable-gstreamer-video',
+      '--disable-gstreamer-interfaces',
+      '--disable-idn',
+      '--disable-meanwhile',
+      '--disable-screensaver',
+      '--disable-sm',
+      '--disable-tk',
+      '--disable-vv',
+      '--enable-consoleui=yes',
+      '--includedir=/usr/local/include',
+      '--oldincludedir=/usr/local/include',
+      "--with-tclconfig=#{CREW_LIB_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}",
+      '--without-x'
     system 'make'
   end
 

--- a/packages/finch.rb
+++ b/packages/finch.rb
@@ -30,8 +30,8 @@ class Finch < Package
       '--disable-tk',
       '--disable-vv',
       '--enable-consoleui=yes',
-      '--includedir=/usr/local/include',
-      '--oldincludedir=/usr/local/include',
+      "--includedir=#{CREW_PREFIX}/include",
+      "--oldincludedir=#{CREW_PREFIX}/include",
       "--with-tclconfig=#{CREW_LIB_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}",
       '--without-x'

--- a/packages/geoip.rb
+++ b/packages/geoip.rb
@@ -3,12 +3,12 @@ require 'package'
 class Geoip < Package
   description 'GeoIP Legacy C API.'
   homepage 'https://github.com/maxmind/geoip-api-c/'
-  version '1.6.11'
+  version '1.6.11-1'
   source_url 'https://github.com/maxmind/geoip-api-c/releases/download/v1.6.11/GeoIP-1.6.11.tar.gz'
   source_sha256 'b0e5a92200b5ab540d118983f7b7191caf4faf1ae879c44afa3ff2a2abcdb0f5'
 
   def self.build
-    system './configure'
+    system './configure', "--libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gnutls < Package
   description 'GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols and technologies around them.'
   homepage 'http://gnutls.org/'
-  version '3.5.14'
+  version '3.5.14-1'
   source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.14.tar.xz'
   source_sha256 '4aa12dec92f42a0434df794aca3d02f6f2a35b47b48c01252de65f355c051bda'
 
@@ -22,7 +22,8 @@ class Gnutls < Package
   def self.build
     system "./configure", "--enable-shared", "--disable-static", "--with-pic",
       "--with-system-priority-file=#{CREW_PREFIX}/etc/gnutls/default-priorities",
-      "--with-unbound-root-key-file=#{CREW_PREFIX}/etc/unbound/root.key"
+      "--with-unbound-root-key-file=#{CREW_PREFIX}/etc/unbound/root.key",
+      "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 

--- a/packages/libtasn1.rb
+++ b/packages/libtasn1.rb
@@ -3,18 +3,18 @@ require 'package'
 class Libtasn1 < Package
   description 'Libtasn1 is the ASN.1 library used by GnuTLS, GNU Shishi and some other packages.'
   homepage 'https://www.gnu.org/software/libtasn1/'
-  version '4.10-1'
+  version '4.10-2'
   source_url 'http://ftpmirror.gnu.org/libtasn1/libtasn1-4.10.tar.gz'
   source_sha256 '681a4d9a0d259f2125713f2e5766c5809f151b3a1392fd91390f780b4b8f5a02'
 
   # bison, diff, cmp are required at compile-time
   depends_on 'buildessential' => :build
-  depends_on 'pkgconfig' => :build
   depends_on 'bison' => :build
   depends_on 'diffutils' => :build
 
   def self.build
-    system "./configure", "--enable-shared", "--disable-static", "--with-pic", "--prefix=/usr/local"
+    system "./configure", "--enable-shared", "--disable-static", "--with-pic",
+      "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 

--- a/packages/libtool.rb
+++ b/packages/libtool.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libtool < Package
   description 'GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries behind a consistent, portable interface.'
   homepage 'https://www.gnu.org/software/libtool/'
-  version '2.4.6-1'
+  version '2.4.6-2'
   source_url 'https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz'
   source_sha256 'e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3'
 
@@ -11,7 +11,7 @@ class Libtool < Package
   depends_on 'm4'
 
   def self.build
-    system "./configure --prefix=/usr/local"
+    system "./configure", "--disable-static", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 

--- a/packages/libunistring.rb
+++ b/packages/libunistring.rb
@@ -3,14 +3,14 @@ require 'package'
 class Libunistring < Package
   description 'A library that provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.'
   homepage 'https://www.gnu.org/software/libunistring/'
-  version '0.9.7'
+  version '0.9.7-1'
   source_url 'http://ftp.gnu.org/gnu/libunistring/libunistring-0.9.7.tar.xz'
   source_sha256 '2e3764512aaf2ce598af5a38818c0ea23dedf1ff5460070d1b6cee5c3336e797'
 
   depends_on 'glibc'
 
   def self.build
-    system "./configure --prefix=/usr/local"
+    system "./configure", "--disable-static", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 

--- a/packages/libxslt.rb
+++ b/packages/libxslt.rb
@@ -3,14 +3,14 @@ require 'package'
 class Libxslt < Package
   description 'Libxslt is the XSLT C library developed for the GNOME project.'
   homepage 'http://xmlsoft.org/libxslt/'
-  version '1.1.29'
+  version '1.1.29-1'
   source_url 'http://xmlsoft.org/sources/libxslt-1.1.29.tar.gz'
   source_sha256 'b5976e3857837e7617b29f2249ebb5eeac34e249208d31f1fbf7a6ba7a4090ce'
 
   depends_on 'libxml2'
 
   def self.build
-    system "./configure CFLAGS=\" -fPIC\" --without-python"
+    system "./configure", "--without-python", "--disable-static", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 

--- a/packages/p11kit.rb
+++ b/packages/p11kit.rb
@@ -3,7 +3,7 @@ require 'package'
 class P11kit < Package
   description "Provides a standard configuration setup for installing PKCS#11 modules in such a way that they're discoverable."
   homepage 'https://p11-glue.freedesktop.org/p11-kit.html'
-  version '0.23.2-1'
+  version '0.23.2-2'
   source_url 'https://p11-glue.freedesktop.org/releases/p11-kit-0.23.2.tar.gz'
   source_sha256 'ba726ea8303c97467a33fca50ee79b7b35212964be808ecf9b145e9042fdfaf0'
 
@@ -12,7 +12,8 @@ class P11kit < Package
   depends_on 'libtasn1'
 
   def self.build
-    system "./configure", "--enable-shared", "--disable-static", "--with-pic", "--prefix=/usr/local"
+    system "./configure", "--enable-shared", "--disable-static", "--with-pic",
+      "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 

--- a/packages/trousers.rb
+++ b/packages/trousers.rb
@@ -3,7 +3,7 @@ require 'package'
 class Trousers < Package
   description 'The open-source TCG Software Stack.'
   homepage 'http://trousers.sourceforge.net/'
-  version '0.3.14'
+  version '0.3.14-1'
   source_url 'https://downloads.sourceforge.net/project/trousers/trousers/0.3.14/trousers-0.3.14.tar.gz'
   source_sha256 'ce50713a261d14b735ec9ccd97609f0ad5ce69540af560e8c3ce9eb5f2d28f47'
 
@@ -12,7 +12,8 @@ class Trousers < Package
   depends_on 'pkgconfig'
 
   def self.build
-    system './configure --prefix=/usr/local --with-gui=none'
+    system "./configure", "--disable-static", "--with-gui=none",
+      "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 


### PR DESCRIPTION
This is try-again PR of #1043.  It was marked as merged although it is not merged yet.

From Chrome OS 60, google decides to not put `/usr/local/lib` to LD_LIBRARY_PATH.  It contains only `/usr/local/lib64` now.  This PR is trying to prepare for that.  Chrome 60 is on beta channel and it will be available stable channel soon.

This PR moves library from `/usr/local/lib` to `/usr/local/lib64` using `CREW_LIB_PREFIX` to not cause any conflicts on i686 or armv7l.  This PR also disable making static libraries.

Tested on armv7l and x86_64.