### PR TITLE
[glibmm] Recompile using gcc-4.9.4

### DIFF
--- a/packages/glibmm.rb
+++ b/packages/glibmm.rb
@@ -3,26 +3,25 @@ require 'package'
 class Glibmm < Package
   description 'Glibmm package is a set of C++ bindings for GLib'
   homepage 'https://www.gtkmm.org/en/'
-  version '2.56.0'
+  version '2.56.0-0'
   source_url 'https://ftp.gnome.org/pub/gnome/sources/glibmm/2.56/glibmm-2.56.0.tar.xz'
   source_sha256 '6e74fcba0d245451c58fc8a196e9d103789bc510e1eee1a9b1e816c5209e79a9'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '0da9d1c303e930b3032ef6a341074990a7b3a2150807bb23b4d58fb040d6239e',
-     armv7l: '0da9d1c303e930b3032ef6a341074990a7b3a2150807bb23b4d58fb040d6239e',
-       i686: '33f2ee3459c31930ba5fb2ba926fb1b9df57ccf3573a356bc1ba0cf4717157e1',
-     x86_64: 'ff20a28d6d3cbd4267bc442d774be4b7ddcd4e48f252d9974d598ee1e93fee82',
+    aarch64: '734ea5bce78ffef9ad52a2d7503b55b2bb47cbe743142c371ac68cb543df4343',
+     armv7l: '734ea5bce78ffef9ad52a2d7503b55b2bb47cbe743142c371ac68cb543df4343',
+       i686: 'c88a048055070b1c14c296f49eb20333a6ffe4a8e4c37fdab06990fd798b6b87',
+     x86_64: '3c30713258dd4972d7118024d44e09f87e1eeea466dfc4b72cb5bb8ea19347bc',
   })
 
   depends_on 'glib'
   depends_on 'libsigcplusplus' # sigc++-2.0
-  depends_on 'libsigcplusplus3' # sigc++-3.0
   depends_on 'mm_common' => :build
 
   def self.build


### PR DESCRIPTION
Recompile using gcc-4.9.4 instead of gcc-7.3.0

linking together two C++ object files built by different major releases of gcc has never been guaranteed to work. 

see [https://forums.gentoo.org/viewtopic-t-1015870-start-0.html](https://forums.gentoo.org/viewtopic-t-1015870-start-0.html
)