### PR TITLE
Update vifm from 0.8.2 to 0.9

### DIFF
--- a/packages/vifm.rb
+++ b/packages/vifm.rb
@@ -3,33 +3,25 @@ require 'package'
 class Vifm < Package
   description 'Vifm is an ncurses based file manager with vi like keybindings/modes/options/commands/configuration, which also borrows some useful ideas from mutt.'
   homepage 'https://vifm.info/'
-  version '0.8.2'
-  source_url 'https://downloads.sourceforge.net/project/vifm/vifm/vifm-0.8.2.tar.bz2'
-  source_sha256 '8b466d766658a24d07fc2039a26fefc6a018f5653684a6035183ca79f02c211f'
+  version '0.9'
+  source_url 'https://downloads.sourceforge.net/project/vifm/vifm/vifm-0.9.tar.bz2'
+  source_sha256 'ab10c99d1e4c24ff8a03c20be1c202cc15874750cc47a1614e6fe4f8d816a7fd'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vifm-0.8.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vifm-0.8.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vifm-0.8.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vifm-0.8.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd40d9b2183d4e6f80febbc92baf43dc51d8843653a86988e9dbcd8834fc0d54c',
-     armv7l: 'd40d9b2183d4e6f80febbc92baf43dc51d8843653a86988e9dbcd8834fc0d54c',
-       i686: '0bfec14d7486442fd2878619cf3915adef6a23a15a2d0ce524ec504a51e35d3f',
-     x86_64: '4075037bc91bed7149b8cb4adfd5ca1688e88e971c6cf25d95df85531602b6b5',
   })
 
   depends_on 'ncurses'
 
   def self.build
     system "./configure", \
-	   "--prefix=/usr/local", \
+	   "--prefix=#{CREW_PREFIX}", \
 	   "--without-gtk", \
 	   "--without-X11", \
-	   #"--with-curses=/usr/local/include/ncursesw" \
+	   #"--with-curses=#{CREW_PREFIX}/include/ncursesw" \
 	   #"--with-curses-name=ncursesw" \
-	   "CPPFLAGS=-I/usr/local/include/ncursesw"
+	   "CPPFLAGS=-I#{CREW_PREFIX}/include/ncursesw"
     system "make"
   end
 


### PR DESCRIPTION
This is a general bugfix and maintenance release.

Tested as working on XE500C13-K01US.