### PR TITLE
Update libgcrypt from 1.7.6 to 1.8.1

### DIFF
--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -3,31 +3,25 @@ require 'package'
 class Libgcrypt < Package
   description 'Libgcrypt is a general purpose cryptographic library originally based on code from GnuPG.'
   homepage 'https://www.gnupg.org/related_software/libgcrypt/index.html'
-  version '1.7.6'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.7.6.tar.bz2'
-  source_sha256 '626aafee84af9d2ce253d2c143dc1c0902dda045780cc241f39970fc60be05bc'
+  version '1.8.1'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.1.tar.bz2'
+  source_sha256 '7a2875f8b1ae0301732e878c0cca2c9664ff09ef71408f085c50e332656a78b3'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.7.6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.7.6-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.7.6-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.7.6-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3e3de169b45e035bbb95032d5737e46d972b88a1e707ca0db19eda74c4fda498',
-     armv7l: '3e3de169b45e035bbb95032d5737e46d972b88a1e707ca0db19eda74c4fda498',
-       i686: '8d9412bc5847ef34b563427bfc930f3bfb503b81c017f796f65c0de54e0d850c',
-     x86_64: '08d0ee064afb5643f69541875a2e5f4ed550ab4018f5d18a88897f016904568b',
   })
 
   depends_on 'libgpgerror'
 
   def self.build
-    system "./configure --prefix=/usr/local"
-    system "make"
+    system './configure',
+      "--prefix=#{CREW_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
This is a bugfix and maintenance release.

Tested as working on XE500C13-K01US. All tests pass on x86_64.