### PR TITLE
Update versions for cmatrix doxygen elixir erlang eudev fish

### DIFF
--- a/packages/cmatrix.rb
+++ b/packages/cmatrix.rb
@@ -12,7 +12,6 @@ class Cmatrix < Package
   binary_sha256 ({
   })
 
-  depends_on 'buildessential'
   depends_on 'ncurses'
 
   def self.build

--- a/packages/cmatrix.rb
+++ b/packages/cmatrix.rb
@@ -3,21 +3,13 @@ require 'package'
 class Cmatrix < Package
   description "CMatrix is a program to see the cool scrolling lines from 'The Matrix' movie."
   homepage 'http://www.asty.org/cmatrix/'
-  version '1.2a-1'
-  source_url 'http://www.asty.org/cmatrix/dist/cmatrix-1.2a.tar.gz'
-  source_sha256 '1fa6e6caea254b6fe70a492efddc1b40ad7ccb950a5adfd80df75b640577064c'
+  version '1.2'
+  source_url 'https://github.com/abishekvashok/cmatrix/archive/1.2.tar.gz'
+  source_sha256 '6b0b9aff4585147843c4cf8a8c9c6048500f66dc4887a38922197dfa326b57c8'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cmatrix-1.2a-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cmatrix-1.2a-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cmatrix-1.2a-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cmatrix-1.2a-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'cd094b3ef03e1f1c47d7d1784549a6ded9ccfb59b2fb4546a5b4b99ce011a954',
-     armv7l: 'cd094b3ef03e1f1c47d7d1784549a6ded9ccfb59b2fb4546a5b4b99ce011a954',
-       i686: '9e97e2fa6ef0a384223b2c456905e5955a2355967f7ca14fcd98b0ebeeb651a3',
-     x86_64: 'a846151b32138a8b0803b3e40dda4d42e804d093dab1105787578714e144131b',
   })
 
   depends_on 'buildessential'

--- a/packages/doxygen.rb
+++ b/packages/doxygen.rb
@@ -3,25 +3,16 @@ require 'package'
 class Doxygen < Package
   description 'Doxygen is the de facto standard tool for generating documentation from annotated C++ sources'
   homepage 'http://www.stack.nl/~dimitri/doxygen/'
-  version '1.8.13'
-  source_url 'https://github.com/doxygen/doxygen/archive/Release_1_8_13.zip'
-  source_sha256 '1a1f67106c7e7642b79884f02faaf753d2e42be1ebac04083c173224123783b5'
+  version '1.8.14'
+  source_url 'https://github.com/doxygen/doxygen/archive/Release_1_8_14.tar.gz'
+  source_sha256 '18bc3790b4d5f4d57cb8ee0a77dd63a52518f3f70d7fdff868a7ce7961a6edc3'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/doxygen-1.8.13-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/doxygen-1.8.13-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/doxygen-1.8.13-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/doxygen-1.8.13-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'c4bb163c36d64a4d76732431aef4d57a11b1f82bc2bb4372bad246e6b5cf92f0',
-     armv7l: 'c4bb163c36d64a4d76732431aef4d57a11b1f82bc2bb4372bad246e6b5cf92f0',
-       i686: '8dae94cac3ae00c944887c83fee4b408a7962bb6d84540b29962c5b9462eae89',
-     x86_64: 'a81ec27bd1e67a5bc6e5c1f45ad78f11ac8493593c7e10418f51d117b63a198a',
   })
 
-  depends_on 'cmake'
-  depends_on 'unzip'
+  depends_on 'cmake' => :build
 
   def self.build
     system "cmake ."

--- a/packages/doxygen.rb
+++ b/packages/doxygen.rb
@@ -15,7 +15,7 @@ class Doxygen < Package
   depends_on 'cmake' => :build
 
   def self.build
-    system "cmake ."
+    system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} ."
     system "make"
   end
 

--- a/packages/elixir.rb
+++ b/packages/elixir.rb
@@ -8,8 +8,16 @@ class Elixir < Package
   source_sha256 '70972b844c12bc1a3960136d628ab4f21ca87dd5539c544ebabe41d6c9239ba9'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '5b2766a7b79e4fcb715604d9fbedbd347b6a7b797d2ff09c76e6b6e35d74eb80',
+     armv7l: '5b2766a7b79e4fcb715604d9fbedbd347b6a7b797d2ff09c76e6b6e35d74eb80',
+       i686: 'df2a3c7a938b52c07b31e9d4028c3aba2b7f24bba20d62ecc17262dc7f72dd50',
+     x86_64: '7a71cc9069e87ae71d5dbdff6ea5580befe78803237822b4828289280e4fd7de',
   })
 
   depends_on 'erlang'

--- a/packages/elixir.rb
+++ b/packages/elixir.rb
@@ -8,16 +8,8 @@ class Elixir < Package
   source_sha256 '70972b844c12bc1a3960136d628ab4f21ca87dd5539c544ebabe41d6c9239ba9'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/elixir-1.5.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5b2766a7b79e4fcb715604d9fbedbd347b6a7b797d2ff09c76e6b6e35d74eb80',
-     armv7l: '5b2766a7b79e4fcb715604d9fbedbd347b6a7b797d2ff09c76e6b6e35d74eb80',
-       i686: 'df2a3c7a938b52c07b31e9d4028c3aba2b7f24bba20d62ecc17262dc7f72dd50',
-     x86_64: '7a71cc9069e87ae71d5dbdff6ea5580befe78803237822b4828289280e4fd7de',
   })
 
   depends_on 'erlang'

--- a/packages/erlang.rb
+++ b/packages/erlang.rb
@@ -3,21 +3,13 @@ require 'package'
 class Erlang < Package
   description 'Erlang is a programming language used to build massively scalable soft real-time systems with requirements on high availability.'
   homepage 'http://www.erlang.org/'
-  version '20.1'
-  source_url 'http://erlang.org/download/otp_src_20.1.tar.gz'
-  source_sha256 '900d35eb563607785a8e27f4b4c03cf6c98b4596028c5d6958569ddde5d4ddbf'
+  version '20.2'
+  source_url 'http://erlang.org/download/otp_src_20.2.tar.gz'
+  source_sha256 '24d9895e84b800bf0145d6b3042c2f2087eb31780a4a45565206844b41eb8f23'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/erlang-20.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/erlang-20.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/erlang-20.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/erlang-20.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bf24687d8812ede4cf40d589ef10ca77b3688bb9f80ca98508b4a650140d87b7',
-     armv7l: 'bf24687d8812ede4cf40d589ef10ca77b3688bb9f80ca98508b4a650140d87b7',
-       i686: '4621102a3c46a60e71d204394b6fc8304ca75772cca7bbabbe268ef3efa63776',
-     x86_64: '288b9aeae32d800ccf6bd82a3fa54ecbf20d523e206c356bb7441264fe81db83',
   })
 
   depends_on 'flex' => :build

--- a/packages/eudev.rb
+++ b/packages/eudev.rb
@@ -3,30 +3,22 @@ require 'package'
 class Eudev < Package
   description 'Gentoo standalone udev'
   homepage 'https://wiki.gentoo.org/wiki/Project:Eudev'
-  version '3.2.4'
-  source_url 'https://github.com/gentoo/eudev/archive/v3.2.4.tar.gz'
-  source_sha256 'a68871be55aecb977ae4a206b5ce5a868a722e025f37387d1a702a409933bbeb'
+  version '3.2.5'
+  source_url 'https://github.com/gentoo/eudev/archive/v3.2.5.tar.gz'
+  source_sha256 '870920011285b919fca5c60eaa5670312eeffe3883dd8cf564cd1179fc639336'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/eudev-3.2.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/eudev-3.2.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/eudev-3.2.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/eudev-3.2.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '0193dd693fbba3f49e792b1890f3060f186fd12e3544786451ed9527c7fec3b7',
-     armv7l: '0193dd693fbba3f49e792b1890f3060f186fd12e3544786451ed9527c7fec3b7',
-       i686: 'c372115b1f1b4369a669f7df22d0b7b2d24591c1e45826e60c5e0e6f549e301f',
-     x86_64: 'eee2bc39b9ad1dcf8bd3db079dcbc7170bbb530e9711d2d02ba772003737a49a',
   })
 
   depends_on 'util_linux'
-  depends_on 'm4'
-  depends_on 'autoconf'
   depends_on 'automake'
   depends_on 'libxslt'
   depends_on 'libtool'
   depends_on 'gperf'
+  depends_on 'automake' => :build
+  depends_on 'util_linux' => :build
 
   def self.build
     system 'autoreconf -f -i -s'

--- a/packages/eudev.rb
+++ b/packages/eudev.rb
@@ -20,7 +20,7 @@ class Eudev < Package
 
   def self.build
     system 'autoreconf -f -i -s'
-    system "./configure --prefix=#{CREW_PREFIX}"
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 

--- a/packages/eudev.rb
+++ b/packages/eudev.rb
@@ -12,8 +12,6 @@ class Eudev < Package
   binary_sha256 ({
   })
 
-  depends_on 'util_linux'
-  depends_on 'automake'
   depends_on 'libxslt'
   depends_on 'libtool'
   depends_on 'gperf'

--- a/packages/fish.rb
+++ b/packages/fish.rb
@@ -3,21 +3,13 @@ require 'package'
 class Fish < Package
   description 'fish is a smart and user-friendly command line shell for macOS, Linux, and the rest of the family.'
   homepage 'http://fishshell.com/'
-  version '2.6.0'
-  source_url 'https://github.com/fish-shell/fish-shell/releases/download/2.6.0/fish-2.6.0.tar.gz'
-  source_sha256 '7ee5bbd671c73e5323778982109241685d58a836e52013e18ee5d9f2e638fdfb'
+  version '2.7.1'
+  source_url 'https://github.com/fish-shell/fish-shell/archive/2.7.1.tar.gz'
+  source_sha256 'eb43ea2eb9accf76661c487dd530a5fd345fa40a3201bd22cef2c52be39fb474'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fish-2.6.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fish-2.6.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fish-2.6.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fish-2.6.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '45bd379b711698286d9461150c18fbf1d01446e61aa75aaf5bfcbc0dab1e1248',
-     armv7l: '45bd379b711698286d9461150c18fbf1d01446e61aa75aaf5bfcbc0dab1e1248',
-       i686: '173692480715219af0c366e67f182314a895dcbd816819c6a4b45a4c43da07c1',
-     x86_64: '6fe888f23b24020270bbb7c30911b2ae4ffc80689c1b66612a6ba6894a50f3a8',
   })
 
   depends_on 'ncurses'

--- a/packages/fish.rb
+++ b/packages/fish.rb
@@ -15,7 +15,7 @@ class Fish < Package
   depends_on 'ncurses'
 
   def self.build
-    system "./configure"
+    system "./configure", "--prefix=#{CREW_PREFIX}"
     system "make"
   end
 


### PR DESCRIPTION
Updating packages to versions:

- cmatrix:  version '1.2'
- elixir:  version '1.5.3'
- doxygen:  version '1.8.14'
- erlang:  version '20.2'
- eudev:  version '3.2.5'
- fish:  version '2.7.1'

[Supporting: #1585 ]

Fixes #

(let GitHub automatically close an issue when this pull request gets merged)

## Before you submit a pull request
This template is not neccessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.

## Description
Provide a description, what your changes do and why they are important

Please link issues and other pull requests connected to this one.

## Addtional information
Mention things we might need to know. Like:

Works properly:
- [x] x86_64
- [ ] aarch64 (reasons why it doesn't)

---

## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
