### PR TITLE
Update libpng from 1.6.32 to 1.6.33

### DIFF
--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -3,29 +3,25 @@ require 'package'
 class Libpng < Package
   description 'libpng is the official PNG reference library.'
   homepage 'http://libpng.org/pub/png/libpng.html'
-  version '1.6.32'
-  source_url 'http://prdownloads.sourceforge.net/libpng/libpng-1.6.32.tar.gz'
-  source_sha256 '1a8ae5c8eafad895cc3fce78fbcb6fdef663b8eb8375f04616e6496360093abb'
+  version '1.6.33'
+  source_url 'http://prdownloads.sourceforge.net/libpng/libpng-1.6.33.tar.gz'
+  source_sha256 '6a6bacae7510dd53321af0604182b6c731a09457e3ddb8d9668bbce614a2751f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.32-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.32-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.32-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.32-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '575871d19e38d2cc4e51889bd3f7866b12dd52d9929d66830065c0f490c3a7e7',
-     armv7l: '575871d19e38d2cc4e51889bd3f7866b12dd52d9929d66830065c0f490c3a7e7',
-       i686: 'd401afe08f7e1ff6b78e6a12cf89a71214d880bb876a71bd5f764fa787db8c3e',
-     x86_64: 'aadb3ac7f63711ccd3410a9775053fc9730d7e4462d39efed0c9e0db93fb5bce',
   })
 
   def self.build
-      system "./configure CFLAGS=\" -fPIC\""
-      system "make"
+      system './configure',
+        "--prefix=#{CREW_PREFIX}",
+        "--libdir=#{CREW_LIB_PREFIX}",
+        '--disable-dependency-tracking',
+        '--disable-maintainer-mode'
+      system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
This is a bugfix and maintenance release.

Tested as working on XE500C13-K01US.