### PR TITLE
[cairomm] fix dependency

### DIFF
--- a/packages/cairomm.rb
+++ b/packages/cairomm.rb
@@ -21,7 +21,7 @@ class Cairomm < Package
   })
 
   depends_on 'cairo'
-  depends_on 'libsigcplusplus'
+  depends_on 'libsigcplusplus3'
   depends_on 'libxxf86vm'
   depends_on 'libxrender'
   depends_on 'gcc7' => :build


### PR DESCRIPTION
The dependency libsigcplusplus (sigc++-3.0) will be renamed to libsigcplusplus3
#2180 
