### PR TITLE
Update GPG and add pinentry dependencies

### DIFF
--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gnupg < Package
   description 'GnuPG is a complete and free implementation of the OpenPGP standard as defined by RFC4880 (also known as PGP).'
   homepage 'https://gnupg.org/'
-  version '2.2.4'
-  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.4.tar.bz2'
-  source_sha256 '401a3e64780fdfa6d7670de0880aa5c9d589b3db7a7098979d7606cec546f2ec'
+  version '2.2.5'
+  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.5.tar.bz2'
+  source_sha256 '3fa189a32d4fb62147874eb1389047c267d9ba088f57ab521cb0df46f08aef57'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.2.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.2.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.2.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnupg-2.2.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'e981d7102f3f88f1c4fdc7f372bc3d039bff0ba08c7df202988d5a2cd282fad7',
-     armv7l: 'e981d7102f3f88f1c4fdc7f372bc3d039bff0ba08c7df202988d5a2cd282fad7',
-       i686: '63e324b9028bead6579d74aa9cd5659db5565b9716cbfb23bec2db02151ba1c6',
-     x86_64: 'd509a69db73fd0bc69d177f6254a81519a19e9aafc2241d15d2e8237371aa8f8',
   })
 
   depends_on 'automake' => :build
@@ -28,6 +20,7 @@ class Gnupg < Package
   depends_on 'libksba'
   depends_on 'npth'
   depends_on 'gettext'
+  depends_on 'pinentry'
 
   def self.build
     system './configure',


### PR DESCRIPTION
Update the GPG package and add the `pinentry` package as a dependencies.

I was not able to generate a key without this package installed:

```
$ gpg --full-generate-key
...

We need to generate a lot of random bytes. It is a good idea to perform
some other action (type on the keyboard, move the mouse, utilize the
disks) during the prime generation; this gives the random number
generator a better chance to gain enough entropy.
gpg: agent_genkey failed: No pinentry
Key generation failed: No pinentry
$
```