### PR TITLE
Update gnupg from 2.1.22 to 2.2.1

### DIFF
--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gnupg < Package
   description 'GnuPG is a complete and free implementation of the OpenPGP standard as defined by RFC4880 (also known as PGP).'
   homepage 'https://gnupg.org/'
-  version '2.1.22'
-  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.22.tar.bz2'
-  source_sha256 '46716faf9e1b92cfca86609f3bfffbf5bb4b6804df90dc853ff7061cfcfb4ad7'
+  version '2.2.1'
+  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.1.tar.bz2'
+  source_sha256 '34d70cd65b9c95f3f2f90a9f5c1e0b6a0fe039a8d685e2d66d69c33d1cbf62fb'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.1.22-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.1.22-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.1.22-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.1.22-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '2b7537b77bda382df365a57f189c6f4fec9c5f23f96c9d1b67b9a85897ef6636',
-     armv7l: '2b7537b77bda382df365a57f189c6f4fec9c5f23f96c9d1b67b9a85897ef6636',
-       i686: '4303dbd05640fb7aadc13756759a3579114b0269a26ac23b6fecf2e137928682',
-     x86_64: '2b179e778449964e11da501685b6e4fbd06fd5c36501a6dd36d78d7fea6b7e1f',
   })
 
   depends_on 'bz2'
@@ -30,12 +22,14 @@ class Gnupg < Package
   depends_on 'gettext'
 
   def self.build
-    system "./autogen.sh"
-    system "./configure"
-    system "make"
+    system './autogen.sh'
+    system './configure',
+      "--prefix=#{CREW_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
This is a bugfix and maintenance release.

Tested as working on XE500C13-K01US. All tests pass on x86_64.