### PR TITLE
[libsigcplusplus] change name to libsigcplusplus3

### DIFF
--- a/packages/libsigcplusplus3.rb
+++ b/packages/libsigcplusplus3.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Libsigcplusplus < Package
+class Libsigcplusplus3 < Package
   description 'libsigc++ implements a typesafe callback system for standard C++.'
   homepage 'http://libsigc.sourceforge.net/'
   version '2.99.10'


### PR DESCRIPTION
Both sigc++-2.0 and sigc++-3.0 are required for building glibmm.
After changing the name, I will recover the libsigcplusplus for sigc++-2.0