### PR TITLE
Fix htop+protobuf dependencies for build only

### DIFF
--- a/packages/htop.rb
+++ b/packages/htop.rb
@@ -8,16 +8,8 @@ class Htop < Package
   source_sha256 '179be9dccb80cee0c5e1a1f58c8f72ce7b2328ede30fb71dcdf336539be2f487'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/htop-2.0.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/htop-2.0.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/htop-2.0.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/htop-2.0.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '82c99e18dc24b915467acdc4b6e06b8e673d76667ca830528411b09df5fc7583',
-     armv7l: '82c99e18dc24b915467acdc4b6e06b8e673d76667ca830528411b09df5fc7583',
-       i686: 'b8b34913c160374c5cfb97646c9f87628d19aa9fbd7bf8565ecb96edadaea0a0',
-     x86_64: '5e1faafcb9559adf098f2a4e03d282202d981522ad4a84d515d2006363fd840c',
   })
 
   depends_on 'buildessential'  => :build

--- a/packages/htop.rb
+++ b/packages/htop.rb
@@ -3,7 +3,7 @@ require 'package'
 class Htop < Package
   description 'htop is an interactive process viewer for Unix systems.'
   homepage 'https://hisham.hm/htop/'
-  version '2.0.2'
+  version '2.0.2-1'
   source_url 'http://hisham.hm/htop/releases/2.0.2/htop-2.0.2.tar.gz'
   source_sha256 '179be9dccb80cee0c5e1a1f58c8f72ce7b2328ede30fb71dcdf336539be2f487'
 

--- a/packages/htop.rb
+++ b/packages/htop.rb
@@ -20,7 +20,7 @@ class Htop < Package
      x86_64: '5e1faafcb9559adf098f2a4e03d282202d981522ad4a84d515d2006363fd840c',
   })
 
-  depends_on 'buildessential'
+  depends_on 'buildessential'  => :build
   depends_on 'ncurses'
 
   def self.build

--- a/packages/htop.rb
+++ b/packages/htop.rb
@@ -24,7 +24,7 @@ class Htop < Package
   depends_on 'ncurses'
 
   def self.build
-    system "./configure --disable-unicode"
+    system "./configure --prefix=#{CREW_PREFIX} --disable-unicode"
     system "make"
   end
 

--- a/packages/protobuf.rb
+++ b/packages/protobuf.rb
@@ -3,7 +3,7 @@ require 'package'
 class Protobuf < Package
   description 'Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data.'
   homepage 'https://developers.google.com/protocol-buffers/'
-  version '3.3.0-1'
+  version '3.3.0-2'
   source_url 'https://github.com/google/protobuf/archive/v3.3.0.tar.gz'
   source_sha256 '94c414775f275d876e5e0e4a276527d155ab2d0da45eed6b7734301c330be36e'
 

--- a/packages/protobuf.rb
+++ b/packages/protobuf.rb
@@ -20,8 +20,8 @@ class Protobuf < Package
      x86_64: 'd96734af335416a6e78fefaa86c39c51baca17a3b5486f4d75022ee11f2aa1f2',
   })
 
-  depends_on 'automake'
-  depends_on 'libtool'
+  depends_on 'automake' => :build
+  depends_on 'libtool'  => :build
 
   def self.build
     system './autogen.sh'

--- a/packages/protobuf.rb
+++ b/packages/protobuf.rb
@@ -8,16 +8,8 @@ class Protobuf < Package
   source_sha256 '94c414775f275d876e5e0e4a276527d155ab2d0da45eed6b7734301c330be36e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/protobuf-3.3.0-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/protobuf-3.3.0-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/protobuf-3.3.0-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/protobuf-3.3.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '2f8b0c4fa32e4675115c93ecf483fb014ed1191b8fb5cfa81c898b0f5d54aec1',
-     armv7l: '2f8b0c4fa32e4675115c93ecf483fb014ed1191b8fb5cfa81c898b0f5d54aec1',
-       i686: '746b00166eac38ea368bc5954aca8b017c7a4182f54143bb15463dcaf43839fc',
-     x86_64: 'd96734af335416a6e78fefaa86c39c51baca17a3b5486f4d75022ee11f2aa1f2',
   })
 
   depends_on 'automake' => :build

--- a/packages/protobuf.rb
+++ b/packages/protobuf.rb
@@ -25,7 +25,7 @@ class Protobuf < Package
 
   def self.build
     system './autogen.sh'
-    system "./configure --prefix=/usr/local --libdir=#{CREW_LIB_PREFIX}"
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 


### PR DESCRIPTION
mark build time dependencies of htop and protobuf pakages so they dont get istalled if we install from binary