### PR TITLE
piping 'y' to `crew install` to handle prompt: 'do you agree? y/n'

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -185,8 +185,8 @@ echo lib >> .git/info/sparse-checkout
 echo crew >> .git/info/sparse-checkout
 git fetch origin master
 git reset --hard origin/master
-crew install buildessential
-crew install less
+yes | crew install buildessential
+yes | crew install less
 echo
 echo "You will have to set the default PAGER environment variable to be able to use less:"
 echo "echo \"export PAGER=$CREW_PREFIX/bin/less\" >> ~/.bashrc && . ~/.bashrc"


### PR DESCRIPTION
I'm not sure what buildessential wanted me to agree to, but the install script got hung up asking me if I wanted to agree.  I realized after the fact that I was pretty much done with the install and could simply have installed buildessential interactively, but at the time I thought it was hung up earlier.

This change says yes to the wayward prompt, which allows installation to complete.