### PR TITLE
Update screenfetch from 3.7.0 to 3.8.0

### DIFF
--- a/packages/screenfetch.rb
+++ b/packages/screenfetch.rb
@@ -3,28 +3,20 @@ require 'package'
 class Screenfetch < Package
   description 'Fetches system/theme information in terminal for Linux desktop screenshots.'
   homepage 'https://github.com/KittyKatt/screenFetch'
-  version '3.7.0'
-  source_url 'https://github.com/KittyKatt/screenFetch/archive/v3.7.0.tar.gz'
-  source_sha256 '6711fe924833919d53c1dfbbb43f3777d33e20357a1b1536c4472f6a1b3c6be0'
+  version '3.8.0'
+  source_url 'https://github.com/KittyKatt/screenFetch/archive/v3.8.0.tar.gz'
+  source_sha256 '248283ee3c24b0dbffb79ed685bdd518554073090c1c167d07ad2a729db26633'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/screenfetch-3.7.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/screenfetch-3.7.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/screenfetch-3.7.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/screenfetch-3.7.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'ae230a5057261354e7ff68120509b9fa4792b5af22b5652d313b00e54b9cdbca',
-     armv7l: 'ae230a5057261354e7ff68120509b9fa4792b5af22b5652d313b00e54b9cdbca',
-       i686: '07ed19dfd9ca9cd1aa10f8344c35bd898dda10c830c03b41aaa9a900a6765e72',
-     x86_64: 'b362fecc330686e6cf334a1ecc2a33f79b19add1d266200ad1d0ff78c4243693',
   })
 
   def self.build
   end
 
   def self.install
-    system "install -D screenfetch-dev #{CREW_DEST_DIR}/usr/local/bin/screenfetch"
-    system "install -D screenfetch.1 #{CREW_DEST_DIR}/usr/local/man/man1/screenfetch.1"
+    system "install -D screenfetch-dev #{CREW_DEST_PREFIX}/bin/screenfetch"
+    system "install -D screenfetch.1 #{CREW_DEST_PREFIX}/man/man1/screenfetch.1"
   end
 end


### PR DESCRIPTION
This is a general maintenance and bugfix release.

Tested as working on XE500C13-K01US.