### PR TITLE
Add libusbmuxd package

### DIFF
--- a/packages/libusbmuxd.rb
+++ b/packages/libusbmuxd.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Libusbmuxd < Package
+  description 'USB Multiplex Daemon'
+  homepage 'http://www.libimobiledevice.org/'
+  version '1.0.9'
+  source_url 'http://www.libimobiledevice.org/downloads/libusbmuxd-1.0.9.tar.bz2'
+  source_sha256 'i2e3f708a3df30ad7832d2d2389eeb29f68f4e4488a42a20149cc99f4f9223dfc'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'glib'
+  depends_on 'libplist'
+
+  def self.build
+    system './configure',
+      "--prefix=#{CREW_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}",
+      '--disable-dependency-tracking'
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+end


### PR DESCRIPTION
libusbmuxd is a USB multiplexing daemon. This is being added as a
dependency for libimobiledevice.

Tested as working on Samsung Chromebook Plus (aarch64).

*NOTE*: Requires merging #1413 first.