### PR TITLE
Update unrar from 5.4.5 to 5.5.7

### DIFF
--- a/packages/unrar.rb
+++ b/packages/unrar.rb
@@ -3,14 +3,11 @@ require 'package'
 class Unrar < Package
   description 'UnRAR is a powerful archive extractor.'
   homepage 'http://www.rarlab.com/'
-  version '5.4.5'
-  source_url 'http://www.rarlab.com/rar/unrarsrc-5.4.5.tar.gz'
-  source_sha256 'e470c584332422893fb52e049f2cbd99e24dc6c6da971008b4e2ae4284f8796c'
+  version '5.5.7'
+  source_url 'http://www.rarlab.com/rar/unrarsrc-5.5.7.tar.gz'
+  source_sha256 '8aef0a0d91bf9c9ac48fab8a26049ac7ac49907e75a2dcbd511a4ba375322d8f'
 
   def self.build
-    system "sed -i '145s,$,/libunrar.so,' makefile" # fix naming mistake
-    system "sed -i '145s,install,install -D,' makefile" # create directory
-
     # force to compile in sequential since unrar Makefile doesn't work in parallel
     system "make", "-j1", "all"
     system "make", "-j1", "lib"


### PR DESCRIPTION
General bugfix and maintenance release. Running ```unrar``` with no arguments
does report incorrect version but this is an upstream bug and does not impact
functionality.

Tested as working on XE500C13-K01US.