### PR TITLE
Change default option for xz to enable multi threads

### DIFF
--- a/crew
+++ b/crew
@@ -37,6 +37,14 @@ Usage:
 version 0.4.3
 DOCOPT
 
+# Set XZ_OPT environment variable for build command.
+# If CREW_XZ_OPT is defined, use it by default.  Use `-7e`, otherwise.
+if ENV["CREW_XZ_OPT"].to_s == ''
+  ENV["XZ_OPT"] = "-7e -T #{CREW_NPROC}"
+else
+  ENV["XZ_OPT"] = ENV["CREW_XZ_OPT"]
+end
+
 # Parse arguments using docopt
 require_relative 'lib/docopt'
 begin

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -26,12 +26,4 @@ CREW_NOT_COMPRESS = ENV["CREW_NOT_COMPRESS"]
 # Set CREW_NOT_STRIP from environment variable
 CREW_NOT_STRIP = ENV["CREW_NOT_STRIP"]
 
-# Set XZ_OPT environment variable for build command.
-# If CREW_XZ_OPT is defined, use it by default.  Use `-7e`, otherwise.
-if ENV["CREW_XZ_OPT"].to_s == ''
-  ENV["XZ_OPT"] = "-7e"
-else
-  ENV["XZ_OPT"] = ENV["CREW_XZ_OPT"]
-end
-
 USER = `whoami`.chomp


### PR DESCRIPTION
This PR changes:

- move codes to define environment variable from `lib/const.rb` to `crew` since it is not constant variables in ruby.
- add "-T #{CREW_PROC}" option for xz to use multi threads in xz to improve the performance.

Tested on armv7l and x86_64.