### PR TITLE
Update apriconv from 1.2.1-1 to 1.2.2

### DIFF
--- a/packages/apriconv.rb
+++ b/packages/apriconv.rb
@@ -3,9 +3,9 @@ require 'package'
 class Apriconv < Package
   description 'a portable implementation of the iconv() library'
   homepage 'http://apr.apache.org/'
-  version '1.2.1-1'
-  source_url 'http://apache.claz.org/apr/apr-iconv-1.2.1.tar.bz2'
-  source_sha256 'c46c919bc2a36a705f91f4dea444b18a83236eef97a417528a988113b3a7e46e'
+  version '1.2.2'
+  source_url 'https://apache.claz.org/apr/apr-iconv-1.2.2.tar.bz2'
+  source_sha256 '7d454e0fe32f2385f671000e3b755839d16aabd7291e3947c973c90377c35313'
 
   binary_url ({
   })
@@ -13,18 +13,21 @@ class Apriconv < Package
   })
 
   depends_on 'apr'
-  depends_on 'httpd'
   depends_on 'libtool'
 
   def self.build
     system "./configure \
             --prefix=#{CREW_PREFIX} \
+            --libdir=#{CREW_LIB_PREFIX} \
             --with-apr=#{CREW_PREFIX}"
+    system "sed -i 's,/usr/local/lib,#{CREW_LIB_PREFIX},g' Makefile"
+    system "sed -i 's,/usr/local/lib,#{CREW_LIB_PREFIX},g' ccs/Makefile"
+    system "sed -i 's,/usr/local/lib,#{CREW_LIB_PREFIX},g' ces/Makefile"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    system "libtool --mode=finish #{CREW_DEST_PREFIX}/lib/iconv"
+    system "libtool --mode=finish #{CREW_DEST_LIB_PREFIX}/iconv"
   end
 end


### PR DESCRIPTION
This update is necessary since the 1.2.1 source is no longer available.