### PR TITLE
Add clozure common lisp package

### DIFF
--- a/packages/ccl.rb
+++ b/packages/ccl.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Ccl < Package
+  description 'Clozure CL is a fast, mature, open source Common Lisp implementation.'
+  homepage 'https://ccl.clozure.com'
+  version '1.11'
+
+  # arm only has a 32-bit build in the archive
+  # intel has both 32-bit and 64-bit in the archive
+  case ARCH
+  when 'aarch64', 'armv7l'
+    source_url 'ftp://ftp.clozure.com/pub/release/1.11/ccl-1.11-linuxarm.tar.gz'
+    source_sha256 '64a1911fbe516b73964b377df360c3a40695c6155e0730a6590c67f1953a88f4'
+  when 'i686', 'x86_64'
+    source_url 'ftp://ftp.clozure.com/pub/release/1.11/ccl-1.11-linuxx86.tar.gz'
+    source_sha256 '08e885e8c2bb6e4abd42b8e8e2b60f257c6929eb34b8ec87ca1ecf848fac6d70'
+  end
+
+  def self.install
+    system "mkdir -p #{CREW_DEST_PREFIX}/share/ccl"
+    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
+    FileUtils.cp_r Dir.pwd, "#{CREW_DEST_PREFIX}/share"
+    # the name of the repl binary and kernel image are different for each arch
+    case ARCH
+    when 'aarch64', 'armv7l'
+      system "ln -s #{CREW_PREFIX}/share/ccl/armcl #{CREW_DEST_PREFIX}/bin/ccl"
+    when 'i686'
+      system "ln -s #{CREW_PREFIX}/share/ccl/lx86cl #{CREW_DEST_PREFIX}/bin/ccl"
+    when 'x86_64'
+      system "ln -s #{CREW_PREFIX}/share/ccl/lx86cl64 #{CREW_DEST_PREFIX}/bin/ccl"
+    end
+  end
+end


### PR DESCRIPTION
Clozure CL (often called CCL for short) is a free Common Lisp implementation
with a long history. Some distinguishing features of the implementation include
fast compilation speed, native threads, a precise, generational, compacting
garbage collector, and a convenient foreign-function interface.

Intel machines have both 32-bit and 64-bit versions available. ARM machines
currently only have a 32-bit version available. 64-bit for ARM is in
development.

Tested as working on Samsung Chromebook Plus (ARMv8).

I don't have an i686 Chromebook for testing so it'd be appreciated if someone could make sure that things work properly on 32-bit Intel.