### PR TITLE
Update perl from 5.24.1-3 to 5.26.1

### DIFF
--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -3,21 +3,13 @@ require 'package'
 class Perl < Package
   description 'Perl 5 is a highly capable, feature-rich programming language with over 29 years of development.'
   homepage 'https://www.perl.org/'
-  version '5.24.1-3'
-  source_url 'http://www.cpan.org/src/5.0/perl-5.24.1.tar.gz'
-  source_sha256 'e6c185c9b09bdb3f1b13f678999050c639859a7ef39c8cad418448075f5918af'
+  version '5.26.1'
+  source_url 'http://www.cpan.org/src/5.0/perl-5.26.1.tar.gz'
+  source_sha256 'e763aa485e8dc1a70483dbe6d615986bbf32b977f38016480d68c99237e701dd'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl-5.24.1-3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '98a97e66b1bef91a97654675197141b4c2b25990b2ba17465ff33d98a494c521',
-     armv7l: '98a97e66b1bef91a97654675197141b4c2b25990b2ba17465ff33d98a494c521',
-       i686: '04930ee73e84e5df65c759e9b9b7be1f956c3c99cdc34dc74b504088d6b73021',
-     x86_64: '4f436341733c7230bfd843349a0737fd910e2762ff3f990ef976b466c305b930',
   })
 
   depends_on 'patch' => :build


### PR DESCRIPTION
This is a bugfix and maintenance release.

Tested as working on Samsung Chromebook Plus (aarch64).

*NOTE*: This does break vim because it can't find libperl.so. I'm not sure if vim needs to be modified or if this package does. Perl works correctly and all tests pass.