### PR TITLE
add ncat package - netcat on steroids - from the nmap suite

### DIFF
--- a/packages/ncat.rb
+++ b/packages/ncat.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Ncat < Package
+  description 'Ncat - Netcat for the 21st Century - a modern netcat with extra features from the makers of nmap.'
+  homepage 'https://nmap.org/ncat'
+  version '7.60'
+  source_url 'https://nmap.org/dist/nmap-7.60.tar.bz2'
+  source_sha256 'a8796ecc4fa6c38aad6139d9515dc8113023a82e9d787e5a5fb5fa1b05516f21'
+
+  binary_url ({
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncat-7.60-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    x86_64: '5660ea321436f1b9642d318a77e9b0b5c379825ac0611daaf5f82dd794753598',
+  })
+
+  depends_on 'buildessential' => :build
+  depends_on 'openssl' 
+  depends_on 'filecmd' => :build   #configure uses file 
+
+  def self.build
+    #fixup "/usr/bin/file" -> "file" in the configure script
+    system "sed -i s#/usr/bin/file#file#g libdnet-stripped/configure"
+    system "./configure"
+    system "cd ncat && make"
+  end
+
+  def self.install
+    system "cd ncat && make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end


### PR DESCRIPTION
Here is what I was talking about  - this removes the reference to the 'eventual install directory' of filecmd which needs to be preinstalled for configure to be happy...

and changes the URL to point bintray, where you can upload it.


The original is at: 

    https://www.clift.org/fred/chromebrew/ncat-7.60-chromeos-x86_64.tar.xz


Does that work?  If so, I'll make new PRs for the other packages