### PR TITLE
Add asciidoc package

### DIFF
--- a/packages/asciidoc.rb
+++ b/packages/asciidoc.rb
@@ -12,13 +12,13 @@ class Asciidoc < Package
 
   def self.build
     system "autoconf"
-    system "mkdir -p #{CREW_DEST_PREFIX}/etc/vim"
-    system "sed -i 's,/etc/vim,#{CREW_DEST_PREFIX}/etc/vim,g' Makefile.in"
+    system "sed -i 's,/etc/vim,#{CREW_PREFIX}/etc/vim,g' Makefile.in"
     system "./configure"
     system "make"
   end
 
   def self.install
+    system "mkdir -p #{CREW_DEST_PREFIX}/etc/vim"
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 end

--- a/packages/asciidoc.rb
+++ b/packages/asciidoc.rb
@@ -12,7 +12,8 @@ class Asciidoc < Package
 
   def self.build
     system "autoconf"
-    system "sed -i 's,/etc/vim,#{CREW_PREFIX}/etc/vim,g' Makefile.in"
+    system "mkdir -p #{CREW_DEST_PREFIX}/etc/vim"
+    system "sed -i 's,/etc/vim,#{CREW_DEST_PREFIX}/etc/vim,g' Makefile.in"
     system "./configure"
     system "make"
   end

--- a/packages/asciidoc.rb
+++ b/packages/asciidoc.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Asciidoc < Package
+  description 'AsciiDoc is a presentable text document format for writing articles, UNIX man pages and other small to medium sized documents.'
+  homepage 'http://asciidoc.org/'
+  version '8.6.8'
+  source_url 'https://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.8/asciidoc-8.6.8.tar.gz'
+  source_sha256 'ffb67f59dccaf6f15db72fcd04fdf21a2f9b703d31f94fcd0c49a424a9fcfbc4'
+
+  depends_on 'autoconf'
+  depends_on 'python27' unless File.exists? "#{CREW_PREFIX}/bin/python"
+
+  def self.build
+    system "autoconf"
+    system "sed -i 's,/etc/vim,#{CREW_PREFIX}/etc/vim,g' Makefile.in"
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end
+


### PR DESCRIPTION
AsciiDoc is a text document format for writing notes, documentation, articles, books, ebooks, slideshows, web pages, man pages and blogs. AsciiDoc files can be translated to many formats including HTML, PDF, EPUB, man page.  See http://asciidoc.org/.