### PR TITLE
Update gdal from 2.2.1 to 2.2.3

### DIFF
--- a/packages/gdal.rb
+++ b/packages/gdal.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gdal < Package
   description 'The Geospatial Data Abstraction Library is a translator for raster and vector geospatial data formats.'
   homepage 'http://www.gdal.org/'
-  version '2.2.1'
-  source_url 'http://download.osgeo.org/gdal/2.2.1/gdal-2.2.1.tar.xz'
-  source_sha256 '927098d54083ac919a497f787b835b099e9a194f2e5444dbff901f7426b86066'
+  version '2.2.3'
+  source_url 'http://download.osgeo.org/gdal/2.2.3/gdal-2.2.3.tar.xz'
+  source_sha256 'a328d63d476b3653f5a25b5f7971e87a15cdf8860ab0729d4b1157ba988b8d0b'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gdal-2.2.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gdal-2.2.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gdal-2.2.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gdal-2.2.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '4c384905671538d0eb26a9e29a8dc7d3b2cf5e3e429282c637a138e11c5d75d2',
-     armv7l: '4c384905671538d0eb26a9e29a8dc7d3b2cf5e3e429282c637a138e11c5d75d2',
-       i686: '8f6a1b7c965c3e58eda805e91c8ecc3e7f145aff766d34f15c2186ff4c3c22fe',
-     x86_64: 'b23583b8becbb229b1f6b958c4ab04374ddfdae0d22c506739bea3af25fdf9a0',
   })
 
   depends_on 'python27'
@@ -27,7 +19,18 @@ class Gdal < Package
   depends_on 'libxml2'
 
   def self.build
-    system "./configure CFLAGS=\" -fPIC\" --with-png=internal --with-libtiff=internal --with-geotiff=internal --with-jpeg=internal --with-gif=internal --with-curl=/usr/local/bin/curl-config --with-geos=/usr/local/bin/geos-config --with-static-proj4=/usr/local/share/proj --with-python"
+    system "./configure",
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           "--with-png=internal",
+           "--with-libtiff=internal",
+           "--with-geotiff=internal",
+           "--with-jpeg=internal",
+           "--with-gif=internal",
+           "--with-curl=#{CREW_PREFIX}/bin/curl-config",
+           "--with-geos=#{CREW_PREFIX}/bin/geos-config",
+           "--with-static-proj4=#{CREW_PREFIX}/share/proj",
+           "--with-python"
     system "make"
   end
 


### PR DESCRIPTION
This is one of the base packages so we need binaries.