### PR TITLE
[cairo] Fix dependencies

### DIFF
--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -10,7 +10,7 @@ class Cairo < Package
   depends_on 'libpng'
   depends_on 'pixman'
   depends_on 'fontconfig' # pango requires cairo with fontconfig
-  depends_on 'gobject_introspection'
+  depends_on 'libtool'
   depends_on 'mesa'
   depends_on 'automake' => :build
 


### PR DESCRIPTION
Remove gobject_introspection from cairo.rb -> Fix dependencies, tested using clean crew 

Combining #1766   can fix infinite loop to find dependencies. like #1765 

