### PR TITLE
Add Micro editor package

### DIFF
--- a/packages/micro.rb
+++ b/packages/micro.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Micro < Package
+  description 'A modern and intuitive terminal-based text editor'
+  homepage 'https://micro-editor.github.io/'
+  version '1.3.3'
+  source_url 'https://github.com/zyedidia/micro/archive/v1.3.3.tar.gz'
+  source_sha256 '22256792cd7136996f0b62f0ac789c1d86b4b96a01390058570b4b067592160b'
+
+  binary_url ({
+     armv7l: 'https://github.com/Alanaktion/chromebrew/releases/download/micro-v1.3.3/micro-1.3.3-arm.tar.xz',
+    aarch64: 'https://github.com/Alanaktion/chromebrew/releases/download/micro-v1.3.3/micro-1.3.3-arm.tar.xz',
+       i686: 'https://github.com/Alanaktion/chromebrew/releases/download/micro-v1.3.3/micro-1.3.3-i686.tar.xz',
+     x86_64: 'https://github.com/Alanaktion/chromebrew/releases/download/micro-v1.3.3/micro-1.3.3-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     armv7l: 'a33553178de468deee6922b6ddbedd2f7340eece225f143e0514838637220d0f',
+    aarch64: 'a33553178de468deee6922b6ddbedd2f7340eece225f143e0514838637220d0f',
+       i686: '90ee8680dbde1ef467f32a0c291fd244ada8dc6eb6ac89d8056a3617cfb93251',
+     x86_64: '7cc32cbc7fccf0e8fd48a2ab38d9e32a0d645dfee69a329c802d1802253ddbab',
+  })
+
+  depends_on 'go' => :build
+
+  def self.build
+    system "go get -d github.com/zyedidia/micro/cmd/micro"
+  end
+
+  def self.install
+    system "cd $GOPATH/src/github.com/zyedidia/micro"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.postinstall
+    system "rm -f #{CREW_DEST_DIR}/{LICENSE,LICENSE-THIRD-PARTY,README.md}"
+  end
+end

--- a/packages/micro.rb
+++ b/packages/micro.rb
@@ -4,30 +4,23 @@ class Micro < Package
   description 'A modern and intuitive terminal-based text editor'
   homepage 'https://micro-editor.github.io/'
   version '1.3.3'
-  source_url 'https://github.com/zyedidia/micro/archive/v1.3.3.tar.gz'
-  source_sha256 '22256792cd7136996f0b62f0ac789c1d86b4b96a01390058570b4b067592160b'
 
-  binary_url ({
-     armv7l: 'https://github.com/Alanaktion/chromebrew/releases/download/micro-v1.3.3/micro-1.3.3-arm.tar.xz',
-    aarch64: 'https://github.com/Alanaktion/chromebrew/releases/download/micro-v1.3.3/micro-1.3.3-arm.tar.xz',
-       i686: 'https://github.com/Alanaktion/chromebrew/releases/download/micro-v1.3.3/micro-1.3.3-i686.tar.xz',
-     x86_64: 'https://github.com/Alanaktion/chromebrew/releases/download/micro-v1.3.3/micro-1.3.3-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-     armv7l: 'a33553178de468deee6922b6ddbedd2f7340eece225f143e0514838637220d0f',
-    aarch64: 'a33553178de468deee6922b6ddbedd2f7340eece225f143e0514838637220d0f',
-       i686: '90ee8680dbde1ef467f32a0c291fd244ada8dc6eb6ac89d8056a3617cfb93251',
-     x86_64: '7cc32cbc7fccf0e8fd48a2ab38d9e32a0d645dfee69a329c802d1802253ddbab',
-  })
-
-  depends_on 'go' => :build
+  case ARCH
+  when 'aarch64'
+    source_url 'https://github.com/zyedidia/micro/releases/download/v1.3.3/micro-1.3.3-linux-arm.tar.gz'
+    source_sha256 '1d6ce6042b13fa19ecbae8b5a4d11b9e8d21b44f3720110993f62014199cd34c'
+  when 'armv7l'
+    source_url 'https://github.com/zyedidia/micro/releases/download/v1.3.3/micro-1.3.3-linux-arm.tar.gz'
+    source_sha256 '1d6ce6042b13fa19ecbae8b5a4d11b9e8d21b44f3720110993f62014199cd34c'
+  when 'i686'
+    source_url 'https://github.com/zyedidia/micro/releases/download/v1.3.3/micro-1.3.3-linux32.tar.gz'
+    source_sha256 '7600666ae08a878c40efa2448fce03a042a18132a2a7f27e134502d36065193d'
+  when 'x86_64'
+    source_url 'https://github.com/zyedidia/micro/releases/download/v1.3.3/micro-1.3.3-linux64.tar.gz'
+    source_sha256 '329f746e4ee9edf244618dda4208b638fda34c593d5cd96d8f71dc3b53e3d994'
+  end
 
   def self.install
-    system "go get -d github.com/zyedidia/micro/cmd/micro"
-    gopath = `go env GOPATH`.strip
-    Dir.chdir "#{gopath}/src/github.com/zyedidia/micro/cmd/micro" do
-      system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
-      system "go build -o #{CREW_DEST_DIR}/usr/local/bin/micro"
-    end
+    system "install -Dm755 micro #{CREW_DEST_PREFIX}/bin/micro"
   end
 end

--- a/packages/micro.rb
+++ b/packages/micro.rb
@@ -22,16 +22,12 @@ class Micro < Package
 
   depends_on 'go' => :build
 
-  def self.build
-    system "go get -d github.com/zyedidia/micro/cmd/micro"
-  end
-
   def self.install
-    system "cd $GOPATH/src/github.com/zyedidia/micro"
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-  end
-
-  def self.postinstall
-    system "rm -f #{CREW_DEST_DIR}/{LICENSE,LICENSE-THIRD-PARTY,README.md}"
+    system "go get -d github.com/zyedidia/micro/cmd/micro"
+    gopath = `go env GOPATH`.strip
+    Dir.chdir "#{gopath}/src/github.com/zyedidia/micro/cmd/micro" do
+      system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
+      system "go build -o #{CREW_DEST_DIR}/usr/local/bin/micro"
+    end
   end
 end


### PR DESCRIPTION
This package adds the excellent Go-based [Micro editor](https://micro-editor.github.io/). The source install seems to work with the Go I have installed, but I couldn't get Go to install from Chromebrew to test it properly. The binary executables are unmodified from the upstream files, just repackaged to include the Chromebrew filelist.