### PR TITLE
add filecmd binary package for x86_64

### DIFF
--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -8,8 +8,10 @@ class Filecmd < Package
   source_sha256 '8639dc4d1b21e232285cd483604afc4a6ee810710e00e579dbe9591681722b50'
 
   binary_url ({
+    x86_64: 'https://www.clift.org/fred/chromebrew/filecmd-5.31-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    x86_64: 'a4c5fc59cd6d7539a26b54f1438a3e893598881fb23730e558ffceae5f408081',
   })
 
   def self.build


### PR DESCRIPTION
adding a binary package... figured it would be nice since I use it in the ncat/nping stuff and configure uses it all over the place