### PR TITLE
Update elixir from 1.5.0 to 1.5.1

### DIFF
--- a/packages/elixir.rb
+++ b/packages/elixir.rb
@@ -3,21 +3,13 @@ require 'package'
 class Elixir < Package
   description 'Elixir is a dynamic, functional language designed for building scalable and maintainable applications.'
   homepage 'http://elixir-lang.org/'
-  version '1.5.0'
-  source_url 'https://github.com/elixir-lang/elixir/releases/download/v1.5.0/Precompiled.zip'
-  source_sha256 '01841d8f973e10ea2e8e29342193063efb5ebe2c598c21dc8a3b93ec8428466a'
+  version '1.5.1'
+  source_url 'https://github.com/elixir-lang/elixir/releases/download/v1.5.1/Precompiled.zip'
+  source_sha256 '84af6eb4cb68d0f60b3edf4e275eb024f8eb8cccae91b18c2bbbc4b70a88934f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'a458311760be3d9ea9f16bfdf2e046fa791afca94e15bd9b0852271403ccef8d',
-     armv7l: 'a458311760be3d9ea9f16bfdf2e046fa791afca94e15bd9b0852271403ccef8d',
-       i686: '948d4aa81a02fd1bd16dbecce969005235beba009d508bf9da852ab765805d98',
-     x86_64: 'f3dac90e7051c6c44ea2c6e0a0dad962efcbe05925718fba1c638d196da5f7f3',
   })
 
   depends_on 'erlang'


### PR DESCRIPTION
This is a general bugfix and maintenance release.

Tested as working on XE500C13-K01US.