### PR TITLE
emacs requires ncurses to run

### DIFF
--- a/packages/emacs.rb
+++ b/packages/emacs.rb
@@ -25,6 +25,7 @@ class Emacs < Package
   depends_on "m4" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "ncurses"
 
   def self.build
     system "./configure --prefix=/usr/local --without-x --without-makeinfo --without-selinux"


### PR DESCRIPTION
The current emacs package doesn't run:
```
chronos@localhost /usr/local/lib/crew/packages $ emacs
emacs: error while loading shared libraries: libncurses.so.6: cannot open shared object file: No such file or directory
chronos@localhost /usr/local/lib/crew/packages $
```

This PR adds it to the dependencies.  It runs fine with this change (so the built files are fine, just need the extra runtime dependency).