### PR TITLE
Update manpages from 4.12 to 4.13

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -3,21 +3,13 @@ require 'package'
 class Mandb < Package
   description 'mandb is used to initialise or manually update index database caches that are usually maintained by man.'
   homepage 'http://savannah.nongnu.org/projects/man-db'
-  version '2.7.6.1-1'
+  version '2.7.6.1-2'
   source_url 'http://download.savannah.gnu.org/releases/man-db/man-db-2.7.6.1.tar.xz'
   source_sha256 '08edbc52f24aca3eebac429b5444efd48b9b90b9b84ca0ed5507e5c13ed10f3f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.7.6.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.7.6.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.7.6.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.7.6.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '178afecbafc791ce5e7635033a2ad060e11ef5ceb08fdb76cfc559c7e17cb334',
-     armv7l: '178afecbafc791ce5e7635033a2ad060e11ef5ceb08fdb76cfc559c7e17cb334',
-       i686: '7f21135eaa1e1d64a1262aa9d271647432af0701c1eff0c924ede416bd1594bc',
-     x86_64: '4194dd6a040716ed26d41a560f8f26c438d2d9a6b3e8e99746a2fa89c3b257ba',
   })
 
   depends_on 'less'
@@ -30,37 +22,39 @@ class Mandb < Package
 
   def self.build
     system './configure',
-      '--with-systemdtmpfilesdir=/usr/local/lib/tmpfiles.d',  # we can't write to /usr/lib/tmpfiles.d
-      '--disable-cache-owner',                                # we can't create the user 'man'
-      '--with-pager=/usr/local/bin/less'                      # the pager is not at the default location
+      "--with-systemdtmpfilesdir=#{CREW_PREFIX}/lib/tmpfiles.d", # we can't write to /usr/lib/tmpfiles.d
+      '--disable-cache-owner',                                   # we can't create the user 'man'
+      "--with-pager=#{CREW_PREFIX}/bin/less"                     # the pager is not at the default location
     system 'make'
   end
 
   def self.install
-    system "mkdir -p #{CREW_DEST_DIR}/usr/local/cache/man"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' include/manconfig.h.in"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' src/manp.c"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' src/tests/mandb-7"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' src/man_db.conf.in"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' init/systemd/man-db.conf"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' manual/db.me"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' manual/files.me"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' man/man1/whatis.man1"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' man/man1/apropos.man1"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' man/man1/man.man1"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' man/man8/accessdb.man8"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' man/man8/mandb.man8"
-    system "sed -i 's,/usr/share/man,/usr/local/share/man,g' tools/chconfig"
-    system "sed -i 's,/var/cache/man,/usr/local/cache/man,g' tools/chconfig"
+    system "mkdir -p #{CREW_DEST_PREFIX}/cache/man"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' include/manconfig.h.in"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' src/manp.c"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' src/tests/mandb-7"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' src/man_db.conf.in"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' init/systemd/man-db.conf"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' manual/db.me"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' manual/files.me"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' man/man1/whatis.man1"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' man/man1/apropos.man1"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' man/man1/man.man1"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' man/man8/accessdb.man8"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' man/man8/mandb.man8"
+    system "sed -i 's,/usr/share/man,#{CREW_PREFIX}/share/man,g' tools/chconfig"
+    system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' tools/chconfig"
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    puts ""
-    puts "You will have to change the default PAGER environment variable to be able to use mandb:".lightblue
-    puts "echo \"export PAGER=/usr/local/bin/less\" >> ~/.bashrc && . ~/.bashrc".lightblue
-    puts ""
-    puts "You will also have to set the MANPATH environment variable:".lightblue
-    puts "echo \"export MANPATH=/usr/local/man:$MANPATH\" >> ~/.bashrc && . ~/.bashrc".lightblue
-    puts ""
+  end
+
+  def self.postinstall
+    puts
+    puts "To finish the installation, set the default PAGER and MANPATH environment variables:".lightblue
+    puts "echo \"export PAGER=#{CREW_PREFIX}/bin/less\" >> ~/.bashrc".lightblue
+    puts "echo \"export MANPATH=#{CREW_PREFIX}/man:$MANPATH\" >> ~/.bashrc".lightblue
+    puts "source ~/.bashrc".lightblue
+    puts
     puts "To create the man databases and get apropos working, type 'mandb -c'.".lightblue
-    puts ""
+    puts
   end
 end

--- a/packages/manpages.rb
+++ b/packages/manpages.rb
@@ -3,25 +3,22 @@ require 'package'
 class Manpages < Package
   description 'The Linux man-pages project documents the Linux kernel and C library interfaces that are employed by user-space programs.'
   homepage 'https://www.kernel.org/doc/man-pages/'
-  version '4.12'
-  source_url 'https://www.kernel.org/pub/linux/docs/man-pages/man-pages-4.12.tar.xz'
-  source_sha256 '6f6d79d991fed04e16e7c7a15705304b0b9d51de772c51c57428555039fbe093'
+  version '4.13'
+  source_url 'https://www.kernel.org/pub/linux/docs/man-pages/man-pages-4.13.tar.xz'
+  source_sha256 'd5c005c5b653248ab6680560de00ea8572ff39e48a57bd5be1468d986a0631bf'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/manpages-4.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/manpages-4.12-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/manpages-4.12-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/manpages-4.12-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'e675407d63878417c0c94bb7302a512e5b483b44cca6e7929aa7e2d47ebb8b37',
-     armv7l: 'e675407d63878417c0c94bb7302a512e5b483b44cca6e7929aa7e2d47ebb8b37',
-       i686: '1478fdbc9abc2c4a2bea07478d1491741af90ecca71bad282a273ce46001a2c4',
-     x86_64: 'b6ca228781e27037ba75ce48d346d557b0fefdb07fa329db2c99dd31097adba0',
   })
 
+  depends_on 'mandb'
+
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "prefix=/usr/local", "install"
-    puts "Try 'man printf' to see if it works. You should have package 'mandb' installed.".lightblue
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "prefix=#{CREW_PREFIX}", "install"
+  end
+
+  def self.postinstall
+    puts "Try 'man printf' to see if it works.".lightblue
   end
 end


### PR DESCRIPTION
- Update manpages and mandb packages to include a postinstall section
- Abstract installation directories with Chromebrew constants