### PR TITLE
Add rlwrap package

### DIFF
--- a/packages/rlwrap.rb
+++ b/packages/rlwrap.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Rlwrap < Package
+  description 'A readline wrapper'
+  homepage 'https://github.com/hanslub42/rlwrap'
+  version '0.43'
+  source_url 'https://github.com/hanslub42/rlwrap/archive/v0.43.tar.gz'
+  source_sha256 '29e5a850fbe4753f353b0734e46ec0da043621bdcf7b52a89b77517f3941aade'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'autoconf'
+
+  def self.build
+    system "autoreconf --install"
+    system "./configure --prefix=#{CREW_PREFIX}"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/rlwrap.rb
+++ b/packages/rlwrap.rb
@@ -13,6 +13,7 @@ class Rlwrap < Package
   })
 
   depends_on 'autoconf'
+  depends_on 'readline'
 
   def self.build
     system "autoreconf --install"

--- a/packages/rlwrap.rb
+++ b/packages/rlwrap.rb
@@ -13,6 +13,7 @@ class Rlwrap < Package
   })
 
   depends_on 'autoconf'
+  depends_on 'automake'
   depends_on 'readline'
 
   def self.build


### PR DESCRIPTION
rlwrap is a 'readline wrapper', a small utility that uses the GNU readline library to allow the editing of keyboard input for any command. I couldn't find anything like it when I needed it, so I wrote
this one back in 1999.  By now, there are (and, in hindsight, even then there were) a number of good readline wrappers around, like rlfe, distributed as part of the GNU readline library, and the amazing socat (http://freecode.com/projects/socat). You should consider rlwrap especially when you need user-defined completion (by way of completion word lists) and persistent history, or if you want to program 'special effects' using the filter mechanism. rlwrap compiles and runs on a fairly wide range of Unix-like systems.  See https://github.com/hanslub42/rlwrap.