### PR TITLE
Add popt package

### DIFF
--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -1,0 +1,27 @@
+require 'package'
+
+class Popt < Package
+  description 'Library for parsing command line options'
+  homepage 'https://directory.fsf.org/wiki/Popt'
+  version '1.16'
+  source_url 'http://rpm5.org/files/popt/popt-1.16.tar.gz'
+  source_sha256 'e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "gzip -9 #{CREW_DEST_PREFIX}/share/man/man3/popt.3"
+  end
+end


### PR DESCRIPTION
The popt library exists essentially for parsing command line options. Some specific advantages of popt are no global variables (allowing multiple passes in parsing argv), parsing an arbitrary array of argv-style elements (allowing parsing of command-line-strings from any source), a standard method of option aliasing, ability to exec external option filters, and automatic generation of help and usage messages.  See https://directory.fsf.org/wiki/Popt.