### PR TITLE
Command suggestions

### DIFF
--- a/crew
+++ b/crew
@@ -11,6 +11,7 @@ require 'digest/sha2'
 require 'json'
 require 'fileutils'
 require_relative 'lib/const'
+require_relative 'lib/util'
 
 # Add lib to LOAD_PATH
 $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"
@@ -51,6 +52,16 @@ require_relative 'lib/docopt'
 begin
   args = Docopt::docopt(DOC)
 rescue Docopt::Exit => e
+  puts "Could not understand \"crew #{ARGV.join(' ')}\".".lightred
+  cmds = ["build", "download", "files", "help", "install", "remove", "search", "update", "upgrade", "whatprovides"]
+  # Looking for similar commands
+  if ARGV.size >= 1 and not cmds.include?(ARGV[0]) then
+    similar = cmds.select {|word| edit_distance(ARGV[0], word) < 4}
+    if not similar.empty? then
+      puts "Did you mean?"
+      similar.each {|sug| puts "  #{sug}"}
+    end
+  end
   puts e.message
   exit 1
 end

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -1,0 +1,31 @@
+require "matrix"
+
+class MutableMatrix < Matrix
+  public :"[]="
+end
+
+# Returns the edit distance between strings a and b
+# https://en.wikipedia.org/wiki/Edit_distance
+def edit_distance (a, b)
+  # memo is the matrix for dynamic programming
+  # memo[i, j] = the edit distance between the
+  # prefixes of a and b of size i and j.
+  memo = MutableMatrix.zero(a.size + 1, b.size + 1)
+  a.size.times {|i| memo[i + 1, 0] = i + 1}
+  b.size.times {|j| memo[0, j + 1] = j + 1}
+  a.size.times do |i|
+    b.size.times do |j|
+      if a[i] == b[j] then
+        memo[i + 1, j + 1] = memo[i, j]
+      else
+        memo[i + 1, j + 1] = [
+          memo[i + 1, j],
+          memo[i, j + 1],
+          memo[i, j]
+        ].min + 1
+      end
+    end
+  end
+
+  return memo[a.size, b.size]
+end


### PR DESCRIPTION
When you mistype a command, it shows similar commands.

For example
```
$ crew updstr
Could not understand "crew updstr".
Did you mean?
  update
Usage:
  crew build [-k|--keep] <name> ...
  ...
```