### PR TITLE
Update sqlite from 3.18.0-1 to 3.20.0

### DIFF
--- a/packages/sqlite.rb
+++ b/packages/sqlite.rb
@@ -3,9 +3,9 @@ require 'package'
 class Sqlite < Package
   description 'SQLite is a self-contained, high-reliability, embedded, full-featured, public-domain, SQL database engine.'
   homepage 'http://www.sqlite.org/'
-  version '3.18.0-1'
-  source_url 'https://www.sqlite.org/2017/sqlite-autoconf-3180000.tar.gz'
-  source_sha256 '3757612463976e7d08c5e9f0af3021613fc24bbcfe1c51197d6776b9ece9ac5c'
+  version '3.20.0'
+  source_url 'https://www.sqlite.org/2017/sqlite-autoconf-3200000.tar.gz'
+  source_sha256 '3814c6f629ff93968b2b37a70497cfe98b366bf587a2261a56a5f750af6ae6a0'
 
   def self.build
     system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--disable-static", "--enable-shared", "--with-pic"


### PR DESCRIPTION
This is a general bugfix and maintenance release. Release notes claim a 2% query
performance increase.

Tested as working on XE500C13-K01US.