### PR TITLE
Update core packages

### DIFF
--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -3,29 +3,27 @@ require 'package'
 class Gnutls < Package
   description 'GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols and technologies around them.'
   homepage 'http://gnutls.org/'
-  version '3.5.15'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.15.tar.xz'
-  source_sha256 '046081108b8b1fe455a13a4c5a4eaa0368e185b678f1670fe09a11a2d7ecfad5'
+  version '3.6.2'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.2.tar.xz'
+  source_sha256 'bcd5db7b234e02267f36b5d13cf5214baac232b7056a506252b7574ea7738d1f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.5.15-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.5.15-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.5.15-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.5.15-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3c9183dae47b19d037204b5bf1e3fb142ac88cd7a3ee2e24f2e22c9e414dd0a2',
-     armv7l: '3c9183dae47b19d037204b5bf1e3fb142ac88cd7a3ee2e24f2e22c9e414dd0a2',
-       i686: '71f725c3c414f203bdc2a9b7deea04ef655b12c8f28b0d7febfac09a1f688c88',
-     x86_64: '1a09cd1e743e08254bec0b1d60b00ac89bcf210af98c98734aa68d36f79d7c7a',
+    aarch64: '18407ecd4cd634a74e93c07f0ace40a3e62bc2b85ce45c9b3ecac5ef068769d5',
+     armv7l: '18407ecd4cd634a74e93c07f0ace40a3e62bc2b85ce45c9b3ecac5ef068769d5',
+       i686: 'e49286dc9b7a740c2281a750c8e66ce9390d2e1887da574992de4f33fb61f372',
+     x86_64: '119494bbb371d74538696b1ffae01bae736824db16ac58ad1c4e05cf35dc6e36',
   })
 
-  depends_on 'buildessential' => :build
   depends_on 'zlibpkg'
   depends_on 'libunistring'
   depends_on 'gmp'
   depends_on 'nettle'
-  depends_on 'pkgconfig' => :build
   depends_on 'libtasn1'
   depends_on 'trousers'
   depends_on 'p11kit'
@@ -45,6 +43,6 @@ class Gnutls < Package
   end
 
   def self.check
-    system "make check"
+    system "make", "check"
   end
 end

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -3,17 +3,36 @@ require 'package'
 class Isl < Package
   description 'Integer Set Library for manipulating sets and relations of integer points bounded by linear constraints'
   homepage 'http://isl.gforge.inria.fr/'
-  version '0.18-1'
+  version '0.19'
+  source_url 'http://repo.or.cz/isl.git/snapshot/0ce949a1277de2e3121ed5715bdde639d6f4ba0f.tar.gz'
+  source_sha256 '4d221ca3f4d6ddd262d03aeb7322c8662e1445538a6dbf3a1cc7847acdf59a6f'
+
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew-cross/isl-0.18-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew-cross/isl-0.18-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew-cross/isl-0.18-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew-cross/isl-0.18-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/isl-0.19-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/isl-0.19-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/isl-0.19-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/isl-0.19-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '34ab13258b490e96932dc8cb79fd3f7f6ec1e724aba829011cc5f2b16644c28e',
-     armv7l: '34ab13258b490e96932dc8cb79fd3f7f6ec1e724aba829011cc5f2b16644c28e',
-       i686: '513b04781a6759ffff0481151090711b19a29bc636a9839e9b571b1cb4276ac7',
-     x86_64: 'dbab5361321ea49a310e8d6507464438f227dff149223d68a797d4479ae1c173',
+    aarch64: '283848ab4ed9cc4df03232f957f6aa9f971622d25740d7c007276bb58127eec1',
+     armv7l: '283848ab4ed9cc4df03232f957f6aa9f971622d25740d7c007276bb58127eec1',
+       i686: '486c9760a9f9bd9da749ce68b9715e310df6346ccba8cd8b999939e0d2a75c91',
+     x86_64: 'e726e35c44fc64c1e0593afd7930606229ed4d8b5942fd9a85016df3fa5b701f',
   })
+
+  def self.build
+    system './autogen.sh'
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "mkdir -p #{CREW_DEST_LIB_PREFIX}"
+    system "ln -s #{CREW_LIB_PREFIX}/libisl.so.19 #{CREW_DEST_LIB_PREFIX}/libisl.so.15"
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
 end

--- a/packages/less.rb
+++ b/packages/less.rb
@@ -3,21 +3,21 @@ require 'package'
 class Less < Package
   description 'GNU less is a program similar to more, but which allows backward movement in the file as well as forward movement.'
   homepage 'https://www.gnu.org/software/less/'
-  version '487-1'
-  source_url 'http://www.greenwoodsoftware.com/less/less-487.tar.gz'
-  source_sha256 'f3dc8455cb0b2b66e0c6b816c00197a71bf6d1787078adeee0bcf2aea4b12706'
+  version '530'
+  source_url 'http://www.greenwoodsoftware.com/less/less-530.tar.gz'
+  source_sha256 '503f91ab0af4846f34f0444ab71c4b286123f0044a4964f1ae781486c617f2e2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/less-487-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/less-487-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/less-487-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/less-487-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/less-530-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/less-530-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/less-530-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/less-530-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b8121181edca892d7d552375e0943af58bd2e4b203466d85e560e41a570e2638',
-     armv7l: 'b8121181edca892d7d552375e0943af58bd2e4b203466d85e560e41a570e2638',
-       i686: '01484da1a6be5af400f1b6f238cd13f84865e359d18eaae8f30edf71e302325f',
-     x86_64: 'e3b116acea3eff0dfb87c38b37751bf561268c1b9305b4ef91be8eb3cc5a939e',
+    aarch64: '9f5b24b30b0eda422aa07c5cf34614403a561ecf80049ef16b85d4b6aafaf131',
+     armv7l: '9f5b24b30b0eda422aa07c5cf34614403a561ecf80049ef16b85d4b6aafaf131',
+       i686: '8807c4e382fe778a6518f3dfe11bf4eba3747dfb749383312263ebf42c9aedbd',
+     x86_64: '163b184835f8094de3e87319f21d0b6d246a5add03f7cc7e9252e2de7555b321',
   })
 
   depends_on 'compressdoc' => :build

--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -3,30 +3,38 @@ require 'package'
 class Libsigsegv < Package
   description 'GNU libsigsegv is a library for handling page faults in user mode.'
   homepage 'https://www.gnu.org/software/libsigsegv/'
-  version '2.11'
-  source_url 'ftp://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.11.tar.gz'
-  source_sha256 'dd7c2eb2ef6c47189406d562c1dc0f96f2fc808036834d596075d58377e37a18'
+  version '2.12'
+  source_url 'https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.12.tar.gz'
+  source_sha256 '3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsigsegv-2.11-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsigsegv-2.11-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsigsegv-2.11-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsigsegv-2.11-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsigsegv-2.12-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsigsegv-2.12-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsigsegv-2.12-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsigsegv-2.12-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '848d1532b32bd8833013093ae05f42bc7289d12aafcd1b29152598deefcd546c',
-     armv7l: '848d1532b32bd8833013093ae05f42bc7289d12aafcd1b29152598deefcd546c',
-       i686: '4f2ed1ee3c5827881d8fbf0e0fe59fa8a9d4f581e5adc03a93ff97e8032a25f4',
-     x86_64: 'a6e4750facffe105650502313c2622368e0923919adeb38865e8875b88288565',
+    aarch64: 'e95892871d5cfd7164b3056e87461fd852d1a224ca0a23f0dd73a98e71a83217',
+     armv7l: 'e95892871d5cfd7164b3056e87461fd852d1a224ca0a23f0dd73a98e71a83217',
+       i686: '626159d654d90139bfb1301323aea5c28b6ad37f895824323471eb7911a5ce4f',
+     x86_64: '02097e964faa7116a1e4701f322da97375d8df1a0928cadc05e86b838fe9fef3',
   })
 
   def self.build
-    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic"
-    system "make"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--enable-shared',
+           '--disable-static',
+           '--with-pic'
+    system 'make'
   end
 
   def self.install
-    system "make check"
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
   end
 end

--- a/packages/libtasn1.rb
+++ b/packages/libtasn1.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libtasn1 < Package
   description 'Libtasn1 is the ASN.1 library used by GnuTLS, GNU Shishi and some other packages.'
   homepage 'https://www.gnu.org/software/libtasn1/'
-  version '4.12'
-  source_url 'https://ftpmirror.gnu.org/libtasn1/libtasn1-4.12.tar.gz'
-  source_sha256 '6753da2e621257f33f5b051cc114d417e5206a0818fe0b1ecfd6153f70934753'
+  version '4.13'
+  source_url 'https://ftpmirror.gnu.org/libtasn1/libtasn1-4.13.tar.gz'
+  source_sha256 '7e528e8c317ddd156230c4e31d082cd13e7ddeb7a54824be82632209550c8cca'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libtasn1-4.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libtasn1-4.12-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libtasn1-4.12-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libtasn1-4.12-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libtasn1-4.13-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libtasn1-4.13-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libtasn1-4.13-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libtasn1-4.13-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '88e880dfcb967d2e267d6a9cb5edd7edc24102e3512b976372a59707aa3f800d',
-     armv7l: '88e880dfcb967d2e267d6a9cb5edd7edc24102e3512b976372a59707aa3f800d',
-       i686: '480a302070acd99918eb8f38ba2811b352e1ffa34c930906072d6f4986c3cd70',
-     x86_64: '0dcf60ecafad42147372010b35f360ec8f364443aaeccb1805f71b8ba568385f',
+    aarch64: '5b445e57a2882b410e6b8493c7997a34d01bec701f67eb0654aa92d114c61ed8',
+     armv7l: '5b445e57a2882b410e6b8493c7997a34d01bec701f67eb0654aa92d114c61ed8',
+       i686: '89e4bf3ab1bd6c561209dd3e1cf298af0a8498cdae6a0b3c270ecfc84392bc4a',
+     x86_64: '51009ec44bf8f51a3fc0432d78f14716b18d99eb99ad9b3b073079b5d168d1b9',
   })
 
   # bison, diff, cmp are required at compile-time

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libunbound < Package
   description 'Unbound is a validating, recursive, and caching DNS resolver.'
   homepage 'https://www.unbound.net/'
-  version '1.6.2'
-  source_url 'https://www.unbound.net/downloads/unbound-1.6.2.tar.gz'
-  source_sha256 '1a323d72c32180b7141c9e6ebf199fc68a0208dfebad4640cd2c4c27235e3b9c'
+  version '1.7.0'
+  source_url 'https://www.unbound.net/downloads/unbound-1.7.0.tar.gz'
+  source_sha256 '94dd9071fb13d8ccd122a3ac67c4524a3324d0e771fc7a8a7c49af8abfb926a2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.6.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.6.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.6.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.6.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.7.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.7.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.7.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.7.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '72a4c0a18e74232aed3c619e97fcd41a9df18a8887b9f5f7b45ab7cb9e0f4e1b',
-     armv7l: '72a4c0a18e74232aed3c619e97fcd41a9df18a8887b9f5f7b45ab7cb9e0f4e1b',
-       i686: '2fd2b4fc97ab09228022f8f76a9fdb64da733dcbd68de247273c34887b749570',
-     x86_64: 'dde8bd43e4fb63f9c21d751198efffce41a4ea59db965a69540538d670ea5048',
+    aarch64: '4444835bc92d3e88e94ad6f1e9599f4c60a2843d206d2a2b15a31460816f76d5',
+     armv7l: '4444835bc92d3e88e94ad6f1e9599f4c60a2843d206d2a2b15a31460816f76d5',
+       i686: '3a2daf9725731c9aa89b3fd495e8fc8e87ff66a0906d8cd5c2ac120860f3e63b',
+     x86_64: '54e53fa1bb5a673611048619d031cf57ef2dc259b4265ade626b661b71a91864',
   })
 
   depends_on 'flex' => :build
@@ -26,12 +26,17 @@ class Libunbound < Package
   depends_on 'expat'
 
   def self.build
-    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--enable-shared',
+           '--disable-static',
+           '--with-pic'
 
     # flex 2.6.3 requires -P option to rename yylex and other funcions
     system "sed", "-i", "Makefile", "-e", '/$(LEX) -t $(srcdir)\/util\/configlexer.lex/s:-t:-t -Pub_c_:'
 
-    system "make"
+    system 'make'
   end
 
   def self.install

--- a/packages/libunistring.rb
+++ b/packages/libunistring.rb
@@ -3,31 +3,39 @@ require 'package'
 class Libunistring < Package
   description 'A library that provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.'
   homepage 'https://www.gnu.org/software/libunistring/'
-  version '0.9.8'
-  source_url 'https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.8.tar.xz'
-  source_sha256 '7b9338cf52706facb2e18587dceda2fbc4a2a3519efa1e15a3f2a68193942f80'
+  version '0.9.9'
+  source_url 'https://ftpmirror.gnu.org/libunistring/libunistring-0.9.9.tar.xz'
+  source_sha256 'a4d993ecfce16cf503ff7579f5da64619cee66226fb3b998dafb706190d9a833'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libunistring-0.9.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libunistring-0.9.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libunistring-0.9.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libunistring-0.9.8-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libunistring-0.9.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libunistring-0.9.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libunistring-0.9.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libunistring-0.9.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '0f4015848022ac926964112d19a3a6dce33e61479756b3cadded402a5a5808cf',
-     armv7l: '0f4015848022ac926964112d19a3a6dce33e61479756b3cadded402a5a5808cf',
-       i686: '127f133faad0ea53013d80e26672db31ab40b4c7379d88f18d6adbf0f2d1ed12',
-     x86_64: '4cd2d13d86fdf810fa468bb7b3b37a42e0f68fa658897897dc0b24c8e0e58da5',
+    aarch64: '570ba012dd7e01f7d4a7e859e4afafc61a607ae7762c32f1bfcdd63f9e04bb18',
+     armv7l: '570ba012dd7e01f7d4a7e859e4afafc61a607ae7762c32f1bfcdd63f9e04bb18',
+       i686: 'd55df8d5c90d2ea1cf9ee75059950859c0afbc134680bd77c11022aec848ffc8',
+     x86_64: '5f0dc6bafb63fd29c678d320c4a211675f6f1812ac8c8d8ef0e1fb950bdbc02f',
   })
 
   depends_on 'glibc'
 
   def self.build
-    system "./configure", "--disable-static", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-static',
+           '--enable-shared'
+    system 'make'
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
   end
 end

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.7-1'
-  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.7.tar.gz'
-  source_sha256 'f63c5e7d30362ed28b38bfa1ac6313f9a80230720b7fb6c80575eeab3ff5900c'
+  version '2.9.8'
+  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.8.tar.gz'
+  source_sha256 '0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.7-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.7-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.7-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.7-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f85fc0891eacc8785930f689321b7771ece6679d520cc6ecc4cd2c9e15b5d8d7',
-     armv7l: 'f85fc0891eacc8785930f689321b7771ece6679d520cc6ecc4cd2c9e15b5d8d7',
-       i686: 'e26444996080e19026958bc6a434623f0a48a3116c34e32b5b730683d010a2e9',
-     x86_64: 'e9b0b85c681e748b4532bd201503caaee5fcce8f73849d7199bf80634e9cbbba',
+    aarch64: '6aec3dc783b8f17309c855900052975389fb644e78f986fc40e307a66eb92b0f',
+     armv7l: '6aec3dc783b8f17309c855900052975389fb644e78f986fc40e307a66eb92b0f',
+       i686: '29abea10be808c0e82c1a420afdfb04ff07f8dc74be3ee26095b97ab3e310e63',
+     x86_64: 'f63743763e5caff9ac62e6e03490de6c48217a6a8c1d7f923e2e3c0396131516',
   })
  
   depends_on 'python27' => :build   # since binary is available, mark it as build depedency

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -3,17 +3,39 @@ require 'package'
 class Mpfr < Package
   description 'The MPFR library is a C library for multiple-precision floating-point computations with correct rounding.'
   homepage 'http://www.mpfr.org/'
-  version '3.1.5-2'
+  version '4.0.1'
+  source_url 'http://www.mpfr.org/mpfr-current/mpfr-4.0.1.tar.xz'
+  source_sha256 '67874a60826303ee2fb6affc6dc0ddd3e749e9bfcb4c8655e3953d0458a6e16e'
+
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew-cross/mpfr-3.1.5-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew-cross/mpfr-3.1.5-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew-cross/mpfr-3.1.5-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew-cross/mpfr-3.1.5-2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mpfr-4.0.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mpfr-4.0.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mpfr-4.0.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mpfr-4.0.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '41170f3c49ea226df739d90bb633895dc0479d855acece2cd96d1bb24818202a',
-     armv7l: '41170f3c49ea226df739d90bb633895dc0479d855acece2cd96d1bb24818202a',
-       i686: '341e8109fbfc376883e5eeb649561897958a8cbf92ba3dc73ca7da5e52fa7e63',
-     x86_64: '5e9fe71170cc82e1d789ee9aecf568b70f4f9694f2c945a6c04ae573bf0509a2',
+    aarch64: '95fb95f4a32a0c91e48c3dee207710614eb44d1e98f3e43d7d439c5be7c1e5eb',
+     armv7l: '95fb95f4a32a0c91e48c3dee207710614eb44d1e98f3e43d7d439c5be7c1e5eb',
+       i686: '1f2598510252794e1eb9c98a132ddc7ad394c2c369cdfa4a690f50a2c981026f',
+     x86_64: 'e5d43065f3f87eabf33debd0c9789988f980d68a0f1a91d6782b3f97916c0680',
   })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-static',
+           '--enable-shared'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "mkdir -p #{CREW_DEST_LIB_PREFIX}"
+    system "ln -s #{CREW_LIB_PREFIX}/libmpfr.so.6 #{CREW_DEST_LIB_PREFIX}/libmpfr.so.4"
+  end
+
+  def self.check
+    system "make", "check"
+  end
 end

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -3,21 +3,21 @@ require 'package'
 class Ncurses < Package
   description 'The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0 (SVr4), and more.'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '6.0-2'
-  source_url 'ftp://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz'
-  source_sha256 'f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260'
+  version '6.1'
+  source_url 'https://ftpmirror.gnu.org/ncurses/ncurses-6.1.tar.gz'
+  source_sha256 'aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.0-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.0-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.0-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.0-2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3951a422aff0fb0358c5190674bff39f30dd36b0b0df6f3c8a2717141be1447d',
-     armv7l: '3951a422aff0fb0358c5190674bff39f30dd36b0b0df6f3c8a2717141be1447d',
-       i686: '57851803decba529076a1a1b9b719dc15ac60c5f96709a2fb9eb769a56f4e81b',
-     x86_64: '761f5a0bac8df8af682ca0df82b42afc3d5a7217a1b359e4b7ba51c7851857e4',
+    aarch64: '4e33d4fc68ea5b47bae07aa710b1f801fd80ba85a02c0060c6f157100acadaf4',
+     armv7l: '4e33d4fc68ea5b47bae07aa710b1f801fd80ba85a02c0060c6f157100acadaf4',
+       i686: '16a5f5c03a4e9591146dc56a1ed4b017c09ad9d72da38d104ce282a3d25ef9fd',
+     x86_64: '1eab39eee49e16799ad61def29e69c50a7ea39b04a8da2ff4f4ada033e81273c',
   })
 
   depends_on 'diffutils' => :build
@@ -25,7 +25,7 @@ class Ncurses < Package
 
   def self.build
     system './configure',
-           '--prefix=/usr/local',
+           "--prefix=#{CREW_PREFIX}",
            "--libdir=#{CREW_LIB_PREFIX}",
            '--without-normal',
            '--with-shared',

--- a/packages/ncursesw.rb
+++ b/packages/ncursesw.rb
@@ -3,21 +3,21 @@ require 'package'
 class Ncursesw < Package
   description 'ncurses wide-character libraries.'
   homepage 'http://www.gnu.org/software/ncurses/'
-  version '6.0-2'
-  source_url 'ftp://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.0.tar.gz'
-  source_sha256 'f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260'
+  version '6.1'
+  source_url 'https://ftpmirror.gnu.org/ncurses/ncurses-6.1.tar.gz'
+  source_sha256 'aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ncursesw-6.0-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ncursesw-6.0-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ncursesw-6.0-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncursesw-6.0-2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ncursesw-6.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ncursesw-6.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ncursesw-6.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncursesw-6.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b777a646e051ed128c596da84a81b8b08d22a1021ff603d04f1f470b94e44773',
-     armv7l: 'b777a646e051ed128c596da84a81b8b08d22a1021ff603d04f1f470b94e44773',
-       i686: '521c5059b8652b42757bf6f30420713a2e058f447ac92fc55ff0d052dff6304b',
-     x86_64: '3b2c098ededca06261007f6b1dc0679c76209c763300ee987f2d96dd51683c12',
+    aarch64: '78f2dd654bfe65e29b43109d4ba4551337af6546e8a0b3d74cb5f4dfe93d0a38',
+     armv7l: '78f2dd654bfe65e29b43109d4ba4551337af6546e8a0b3d74cb5f4dfe93d0a38',
+       i686: '2287e7bab7b63649624132265cb2f33477703ae8ee754a866f13e4bf66b71ea5',
+     x86_64: 'a2542e59a79bd82178b29ac96af4dc53cabc73bad7faca3ea8f5bb2afc99f5aa',
   })
 
   depends_on 'diffutils' => :build
@@ -34,7 +34,7 @@ class Ncursesw < Package
     end
     # Build ncursesw
     system './configure',
-           '--prefix=/usr/local',
+           "--prefix=#{CREW_PREFIX}",
            "--libdir=#{CREW_LIB_PREFIX}",
            '--without-normal',
            '--with-shared',

--- a/packages/patch.rb
+++ b/packages/patch.rb
@@ -3,26 +3,28 @@ require 'package'
 class Patch < Package
   description 'Patch takes a patch file containing a difference listing produced by the diff program and applies those differences to one or more original files, producing patched versions.'
   homepage 'http://savannah.gnu.org/projects/patch/'
-  version '2.7.5'
-  source_url 'https://ftp.gnu.org/gnu/patch/patch-2.7.5.tar.xz'
-  source_sha256 'fd95153655d6b95567e623843a0e77b81612d502ecf78a489a4aed7867caa299'
+  version '2.7.6'
+  source_url 'https://ftpmirror.gnu.org/patch/patch-2.7.6.tar.xz'
+  source_sha256 'ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/patch-2.7.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/patch-2.7.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/patch-2.7.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/patch-2.7.5-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/patch-2.7.6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/patch-2.7.6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/patch-2.7.6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/patch-2.7.6-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '995d2690c10f31fcf48d6cc44004e506b572e4db182b334476d2473bfe1ac145',
-     armv7l: '995d2690c10f31fcf48d6cc44004e506b572e4db182b334476d2473bfe1ac145',
-       i686: '27bde4b24b9bae10efe371bd8569ecdf6f170ec042b2c16b8cc297131b5db48e',
-     x86_64: 'd2b06c3df2ba789756703c55f6eab0fc347ba5e3c546d78c59223e6621b2fcd3',
+    aarch64: 'f5ed23759094417cda17c86653388d8bfdacd8073f50b63754115bd1e3470718',
+     armv7l: 'f5ed23759094417cda17c86653388d8bfdacd8073f50b63754115bd1e3470718',
+       i686: '4e7dac3d38983a690496b00163b6a331754f9d510781a922f02fb2cedf1fe7ed',
+     x86_64: '2c756988d1ed11102e6bc33146d43349e303bac645ec8d16ef7ec521f3d0b5d9',
   })
 
   def self.build
-    system './configure --prefix=/usr/local'
-    system "make"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
   end
 
   def self.install

--- a/packages/slang.rb
+++ b/packages/slang.rb
@@ -3,21 +3,21 @@ require 'package'
 class Slang < Package
   description 'S-Lang is a multi-platform programmer\'s library designed to allow a developer to create robust multi-platform software.'
   homepage 'http://www.jedsoft.org/slang/'
-  version '2.3.1a-1'
-  source_url 'http://www.jedsoft.org/releases/slang/slang-2.3.1a.tar.bz2'
-  source_sha256 '54f0c3007fde918039c058965dffdfd6c5aec0bad0f4227192cc486021f08c36'
+  version '2.3.2'
+  source_url 'https://www.jedsoft.org/releases/slang/slang-2.3.2.tar.bz2'
+  source_sha256 'fc9e3b0fc4f67c3c1f6d43c90c16a5c42d117b8e28457c5b46831b8b5d3ae31a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/slang-2.3.1a-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/slang-2.3.1a-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/slang-2.3.1a-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/slang-2.3.1a-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/slang-2.3.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/slang-2.3.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/slang-2.3.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/slang-2.3.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '62868aea89e8cacb5de9e6eb7c76bd91604bb52bf3f0d3acfb5c47fc15e76bba',
-     armv7l: '62868aea89e8cacb5de9e6eb7c76bd91604bb52bf3f0d3acfb5c47fc15e76bba',
-       i686: 'db92dbb4200f37acd33dc558e35496088c8d975fa4dc8273afbd212a419f9dd5',
-     x86_64: '15ff98f70426d6c55a5a99687862b9bbf5c5f3f6d6cc9ea47fabd0eb4a8277c8',
+    aarch64: 'c957e37812aadaecea026ef184729f1892fe5a24a843bc0b28fc0ee322855e87',
+     armv7l: 'c957e37812aadaecea026ef184729f1892fe5a24a843bc0b28fc0ee322855e87',
+       i686: '8fa398bb8d47a423eac2a687c16a409c671342edaa6bb1afeeceac440c0459ca',
+     x86_64: '6d7968b8a251a184c06d96e0466c9c7fabae9033c7be9ad9fc4b2b60816eaa37',
   })
 
   def self.build
@@ -32,5 +32,9 @@ class Slang < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
   end
 end

--- a/packages/wget.rb
+++ b/packages/wget.rb
@@ -3,24 +3,23 @@ require 'package'
 class Wget < Package
   description 'GNU Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS.'
   homepage 'https://www.gnu.org/software/wget/'
-  version '1.19'
-  source_url 'https://ftp.gnu.org/gnu/wget/wget-1.19.tar.xz'
+  version '1.19.4'
+  source_url 'https://ftpmirror.gnu.org/wget/wget-1.19.tar.xz'
   source_sha256 '0f1157bbf4daae19f3e1ddb70c6ccb2067feb834a6aa23c9d9daa7f048606384'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '306ce8e73db8c90fec3bacf29bcdcc904bc96bd9eb47fe760cebeb036c17d6fa',
-     armv7l: '306ce8e73db8c90fec3bacf29bcdcc904bc96bd9eb47fe760cebeb036c17d6fa',
-       i686: 'e13a781140e81610c6e56422e4ff8622d6f3ffb9422521adee08eb077dd90d62',
-     x86_64: '572913991ca7d70a2eb643457c579b78b80b01bbf2fb9020fdc55fc29393ad3f',
+    aarch64: 'bab5af68ea69bfe5bd74d533fa6f7f5fefa428ac05c8e505f9725ac3deb7c56d',
+     armv7l: 'bab5af68ea69bfe5bd74d533fa6f7f5fefa428ac05c8e505f9725ac3deb7c56d',
+       i686: '6019d23e65947cae46590465e653d556a42a6ee987d20bd617e32ba79f5a4521',
+     x86_64: '31077b80d13d573384154a222a490bb97d640e85fc0c8e0c444568a01e4f4df4',
   })
 
-  depends_on 'buildessential' => :build
   depends_on 'gnutls'
 
   def self.build
@@ -33,5 +32,9 @@ class Wget < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/wget.rb
+++ b/packages/wget.rb
@@ -4,8 +4,8 @@ class Wget < Package
   description 'GNU Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS.'
   homepage 'https://www.gnu.org/software/wget/'
   version '1.19.4'
-  source_url 'https://ftpmirror.gnu.org/wget/wget-1.19.tar.xz'
-  source_sha256 '0f1157bbf4daae19f3e1ddb70c6ccb2067feb834a6aa23c9d9daa7f048606384'
+  source_url 'https://ftpmirror.gnu.org/wget/wget-1.19.4.tar.gz'
+  source_sha256 '93fb96b0f48a20ff5be0d9d9d3c4a986b469cb853131f9d5fe4cc9cecbc8b5b5'
 
   binary_url ({
     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wget-1.19.4-chromeos-armv7l.tar.xz',


### PR DESCRIPTION
Update gnutls from 3.5.15 to 3.6.2.
Update isl from 0.18-1 to 0.19.
Update less from 487-1 to 530.
Update libsigsegv from 2.11 to 2.12.
Update libtasn1 from 4.12 to 4.13.
Update libunbound from 1.6.2 to 1.7.0.
Update libunistring from 0.9.8 to 0.9.9.
Update libxml2 from 2.9.7-1 to 2.9.8.
Update mpfr from 3.1.5-2 to 4.0.1.
Update ncurses from 6.0-2 to 6.1.
Update ncursesw from 6.0-2 to 6.1.
Update patch from 2.7.5 to 2.7.6.
Update slang from 2.3.1a-1 to 2.3.2.
Update wget from 1.19 to 1.19.4.

Tested on:
- [x] armv7l
- [x] i686
- [x] x86_64

