### PR TITLE
Update sshfs from 2.8 to 2.10

### DIFF
--- a/packages/sshfs.rb
+++ b/packages/sshfs.rb
@@ -3,9 +3,9 @@ require 'package'
 class Sshfs < Package
   description 'A network filesystem client to connect to SSH servers.'
   homepage 'https://github.com/libfuse/sshfs'
-  version '2.8'
-  source_url 'https://github.com/libfuse/sshfs/releases/download/sshfs_2.8/sshfs-2.8.tar.gz'
-  source_sha256 '7f689174d02e6b7e2631306fda4fb8e6b4483102d1bce82b3cdafba33369ad22'
+  version '2.10'
+  source_url 'https://github.com/libfuse/sshfs/releases/download/sshfs-2.10/sshfs-2.10.tar.gz'
+  source_sha256 '70845dde2d70606aa207db5edfe878e266f9c193f1956dd10ba1b7e9a3c8d101'
 
   depends_on 'glib'
   depends_on 'fuse'


### PR DESCRIPTION
This is a bugfix and general maintenance release.

The project recommends updating to the 3.x line which requires updates to fuse
as well as creating packages for the meson build system and adding ninja as a
dependency at build time. This update will be forthcoming as I have time or
someone else tackles this.

Tested as working on XE500C13-K01US.