### PR TITLE
Update README.md to include crew files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supported Systems
 | x86_64 | Yes |
 | i686 | Yes |
 | armv7l | Yes |
-| aarch64 | Yes (use armv7l binaries) |
+| aarch64 | Yes |
 
 Overview
 --------
@@ -35,25 +35,33 @@ If this command returns `ERROR: unknown command: shell` please have a second loo
 
 Then download and run the installation script below:
 
-    wget -q -O - https://raw.github.com/skycocker/chromebrew/master/install.sh | bash
+    `wget -q https://raw.github.com/skycocker/chromebrew/master/install.sh && yes | bash install.sh`
 
-On a rooted Google OnHub, the command need to be run with "chronos" user. In order to make sudo work, a password is needed for chronos user.
+    -- or --
 
-    passwd chronos
-    # Choose your password
-    su - chronos
-    curl -L https://raw.github.com/skycocker/chromebrew/master/install.sh | bash
-    # When prompt, use the password you just created for "chronos" user.
+    `curl -Ls git.io/vddgY -o install.sh && yes | bash install.sh`
 
+On a rooted Google OnHub, the command needs to be run with the "chronos" user. In order to make su work, a password is needed for the chronos user.
+
+    ```bash
+    # passwd chronos
+    Changing password for chronos.
+    Enter new UNIX password:
+    Retype new UNIX password:
+    # su - chronos
+    Password:
+    $ curl -Ls https://raw.github.com/skycocker/chromebrew/master/install.sh | bash
+    ```
 Usage
 -----
 
-    crew <command> [-k|--keep] <package1> [<package2> ...]
+    `crew <command> [-k|--keep] <package1> [<package2> ...]`
 
 Where available commands are:
 
   * build [build package(s) from source and store the archive and checksum in the current working directory]
   * download [download package(s) to `CREW_BREW_DIR` (`/usr/local/tmp/crew` by default), but don't install]
+  * files [display installed files of package(s).]
   * help [get information about command usage]
   * install [install package(s) along with dependencies after prompting for confirmation]
   * remove [remove package(s)]
@@ -66,7 +74,7 @@ Available packages are listed in the [packages directory](https://github.com/sky
 
 Chromebrew will wipe its `BREW_DIR` (`/usr/local/tmp/crew` by default) after installation unless you pass `-k` or `--keep` when running `crew install`.
 
-    crew install --keep <package1> [<package2> ...]
+    `crew install --keep <package1> [<package2> ...]`
 
 License
 -------


### PR DESCRIPTION
- Remove mention of armv7l binaries for aarch64
- Update install line to handle Y/n prompts
- Add optional curl install line
- Hash commands for clarity

In support of @efmeeks, I added the install line as suggested in #1310.

Closes #1353.