### PR TITLE
Update nano from 2.9.0 to 2.9.1

### DIFF
--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -3,9 +3,9 @@ require 'package'
 class Nano < Package
   description 'Nano\'s ANOther editor, an enhanced free Pico clone.'
   homepage 'https://www.nano-editor.org/'
-  version '2.9.0'
-  source_url 'https://www.nano-editor.org/dist/v2.9/nano-2.9.0.tar.xz'
-  source_sha256 'd2d30c39caef53aba1ec1b4baff4186d4496f35d2411b0848242a5f2e27e129e'
+  version '2.9.1'
+  source_url 'https://www.nano-editor.org/dist/v2.9/nano-2.9.1.tar.xz'
+  source_sha256 '6316d52d0d26af3e79a13dcb4db1c7a4aeac61b37fd9381e801a4189a2ecba7c'
 
   binary_url ({
   })


### PR DESCRIPTION
This is a general bugfix and maintenance release.

Tested as working on Samsung Chromebook Plus (aarch64).