### PR TITLE
Adding elinks package

### DIFF
--- a/packages/elinks.rb
+++ b/packages/elinks.rb
@@ -3,10 +3,10 @@ require 'package'
 class Elinks < Package
   description 'Full-Featured Text WWW Browser'
   homepage 'http://elinks.or.cz/'
-  version 'f86be65971'
+  version 'f86be659'
 
-  source_url 'https://git.phpizza.com/alan/elinks/archive/f86be659718c0cd0a67f88b42f07044c23d0d028.tar.gz'
-  source_sha256 'ce416fdd57b23442275b5d74c80e0ac5793b66ec0f8ed07500c64eb647339838'
+  source_url 'https://gitlab.com/alanaktion/elinks-mirror/repository/f86be659718c0cd0a67f88b42f07044c23d0d028/archive.tar.gz'
+  source_sha256 'c19a342a5a6716b5213a4c539a149711491136d8b12daba7846bc2225c5fb309'
 
   depends_on 'bz2'
   depends_on 'lzip'

--- a/packages/elinks.rb
+++ b/packages/elinks.rb
@@ -3,10 +3,10 @@ require 'package'
 class Elinks < Package
   description 'Full-Featured Text WWW Browser'
   homepage 'http://elinks.or.cz/'
-  version '0.13'
+  version 'f86be65971'
 
-  source_url 'http://elinks.cz/download/elinks-current-0.13.tar.gz'
-  source_sha256 '39f3101c1c39808193b92907dbb779b21bc175a8d381ee05d663680c65aef557'
+  source_url 'https://git.phpizza.com/alan/elinks/archive/f86be659718c0cd0a67f88b42f07044c23d0d028.tar.gz'
+  source_sha256 'ce416fdd57b23442275b5d74c80e0ac5793b66ec0f8ed07500c64eb647339838'
 
   depends_on 'bz2'
   depends_on 'lzip'

--- a/packages/elinks.rb
+++ b/packages/elinks.rb
@@ -1,0 +1,27 @@
+require 'package'
+
+class Elinks < Package
+  description 'Full-Featured Text WWW Browser'
+  homepage 'http://elinks.or.cz/'
+  version '0.13'
+
+  source_url 'http://elinks.cz/download/elinks-current-0.13.tar.gz'
+  source_sha256 '39f3101c1c39808193b92907dbb779b21bc175a8d381ee05d663680c65aef557'
+
+  depends_on 'bz2'
+  depends_on 'lzip'
+  depends_on 'openssl'
+  depends_on 'zlibpkg'
+
+  def self.build
+    system "wget -O config/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'"
+    system "wget -O config/config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'"
+    system "sh autogen.sh" unless File.executable? "configure"
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "make"
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end


### PR DESCRIPTION
This adds the [ELinks](http://elinks.cz/) web browser. I'm using the latest 0.13 git release since the stable releases are very old and missing a lot of features and modern architecture support.

One thing that may not work with this package is that the `source_url` file is rebuilt every day, so the hash likely won't match. Would it be a good idea to mirror this file somewhere else so the hash stays valid?