### PR TITLE
Updated packages: bind elinks gnupg pinentry

### DIFF
--- a/packages/bind.rb
+++ b/packages/bind.rb
@@ -3,21 +3,13 @@ require 'package'
 class Bind < Package
   description 'BIND is open source software that enables you to publish your Domain Name System (DNS) information on the Internet, and to resolve DNS queries for your users.'
   homepage 'https://www.isc.org/downloads/bind/'
-  version '9.10.5-p3'
-  source_url 'https://www.isc.org/downloads/file/9-10-5-p3/?version=tar-gz'
-  source_sha256 '8d7e96b5b0bbac7b900d4c4bbb82e0956b4e509433c5fa392bb72a929b96606a'
+  version '9.12.0'
+  source_url 'https://www.isc.org/downloads/file/bind-9-12-0/'
+  source_sha256 '29870e9bf9dcc31ead3793ca754a7b0236a0785a7a9dc0f859a0bc42e19b3c82'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.10.5-p3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.10.5-p3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.10.5-p3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.10.5-p3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5d0ffc0fdfadccb9f838730797e645c249444abb077e5b3d05ad8f0a8241924f',
-     armv7l: '5d0ffc0fdfadccb9f838730797e645c249444abb077e5b3d05ad8f0a8241924f',
-       i686: '8d52384957c720b527650357ad3e5fd3732fbcae2083613c68993b913f603855',
-     x86_64: '3ca89eb998a259f393920174ac2bd1427465101eeb2a9cc8dcb5a880bbe0e4e0',
   })
 
   depends_on "buildessential"

--- a/packages/bind.rb
+++ b/packages/bind.rb
@@ -12,14 +12,18 @@ class Bind < Package
   binary_sha256 ({
   })
 
-  depends_on "buildessential"
   depends_on "openssl"
   depends_on "libcap"
   depends_on "readline"
   depends_on "diffutils"
 
   def self.build
-    system "BUILD_CC=gcc ./configure --with-randomdev=no --with-ecdsa=yes --with-gost=yes --prefix=/usr/local"
+    system "BUILD_CC=gcc ./configure \
+                --with-randomdev=no \
+                --with-ecdsa=yes \
+                --with-gost=yes \
+                --prefix=#{CREW_PREFIX} \
+                --libdir=#{CREW_LIB_PREFIX}"  
     system "make"
   end
 

--- a/packages/elinks.rb
+++ b/packages/elinks.rb
@@ -3,35 +3,24 @@ require 'package'
 class Elinks < Package
   description 'Full-Featured Text WWW Browser'
   homepage 'http://elinks.or.cz/'
-  version 'f86be659'
+  version 'f86be6597'
 
   source_url 'https://gitlab.com/alanaktion/elinks-mirror/repository/f86be659718c0cd0a67f88b42f07044c23d0d028/archive.tar.gz'
   source_sha256 'c19a342a5a6716b5213a4c539a149711491136d8b12daba7846bc2225c5fb309'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/elinks-f86be659-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/elinks-f86be659-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/elinks-f86be659-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/elinks-f86be659-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'c715668400a4065542f82b32f3ad459549783eae859204fa9223385be4e1aa04',
-     armv7l: 'c715668400a4065542f82b32f3ad459549783eae859204fa9223385be4e1aa04',
-       i686: '0f871561f1a9bc6bba4be57576888a45b217dc5783a3fb7c184d465519779ff2',
-     x86_64: 'cf7dfba80f9c66c31f4d2136db0a39043e38eaea217b6a04f20fe16737b248a8',
   })
 
   depends_on 'bz2'
   depends_on 'lzip'
   depends_on 'openssl'
   depends_on 'zlibpkg'
-  depends_on 'libx11'
 
   def self.build
-    system "wget -O config/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'"
-    system "wget -O config/config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'"
-    system "sh autogen.sh" unless File.executable? "configure"
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "sh autogen.sh"
+    system "./configure --without-x --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 

--- a/packages/elinks.rb
+++ b/packages/elinks.rb
@@ -25,6 +25,7 @@ class Elinks < Package
   depends_on 'lzip'
   depends_on 'openssl'
   depends_on 'zlibpkg'
+  depends_on 'libx11'
 
   def self.build
     system "wget -O config/config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'"

--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -12,8 +12,8 @@ class Gnupg < Package
   binary_sha256 ({
   })
 
+  depends_on 'automake' => :build
   depends_on 'bz2'
-  depends_on 'automake'
   depends_on 'libgpgerror'
   depends_on 'libgcrypt'
   depends_on 'libassuan'

--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gnupg < Package
   description 'GnuPG is a complete and free implementation of the OpenPGP standard as defined by RFC4880 (also known as PGP).'
   homepage 'https://gnupg.org/'
-  version '2.2.2'
-  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.2.tar.bz2'
-  source_sha256 'bfb62c7412ceb3b9422c6c7134a34ff01a560f98eb981c2d96829c1517c08197'
+  version '2.2.4'
+  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.4.tar.bz2'
+  source_sha256 '401a3e64780fdfa6d7670de0880aa5c9d589b3db7a7098979d7606cec546f2ec'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.2.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.2.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.2.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.2.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '469b4f0abbdc7dda28a0f1b900cbc75d48ab829845a2cceed279aa6dbc7596ce',
-     armv7l: '469b4f0abbdc7dda28a0f1b900cbc75d48ab829845a2cceed279aa6dbc7596ce',
-       i686: 'f4e61eed1efb7cbe9bf2d56973dac877c2a780cb6f57ce46a5946c7d06e239c4',
-     x86_64: '541012cd8afcf0c122b8beadb0ed40fc568bc134f01608aaa1648cd36a0a3f15',
   })
 
   depends_on 'bz2'

--- a/packages/pinentry.rb
+++ b/packages/pinentry.rb
@@ -3,21 +3,13 @@ require 'package'
 class Pinentry < Package
   description "A collection of passphrase entry dialogs which is required for almost all usages of GnuPG"
   homepage 'https://gnupg.org/software/pinentry/index.html'
-  version '1.0.0'
-  source_url 'https://gnupg.org/ftp/gcrypt/pinentry/pinentry-1.0.0.tar.bz2'
-  source_sha256 '1672c2edc1feb036075b187c0773787b2afd0544f55025c645a71b4c2f79275a'
+  version '1.1.0'
+  source_url 'https://gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.0.tar.bz2'
+  source_sha256 '68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f56570'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pinentry-1.0.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pinentry-1.0.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pinentry-1.0.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pinentry-1.0.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '959808266c3b49c00f333fbdb3b6b5f14ec4abcfb5457091654d8e1254904149',
-     armv7l: '959808266c3b49c00f333fbdb3b6b5f14ec4abcfb5457091654d8e1254904149',
-       i686: '298c471c2f0ad055aff1c480658b93e7e16fd5e936c7bb6d8b11997018d66f41',
-     x86_64: '86d2d87126edcdec32f14592ef74dad9b26d0b683b4699ba4f12452bf2640e19',
   })
 
   depends_on 'gnupg'


### PR DESCRIPTION
* bind 9.10.5-p3 -> 9.12.0
* elinks: already on latest commit; added dep: x11libs
* gnupg 2.2.2 -> 2.2.4
* pinentry 1.0.0 -> 1.1.0

Works to fix #1585 

## Description
Updates to: bind, gnupg, pinentry. elinks seems to already be on the latest commit, but package was missing x11libs dep.

Works properly:
- [x] x86_64

---
