### PR TITLE
Update stressng from 0.08.16 to 0.09.02

### DIFF
--- a/packages/stressng.rb
+++ b/packages/stressng.rb
@@ -3,9 +3,9 @@ require 'package'
 class Stressng < Package
   description 'stress-ng will stress test a computer system in various selectable ways.'
   homepage 'http://kernel.ubuntu.com/~cking/stress-ng/'
-  version '0.08.16'
-  source_url 'http://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.08.16.tar.gz'
-  source_sha256 '315311d4fd09d1e06935bcb9c72b8bbb8289f8d4385a32a6b427bd067d816a87'
+  version '0.09.02'
+  source_url 'http://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.09.02.tar.gz'
+  source_sha256 '9fffd8e8157ee969dfe99d1a5b310ff3337b1dbecd276ccaa8c30c1cc14392fd'
 
   binary_url ({
   })


### PR DESCRIPTION
This is a bugfix and maintenance release.

Tested as working on Samsung Chromebook Plus (aarch64).