### PR TITLE
Update libtiff from 4.0.7-1 to 4.0.8

### DIFF
--- a/packages/libtiff.rb
+++ b/packages/libtiff.rb
@@ -3,9 +3,9 @@ require 'package'
 class Libtiff < Package
   description 'LibTIFF provides support for the Tag Image File Format (TIFF), a widely used format for storing image data.'
   homepage 'http://www.libtiff.org/'
-  version '4.0.7-1'
-  source_url 'ftp://download.osgeo.org/libtiff/tiff-4.0.7.tar.gz'
-  source_sha256 '9f43a2cfb9589e5cecaa66e16bf87f814c945f22df7ba600d63aac4632c4f019'
+  version '4.0.8'
+  source_url 'ftp://download.osgeo.org/libtiff/tiff-4.0.8.tar.gz'
+  source_sha256 '59d7a5a8ccd92059913f246877db95a2918e6c04fb9d43fd74e5c3390dac2910'
 
   def self.build
     system "./configure CFLAGS=\" -fPIC\""


### PR DESCRIPTION
General bugfix and maintenance release. Tested as working on XE500C13-K01US.