### PR TITLE
Update libxml2 from 2.9.6 to 2.9.7

### DIFF
--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,9 +3,9 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.6'
-  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.6.tar.gz'
-  source_sha256 '8b9038cca7240e881d462ea391882092dfdc6d4f483f72683e817be08df5ebbc'
+  version '2.9.7'
+  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz'
+  source_sha256 'f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c'
 
   binary_url ({
   })


### PR DESCRIPTION
This is a bugfix and maintenance release.

Tested as working on Samsung Chromebook Plus (aarch64).