### PR TITLE
Adding texlive package

### DIFF
--- a/packages/texlive.rb
+++ b/packages/texlive.rb
@@ -11,8 +11,8 @@ class Texlive < Package
 
   def self.build
     system "rm -rf *"
-    system "wget mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
-    system "wget mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz.sha512"
+    system "wget ftp://ftp.fu-berlin.de/tex/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz"
+    system "wget ftp://ftp.fu-berlin.de/tex/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz.sha512"
     system "cat install-tl-unx.tar.gz.sha512 | xargs | cut -d' ' -f1 > sha512"
     sha512 = open('sha512').read.chomp
     abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA512.hexdigest( File.read('install-tl-unx.tar.gz') ) == "#{sha512}"

--- a/packages/texlive.rb
+++ b/packages/texlive.rb
@@ -5,7 +5,7 @@ class Texlive < Package
   homepage 'https://www.tug.org/texlive/'
   version '2017'
   source_url 'http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz'
-  source_sha256 '9bc5c663bf5fb7066b4bf3c54e5ce93251923d4edaeadb485224621a02297a39'
+  source_sha256 '13e36ba42cf6fb3b4eb96878bdb2828b38709c9538e9446c723ca82fd00a6ac4'
 
   def self.build
   end
@@ -18,15 +18,15 @@ class Texlive < Package
            TEXLIVE_INSTALL_TEXMFHOME=#{dir}/local \
            ./install-tl --scheme=basic --no-cls"
     system "find #{dir} -iname '*.pdf' -delete" # saving some space
-    system "mkdir -p #{CREW_DEST_PREFIX}/man"
-    system "mv #{dir}/2017/texmf-dist/doc/man/* #{CREW_DEST_PREFIX}/man/" # copying manpages
-    system "rm -rf #{dir}/2017/texmf-dist/doc"
-    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
-    system "find #{dir}/2017/bin/ -xtype f -exec ln -rs {} #{CREW_DEST_PREFIX}/bin ';'" # linking binaries
-    system "#{CREW_DEST_PREFIX}/bin/tlmgr init-usertree"
+    system "find #{dir}/2017/texmf-dist/doc -type f -and -not -path '*man*' -delete"
+    system "find #{dir} -name 'tlmgr' -exec {} init-usertree ';'"
   end
 
   def self.postinstall
-    puts "This is a very small installation, with only the basic packages. To install more, use `tlmgr install <package>`.".lightblue
+    puts "\nPlease add texlive to your PATH and MANPATH to be able to use the executables and manpages. Use the following commands:".lightblue
+    puts " echo \"export PATH=\$PATH:#{CREW_PREFIX}/share/texlive/2017/bin/#{ARCH}-linux\" >> ~/.bashrc".lightblue
+    puts " echo \"export MANPATH=\$MANPATH:#{CREW_PREFIX}/share/texlive/2017/bin/texmf-dist/doc/man\" >> ~/.bashrc".lightblue
+    puts " source ~/.bashrc".lightblue
+    puts "\nThis is a very small installation, with only the basic packages. To install more, use `tlmgr install <package>`.".lightblue
   end
 end

--- a/packages/texlive.rb
+++ b/packages/texlive.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Texlive < Package
+  description 'TeX Live is an easy way to get up and running with the TeX document production system.'
+  homepage 'https://www.tug.org/texlive/'
+  version '2017'
+  source_url 'http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz'
+  source_sha256 '9bc5c663bf5fb7066b4bf3c54e5ce93251923d4edaeadb485224621a02297a39'
+
+  def self.build
+  end
+
+  def self.install
+    dir = "#{CREW_DEST_PREFIX}/share/texlive"
+    system "yes I | TEXLIVE_INSTALL_PREFIX=#{dir} \
+           TEXLIVE_INSTALL_TEXMFVAR=#{dir}/local/texmf-var \
+           TEXLIVE_INSTALL_TEXMFCONFIG=#{dir}/local/texmf-config \
+           TEXLIVE_INSTALL_TEXMFHOME=#{dir}/local \
+           ./install-tl --scheme=basic --no-cls"
+    system "find #{dir} -iname '*.pdf' -delete" # saving some space
+    system "mkdir -p #{CREW_DEST_PREFIX}/man"
+    system "mv #{dir}/2017/texmf-dist/doc/man/* #{CREW_DEST_PREFIX}/man/" # copying manpages
+    system "rm -rf #{dir}/2017/texmf-dist/doc"
+    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
+    system "find #{dir}/2017/bin/ -xtype f -exec ln -rs {} #{CREW_DEST_PREFIX}/bin ';'" # linking binaries
+    system "#{CREW_DEST_PREFIX}/bin/tlmgr init-usertree"
+  end
+
+  def self.postinstall
+    puts "This is a very small installation, with only the basic packages. To install more, use `tlmgr install <package>`.".lightblue
+  end
+end

--- a/packages/texlive.rb
+++ b/packages/texlive.rb
@@ -4,8 +4,8 @@ class Texlive < Package
   description 'TeX Live is an easy way to get up and running with the TeX document production system.'
   homepage 'https://www.tug.org/texlive/'
   version '2017'
-  source_url 'http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz'
-  source_sha256 '13e36ba42cf6fb3b4eb96878bdb2828b38709c9538e9446c723ca82fd00a6ac4'
+  source_url 'ftp://ftp.fu-berlin.de/tex/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz'
+  source_sha256 '7145f52c1ec6941f18285dfe13e9faaefd55092bd38f900b6cff07342311e243'
 
   def self.build
   end

--- a/packages/texlive.rb
+++ b/packages/texlive.rb
@@ -5,7 +5,7 @@ class Texlive < Package
   homepage 'https://www.tug.org/texlive/'
   version '2017'
   source_url 'ftp://ftp.fu-berlin.de/tex/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz'
-  source_sha256 '7145f52c1ec6941f18285dfe13e9faaefd55092bd38f900b6cff07342311e243'
+  source_sha256 '1e09ffe84046af5fa68c788a3fd3c517f9c7e131d9d08603e2856cba22adf36e'
 
   def self.build
   end

--- a/packages/texlive.rb
+++ b/packages/texlive.rb
@@ -4,10 +4,21 @@ class Texlive < Package
   description 'TeX Live is an easy way to get up and running with the TeX document production system.'
   homepage 'https://www.tug.org/texlive/'
   version '2017'
-  source_url 'ftp://ftp.fu-berlin.de/tex/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz'
-  source_sha256 '1e09ffe84046af5fa68c788a3fd3c517f9c7e131d9d08603e2856cba22adf36e'
+  source_url 'ftp://tug.org/historic/systems/texlive/2017/texlive-20170524-extra.tar.xz'
+  source_sha256 'afe49758c26fb51c2fae2e958d3f0c447b5cc22342ba4a4278119d39f5176d7f'
+
+  depends_on 'perl'
 
   def self.build
+    system "rm -rf *"
+    system "wget mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
+    system "wget mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz.sha512"
+    system "cat install-tl-unx.tar.gz.sha512 | xargs | cut -d' ' -f1 > sha512"
+    sha512 = open('sha512').read.chomp
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA512.hexdigest( File.read('install-tl-unx.tar.gz') ) == "#{sha512}"
+    system "tar xvf install-tl-unx.tar.gz"
+    system "mv install-tl-2017*/* ."
+    system "rm -rf install-tl-2017*/"
   end
 
   def self.install

--- a/packages/texlive.rb
+++ b/packages/texlive.rb
@@ -17,8 +17,8 @@ class Texlive < Package
     sha512 = open('sha512').read.chomp
     abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA512.hexdigest( File.read('install-tl-unx.tar.gz') ) == "#{sha512}"
     system "tar xvf install-tl-unx.tar.gz"
-    system "mv install-tl-2017*/* ."
-    system "rm -rf install-tl-2017*/"
+    system "mv install-tl-20*/* ."
+    system "rm -rf install-tl-20*/"
   end
 
   def self.install
@@ -29,14 +29,15 @@ class Texlive < Package
            TEXLIVE_INSTALL_TEXMFHOME=#{dir}/local \
            ./install-tl --scheme=basic --no-cls"
     system "find #{dir} -iname '*.pdf' -delete" # saving some space
-    system "find #{dir}/2017/texmf-dist/doc -type f -and -not -path '*man*' -delete"
+    system "find #{dir}/20*/texmf-dist/doc -type f -and -not -path '*man*' -delete"
     system "find #{dir} -name 'tlmgr' -exec {} init-usertree ';'"
   end
 
   def self.postinstall
+    path = `echo #{CREW_PREFIX}/share/texlive/20*`.chomp
     puts "\nPlease add texlive to your PATH and MANPATH to be able to use the executables and manpages. Use the following commands:".lightblue
-    puts " echo \"export PATH=\$PATH:#{CREW_PREFIX}/share/texlive/2017/bin/#{ARCH}-linux\" >> ~/.bashrc".lightblue
-    puts " echo \"export MANPATH=\$MANPATH:#{CREW_PREFIX}/share/texlive/2017/bin/texmf-dist/doc/man\" >> ~/.bashrc".lightblue
+    puts " echo \"export PATH=\$PATH:#{path}/bin/#{ARCH}-linux\" >> ~/.bashrc".lightblue
+    puts " echo \"export MANPATH=\$MANPATH:#{path}/bin/texmf-dist/doc/man\" >> ~/.bashrc".lightblue
     puts " source ~/.bashrc".lightblue
     puts "\nThis is a very small installation, with only the basic packages. To install more, use `tlmgr install <package>`.".lightblue
   end


### PR DESCRIPTION
Texlive has all the useful tex and latex stuff to create documents.

The installation is not an usual one so I had to move a bunch of things by hand.

There are still some problems:
- I'm not sure if it works on other architectures. I think it does, the install script probably figures it out. But it would be great if someone could test it.
- The script does not install the binaries to a reasonable location. It installs to INSTALL_TEXLIVE_PREFIX/texlive/2017/bin/ARCHITECTURE/. I made the install prefix be /usr/local/share and my solution was to symlink all the binaries there to /usr/local/bin. **This is not great**, since if you install more binaries using `tlmgr` (their package manager), they will go to their binaries directory, and not be symlinked to /usr/local/bin. Their recommendation is to change the PATH but as I've seen that packages here usually do not do that. **Is there a better solution to this?** 