### PR TITLE
Modify crew to add postinstall function

### DIFF
--- a/crew
+++ b/crew
@@ -424,6 +424,13 @@ def build_and_preconfigure (target_dir)
   end
 end
 
+def post_install (target_dir)
+  Dir.chdir target_dir do
+    puts "Performing post-install..."
+    @pkg.postinstall
+  end
+end
+
 def compress_doc (dir)
   # check whether crew should compress
   return if CREW_NOT_COMPRESS || !File.exist?("#{CREW_PREFIX}/bin/compressdoc")
@@ -609,6 +616,9 @@ def install
     puts "Installing..."
     install_package dest_dir
   end
+
+  # perform post-install process
+  post_install target_dir
 
   #add to installed packages
   @device[:installed_packages].push(name: @pkg.name, version: @pkg.version)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -69,10 +69,23 @@ class Package
     @is_fake
   end
 
+  # Function to perform build from source.
   def self.build
 
   end
 
+  # Function to perform install from source build.
+  def self.install
+
+  end
+
+  # Function to perform post-install for all even if it is a fake package.
+  def self.postinstall
+
+  end
+
+  # Function to perform check from source build.
+  # This is execute if and only if `crew build`.
   def self.check
 
   end


### PR DESCRIPTION
This PR adds postinstall function to crew to solve 1st problem described in https://github.com/skycocker/chromebrew/issues/1082#issuecomment-323236206.

Using this PR, what we have in one of package:
```
  def self.install
    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
    puts
    puts "To complete installation, execute the following:".lightblue
    puts "echo '# bash completion' >> ~/.bashrc".lightblue
    puts "echo '[[ $PS1 && -f /usr/local/share/bash-completion/bash_completion ]] && \\' >> ~/.bashrc".lightblue
    puts "echo '. /usr/local/share/bash-completion/bash_completion' >> ~/.bashrc".lightblue
    puts "source ~/.bashrc".lightblue
    puts
  end
```
can be modified like
```
  def self.install
    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
  end

  # this postinstall part is executed for both source and binary installations
  def self.postinstall
    puts
    puts "To complete installation, execute the following:".lightblue
    puts "echo '# bash completion' >> ~/.bashrc".lightblue
    puts "echo '[[ $PS1 && -f /usr/local/share/bash-completion/bash_completion ]] && \\' >> ~/.bashrc".lightblue
    puts "echo '. /usr/local/share/bash-completion/bash_completion' >> ~/.bashrc".lightblue
    puts "source ~/.bashrc".lightblue
    puts
  end
```
This postinstall part is executed for not only compile-from-source but also install-from-binary-distribution.  So we don't miss these guide messages.