### PR TITLE
Change valgrind.rb to make it work on arm

### DIFF
--- a/packages/valgrind.rb
+++ b/packages/valgrind.rb
@@ -58,7 +58,7 @@ class Valgrind < Package
  
  #  elif defined(VGP_arm64_linux)
 EOF'
-    system './configure --prefix=/usr/local'
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 

--- a/packages/valgrind.rb
+++ b/packages/valgrind.rb
@@ -3,7 +3,7 @@ require 'package'
 class Valgrind < Package
   description 'Valgrind is an instrumentation framework for building dynamic analysis tools.'
   homepage 'http://valgrind.org/'
-  version '3.13.0-1'
+  version '3.13.0-2'
   source_url 'ftp://sourceware.org/pub/valgrind/valgrind-3.13.0.tar.bz2'
   source_sha256 'd76680ef03f00cd5e970bbdcd4e57fb1f6df7d2e2c071635ef2be74790190c3b'
 
@@ -13,7 +13,7 @@ class Valgrind < Package
     system 'patch -p0 << EOF
 --- coregrind/m_redir.c
 +++ coregrind/m_redir.c
-@@ -1214,9 +1214,11 @@
+@@ -1340,9 +1340,11 @@
        add_hardwired_spec(
           "ld-linux.so.2", "index",
           (Addr)&VG_(x86_linux_REDIR_FOR_index), mandatory);
@@ -23,26 +23,41 @@ class Valgrind < Package
           (Addr)&VG_(x86_linux_REDIR_FOR_strlen), mandatory);
 +#endif
     }
-
+ 
  #  elif defined(VGP_amd64_linux)
-@@ -1238,6 +1240,7 @@
-       the start, otherwise ld.so makes a lot of noise. */
-    if (0==VG_(strcmp)("Memcheck", VG_(details).name)) {
-
+@@ -1367,6 +1369,7 @@
+       add_hardwired_spec(
+          "ld-linux-x86-64.so.2", "index",
+          (Addr)&VG_(amd64_linux_REDIR_FOR_index), NULL);
 +#if CI_HACK_strlen
        add_hardwired_spec(
           "ld-linux-x86-64.so.2", "strlen",
           (Addr)&VG_(amd64_linux_REDIR_FOR_strlen),
-@@ -1251,6 +1254,8 @@
+@@ -1378,6 +1381,7 @@
           complain_about_stripped_glibc_ldso
  #        endif
+       );   
++#endif
+    }
+ 
+ #  elif defined(VGP_ppc32_linux)
+@@ -1452,6 +1456,7 @@
+       distros, ld.so\'s soname is ld-linux.so.3, but Ubuntu 14.04 on
+       Odroid uses ld-linux-armhf.so.3 for some reason. */
+    if (0==VG_(strcmp)("Memcheck", VG_(details).name)) {
++#if CI_HACK_strlen
+       /* strlen */
+       add_hardwired_spec(
+          "ld-linux.so.3", "strlen",
+@@ -1485,6 +1490,7 @@
+          (Addr)&VG_(arm_linux_REDIR_FOR_strcmp),
+          complain_about_stripped_glibc_ldso
        );
 +#endif
-+
     }
-
- #  elif defined(VGP_ppc32_linux)
- EOF'
+ 
+ #  elif defined(VGP_arm64_linux)
+EOF'
     system './configure --prefix=/usr/local'
     system 'make'
   end


### PR DESCRIPTION
In #959, @yancouto showed how to fix valgind for x86_64 and i686.  This PR applies similar techniques to armv7l.  This fixes valgrind on armv7l also.

Tested on armv7l, i686, x86_64.