### PR TITLE
Update screen from 4.3.1 to 4.6.1

### DIFF
--- a/packages/screen.rb
+++ b/packages/screen.rb
@@ -3,9 +3,9 @@ require 'package'
 class Screen < Package
   description 'Screen is a full-screen window manager that multiplexes a physical terminal between several processes, typically interactive shells.'
   homepage 'https://www.gnu.org/software/screen/'
-  version '4.3.1'
-  source_url 'ftp://ftp.gnu.org/gnu/screen/screen-4.3.1.tar.gz'
-  source_sha256 'fa4049f8aee283de62e283d427f2cfd35d6c369b40f7f45f947dbfd915699d63'
+  version '4.6.1'
+  source_url 'ftp://ftp.gnu.org/gnu/screen/screen-4.6.1.tar.gz'
+  source_sha256 'aba9af66cb626155d6abce4703f45cce0e30a5114a368bd6387c966cbbbb7c64'
 
   depends_on 'ncurses'
 


### PR DESCRIPTION
This release includes a security patch resolving CVE-2017-5618 in addition to
fixing several issues with coredumps. It's recommended that everyone update.

Tested as working on XE500C13-K01US.