### PR TITLE
Update libomxil_bellagio.rb

### DIFF
--- a/packages/libomxil_bellagio.rb
+++ b/packages/libomxil_bellagio.rb
@@ -9,7 +9,7 @@ class Libomxil_bellagio < Package
 
   def self.build
     system "./configure","--prefix=#{CREW_PREFIX}","--libdir=#{CREW_LIB_PREFIX}"
-    system "make", "-j1 CFLAGS=-Wno-error=switch"    # only -j1 possible (tested on armv7l)
+    system "make", "CFLAGS=-Wno-error=switch"    # only -j1 possible (tested on armv7l)
   end
 
   def self.install


### PR DESCRIPTION
remove compile option flag -j1 to make it work together with #1677 



Works properly:
- [] x86_64
- [x] armv7l

