### PR TITLE
Update libunwind from 1.2 to 1.2.1

### DIFF
--- a/packages/libunwind.rb
+++ b/packages/libunwind.rb
@@ -3,9 +3,9 @@ require 'package'
 class Libunwind < Package
   description 'libunwind is a portable and efficient C programming interface (API) to determine the call-chain of a program.'
   homepage 'http://www.nongnu.org/libunwind/'
-  version '1.2'
-  source_url 'http://download.savannah.gnu.org/releases/libunwind/libunwind-1.2.tar.gz'
-  source_sha256 '1de38ffbdc88bd694d10081865871cd2bfbb02ad8ef9e1606aee18d65532b992'
+  version '1.2.1'
+  source_url 'http://download.savannah.gnu.org/releases/libunwind/libunwind-1.2.1.tar.gz'
+  source_sha256 '3f3ecb90e28cbe53fba7a4a27ccce7aad188d3210bb1964a923a731a27a75acb'
 
   depends_on 'buildessential' => :build
   depends_on 'openssl' => :build


### PR DESCRIPTION
Includes minor package fixes for tilegx, mips, others.

Tested as working on XE500C13-K01US.