### PR TITLE
Correct install line

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
             <h5>Available on aarch64, armv7l, i686 and x86_64.</h5>
           </div>
           <div class="highlight">
-            <pre><code>wget -q -O - https://raw.github.com/skycocker/chromebrew/master/install.sh | bash</code></pre>
+            <pre><code>$ curl -Ls git.io/vddgY -o install.sh && yes | bash install.sh</code></pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The previous install line was not working.

Preview: http://htmlpreview.github.io/?https://github.com/uberhacker/chromebrew/blob/gh-pages-change-install-line/index.html