### PR TITLE
PHP 5 or 7 don't seem to work without the version 7.0 of readline now

### DIFF
--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -15,7 +15,7 @@ class Php5 < Package
   depends_on 'openssl'
   depends_on 'curl'
   depends_on 'pcre'
-  depends_on 'readline'
+  depends_on 'readline7'
 
   def self.build
     system './configure \

--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -15,7 +15,7 @@ class Php7 < Package
   depends_on 'openssl'
   depends_on 'curl'
   depends_on 'pcre'
-  depends_on 'readline'
+  depends_on 'readline7'
 
   def self.build
     system './configure \


### PR DESCRIPTION
I don't remember why there's a readline and a readline7 package. but readline is 6.x and php5 and php7 (at least from the new amazing binary packages) don't seem to work without readline 7.x

Once that's installed all works well.

Otherwise php complains about not being able to find "libreadline.so.7"

opinions on this fix, or readline's two versions are much appreciated.
