### PR TITLE
[compressdoc] Download single file instead of archive

### DIFF
--- a/packages/compressdoc.rb
+++ b/packages/compressdoc.rb
@@ -3,25 +3,16 @@ require 'package'
 class Compressdoc < Package
   description 'Compress (with bzip2 or gzip) all man pages in a hierarchy and update symlinks'
   homepage 'https://github.com/ojab/BLFS/blob/master/auxfiles/compressdoc'
-  version '9b2b12'
-  source_url 'https://github.com/ojab/BLFS/archive/9b2b12c0d809e287e1ea3fa4790a73a71feffbe4.tar.gz'
-  source_sha256 '6ebe4a9bbef5d0e84a36e56ac6fb1f0a2cfa86cb00c49628a0d3151d37f5d2f1'
+  version '20080421.1623'
+  source_url 'https://raw.githubusercontent.com/ojab/BLFS/af6c11d985fe36c8828abaa9d5124c8725580b15/auxfiles/compressdoc'
+  source_sha256 'f380473baaa8785b1c7a7a30f2dda4b748a9baed3b335655faedad49ebf8246b'
+
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/compressdoc-9b2b12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/compressdoc-9b2b12-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/compressdoc-9b2b12-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/compressdoc-9b2b12-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b3af093343c2651168f28aea8dc4ac36709b2c13c0b6430553762580b0330ccd',
-     armv7l: 'b3af093343c2651168f28aea8dc4ac36709b2c13c0b6430553762580b0330ccd',
-       i686: '88addb581c6c8b6764d896097d412ff805fdc646a8a801f6246db9ced322a4e1',
-     x86_64: 'f2eebdff47e0e6758ab1bf504577ea2d4513a2cbfb768b12439624db73e5fbaf',
   })
 
   def self.install
-    system "chmod +x auxfiles/compressdoc"
-    system "mkdir -p #{CREW_DEST_DIR}/usr/local/bin"
-    system "cp auxfiles/compressdoc #{CREW_DEST_DIR}/usr/local/bin"
+    system "install -Dm755 ../compressdoc #{CREW_DEST_PREFIX}/bin/compressdoc"
   end
 end


### PR DESCRIPTION
We only require the shellscript named compressdoc but have been
downloading a 1.9M archive and then copying the file into our bin
directory.

This changes the behavior to download the one file that we need via
Github's raw user content service.

It also simplifies the installation to a single line using the install
command.

Closes #1326.