### PR TITLE
Adding tree dependency to pass

### DIFF
--- a/packages/pass.rb
+++ b/packages/pass.rb
@@ -8,6 +8,7 @@ class Pass < Package
   source_sha256 'f6d2199593398aaefeaa55e21daddfb7f1073e9e096af6d887126141e99d9869'
 
   depends_on 'gnupg'
+  depends_on 'tree'
 
   def self.install
     system  "make", "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", "install"

--- a/packages/pass.rb
+++ b/packages/pass.rb
@@ -3,7 +3,7 @@ require 'package'
 class Pass < Package
   description "The standard unix password manager"
   homepage 'https://www.passwordstore.org/'
-  version '1.7.1'
+  version '1.7.1-1'
   source_url 'https://git.zx2c4.com/password-store/snapshot/password-store-1.7.1.tar.xz'
   source_sha256 'f6d2199593398aaefeaa55e21daddfb7f1073e9e096af6d887126141e99d9869'
 


### PR DESCRIPTION
The pass program requires tree to list the stored passwords correctly.