### PR TITLE
Update postinstall process

### DIFF
--- a/crew
+++ b/crew
@@ -424,8 +424,8 @@ def build_and_preconfigure (target_dir)
   end
 end
 
-def post_install (target_dir)
-  Dir.chdir target_dir do
+def post_install (dest_dir)
+  Dir.chdir dest_dir do
     puts "Performing post-install..."
     @pkg.postinstall
   end
@@ -617,7 +617,7 @@ def install
     install_package dest_dir
 
     # perform post-install process
-    post_install target_dir
+    post_install dest_dir
   end
 	
   #add to installed packages

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -79,7 +79,7 @@ class Package
 
   end
 
-  # Function to perform post-install for all even if it is a fake package.
+  # Function to perform post-install for both source build and binary distribution
   def self.postinstall
 
   end


### PR DESCRIPTION
This PR modifies following two points to help postinstall process development.

1. Change working directory of postinstall process to DESTDIR for source build or extracted dir for binary distribution.  So, the contents of working directory are identical for both cases source build and pre-built binary distribution.  This modification is for the ease of development.
2. Change comments in lib/packages.rb file.

Tested on armv7l.