### PR TITLE
Add entr package

### DIFF
--- a/packages/entr.rb
+++ b/packages/entr.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Entr < Package
+  description 'Run arbitrary commands when files change'
+  homepage 'http://entrproject.org/'
+  version '3.9'
+  source_url 'http://entrproject.org/code/entr-3.9.tar.gz'
+  source_sha256 '02d78f18ae530e64bfbb9d8e0250962f85946e10850dd065899d03af15f26876'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system 'cp Makefile.linux Makefile'
+    system "PREFIX=#{CREW_PREFIX} make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
A utility for running arbitrary commands when files change. Uses kqueue(2) or inotify(7) to avoid polling. entr was written to make rapid feedback and automated testing natural and completely ordinary.  See https://bitbucket.org/eradman/entr/ and http://entrproject.org/.