### PR TITLE
fix a few dependency and filecmd nits with nmap build

### DIFF
--- a/packages/nmap.rb
+++ b/packages/nmap.rb
@@ -20,9 +20,12 @@ class Nmap < Package
      x86_64: '12eb815ec4bc47ac0d778575c7125907421937396fa491745d5ab48486380550',
   })
 
-  depends_on 'buildessential'
+  depends_on 'buildessential' => :build
+  depends_on 'filecmd' => :build
 
   def self.build
+    #fixup "/usr/bin/file" -> "/usr/local/bin/file" in the configure scripts
+    system "sed -i s#/usr/bin/file#/usr/local/bin/file#g libdnet-stripped/configure" 
     system "./configure --with-pcap=linux --without-zenmap"
     system "make"
   end


### PR DESCRIPTION
In particular, one of the library configure scripts uses /usr/bin/file to do some detection

leading to:

./configure: line 5822: /usr/bin/file: No such file or directory


sometime during the configure.

We probably have this (very minor) problem with many other packages.

It happens in this case to accidentally get the right configuration because the default is what it would have found if the file command works.  Who knows if this will continue to always be right - pretty good chance since it is autoconf generated code, but perhaps this works on x86_64 but not on another arch?  I can't check because ... no hardware.

So this adds filecmd as a dependency and edits the configure script before it is run to refer to /usr/local/bin/file instead of /usr/bin/file

This probably doesn't require a change to the binary packages...