### PR TITLE
Add psmisc package

### DIFF
--- a/packages/psmisc.rb
+++ b/packages/psmisc.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Psmisc < Package
+  description 'PSmisc is a set of some small useful utilities that use the proc filesystem.'
+  homepage 'http://psmisc.sourceforge.net/'
+  version '23.1'
+  source_url 'http://downloads.sourceforge.net/project/psmisc/psmisc/psmisc-23.1.tar.xz'
+  source_sha256 '2e84d474cf75dfbe3ecdacfb797bbfab71a35c7c2639d1b9f6d5f18b2149ba30'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'ncurses'
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX}"
+    system "make CFLAGS=' -I#{CREW_PREFIX}/include/ncurses'"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
This PSmisc package is a set of some small useful utilities that use the proc filesystem. We're not about changing the world, but providing the system administrator with some help in common tasks.

There is options for using SELinux if you need it and fuser understands IPv6. It also speaks various languages using the gettext facilities.

The package contains the following programs:

- fuser - identifies what processes are using files.
- killall - kills a process by its name, similar to a pkill found in some other Unices.
- pstree - Shows currently running processes in a tree format.
- peekfd - Peek at file descriptors of running processes.

See http://psmisc.sourceforge.net/.