### PR TITLE
Add pre-built binaries for m-z packages

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -8,8 +8,16 @@ class Mandb < Package
   source_sha256 '08edbc52f24aca3eebac429b5444efd48b9b90b9b84ca0ed5507e5c13ed10f3f'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.7.6.1-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.7.6.1-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.7.6.1-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.7.6.1-2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd583e56cd4c924f328f2b0052de2d08b8f0e6519db7a6c9b232852bbca76f6bf',
+     armv7l: 'd583e56cd4c924f328f2b0052de2d08b8f0e6519db7a6c9b232852bbca76f6bf',
+       i686: '64ca4d1b671f87fa2fa72edc35368fe54ab5ca4d8fddbb99981b6179deb5fd88',
+     x86_64: '37da9857a8e52bfb5ca02e672c2632eceba5eb42d331698c28d8c98029cf3351',
   })
 
   depends_on 'less'

--- a/packages/manpages.rb
+++ b/packages/manpages.rb
@@ -8,8 +8,16 @@ class Manpages < Package
   source_sha256 'd5c005c5b653248ab6680560de00ea8572ff39e48a57bd5be1468d986a0631bf'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/manpages-4.13-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/manpages-4.13-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/manpages-4.13-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/manpages-4.13-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '97ddc239d22e2d9651d531d16872cfbcbc4f1fb9a9cc98379ce3141c2f088872',
+     armv7l: '97ddc239d22e2d9651d531d16872cfbcbc4f1fb9a9cc98379ce3141c2f088872',
+       i686: '744a2625e56519fc7d5a9bb9d110431f59fa400eebaad162659dc48c0ed9cfd9',
+     x86_64: '9d617f18a4cdfb42b45a2b475e36b82dc693244065e021387aa5c222395877ac',
   })
 
   depends_on 'mandb'

--- a/packages/mdp.rb
+++ b/packages/mdp.rb
@@ -8,8 +8,16 @@ class Mdp < Package
   source_sha256 '7384c1ba32bd8e4b11342570d2144165a60682499b4cb54e50c8eb3164cfabc5'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mdp-1.0.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mdp-1.0.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mdp-1.0.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mdp-1.0.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '2478dbee17514f83d0340c0ac6eb2ccf957aa000e48a0b0d2c614df523f98315',
+     armv7l: '2478dbee17514f83d0340c0ac6eb2ccf957aa000e48a0b0d2c614df523f98315',
+       i686: 'f3a418a1ab54584b5f6ec1e6ada44075e982c86274edb009ba031199af591984',
+     x86_64: 'a444f58edb9b973d4274e99e31c9e339fe1c88cf0641c55bb7d7f10413f761a4',
   })
 
   depends_on 'ncurses'

--- a/packages/memcached.rb
+++ b/packages/memcached.rb
@@ -8,8 +8,16 @@ class Memcached < Package
   source_sha256 '258cc3ddb7613685465acfd0215f827220a3bbdd167fd2c080632105b2d2f3ce'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/memcached-1.5.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/memcached-1.5.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/memcached-1.5.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/memcached-1.5.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '24640b0e777ede59135083f836f2e2dbfdb007d943d48c23719af2ff63d8c7c5',
+     armv7l: '24640b0e777ede59135083f836f2e2dbfdb007d943d48c23719af2ff63d8c7c5',
+       i686: 'c544b7afdcdc6307e9aa547f3ab238d6daeb8d064625177622207ffa3ebe9fde',
+     x86_64: '0ae6afff645bddd1fdebe42fcc1289c9ec259901e89e6312e0c94054061402ee',
   })
 
   depends_on 'libevent'

--- a/packages/mg.rb
+++ b/packages/mg.rb
@@ -7,6 +7,19 @@ class Mg < Package
   source_url 'https://devio.us/~bcallah/mg/mg-20170917.tar.gz'
   source_sha256 'def9237a89ec6a14241abaf12714bc5fcb3b0e2f8d9d466ff7561628d35b7ff1'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mg-20170917-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mg-20170917-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mg-20170917-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mg-20170917-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '9c9ee8e796407f78ce16b6f6da3c1faf2d04f1a6691bc2f020cf27258cfd585f',
+     armv7l: '9c9ee8e796407f78ce16b6f6da3c1faf2d04f1a6691bc2f020cf27258cfd585f',
+       i686: '9655b3efbe43f45e6ec46eb9f0ff36727f155e2dce90c5d3b03266b3df1c825c',
+     x86_64: 'b33010e42645f5b311ca7b1ca3dcbab53ad033aab3cedab2ec6a3e73f7a1dafa',
+  })
+
   depends_on 'ncurses'
 
   def self.build

--- a/packages/micro.rb
+++ b/packages/micro.rb
@@ -20,6 +20,19 @@ class Micro < Package
     source_sha256 '329f746e4ee9edf244618dda4208b638fda34c593d5cd96d8f71dc3b53e3d994'
   end
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/micro-1.3.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/micro-1.3.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/micro-1.3.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/micro-1.3.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '6522c21cd8861a6477172cfc59d84a2e0339c7ef935fbbdac9207dae8a204c80',
+     armv7l: '6522c21cd8861a6477172cfc59d84a2e0339c7ef935fbbdac9207dae8a204c80',
+       i686: '13579b24473499d0509932bb73bcb01ec2e1946e2d4012ee0698948b608d4bbf',
+     x86_64: '36bfbe54a6971ccd4b33687904677b98c43cc29155949aa664ae1ea428a1fa2a',
+  })
+
   def self.install
     system "install -Dm755 micro #{CREW_DEST_PREFIX}/bin/micro"
   end

--- a/packages/miniupnpc.rb
+++ b/packages/miniupnpc.rb
@@ -8,8 +8,16 @@ class Miniupnpc < Package
   source_sha256 'd434ceb8986efbe199c5ca53f90ed53eab290b1e6d0530b717eb6fa49d61f93b'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/miniupnpc-2.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/miniupnpc-2.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/miniupnpc-2.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/miniupnpc-2.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '4d2540a3b8465f16d54a74aa8fb3aee103f28a24e6e0800049c19f4ac116619a',
+     armv7l: '4d2540a3b8465f16d54a74aa8fb3aee103f28a24e6e0800049c19f4ac116619a',
+       i686: '061732c34b114a957b2eede570e0aee3b468e3c94600fc52902aec04a1ddc7cd',
+     x86_64: '6092ef9f6538f1403c904c349535cd2bddedfd27fe8e7e7b39627c3518b8bf44',
   })
 
   def self.build

--- a/packages/mp4v2.rb
+++ b/packages/mp4v2.rb
@@ -7,6 +7,19 @@ class Mp4v2 < Package
   source_url 'https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mp4v2/mp4v2-2.0.0.tar.bz2'
   source_sha256 '0319b9a60b667cf10ee0ec7505eb7bdc0a2e21ca7a93db96ec5bd758e3428338'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mp4v2-2.0.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mp4v2-2.0.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mp4v2-2.0.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mp4v2-2.0.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'a636db38c7bc1f2ea3d01f64d271f56edd37ffeafdbb792701a352ce996bcc2e',
+     armv7l: 'a636db38c7bc1f2ea3d01f64d271f56edd37ffeafdbb792701a352ce996bcc2e',
+       i686: '364b76b514b0f942336f821fc2c8216d1b5cb540b820fcf0233eda451ec578ce',
+     x86_64: '0c65a40cbef64c0d33c3d2e7d2b46ea83d0a14f053de873f0efa62dc79f8841b',
+  })
+
   def self.preinstall
     system "curl -Ls -o autoaux/config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'"
     system "curl -Ls -o autoaux/config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'"

--- a/packages/msttcorefonts.rb
+++ b/packages/msttcorefonts.rb
@@ -8,8 +8,16 @@ class Msttcorefonts < Package
   source_sha256 'c23a2c519acad44fb65dfdd5b6f7de7b351ec15394df52cc744e3c6deb51d42f'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/msttcorefonts-3.6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/msttcorefonts-3.6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/msttcorefonts-3.6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/msttcorefonts-3.6-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f6c8457c11a02cd39c89a35af70038de861610c75dcb6304d7baf0f283306370',
+     armv7l: 'f6c8457c11a02cd39c89a35af70038de861610c75dcb6304d7baf0f283306370',
+       i686: 'ff4943e48567b37bfb3c871aa458351572016f9f501c789c5d7f8cd4b5db49a7',
+     x86_64: 'ce135a84d46fa69fbc29638d389d4ac6cf4fef4b1921f4f9a1497d17d6f4fed7',
   })
 
   depends_on 'cabextract'

--- a/packages/mutt.rb
+++ b/packages/mutt.rb
@@ -8,8 +8,16 @@ class Mutt < Package
   source_sha256 '749b83a96373c6e2101ebe8c4b9a651735e02c478edb750750a5146a15d91bb1'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mutt-1.9.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mutt-1.9.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mutt-1.9.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mutt-1.9.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '7d0ecbe964f7c76e8206297c29dfabf40e725ed0677a5cdd6ba89c6591c57c63',
+     armv7l: '7d0ecbe964f7c76e8206297c29dfabf40e725ed0677a5cdd6ba89c6591c57c63',
+       i686: 'c755e1e814a1f7660316308b86b53e8cf11db72c83c1223c84f63abc61f00230',
+     x86_64: 'fec90a3d7928479772c0b285ccc44f4746c4f1de86e96d7aa7598edf24218da2',
   })
 
   depends_on 'libxslt'

--- a/packages/ncat.rb
+++ b/packages/ncat.rb
@@ -8,10 +8,16 @@ class Ncat < Package
   source_sha256 'a8796ecc4fa6c38aad6139d9515dc8113023a82e9d787e5a5fb5fa1b05516f21'
 
   binary_url ({
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncat-7.60-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ncat-7.60-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ncat-7.60-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ncat-7.60-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncat-7.60-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    x86_64: '5660ea321436f1b9642d318a77e9b0b5c379825ac0611daaf5f82dd794753598',
+    aarch64: '1607433b71f7faef46bc911acac09d0c34170c874ce9b7b876b4bdb6bee7b0f1',
+     armv7l: '1607433b71f7faef46bc911acac09d0c34170c874ce9b7b876b4bdb6bee7b0f1',
+       i686: '9900b3105aa411615c45d4b4db18ec0cae0e3a49d7e4a5df708c3b7bdfaf68d5',
+     x86_64: '5660ea321436f1b9642d318a77e9b0b5c379825ac0611daaf5f82dd794753598',
   })
 
   depends_on 'buildessential' => :build

--- a/packages/nping.rb
+++ b/packages/nping.rb
@@ -8,10 +8,16 @@ class Nping < Package
   source_sha256 'a8796ecc4fa6c38aad6139d9515dc8113023a82e9d787e5a5fb5fa1b05516f21'
 
   binary_url ({
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nping-7.60-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nping-7.60-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nping-7.60-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nping-7.60-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nping-7.60-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    x86_64: '208ed7878333564c9ea15d82174d542ea1c6e5d93b2ef0219000c5b8de695eb2',
+    aarch64: 'e57915081b9648b6f4ea639a40f611306d870fced74b47ee3438daa8414e1921',
+     armv7l: 'e57915081b9648b6f4ea639a40f611306d870fced74b47ee3438daa8414e1921',
+       i686: 'a45af5836acefe2c9aad17a732cea4edad65e272d079d574c8dbf3cfdab26910',
+     x86_64: '558f8cc197f92003dfd44adab12ec4461b594f322e41d0498a8e961ae030f00a',
   })
 
   depends_on 'buildessential' => :build

--- a/packages/ocaml.rb
+++ b/packages/ocaml.rb
@@ -8,8 +8,16 @@ class Ocaml < Package
   source_sha256 '04a527ba14b4d7d1b2ea7b2ae21aefecfa8d304399db94f35a96df1459e02ef9'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.05.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.05.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.05.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.05.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '897f5f8ec198ecf1a0f4efd7fc8647084e47d910b009c54bdd52fa152c1cf47b',
+     armv7l: '897f5f8ec198ecf1a0f4efd7fc8647084e47d910b009c54bdd52fa152c1cf47b',
+       i686: '2adb65a674e740576a827e7f1535a70c202d651b459905809e02f0df51f6e9b8',
+     x86_64: '744e1c98a8f5c12e922ed4883aa5d0560656c36069aad8dd43bbe51005cf0563',
   })
 
   depends_on 'buildessential' => :build

--- a/packages/octane.rb
+++ b/packages/octane.rb
@@ -8,8 +8,16 @@ class Octane < Package
   source_sha256 'c355dd9a37df421826f3d8028d89e8c8b58faa12a49da88fa2641788f9482fe7'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/octane-2.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/octane-2.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/octane-2.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/octane-2.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'c195233b1d220e0905a439e631c1eca73d23631ed20f896a1d6527e64ea2b78c',
+     armv7l: 'c195233b1d220e0905a439e631c1eca73d23631ed20f896a1d6527e64ea2b78c',
+       i686: 'c06f5505a461387d883eeb28c506d85e07acd008bce61e38b7226b4d894f9e88',
+     x86_64: '4bf8e2f68b3cfb22b212b824c5239f3ca4f3cd36cddd8e9c79991359aead9139',
   })
 
   def self.install

--- a/packages/od1n.rb
+++ b/packages/od1n.rb
@@ -7,6 +7,19 @@ class Od1n < Package
   source_url 'https://github.com/CoolerVoid/0d1n/archive/2.3.tar.gz'
   source_sha256 '7fe26f0268fe63ec0352502ae590a7a5e258248f253649661dc782ca7edd52ae'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/od1n-2.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/od1n-2.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/od1n-2.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/od1n-2.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '205e61cefc8dd5655c9621b57701c627b53915af79ec547fdc3ec7796cdaacf5',
+     armv7l: '205e61cefc8dd5655c9621b57701c627b53915af79ec547fdc3ec7796cdaacf5',
+       i686: '0a2ac8d246e4f6a58a8f836f6c5e1dc66d99161a7c9523a126806b8dc74bdee2',
+     x86_64: '38b19eb0cb14694e30040105ac05fd0e250ced2bbac6c0e7428b8adbd495dd2c',
+  })
+
   depends_on 'curl'
 
   def self.build

--- a/packages/owl.rb
+++ b/packages/owl.rb
@@ -8,8 +8,16 @@ class Owl < Package
   source_sha256 '4d9982da3582456d1e769e25a7d0b2daefe859c45e262c8f56f794114f9a29a0'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/owl-0.1.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/owl-0.1.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/owl-0.1.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/owl-0.1.14-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '305978182d9826979fdd56b7085cdcf0cc24cc6c234a96d7c513756f55028bc0',
+     armv7l: '305978182d9826979fdd56b7085cdcf0cc24cc6c234a96d7c513756f55028bc0',
+       i686: '0af189fa0385b41f86f024863a97d89cae96bcf7b1b8b408a0bd2b0db476cbe1',
+     x86_64: 'f902a68ce2f16363477ab0f5aaf11b93fd8d1b236c08ea66dab4cb063ce209f0',
   })
 
   def self.build

--- a/packages/pagein.rb
+++ b/packages/pagein.rb
@@ -8,8 +8,16 @@ class Pagein < Package
   source_sha256 '3f81409f6227887212083c585abf5143a082dde2bbcab1d2ae8c74b6d294e8b3'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pagein-0.00.05-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pagein-0.00.05-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pagein-0.00.05-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pagein-0.00.05-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '6a51692fb5beb3c0ea8c01773c005e312afcb777ae41bee0f2e5ba87cd38cad3',
+     armv7l: '6a51692fb5beb3c0ea8c01773c005e312afcb777ae41bee0f2e5ba87cd38cad3',
+       i686: '651edceb92170eca73cc53056f6999ffe8dd3f896f4c997b064effdb1f8c0740',
+     x86_64: 'b488a5ff3a3cc89a40386a1a1de0c0c449e3587356052d69b9fbc776afa527ec',
   })
 
   def self.build

--- a/packages/pass.rb
+++ b/packages/pass.rb
@@ -7,6 +7,19 @@ class Pass < Package
   source_url 'https://git.zx2c4.com/password-store/snapshot/password-store-1.7.1.tar.xz'
   source_sha256 'f6d2199593398aaefeaa55e21daddfb7f1073e9e096af6d887126141e99d9869'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pass-1.7.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pass-1.7.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pass-1.7.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pass-1.7.1-1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '0068206d91cb8b9b521456f9019f6a4aaf76d5a90ac55c568a6ee116d0998b65',
+     armv7l: '0068206d91cb8b9b521456f9019f6a4aaf76d5a90ac55c568a6ee116d0998b65',
+       i686: '77fb2f33e609b5df5ca27902e44156ce6e20ab85af9a0c7c754b45a9a8ea44e0',
+     x86_64: '0b111fc35629c26203e3d709b9ec44c51f815d385d8b30fa1e852b5309db4af1',
+  })
+
   depends_on 'gnupg'
   depends_on 'tree'
 

--- a/packages/pdfcrack.rb
+++ b/packages/pdfcrack.rb
@@ -8,8 +8,16 @@ class Pdfcrack < Package
   source_sha256 '7865b203074ccfd5c612c8ce00c46ffcb4fabaa26154ce9304dfc668c7cb73ef'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pdfcrack-0.16-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pdfcrack-0.16-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pdfcrack-0.16-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pdfcrack-0.16-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f2aeae2872eddaa3034f024d80a6a10302ba88274c07b77112aac24f7146f4e9',
+     armv7l: 'f2aeae2872eddaa3034f024d80a6a10302ba88274c07b77112aac24f7146f4e9',
+       i686: '0a8bb96eaaa224e97a6ba6d77890359398cc06c5844e99de19aa63a2e39c7c6d',
+     x86_64: 'fe283684679ffe42701876251ef2ae9dc4b19272a91a0df93f968f0e2d148c1b',
   })
 
   def self.build

--- a/packages/perl_xml_parser.rb
+++ b/packages/perl_xml_parser.rb
@@ -7,6 +7,19 @@ class Perl_xml_parser < Package
   source_url 'https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz'
   source_sha256 '1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.44-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.44-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.44-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.44-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '08721209d18f180afd8906e8e1d774a1cd148398fae1b638f58e049d8ff98bf5',
+     armv7l: '08721209d18f180afd8906e8e1d774a1cd148398fae1b638f58e049d8ff98bf5',
+       i686: '5cb03cfd2bc61e3a8e55200f95a4b834c1253d278c873c5f5af9fdd87fb3eca1',
+     x86_64: 'b07d8e5fc001b8d48debb7b46bbc4c44fa03f47bf561a36dcbcd8e9c2fd9bb30',
+  })
+
   depends_on 'expat'
   depends_on 'perl'
 

--- a/packages/perl_xml_sax_parserfactory.rb
+++ b/packages/perl_xml_sax_parserfactory.rb
@@ -7,6 +7,19 @@ class Perl_xml_sax_parserfactory < Package
   source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-0.99.tar.gz'
   source_sha256 '32b04b8e36b6cc4cfc486de2d859d87af5386dd930f2383c49347050d6f5ad84'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-0.99-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-0.99-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-0.99-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-0.99-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '2e6a336ca325eb357f004fa6098be754a0ad12a5a75c2d47d9e8db9029ca45e7',
+     armv7l: '2e6a336ca325eb357f004fa6098be754a0ad12a5a75c2d47d9e8db9029ca45e7',
+       i686: '422881325203864e4207eb056efcfa5e6424e8338344eb806b192975c28b2d99',
+     x86_64: 'a40967f018b01f5463597cc39b0abf07a1053aa551e5b04be2aaec6119894b94',
+  })
+
   depends_on 'perl'
 
   def self.build

--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -8,8 +8,16 @@ class Php5 < Package
   source_sha256 '8c2b4f721c7475fb9eabda2495209e91ea933082e6f34299d11cba88cd76e64b'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.32-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.32-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.32-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.32-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '95eb2d46dd04f3690063df002397e085bffb7bc8a6275c495fe3bea23f41dbfa',
+     armv7l: '95eb2d46dd04f3690063df002397e085bffb7bc8a6275c495fe3bea23f41dbfa',
+       i686: 'aa5af655b82610cc11a1f1343d6fc796a0d9e6d70706974d1d8dc8f2667b6f48',
+     x86_64: '4895c65b7e8eaaf2814b5a76fdbd8cd532821df241163288f9e635427e1c27b7',
   })
 
   depends_on 'pkgconfig'

--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -8,8 +8,16 @@ class Php7 < Package
   source_sha256 'a0118850774571b1f2d4e30b4fe7a4b958ca66f07d07d65ebdc789c54ba6eeb3'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.12-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.12-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.12-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.12-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'fa1a0897dd78ea1cf94bc353a78e56e15789f7705babaabdee8c353f651ae89a',
+     armv7l: 'fa1a0897dd78ea1cf94bc353a78e56e15789f7705babaabdee8c353f651ae89a',
+       i686: '6fbea0ee47680e4f08e61712e6a2aa8128af7987e8fe20c4458a6b988458e213',
+     x86_64: '78fa2609dd43dea42c62436551ec9b3efba1e037dd8e983f68ab81636f4b10b9',
   })
 
   depends_on 'pkgconfig'

--- a/packages/pinentry.rb
+++ b/packages/pinentry.rb
@@ -7,6 +7,19 @@ class Pinentry < Package
   source_url 'https://gnupg.org/ftp/gcrypt/pinentry/pinentry-1.0.0.tar.bz2'
   source_sha256 '1672c2edc1feb036075b187c0773787b2afd0544f55025c645a71b4c2f79275a'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pinentry-1.0.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pinentry-1.0.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pinentry-1.0.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pinentry-1.0.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '959808266c3b49c00f333fbdb3b6b5f14ec4abcfb5457091654d8e1254904149',
+     armv7l: '959808266c3b49c00f333fbdb3b6b5f14ec4abcfb5457091654d8e1254904149',
+       i686: '298c471c2f0ad055aff1c480658b93e7e16fd5e936c7bb6d8b11997018d66f41',
+     x86_64: '86d2d87126edcdec32f14592ef74dad9b26d0b683b4699ba4f12452bf2640e19',
+  })
+
   depends_on 'gnupg'
   depends_on 'libcap'
   depends_on 'ncurses'

--- a/packages/pmd.rb
+++ b/packages/pmd.rb
@@ -8,8 +8,16 @@ class Pmd < Package
   source_sha256 '2d854e30717b66e253213f36d4bcd202b83b180ea427836797d13a857c19a6b4'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pmd-5.8.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pmd-5.8.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pmd-5.8.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pmd-5.8.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '3a67cbb0aa75d9b5bb6b30d54029cf8598810045e10cc5b8622c52ae0f0f67a4',
+     armv7l: '3a67cbb0aa75d9b5bb6b30d54029cf8598810045e10cc5b8622c52ae0f0f67a4',
+       i686: '8271fa0b8d53652830d7d791dbc859d298f1dc573cf956c6029e5f52edd15435',
+     x86_64: '0faf4b05cbaad158d8776b7229e85fce484e9c9d1245c4977647bdb653c2e1b8',
   })
 
   depends_on 'jdk8'

--- a/packages/postgres.rb
+++ b/packages/postgres.rb
@@ -8,8 +8,16 @@ class Postgres < Package
   source_sha256 '06da12a7e3dddeb803962af8309fa06da9d6989f49e22865335f0a14bad0744c'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/postgres-9.6.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/postgres-9.6.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/postgres-9.6.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/postgres-9.6.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '9e0004789da8e05332b53e050df96ca73659e4f94c9715ef53162959b6b8a3e7',
+     armv7l: '9e0004789da8e05332b53e050df96ca73659e4f94c9715ef53162959b6b8a3e7',
+       i686: '6aa981708ff298e1b423fbcff6f17faa52aca9cb1dfe7cda278b50fd09c6acd2',
+     x86_64: '7c6725c690d0118f53ca0c60cd96a38afd764cc38b1109e07b566d12f2c7a9bf',
   })
 
   depends_on 'buildessential'

--- a/packages/powerstat.rb
+++ b/packages/powerstat.rb
@@ -8,8 +8,16 @@ class Powerstat < Package
   source_sha256 '79b059d12dc776f7f47d3bef0b1c60185a0ba49765d1c89e920fa2f24a081711'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.14-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '4ea5f8f48a1180b348dc90b150f7a97c9cb0e0289ac4b093b01ef8f087853dd0',
+     armv7l: '4ea5f8f48a1180b348dc90b150f7a97c9cb0e0289ac4b093b01ef8f087853dd0',
+       i686: '5c3cfbba81c9adf2010b2f9e69dd5adcaa96cdf15446eabfcc1a80e0ce2160be',
+     x86_64: '81b9ad7bfdf9bcc6c95148a4d8216f0105a0a54ed31419bb637eeb374901afd5',
   })
 
   def self.build

--- a/packages/proxychains.rb
+++ b/packages/proxychains.rb
@@ -6,6 +6,19 @@ class Proxychains < Package
   version '4.2.0'
   source_url 'https://github.com/haad/proxychains/archive/proxychains-4.2.0.tar.gz'
   source_sha256 '225284e5553fb062d09ed425d2815387eda9c1c0d6e2bc24ea95393a71601619'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/proxychains-4.2.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/proxychains-4.2.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/proxychains-4.2.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/proxychains-4.2.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '570e3bbbc4ef4429d409c65b1bb434b8fa5178f62c156c7f40390ffa7560ad63',
+     armv7l: '570e3bbbc4ef4429d409c65b1bb434b8fa5178f62c156c7f40390ffa7560ad63',
+       i686: 'c91eac05feaf24420161f659b9bfea4d9caba0ffb8710945b2e483187aa259f3',
+     x86_64: 'f5de3f217b624363140f63e68bf188ff8b8de93f18b3af946b51a62a8c0c3271',
+  })
   def self.build
     system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -7,6 +7,19 @@ class Pulseaudio < Package
   source_url 'https://freedesktop.org/software/pulseaudio/releases/pulseaudio-11.1.tar.xz'
   source_sha256 'f2521c525a77166189e3cb9169f75c2ee2b82fa3fcf9476024fbc2c3a6c9cd9e'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-11.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-11.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-11.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-11.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '28ac4cfa32ca97dbd51cf678bfdc3f98e4eb4939bbf5bffc256f7021577d1bcf',
+     armv7l: '28ac4cfa32ca97dbd51cf678bfdc3f98e4eb4939bbf5bffc256f7021577d1bcf',
+       i686: '61cfd90e78fc8bb5c7a2422d3026883dae1f7efbb00e090946b58b2b365f0f42',
+     x86_64: '67608beaffd35ca0f5a3c35769797d2eae4193d5c81c8cad5e6e123f2d667e44',
+  })
+
   depends_on 'alsa_plugins'
   depends_on 'dbus'
   depends_on 'intltool'

--- a/packages/qpdf.rb
+++ b/packages/qpdf.rb
@@ -8,8 +8,16 @@ class Qpdf < Package
   source_sha256 '2e0a26f7a03fe41c72be8e95c420744f98dbf553e025fb0d4c990f83df023d90'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qpdf-7.0.b1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qpdf-7.0.b1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qpdf-7.0.b1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qpdf-7.0.b1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '2d01edee3bbe5b8d8b8bee704889307dbe48fe5fdb6b064516b1a290be8bc2fa',
+     armv7l: '2d01edee3bbe5b8d8b8bee704889307dbe48fe5fdb6b064516b1a290be8bc2fa',
+       i686: '851a7ad6e4f60feac3b0acd592649e784837d774e76916c153881db895b8df6e',
+     x86_64: '980b28cfb28952ba95560acf4745dd0ef899c3be2fe04b9d343a89a28f566e28',
   })
 
   def self.build

--- a/packages/r.rb
+++ b/packages/r.rb
@@ -8,8 +8,16 @@ class R < Package
   source_sha256 '971e30c2436cf645f58552905105d75788bd9733bddbcb7c4fbff4c1a6d80c64'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.4.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.4.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.4.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.4.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'dac307e30891e02a849e6431df21acac81c8f20bae560c88f5db3216dd2261d0',
+     armv7l: 'dac307e30891e02a849e6431df21acac81c8f20bae560c88f5db3216dd2261d0',
+       i686: '',
+     x86_64: '44be08fad3ef36250aa8b82a26ed3131e8726ba72e0ffbfe6ab120125ea1a26b',
   })
 
   # depends_on 'gfortran'       # require gfortran enabled gcc

--- a/packages/redis.rb
+++ b/packages/redis.rb
@@ -8,8 +8,16 @@ class Redis < Package
   source_sha256 'b1a0915dbc91b979d06df1977fe594c3fa9b189f1f3d38743a2948c9f7634813'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/redis-4.0.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/redis-4.0.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/redis-4.0.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/redis-4.0.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'a4f24f53f082024ce3e6b7e67c5cc345a8839f3beefe6dee29a544e29df12c8f',
+     armv7l: 'a4f24f53f082024ce3e6b7e67c5cc345a8839f3beefe6dee29a544e29df12c8f',
+       i686: '6d0a44c6cc3d28126d7ef5fe2d1530d40b29ddb0922f34b8a61b9ba38036d9e5',
+     x86_64: 'b67ed9e6102db702dbf1d1b9b31bcbe377a4f6b43643ee5a1c98cc656909a028',
   })
 
   depends_on 'buildessential'

--- a/packages/rlwrap.rb
+++ b/packages/rlwrap.rb
@@ -8,8 +8,16 @@ class Rlwrap < Package
   source_sha256 '29e5a850fbe4753f353b0734e46ec0da043621bdcf7b52a89b77517f3941aade'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rlwrap-0.43-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rlwrap-0.43-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rlwrap-0.43-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rlwrap-0.43-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'bc4979020c1fe51241c491c674283c4f0a0b51521baca9b82553d69b6e984855',
+     armv7l: 'bc4979020c1fe51241c491c674283c4f0a0b51521baca9b82553d69b6e984855',
+       i686: '96078b16189de486043d84e1094b7a63a30d2e890662b414c548a4ee136fb58d',
+     x86_64: '288e6db9c583ec36d275a95be28daba69e254ae30d7cd5649214bf1df2b4540e',
   })
 
   depends_on 'autoconf'

--- a/packages/ruby_latest.rb
+++ b/packages/ruby_latest.rb
@@ -8,8 +8,16 @@ class Ruby_latest < Package
   source_sha256 '748a8980d30141bd1a4124e11745bb105b436fb1890826e0d2b9ea31af27f735'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ruby_latest-2.4.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ruby_latest-2.4.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ruby_latest-2.4.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ruby_latest-2.4.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'e21f4c1301c534048773353d5b5b55d1b70a16c42bc6a8263ea8fadd50ef6aee',
+     armv7l: 'e21f4c1301c534048773353d5b5b55d1b70a16c42bc6a8263ea8fadd50ef6aee',
+       i686: '4a5b77ed24bd03a3265df547b19baa5c3b5d998aeebb7f07b694d0a824d3ed54',
+     x86_64: '3f2e8a72d34aa25010e4cbf6cc1534a622aef1550e7cbdb1590ebeb4e8af7a3f',
   })
 
   depends_on 'readline'

--- a/packages/scheme48.rb
+++ b/packages/scheme48.rb
@@ -8,8 +8,16 @@ class Scheme48 < Package
   source_sha256 '9c4921a90e95daee067cd2e9cc0ffe09e118f4da01c0c0198e577c4f47759df4'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/scheme48-1.9.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/scheme48-1.9.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/scheme48-1.9.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/scheme48-1.9.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'ea7ebd83c9fd176cadeb3ba22e70d030942a199660a1c47d1e6c10d4c441febd',
+     armv7l: 'ea7ebd83c9fd176cadeb3ba22e70d030942a199660a1c47d1e6c10d4c441febd',
+       i686: 'c2ccae4624713af8a7708940d6f6f364b25ee39cf5d7f0259ce0960bdf11d554',
+     x86_64: '576f041ade2a539f3ed8a9c9dd5e20f0bf831620f8e8847fec7064b81804807c',
   })
 
   def self.build

--- a/packages/screen.rb
+++ b/packages/screen.rb
@@ -8,8 +8,16 @@ class Screen < Package
   source_sha256 '1b6922520e6a0ce5e28768d620b0f640a6631397f95ccb043b70b91bb503fa3a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/screen-4.6.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/screen-4.6.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/screen-4.6.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/screen-4.6.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f8d903c06175118730ea3d44ed59f6d6fbd94c7f5c6ed190e8e7ca42bb3cfc76',
+     armv7l: 'f8d903c06175118730ea3d44ed59f6d6fbd94c7f5c6ed190e8e7ca42bb3cfc76',
+       i686: '43e1b9056ee3d67b7b3f45ef52c381a62340bcaf97748a7ebc8b92adfed10026',
+     x86_64: '27ec590cfff20b1429f86baca0d42a6e3819a4978d13155b5ec31db04a374b5b',
   })
 
   depends_on 'ncurses'

--- a/packages/screenfetch.rb
+++ b/packages/screenfetch.rb
@@ -8,8 +8,16 @@ class Screenfetch < Package
   source_sha256 '248283ee3c24b0dbffb79ed685bdd518554073090c1c167d07ad2a729db26633'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/screenfetch-3.8.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/screenfetch-3.8.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/screenfetch-3.8.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/screenfetch-3.8.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '5d7f1f55c7638e2991bc634de5b8bf7af4aa47321bb304cdcebfa3fa30bcb0bf',
+     armv7l: '5d7f1f55c7638e2991bc634de5b8bf7af4aa47321bb304cdcebfa3fa30bcb0bf',
+       i686: '4841e28fff7332962646ab481405e3cad106224a673398e6292703533c85f63e',
+     x86_64: '0263d3a55d4d86358aac7a8f828b7747a57c13b78daee3a355b729ea8c8e7f54',
   })
 
   depends_on 'bc'

--- a/packages/shhmsg.rb
+++ b/packages/shhmsg.rb
@@ -8,8 +8,16 @@ class Shhmsg < Package
   source_sha256 '88c69e3f0b920b1ef93f6c10f354786f171d7cb3ab170a463bb9ab8bbf13a02b'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/shhmsg-1.4.2-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/shhmsg-1.4.2-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/shhmsg-1.4.2-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/shhmsg-1.4.2-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '8f510ed281584b1eaa1a3ef81f6b33ed70d3dbf337146a13dcf1f07fbb532891',
+     armv7l: '8f510ed281584b1eaa1a3ef81f6b33ed70d3dbf337146a13dcf1f07fbb532891',
+       i686: '40421382202fd4a786f26e7c7ef95ebf5436709b3400200b59a381a7904023a7',
+     x86_64: 'd7cb7e3b459a501b2c745d26458a3ecb20664df46a043134651a29d307a06857',
   })
 
   def self.build

--- a/packages/shhopt.rb
+++ b/packages/shhopt.rb
@@ -8,8 +8,16 @@ class Shhopt < Package
   source_sha256 'bae94335124efa6fcc2f0a55cabd68c9c90be935bcdb8054d7e5188e0d5da679'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/shhopt-1.1.7-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/shhopt-1.1.7-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/shhopt-1.1.7-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/shhopt-1.1.7-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd91aea2a6169c7092851f690a289242a0a0bacc0cee6f7f4289aad659d32af0a',
+     armv7l: 'd91aea2a6169c7092851f690a289242a0a0bacc0cee6f7f4289aad659d32af0a',
+       i686: 'f964a0697bfdfd47a26ab7e771efe22525c7afbc2404208c62d73fb361ab225d',
+     x86_64: '5f81978b73c4722a4b5821d7bf865d77eacd94f907f8f3ede2a4b2d366ca9d6a',
   })
 
   def self.build

--- a/packages/smem.rb
+++ b/packages/smem.rb
@@ -8,8 +8,16 @@ class Smem < Package
   source_sha256 '2ea9f878f4cf3c276774c3f7e2a41977a1f2d64f98d2dcb6a15f1f3d84df61ec'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/smem-1.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/smem-1.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/smem-1.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/smem-1.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '914a30f98944155240bfefd8b4181b06a5b868f2e5949d86c806fe02fecf7c49',
+     armv7l: '914a30f98944155240bfefd8b4181b06a5b868f2e5949d86c806fe02fecf7c49',
+       i686: 'a971c2ea408330aa01ab3ad1740057d480f6dcbc64f1507e45d33a4f9d82d695',
+     x86_64: 'aff43254df620f1dcd080a5071a0f58b223d57b6f48d8545ed453062c115ada6',
   })
 
   depends_on 'buildessential' => :build

--- a/packages/speexdsp.rb
+++ b/packages/speexdsp.rb
@@ -7,6 +7,19 @@ class Speexdsp < Package
   source_url 'http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz'
   source_sha256 '4ae688600039f5d224bdf2e222d2fbde65608447e4c2f681585e4dca6df692f1'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/speexdsp-1.2rc3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/speexdsp-1.2rc3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/speexdsp-1.2rc3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/speexdsp-1.2rc3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '0aa0fe549eb030ed9e134a39526751817d9e117509ce3dcbae1c7e3b6dfe8602',
+     armv7l: '0aa0fe549eb030ed9e134a39526751817d9e117509ce3dcbae1c7e3b6dfe8602',
+       i686: '5c3d9bd633a11a8da1e8408d6db745f620d759ea2e4f8239a9ab5b34a9fe6b6a',
+     x86_64: '8a83dac7387460d2dbeb3602712cd7b1d0999ba5b6e3f86449e8f215b4a83682',
+  })
+
   def self.build
     system "./configure \
             --prefix=#{CREW_PREFIX} \

--- a/packages/sqlite.rb
+++ b/packages/sqlite.rb
@@ -8,8 +8,16 @@ class Sqlite < Package
   source_sha256 'd7dd516775005ad87a57f428b6f86afd206cb341722927f104d3f0cf65fbbbe3'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlite-3.21.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sqlite-3.21.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sqlite-3.21.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlite-3.21.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '78ab93dbb2776ecfa6f03c46e7ef7adee58f1a7d342ffa73c2da8a4e4e20e48c',
+     armv7l: '78ab93dbb2776ecfa6f03c46e7ef7adee58f1a7d342ffa73c2da8a4e4e20e48c',
+       i686: 'a9b9ae6eb22b1e9a830adad55b3bee807ed6cc0ce30a79525f3cee7b8756586e',
+     x86_64: '68bb1487bcb4feb71306fc5a7947c779ed63e1f3d6b4c4acbc8d36d6863019ec',
   })
 
   def self.build

--- a/packages/squashfs.rb
+++ b/packages/squashfs.rb
@@ -8,8 +8,16 @@ class Squashfs < Package
   source_sha256 '0d605512437b1eb800b4736791559295ee5f60177e102e4d4ccd0ee241a5f3f6'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/squashfs-4.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/squashfs-4.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/squashfs-4.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/squashfs-4.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '46d88da52b018f54fc8c177f3d13ba3f925167058ff4c9c20628683be8a7142c',
+     armv7l: '46d88da52b018f54fc8c177f3d13ba3f925167058ff4c9c20628683be8a7142c',
+       i686: '913c4ef36694ba34eb9542ead201e59aeaa4ebdd4cec0a6fc78395fbe19a85ca',
+     x86_64: 'b9f8bb91f7ab76540d0a8484cd3bc7ce64f90bea6279474d1e4a8f32c79f990f',
   })
 
   depends_on 'compressdoc' => :build

--- a/packages/stack.rb
+++ b/packages/stack.rb
@@ -18,8 +18,16 @@ class Stack < Package
   end
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/stack-1.5.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/stack-1.5.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/stack-1.5.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/stack-1.5.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '4c7be5f76b9c48e2b87da03f69d1dc90567e1ccf2e7551a34b0eab29d0264c08',
+     armv7l: '4c7be5f76b9c48e2b87da03f69d1dc90567e1ccf2e7551a34b0eab29d0264c08',
+       i686: 'b478976d8e39abf913d2666f4f3da888d77655e7e97adce6f2411fb1b356780e',
+     x86_64: 'a9b9e84bb5102b3b8cd2e8147e4fe9d1f15f37baf601600b19b13f987c4cd77b',
   })
 
   def self.install

--- a/packages/stow.rb
+++ b/packages/stow.rb
@@ -7,6 +7,19 @@ class Stow < Package
   source_url 'https://ftp.gnu.org/gnu/stow/stow-2.2.2.tar.gz'
   source_sha256 'e2f77649301b215b9adbc2f074523bedebad366812690b9dc94457af5cf273df'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/stow-2.2.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/stow-2.2.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/stow-2.2.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/stow-2.2.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '3ea38b90ba0477578caa6a01326587f3826d5829a01f1725a781588fead751bc',
+     armv7l: '3ea38b90ba0477578caa6a01326587f3826d5829a01f1725a781588fead751bc',
+       i686: 'e53ad50ae437b0dd709ba44c91a02aa5b8b9ec8ce2255565690ffce58ec59753',
+     x86_64: '0c51e9d9c4963fd53d93ba87facd08812ad204414df888f14564a420f9f2f664',
+  })
+
   depends_on 'buildessential' => :build
   depends_on 'perl'
 

--- a/packages/strace.rb
+++ b/packages/strace.rb
@@ -8,8 +8,16 @@ class Strace < Package
   source_sha256 '7c93ebc6c29280f47c24a0eb86873a99ccb2cac6512c60a60ba4ef99ab807281'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/strace-4.19-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/strace-4.19-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/strace-4.19-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/strace-4.19-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'adf4e8647fc1704a807811e38dc86d750ba520b372c1e1f577e39e094fe7a64b',
+     armv7l: 'adf4e8647fc1704a807811e38dc86d750ba520b372c1e1f577e39e094fe7a64b',
+       i686: '223bd03968d2c19a3d9a20df07dc9e14dab8520386053b2f2a32d2cfdc865316',
+     x86_64: '3e55cfd9b94a71ad590e023d24ec1a5830c4780f1d9e35eacd462fd3086c0dc3',
   })
 
   depends_on 'buildessential'

--- a/packages/stressng.rb
+++ b/packages/stressng.rb
@@ -8,8 +8,16 @@ class Stressng < Package
   source_sha256 '9fffd8e8157ee969dfe99d1a5b310ff3337b1dbecd276ccaa8c30c1cc14392fd'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/stressng-0.09.02-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/stressng-0.09.02-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/stressng-0.09.02-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/stressng-0.09.02-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'c125713560fc1b94cf7608fb4b5750579a5b204daf94a2a513225ce5c9c2fd51',
+     armv7l: 'c125713560fc1b94cf7608fb4b5750579a5b204daf94a2a513225ce5c9c2fd51',
+       i686: 'ae548b400f4130bfa2613bd76d64483ee6df9d63dd0ec66b3de43ae63029db44',
+     x86_64: 'b1717d935512bca5caf350790b00d5a5f08fbfdec855a0221d95ea7f7879b383',
   })
 
   def self.build

--- a/packages/swig.rb
+++ b/packages/swig.rb
@@ -8,8 +8,16 @@ class Swig < Package
   source_sha256 '7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/swig-3.0.12-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/swig-3.0.12-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/swig-3.0.12-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/swig-3.0.12-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'e01ff7b79ecee04da5ab1e36ddbffb016d570d78c91187f6a9b4c000c615a541',
+     armv7l: 'e01ff7b79ecee04da5ab1e36ddbffb016d570d78c91187f6a9b4c000c615a541',
+       i686: '88e6f649ef905cf852ab4a51594f1497c0b2be93f4a5c9ef737ee2a2376f489d',
+     x86_64: '1ada3fd45ea500a386c1ed491b0520ceb0a822f151d70fe0019446f0b05cc8e8',
   })
 
   depends_on 'pcre'

--- a/packages/tcpdump.rb
+++ b/packages/tcpdump.rb
@@ -8,8 +8,16 @@ class Tcpdump < Package
   source_sha256 '798b3536a29832ce0cbb07fafb1ce5097c95e308a6f592d14052e1ef1505fe79'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tcpdump-4.9.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tcpdump-4.9.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tcpdump-4.9.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tcpdump-4.9.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'fd6105f6f5d0e3d516a2841cef121d6a9e48311cae1bcb3081aed66f7c008aaa',
+     armv7l: 'fd6105f6f5d0e3d516a2841cef121d6a9e48311cae1bcb3081aed66f7c008aaa',
+       i686: '6baee68c9c358efd4118f2c8555339554e2b75dfd31bd5809db9d9006cd2b620',
+     x86_64: 'cbf185dd7cfbbf0d7cf5779fcd661b76c8f9f153f9896bb0a712b196eedc2674',
   })
 
   depends_on 'libpcap'

--- a/packages/texinfo.rb
+++ b/packages/texinfo.rb
@@ -8,8 +8,16 @@ class Texinfo < Package
   source_sha256 '77774b3f4a06c20705cc2ef1c804864422e3cf95235e965b1f00a46df7da5f62'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/texinfo-6.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/texinfo-6.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/texinfo-6.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/texinfo-6.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '5efcbcab8d9961230704abb8dbc2f4a3b18c27898231e70d0bbefb5818c908e2',
+     armv7l: '5efcbcab8d9961230704abb8dbc2f4a3b18c27898231e70d0bbefb5818c908e2',
+       i686: '07157f88ec58254a8e5c2965a1b1c8eac1159358c22b64dc191f150567d024a2',
+     x86_64: '5725777dd74498d46aab775b7152ba42b33d8551e73c77ced2b8807e8e9ccf38',
   })
 
   depends_on 'gettext' => :build

--- a/packages/tmux.rb
+++ b/packages/tmux.rb
@@ -8,8 +8,16 @@ class Tmux < Package
   source_sha256 'ae135ec37c1bf6b7750a84e3a35e93d91033a806943e034521c8af51b12d95df'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tmux-2.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tmux-2.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tmux-2.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tmux-2.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f974bcaa1533327eb6beecc4aa2572dd6e557fede27cf91c80832df3b16dc399',
+     armv7l: 'f974bcaa1533327eb6beecc4aa2572dd6e557fede27cf91c80832df3b16dc399',
+       i686: 'ebdabcaddde645887615ce990d1487c2f7dc50a77785e1dd81595fb930860ac9',
+     x86_64: '1901576a8c7ac2ca156e219892c1df41046e76608a64418a0a1dbeb1097dcbd5',
   })
 
   depends_on 'readline'

--- a/packages/units.rb
+++ b/packages/units.rb
@@ -7,6 +7,19 @@ class Units < Package
   source_url 'https://ftp.gnu.org/gnu/units/units-2.16.tar.gz'
   source_sha256 'dcf3f78482a13b150fc6bf0f8d611510816a3424bc2b26229b85b1cadeb81686'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/units-2.16-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/units-2.16-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/units-2.16-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/units-2.16-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'b2eb014f6c3c3c2b5d7c238c7b3be53707e01e78154feff8af599d183a8ac524',
+     armv7l: 'b2eb014f6c3c3c2b5d7c238c7b3be53707e01e78154feff8af599d183a8ac524',
+       i686: '2f9a42090de1462c5c072e49a74fca296975c6cd32fd82d4572dcd672a792c62',
+     x86_64: 'db36428275e1b1d9bcaf702f527e4b9d7dd5cba83c2cdaff8191f60924777ef9',
+  })
+
   def self.build
     system './configure',
       "--prefix=#{CREW_PREFIX}"

--- a/packages/unrtf.rb
+++ b/packages/unrtf.rb
@@ -8,8 +8,16 @@ class Unrtf < Package
   source_sha256 '22a37826f96d754e335fb69f8036c068c00dd01ee9edd9461a36df0085fb8ddd'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/unrtf-0.21.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/unrtf-0.21.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/unrtf-0.21.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/unrtf-0.21.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '60ac4110be548c1d7f52210f30b2af30774ca532b245778badd0f5ecec4fc669',
+     armv7l: '60ac4110be548c1d7f52210f30b2af30774ca532b245778badd0f5ecec4fc669',
+       i686: 'c6ebb018e9c82cede4d0847b00c4cea44b209ca4f23ffa404d62276d6baa95d1',
+     x86_64: '905c08e45a27b7a40aa2986ce9576f24fc36118f185dad78cd728cef51af8e54',
   })
 
   depends_on 'glibc'

--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -7,6 +7,19 @@ class Util_linux < Package
   source_url 'https://www.kernel.org/pub/linux/utils/util-linux/v2.30/util-linux-2.30.tar.xz'
   source_sha256 'c208a4ff6906cb7f57940aa5bc3a6eed146e50a7cc0a092f52ef2ab65057a08d'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.30-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.30-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.30-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.30-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '5ff514e1b234fea8d7df4dc27d3c17e1741a4289353d2335dc3e28eb948ee404',
+     armv7l: '5ff514e1b234fea8d7df4dc27d3c17e1741a4289353d2335dc3e28eb948ee404',
+       i686: 'f974237691ae726c55045b2b1e556af0efcbf943e34961c4801601c6ccf8ed6e',
+     x86_64: 'eab34f391bc111d3f6985de8619e6b5c41e1bd0652256e80cb57f4422bdfb72a',
+  })
+
   depends_on 'python27'
   depends_on 'libcap_ng'
   depends_on 'vdev'

--- a/packages/vagrant.rb
+++ b/packages/vagrant.rb
@@ -8,8 +8,16 @@ class Vagrant < Package
   source_sha256 '212b91c45f60a825fcfc656424021e2550833778a6d4ebe13458676201a04eba'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vagrant-2.0.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vagrant-2.0.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vagrant-2.0.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vagrant-2.0.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'c87a9597690114da4fc34cd0c8c2a6af0f9c1b0591d5dc1e98fa59fddbdc6768',
+     armv7l: 'c87a9597690114da4fc34cd0c8c2a6af0f9c1b0591d5dc1e98fa59fddbdc6768',
+       i686: '4f52401baa59d15382e491d8c95e5470482725d80aa2d9b661c78496a35266bc',
+     x86_64: '4ba294be3189df94ffdf603e710ffe21b706f9e41466afac2e24566f9e64948d',
   })
 
   depends_on 'ruby'

--- a/packages/valgrind.rb
+++ b/packages/valgrind.rb
@@ -8,8 +8,16 @@ class Valgrind < Package
   source_sha256 'd76680ef03f00cd5e970bbdcd4e57fb1f6df7d2e2c071635ef2be74790190c3b'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/valgrind-3.13.0-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/valgrind-3.13.0-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/valgrind-3.13.0-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/valgrind-3.13.0-2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '859913a6f0f4a629f464fb01912e0e99d59a2f4dd0ef19a0ebfd8874180de0b9',
+     armv7l: '859913a6f0f4a629f464fb01912e0e99d59a2f4dd0ef19a0ebfd8874180de0b9',
+       i686: 'b6b11f8f929583a90fb3ea4fe939c320b4b8c0570280b572228daad1a6638867',
+     x86_64: 'ae45af143f6b45454da54d426246e11b2cb5add80d134d1e617d625b756c6e6c',
   })
 
   depends_on 'patch' => :build

--- a/packages/vdev.rb
+++ b/packages/vdev.rb
@@ -7,6 +7,19 @@ class Vdev < Package
   source_url 'https://github.com/jcnelson/vdev/archive/ceb7a6c4f44dec542dc1c3c3d5abd27dec7f3e0e.tar.gz'
   source_sha256 'dbf561890aa70a8619506d166803a72d0c2a5b7590226feef784ec623bcb4739'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'bf9bd2fdde42e0897e6aab47a18e2f2649b6dbd01de14bf6165c55c2a716e133',
+     armv7l: 'bf9bd2fdde42e0897e6aab47a18e2f2649b6dbd01de14bf6165c55c2a716e133',
+       i686: '8bb09676d68f9b00da89f0e9bc9499bc5d38332081cbbc698266f74644af89e1',
+     x86_64: '45e3ca2fe33ec0dce519ad5053b63fefc4c50a38ce5fb842faca3ec941006f61',
+  })
+
   depends_on 'glibc'
   depends_on 'fuse'
   depends_on 'libpstat'

--- a/packages/wget.rb
+++ b/packages/wget.rb
@@ -8,8 +8,16 @@ class Wget < Package
   source_sha256 '0f1157bbf4daae19f3e1ddb70c6ccb2067feb834a6aa23c9d9daa7f048606384'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '306ce8e73db8c90fec3bacf29bcdcc904bc96bd9eb47fe760cebeb036c17d6fa',
+     armv7l: '306ce8e73db8c90fec3bacf29bcdcc904bc96bd9eb47fe760cebeb036c17d6fa',
+       i686: 'e13a781140e81610c6e56422e4ff8622d6f3ffb9422521adee08eb077dd90d62',
+     x86_64: '572913991ca7d70a2eb643457c579b78b80b01bbf2fb9020fdc55fc29393ad3f',
   })
 
   depends_on 'buildessential' => :build

--- a/packages/whitedb.rb
+++ b/packages/whitedb.rb
@@ -8,8 +8,16 @@ class Whitedb < Package
   source_sha256 '10c4ccd754ed2d53dbdef9ec16c88c732aa73d923fc0ee114e7e3a78a812849d'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/whitedb-0.7.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/whitedb-0.7.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/whitedb-0.7.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/whitedb-0.7.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'e27c9bcfd7733bed9ad37fa39295e3b1f45f147c6c1e3864263092a277a175fc',
+     armv7l: 'e27c9bcfd7733bed9ad37fa39295e3b1f45f147c6c1e3864263092a277a175fc',
+       i686: '9f67c9dfd8314d203df73d13f6eb7700c92bea7e03228f7096994979503d4125',
+     x86_64: 'eda584a55d77f6fda81ed0266ce0c43da1c77591a1576b9a866dd73b5df28782',
   })
 
   def self.build

--- a/packages/wput.rb
+++ b/packages/wput.rb
@@ -7,6 +7,19 @@ class Wput < Package
   source_url 'https://prdownloads.sourceforge.net/wput/wput-0.6.1.tgz'
   source_sha256 '67125acab1d520e5d2a0429cd9cf7fc379987f30d5bbed0b0e97b92b554fcc13'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wput-0.6.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wput-0.6.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/wput-0.6.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wput-0.6.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '48230c2499ce7b4f0f144e3b9d8146d15c96dfde44c577cbe9b21dfafd5498ea',
+     armv7l: '48230c2499ce7b4f0f144e3b9d8146d15c96dfde44c577cbe9b21dfafd5498ea',
+       i686: '2c00e900e41225455efd129b605ec11a027822f43c10d765832261b38ca98311',
+     x86_64: '1c2dfc74e86f4b50ad805079b4d9b1e92e10ba6da31060b5de62a8f3af8d06a2',
+  })
+
   depends_on 'gnutls'
 
   def self.preinstall

--- a/packages/xe.rb
+++ b/packages/xe.rb
@@ -8,8 +8,16 @@ class Xe < Package
   source_sha256 '8993cea06b2c664195df2a6124d0386d1bce7c27eb6ecbf968866bfd05cb9d7a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xe-0.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xe-0.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xe-0.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xe-0.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'a8abe1abf912587ec016f7bdeab423c7a60f750c2da52bc298e4b64006affd97',
+     armv7l: 'a8abe1abf912587ec016f7bdeab423c7a60f750c2da52bc298e4b64006affd97',
+       i686: '346d26cca7c6baf20a2fa375f5c8078c602b1cd472a47b0acca5ce12c507d4cd',
+     x86_64: 'd19c870b8a7671d590b7f383507d384e6a8d0591c50b72af8f12cb0eca01aec5',
   })
 
   def self.build

--- a/packages/xf86driproto.rb
+++ b/packages/xf86driproto.rb
@@ -7,6 +7,19 @@ class Xf86driproto < Package
   source_url 'https://www.x.org/archive/individual/proto/xf86driproto-2.1.1.tar.gz'
   source_sha256 '18ff8de129b89fa24a412a1ec1799f8687f96c186c655b44b1a714a3a5d15d6c'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xf86driproto-2.1.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xf86driproto-2.1.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xf86driproto-2.1.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xf86driproto-2.1.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '7b50e61fba22d3c78f2f65f5263aa1b922fe9858a9a4b3e5ad39db5117c5837c',
+     armv7l: '7b50e61fba22d3c78f2f65f5263aa1b922fe9858a9a4b3e5ad39db5117c5837c',
+       i686: '1e73a1c26eb143448522ef553b7be4b57471e03437bffc671f035460ec69ff94',
+     x86_64: '434fd1676fa2f37eee07ea1f3ee8f4ded04cf5481b4c6c52c4215e248c008b71',
+  })
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
   end

--- a/packages/xmlclitools.rb
+++ b/packages/xmlclitools.rb
@@ -8,8 +8,16 @@ class Xmlclitools < Package
   source_sha256 '262ce2f119a278ee2f965722f4d23b6b67f8baaa594858b9a0124849726e5a63'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xmlclitools-1.61-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xmlclitools-1.61-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xmlclitools-1.61-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xmlclitools-1.61-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'e22665bdf25bbce519a68103f4021ee803006368bbea85f9106b5a6dc8229dbf',
+     armv7l: 'e22665bdf25bbce519a68103f4021ee803006368bbea85f9106b5a6dc8229dbf',
+       i686: '6ebfd4ffa8c126a876bd8259b7684640cd4536d284cac275b036fa66e6091d21',
+     x86_64: 'eb02a6633241f4bf4584f212d5bb693b3e22fa7e938f4885a8d1890d109cad7d',
   })
 
   depends_on 'glib'

--- a/packages/xxhash.rb
+++ b/packages/xxhash.rb
@@ -8,8 +8,16 @@ class Xxhash < Package
   source_sha256 'd8c739ec666ac2af983a61dc932aaa2a8873df974d333a9922d472a121f2106e'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.6.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.6.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.6.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.6.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '2e1ff84aa860e3706752729eee3b625e55e73bd8ab5cf4f6d5f5c9a88aa2a6ac',
+     armv7l: '2e1ff84aa860e3706752729eee3b625e55e73bd8ab5cf4f6d5f5c9a88aa2a6ac',
+       i686: 'aeee95d5f6d8848bfcad8247bfa5f985ebbda3017b4d49f6748d93a2213b0d47',
+     x86_64: '8996d96cc1981728bc2a826f139c0f7b6189d93075e20d7f2cb56cbd4d119a3e',
   })
 
   def self.build

--- a/packages/zeromq.rb
+++ b/packages/zeromq.rb
@@ -8,8 +8,16 @@ class Zeromq < Package
   source_sha256 '5b23f4ca9ef545d5bd3af55d305765e3ee06b986263b31967435d285a3e6df6b'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/zeromq-4.2.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/zeromq-4.2.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/zeromq-4.2.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/zeromq-4.2.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '9153ad8e7f6ec0b271b3dc7ab83469315727f674b0b9fa40608d6f1acafee21a',
+     armv7l: '9153ad8e7f6ec0b271b3dc7ab83469315727f674b0b9fa40608d6f1acafee21a',
+       i686: 'ce518f73155b3036ebf97f64fe9d62e1820f610dcb17524303c1027cbcac1c32',
+     x86_64: '6d5a1494e5a90f72e152b737738c9e4949a2e24eae9f10c5561cfecc55263314',
   })
 
   depends_on 'libunwind'

--- a/packages/zile.rb
+++ b/packages/zile.rb
@@ -8,8 +8,16 @@ class Zile < Package
   source_sha256 '7a78742795ca32480f2bab697fd5e328618d9997d6f417cf1b14e9da9af26b74'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/zile-2.4.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/zile-2.4.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/zile-2.4.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/zile-2.4.14-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '9af8d03f90d5a5f6ffd48774ccdc053ffb8d0a878baf883a301ff709d1d8d2d4',
+     armv7l: '9af8d03f90d5a5f6ffd48774ccdc053ffb8d0a878baf883a301ff709d1d8d2d4',
+       i686: '24b7a3e4dca4fd149a34ab37d7b7e5f297198edf8264825d65c5406d1c3d1582',
+     x86_64: '7acde7380f56dc54d6c74ec5cf7fd9f7ebb666524144d4c1d229ff31e2c66da3',
   })
 
   depends_on 'acl'


### PR DESCRIPTION
This isn't everything but it only leaves a handful of packages that need binaries.  If binaries didn't compile for any of the architectures, I excluded the whole package.