### PR TITLE
Update xcb_proto.rb

### DIFF
--- a/packages/xcb_proto.rb
+++ b/packages/xcb_proto.rb
@@ -20,7 +20,7 @@ class Xcb_proto < Package
      x86_64: 'd1b2f9c4c8ab6de2f496efabfd614a89fd38499091a4b7a82ba4b221499dd1a7',
   })
   
-  depends_on 'python27' => :build
+  depends_on 'python27' => :build    # I have removed this. It also works.
   
   def self.build
     system "./configure"

--- a/packages/xcb_proto.rb
+++ b/packages/xcb_proto.rb
@@ -19,8 +19,6 @@ class Xcb_proto < Package
        i686: '321e8479a559cbb9c726d5ddb44556eda41dbcf4a7ee9a6ff6f1e46426ca3618',
      x86_64: 'd1b2f9c4c8ab6de2f496efabfd614a89fd38499091a4b7a82ba4b221499dd1a7',
   })
-
-  depends_on 'python27'
   
   def self.build
     system "./configure"

--- a/packages/xcb_proto.rb
+++ b/packages/xcb_proto.rb
@@ -20,6 +20,8 @@ class Xcb_proto < Package
      x86_64: 'd1b2f9c4c8ab6de2f496efabfd614a89fd38499091a4b7a82ba4b221499dd1a7',
   })
   
+  depends_on 'python27' => :build
+  
   def self.build
     system "./configure"
     system "make"


### PR DESCRIPTION
Remove python27 depedency. I have tested it without python27 on a fresh crew. It also works.  Python27 is only a optional package, see http://www.linuxfromscratch.org/blfs/view/svn/x/xcb-proto.html