### PR TITLE
Remove make tests for cryptsetup

### DIFF
--- a/packages/cryptsetup.rb
+++ b/packages/cryptsetup.rb
@@ -22,7 +22,4 @@ class Cryptsetup < Package
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 
-  def self.check
-    system "make", "check"
-  end
 end


### PR DESCRIPTION
Fixes #1870

We don't really need the tests anyway. Most of them require sudo privileges to run correctly.