### PR TITLE
Update xe from 0.9 to 0.10

### DIFF
--- a/packages/xe.rb
+++ b/packages/xe.rb
@@ -3,9 +3,9 @@ require 'package'
 class Xe < Package
   description 'simple xargs and apply replacement.'
   homepage 'https://github.com/chneukirchen/xe/'
-  version '0.9'
-  source_url 'https://github.com/chneukirchen/xe/archive/v0.9.tar.gz'
-  source_sha256 '0e72bafd0d5c30953ef7a5dca710296aec621a60fb62c0aaf7ee2af5e68c2ac2'
+  version '0.10'
+  source_url 'https://github.com/chneukirchen/xe/archive/v0.10.tar.gz'
+  source_sha256 '8993cea06b2c664195df2a6124d0386d1bce7c27eb6ecbf968866bfd05cb9d7a'
 
   binary_url ({
   })


### PR DESCRIPTION
This is a bugfix and maintenance release.

Tested as working on Samsung Chromebook Plus (aarch64).