### PR TITLE
Add gcc 7.3 package.

### DIFF
--- a/packages/gcc7.rb
+++ b/packages/gcc7.rb
@@ -10,28 +10,31 @@ class Gcc7 < Package
   source_sha256 'd8cb199f0d98bd83e3dac645126722e44137c24cbe5e87e1113dd4270f7530c6'
 
   depends_on 'buildessential'
-  depends_on 'binutils'
-  depends_on 'gmp'
-  depends_on 'mpfr'
-  depends_on 'mpc'
-  depends_on 'isl'
-  depends_on 'cloog'
-  depends_on 'glibc'
   depends_on 'gawk'
+  depends_on 'unzip' => :build
 
   def self.build
     system "mkdir", "build"
     Dir.chdir "build" do
-      ENV["LIBRARY_PATH"] = "/usr/local/lib64"
-      system "../configure", "-v", "--build=x86_64-linux-gnu", "--host=x86_64-linux-gnu", "--target=x86_64-linux-gnu", "--libdir=#{CREW_LIB_PREFIX}", "--prefix=#{CREW_PREFIX}", "--enable-checking=release", "--enable-languages=c,c++,fortran", "--disable-multilib", "--disable-libmpx", "--program-suffix=-7.3"
+      ENV["LIBRARY_PATH"] = "#{CREW_LIB_PREFIX}"
+      system "../configure",
+             "-v",
+             "--libdir=#{CREW_LIB_PREFIX}",
+             "--prefix=#{CREW_PREFIX}",
+             "--enable-checking=release",
+             "--enable-languages=c,c++,fortran",
+             "--disable-multilib",
+             "--disable-libmpx",
+             "--program-suffix=-7.3"
       system "make"
     end
   end
 
   def self.install
     Dir.chdir "build" do
-      ENV["LIBRARY_PATH"] = "/usr/local/lib64"
-      system "make", "install-strip"
+      ENV["LIBRARY_PATH"] = "#{CREW_LIB_PREFIX}"
+      system "make",
+             "install-strip"
     end
   end
 end

--- a/packages/gcc7.rb
+++ b/packages/gcc7.rb
@@ -33,6 +33,7 @@ class Gcc7 < Package
     Dir.chdir "build" do
       ENV["LIBRARY_PATH"] = "#{CREW_LIB_PREFIX}"
       system "make",
+             "DESTDIR=#{CREW_DEST_DIR}",
              "install-strip"
     end
   end

--- a/packages/gcc7.rb
+++ b/packages/gcc7.rb
@@ -9,7 +9,6 @@ class Gcc7 < Package
 
   source_sha256 'd8cb199f0d98bd83e3dac645126722e44137c24cbe5e87e1113dd4270f7530c6'
 
-  depends_on 'buildessential'
   depends_on 'gawk'
   depends_on 'unzip' => :build
 

--- a/packages/gcc7.rb
+++ b/packages/gcc7.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Gcc7 < Package
+  description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
+  homepage 'https://www.gnu.org/software/gcc/'
+  version '7.3.0'
+
+  source_url 'https://github.com/gcc-mirror/gcc/archive/gcc-7_3_0-release.zip'
+
+  source_sha256 'd8cb199f0d98bd83e3dac645126722e44137c24cbe5e87e1113dd4270f7530c6'
+
+  depends_on 'buildessential'
+  depends_on 'binutils'
+  depends_on 'gmp'
+  depends_on 'mpfr'
+  depends_on 'mpc'
+  depends_on 'isl'
+  depends_on 'cloog'
+  depends_on 'glibc'
+  depends_on 'gawk'
+
+  def self.build
+    system "mkdir", "build"
+    Dir.chdir "build" do
+      ENV["LIBRARY_PATH"] = "/usr/local/lib64"
+      system "../configure", "-v", "--build=x86_64-linux-gnu", "--host=x86_64-linux-gnu", "--target=x86_64-linux-gnu", "--libdir=#{CREW_LIB_PREFIX}", "--prefix=#{CREW_PREFIX}", "--enable-checking=release", "--enable-languages=c,c++,fortran", "--disable-multilib", "--disable-libmpx", "--program-suffix=-7.3"
+      system "make"
+    end
+  end
+
+  def self.install
+    Dir.chdir "build" do
+      ENV["LIBRARY_PATH"] = "/usr/local/lib64"
+      system "make", "install-strip"
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR adds gcc 7.3 as a new package.  It installs from source, so be prepared to wait a while.

Related to issue #2059 

## Addtional information
This is only configured for x86_64.  All I have is a Pixelbook so I don't have access to the other architectures to set it up for those.  

Works properly:
- [x] x86_64
- [ ] aarch64

