### PR TITLE
Add alsa_lib and alsa_plugins packages

### DIFF
--- a/packages/alsa_lib.rb
+++ b/packages/alsa_lib.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Alsa_lib < Package
+  description 'The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionality to the Linux operating system.'
+  homepage 'https://www.alsa-project.org/main/index.php/Main_Page'
+  version '1.1.4.1'
+  source_url 'ftp://ftp.alsa-project.org/pub/lib/alsa-lib-1.1.4.1.tar.bz2'
+  source_sha256 '91bb870c14d1c7c269213285eeed874fa3d28112077db061a3af8010d0885b76'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/alsa_plugins.rb
+++ b/packages/alsa_plugins.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Alsa_plugins < Package
+  description 'alsa-plugins contains plugins for various ALSA needs (e.g. Jack).'
+  homepage 'https://www.alsa-project.org/main/index.php/Main_Page'
+  version '1.1.4'
+  source_url 'ftp://ftp.alsa-project.org/pub/plugins/alsa-plugins-1.1.4.tar.bz2'
+  source_sha256 '530d1c3bdaeb058f2a03607a33b9e16ee5369bfd30a96bc09bd2c69b4ddd1a8a'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'alsa_lib'
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionality to the Linux operating system. alsa-plugins contains plugins for various ALSA needs (e.g. Jack). See https://www.alsa-project.org/main/index.php/Main_Page.