### PR TITLE
Fixing cbase and misctool links

### DIFF
--- a/packages/cbase.rb
+++ b/packages/cbase.rb
@@ -2,9 +2,9 @@ require 'package'
 
 class Cbase < Package
   description 'cbase is a C library of useful functions that simplify systems software development on System V UNIX.'
-  homepage 'http://www.hyperrealm.com/main.php?s=cbase'
-  version '1.3.7'
-  source_url 'http://www.hyperrealm.com/cbase/cbase-1.3.7.tar.gz'
+  homepage 'http://www.hyperrealm.com/oss_cbase.shtml'
+  version '1.3.7-1'
+  source_url 'http://www.hyperrealm.com/packages/cbase-1.3.7.tar.gz'
   source_sha256 'c4d155686ac2e9d1480319de311967fadad745a6ab6971d53d495d9a9e52dc47'
 
   binary_url ({
@@ -13,8 +13,8 @@ class Cbase < Package
   })
 
   def self.build
-    system './configure'
-    system 'make'
+    system "./configure --prefix=#{CREW_PREFIX}"
+    system "make"
   end
 
   def self.install

--- a/packages/misctools.rb
+++ b/packages/misctools.rb
@@ -2,10 +2,10 @@ require 'package'
 
 class Misctools < Package
   description 'The misctools package is a collection of small but useful utilities.'
-  homepage 'http://www.hyperrealm.com/main.php?s=misctools'
-  version '2.5.5'
-  source_url 'http://www.hyperrealm.com/misctools/misctools-2.5.5.tar.bz2'
-  source_sha256 '4eb5913566da3e243ebd9cab499f927a2d46a2191baa51b810214f83eebb3ae9'
+  homepage 'http://www.hyperrealm.com/oss_misctools.shtml'
+  version '2.6'
+  source_url 'http://www.hyperrealm.com/packages/misctools-2.6.tar.bz2'
+  source_sha256 'b1f13bb3af52ffffddf45efd8c10f942a8c1548352b7878668fbbf27ffa68e1a'
 
   binary_url ({
   })
@@ -15,8 +15,8 @@ class Misctools < Package
   depends_on 'cbase'
 
   def self.build
-    system './configure'
-    system 'make'
+    system "./configure --prefix=#{CREW_PREFIX}"
+    system "make"
   end
 
   def self.install


### PR DESCRIPTION
Fixes part of #1051. Currently the links do not work. The site changed the location of the files.