### PR TITLE
Add inxi package

### DIFF
--- a/packages/inxi.rb
+++ b/packages/inxi.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Inxi < Package
+  description 'inxi is a full featured CLI system information tool.'
+  homepage 'https://smxi.org/docs/inxi.htm'
+  version '811a19'
+  source_url 'https://github.com/smxi/inxi/archive/811a199badbacc8d54254264c51de8dc3f5c82d2.tar.gz'
+  source_sha256 'fd4d7e89166f4cd96fe91448753a1279520bc0f9ee3a2cfbd92ff4a2b1cf487a'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'gawk'
+
+  def self.install
+    system "install -Dm755 inxi #{CREW_DEST_PREFIX}/bin/inxi"
+    system "install -Dm644 inxi.1.gz #{CREW_DEST_PREFIX}/man/man1/inxi.1.gz"
+  end
+end

--- a/packages/inxi.rb
+++ b/packages/inxi.rb
@@ -13,6 +13,11 @@ class Inxi < Package
   })
 
   depends_on 'gawk'
+  depends_on 'perl'
+
+  def self.build
+    system "sed -i 's,/os-release,/lsb-release,g' inxi"
+  end
 
   def self.install
     system "install -Dm755 inxi #{CREW_DEST_PREFIX}/bin/inxi"


### PR DESCRIPTION
A full featured system information script.  See https://smxi.org/docs/inxi.htm.

Example output:
```
$ inxi -F
Resuming in non X mode: xdpyinfo not found. For package install advice run: inxi --recommends
System:    Host: localhost Kernel: 4.4.64 i686 bits: 32 Desktop: N/A Distro: unknown
Machine:   Device: vmware System: VMware product: VMware Virtual Platform serial: N/A
           Mobo: Intel model: 440BX Desktop Reference Platform serial: N/A BIOS: Phoenix v: 6.00 date: 07/02/2015
CPU:       Single core Intel Core i7-4710HQ (-UP-) cache: 6144 KB speed: 2493 MHz (max)
Graphics:  Card: VMware SVGA II Adapter
           Display Server: X.org 1.12.4 drivers: vmware (unloaded: fbdev) tty size: 159x42
Audio:     Card Ensoniq ES1371 / Creative Labs CT2518 [AudioPCI-97] driver: snd_ens1371 Sound: ALSA v: k4.4.64
Network:   Card: Advanced Micro Devices [AMD] 79c970 [PCnet32 LANCE] driver: pcnet32
           IF: eth0 state: unknown speed: N/A duplex: N/A mac: 00:0c:29:c6:23:6f
Drives:    HDD Total Size: 10.7GB (Used Error!)
           ID-1: /dev/sda model: VMware_Virtual_S size: 10.7GB
Partition: ID-1: / size: 2.0G used: 1.2G (60%) fs: ext2 dev: /dev/root
           ID-2: swap-1 size: 12.46GB used: 0.00GB (0%) fs: swap dev: /dev/zram0
Sensors:   None detected - is lm-sensors installed and configured?
Info:      Processes: 148 Uptime: 51 min Memory: 981.8/8114.1MB Init: Upstart Client: Shell (bash) inxi: 2.3.53 
```