### PR TITLE
Update intltool.rb

### DIFF
--- a/packages/intltool.rb
+++ b/packages/intltool.rb
@@ -13,6 +13,7 @@ class Intltool < Package
 
   def self.patch
     system "wget https://raw.githubusercontent.com/Alexpux/MSYS2-packages/master/intltool/perl-5.22-compatibility.patch"
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('perl-5.22-compatibility.patch') ) == '9c6527072aada6e3cb9aceb6e07cfdf51d58839a2beb650168da0601a85ebda3'
     system "patch intltool-update.in perl-5.22-compatibility.patch"
   end
   def self.build

--- a/packages/intltool.rb
+++ b/packages/intltool.rb
@@ -7,22 +7,14 @@ class Intltool < Package
   source_url 'https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz'
   source_sha256 '67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/intltool-0.51.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/intltool-0.51.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/intltool-0.51.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/intltool-0.51.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '9dde9cb290ede337fbb4017d492ed623f58bec9703657ad95210beb2ae402e91',
-     armv7l: '9dde9cb290ede337fbb4017d492ed623f58bec9703657ad95210beb2ae402e91',
-       i686: 'f2177c902c6bc94da49ec78c436f01d99abc68e35650228ac9835f789d123c66',
-     x86_64: 'e6a6069282bf20d1fdd70b6619a839bcbd8a311ac840eed36418a143515e291e',
-  })
-
   depends_on 'libtool'
   depends_on 'perl_xml_parser'
+  depends_on 'patch' => 'build'
 
+  def self.patch
+    system "wget https://raw.githubusercontent.com/Alexpux/MSYS2-packages/master/intltool/perl-5.22-compatibility.patch"
+    system "patch intltool-update.in perl-5.22-compatibility.patch"
+  end
   def self.build
     system "./configure --prefix=#{CREW_PREFIX}"
     system "make"


### PR DESCRIPTION
Since intltool-update fails with perl 5.26, see https://bugs.launchpad.net/intltool/+bug/1696658,   
applying patch from https://github.com/Alexpux/MSYS2-packages/blob/master/intltool/perl-5.22-compatibility.patch

