### PR TITLE
Update curl from 7.56.1 to 7.57.0

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,21 +3,13 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.haxx.se/'
-  version '7.56.1'
-  source_url 'https://curl.haxx.se/download/curl-7.56.1.tar.xz'
-  source_sha256 '8eed282cf3a0158d567a0feaa3c4619e8e847970597b5a2c81879e8f0d1a39d1'
+  version '7.57.0'
+  source_url 'https://curl.haxx.se/download/curl-7.57.0.tar.xz'
+  source_sha256 'f5f6fd3c72b7b8389969f4fb671ed8532fa9b5bb7a5cae7ca89bc1cea45c7878'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.56.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.56.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.56.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.56.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '7b2e42aa02044eb77dc45cc74657a26e937f02829ad396dd28f18fa5116ad57c',
-     armv7l: '7b2e42aa02044eb77dc45cc74657a26e937f02829ad396dd28f18fa5116ad57c',
-       i686: '40f88fd927b1722715b155310a85421fd72540594aa9ff4ad2f08d730562d71c',
-     x86_64: '082dc3d26e7ffbd76486ed929246ff599e6b18e8daa2737778455bdcc2653915',
   })
 
   depends_on 'groff' => :build


### PR DESCRIPTION
This is a security release addressing CVE-2017-8816, CVE-2017-8817, and
CVE-2017-8818.

Tested as working on Samsung Chromebook Plus (aarch64).