### PR TITLE
Update libuv from 1.14.1 to 1.15.0

### DIFF
--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -3,9 +3,9 @@ require 'package'
 class Libuv < Package
   description 'libuv is a multi-platform support library with a focus on asynchronous I/O.'
   homepage 'http://libuv.org/'
-  version '1.14.1'
-  source_url 'https://dist.libuv.org/dist/v1.14.1/libuv-v1.14.1.tar.gz'
-  source_sha256 'f32243d2ad8eb7604cdfff8f719353bbcc4ebbc41def78930569372d7f257d22'
+  version '1.15.0'
+  source_url 'https://dist.libuv.org/dist/v1.15.0/libuv-v1.15.0.tar.gz'
+  source_sha256 '28b1b334ae79fdbb025c7a4dacf3cb14738f9d336998bc42bbdbe72b8799fe85'
 
   binary_url ({
   })


### PR DESCRIPTION
This is a bugfix and maintenance release.

Tested as working on Samsung Chromebook Plus (ARMv8). All tests passing.