### PR TITLE
Update byobu from 5.119 to 5.123

### DIFF
--- a/packages/byobu.rb
+++ b/packages/byobu.rb
@@ -3,27 +3,23 @@ require 'package'
 class Byobu < Package
   description 'Byobu is a GPLv3 open source text-based window manager and terminal multiplexer.'
   homepage 'http://byobu.org/'
-  version '5.119'
-  source_url 'https://launchpadlibrarian.net/322131788/byobu_5.119.orig.tar.gz'
-  source_sha256 '4b092ca12d3a33e89d84cc90c4a41af2ba8697d48e26080a45d64d6b7800ca77'
+  version '5.123'
+  source_url 'https://launchpad.net/byobu/trunk/5.123/+download/byobu_5.123.orig.tar.gz'
+  source_sha256 '2e5a5425368d2f74c0b8649ce88fc653420c248f6c7945b4b718f382adc5a67d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/byobu-5.119-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/byobu-5.119-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/byobu-5.119-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/byobu-5.119-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '9abd65ef1e50517041840f45d0996ba934772064d5d369481eca19d051ab784c',
-     armv7l: '9abd65ef1e50517041840f45d0996ba934772064d5d369481eca19d051ab784c',
-       i686: 'eace545af06c52b9103fc1bdf6309c14113e8c483c50a8ee9acd2bf43ba24939',
-     x86_64: 'fe135c3fe2fd13624759a474b011bfbb1eddfb0c1325d656e7b2b12e1c40d903',
   })
 
   depends_on 'gawk'
+  depends_on 'tmux' unless File.exists? "#{CREW_PREFIX}/bin/screen"
 
   def self.build
     system './configure'
+    system "sed -i '249d' Makefile && sed -i '262d' Makefile"
+    system "sed -i '242iprefix = #{CREW_PREFIX}' Makefile"
+    system "sed -i '243iexec_prefix = \${prefix}' Makefile"
     system 'make'
   end
 


### PR DESCRIPTION
This package installs files in `/usr/local/lib` but since that path is so tightly integrated into the executables, changing it was more trouble than it's probably worth.