### PR TITLE
Clarify prereqs.  Wiki just gets you in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ Chromebooks with Chrome OS run a Linux kernel. The only missing pieces to use th
 Prerequisites
 -------------
 
-You will need a Chromebook with developer mode enabled.
+You will need a Chromebook with developer mode enabled.  To do so, select your device on
+[the ChromiumOS Wiki](https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices) and follow the instructions listed there.
 
-On [the ChromiumOS Wiki](https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices) select your device and follow the instructions listed there.
-
-Please be aware of the fact that developer mode is insecure if not properly configured.
+Please be aware of the fact that developer mode is insecure if not properly configured. Setting a password as instructed in the VT-2 login screen is essential.
 
 Installation
 ------------


### PR DESCRIPTION
When I read the Prerequisites in the README.md the first time, I didn't see anything on the given wiki page telling me anything about crew, so I felt lost. Finally I realized that although the instruction to visit the wiki was in a separate paragraph from the one above which had already said I needed to be in dev mod, it didn't expect me to have already gotten in to dev mode, and was sending me to the wiki to do so.

So I've simply rephrased the README.md in order to help people know what they're looking for on the wiki.
I also gave at least one hint on what is needed for security in dev mode. That could and should be expanded somewhere but I don't know of a good source yet.