### PR TITLE
[crew] remove *.la during compilation

### DIFF
--- a/crew
+++ b/crew
@@ -439,12 +439,12 @@ def build_and_preconfigure (target_dir)
     # Remove /usr/local/lib64/*.la to resolve any "can not find /usr/local/*.la" compile errors when building the packages (only needed for x86_64).
     # https://gnunet.org/faq-la-files
     # https://stackoverflow.com/questions/42963653/libquadmath-la-is-not-a-valid-libtool-archive-when-configuring-openmpi-with-g
-    if ARCH == 'x86_64'
-      if @opt_verbose then
-        system "rm -rvf #{CREW_LIB_PREFIX}/*.la"
-      else
-        system "rm -rf #{CREW_LIB_PREFIX}/*.la"
-      end
+    
+    # Since pkgconfig is recompiled, the *.la problem appear also for i686 and armv7l. Remove any .la files to resolve it.
+    if @opt_verbose then
+      system "rm -rvf #{CREW_LIB_PREFIX}/*.la"
+    else
+      system "rm -rf #{CREW_LIB_PREFIX}/*.la"
     end
     @pkg.in_build = true
     @pkg.preinstall


### PR DESCRIPTION
Since last update of pkgconfig. The problem mainly for x86_64 (can not find /usr/local/lib(64)/*.la) appears also for i686 and armv7l. Removing these files resolves it.