### PR TITLE
Updated libassuan to v 2.5.1, plus added support to put libraries in lib64 for x86_64

### DIFF
--- a/packages/libassuan.rb
+++ b/packages/libassuan.rb
@@ -8,12 +8,7 @@ class Libassuan < Package
   source_sha256 '47f96c37b4f2aac289f0bc1bacfa8bd8b4b209a488d3d15e2229cb6cc9b26449'
 
   def self.build
-    case ARCH
-      when 'x86_64'
-        system './configure --prefix=/usr/local --libdir=/usr/local/lib64'
-      else
-        system './configure --prefix=/usr/local'
-    end
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 

--- a/packages/libassuan.rb
+++ b/packages/libassuan.rb
@@ -3,25 +3,17 @@ require 'package'
 class Libassuan < Package
   description 'Libassuan is a small library implementing the so-called Assuan protocol.'
   homepage 'https://www.gnupg.org/related_software/libassuan/index.html'
-  version '2.4.3'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.4.3.tar.bz2'
-  source_sha256 '22843a3bdb256f59be49842abf24da76700354293a066d82ade8134bb5aa2b71'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libassuan-2.4.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libassuan-2.4.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libassuan-2.4.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libassuan-2.4.3-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'c582619a230bd2f766ff2b10d6d8a61a433314491ed34a5c332c54904dc8bfe2',
-     armv7l: 'c582619a230bd2f766ff2b10d6d8a61a433314491ed34a5c332c54904dc8bfe2',
-       i686: '932dfeb2bce8fc736c89bffe10713e366a867722bf807cfdcfbd7fcc2f9a78f2',
-     x86_64: '05dd4fd2634875a990ab4abd1f3d477deaaee37c7015d08b59b31d1e369fc9b9',
-  })
+  version '2.5.1'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.5.1.tar.bz2'
+  source_sha256 '47f96c37b4f2aac289f0bc1bacfa8bd8b4b209a488d3d15e2229cb6cc9b26449'
 
   def self.build
-    system './configure --prefix=/usr/local'
+    case ARCH
+      when 'x86_64'
+        system './configure --prefix=/usr/local --libdir=/usr/local/lib64'
+      else
+        system './configure --prefix=/usr/local'
+    end
     system 'make'
   end
 

--- a/packages/libassuan.rb
+++ b/packages/libassuan.rb
@@ -7,6 +7,8 @@ class Libassuan < Package
   source_url 'https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.5.1.tar.bz2'
   source_sha256 '47f96c37b4f2aac289f0bc1bacfa8bd8b4b209a488d3d15e2229cb6cc9b26449'
 
+  depends_on 'libgpgerror'
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system 'make'


### PR DESCRIPTION
  x86_64 hosts

Supports #1585 

## Description
Updated libassuan to v2.5.1.  Also, added support to put library files in .../lib64 for x86_64 hosts
## Additional information

Built & tested on:
- [x] x86_64
- [x]  armv7l
- [x] i686 (No hardware to test)
- [ ] aarch64 (No hardware to test)

 Also, removed pre-built stanzas
