### PR TITLE
Add tack package

### DIFF
--- a/packages/tack.rb
+++ b/packages/tack.rb
@@ -1,0 +1,27 @@
+require 'package'
+
+class Tack < Package
+  description 'terminfo action checker'
+  homepage 'https://www.gnu.org/software/ncurses/'
+  version '1.08'
+  source_url 'https://ftpmirror.gnu.org/ncurses/tack-1.08.tar.gz'
+  source_sha256 '60f8515eed87176e1f74ac81372645df14dcffbf200d778353e56f640d55b1f2'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'ncurses'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "CPPFLAGS=-I#{CREW_PREFIX}/include/ncurses"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Generally speaking, applications that use internal details of a library are unsupported. There was exactly one exception for ncurses: the tack program used the internal details of TERMINAL, because it provides an ncurses-specific feature for interactively modifying a terminfo description and writing the updated description to a text-file. It was possible to not only separate tack from these internal details of ncurses, but to generalize it so that the program works with Unix curses (omitting the ncurses-specific feature). That was released as tack 1.08 in July 2017.

While making changes to tack to eliminate its dependency upon ncurses internals, the publicly-visible details of those internals were reviewed, and some symbols were moved to private header files, while others were marked explicitly as ncurses internals. Future releases of ncurses may eliminate some of those symbols (such as those used by tack 1.07) because they are neither part of the API or the ABI.

See https://www.gnu.org/software/ncurses/.