### PR TITLE
Add missing libxcb dependency

### DIFF
--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -3,21 +3,13 @@ require 'package'
 class Ffmpeg < Package
   description 'A complete, cross-platform solution to record, convert and stream audio and video.'
   homepage 'https://ffmpeg.org/'
-  version '3.3.3'
+  version '3.3.3-1'
   source_url 'https://ffmpeg.org/releases/ffmpeg-3.3.3.tar.xz'
   source_sha256 'd2a9002cdc6b533b59728827186c044ad02ba64841f1b7cd6c21779875453a1e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.3.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.3.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.3.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.3.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '397191b677f632d8e3bcc83412612ca0efa9d9d4cc8a5fe821bcb9ab611b62a7',
-     armv7l: '397191b677f632d8e3bcc83412612ca0efa9d9d4cc8a5fe821bcb9ab611b62a7',
-       i686: '73bb71ef72c1c389c06b6d700f623da8992249210f52a6a7c6b279826c96f4aa',
-     x86_64: '26a93616aa93b2a70e34e7fd4cb4410dd346a7f491621f1d1518a1cd846541aa',
   })
 
   depends_on 'gnutls'
@@ -39,6 +31,7 @@ class Ffmpeg < Package
   depends_on 'rtmpdump'
   depends_on 'speex'
   depends_on 'vidstab'
+  depends_on 'libxcb'
 
   def self.build
     system "TMPDIR=#{CREW_BREW_DIR} ./configure \


### PR DESCRIPTION
This adds libxcb to the dependency list as it was missing. Resolves #1224.

Tested as working on XE500C13-K01US.