### PR TITLE
Add used disk space to the files command

### DIFF
--- a/crew
+++ b/crew
@@ -234,7 +234,7 @@ def files (pkgName)
   if File.exists? "#{filelist}"
     system "sort #{filelist}"
     lines = `wc -l "#{filelist}"`.strip.split(' ')[0].to_i
-    size = `du -ch $file_list | tail -1 | cut -f 1`
+    size = `du -ch $(cat #{filelist}) | tail -1 | cut -f 1`
     puts "Total found: #{lines}".lightgreen
     puts "Total disk space used by #{pkgName}: #{size}".lightgreen
   else

--- a/crew
+++ b/crew
@@ -236,7 +236,7 @@ def files (pkgName)
     lines = `wc -l "#{filelist}"`.strip.split(' ')[0].to_i
     size = `du -ch $(cat #{filelist}) | tail -1 | cut -f 1`
     puts "Total found: #{lines}".lightgreen
-    puts "Total disk space used by #{pkgName}: #{size}".lightgreen
+    puts "Disk usage: #{size}".lightgreen
   else
     puts "Package #{pkgName} is not installed. :(".lightred
   end

--- a/crew
+++ b/crew
@@ -234,7 +234,9 @@ def files (pkgName)
   if File.exists? "#{filelist}"
     system "sort #{filelist}"
     lines = `wc -l "#{filelist}"`.strip.split(' ')[0].to_i
+    size = `du -ch $file_list | tail -1 | cut -f 1`
     puts "Total found: #{lines}".lightgreen
+    puts "Total disk space used by #{pkgName}: #{size}".lightgreen
   else
     puts "Package #{pkgName} is not installed. :(".lightred
   end


### PR DESCRIPTION
Following this issue, https://github.com/skycocker/chromebrew/issues/2145

@uberhacker proposed that we add a line that shows the disk space used by the package that we call using `crew file <package>`