### PR TITLE
Update git from 2.14.1-1 to 2.15.1

### DIFF
--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,21 +3,13 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  version '2.14.1-1'
-  source_url 'https://github.com/git/git/archive/v2.14.1.tar.gz'
-  source_sha256 'ccc366d5d674fb755fd98d219c23f2b4e5da8a49d8582a6314813b280d75536b'
+  version '2.15.1'
+  source_url 'https://github.com/git/git/archive/v2.15.1.tar.gz'
+  source_sha256 '3cbc474c7fe9013b1cd4310636f0992d767d435ac9f642744551fd9a2b4b9d15'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.14.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.14.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.14.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.14.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '8548a8273beeb7956fed40e5db078d624b3d0f9c7b5897980b31aaba5d0837b8',
-     armv7l: '8548a8273beeb7956fed40e5db078d624b3d0f9c7b5897980b31aaba5d0837b8',
-       i686: '11c1979b55f8ce623ceee18e78b3177c7038d6909bcbba717bda9fc8e9a6d3f2',
-     x86_64: '5950f17a8016f39002e3e25d9c2bd015bb82e5b253285ae144a18a0f8c8fb2f6',
   })
 
   # use system zlibpkg, openssl, curl, expat
@@ -44,9 +36,12 @@ class Git < Package
     system "#{@make_cmd} DESTDIR=#{CREW_DEST_DIR} install"
     system "mkdir -p #{CREW_DEST_PREFIX}/share/git-completion"
     system "cp -r contrib/completion/* #{CREW_DEST_PREFIX}/share/git-completion"
+  end
+
+  def self.postinstall
     puts
-    puts "Git completion support is available for the following shells:"
-    system "ls contrib/completion"
+    puts "Git completion support is available for the following shells:".lightblue
+    system "ls #{CREW_PREFIX}/share/git-completion"
     puts
     puts "To add git completion for bash, execute the following:".lightblue
     puts "echo '# git completion' >> ~/.bashrc".lightblue


### PR DESCRIPTION
This also adds the important post-install message about git completion we miss with the current binary install.