### PR TITLE
Add abcde package

### DIFF
--- a/packages/abcde.rb
+++ b/packages/abcde.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Abcde < Package
+  description 'Grab an entire CD and compress it to Ogg/Vorbis, MP3, FLAC, AAC, Ogg/Speex and/or MPP/MP+(Musepack) format.'
+  homepage 'https://abcde.einval.com/wiki/'
+  version '2.8.1'
+  source_url 'https://abcde.einval.com/download/abcde-2.8.1.tar.gz'
+  source_sha256 'e49c71d7ddcd312dcc819c3be203abd3d09d286500ee777cde434c7881962b39'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system "sed -i 's,prefix = /usr/local,prefix = #{CREW_DEST_PREFIX},' Makefile"
+    system "sed -i 's,sysconfdir = /etc,sysconfdir = #{CREW_DEST_PREFIX}/etc,' Makefile"
+  end
+
+  def self.install
+    system "make install"
+  end
+end


### PR DESCRIPTION
abcde - A Better CD Encoder

Grab an entire CD and compress it to Ogg/Vorbis, MP3, FLAC, AAC, Ogg/Speex and/or MPP/MP+(Musepack) format.

Why abcde?

Ordinarily, the process of grabbing the data off a CD and encoding it, then tagging or commenting it, is very involved. abcde is designed to automate this. It will take an entire CD and convert it into a compressed audio format - Ogg/Vorbis, MPEG Audio Layer III, Free Lossless Audio Codec (FLAC), Ogg/Speex, MPP/MP+(Musepack), M4A (AAC) or Opus format(s). With one command, it will:

- Do a CDDB or Musicbrainz query over the Internet to look up your CD or use a locally stored CDDB entry, or read CD-TEXT from your CD as a fallback for track information
- Grab an audio track (or all the audio CD tracks) from your CD
- Normalize the volume of the individual file (or the album as a single unit)
- Compress to Ogg/Vorbis, MP3, FLAC, Ogg/Speex, MPP/MP+(Musepack), M4A and/or Opus format(s), all in one CD read
- Comment or ID3/ID3v2 tag
- Give an intelligible filename
- Calculate replaygain values for the individual file (or the album as a single unit)
- Delete the intermediate WAV file (or save it for later use)
- Repeat until finished

Alternatively, abcde can also grab a CD and turn it into a single FLAC file with an embedded cuesheet which can be user later on as a source for other formats, and will be treated as if it was the original CD. In a way, abcde can take a compressed backup of your CD collection.

See https://abcde.einval.com/wiki/.
