### PR TITLE
Add shhmsg package

### DIFF
--- a/packages/shhmsg.rb
+++ b/packages/shhmsg.rb
@@ -1,0 +1,22 @@
+require 'package'
+
+class Shhmsg < Package
+  description 'C-functions for error messages, verbose messages and \'normal\' messages in terminal-based programs.'
+  homepage 'http://shh.thathost.com/pub-unix/#sshmsg'
+  version '1.4.2'
+  source_url 'http://shh.thathost.com/pub-unix/files/shhmsg-1.4.2.tar.gz'
+  source_sha256 '88c69e3f0b920b1ef93f6c10f354786f171d7cb3ab170a463bb9ab8bbf13a02b'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Shhmsg is a collection of C-functions for error messages, verbose messages and
`normal' messages in terminalbased programs.

Tested as working on XE500C13-K01US. Added as a dependency for `banner`.