### PR TITLE
Update pango.rb

### DIFF
--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -22,7 +22,8 @@ class Pango < Package
   end
 
   def self.install
-    system "pip install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR} six"
+    system "pip install six"   # fix installation error,  "pip install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR} six" does not work
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "pip uninstall --yes six"
   end
 end


### PR DESCRIPTION
 "pip install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR} six" does not work.  six packages not found.
Fix this error using normal installation of six in python