### PR TITLE
Add snooze package

### DIFF
--- a/packages/snooze.rb
+++ b/packages/snooze.rb
@@ -1,0 +1,22 @@
+require 'package'
+
+class Snooze < Package
+  description 'run a command at a particular time'
+  homepage 'https://github.com/chneukirchen/snooze/'
+  version '0.2'
+  source_url 'https://github.com/chneukirchen/snooze/archive/v0.2.tar.gz'
+  source_sha256 '69242bb1534b11b569dfd1535aca20e3e6be95c6285aff1ccf612b2a9f906a1a'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system 'make', "PREFIX=#{CREW_PREFIX}"
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end


### PR DESCRIPTION
`snooze` is a new tool for waiting until a particular time and then
running a command.  Together with a service supervision system such as
runit, this can be used to replace cron(8).

`snooze` has been tested on Linux 4.2.
It will likely work on other Unix-like systems with C99.

Over cron:
- mnemonic syntax
- no overlapping job runs possible
- filtering by ISO week and day of year
- due to supervision, no centralized daemon required
- due to supervision, can easily disable jobs or force their
  execution instantly
- due to supervision, have custom logs
- due to no centralized daemon, no fuzzing with multiple users/permissions
- very robust with respect to external time changes
- can use a file timestamp to ensure minimum waiting time between two
  runs, even across reboots
- randomized delays (some cron have that)
- variable slack (no need for anacron)
- ad-hoc usage possible, just run the program from command line

Over runwhen:
- less confusing usage (I hope)
- filtering by ISO week and day of year
- zero dependencies

Over uschedule:
- due to supervision, no centralized daemon required
- filtering by ISO week and day of year

## Addtional information
Mention things we might need to know. Like:

Works properly:
- [x] x86_64
- [x] arm7l (reasons why it doesn't)
