### PR TITLE
Update ffmpeg from 3.3.3-1 to 3.4.1

### DIFF
--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -3,21 +3,21 @@ require 'package'
 class Ffmpeg < Package
   description 'A complete, cross-platform solution to record, convert and stream audio and video.'
   homepage 'https://ffmpeg.org/'
-  version '3.3.3-1'
-  source_url 'https://ffmpeg.org/releases/ffmpeg-3.3.3.tar.xz'
-  source_sha256 'd2a9002cdc6b533b59728827186c044ad02ba64841f1b7cd6c21779875453a1e'
+  version '3.4.1'
+  source_url 'https://ffmpeg.org/releases/ffmpeg-3.4.1.tar.xz'
+  source_sha256 '5a77278a63741efa74e26bf197b9bb09ac6381b9757391b922407210f0f991c0'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.3.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.3.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.3.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.3.3-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.4.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.4.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.4.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-3.4.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '4748d900703d05d05fdb584b534ffd6ea1b5ecad3a78187804d23af3254dd87e',
-     armv7l: '4748d900703d05d05fdb584b534ffd6ea1b5ecad3a78187804d23af3254dd87e',
-       i686: 'a85f9c79aaefe5b80bf59c2067c6a9b16b5c96edc604c49d33c3d5ac9ffb3a0d',
-     x86_64: '8e78f2b9f7bd47a7f9f04e157bf441a8a7c54d5c32833b20d38ac9d10300e43e',
+    aarch64: '69b5a4c0f2e48c31a33cbd1f99df02d662d483e14d24a0bcd50da8312fc6cd82',
+     armv7l: '69b5a4c0f2e48c31a33cbd1f99df02d662d483e14d24a0bcd50da8312fc6cd82',
+       i686: '4315c7f32fe05c13cbd1d97950dddfe259c84432406b6f83cd7c548b512788bb',
+     x86_64: 'cf4569ffb65ab474528d3cbf68189b4e49de323d15bb19360ba6c5ebc2bf245f',
   })
 
   depends_on 'gnutls'
@@ -42,6 +42,8 @@ class Ffmpeg < Package
 
   def self.build
     system "TMPDIR=#{CREW_BREW_DIR} ./configure \
+             --prefix=#{CREW_PREFIX} \
+             --libdir=#{CREW_LIB_PREFIX} \
              --arch=#{ARCH} \
              --enable-gpl \
              --enable-nonfree \


### PR DESCRIPTION
Fixes #1618.  I went ahead and added the pre-built binaries also since it takes an eternity to compile.

Tested and working on:
- [x] x86_64
- [x] i686
- [x] armv7l