### PR TITLE
Update tig from 2.2.1 to 2.2.2

### DIFF
--- a/packages/tig.rb
+++ b/packages/tig.rb
@@ -3,10 +3,11 @@ require 'package'
 class Tig < Package
   description 'Tig is an ncurses-based text-mode interface for git.'
   homepage 'http://jonas.nitro.dk/tig/'
-  version '2.2.1'
-  source_url 'https://github.com/jonas/tig/archive/tig-2.2.1.tar.gz'
-  source_sha256 '92d96635068d779df58aea3fbfa86c5869e39c11c7868d5b3d62229360b5336f'
+  version '2.2.2'
+  source_url 'https://github.com/jonas/tig/archive/tig-2.2.2.tar.gz'
+  source_sha256 '01a8e3ceb7aab9fd6298eccd6349cb7e813c4fc396d0da41e8c48edf6570c487'
 
+  depends_on 'automake'
   depends_on 'readline'
   depends_on 'ncurses'
 


### PR DESCRIPTION
General bugfix release. Tested as working on XE500C13-K01US.