### PR TITLE
Change scrollz to disable the use of termcap library

### DIFF
--- a/packages/scrollz.rb
+++ b/packages/scrollz.rb
@@ -13,7 +13,9 @@ class Scrollz < Package
   def self.build
     # Scrollz prefers termcap over ncurses, but scrollz doesn't work our termcap
     # because of link errors.  This configure option prohibits choosing termcap.
-    system "CFLAGS=-I/usr/local/include/ncurses ./configure ac_cv_header_termcap_h=no ac_cv_lib_termcap_tgetent=no"
+    system "CFLAGS=-I#{CREW_PREFIX}/include/ncurses " \
+      "./configure --prefix=#{CREW_PREFIX} " \
+      "ac_cv_header_termcap_h=no ac_cv_lib_termcap_tgetent=no"
     system "make"
   end
 

--- a/packages/scrollz.rb
+++ b/packages/scrollz.rb
@@ -3,7 +3,7 @@ require 'package'
 class Scrollz < Package
   description 'ScrollZ is an advanced IRC client based on ircII.'
   homepage 'http://www.scrollz.info/'
-  version '2.3'
+  version '2.3-1'
   source_url 'http://www.scrollz.info/download/ScrollZ-2.3.tar.gz'
   source_sha256 '22535bcc54ad752107ab181775d90d9cf1b37648f500d627f428388a9d3710e6'
 
@@ -11,7 +11,9 @@ class Scrollz < Package
   depends_on 'ncurses'
 
   def self.build
-    system "CFLAGS=-I/usr/local/include/ncurses ./configure"
+    # Scrollz prefers termcap over ncurses, but scrollz doesn't work our termcap
+    # because of link errors.  This configure option prohibits choosing termcap.
+    system "CFLAGS=-I/usr/local/include/ncurses ./configure ac_cv_header_termcap_h=no ac_cv_lib_termcap_tgetent=no"
     system "make"
   end
 


### PR DESCRIPTION
If both of `termcap` and `ncurses` are installed on the system, `scrollz` prefer to use `termcap`.  However, it doesn't work with our `termcap` library.  So, users need to uninstall `termcap` by hand.

This PR modifies the way of configuration to make `scrollz` use only `ncurses` event `termcap` is installed.

Tested on armv7l and x86_64.