### PR TITLE
Disable MPI assembler modules for ARMv8

### DIFF
--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libgcrypt < Package
   description 'Libgcrypt is a general purpose cryptographic library originally based on code from GnuPG.'
   homepage 'https://www.gnupg.org/related_software/libgcrypt/index.html'
-  version '1.8.1'
+  version '1.8.1-1'
   source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.1.tar.bz2'
   source_sha256 '7a2875f8b1ae0301732e878c0cca2c9664ff09ef71408f085c50e332656a78b3'
 
@@ -15,9 +15,18 @@ class Libgcrypt < Package
   depends_on 'libgpgerror'
 
   def self.build
-    system './configure',
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}"
+    case ARCH
+    when 'aarch64'
+      system 'export gcry_cv_gcc_arm_platform_as_ok=no'
+      system './configure',
+        "--prefix=#{CREW_PREFIX}",
+        "--libdir=#{CREW_LIB_PREFIX}",
+        '--disable-asm'
+    else
+      system './configure',
+        "--prefix=#{CREW_PREFIX}",
+        "--libdir=#{CREW_LIB_PREFIX}"
+    end
     system 'make'
   end
 


### PR DESCRIPTION
The included MPI assembler code doesn't work for the ARMv8 processor in
the Samsung Chromebook Plus (and possibly others). Until upstream adds
support for these processors they must be disabled for the package to
build properly.

In the future support will probably be added for these processors
enabling us to re-enable support for MPI ASM modules.

Closes #1344 