### PR TITLE
Add crew files command

### DIFF
--- a/crew
+++ b/crew
@@ -21,6 +21,7 @@ Chromebrew - Package manager for Chrome OS http://skycocker.github.io/chromebrew
 Usage:
   crew build [-k|--keep] <name> ...
   crew download <name> ...
+  crew files <name> ...
   crew help [<command>]
   crew install [-k|--keep] [-s|--build-from-source] <name> ...
   crew remove <name> ...
@@ -163,6 +164,12 @@ def help (pkgName)
   else
     puts "Available commands: build, download, install, remove, search, update, upgrade, whatprovides"
   end
+end
+
+def files (pkgName)
+  system "cat #{CREW_PREFIX}/etc/crew/meta/#{pkgName}.filelist"
+  print "Total found: ".lightgreen
+  system "wc -l #{CREW_PREFIX}/etc/crew/meta/#{pkgName}.filelist | cut -d' ' -f1"
 end
 
 def whatprovides (pkgName)
@@ -684,6 +691,14 @@ def download_command (args)
     @pkgName = name
     search @pkgName
     download
+  end
+end
+
+def files_command (args)
+  args["<name>"].each do |name|
+    @pkgName = name
+    search @pkgName
+    files name
   end
 end
 

--- a/crew
+++ b/crew
@@ -171,9 +171,11 @@ def help (pkgName)
 end
 
 def files (pkgName)
-  system "cat #{CREW_PREFIX}/etc/crew/meta/#{pkgName}.filelist"
-  print "Total found: ".lightgreen
-  system "wc -l #{CREW_PREFIX}/etc/crew/meta/#{pkgName}.filelist | cut -d' ' -f1"
+  filelist = "#{CREW_PREFIX}/etc/crew/meta/#{pkgName}.filelist"
+  abort "Package #{pkgName} is not installed.".lightred unless File.exists? #{filelist}
+  system "cat #{filelist}"
+  lines = `wc -l "#{filelist}"`.strip.split(' ')[0].to_i
+  puts "Total found: #{lines}".lightgreen
 end
 
 def whatprovides (pkgName)

--- a/crew
+++ b/crew
@@ -172,10 +172,13 @@ end
 
 def files (pkgName)
   filelist = "#{CREW_PREFIX}/etc/crew/meta/#{pkgName}.filelist"
-  abort "Package #{pkgName} is not installed.".lightred unless File.exists? #{filelist}
-  system "cat #{filelist}"
-  lines = `wc -l "#{filelist}"`.strip.split(' ')[0].to_i
-  puts "Total found: #{lines}".lightgreen
+  if File.exists? "#{filelist}"
+    system "cat #{filelist}"
+    lines = `wc -l "#{filelist}"`.strip.split(' ')[0].to_i
+    puts "Total found: #{lines}".lightgreen
+  else
+    puts "Package #{pkgName} is not installed. :(".lightred
+  end
 end
 
 def whatprovides (pkgName)

--- a/crew
+++ b/crew
@@ -125,6 +125,10 @@ def help (pkgName)
     puts "Download package(s)."
     puts "Usage: crew download <package1> [<package2> ...]"
     puts "Download package(s) to `CREW_BREW_DIR` (#{CREW_BREW_DIR}), but don't install."
+  when "files"
+    puts "Display installed files of package(s)."
+    puts "Usage: crew files <package1> [<package2> ...]"
+    puts "The package(s) must be currently installed."
   when "install"
     puts "Install package(s)."
     puts "Usage: crew install [-k|--keep] [-s|--build-from-source] <package1> [<package2> ...]"
@@ -162,7 +166,7 @@ def help (pkgName)
     puts "Usage: crew whatprovides <pattern> ..."
     puts "The <pattern> is a search string which can contain regular expressions."
   else
-    puts "Available commands: build, download, install, remove, search, update, upgrade, whatprovides"
+    puts "Available commands: build, download, files, install, remove, search, update, upgrade, whatprovides"
   end
 end
 

--- a/crew
+++ b/crew
@@ -173,7 +173,7 @@ end
 def files (pkgName)
   filelist = "#{CREW_PREFIX}/etc/crew/meta/#{pkgName}.filelist"
   if File.exists? "#{filelist}"
-    system "cat #{filelist}"
+    system "sort #{filelist}"
     lines = `wc -l "#{filelist}"`.strip.split(' ')[0].to_i
     puts "Total found: #{lines}".lightgreen
   else


### PR DESCRIPTION
Introducing `crew files <package> ...`.  This is a very simple but useful command.  Example:
```
$ crew files autossh
(i) autossh: The purpose of autossh is to start an SSH connection, monitor it, and restart it if necessary.
http://www.harding.motd.ca/autossh
version 9c72d3
/usr/local/man/man1/autossh.1
/usr/local/bin/autossh
/usr/local/share/examples/autossh/rscreen
/usr/local/share/examples/autossh/autossh.host
/usr/local/share/doc/autossh/CHANGES
/usr/local/share/doc/autossh/README
Total found: 6
```