### PR TITLE
Added a set of formulae for llvm5 and family.

### DIFF
--- a/packages/clang.rb
+++ b/packages/clang.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Clang < Package
+  description 'C language family frontend for LLVM.'
+  homepage 'https://clang.llvm.org/'
+  version '5.0.1'
+  source_url 'https://releases.llvm.org/5.0.1/cfe-5.0.1.src.tar.xz'
+  source_sha256 '135f6c9b0cd2da1aff2250e065946258eb699777888df39ca5a5b4fe5e23d0ff'
+
+  depends_on 'cmake' => :build
+  depends_on 'llvm'
+  depends_on 'clang_libcpp'
+  depends_on 'clang_openmp'
+  depends_on 'llvm_compiler_rt'
+  depends_on 'llvm_polly'
+  depends_on 'llvm_unwind'
+  depends_on 'lld'
+
+  def self.build
+    Dir.mkdir 'mybuilddir'
+    Dir.chdir "mybuilddir" do
+      system "cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .."
+      system "cmake --build . --  -j#{CREW_NPROC}"
+    end
+  end
+
+  def self.install
+    Dir.chdir "mybuilddir" do
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -P cmake_install.cmake"
+      FileUtils.cd("#{CREW_DEST_PREFIX}/bin") do
+        system "echo '#!/bin/bash' > clangppw"
+        system "echo 'GCCVERSION=`gcc --version | grep ^gcc | sed '\\''s/^.* //g'\\''`' >> clangppw"
+        system "echo 'TARGET=`gcc -dumpmachine`' >> clangppw"
+        system "echo '#{CREW_PREFIX}/bin/clang++ -I#{CREW_PREFIX}/include/c++/v1 -B#{CREW_PREFIX}/lib/gcc/${TARGET}/${GCCVERSION} -lc++ $@' >> clangppw"
+        system "chmod 755 clangppw"
+        system "echo '#!/bin/bash' > clangw"
+        system "echo 'GCCVERSION=`gcc --version | grep ^gcc | sed '\\''s/^.* //g'\\''`' >> clangw"
+        system "echo 'TARGET=`gcc -dumpmachine`' >> clangw"
+        system "echo '#{CREW_PREFIX}/bin/clang -B#{CREW_PREFIX}/lib/gcc/${TARGET}/${GCCVERSION} $@' >> clangw"
+        system "chmod 755 clangw"
+      end
+    end
+  end
+end
+

--- a/packages/clang_libcpp.rb
+++ b/packages/clang_libcpp.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Clang_libcpp < Package
+  description 'Standard library for Clang5.'
+  homepage 'https://libcxx.llvm.org/'
+  version '5.0.1'
+  source_url 'https://releases.llvm.org/5.0.1/libcxx-5.0.1.src.tar.xz'
+  source_sha256 'fa8f99dd2bde109daa3276d529851a3bce5718d46ce1c5d0806f46caa3e57c00'
+
+  depends_on 'cmake' => :build
+  depends_on 'llvm'
+
+  def self.build
+    Dir.mkdir 'mybuilddir'
+    Dir.chdir "mybuilddir" do
+      system "cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .."
+      system "cmake --build . --  -j#{CREW_NPROC}"
+    end
+  end
+
+  def self.install
+    Dir.chdir "mybuilddir" do
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -P cmake_install.cmake"
+    end
+  end
+end

--- a/packages/clang_openmp.rb
+++ b/packages/clang_openmp.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Clang_openmp < Package
+  description 'The OpenMP subproject of LLVM contains the components required to build an executable OpenMP program that are outside the compiler itself.'
+  homepage 'https://openmp.llvm.org/'
+  version '5.0.1'
+  source_url 'https://releases.llvm.org/5.0.1/openmp-5.0.1.src.tar.xz'
+  source_sha256 'adb635cdd2f9f828351b1e13d892480c657fb12500e69c70e007bddf0fca2653'
+
+  depends_on 'cmake' => :build
+
+  def self.build
+    Dir.mkdir 'mybuilddir'
+    Dir.chdir "mybuilddir" do
+      system "cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .."
+      system "cmake --build . --  -j#{CREW_NPROC}"
+    end
+  end
+
+  def self.install
+    Dir.chdir "mybuilddir" do
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -P cmake_install.cmake"
+    end
+  end
+end

--- a/packages/lld.rb
+++ b/packages/lld.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Lld < Package
+  description 'LLD is a linker from the LLVM project.'
+  homepage 'https://lld.llvm.org/'
+  version '5.0.1'
+  source_url 'https://releases.llvm.org/5.0.1/lld-5.0.1.src.tar.xz'
+  source_sha256 'd5b36c0005824f07ab093616bdff247f3da817cae2c51371e1d1473af717d895'
+
+  depends_on 'cmake' => :build
+
+  def self.build
+    Dir.mkdir 'mybuilddir'
+    Dir.chdir "mybuilddir" do
+      system "cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .."
+      system "cmake --build . --  -j#{CREW_NPROC}"
+    end
+  end
+
+  def self.install
+    Dir.chdir "mybuilddir" do
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -P cmake_install.cmake"
+    end
+  end
+end

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -2,38 +2,24 @@ require 'package'
 
 class Llvm < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies.'
-  homepage 'http://llvm.org/'
-  version '3.8.1-1'
-  source_url 'http://llvm.org/releases/3.8.1/llvm-3.8.1.src.tar.xz'
-  source_sha256 '6e82ce4adb54ff3afc18053d6981b6aed1406751b8742582ed50f04b5ab475f9'
+  homepage 'https://llvm.org/'
+  version '5.0.1'
+  source_url 'https://releases.llvm.org/5.0.1/llvm-5.0.1.src.tar.xz'
+  source_sha256 '5fa7489fc0225b11821cab0362f5813a05f2bcf2533e8a4ea9c9c860168807b0'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-3.8.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-3.8.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-3.8.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-3.8.1-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '94255baa409229bbd0ad5f23981ee807fc39cb0c5160451daa0c3bfb1ebb78ae',
-     armv7l: '94255baa409229bbd0ad5f23981ee807fc39cb0c5160451daa0c3bfb1ebb78ae',
-       i686: '1d906912c090feeb81bb1777b8ff1ec7dcdadea08adea68c8a9cf9dfdcd8f2bb',
-     x86_64: 'efd72e40446eb7fb266b39a2e20df8398846ed76c96197b65dd31cb0fe023438',
-  })
-
-  depends_on 'buildessential'
-  depends_on 'cmake'
+  depends_on 'cmake' => :build
 
   def self.build
-    system "mkdir mybuilddir"
+    Dir.mkdir 'mybuilddir'
     Dir.chdir "mybuilddir" do
- 	    system "cmake .. -DLLVM_BUILD_LLVM_DYLIB=true"
-    	system "cmake --build ."
+      system "cmake .. -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DLLVM_OPTIMIZED_TABLEGEN=ON"
+      system "cmake --build . --  -j#{CREW_NPROC}"
     end
   end
 
   def self.install
     Dir.chdir "mybuilddir" do
-       system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_DIR}/usr/local -P cmake_install.cmake"
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -P cmake_install.cmake"
     end
   end
 end

--- a/packages/llvm_compiler_rt.rb
+++ b/packages/llvm_compiler_rt.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Llvm_compiler_rt < Package
+  description 'Part of the LLVM project.'
+  homepage 'https://compiler-rt.llvm.org/'
+  version '5.0.1'
+  source_url 'https://releases.llvm.org/5.0.1/compiler-rt-5.0.1.src.tar.xz'
+  source_sha256 '4edd1417f457a9b3f0eb88082530490edf3cf6a7335cdce8ecbc5d3e16a895da'
+
+  depends_on 'cmake' => :build
+
+  def self.build
+    Dir.mkdir 'mybuilddir'
+    Dir.chdir "mybuilddir" do
+      system "cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .."
+      system "cmake --build . --  -j#{CREW_NPROC}"
+    end
+  end
+
+  def self.install
+    Dir.chdir "mybuilddir" do
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -P cmake_install.cmake"
+    end
+  end
+end

--- a/packages/llvm_polly.rb
+++ b/packages/llvm_polly.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Llvm_polly < Package
+  description 'Polly is a high-level loop and data-locality optimizer and optimization infrastructure for LLVM.'
+  homepage 'https://polly.llvm.org/'
+  version '5.0.1'
+  source_url 'https://releases.llvm.org/5.0.1/polly-5.0.1.src.tar.xz'
+  source_sha256 '9dd52b17c07054aa8998fc6667d41ae921430ef63fa20ae130037136fdacf36e'
+
+  depends_on 'cmake' => :build
+  depends_on 'llvm'
+
+  def self.build
+    Dir.mkdir 'mybuilddir'
+    Dir.chdir "mybuilddir" do
+      system "cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .."
+      system "cmake --build . --  -j#{CREW_NPROC}"
+    end
+  end
+
+  def self.install
+    Dir.chdir "mybuilddir" do
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -P cmake_install.cmake"
+    end
+  end
+end

--- a/packages/llvm_unwind.rb
+++ b/packages/llvm_unwind.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Llvm_unwind < Package
+  description 'Part of the LLVM project.'
+  homepage 'https://github.com/llvm-mirror/libunwind'
+  version '5.0.1'
+  source_url 'https://releases.llvm.org/5.0.1/libunwind-5.0.1.src.tar.xz'
+  source_sha256 '6bbfbf6679435b858bd74bdf080386d084a76dfbf233fb6e47b2c28e0872d0fe'
+
+  depends_on 'cmake' => :build
+  depends_on 'llvm'
+
+  def self.build
+    Dir.mkdir 'mybuilddir'
+    Dir.chdir "mybuilddir" do
+      system "cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .."
+      system "cmake --build . --  -j#{CREW_NPROC}"
+    end
+  end
+
+  def self.install
+    Dir.chdir "mybuilddir" do
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -P cmake_install.cmake"
+    end
+  end
+end


### PR DESCRIPTION
## Description
GCC 4.9.1 lets us build a lot of packages, but it's not only on the old side (not supporting some modern compiler features), it also lacks some development features - libclang is pretty nice and enables things like YouCompleteMe (https://valloric.github.io/YouCompleteMe/). Finally, some people just plain prefer it.

This package contains the entire LLVM/Clang 5.0.1 toolchain, with the exception of `lldb`, `llvm-test-suite`, `clang-tools-extra`, and `libc++-abi`. Those packages could be added in the future if they were needed by someone.

## Addtional information
* The actual build of these packages takes forever on many Chromebooks. On my ARM Asus Chromebook Flip, compiling the entire set of packages would probably take 5-6 hours. One of my first priorities is to upload some binary packages. After I build these, do you how would I go about getting them on your BIntray?

* For speed of build and space considerations (my Chromebook was actually running out of disk space during the build), I've limited the targets to x86 and ARM, since this means that clang can target all (?) Chromebooks.
* The install adds the shortcuts `clang++w` and `clangw` (w is for "wrapper"), which automatically inserts command line arguments for the standard include and library paths and passes the remaining arguments for whatever variant of Clang is being used.

* This supports the C++17 standard.

* I've successfully built simple programs with this. More complicate projects such as ones built with CMake will require debugging as we proceed.

* the build of `lldb` version 5 will require stashing the LLVM source somewhere and then providing it for the build. I'll probably just have `llvm5` copy the source code to the `share` directory for dependent package(s) to reference. This pull request was getting big enough as it was. 

* This puts the old `lldb` package in a weird place. You might just want to get rid of it and drop the "5" suffix here. Let me know if that would be best.

* I have Spacemacs up and running with full semantic completion in C++ through YouCompleteMe. That might be a package for the future, as it makes my Chromebook viable for native C++ development.

Works properly:
- [? ] x86_64
- [* ] aarch64 (reasons why it doesn't)