### PR TITLE
Add units package

### DIFF
--- a/packages/units.rb
+++ b/packages/units.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Units < Package
+  description 'GNU Units converts quantities expressed in various systems of measurement to their equivalents in other systems of measurement.'
+  homepage 'https://www.gnu.org/software/units/units.html'
+  version '2.14'
+  source_url 'https://ftp.gnu.org/gnu/units/units-2.14.tar.gz'
+  source_sha256 '9d33893d82f3ddd831d5822992007c40bcd0826ae67d3cbc96539951fb0a82e8'
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
GNU Units converts quantities expressed in various systems of measurement to their equivalents in other systems of measurement. Like many similar programs, it can handle multiplicative scale changes. It can also handle nonlinear conversions such as Fahrenheit to Celsius or wire gauge, and it can convert from and to sums of units, such as converting between meters and feet plus inches.

Beyond simple unit conversions, GNU Units can be used as a general-purpose scientific calculator that keeps track of units in its calculations. You can form arbitrary complex mathematical expressions of dimensions including sums, products, quotients, powers, and even roots of dimensions. Thus you can ensure accuracy and dimensional consistency when working with long expressions that involve many different units that may combine in complex ways.

The units are defined in an external data file. You can use the extensive data file that comes with this program, or you can provide your own data file to suit your needs. You can also use your own data file to supplement the standard data file.

Examples

Two simple conversion examples:

You have: mile
You want: km
        * 1.609344
        / 0.62137119

You have: furlongs per fortnight
You want: m/s  
        * 0.00016630986
        / 6012.8727

See https://www.gnu.org/software/units/units.html.