### PR TITLE
Fixing libgcrypt build on aarch64

### DIFF
--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -15,9 +15,16 @@ class Libgcrypt < Package
   depends_on 'libgpgerror'
 
   def self.build
-    system './configure',
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}"
+    if ARCH == 'aarch64'
+      system './configure',
+        "--prefix=#{CREW_PREFIX}",
+        "--libdir=#{CREW_LIB_PREFIX}",
+        "--build=armv7l"
+    else
+      system './configure',
+        "--prefix=#{CREW_PREFIX}",
+        "--libdir=#{CREW_LIB_PREFIX}"
+    end
     system 'make'
   end
 


### PR DESCRIPTION
Currently the libgcrypt configure script tries to compile for aarch64 by default on aarch64 devices and fails to build. This fixes the issue on that architecture.