### PR TITLE
gnupg.rb : update to version 2.2.2

### DIFF
--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -22,7 +22,6 @@ class Gnupg < Package
   depends_on 'gettext'
 
   def self.build
-    system './autogen.sh'
     system './configure',
       "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}"

--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -3,9 +3,9 @@ require 'package'
 class Gnupg < Package
   description 'GnuPG is a complete and free implementation of the OpenPGP standard as defined by RFC4880 (also known as PGP).'
   homepage 'https://gnupg.org/'
-  version '2.2.1'
-  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.1.tar.bz2'
-  source_sha256 '34d70cd65b9c95f3f2f90a9f5c1e0b6a0fe039a8d685e2d66d69c33d1cbf62fb'
+  version '2.2.2'
+  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.2.tar.bz2'
+  source_sha256 'bfb62c7412ceb3b9422c6c7134a34ff01a560f98eb981c2d96829c1517c08197'
 
   binary_url ({
   })


### PR DESCRIPTION
--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -3,9 +3,9 @@ require 'package'
 class Gnupg < Package
    description 'GnuPG is a complete and free implementation of the
    OpenPGP standard as defined by RFC4880 (also known as PGP).'
       homepage 'https://gnupg.org/'
       -  version '2.2.1'
       -  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.1.tar.bz2'
       -  source_sha256 '34d70cd65b9c95f3f2f90a9f5c1e0b6a0fe039a8d685e2d66d69c33d1cbf62fb'
       +  version '2.2.2'
       +  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.2.tar.bz2'
       +  source_sha256 'bfb62c7412ceb3b9422c6c7134a34ff01a560f98eb981c2d96829c1517c08197'

	   binary_url ({
	      })