### PR TITLE
Add nmon package

### DIFF
--- a/packages/nmon.rb
+++ b/packages/nmon.rb
@@ -1,0 +1,27 @@
+require 'package'
+
+class Nmon < Package
+  description "nmon is short for Nigel's performance MONitor for Linux"
+  homepage 'http://nmon.sourceforge.net/pmwiki.php'
+  version '16g'
+  source_url 'http://downloads.sourceforge.net/project/nmon/lmon16g.c'
+  source_sha256 'da82dd693b503b062854dfe7dbb5d36b347872ab44a4aa05b97e9d577747f688'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'ncurses'
+
+  def self.build
+    system 'wget http://downloads.sourceforge.net/project/nmon/lmon16g.c'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('lmon16g.c') ) == 'da82dd693b503b062854dfe7dbb5d36b347872ab44a4aa05b97e9d577747f688'
+    system "sed -i 's,<ncurses.h>,<#{CREW_PREFIX}/include/ncurses/ncurses.h>,' lmon16g.c"
+    system 'cc -o nmon lmon16g.c -g -O3 -Wall -D JFS -D GETUSER -D LARGEMEM -lncurses -lm -g -D POWER'
+  end
+
+  def self.install
+    system "install -Dm755 nmon #{CREW_DEST_PREFIX}/bin/nmon"
+  end
+end


### PR DESCRIPTION
This systems administrator, tuner, benchmark tool gives you a huge amount of important performance information in one go. It can output the data in two ways:

1. On screen (console, telnet, VNC, putty or X Windows) using curses for low CPU impact which is updated once every two seconds. You hit single characters on you keyboard to enable/disable the various sorts of data.
You can display the CPU, memory, network, disks (mini graphs or numbers), file systems, NFS, top processes, resources (Linux version & processors) and on Power micro-partition information.

2. Save the data to a comma separated file for analysis and longer term data capture.
- Use nmonchart (from this website) to generate a Googlechart webpage.
- Use this together with nmon Analyser Microsoft Excel spreadsheet, which loads the nmon output file and automatically creates dozens of graphs ready for you to study or write performance reports.
- Filter this data, add it to a rrd database (using an excellent freely available utility called rrdtool). This graphs the data to .gif or .png files plus generates the webpage .html file and you can then put the graphs directly on a website automatically on AIX with no need of a Windows based machine.
- Directly put the data into a rrd database or other database for your own analysis.

See http://nmon.sourceforge.net/pmwiki.php.