### PR TITLE
Added a package for Nethack 3.6.

### DIFF
--- a/packages/nethack.rb
+++ b/packages/nethack.rb
@@ -12,17 +12,21 @@ class Nethack < Package
   depends_on 'flex'
   depends_on 'ncurses'
 
-  def self.build
+  def self.patch
     # Apply a patch to set a hints file that will work for the current build environment. 
     system "curl -L 'https://gist.githubusercontent.com/anonymous/77b05c6cd87628ab3cb944e75ecc45b7/raw/d5f327450aa6b4d50cafb5352fad06ed60f91b69/nethack_chromebrew.patch' | patch -p0"
+  end
+
+  def self.build
+    self.patch
     system "./sys/unix/setup.sh", "./sys/unix/hints/linux"
     system "make"
   end
 
   def self.install
-    system "make", "PREFIX=#{CREW_DEST_DIR}/usr/local/", "install"
-    system "mkdir", "#{CREW_DEST_DIR}/usr/local/bin/"
-    system "sed", "-i", "s|^HACKDIR=.*$|HACKDIR=#{CREW_PREFIX}/games/lib/nethackdir|g", "#{CREW_DEST_DIR}/usr/local/games/nethack"
-    system "cp", "#{CREW_DEST_DIR}/usr/local/games/nethack", "#{CREW_DEST_DIR}/usr/local/bin/nethack"
+    system "make", "PREFIX=#{CREW_DEST_PREFIX}", "install"
+    system "mkdir", "#{CREW_DEST_PREFIX}/bin/"
+    system "sed", "-i", "s|^HACKDIR=.*$|HACKDIR=#{CREW_PREFIX}/games/lib/nethackdir|g", "#{CREW_DEST_PREFIX}/games/nethack"
+    system "cp", "#{CREW_DEST_PREFIX}/games/nethack", "#{CREW_DEST_PREFIX}/bin/nethack"
   end
 end

--- a/packages/nethack.rb
+++ b/packages/nethack.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Nethack < Package
+  description 'Nethack is a classic roguelike. Descend through the dungeon and retrieve the Amulet of Yendor.'
+  homepage 'https://www.nethack.org/'
+  version '3.6.0'
+  source_url 'https://github.com/NetHack/NetHack/archive/NetHack-3.6.0_Release.tar.gz'
+  source_sha256 '5735e4d132d8aec0c49f0e2a72156c7cbe84ea7b5a3153531da61aa660c668a1'
+
+  depends_on 'patch'
+  depends_on 'bison'
+  depends_on 'flex'
+  depends_on 'ncurses'
+
+  def self.build
+    # Apply a patch to set a hints file that will work for the current build environment. 
+    system "curl -L 'https://gist.githubusercontent.com/anonymous/77b05c6cd87628ab3cb944e75ecc45b7/raw/d5f327450aa6b4d50cafb5352fad06ed60f91b69/nethack_chromebrew.patch' | patch -p0"
+    system "./sys/unix/setup.sh", "./sys/unix/hints/linux"
+    system "make"
+  end
+
+  def self.install
+    system "make", "PREFIX=#{CREW_DEST_DIR}/usr/local/", "install"
+    system "mkdir", "#{CREW_DEST_DIR}/usr/local/bin/"
+    system "sed", "-i", "s|^HACKDIR=.*$|HACKDIR=#{CREW_PREFIX}/games/lib/nethackdir|g", "#{CREW_DEST_DIR}/usr/local/games/nethack"
+    system "cp", "#{CREW_DEST_DIR}/usr/local/games/nethack", "#{CREW_DEST_DIR}/usr/local/bin/nethack"
+  end
+end


### PR DESCRIPTION
No package manager is complete without NetHack.

Stuff I thought about while making this package:
1. There does not currently seem to be a way to change `CREW_PREFIX`. If there ever is one, this package will not work without modification, because the wrapper that is created to change to `HACKDIR` contains the absolute path to `HACKDIR` when `make install` is run.

2. It would be nice to add some binary packages. I figure they could be added to the Bintray hosting. There doesn't seem to be any documentation on how to do this, so I left that part out for now.

3. This version of Nethack is console-only. A version that includes tiles and linkage to X11 should probably be a separate package.