### PR TITLE
Add duplicity package

### DIFF
--- a/packages/duplicity.rb
+++ b/packages/duplicity.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Duplicity < Package
+  description 'Duplicity backs directories by producing encrypted tar-format volumes and uploading them to a remote or local file server.'
+  homepage 'http://duplicity.nongnu.org/'
+  version '0.7.15'
+  source_url 'https://code.launchpad.net/duplicity/0.7-series/0.7.15/+download/duplicity-0.7.15.tar.gz'
+  source_sha256 '50bf7d14413284ecb036146ab9ba0e271937f2fa7826f8c8300b2965eb450a6c'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'python27' unless File.exists? "#{CREW_PREFIX}/bin/python"
+  depends_on 'librsync'
+  depends_on 'gnupg'
+  depends_on 'openssh'
+
+  def self.install
+    system "pip install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR} fasteners"
+    system "python setup.py install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"
+  end
+end


### PR DESCRIPTION
Duplicity backs directories by producing encrypted tar-format volumes and uploading them to a remote or local file server. Because duplicity uses librsync, the incremental archives are space efficient and only record the parts of files that have changed since the last backup. Because duplicity uses GnuPG to encrypt and/or sign these archives, they will be safe from spying and/or modification by the server.  See http://duplicity.nongnu.org/.  Depends on PR #1599.