### PR TITLE
Add alive package

### DIFF
--- a/packages/alive.rb
+++ b/packages/alive.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Alive < Package
+  description 'Automatic login and keep-alive utility for Internet connections.'
+  homepage 'https://www.gnu.org/software/alive/'
+  version '2.0.2'
+  source_url 'https://ftpmirror.gnu.org/alive/alive-2.0.2.tar.xz'
+  source_sha256 '120dd9ef361833623be353ad8cfac585abae51a16fedd3a84f1d99a842793fef'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'guile'
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
GNU Alive is a periodic ping program. It functions similarly to ‘ping -n -i PERIOD HOST’ (so if you are comfortable typing that at a shell prompt you probably do not need GNU Alive).  See https://www.gnu.org/software/alive/.