### PR TITLE
Supporting #1585, again.  update 42 packages.

### DIFF
--- a/packages/bind.rb
+++ b/packages/bind.rb
@@ -3,21 +3,13 @@ require 'package'
 class Bind < Package
   description 'BIND is open source software that enables you to publish your Domain Name System (DNS) information on the Internet, and to resolve DNS queries for your users.'
   homepage 'https://www.isc.org/downloads/bind/'
-  version '9.10.5-p3'
-  source_url 'https://www.isc.org/downloads/file/9-10-5-p3/?version=tar-gz'
-  source_sha256 '8d7e96b5b0bbac7b900d4c4bbb82e0956b4e509433c5fa392bb72a929b96606a'
+  version '9.11.2'
+  source_url 'https://ftp.isc.org/isc/bind9/9.11.2/bind-9.11.2.tar.gz'
+  source_sha256 '7f46ad8620f7c3b0ac375d7a5211b15677708fda84ce25d7aeb7222fe2e3c77a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.10.5-p3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.10.5-p3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.10.5-p3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.10.5-p3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5d0ffc0fdfadccb9f838730797e645c249444abb077e5b3d05ad8f0a8241924f',
-     armv7l: '5d0ffc0fdfadccb9f838730797e645c249444abb077e5b3d05ad8f0a8241924f',
-       i686: '8d52384957c720b527650357ad3e5fd3732fbcae2083613c68993b913f603855',
-     x86_64: '3ca89eb998a259f393920174ac2bd1427465101eeb2a9cc8dcb5a880bbe0e4e0',
   })
 
   depends_on "buildessential"

--- a/packages/cmatrix.rb
+++ b/packages/cmatrix.rb
@@ -3,21 +3,13 @@ require 'package'
 class Cmatrix < Package
   description "CMatrix is a program to see the cool scrolling lines from 'The Matrix' movie."
   homepage 'http://www.asty.org/cmatrix/'
-  version '1.2a-1'
-  source_url 'http://www.asty.org/cmatrix/dist/cmatrix-1.2a.tar.gz'
-  source_sha256 '1fa6e6caea254b6fe70a492efddc1b40ad7ccb950a5adfd80df75b640577064c'
+  version '1.2'
+  source_url 'https://github.com/abishekvashok/cmatrix/archive/1.2.tar.gz'
+  source_sha256 '6b0b9aff4585147843c4cf8a8c9c6048500f66dc4887a38922197dfa326b57c8'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cmatrix-1.2a-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cmatrix-1.2a-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cmatrix-1.2a-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cmatrix-1.2a-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'cd094b3ef03e1f1c47d7d1784549a6ded9ccfb59b2fb4546a5b4b99ce011a954',
-     armv7l: 'cd094b3ef03e1f1c47d7d1784549a6ded9ccfb59b2fb4546a5b4b99ce011a954',
-       i686: '9e97e2fa6ef0a384223b2c456905e5955a2355967f7ca14fcd98b0ebeeb651a3',
-     x86_64: 'a846151b32138a8b0803b3e40dda4d42e804d093dab1105787578714e144131b',
   })
 
   depends_on 'buildessential'

--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -3,9 +3,9 @@ require 'package'
 class Coreutils < Package
   description 'The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system.'
   homepage 'http://www.gnu.org/software/coreutils/coreutils.html'
-  version '8.28'
-  source_url 'https://ftp.gnu.org/gnu/coreutils/coreutils-8.28.tar.xz'
-  source_sha256 '1117b1a16039ddd84d51a9923948307cfa28c2cea03d1a2438742253df0a0c65'
+  version '8.29'
+  source_url 'https://ftp.gnu.org/gnu/coreutils/coreutils-8.29.tar.xz'
+  source_sha256 '92d0fa1c311cacefa89853bdb53c62f4110cdfda3820346b59cbd098f40f955e'
 
   binary_url ({
   })

--- a/packages/erlang.rb
+++ b/packages/erlang.rb
@@ -3,9 +3,9 @@ require 'package'
 class Erlang < Package
   description 'Erlang is a programming language used to build massively scalable soft real-time systems with requirements on high availability.'
   homepage 'http://www.erlang.org/'
-  version '20.1'
-  source_url 'http://erlang.org/download/otp_src_20.1.tar.gz'
-  source_sha256 '900d35eb563607785a8e27f4b4c03cf6c98b4596028c5d6958569ddde5d4ddbf'
+  version '20.2'
+  source_url 'http://erlang.org/download/otp_src_20.2.tar.gz'
+  source_sha256 '24d9895e84b800bf0145d6b3042c2f2087eb31780a4a45565206844b41eb8f23'
 
   binary_url ({
   })

--- a/packages/fish.rb
+++ b/packages/fish.rb
@@ -3,21 +3,13 @@ require 'package'
 class Fish < Package
   description 'fish is a smart and user-friendly command line shell for macOS, Linux, and the rest of the family.'
   homepage 'http://fishshell.com/'
-  version '2.6.0'
-  source_url 'https://github.com/fish-shell/fish-shell/releases/download/2.6.0/fish-2.6.0.tar.gz'
-  source_sha256 '7ee5bbd671c73e5323778982109241685d58a836e52013e18ee5d9f2e638fdfb'
+  version '2.7.1'
+  source_url 'https://github.com/fish-shell/fish-shell/archive/2.7.1.tar.gz'
+  source_sha256 'eb43ea2eb9accf76661c487dd530a5fd345fa40a3201bd22cef2c52be39fb474'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fish-2.6.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fish-2.6.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fish-2.6.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fish-2.6.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '45bd379b711698286d9461150c18fbf1d01446e61aa75aaf5bfcbc0dab1e1248',
-     armv7l: '45bd379b711698286d9461150c18fbf1d01446e61aa75aaf5bfcbc0dab1e1248',
-       i686: '173692480715219af0c366e67f182314a895dcbd816819c6a4b45a4c43da07c1',
-     x86_64: '6fe888f23b24020270bbb7c30911b2ae4ffc80689c1b66612a6ba6894a50f3a8',
   })
 
   depends_on 'ncurses'

--- a/packages/gifsicle.rb
+++ b/packages/gifsicle.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gifsicle < Package
   description 'Gifsicle is a command-line tool for creating, editing, and getting information about GIF images and animations.'
   homepage 'http://www.lcdf.org/gifsicle/'
-  version '1.89'
-  source_url 'https://github.com/kohler/gifsicle/archive/v1.89.tar.gz'
-  source_sha256 '9b19ff8d50d88af5a5151eaf9e62beb1dd5b72002e7b7cc3aec9b385780e6b83'
+  version '1.90'
+  source_url 'https://github.com/kohler/gifsicle/archive/v1.90.tar.gz'
+  source_sha256 'eb0f4bf3527a1befd0d8ef9e12a6048536adee4705e91ff4bdb3ea7364007e14'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gifsicle-1.89-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gifsicle-1.89-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gifsicle-1.89-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gifsicle-1.89-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '6cbb8a84e03b8446d26d94341d166917ae50919a6148d2ce2da54e103ebf6310',
-     armv7l: '6cbb8a84e03b8446d26d94341d166917ae50919a6148d2ce2da54e103ebf6310',
-       i686: '5e6e15e3ff4093e5b287ceecd60f170cf32275761aa60f706977a746eb58f3a3',
-     x86_64: 'fd897442df51c04763921fbcba22143079eab0e6127ee2c031103f93768c755a',
   })
 
   def self.build

--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -3,9 +3,9 @@ require 'package'
 class Gnupg < Package
   description 'GnuPG is a complete and free implementation of the OpenPGP standard as defined by RFC4880 (also known as PGP).'
   homepage 'https://gnupg.org/'
-  version '2.2.2'
-  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.2.tar.bz2'
-  source_sha256 'bfb62c7412ceb3b9422c6c7134a34ff01a560f98eb981c2d96829c1517c08197'
+  version '2.2.4'
+  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.4.tar.bz2'
+  source_sha256 '401a3e64780fdfa6d7670de0880aa5c9d589b3db7a7098979d7606cec546f2ec'
 
   binary_url ({
   })

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gnutls < Package
   description 'GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols and technologies around them.'
   homepage 'http://gnutls.org/'
-  version '3.5.15'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.15.tar.xz'
-  source_sha256 '046081108b8b1fe455a13a4c5a4eaa0368e185b678f1670fe09a11a2d7ecfad5'
+  version '3.6.1'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.1.tar.xz'
+  source_sha256 '20b10d2c9994bc032824314714d0e84c0f19bdb3d715d8ed55beb7364a8ebaed'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.5.15-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.5.15-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.5.15-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.5.15-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3c9183dae47b19d037204b5bf1e3fb142ac88cd7a3ee2e24f2e22c9e414dd0a2',
-     armv7l: '3c9183dae47b19d037204b5bf1e3fb142ac88cd7a3ee2e24f2e22c9e414dd0a2',
-       i686: '71f725c3c414f203bdc2a9b7deea04ef655b12c8f28b0d7febfac09a1f688c88',
-     x86_64: '1a09cd1e743e08254bec0b1d60b00ac89bcf210af98c98734aa68d36f79d7c7a',
   })
 
   depends_on 'buildessential' => :build

--- a/packages/gpgme.rb
+++ b/packages/gpgme.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gpgme < Package
   description 'GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG easier for applications.'
   homepage 'https://www.gnupg.org/related_software/gpgme/index.html'
-  version '1.9.0'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.9.0.tar.bz2'
-  source_sha256 '1b29fedb8bfad775e70eafac5b0590621683b2d9869db994568e6401f4034ceb'
+  version '1.10.0'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.10.0.tar.bz2'
+  source_sha256 '1a8fed1197c3b99c35f403066bb344a26224d292afc048cfdfc4ccd5690a0693'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gpgme-1.9.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gpgme-1.9.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gpgme-1.9.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gpgme-1.9.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '759ff099b5540be347291b4b8efb12560272e81af8b6b05b0b9d1806789cd4cb',
-     armv7l: '759ff099b5540be347291b4b8efb12560272e81af8b6b05b0b9d1806789cd4cb',
-       i686: '4a410cb150dafad7f78b930b45d2999129a251c949b4711f47ea2688d30ea04a',
-     x86_64: 'fcb3d155785a0a603f0dfee377f7e2ba2cda057b69d61a632c5cdaa14814804e',
   })
 
   depends_on 'libgpgerror'

--- a/packages/gzsize.rb
+++ b/packages/gzsize.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gzsize < Package
   description 'Print the uncompressed size of a GZipped file.'
   homepage 'https://bfontaine.github.io/gzsize/'
-  version '0.1.1'
-  source_url 'https://github.com/bfontaine/gzsize/archive/0.1.1.tar.gz'
-  source_sha256 'ffb9cc1e5ed10443b1bcf2f711787bc7f69eee27ed83b48f2ccf9d80e39554dd'
+  version '1.2'
+  source_url 'https://github.com/bfontaine/gzsize/archive/0.1.2.tar.gz'
+  source_sha256 '32e20cb2e570f16bc30e62c4fda406ede23b23dfd313fc82528173827487b170'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gzsize-0.1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gzsize-0.1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gzsize-0.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gzsize-0.1.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd4a24b086e172b771b389d5ce421877e5c3763dc66731cbbfa3bfe2fc40b66c6',
-     armv7l: 'd4a24b086e172b771b389d5ce421877e5c3763dc66731cbbfa3bfe2fc40b66c6',
-       i686: 'e8bbc0b2342a40b5c6cb231d61425a78e2804df614bd34bfe37ffc0cb2659c84',
-     x86_64: '5da9324de5a8799dad4cc5126033eefbed40aeb5c2e5616aede325010f500b91',
   })
 
   def self.build

--- a/packages/help2man.rb
+++ b/packages/help2man.rb
@@ -3,21 +3,13 @@ require 'package'
 class Help2man < Package
   description "help2man produces simple manual pages from the '--help' and '--version' output of other commands."
   homepage 'https://www.gnu.org/software/help2man/'
-  version '1.47.4'
-  source_url 'https://ftpmirror.gnu.org/help2man/help2man-1.47.4.tar.xz'
-  source_sha256 'd4ecf697d13f14dd1a78c5995f06459bff706fd1ce593d1c02d81667c0207753'
+  version '1.47.5'
+  source_url 'https://mirror.sergal.org/gnu/help2man/help2man-1.47.5.tar.xz'
+  source_sha256 '7ca60b2519fdbe97f463fe2df66a6188d18b514bfd44127d985f0234ee2461b1'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/help2man-1.47.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/help2man-1.47.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/help2man-1.47.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/help2man-1.47.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'cc7d19aaa9ecb015b68f54d1d58308bf8c280a2a0248d0b1b27b6e6ae282fb5d',
-     armv7l: 'cc7d19aaa9ecb015b68f54d1d58308bf8c280a2a0248d0b1b27b6e6ae282fb5d',
-       i686: '05026d7d242bb60cc357cbdb91bcf0cb701240ed748952cecb088a7b8902b89e',
-     x86_64: '2b80d202e591f249ff3760a33d4e8457dd78cc260549d2fc7a24b84a37b7c168',
   })
 
   def self.build

--- a/packages/imagemagick.rb
+++ b/packages/imagemagick.rb
@@ -3,9 +3,9 @@ require 'package'
 class Imagemagick < Package
   description 'Use ImageMagick to create, edit, compose, or convert bitmap images.'
   homepage 'http://www.imagemagick.org/script/index.php'
-  version '7.0.7-11'
-  source_url 'https://www.imagemagick.org/download/releases/ImageMagick-7.0.7-11.tar.xz'
-  source_sha256 '7993942d64c138f6c3e9d4bce6d8c13f747128bafe5c2295dcb45d91d1ff21e3'
+  version '7.0.7-18'
+  source_url 'https://www.imagemagick.org/download/releases/ImageMagick-7.0.7-18.tar.xz'
+  source_sha256 'd4987d7dc394c302916c1f1471e58932cda99706d7595d3a2467e501d971e136'
 
   binary_url ({
   })

--- a/packages/jsonc.rb
+++ b/packages/jsonc.rb
@@ -3,21 +3,13 @@ require 'package'
 class Jsonc < Package
   description 'JSON-C implements a reference counting object model that allows you to easily construct JSON objects in C, output them as JSON formatted strings and parse JSON formatted strings back into the C representation of JSON objects.'
   homepage 'https://github.com/json-c/json-c/wiki'
-  version '0.12.1-nodoc'
-  source_url 'https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12.1-nodoc.tar.gz'
-  source_sha256 '5a617da9aade997938197ef0f8aabd7f97b670c216dc173977e1d56eef9e1291'
+  version '0.13-20171207'
+  source_url 'https://github.com/json-c/json-c/archive/json-c-0.13-20171207.tar.gz'
+  source_sha256 '26e642456caab38aa9459279b9712ffec52f751e9f46641d28461c244bd6bae6'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/jsonc-0.12.1-nodoc-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/jsonc-0.12.1-nodoc-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/jsonc-0.12.1-nodoc-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/jsonc-0.12.1-nodoc-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '48fa744832dce095fe3d1a5d362b896b2d5a754207db4c9744acb58cf75a5dc1',
-     armv7l: '48fa744832dce095fe3d1a5d362b896b2d5a754207db4c9744acb58cf75a5dc1',
-       i686: 'c6f53630a47e62238fdc973e6b9ea7c0a0b0346cb320a9ea19d5e72b30e7c6d0',
-     x86_64: 'fdd9d9e5d263fef32972f841cc92e77be61a6df5d175e8ae4033c0df62737ba9',
   })
 
   def self.build

--- a/packages/lcms.rb
+++ b/packages/lcms.rb
@@ -3,21 +3,13 @@ require 'package'
 class Lcms < Package
   description 'Little CMS intends to be an OPEN SOURCE small-footprint color management engine, with special focus on accuracy and performance.'
   homepage 'http://www.littlecms.com/'
-  version '2.8'
-  source_url 'https://downloads.sourceforge.net/project/lcms/lcms/2.8/lcms2-2.8.tar.gz'
-  source_sha256 '66d02b229d2ea9474e62c2b6cd6720fde946155cd1d0d2bffdab829790a0fb22'
+  version '2.2.9'
+  source_url 'https://downloads.sourceforge.net/project/lcms/lcms/2.9/lcms2-2.9.tar.gz'
+  source_sha256 '48c6fdf98396fa245ed86e622028caf49b96fa22f3e5734f853f806fbc8e7d20'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/lcms-2.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/lcms-2.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/lcms-2.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/lcms-2.8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'ef1a4f2b84a946f4b940cf145d0db308258e03937a959008ecd94951f073bda6',
-     armv7l: 'ef1a4f2b84a946f4b940cf145d0db308258e03937a959008ecd94951f073bda6',
-       i686: '597a0adaad471ea2f66a516ec9d76464d3c2ffd310e22f7fb5641e6096077994',
-     x86_64: '2d8a3940bee7c5e7da15d465820ba7f59d893b3beccb30ef228d4a1bec11e344',
   })
 
   def self.build

--- a/packages/libcheck.rb
+++ b/packages/libcheck.rb
@@ -3,21 +3,13 @@ require 'package'
 class Libcheck < Package
   description 'A unit testing framework for C'
   homepage 'https://github.com/libcheck/check'
-  version '0.11.0'
-  source_url 'https://github.com/libcheck/check/releases/download/0.11.0/check-0.11.0.tar.gz'
-  source_sha256 '24f7a48aae6b74755bcbe964ce8bc7240f6ced2141f8d9cf480bc3b3de0d5616'
+  version '0.12.0'
+  source_url 'https://github.com/libcheck/check/releases/download/0.12.0/check-0.12.0.tar.gz'
+  source_sha256 '464201098bee00e90f5c4bdfa94a5d3ead8d641f9025b560a27755a83b824234'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcheck-0.11.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcheck-0.11.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcheck-0.11.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcheck-0.11.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '362cace0e6df18c1f0964f9dc28f4b0a138b05c459288d4bafc50d08ac878105',
-     armv7l: '362cace0e6df18c1f0964f9dc28f4b0a138b05c459288d4bafc50d08ac878105',
-       i686: 'cf0682c591f52665cc76d19a8a1f804095d70c1117567f5356018f106662f5d2',
-     x86_64: 'ec0188da2f01443784d9c674726b8279f99642e0a6cdef93dc257a8b1b1dc3e0',
   })
 
   depends_on 'libtool'

--- a/packages/libsdl2.rb
+++ b/packages/libsdl2.rb
@@ -3,21 +3,13 @@ require 'package'
 class Libsdl2 < Package
   description 'Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.'
   homepage 'http://www.libsdl.org'
-  version '2.0.5-1'
-  source_url 'https://www.libsdl.org/release/SDL2-2.0.5.tar.gz'
-  source_sha256 '442038cf55965969f2ff06d976031813de643af9c9edc9e331bd761c242e8785'
+  version '2.0.7'
+  source_url 'https://www.libsdl.org/release/SDL2-2.0.7.tar.gz'
+  source_sha256 'ee35c74c4313e2eda104b14b1b86f7db84a04eeab9430d56e001cea268bf4d5e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl2-2.0.5-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl2-2.0.5-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl2-2.0.5-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl2-2.0.5-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '79597d7b228ebb8929ceef776032226f9fa9d70672f40b421447b964469da2f0',
-     armv7l: '79597d7b228ebb8929ceef776032226f9fa9d70672f40b421447b964469da2f0',
-       i686: 'b242dc03f077e0758336956bcc28e935773f75cca0720d047d1d8f3be94cb8c3',
-     x86_64: '84d257d6f385e4535f8643d6dc0c5dc455fa197705ff17e058024822f0fe7f86',
   })
 
   def self.build

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -3,21 +3,13 @@ require 'package'
 class Libunbound < Package
   description 'Unbound is a validating, recursive, and caching DNS resolver.'
   homepage 'https://www.unbound.net/'
-  version '1.6.2'
-  source_url 'https://www.unbound.net/downloads/unbound-1.6.2.tar.gz'
-  source_sha256 '1a323d72c32180b7141c9e6ebf199fc68a0208dfebad4640cd2c4c27235e3b9c'
+  version '1.6.7'
+  source_url 'https://www.unbound.net/downloads/unbound-1.6.7.tar.gz'
+  source_sha256 '4e7bd43d827004c6d51bef73adf941798e4588bdb40de5e79d89034d69751c9f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.6.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.6.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.6.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.6.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '72a4c0a18e74232aed3c619e97fcd41a9df18a8887b9f5f7b45ab7cb9e0f4e1b',
-     armv7l: '72a4c0a18e74232aed3c619e97fcd41a9df18a8887b9f5f7b45ab7cb9e0f4e1b',
-       i686: '2fd2b4fc97ab09228022f8f76a9fdb64da733dcbd68de247273c34887b749570',
-     x86_64: 'dde8bd43e4fb63f9c21d751198efffce41a4ea59db965a69540538d670ea5048',
   })
 
   depends_on 'flex' => :build

--- a/packages/libwayland.rb
+++ b/packages/libwayland.rb
@@ -3,21 +3,13 @@ require 'package'
 class Libwayland < Package
   description 'Wayland is intended as a simpler replacement for X, easier to develop and maintain.'
   homepage 'https://wayland.freedesktop.org'
-  version '1.32.92'
-  source_url 'https://wayland.freedesktop.org/releases/wayland-1.13.92.tar.xz'
-  source_sha256 '1253392261ccb44b312ec0486457c28d24c2f9d8940162181ed5ddc568b8f858'
+  version '1.14.0'
+  source_url 'https://wayland.freedesktop.org/releases/wayland-1.14.0.tar.xz'
+  source_sha256 'ed80cabc0961a759a42092e2c39aabfc1ec9a13c86c98bbe2b812f008da27ab8'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libwayland-1.32.92-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libwayland-1.32.92-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libwayland-1.32.92-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libwayland-1.32.92-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'be74f12aa6e33fd0edb6fabc6cf495b881ce47517dec861c7461dd017a29cfd0',
-     armv7l: 'be74f12aa6e33fd0edb6fabc6cf495b881ce47517dec861c7461dd017a29cfd0',
-       i686: 'f6bab1538ee845e1674f4fc7c72ce4d8e092ac4c13bcc0eb8af45cdc0eb3d34f',
-     x86_64: '91163ec6410bd211d3b0dc8b514da2428e45c102a79255012380705bc709a5ec',
   })
 
   depends_on 'libffi'

--- a/packages/libwebp.rb
+++ b/packages/libwebp.rb
@@ -3,21 +3,13 @@ require 'package'
 class Libwebp < Package
   description 'WebP is a modern image format that provides superior lossless and lossy compression for images on the web.'
   homepage 'https://developers.google.com/speed/webp/'
-  version '0.6.0'
-  source_url 'https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-0.6.0.tar.gz'
-  source_sha256 'c928119229d4f8f35e20113ffb61f281eda267634a8dc2285af4b0ee27cf2b40'
+  version '0.6.1'
+  source_url 'https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-0.6.1.tar.gz'
+  source_sha256 '06503c782d9f151baa325591c3579c68ed700ffc62d4f5a32feead0ff017d8ab'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libwebp-0.6.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libwebp-0.6.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libwebp-0.6.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libwebp-0.6.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f35c27b6360a7d7750e5f0ce841a0b3769bf3f0e65db84d82f2d3480fb99365c',
-     armv7l: 'f35c27b6360a7d7750e5f0ce841a0b3769bf3f0e65db84d82f2d3480fb99365c',
-       i686: 'f5aa924cd9837b5f0f408432b718638a65e6fef4d29b071c172636e9c29a5a27',
-     x86_64: '6db6eaed9f0ce7761a41f40b42e6d5db9fdc4e60cd20e35a43decaee17f3cd06',
   })
 
   def self.build

--- a/packages/lvm2.rb
+++ b/packages/lvm2.rb
@@ -3,9 +3,9 @@ require 'package'
 class Lvm2 < Package
   description 'LVM2 refers to the userspace toolset that provide logical volume management facilities on linux.'
   homepage 'https://sourceware.org/lvm2'
-  version '2.02.176'
-  source_url 'ftp://sources.redhat.com/pub/lvm2/releases/LVM2.2.02.176.tgz'
-  source_sha256 'dece83628c2c78a267a126ce6046d506582185ae5d40fb8d59b56547fccea473'
+  version '2.02.177'
+  source_url 'ftp://sources.redhat.com/pub/lvm2/releases/LVM2.2.02.177.tgz'
+  source_sha256 '4025a23ec9b15c2cb7486d151c29dc953b75efc4d452cfe9dbbc7c0fac8e80f2'
 
   depends_on 'readline'
 

--- a/packages/manpages.rb
+++ b/packages/manpages.rb
@@ -3,9 +3,9 @@ require 'package'
 class Manpages < Package
   description 'The Linux man-pages project documents the Linux kernel and C library interfaces that are employed by user-space programs.'
   homepage 'https://www.kernel.org/doc/man-pages/'
-  version '4.13'
-  source_url 'https://www.kernel.org/pub/linux/docs/man-pages/man-pages-4.13.tar.xz'
-  source_sha256 'd5c005c5b653248ab6680560de00ea8572ff39e48a57bd5be1468d986a0631bf'
+  version '4.14'
+  source_url 'https://www.kernel.org/pub/linux/docs/man-pages/man-pages-4.14.tar.xz'
+  source_sha256 '3052b87898c313c089848a913e5cf44a0565cc4d21d94119ef6586d971f5c971'
 
   binary_url ({
   })

--- a/packages/mdp.rb
+++ b/packages/mdp.rb
@@ -3,9 +3,9 @@ require 'package'
 class Mdp < Package
   description 'A command-line based markdown presentation tool.'
   homepage 'https://github.com/visit1985/mdp'
-  version '1.0.10'
-  source_url 'https://github.com/visit1985/mdp/archive/1.0.10.tar.gz'
-  source_sha256 '7384c1ba32bd8e4b11342570d2144165a60682499b4cb54e50c8eb3164cfabc5'
+  version '1.0.11'
+  source_url 'https://github.com/visit1985/mdp/archive/1.0.11.tar.gz'
+  source_sha256 '885660432d77dfce9f443c518e595b2a3780b5883a06cc21e593d13af1afcf4a'
 
   binary_url ({
   })

--- a/packages/memcached.rb
+++ b/packages/memcached.rb
@@ -3,9 +3,9 @@ require 'package'
 class Memcached < Package
   description 'Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.'
   homepage 'https://memcached.org/'
-  version '1.5.3'
-  source_url 'https://memcached.org/files/memcached-1.5.3.tar.gz'
-  source_sha256 '258cc3ddb7613685465acfd0215f827220a3bbdd167fd2c080632105b2d2f3ce'
+  version '1.5.4'
+  source_url 'https://www.memcached.org/files/memcached-1.5.4.tar.gz'
+  source_sha256 'e0c3cfa89fa4c2ffd8aa45df7825c6d1a2423ac89ab1a7c4f42bb9803f7403d4'
 
   binary_url ({
   })

--- a/packages/mutt.rb
+++ b/packages/mutt.rb
@@ -3,9 +3,9 @@ require 'package'
 class Mutt < Package
   description 'Mutt is a small but very powerful text-based mail client for Unix operating systems.'
   homepage 'http://mutt.org/'
-  version '1.9.1'
-  source_url 'ftp://ftp.mutt.org/pub/mutt/mutt-1.9.1.tar.gz'
-  source_sha256 '749b83a96373c6e2101ebe8c4b9a651735e02c478edb750750a5146a15d91bb1'
+  version '1.9.2'
+  source_url 'ftp://ftp.mutt.org/pub/mutt/mutt-1.9.2.tar.gz'
+  source_sha256 'a2e152a352bbf02d222d54074199d9c53821c19f700c4cb85f78fa85faed7896'
 
   binary_url ({
   })

--- a/packages/ninja.rb
+++ b/packages/ninja.rb
@@ -3,21 +3,13 @@ require 'package'
 class Ninja < Package
   description 'a small build system with a focus on speed'
   homepage 'https://ninja-build.org'
-  version '1.7.2'
-  source_url 'https://github.com/ninja-build/ninja/archive/v1.7.2.tar.gz'
-  source_sha256 '2edda0a5421ace3cf428309211270772dd35a91af60c96f93f90df6bc41b16d9'
+  version '1.8.2'
+  source_url 'https://github.com/ninja-build/ninja/archive/v1.8.2.tar.gz'
+  source_sha256 '86b8700c3d0880c2b44c2ff67ce42774aaf8c28cbf57725cb881569288c1c6f4'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.7.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.7.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.7.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.7.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3ff2fc875e7fce5f69880d0db463afe580aa2c963c36e07301348b3ea597f469',
-     armv7l: '3ff2fc875e7fce5f69880d0db463afe580aa2c963c36e07301348b3ea597f469',
-       i686: '45c4ea8662459b4846c09bf440982b3431162556b6d955268ebd2d7e5d2ba157',
-     x86_64: '1dbb0af40656a2dda2d2e0c157f3860ee8ea9b79edff4a28b90f34d08d3f81d5',
   })
 
   depends_on 'python3'

--- a/packages/nodebrew.rb
+++ b/packages/nodebrew.rb
@@ -3,21 +3,13 @@ require 'package'
 class Nodebrew < Package
   description 'Node.js version manager'
   homepage 'https://github.com/hokaccha/nodebrew'
-  version 'v0.9.7-1'
-  source_url 'https://github.com/hokaccha/nodebrew/archive/v0.9.7.tar.gz'
-  source_sha256 '3aa8b0cf30024d105f1ac6921aadf0440bc95bcae43df9d6ec58fc9de8cd352e'
+  version '0.9.8'
+  source_url 'https://github.com/hokaccha/nodebrew/archive/v0.9.8.tar.gz'
+  source_sha256 '040c1b32ddce6d83fda76a50ce9bc635ce0040f76a63617d74234449b8ff078b'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nodebrew-v0.9.7-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nodebrew-v0.9.7-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nodebrew-v0.9.7-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nodebrew-v0.9.7-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bd9aa8fcac6099e5367d687a90578cab3ec2281f50301c57268540b82d40b203',
-     armv7l: 'bd9aa8fcac6099e5367d687a90578cab3ec2281f50301c57268540b82d40b203',
-       i686: '8b4bf0c1169bf44b1d45a13d3adaff3c2a9573c43acd262bd3255ef07e276351',
-     x86_64: '8ec7697374c124d37cc905ba0d6e7c07fad4cbee789ada940d9528c114a691de',
   })
 
   depends_on 'perl'

--- a/packages/nvm.rb
+++ b/packages/nvm.rb
@@ -3,21 +3,13 @@ require 'package'
 class Nvm < Package
   description 'Node Version Manager - Simple bash script to manage multiple active node.js versions.'
   homepage 'https://github.com/creationix/nvm'
-  version '0.33.2'
-  source_url 'https://github.com/creationix/nvm/archive/v0.33.2.tar.gz'
-  source_sha256 '2ad455a0752d5bae49ecff38a8a7778cc734c2d0ece9942dfdd164c2f01e80da'
+  version '0.33.8'
+  source_url 'https://github.com/creationix/nvm/archive/v0.33.8.tar.gz'
+  source_sha256 '59429f4bf3da7c2b7bcac06c488054dd774ae6962bdcefe249015d3590704b0b'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nvm-0.33.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nvm-0.33.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nvm-0.33.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nvm-0.33.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f0d15c5ff6bac0d2cea927db6ed3cb778f73f1e25f5e8d3975f6ea73c7fc52f1',
-     armv7l: 'f0d15c5ff6bac0d2cea927db6ed3cb778f73f1e25f5e8d3975f6ea73c7fc52f1',
-       i686: 'a6a161692e32907872fc5864b0d2dee0509b7980d30594796aa72be897b66352',
-     x86_64: '67e327de8bcfb1ec8266827d2d7f1fd48486b7af4f9a0179caad9caf4e05d3c1',
   })
 
   def self.install

--- a/packages/od1n.rb
+++ b/packages/od1n.rb
@@ -3,9 +3,9 @@ require 'package'
 class Od1n < Package
   description '0d1n is a tool for automating customized attacks against web applications.'
   homepage 'https://github.com/CoolerVoid/0d1n'
-  version '2.3'
-  source_url 'https://github.com/CoolerVoid/0d1n/archive/2.3.tar.gz'
-  source_sha256 '7fe26f0268fe63ec0352502ae590a7a5e258248f253649661dc782ca7edd52ae'
+  version '2.5'
+  source_url 'https://github.com/CoolerVoid/0d1n/archive/0d1n2.5.tar.gz'
+  source_sha256 'c883907e44e7fc087af170ff82f063febde941dce9b46646b4ecc8410b887b3d'
 
   depends_on 'curl'
 

--- a/packages/pagemon.rb
+++ b/packages/pagemon.rb
@@ -3,21 +3,13 @@ require 'package'
 class Pagemon < Package
   description 'Pagemon is an interactive memory/page monitoring tool allowing one to browse the memory map of an active running process.'
   homepage 'http://kernel.ubuntu.com/~cking/pagemon/'
-  version '0.01.10'
-  source_url 'http://kernel.ubuntu.com/~cking/tarballs/pagemon/pagemon-0.01.10.tar.gz'
-  source_sha256 '82c240b44b7000fc57355b366bfe28a47a4da857ddaea0ee0ade9d3eae037f54'
+  version '0.01.11'
+  source_url 'http://kernel.ubuntu.com/~cking/tarballs/pagemon/pagemon-0.01.11.tar.gz'
+  source_sha256 'c1371f362fe6f2a7e8424a74618eb5e9cb39151e41ee6fb1a466cc0e66ab8e94'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pagemon-0.01.10-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pagemon-0.01.10-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pagemon-0.01.10-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pagemon-0.01.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '83b518d6b28a899e94c40ed5cf23e4ddae10f67fcd10a2e9664d15f94d910f02',
-     armv7l: '83b518d6b28a899e94c40ed5cf23e4ddae10f67fcd10a2e9664d15f94d910f02',
-       i686: '66ade8bf2dd6cf5eb730a17d17bb754cf80212be05bbcb5b790763736d109efe',
-     x86_64: '084d8ab1ccd2ba203554523f4a5f579be554f58a31cf360524a3f3ca10343a9e',
   })
 
   depends_on 'ncurses'

--- a/packages/pciutils.rb
+++ b/packages/pciutils.rb
@@ -3,21 +3,13 @@ require 'package'
 class Pciutils < Package
   description 'The PCI Utilities are a collection of programs for inspecting and manipulating configuration of PCI devices, all based on a common portable library libpci which offers access to the PCI configuration space on a variety of operating systems.'
   homepage 'http://mj.ucw.cz/sw/pciutils/'
-  version '3.5.5'
-  source_url 'https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.5.5.tar.xz'
-  source_sha256 '1d62f8fa192f90e61c35a6fc15ff3cb9a7a792f782407acc42ef67817c5939f5'
+  version '3.5.6'
+  source_url 'https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.5.6.tar.xz'
+  source_sha256 'f346eeb90cce0910c05b877fe49eadc760fa084c0455fd313e39d4b2c2d4bb21'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pciutils-3.5.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pciutils-3.5.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pciutils-3.5.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pciutils-3.5.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'fb69cd22643e7aca50db2e799685a72b661911bba4f5355ecd93b990b4c588c8',
-     armv7l: 'fb69cd22643e7aca50db2e799685a72b661911bba4f5355ecd93b990b4c588c8',
-       i686: 'b192456ab12ce8c0ba998a4e5153669197831a667f038e6dcf437e3db16d7cbe',
-     x86_64: 'd65b94cefe4cf908fd9fec6d35710e8b35959c6aad7332bbc33d1cdd626043c1',
   })
 
   def self.build

--- a/packages/pinentry.rb
+++ b/packages/pinentry.rb
@@ -3,9 +3,9 @@ require 'package'
 class Pinentry < Package
   description "A collection of passphrase entry dialogs which is required for almost all usages of GnuPG"
   homepage 'https://gnupg.org/software/pinentry/index.html'
-  version '1.0.0'
-  source_url 'https://gnupg.org/ftp/gcrypt/pinentry/pinentry-1.0.0.tar.bz2'
-  source_sha256 '1672c2edc1feb036075b187c0773787b2afd0544f55025c645a71b4c2f79275a'
+  version '1.1.0'
+  source_url 'https://gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.0.tar.bz2'
+  source_sha256 '68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f56570'
 
   depends_on 'gnupg'
   depends_on 'libcap'

--- a/packages/protobuf.rb
+++ b/packages/protobuf.rb
@@ -3,9 +3,9 @@ require 'package'
 class Protobuf < Package
   description 'Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data.'
   homepage 'https://developers.google.com/protocol-buffers/'
-  version '3.3.0-2'
-  source_url 'https://github.com/google/protobuf/archive/v3.3.0.tar.gz'
-  source_sha256 '9a36bc1265fa83b8e818714c0d4f08b8cec97a1910de0754a321b11e66eb76de'
+  version '3.5.1'
+  source_url 'https://github.com/google/protobuf/archive/v3.5.1.tar.gz'
+  source_sha256 '826425182ee43990731217b917c5c3ea7190cfda141af4869e6d4ad9085a740f'
 
   binary_url ({
   })

--- a/packages/sfk.rb
+++ b/packages/sfk.rb
@@ -3,21 +3,13 @@ require 'package'
 class Sfk < Package
   description 'The Swiss File Knife - A Command Line Tools Collection for Windows / Linux / Mac.'
   homepage 'http://swissfileknife.sourceforge.net/'
-  version '1.8.7'
-  source_url 'https://sourceforge.net/projects/swissfileknife/files/1-swissfileknife/1.8.7/sfk-1.8.7.tar.gz'
-  source_sha256 '1c53d4d9d05af752546c8341a718bf64be99b62491ff91db02ef100e2f93bfc3'
+  version '1.8.9'
+  source_url 'https://downloads.sourceforge.net/project/swissfileknife/1-swissfileknife/1.8.9.0/sfk-1.8.9.tar.gz'
+  source_sha256 '0f974f491d28bf5442d94f9ddeb983bfc69ead96842965ad55152969381fcd8e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sfk-1.8.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sfk-1.8.7-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sfk-1.8.7-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sfk-1.8.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1666f3bd5271973be9ce535e6cc1a71a831ba3d479ba2a08b7c587d2142ef360',
-     armv7l: '1666f3bd5271973be9ce535e6cc1a71a831ba3d479ba2a08b7c587d2142ef360',
-       i686: 'e2366c801933f920eef6058c559883be2ab31470f314c0fc0bdd40187014331c',
-     x86_64: '86c8b0fc3953d74b5225e16aec90dfb8e5c6f794f4d02ffb731e8ab8469c97e6',
   })
 
   def self.build

--- a/packages/strace.rb
+++ b/packages/strace.rb
@@ -3,9 +3,9 @@ require 'package'
 class Strace < Package
   description 'strace is a diagnostic, debugging and instructional userspace utility for Linux.'
   homepage 'https://strace.io/'
-  version '4.19'
-  source_url 'https://downloads.sourceforge.net/project/strace/strace/4.19/strace-4.19.tar.xz'
-  source_sha256 '7c93ebc6c29280f47c24a0eb86873a99ccb2cac6512c60a60ba4ef99ab807281'
+  version '4.20'
+  source_url 'https://downloads.sourceforge.net/project/strace/strace/4.20/strace-4.20.tar.xz'
+  source_sha256 '5bf3148dd17306a42566f7da17368fdd781afa147db05ea63a4ca2b50f58c523'
 
   binary_url ({
   })

--- a/packages/stressng.rb
+++ b/packages/stressng.rb
@@ -3,9 +3,9 @@ require 'package'
 class Stressng < Package
   description 'stress-ng will stress test a computer system in various selectable ways.'
   homepage 'http://kernel.ubuntu.com/~cking/stress-ng/'
-  version '0.09.02'
-  source_url 'http://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.09.02.tar.gz'
-  source_sha256 '9fffd8e8157ee969dfe99d1a5b310ff3337b1dbecd276ccaa8c30c1cc14392fd'
+  version '0.09.07'
+  source_url 'http://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.09.07.tar.xz'
+  source_sha256 'e4dc07e127e23de7c55f69687ef5f55ee718c386a45ba53f3560e01819a3205e'
 
   binary_url ({
   })

--- a/packages/stunnel.rb
+++ b/packages/stunnel.rb
@@ -3,21 +3,13 @@ require 'package'
 class Stunnel < Package
   description "Stunnel is a proxy designed to add TLS encryption functionality to existing clients and servers without any changes in the programs' code."
   homepage 'https://www.stunnel.org/index.html'
-  version '5.42'
-  source_url 'https://www.stunnel.org/downloads/stunnel-5.42.tar.gz'
-  source_sha256 '1b6a7aea5ca223990bc8bd621fb0846baa4278e1b3e00ff6eee279cb8e540fab'
+  version '5.44'
+  source_url 'https://www.stunnel.org/downloads/stunnel-5.44.tar.gz'
+  source_sha256 '990a325dbb47d77d88772dd02fbbd27d91b1fea3ece76c9ff4461eca93f12299'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/stunnel-5.42-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/stunnel-5.42-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/stunnel-5.42-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/stunnel-5.42-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '6d16c4bec0d34b70aeea87c50523082cd237c1f453804adc094add3c0811e7d8',
-     armv7l: '6d16c4bec0d34b70aeea87c50523082cd237c1f453804adc094add3c0811e7d8',
-       i686: 'cf9d32c8abf695a786c7b0dfe5573b1dc5355e2f45b3eb7d1979012532f7c5c9',
-     x86_64: '35876775273e30f179df5966c0444c3a7290d22d668a81c83959ba6c8a644a2f',
   })
 
   depends_on 'openssl'

--- a/packages/tinycc.rb
+++ b/packages/tinycc.rb
@@ -3,21 +3,13 @@ require 'package'
 class Tinycc < Package
   description 'TinyCC (aka TCC) is a small but hyper fast C compiler.'
   homepage 'http://bellard.org/tcc/'
-  version '0.9.26'
-  source_url 'http://download.savannah.gnu.org/releases/tinycc/tcc-0.9.26.tar.bz2'
-  source_sha256 '521e701ae436c302545c3f973a9c9b7e2694769c71d9be10f70a2460705b6d71'
+  version '0.9.27'
+  source_url 'http://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27.tar.bz2'
+  source_sha256 'de23af78fca90ce32dff2dd45b3432b2334740bb9bb7b05bf60fdbfc396ceb9c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tinycc-0.9.26-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tinycc-0.9.26-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tinycc-0.9.26-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tinycc-0.9.26-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'c78b224e101a385e611ea9e558f743248113e954f4e9ef038e15e7ac1491e0d9',
-     armv7l: 'c78b224e101a385e611ea9e558f743248113e954f4e9ef038e15e7ac1491e0d9',
-       i686: 'fb9164d86849536d3d81dadea75232e2fe2c1392c20ae0e8974aecbb9300141c',
-     x86_64: '45ee7ac7842428d52742be8b4aa873b0bb7fa301995a4cf303c85b22751897f8',
   })
 
   def self.build

--- a/packages/tmux.rb
+++ b/packages/tmux.rb
@@ -3,9 +3,9 @@ require 'package'
 class Tmux < Package
   description 'tmux is a terminal multiplexer'
   homepage 'http://tmux.github.io/'
-  version '2.5'
-  source_url 'https://github.com/tmux/tmux/releases/download/2.5/tmux-2.5.tar.gz'
-  source_sha256 'ae135ec37c1bf6b7750a84e3a35e93d91033a806943e034521c8af51b12d95df'
+  version '2.6'
+  source_url 'https://github.com/tmux/tmux/releases/download/2.6/tmux-2.6.tar.gz'
+  source_sha256 'b17cd170a94d7b58c0698752e1f4f263ab6dc47425230df7e53a6435cc7cd7e8'
 
   binary_url ({
   })

--- a/packages/wget.rb
+++ b/packages/wget.rb
@@ -3,9 +3,9 @@ require 'package'
 class Wget < Package
   description 'GNU Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS.'
   homepage 'https://www.gnu.org/software/wget/'
-  version '1.19'
-  source_url 'https://ftp.gnu.org/gnu/wget/wget-1.19.tar.xz'
-  source_sha256 '0f1157bbf4daae19f3e1ddb70c6ccb2067feb834a6aa23c9d9daa7f048606384'
+  version '1.19.2'
+  source_url 'https://ftp.gnu.org/gnu/wget/wget-1.19.2.tar.gz'
+  source_sha256 '4f4a673b6d466efa50fbfba796bd84a46ae24e370fa562ede5b21ab53c11a920'
 
   binary_url ({
   })

--- a/packages/xe.rb
+++ b/packages/xe.rb
@@ -3,9 +3,9 @@ require 'package'
 class Xe < Package
   description 'simple xargs and apply replacement.'
   homepage 'https://github.com/chneukirchen/xe/'
-  version '0.10'
-  source_url 'https://github.com/chneukirchen/xe/archive/v0.10.tar.gz'
-  source_sha256 '8993cea06b2c664195df2a6124d0386d1bce7c27eb6ecbf968866bfd05cb9d7a'
+  version '0.11'
+  source_url 'https://github.com/chneukirchen/xe/archive/v0.11.tar.gz'
+  source_sha256 '4087d40be2db3df81a836f797e1fed17d6ac1c788dcf0fd6a904f2d2178a6f1a'
 
   binary_url ({
   })

--- a/packages/xxhash.rb
+++ b/packages/xxhash.rb
@@ -3,9 +3,9 @@ require 'package'
 class Xxhash < Package
   description 'xxHash is an extremely fast non-cryptographic hash algorithm, working at speeds close to RAM limits.'
   homepage 'http://cyan4973.github.io/xxHash/'
-  version '0.6.3'
-  source_url 'https://github.com/Cyan4973/xxHash/archive/v0.6.3.tar.gz'
-  source_sha256 'd8c739ec666ac2af983a61dc932aaa2a8873df974d333a9922d472a121f2106e'
+  version '0.6.4'
+  source_url 'https://github.com/Cyan4973/xxHash/archive/v0.6.4.tar.gz'
+  source_sha256 '4570ccd111df6b6386502791397906bf69b7371eb209af7d41debc2f074cdb22'
 
   binary_url ({
   })

--- a/packages/zsh.rb
+++ b/packages/zsh.rb
@@ -3,21 +3,13 @@ require 'package'
 class Zsh < Package
   description 'Zsh is a shell designed for interactive use, although it is also a powerful scripting language.'
   homepage 'http://zsh.sourceforge.net/'
-  version '5.0.7-1'
-  source_url 'http://sourceforge.net/projects/zsh/files/zsh/5.0.7/zsh-5.0.7.tar.gz/download'
-  source_sha256 '43f0a4c179ef79bb8c9153575685f7f45f28a3615c8cf96345f503d5b9e7b919'
+  version '5.4.2'
+  source_url 'https://downloads.sourceforge.net/project/zsh/zsh/5.4.2/zsh-5.4.2.tar.xz'
+  source_sha256 'a80b187b6b770f092ea1f53e89021d06c03d8bbe6a5e996bcca3267de14c5e52'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/zsh-5.0.7-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/zsh-5.0.7-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/zsh-5.0.7-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/zsh-5.0.7-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'daaecbc646bada9365f22f26ba7de4a835079fd10a5353f3fa1c67beb27d5881',
-     armv7l: 'daaecbc646bada9365f22f26ba7de4a835079fd10a5353f3fa1c67beb27d5881',
-       i686: '2e138f7ddfc2252c81a379e379837ebd69f19e001184729180b9c43b979301aa',
-     x86_64: '132f36ade3c10430d8f702112f82065fab8449ebd8dc409542930de5cc95e3c2',
   })
 
   depends_on 'ncurses'


### PR DESCRIPTION
Supports #1585 

## Description

- bind - update to 9.11.2
- cmatrix - update to 1.2
- coreutils - update to 8.29
- erlang - update to 20.2
- fish - update to 2.7.1
- gifsicle - update to 1.90
- gnupg - update to 2.2.4
- gnutls - update to 3.6.1
- gpgme - update to 1.10.0
- gzsize - update to 1.2
- help2man - update to 1.47.5
- imagemagick - update to 7.0.7-18
- jsonc - update to 0.13-20171207
- lcms - update to 2.2.9
- libcheck - update to 0.12.0
- libsdl2 - update to 2.0.7
- libunbound - update to 1.6.7
- ibwayland - update to 1.14.0
- bwebp - update to 0.6.1
- lvm2 - update to 2.02.177
- manpages - update to 4.14
- mdp - update to 1.0.11
- memcached - update to 1.5.4
- mutt - update to 1.9.2
- ninja - update to 1.8.2
- nodebrew - update to 0.9.8
- nvm - update to 0.33.8
- od1n - update to 2.5
- pagemon - update to 0.01.11
- pciutils - update to 3.5.6
- pinentry - update to 1.1.0
- protobuf - update to 3.5.1
- sfk - update to 1.8.9
- strace - update to 4.20
- stressng - update to 0.09.07
- stunnel - update to 5.44
- tinycc - update to 0.9.27
- tmux - update to 2.6
- wget - update to 1.19.2
- xe - update to 0.11
- xxhash - update to 0.6.4
- zsh - update to 5.4.2

## Notes
Again, builds on x86_64, but not tested past that.