### PR TITLE
Use Ruby ENV for libgcrypt build

### DIFF
--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -17,7 +17,7 @@ class Libgcrypt < Package
   def self.build
     case ARCH
     when 'aarch64'
-      system 'export gcry_cv_gcc_arm_platform_as_ok=no'
+      ENV['gcry_cv_gcc_arm_platform_as_ok'] = 'no'
       system './configure',
         "--prefix=#{CREW_PREFIX}",
         "--libdir=#{CREW_LIB_PREFIX}",


### PR DESCRIPTION
This fixes issues with building libgcrypt on aarch64 without manually setting an environment variable. See #1346.

I didn't bump the version number here since the package would not have built properly on the affected architecture. That seems correct to me until a decision is reached on #1123.