### PR TITLE
Update dropbox from 32.4.23-1 to 33.4.23

### DIFF
--- a/packages/dropbox.rb
+++ b/packages/dropbox.rb
@@ -3,34 +3,36 @@ require 'package'
 class Dropbox < Package
   description 'Dropbox simplifies the way you create, share and collaborate.  Bring your photos, docs, and videos anywhere and keep your files safe.'
   homepage 'https://www.dropbox.com/'
-  version '32.4.23-1'
+  version '33.4.23'
   case ARCH
   when 'i686'
-    source_url 'https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86-32.4.23.tar.gz'
-    source_sha256 'd7e130f2872fb2d141f8d2f892f7a2c29b95ccd3620398c21ea53dee878dc075'
+    source_url 'https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86-33.4.23.tar.gz'
+    source_sha256 '27e1bfd3823bdab797b27614cb3b1761316da6a29a2b39505fa6d07a7b0c521f'
   when 'x86_64'
-    source_url 'https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-32.4.23.tar.gz'
-    source_sha256 'a18dca750e72e0604b9798bfe5e0b9b7a2b5ed43116ab96166a298ae3c1b5086'
+    source_url 'https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-33.4.23.tar.gz'
+    source_sha256 'bf635cc4dad1094dc3c42cac6208c8a7ad791e9419f0873ac1cb75b0c3691a7d'
   else
     puts 'Unable to install dropboxd.  Supported architectures include i686 and x86_64 only.'.lightred
   end
 
   binary_url ({
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/dropbox-32.4.23-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dropbox-32.4.23-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-       i686: '9b1223d26c8d93a9e1b981bb0746fcb2053c175caaa57494af9de779551ffb7b',
-     x86_64: '372981c324e128d2b9df037c1c8413c9e7a055aae3267954cd9f213cf00c8f16',
   })
 
-  depends_on 'python27' unless File.exists? '/usr/local/bin/python'
+  depends_on 'python27' unless File.exists? "#{CREW_PREFIX}/bin/python"
 
   def self.build
     system "wget https://linux.dropbox.com/packages/dropbox.py"
     system "sed -i 's,~/.dropbox-dist,#{CREW_LIB_PREFIX}/dropbox,g' dropbox.py"
+    system "echo '#!/bin/bash' > dropboxd"
+    system "echo 'PWD=$(pwd)' >> dropboxd"
+    system "echo 'cd #{CREW_LIB_PREFIX}/dropbox' >> dropboxd"
+    system "echo './dropboxd' >> dropboxd"
+    system "echo 'cd $PWD' >> dropboxd"
+    system "chmod +x dropboxd"
     system "echo '#!/bin/bash' > dropbox"
-    system "echo 'python #{CREW_PREFIX}/bin/dropbox.py \"\$@\"' >> dropbox"
+    system "echo 'python #{CREW_PREFIX}/bin/dropbox.py \"$@\"' >> dropbox"
     system "chmod +x dropbox"
   end
 
@@ -39,6 +41,16 @@ class Dropbox < Package
     system "mkdir -p #{CREW_DEST_LIB_PREFIX}/dropbox"
     system "cp -r .dropbox-dist/* #{CREW_DEST_LIB_PREFIX}/dropbox"
     system "cp dropbox.py #{CREW_DEST_PREFIX}/bin"
+    system "cp dropboxd #{CREW_DEST_PREFIX}/bin"
     system "cp dropbox #{CREW_DEST_PREFIX}/bin"
+  end
+
+  def self.postinstall
+    puts
+    puts "To finish the installation, execute 'dropboxd'.".lightblue
+    puts "Type Ctrl+C to exit dropboxd after linking your system.".lightblue
+    puts "Execute 'dropbox start' and after synching is complete, files will be available in ~/Dropbox.".lightblue
+    puts "Execute 'dropbox' to see the full list of available options.".lightblue
+    puts
   end
 end

--- a/packages/dropbox.rb
+++ b/packages/dropbox.rb
@@ -48,6 +48,7 @@ class Dropbox < Package
   def self.postinstall
     puts
     puts "To finish the installation, execute 'dropboxd'.".lightblue
+    puts "Login to Dropbox, highlight the url and paste into Chrome.".lightblue
     puts "Type Ctrl+C to exit dropboxd after linking your system.".lightblue
     puts "Execute 'dropbox start' and after synching is complete, files will be available in ~/Dropbox.".lightblue
     puts "Execute 'dropbox' to see the full list of available options.".lightblue

--- a/packages/dropbox.rb
+++ b/packages/dropbox.rb
@@ -48,7 +48,7 @@ class Dropbox < Package
   def self.postinstall
     puts
     puts "To finish the installation, execute 'dropboxd'.".lightblue
-    puts "Login to Dropbox, highlight the url and paste into Chrome.".lightblue
+    puts "Login to dropbox.com, highlight the url and paste into Chrome.".lightblue
     puts "Type Ctrl+C to exit dropboxd after linking your system.".lightblue
     puts "Execute 'dropbox start' and after synching is complete, files will be available in ~/Dropbox.".lightblue
     puts "Execute 'dropbox' to see the full list of available options.".lightblue


### PR DESCRIPTION
@vince: Please check this update when you get a chance.  Unlike you, I was unable to get the headless install to work because of permission issues.  However, this update now has a working `dropboxd` command that did give me the prompt to link my system to the Dropbox account.  Reference issue #848.