### PR TITLE
Adding keybase package

### DIFF
--- a/packages/keybase.rb
+++ b/packages/keybase.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Keybase < Package
+  description 'Keybase is encryption for everyone. Installs keybase cli'
+  homepage 'https://keybase.io'
+  version '1.0.40'
+  source_url 'https://github.com/keybase/client/archive/v1.0.40.tar.gz'
+  source_sha256 '79f11737b3bdc279b34d2b978584b3c12e1c24ccdeb3b86dbf7670aa9c634913'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'go'
+
+  def self.install
+    system "go get github.com/keybase/client/go/keybase"
+    system "go build -o #{CREW_DEST_PREFIX}/bin/keybase -tags production github.com/keybase/client/go/keybase"
+  end
+end


### PR DESCRIPTION
## Description
Adding Keybase package: encryption for everyone! This package provides only the Keybase CLI.

## Addtional information
I'm not entirely sure the Keybase package is a good fit for Chromebrew, since the Go package manager does a fine job of installing Keybase on it's own. This PR basically wraps the ```go get``` and ```go build``` commands, targeting ```#{CREW_DEST_PREFIX}/bin``` as the output. 

Second, the ```remove``` process merely rm's ```#{CREW_DEST_PREFIX}/bin/keybase``` but does nothing to remove the actual package from Go's internal repo; doing that would require either a) tedious file by file ```rm``` commands, or b) a more dangerous ```rm -rf ${GO_PATH}/path/to/package```.

Third, since Chromebrew packages require a source URL, the keybase tarball is needlessly downloaded and then removed. Actually compiling from the tarball seems to be way more trouble than it's worth (points back to the fine job of the Go package manager).

The only real upside I see: users would likely keep the Keybase bin updated more regularly (assuming the Chromebrew package is updated). Also, having Keybase in Chromebrew might give more exposure to the Keybase project.

All of that said, my feelings would definitely not be hurt if this PR is rejected.

Works properly:
- [x] x86_64