### PR TITLE
Add brotli package

### DIFF
--- a/packages/brotli.rb
+++ b/packages/brotli.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Brotli < Package
+  description 'Brotli compression format '
+  homepage 'https://github.com/google/brotli'
+  version '1.0.1'
+  source_url 'https://github.com/google/brotli/archive/v1.0.1.tar.gz'
+  source_sha256 '6870f9c2c63ef58d7da36e5212a3e1358427572f6ac5a8b5a73a815cf3e0c4a6'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'cmake' => :build
+
+  def self.build
+    system 'mkdir out'
+    Dir.chdir 'out' do
+      system "cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX}"
+      system "cmake --build . --config Release --target install"
+    end
+  end
+
+  def self.install
+    #system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    Dir.chdir 'out' do
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX} -P cmake_install.cmake"
+    end
+  end
+end

--- a/packages/brotli.rb
+++ b/packages/brotli.rb
@@ -17,7 +17,7 @@ class Brotli < Package
   def self.build
     system 'mkdir out'
     Dir.chdir 'out' do
-      system "cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX}"
+      system "cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DCMAKE_INSTALL_LIBDIR=#{CREW_DEST_LIB_PREFIX}"
       system "cmake --build . --config Release --target install"
     end
   end
@@ -25,7 +25,7 @@ class Brotli < Package
   def self.install
     #system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     Dir.chdir 'out' do
-      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX} -P cmake_install.cmake"
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -DCMAKE_INSTALL_LIBDIR=#{CREW_DEST_LIB_PREFIX} -P cmake_install.cmake"
     end
   end
 end


### PR DESCRIPTION
Brotli is a generic-purpose lossless compression algorithm from Google.

Tested as working on XE500C13-K01US.

@uberhacker @jam7 I'm not very familiar with CMake and haven't been able to figure out why the libraries show as installed in the build output but don't show up when running `crew files brotli`