### PR TITLE
Update libuv from 1.9.1 to 1.14.0

### DIFF
--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -3,24 +3,18 @@ require 'package'
 class Libuv < Package
   description 'libuv is a multi-platform support library with a focus on asynchronous I/O.'
   homepage 'http://libuv.org/'
-  version '1.9.1'
-  source_url 'http://dist.libuv.org/dist/v1.9.1/libuv-v1.9.1.tar.gz'
-  source_sha256 'e83953782c916d7822ef0b94e8115ce5756fab5300cca173f0de5f5b0e0ae928'
+  version '1.14.0'
+  source_url 'https://dist.libuv.org/dist/v1.14.0/libuv-v1.14.0.tar.gz'
+  source_sha256 '7267f1564fc6bd84e1721ad7e3cdd7b5da06faab9fa09522f33589dc08d3edf9'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.9.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.9.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.9.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.9.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '4f39008b460b6762a5d0d535124bca9825be1e42a7919006f2be63dc38dee0e8',
-     armv7l: '4f39008b460b6762a5d0d535124bca9825be1e42a7919006f2be63dc38dee0e8',
-       i686: '1db5d574b282aaee557f6b062f290cf48989e839c3b6b2bb6ddcb9fea1ce57ee',
-     x86_64: 'ede50a331c2baa80058efcfe2ac83fc3f5ff6c4a6f985148a6f6d32f95154a71',
   })
 
+  depends_on 'automake'
   depends_on 'glibc'
+  depends_on 'libtool'
 
   def self.build
     system './autogen.sh'


### PR DESCRIPTION
This is a general bugfix and maintenance release.

Tested as working on XE500C13-K01US.

This also adds two missing dependencies: automake and libtool.