### PR TITLE
Update libxslt from 1.1.28-1 to 1.1.29

### DIFF
--- a/packages/libxslt.rb
+++ b/packages/libxslt.rb
@@ -3,9 +3,9 @@ require 'package'
 class Libxslt < Package
   description 'Libxslt is the XSLT C library developed for the GNOME project.'
   homepage 'http://xmlsoft.org/libxslt/'
-  version '1.1.28-1'
-  source_url 'http://xmlsoft.org/sources/libxslt-1.1.28.tar.gz'
-  source_sha256 '5fc7151a57b89c03d7b825df5a0fae0a8d5f05674c0e7cf2937ecec4d54a028c'
+  version '1.1.29'
+  source_url 'http://xmlsoft.org/sources/libxslt-1.1.29.tar.gz'
+  source_sha256 'b5976e3857837e7617b29f2249ebb5eeac34e249208d31f1fbf7a6ba7a4090ce'
 
   depends_on 'libxml2'
 


### PR DESCRIPTION
This is a general maintenance and bugfix release.

Tested as working on XE500C13-K01US.