### PR TITLE
Supporting 1585 - update ascii, asciidoc, datamash, whois, avocado, aria2, wput, bdwgc

### DIFF
--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -4,8 +4,8 @@ class Aria2 < Package
   description 'aria2 is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.'
   homepage 'https://aria2.github.io/'
   version '1.33.1'
-  source_url 'https://github.com/aria2/aria2/releases/download/release-1.33.1/aria2-1.33.1.tar.bz2'
-  source_sha256 '32e8dc76da0c630da18d6a656afb117fef8f2f71d6f38e326a6e09fa113e2109'
+  source_url 'https://github.com/aria2/aria2/releases/download/release-1.33.1/aria2-1.33.1.tar.xz'
+  source_sha256 '2539e4844f55a1f1f5c46ad42744335266053a69162e964d9a2d80a362c75e1b'
 
   binary_url ({
   })

--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -3,9 +3,9 @@ require 'package'
 class Aria2 < Package
   description 'aria2 is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.'
   homepage 'https://aria2.github.io/'
-  version '1.33.0'
-  source_url 'https://github.com/aria2/aria2/releases/download/release-1.33.0/aria2-1.33.0.tar.xz'
-  source_sha256 '996e3fc2fd07ce2dd517e20a1f79b8b3dbaa5c7e27953b5fc19dae38f3874b8c'
+  version '1.33.1'
+  source_url 'https://github.com/aria2/aria2/releases/download/release-1.33.1/aria2-1.33.1.tar.bz2'
+  source_sha256 '32e8dc76da0c630da18d6a656afb117fef8f2f71d6f38e326a6e09fa113e2109'
 
   binary_url ({
   })

--- a/packages/ascii.rb
+++ b/packages/ascii.rb
@@ -8,8 +8,16 @@ class Ascii < Package
   source_sha256 'a94bb3970e8f1f63566f055517aecbdd46b11c4ccf142f77ffb80a79994f03a9'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ascii-3.16-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ascii-3.16-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ascii-3.16-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ascii-3.16-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '8afd3dd8d8bbb56f039bd51dd2e0a65fdd23449b3858fb328fd0d2cbb75382b9',
+     armv7l: '8afd3dd8d8bbb56f039bd51dd2e0a65fdd23449b3858fb328fd0d2cbb75382b9',
+       i686: '9c5f93b333c1b40e558c76ab082bf5cfd7541a6f36f3c4561250e7dc2db45d26',
+     x86_64: 'cfce0c56efacea56a77d481d6f5001645972fa4780a2a8dea921f9435dffc466',
   })
 
   def self.build

--- a/packages/ascii.rb
+++ b/packages/ascii.rb
@@ -3,21 +3,13 @@ require 'package'
 class Ascii < Package
   description 'List ASCII idiomatic names and octal/decimal code-point forms.'
   homepage 'http://www.catb.org/~esr/ascii/'
-  version '3.16-1'
-  source_url 'http://www.catb.org/~esr/ascii/ascii-3.16.tar.gz'
-  source_sha256 'a94bb3970e8f1f63566f055517aecbdd46b11c4ccf142f77ffb80a79994f03a9'
+  version '3.18'
+  source_url 'http://www.catb.org/~esr/ascii/ascii-3.18.tar.gz'
+  source_sha256 '728422d5f4da61a37a17b4364d06708e543297de0a5f70305243236d80df072d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ascii-3.16-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ascii-3.16-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ascii-3.16-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ascii-3.16-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '8afd3dd8d8bbb56f039bd51dd2e0a65fdd23449b3858fb328fd0d2cbb75382b9',
-     armv7l: '8afd3dd8d8bbb56f039bd51dd2e0a65fdd23449b3858fb328fd0d2cbb75382b9',
-       i686: '9c5f93b333c1b40e558c76ab082bf5cfd7541a6f36f3c4561250e7dc2db45d26',
-     x86_64: 'cfce0c56efacea56a77d481d6f5001645972fa4780a2a8dea921f9435dffc466',
   })
 
   def self.build

--- a/packages/asciidoc.rb
+++ b/packages/asciidoc.rb
@@ -7,6 +7,11 @@ class Asciidoc < Package
   source_url 'https://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz'
   source_sha256 '78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0'
 
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
   depends_on 'autoconf'
   depends_on 'python27' unless File.exists? "#{CREW_PREFIX}/bin/python"
 

--- a/packages/asciidoc.rb
+++ b/packages/asciidoc.rb
@@ -3,22 +3,9 @@ require 'package'
 class Asciidoc < Package
   description 'AsciiDoc is a presentable text document format for writing articles, UNIX man pages and other small to medium sized documents.'
   homepage 'http://asciidoc.org/'
-  version '8.6.8'
-  source_url 'https://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.8/asciidoc-8.6.8.tar.gz'
-  source_sha256 'ffb67f59dccaf6f15db72fcd04fdf21a2f9b703d31f94fcd0c49a424a9fcfbc4'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/asciidoc-8.6.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/asciidoc-8.6.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/asciidoc-8.6.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/asciidoc-8.6.8-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '8964ae17ca0feef6ee98d89139a27a3f6fddf9b20cad7c6d62efc31b842227a2',
-     armv7l: '8964ae17ca0feef6ee98d89139a27a3f6fddf9b20cad7c6d62efc31b842227a2',
-       i686: 'bfbcc0789959c06eda29a0ce1d2cac7d8120d103581ba75fd8f899b69b75d309',
-     x86_64: '035b371c2dd72ef63d2c0dbeb1671ca1de9babb33ae8226153684d3d0904ca0d',
-  })
+  version '8.6.9'
+  source_url 'https://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz'
+  source_sha256 '78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0'
 
   depends_on 'autoconf'
   depends_on 'python27' unless File.exists? "#{CREW_PREFIX}/bin/python"

--- a/packages/avocado.rb
+++ b/packages/avocado.rb
@@ -3,9 +3,9 @@ require 'package'
 class Avocado < Package
   description 'Avocado is a next generation testing framework inspired by Autotest and modern development tools such as git.'
   homepage 'http://avocado-framework.github.io/'
-  version '55.0'
-  source_url 'https://github.com/avocado-framework/avocado/archive/55.0.tar.gz'
-  source_sha256 '0ec798afaca0910d7b3853aa8a7782c4d95e54bbf5ff8473005bcd70829e5a9f'
+  version '57.0'
+  source_url 'https://github.com/avocado-framework/avocado/archive/57.0.tar.gz'
+  source_sha256 'c49fdf0946eed445fd8397354db3491869389ed4578ba477d447f105c99f15e4'
 
   binary_url ({
   })

--- a/packages/bdwgc.rb
+++ b/packages/bdwgc.rb
@@ -3,21 +3,13 @@ require 'package'
 class Bdwgc < Package
   description 'The Boehm-Demers-Weiser conservative C/C++ Garbage Collecto'
   homepage 'https://github.com/ivmai/bdwgc'
-  version '7.6.0'
-  source_url 'https://github.com/ivmai/bdwgc/files/1005477/gc-7.6.0.tar.gz'
-  source_sha256 'a14a28b1129be90e55cd6f71127ffc5594e1091d5d54131528c24cd0c03b7d90'
+  version '7.6.2'
+  source_url 'https://github.com/ivmai/bdwgc/releases/download/v7.6.2/gc-7.6.2.tar.gz'
+  source_sha256 'bd112005563d787675163b5afff02c364fc8deb13a99c03f4e80fdf6608ad41e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bdwgc-7.6.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bdwgc-7.6.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bdwgc-7.6.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bdwgc-7.6.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'be29d91fd1e4ca65bc1f624f045b04b11178d689a9bd898c9a1e91b2e8cf8221',
-     armv7l: 'be29d91fd1e4ca65bc1f624f045b04b11178d689a9bd898c9a1e91b2e8cf8221',
-       i686: '6444b15b6cfa80b0e2ed0702944572b24ff2e6eb6fbe9baacc0acebdebe08c9d',
-     x86_64: 'cfb243044ce59c9b36b862400f30008413c7f48da01a162364e5ec796f4690b6',
   })
 
   depends_on 'libatomic_ops'

--- a/packages/datamash.rb
+++ b/packages/datamash.rb
@@ -4,7 +4,7 @@ class Datamash < Package
   description 'GNU Datamash is a command-line program which performs basic numeric,textual and statistical operations on input textual data files.'
   homepage 'http://savannah.gnu.org/projects/datamash'
   version '1.2'
-  source_url 'https://mirror.sergal.org/gnu/datamash/datamash-1.2.tar.gz'
+  source_url 'https://ftpmirror.gnu.org/datamash/datamash-1.2.tar.gz'
   source_sha256 'e8d46fb22ccc77e5380f26cde622a733f363d388b04a2c22e7fb6de0e9d85996'
 
   binary_url ({

--- a/packages/datamash.rb
+++ b/packages/datamash.rb
@@ -3,21 +3,13 @@ require 'package'
 class Datamash < Package
   description 'GNU Datamash is a command-line program which performs basic numeric,textual and statistical operations on input textual data files.'
   homepage 'http://savannah.gnu.org/projects/datamash'
-  version '1.1.1'
-  source_url 'https://ftpmirror.gnu.org/datamash/datamash-1.1.1.tar.gz'
-  source_sha256 '420819b3d7372ee3ce704add847cff7d08c4f8176c1d48735d4a632410bb801b'
+  version '1.2'
+  source_url 'https://mirror.sergal.org/gnu/datamash/datamash-1.2.tar.gz'
+  source_sha256 'e8d46fb22ccc77e5380f26cde622a733f363d388b04a2c22e7fb6de0e9d85996'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/datamash-1.1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/datamash-1.1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/datamash-1.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/datamash-1.1.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'e664ff3f0882182ae85207bd1206fe71c0f7cbd57f32dca37791ed9ec4dc51e0',
-     armv7l: 'e664ff3f0882182ae85207bd1206fe71c0f7cbd57f32dca37791ed9ec4dc51e0',
-       i686: '6bddfe6f7e92197c65c64ec2ee39cd88f57eafa96f93496bf058174f33eae882',
-     x86_64: '179497c275e0f4f51c0c6512515d0bbe9bbcd8397b0737e45ff63be4acb907d7',
   })
 
   def self.build

--- a/packages/whois.rb
+++ b/packages/whois.rb
@@ -3,21 +3,13 @@ require 'package'
 class Whois < Package
   description 'Intelligent WHOIS client'
   homepage 'https://github.com/rfc1036/whois'
-  version '5.2.16'
-  source_url 'https://github.com/rfc1036/whois/archive/v5.2.16.tar.gz'
-  source_sha256 'd8204ca199329f14c33cb9f893b0f50918dbef34a6838317270e65c55ab32615'
+  version '5.2.20'
+  source_url 'https://github.com/rfc1036/whois/archive/v5.2.20.tar.gz'
+  source_sha256 '1812b9c64a41d8ed70507bb1161a18a0a7b2f29ba5b442ca7828a5acb1e44c7e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/whois-5.2.16-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/whois-5.2.16-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/whois-5.2.16-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/whois-5.2.16-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '6af8f5df827b4df623dcc9e6b8adc4d6c5627391cc4cc5a575db429e994c6264',
-     armv7l: '6af8f5df827b4df623dcc9e6b8adc4d6c5627391cc4cc5a575db429e994c6264',
-       i686: '0535b924068cb2be49b0d722969c8e7459c9d73998f32638a72db33ed9672674',
-     x86_64: '778b41edd15d5c6aad04168c5be30f160fae7d5030aa7a6f90b66117ac389486',
   })
 
   depends_on 'gettext'

--- a/packages/wput.rb
+++ b/packages/wput.rb
@@ -3,9 +3,9 @@ require 'package'
 class Wput < Package
   description 'wput is a command line file upload tool, the opposite of wget'
   homepage 'http://wput.sourceforge.net/'
-  version '0.6.1'
-  source_url 'https://prdownloads.sourceforge.net/wput/wput-0.6.1.tgz'
-  source_sha256 '67125acab1d520e5d2a0429cd9cf7fc379987f30d5bbed0b0e97b92b554fcc13'
+  version '0.6.2'
+  source_url 'https://downloads.sourceforge.net/project/wput/wput/0.6.2/wput-0.6.2.tgz'
+  source_sha256 '229d8bb7d045ca1f54d68de23f1bc8016690dc0027a16586712594fbc7fad8c7'
 
   depends_on 'gnutls'
 


### PR DESCRIPTION
Updates #1585 

## Description

Programatically updated following packages:
- asciidoc - update to 8.6.9
- ascii - update to 3.18
- datamash - update to 1.2
- whois - update to 5.2.20
- avocado - update to 57.0
- aria2 - update to 1.33.1
- wput - update to 0.6.2
- bdwgc - update to 7.6.2

## Addtional information
At this point, these have been tested only on x86_64 that the packages build.
