### PR TITLE
Update yelp_tools.rb

### DIFF
--- a/packages/yelp_tools.rb
+++ b/packages/yelp_tools.rb
@@ -9,7 +9,8 @@ class Yelp_tools < Package
 
   depends_on 'automake' => :build
   depends_on 'yelp_xsl'
-
+  depends_on 'libxslt'
+  
   def self.build
     system "./autogen.sh"
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"


### PR DESCRIPTION
Fix dependency

It should fix #1793 

Confirm it works, since libxslt is the last dependency.