### PR TITLE
Fix perl, php5 and php7

### DIFF
--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -8,8 +8,16 @@ class Perl < Package
   source_sha256 'e6c185c9b09bdb3f1b13f678999050c639859a7ef39c8cad418448075f5918af'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '98a97e66b1bef91a97654675197141b4c2b25990b2ba17465ff33d98a494c521',
+     armv7l: '98a97e66b1bef91a97654675197141b4c2b25990b2ba17465ff33d98a494c521',
+       i686: '04930ee73e84e5df65c759e9b9b7be1f956c3c99cdc34dc74b504088d6b73021',
+     x86_64: '4f436341733c7230bfd843349a0737fd910e2762ff3f990ef976b466c305b930',
   })
 
   depends_on 'patch' => :build

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -3,21 +3,13 @@ require 'package'
 class Perl < Package
   description 'Perl 5 is a highly capable, feature-rich programming language with over 29 years of development.'
   homepage 'https://www.perl.org/'
-  version '5.24.1-2'
+  version '5.24.1-3'
   source_url 'http://www.cpan.org/src/5.0/perl-5.24.1.tar.gz'
   source_sha256 'e6c185c9b09bdb3f1b13f678999050c639859a7ef39c8cad418448075f5918af'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'fe79dbe04afeddb1fe5f05aeaad6a5cad2cc7ebe5bebb81c0fa0adb6b3dc832a',
-     armv7l: 'fe79dbe04afeddb1fe5f05aeaad6a5cad2cc7ebe5bebb81c0fa0adb6b3dc832a',
-       i686: '3c00ae12d21edea1d4c97f35730c6047c1efcb286ffbaf80f06ba73f83151229',
-     x86_64: 'cdd728843bda0e1cdac2024ca6fd534e2ab167fefcd636a73b2aa2453b1c382e',
   })
 
   depends_on 'patch' => :build

--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -8,8 +8,16 @@ class Php5 < Package
   source_sha256 'c464af61240a9b7729fabe0314cdbdd5a000a4f0c9bd201f89f8628732fe4ae4'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.31-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.31-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.31-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.31-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '0e4862b4afb8c8846e462ce77f88e01d2bb3853fc108844ad48f2113045b6b50',
+     armv7l: '0e4862b4afb8c8846e462ce77f88e01d2bb3853fc108844ad48f2113045b6b50',
+       i686: 'f1527a845d79ea3a689f80198938ee4e26e2236766442040166a8fb45c61c72c',
+     x86_64: 'aefef7c188611a259d15500ecd9ebd6a5b91fa5d266e8659e6ac7b13c400d154',
   })
 
   depends_on 'pkgconfig'

--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -3,21 +3,13 @@ require 'package'
 class Php5 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.31'
+  version '5.6.31-1'
   source_url 'http://php.net/distributions/php-5.6.31.tar.xz'
   source_sha256 'c464af61240a9b7729fabe0314cdbdd5a000a4f0c9bd201f89f8628732fe4ae4'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.31-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.31-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.31-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.31-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'aeca560c546742d3204b65148f3a8da748e4f3228e3e24a9d8779ce8e44195dd',
-     armv7l: 'aeca560c546742d3204b65148f3a8da748e4f3228e3e24a9d8779ce8e44195dd',
-       i686: '88423ffa51e79a7377bb85c94600513428d2f0505d1fa6522598a678c6546666',
-     x86_64: '10a66b8ebe73dfd60f8c194664746330274c033564259f345c802de173c88cf7',
   })
 
   depends_on 'pkgconfig'

--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -8,8 +8,16 @@ class Php7 < Package
   source_sha256 '8943858738604acb33ecedb865d6c4051eeffe4e2d06f3a3c8f794daccaa2aab'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f16f0456a071bc67d8f52d822b8a854e7e73903bad3b91bec87101f5ab8bb61f',
+     armv7l: 'f16f0456a071bc67d8f52d822b8a854e7e73903bad3b91bec87101f5ab8bb61f',
+       i686: '873824cdb85932a082fca7ab4e81eeed39ec03cff1621ee650e61892afff2490',
+     x86_64: 'b39ae5ea701573c27022ce0838b1cf64302b502ed8b54b3845ffd4793a99e82b',
   })
 
   depends_on 'pkgconfig'

--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -3,21 +3,13 @@ require 'package'
 class Php7 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.1.8'
+  version '7.1.8-1'
   source_url 'https://php.net/distributions/php-7.1.8.tar.xz'
   source_sha256 '8943858738604acb33ecedb865d6c4051eeffe4e2d06f3a3c8f794daccaa2aab'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '189dd7432d81613f46c36df7e833308fa4c4dfd42930fbb8ee259c7e5acdd2bc',
-     armv7l: '189dd7432d81613f46c36df7e833308fa4c4dfd42930fbb8ee259c7e5acdd2bc',
-       i686: 'e7af55ce2d1330b2078259e67a6437ff08b78134b5db7c2acb919265eb8bf02a',
-     x86_64: '0ed419400ca523f36d428e0aa778813274d4faf7554a5fcf3eab2d811c031414',
   })
 
   depends_on 'pkgconfig'


### PR DESCRIPTION
This PR update pre-compiled binary files for perl, php5 and php7 to fix following problems.

 - perl: The version number of source and pre-compiled binary is not matched.  So, this PR bump version number again and provides correct versioned pre-compiled binary files.
 - php5 and php7: The pre-compiled binary for x86_64 depends on readline7 instead of readline6 as described in #1149.

Tested on armv7l, i686 and x86_64.