### PR TITLE
Update curl from 7.56.0 to 7.56.1

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,9 +3,9 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.haxx.se/'
-  version '7.56.0'
-  source_url 'https://curl.haxx.se/download/curl-7.56.0.tar.xz'
-  source_sha256 '32437bcca0e9434384329fdc733547879d25ba70335b3cf9e3d9cbc3e71fd172'
+  version '7.56.1'
+  source_url 'https://curl.haxx.se/download/curl-7.56.1.tar.xz'
+  source_sha256 '8eed282cf3a0158d567a0feaa3c4619e8e847970597b5a2c81879e8f0d1a39d1'
 
   binary_url ({
   })


### PR DESCRIPTION
This is a maintenance and bugfix release.

Tested as working on Samsung Chromebook Plus (aarch64).