### PR TITLE
Update libxml2 from 2.9.4 to 2.9.5

### DIFF
--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -14,6 +14,7 @@ class Libxml2 < Package
 
   def self.build
     system "./configure",
+      "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}",
       "--enable-shared",
       "--disable-static",

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,27 +3,24 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.4-1'
-  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz'
-  source_sha256 'ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c'
+  version '2.9.5'
+  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.5.tar.gz'
+  source_sha256 '4031c1ecee9ce7ba4f313e91ef6284164885cdb69937a123f6a83bb6a72dcd38'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.4-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.4-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.4-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.4-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '802105d36c6e2c241f2a21937adb98631e26f4f2cadd5fa33d1e4f6f190ff6ce',
-     armv7l: '802105d36c6e2c241f2a21937adb98631e26f4f2cadd5fa33d1e4f6f190ff6ce',
-       i686: '83f9175166eb10cfde77607fa0fdd902929d72fd7308efdf1b23ebe94e7d47c4',
-     x86_64: '0a34998228e43b4d88a480b88ce8095753a7be1902f87987377138e8429f8a1f',
   })
 
   def self.build
-    system "./configure", "--libdir=#{CREW_LIB_PREFIX}",
-      "--enable-shared", "--disable-static", "--with-pic", "--without-python",
-      "--without-lzma", "--without-zlib"
+    system "./configure",
+      "--libdir=#{CREW_LIB_PREFIX}",
+      "--enable-shared",
+      "--disable-static",
+      "--with-pic",
+      "--without-python",
+      "--without-lzma",
+      "--without-zlib"
     system "make"
   end
 


### PR DESCRIPTION
This is a security and bugfix release. No CVEs referenced.

Tested on XE500C13-K01US.