### PR TITLE
Fix armadillo package

### DIFF
--- a/packages/armadillo.rb
+++ b/packages/armadillo.rb
@@ -21,7 +21,6 @@ class Armadillo < Package
   def self.install
     system "make",
            "DESTDIR=#{CREW_DEST_DIR}",
-           "LIBDIR=#{CREW_LIB_PREFIX}",
            "install"
   end
 

--- a/packages/armadillo.rb
+++ b/packages/armadillo.rb
@@ -8,17 +8,21 @@ class Armadillo < Package
   source_url 'https://downloads.sourceforge.net/project/arma/armadillo-8.400.0.tar.xz'
   source_sha256 '5cb6bc2f457a9d6a0758cfb15c418d48289909daccd79d0e428452029285dd9b'
 
+  depends_on 'cmake' => :build
   depends_on 'openblas'
 
   def self.build
     system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+           "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+           "-DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX}"
     system "make"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "make",
+           "DESTDIR=#{CREW_DEST_DIR}",
+           "LIBDIR=#{CREW_LIB_PREFIX}",
+           "install"
   end
 
 end


### PR DESCRIPTION
## Description

Adds `cmake` as a build dependency and fixes install paths.

## Addtional information

Works properly:
- [x] x86_64
- [ ] aarch64 (reasons why it doesn't)
