### PR TITLE
Change expect to increment version number.

### DIFF
--- a/packages/expect.rb
+++ b/packages/expect.rb
@@ -3,7 +3,7 @@ require 'package'
 class Expect < Package
   description 'Expect is a tool for automating interactive applications such as telnet, ftp, passwd, fsck, rlogin, tip, etc.'
   homepage 'http://expect.sourceforge.net/'
-  version '5.45-1'
+  version '5.45-2'
   source_url 'http://prdownloads.sourceforge.net/expect/expect5.45.tar.gz'
   source_sha256 'b28dca90428a3b30e650525cdc16255d76bb6ccd65d448be53e620d95d5cc040'
 


### PR DESCRIPTION
I forgot to increment the version number of `expect.rb` at #1078.

#1078 changes its library directory on x86_64 from `/usr/local/lib` to `/usr/local/lib64`.  So, upgrade is required.  However, crew doesn't upgrade it without the modifications of version number.  This PR solves that problem.