### PR TITLE
Update php7 from 7.1.8-1 to 7.1.11

### DIFF
--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -3,21 +3,13 @@ require 'package'
 class Php7 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.1.8-1'
-  source_url 'https://php.net/distributions/php-7.1.8.tar.xz'
-  source_sha256 '8943858738604acb33ecedb865d6c4051eeffe4e2d06f3a3c8f794daccaa2aab'
+  version '7.1.9'
+  source_url 'https://php.net/distributions/php-7.1.9.tar.xz'
+  source_sha256 'ec9ca348dd51f19a84dc5d33acfff1fba1f977300604bdac08ed46ae2c281e8c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.8-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f16f0456a071bc67d8f52d822b8a854e7e73903bad3b91bec87101f5ab8bb61f',
-     armv7l: 'f16f0456a071bc67d8f52d822b8a854e7e73903bad3b91bec87101f5ab8bb61f',
-       i686: '873824cdb85932a082fca7ab4e81eeed39ec03cff1621ee650e61892afff2490',
-     x86_64: 'b39ae5ea701573c27022ce0838b1cf64302b502ed8b54b3845ffd4793a99e82b',
   })
 
   depends_on 'pkgconfig'
@@ -31,11 +23,13 @@ class Php7 < Package
   depends_on 'readline'
 
   def self.build
-    system './configure \
-      --prefix=/usr/local \
-      --docdir=/usr/local/doc \
-      --infodir=/usr/local/info \
-      --mandir=/usr/local/man \
+    system "./configure \
+      --prefix=#{CREW_PREFIX} \
+      --docdir=#{CREW_PREFIX}/doc \
+      --infodir=#{CREW_PREFIX}/info \
+      --libdir=#{CREW_LIB_PREFIX} \
+      --localstatedir=#{CREW_PREFIX}/tmp \
+      --mandir=#{CREW_PREFIX}/man \
       --with-curl \
       --with-gd \
       --with-xsl \
@@ -43,7 +37,7 @@ class Php7 < Package
       --with-openssl \
       --with-pcre-regex \
       --with-readline \
-      --with-zlib'
+      --with-zlib"
     system 'make'
   end
 
@@ -51,8 +45,8 @@ class Php7 < Package
     system "make", "INSTALL_ROOT=#{CREW_DEST_DIR}", "install"
 
     # clean up some files created under #{CREW_DEST_DIR}. check http://pear.php.net/bugs/bug.php?id=20383 for more details
-    system "mv", "#{CREW_DEST_DIR}/.depdb", "#{CREW_DEST_DIR}/usr/local/lib/php"
-    system "mv", "#{CREW_DEST_DIR}/.depdblock", "#{CREW_DEST_DIR}/usr/local/lib/php"
+    system "mv", "#{CREW_DEST_DIR}/.depdb", "#{CREW_DEST_LIB_PREFIX}/php"
+    system "mv", "#{CREW_DEST_DIR}/.depdblock", "#{CREW_DEST_LIB_PREFIX}/php"
     system "rm", "-rf", "#{CREW_DEST_DIR}/.channels", "#{CREW_DEST_DIR}/.filemap", "#{CREW_DEST_DIR}/.lock", "#{CREW_DEST_DIR}/.registry"
   end
 end

--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php7 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.1.10'
-  source_url 'https://php.net/distributions/php-7.1.10.tar.xz'
-  source_sha256 '2b8efa771a2ead0bb3ae67b530ca505b5b286adc873cca9ce97a6e1d6815c50b'
+  version '7.1.11'
+  source_url 'https://php.net/distributions/php-7.1.11.tar.xz'
+  source_sha256 '074093e9d7d21afedc5106904218a80a47b854abe368d2728ed22184c884893e'
 
   binary_url ({
   })

--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php7 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.1.9'
-  source_url 'https://php.net/distributions/php-7.1.9.tar.xz'
-  source_sha256 'ec9ca348dd51f19a84dc5d33acfff1fba1f977300604bdac08ed46ae2c281e8c'
+  version '7.1.10'
+  source_url 'https://php.net/distributions/php-7.1.10.tar.xz'
+  source_sha256 '2b8efa771a2ead0bb3ae67b530ca505b5b286adc873cca9ce97a6e1d6815c50b'
 
   binary_url ({
   })


### PR DESCRIPTION
  - Replaced /usr/local with #{CREW_PREFIX}
  - Replaced #{CREW_DEST_DIR}/usr/local/lib with #{CREW_DEST_LIB_PREFIX}
  - Added --libdir and --localstatedir configure options

`--localstatedir=#{CREW_PREFIX}/tmp` was needed to prevent the following errors on CloudReady:
```
tar: ./usr/local/var/log: Cannot utime: Operation not permitted
tar: ./usr/local/var/log: Cannot change mode to rwxr-xr-x: Operation not permitted
tar: Exiting with failure status due to previous errors
```