### PR TITLE
add unified xor protocols and recompile the related packages

### DIFF
--- a/packages/libdmx.rb
+++ b/packages/libdmx.rb
@@ -3,25 +3,23 @@ require 'package'
 class Libdmx < Package
   description 'X.org X Window System DMX (Distributed Multihead X) extension library'
   homepage 'http://www.x.org'
-  version '1.1.3'
+  version '1.1.3-0'
   source_url 'https://www.x.org/archive/individual/lib/libdmx-1.1.3.tar.gz'
   source_sha256 'c4b24d7e13e5a67ead7a18f0b4cc9b7b5363c9d04cd01b83b5122ff92b3b4996'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libdmx-1.1.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libdmx-1.1.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libdmx-1.1.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libdmx-1.1.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libdmx-1.1.3-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libdmx-1.1.3-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libdmx-1.1.3-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libdmx-1.1.3-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '78e8c7ea5d24310a372b6162d1ed559a52e7cb9886f3f76b36d7ff79f0c923f2',
-     armv7l: '78e8c7ea5d24310a372b6162d1ed559a52e7cb9886f3f76b36d7ff79f0c923f2',
-       i686: '021346d67ea742eaa4bb33e972bd8d428f08441b7d222f9154f6ca2321eb6a6f',
-     x86_64: '947c4cef27723aeb3bdebbdf2430b3282399c5bfa3001d0f733a07cf53623829',
+    aarch64: 'ac58dc16bc412a006f1c83d8c9ef3c0d6bba2fd0563165afab785f3754b15908',
+     armv7l: 'ac58dc16bc412a006f1c83d8c9ef3c0d6bba2fd0563165afab785f3754b15908',
+       i686: 'c943c38df5f29ba6f10e4c215437277b60be511da23e536292ef219971be8522',
+     x86_64: 'afefd087d3752574ab61951788c05452944239c1b797753381c69ffb88a93e13',
   })
 
-  depends_on 'xextproto'
-  depends_on 'dmxproto'
   depends_on 'libxext'
   depends_on 'libx11'
   

--- a/packages/libfs.rb
+++ b/packages/libfs.rb
@@ -3,27 +3,26 @@ require 'package'
 class Libfs < Package
   description 'X.org library interface to the X Font Server.'
   homepage 'http://www.x.org'
-  version '1.0.7'
+  version '1.0.7-0'
   source_url 'https://www.x.org/archive/individual/lib/libFS-1.0.7.tar.gz'
   source_sha256 '91bf1c5ce4115b7dbf4e314fdbee54052708e8f7b6a2ec6e82c309bcbe40ef3d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libfs-1.0.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libfs-1.0.7-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libfs-1.0.7-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libfs-1.0.7-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libfs-1.0.7-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libfs-1.0.7-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libfs-1.0.7-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libfs-1.0.7-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f6c1e8ecfddad8ccff8277b6b252965afd7275e99c3e86f2bdb20d39272fc134',
-     armv7l: 'f6c1e8ecfddad8ccff8277b6b252965afd7275e99c3e86f2bdb20d39272fc134',
-       i686: '3e54b814e5b9d208a48b4ac097076d0f956b32943ac2f45da5ac551934ba7f42',
-     x86_64: '1092805d6bada562543bc23fb5395d675c6a9c00cba4387ba7f97b42df0d9463',
+    aarch64: '70879f9509e6c33cc7377706e251e53397c772c6ab1d59ffec7370bd6f247eb2',
+     armv7l: '70879f9509e6c33cc7377706e251e53397c772c6ab1d59ffec7370bd6f247eb2',
+       i686: 'b287f1ae9e043b83b14aa54e23f4abe3b9f10760316e41cedf994be2e1e72a52',
+     x86_64: '98f7cc48a3a2406ea1d110b051b3f18f5682b2096cfdb7f4f4f9c4b2255f2f42',
   })
 
-  depends_on 'xproto'
-  depends_on 'fontsproto'
+
+  depends_on 'xorg_proto'
   depends_on 'libxtrans'
-  depends_on 'util_macros'
   
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libice.rb
+++ b/packages/libice.rb
@@ -3,27 +3,26 @@ require 'package'
 class Libice < Package
   description 'X.org X Inter Client Exchange Library'
   homepage 'http://www.x.org'
-  version '1.0.9'
+  version '1.0.9-0'
   source_url 'https://www.x.org/archive/individual/lib/libICE-1.0.9.tar.gz'
   source_sha256 '7812a824a66dd654c830d21982749b3b563d9c2dfe0b88b203cefc14a891edc0'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libice-1.0.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libice-1.0.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libice-1.0.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libice-1.0.9-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libice-1.0.9-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libice-1.0.9-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libice-1.0.9-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libice-1.0.9-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '8ff70756004cfc0d6ac843083989eadae6a34c2545e683e62fb4e2b07e547b4a',
-     armv7l: '8ff70756004cfc0d6ac843083989eadae6a34c2545e683e62fb4e2b07e547b4a',
-       i686: 'f78ca2bc72fa4ae1357c82949e5c5d82cae5cb1b2df43a7832b8d7bc7bb48a78',
-     x86_64: 'd65e2c73d6aaecede6d2df5d74e481f36bcf8e896e6b7f813fca7447316e3e71',
+    aarch64: '9950466b86446a797a1331d6778a5d339af17960cad8c2c9a8e5a038c63c5b57',
+     armv7l: '9950466b86446a797a1331d6778a5d339af17960cad8c2c9a8e5a038c63c5b57',
+       i686: 'b5591b7c29b39dc1490481990590ca062f62ca717a0decdd342f8b1ce62a7145',
+     x86_64: 'f12df0a9802c23816595d13ddaa15ca46727b9ace7c7f57ede4cdbcc1ecbd8f8',
   })
 
-  depends_on 'xproto'
   depends_on 'libxtrans'
-  depends_on 'util_macros'  
   depends_on 'libx11'
+  depends_on 'libbsd'
   
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libx11.rb
+++ b/packages/libx11.rb
@@ -3,28 +3,25 @@ require 'package'
 class Libx11 < Package
   description 'C interface to the X window system'
   homepage 'https://x.org'
-  version '1.6.5-0'
+  version '1.6.5-1'
   source_url 'https://www.x.org/archive/individual/lib/libX11-1.6.5.tar.gz'
   source_sha256 '3abce972ba62620611fab5b404dafb852da3da54e7c287831c30863011d28fb3'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'fb45a99ab1b5f04df4bcca139ce7f2f82118a4ae3aeb4c45e22b7aff88a44fea',
-     armv7l: 'fb45a99ab1b5f04df4bcca139ce7f2f82118a4ae3aeb4c45e22b7aff88a44fea',
-       i686: '6305ea62f76ebe2ab3a1e70182929309a08ef19681f1edf07fe9383d3efb073e',
-     x86_64: '8728fdd9b7282e4aae047ade6efe162ac6a3f6c851c5c23bae5f93fcd17d40ec',
+    aarch64: 'ff6bc290a58bee7558e7a02e587e7820b6b376d8c33254eac18e63e157c3365b',
+     armv7l: 'ff6bc290a58bee7558e7a02e587e7820b6b376d8c33254eac18e63e157c3365b',
+       i686: '0c90a7c81ef29662eab897399bd3fb7f49b7d933e2a97abe8a762e21b3eaa5c4',
+     x86_64: '566173764c75b30509d33f16efb13d59244a79274b5af833b17a2e1483e26e97',
   })
 
-  depends_on 'kbproto'
+  depends_on 'xorg_proto'
   depends_on 'libxcb'
-  depends_on 'xproto'
-  depends_on 'inputproto'
-  depends_on 'xextproto'
   depends_on 'libxtrans'
   
   def self.build

--- a/packages/libxau.rb
+++ b/packages/libxau.rb
@@ -3,24 +3,24 @@ require 'package'
 class Libxau < Package
   description 'xau library for libX11'
   homepage 'https://x.org'
-  version '1.0.8-0'
+  version '1.0.8-1'
   source_url 'https://www.x.org/archive/individual/lib/libXau-1.0.8.tar.gz'
   source_sha256 'c343b4ef66d66a6b3e0e27aa46b37ad5cab0f11a5c565eafb4a1c7590bc71d7b'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '2a74fc3599a7b3fffb1bf7162f21180bc605577c0b321ccf5c2c80fb9ccd8ee6',
-     armv7l: '2a74fc3599a7b3fffb1bf7162f21180bc605577c0b321ccf5c2c80fb9ccd8ee6',
-       i686: 'ffae80264a076163bd87e1d58f84987f10889eee72899b35ab0f7645457120f7',
-     x86_64: 'ddd472d59b42ef0ec6b8103d4e1b3293e31a6c2a81d900f7292fe052c151ac4c',
+    aarch64: 'cddb13bfb9a81cfe5990cf1dd807c78951262bb3c2d5b8d5341da6b491d379e9',
+     armv7l: 'cddb13bfb9a81cfe5990cf1dd807c78951262bb3c2d5b8d5341da6b491d379e9',
+       i686: 'd902285f810cf1eff4bedcbd344c77997ec39631179c1d3ae2192458d58b44c8',
+     x86_64: '199a18b19af06eababe37e01a9308c11726bb6415613cc4ffde38631eaad8269',
   })
   
-  depends_on 'xproto'
+  depends_on 'xorg_proto'
   
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libxcomposite.rb
+++ b/packages/libxcomposite.rb
@@ -3,28 +3,26 @@ require 'package'
 class Libxcomposite < Package
   description 'X.org X Composite Library'
   homepage 'http://www.x.org'
-  version '0.4.4'
+  version '0.4.4-0'
   source_url 'https://www.x.org/archive/individual/lib/libXcomposite-0.4.4.tar.gz'
   source_sha256 '83c04649819c6f52cda1b0ce8bcdcc48ad8618428ad803fb07f20b802f1bdad1'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcomposite-0.4.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxcomposite-0.4.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxcomposite-0.4.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcomposite-0.4.4-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcomposite-0.4.4-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxcomposite-0.4.4-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxcomposite-0.4.4-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcomposite-0.4.4-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '00bd04423ca18062801954d921ca5a5bec6f20bf19a3b1bf565131b68348e3e4',
-     armv7l: '00bd04423ca18062801954d921ca5a5bec6f20bf19a3b1bf565131b68348e3e4',
-       i686: 'acd307b13fe243b4337563051594cb80c899c42ffcd02458a4816604075358bb',
-     x86_64: '6d241e46fa5e691da0d14978277a8ae64daffd0eafdb63655d19925cf4e33093',
+    aarch64: '51fed1a509655b6ec0519cb794a76d88ad32a8101afe229f1fc61447c795524b',
+     armv7l: '51fed1a509655b6ec0519cb794a76d88ad32a8101afe229f1fc61447c795524b',
+       i686: 'e19d057513a36b18d11e0dc581dadb8df326ec9544faec0bc52c1345cd422e79',
+     x86_64: '98e5446890fee2b29f9d214c683216a9a1611776b2e408d0143773477bf94c50',
   })
 
-  depends_on 'compositeproto'
-  depends_on 'fixesproto'
+
   depends_on 'libxfixes'
   depends_on 'libxext'
-  depends_on 'util_macros'
   
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libxcursor.rb
+++ b/packages/libxcursor.rb
@@ -3,27 +3,25 @@ require 'package'
 class Libxcursor < Package
   description 'X.org X Cursor management library'
   homepage 'http://www.x.org'
-  version '1.1.15'
+  version '1.1.15-0'
   source_url 'https://www.x.org/archive/individual/lib/libXcursor-1.1.15.tar.gz'
   source_sha256 '449befea2b11dde58ba3323b2c1ec30550013bd84d80501eb56d0048e62251a1'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcursor-1.1.15-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxcursor-1.1.15-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxcursor-1.1.15-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcursor-1.1.15-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcursor-1.1.15-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxcursor-1.1.15-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxcursor-1.1.15-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcursor-1.1.15-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bf39ec0fd945b6617bb38bd88bbd4b834df8bb6996de7bff8710a7df7d4b6e4a',
-     armv7l: 'bf39ec0fd945b6617bb38bd88bbd4b834df8bb6996de7bff8710a7df7d4b6e4a',
-       i686: 'd723ebdb2178a4d48c626ac061550efa62f2282496d740d7e93c263d2f77e222',
-     x86_64: 'bf3d0f82c0a72818877362124a2039baff3fa5fa24d571c2293227c52d9db821',
+    aarch64: '6f13dd900d180de34d5fa91feae0d2e388f5f3b851df96dc0652918c765b7ee9',
+     armv7l: '6f13dd900d180de34d5fa91feae0d2e388f5f3b851df96dc0652918c765b7ee9',
+       i686: 'a7e936b74307fc50916d1b50328ba1424f61ae6a7535bad579dd325a92626294',
+     x86_64: 'a8749cfe441d3facd5c1c9a6feabe3e764e7e630d4687ececd83a15fff59e2de',
   })
 
-  depends_on 'fixesproto'
   depends_on 'libxrender'
   depends_on 'libxfixes'
-  depends_on 'util_macros'
   
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libxdamage.rb
+++ b/packages/libxdamage.rb
@@ -3,28 +3,26 @@ require 'package'
 class Libxdamage < Package
   description 'library for the X window system'
   homepage 'https://x.org'
-  version '1.1.4-0'
+  version '1.1.4-1'
   source_url 'https://www.x.org/archive/individual/lib/libXdamage-1.1.4.tar.gz'
   source_sha256 '4bb3e9d917f5f593df2277d452926ee6ad96de7b7cd1017cbcf4579fe5d3442b'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdamage-1.1.4-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxdamage-1.1.4-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxdamage-1.1.4-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdamage-1.1.4-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdamage-1.1.4-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxdamage-1.1.4-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxdamage-1.1.4-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdamage-1.1.4-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '52d8da8a4f1cc00f749a464380949d754fe7f8ce41c70a808c031b93a239d462',
-     armv7l: '52d8da8a4f1cc00f749a464380949d754fe7f8ce41c70a808c031b93a239d462',
-       i686: '20f49056f9a39a1b0c08d760c44f1b3ca8bad1b572b0c67b475f0e0b36d4a5d8',
-     x86_64: '4f1552b42c293b8a7282ed13f45bdd9407d113d261aab337bbca75a5f411fe5d',
+    aarch64: 'efd0c9702116e4aec5cf5474d9b7d8e838baaf2c1b5990e4ad48290085f2b42d',
+     armv7l: 'efd0c9702116e4aec5cf5474d9b7d8e838baaf2c1b5990e4ad48290085f2b42d',
+       i686: '56d02bc914ca1fd84986ab5fbc00e63c7f704985d291ef52ef03358c51b67883',
+     x86_64: 'ec0c7da854f939617bb29730726f7488a0df1cc0bfb4fd96cbdf6e257890f678',
   })
 
-  depends_on 'fixesproto'
   depends_on 'libxfixes'
-  depends_on 'xextproto'
   depends_on 'libx11'
-  depends_on 'damageproto'
+
 
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libxdmcp.rb
+++ b/packages/libxdmcp.rb
@@ -3,25 +3,25 @@ require 'package'
 class Libxdmcp < Package
   description 'The libXdmcp package contains a library implementing the X Display Manager Control Protocol.'
   homepage 'http://www.x.org'
-  version '1.1.2'
+  version '1.1.2-0'
   source_url 'https://www.x.org/pub/individual/lib/libXdmcp-1.1.2.tar.bz2'
   source_sha256 '81fe09867918fff258296e1e1e159f0dc639cb30d201c53519f25ab73af4e4e2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.2-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.2-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.2-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.2-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '795e6e9328928a824a725ad550aab351ab19812f3fd00344d74fca77a62a8a33',
-     armv7l: '795e6e9328928a824a725ad550aab351ab19812f3fd00344d74fca77a62a8a33',
-       i686: '76f300b165fa8d983ea60b3f37e7bec53fdbae45ae1937776de388883e7aac1e',
-     x86_64: 'b486612a4ef87e4d1b13d0c914dd4df7a5e09d4e1267e3eec30e965372ae5830',
+    aarch64: '409aa7e74743cd1ac2bc619bba6b6890a59d9e15c591ab8d548ddf7991354e1f',
+     armv7l: '409aa7e74743cd1ac2bc619bba6b6890a59d9e15c591ab8d548ddf7991354e1f',
+       i686: 'bb5fef68c987cca02dd84eb1cccf9f30598522b4932739f39d6126e2446c1179',
+     x86_64: 'b9b1a87572a321a7ff1be4bcb9c20b25c67b4a80fb5fe8867d0f24d29ecce5ae',
   })
 
-  depends_on "util_macros" => :build
-  depends_on "xproto" => :build
+  depends_on "util_macros"
+  depends_on "xorg_proto"
 
 
   def self.build

--- a/packages/libxfixes.rb
+++ b/packages/libxfixes.rb
@@ -3,26 +3,23 @@ require 'package'
 class Libxfixes < Package
   description 'library for the X window system'
   homepage 'https://x.org'
-  version '5.0.3-0'
+  version '5.0.3-1'
   source_url 'https://www.x.org/archive/individual/lib/libXfixes-5.0.3.tar.gz'
   source_sha256 '9ab6c13590658501ce4bd965a8a5d32ba4d8b3bb39a5a5bc9901edffc5666570'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfixes-5.0.3-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxfixes-5.0.3-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxfixes-5.0.3-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfixes-5.0.3-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfixes-5.0.3-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxfixes-5.0.3-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxfixes-5.0.3-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfixes-5.0.3-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '46dba76831c0ff2458b76022c57c9c123340915c2126b70aad6a7d031c82a35e',
-     armv7l: '46dba76831c0ff2458b76022c57c9c123340915c2126b70aad6a7d031c82a35e',
-       i686: '0b20661456a881be0f0ac34833b096cec7c32355fbc4db0594014ba8af7ba34c',
-     x86_64: 'a4d50d68f16ed1937fdfc8ee693c5dd8fac28050673da9834f97fba472449bab',
+    aarch64: '053fad492759a5dd5df72239a28416fa93e64f84ebc49e26ce1a410924345463',
+     armv7l: '053fad492759a5dd5df72239a28416fa93e64f84ebc49e26ce1a410924345463',
+       i686: '0ee965d91984d4aceff29cc3859cff2d1c1df3badf824cbe09c350004e367873',
+     x86_64: '7c1ea8c44eceafccacbbb99b7ffceb641aec47d063e5f4cd65b44defc1b721e8',
   })
 
-  depends_on 'fixesproto'
-  depends_on 'xproto'
-  depends_on 'xextproto'
   depends_on 'libx11'
   
   def self.build

--- a/packages/libxi.rb
+++ b/packages/libxi.rb
@@ -3,26 +3,24 @@ require 'package'
 class Libxi < Package
   description 'X.org libXi Client library for XInput'
   homepage 'https://x.org'
-  version '1.7.9'
+  version '1.7.9-0'
   source_url 'https://github.com/mirror/libXi/archive/libXi-1.7.9.tar.gz'
   source_sha256 'e3bc48654d4c21ac37592e8b41c87a5de73872a243e7b0fb39ebd565be5b943d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxi-1.7.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxi-1.7.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxi-1.7.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxi-1.7.9-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxi-1.7.9-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxi-1.7.9-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxi-1.7.9-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxi-1.7.9-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '7ae20037aa3d29612005e7ebca7770436896683963f6d063e99a8000ad7a5eed',
-     armv7l: '7ae20037aa3d29612005e7ebca7770436896683963f6d063e99a8000ad7a5eed',
-       i686: '3085dc4c94ece39623fb922b2d72a6eeefc1213578d24fe7197b4a86e386c0bc',
-     x86_64: '45f5b9b930badb56fab199c94bc7ba69eb4a32c07413a930f498ecc3047199d6',
+    aarch64: 'ce61bfb13daa4fb6d8a5ee3afb84c46251e807e78a874a21cb229b4bc3206dcd',
+     armv7l: 'ce61bfb13daa4fb6d8a5ee3afb84c46251e807e78a874a21cb229b4bc3206dcd',
+       i686: 'da26d60e3bc75d9e6a61f3e15954dd68084f695a0d879fe1ff197d78c409ce6f',
+     x86_64: '6bdce3e377a8e7a96b3a606d5c1e64bb251ed5763e2a7b167008c978041e5bc9',
   })
 
-  depends_on 'automake' => :build
   depends_on 'libx11'
-  depends_on 'util_macros'
 
   def self.build
     system "./autogen.sh"

--- a/packages/libxrandr.rb
+++ b/packages/libxrandr.rb
@@ -3,25 +3,24 @@ require 'package'
 class Libxrandr < Package
   description 'X.org X Resize, Rotate and Reflection extension library'
   homepage 'http://www.x.org'
-  version '1.5.1'
+  version '1.5.1-0'
   source_url 'https://www.x.org/archive/individual/lib/libXrandr-1.5.1.tar.gz'
   source_sha256 '2baa7fb3eca78fe7e11a09b373ba898b717f7eeba4a4bfd68187e04b4789b0d3'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxrandr-1.5.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxrandr-1.5.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxrandr-1.5.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxrandr-1.5.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxrandr-1.5.1-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxrandr-1.5.1-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxrandr-1.5.1-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxrandr-1.5.1-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'ce4a37a03adeeea36096c183113824de7178a1c7c5511d706c5f789485640676',
-     armv7l: 'ce4a37a03adeeea36096c183113824de7178a1c7c5511d706c5f789485640676',
-       i686: '48dbeb74bd37f378f292b3fd027698d0d66ffff7c3e54c7e3efa57f288970b34',
-     x86_64: 'fb19adcd935509790fccff7b874204240cf70b91ed67b60d2ea2eb5aeeb65a13',
+    aarch64: 'e5c828eb0ab26b68b7e3dccbb8d786267230584cbf8f33593796e20349895147',
+     armv7l: 'e5c828eb0ab26b68b7e3dccbb8d786267230584cbf8f33593796e20349895147',
+       i686: 'a488a6f27c2670310d7f144409a5657d8271e42a23f0bc578112615c706f16a0',
+     x86_64: '6a37502061445761f860acefaddd5bf06b7c64b4b5e468f4e3902e67baaef05e',
   })
 
   depends_on 'libxrender'
-  depends_on 'randrproto'
   depends_on 'libx11'
    
   def self.build

--- a/packages/libxrender.rb
+++ b/packages/libxrender.rb
@@ -3,25 +3,23 @@ require 'package'
 class Libxrender < Package
   description 'X Rendering Extension client library.'
   homepage 'http://www.x.org'
-  version '0.9.10'
+  version '0.9.10-0'
   source_url 'https://www.x.org/releases/individual/lib/libXrender-0.9.10.tar.gz'
   source_sha256 '770527cce42500790433df84ec3521e8bf095dfe5079454a92236494ab296adf'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxrender-0.9.10-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxrender-0.9.10-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxrender-0.9.10-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxrender-0.9.10-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxrender-0.9.10-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxrender-0.9.10-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxrender-0.9.10-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxrender-0.9.10-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '302d54a2e3501ae6372cc41fd4f3db01f80d36ca133f2f20b63d99a368a60fd2',
-     armv7l: '302d54a2e3501ae6372cc41fd4f3db01f80d36ca133f2f20b63d99a368a60fd2',
-       i686: 'ccfc71a3d277ceda7392415c7aaa85df0aa89e738e7238d03700fbd5a8f9b6ac',
-     x86_64: 'c696771f631a598591a1f26ad714271ffc6d516d5cba119c17e06574e8bd6ec7',
+    aarch64: 'f6a33f234184d2dae8646449940234d749deefffb7148a141ac09a402a054e22',
+     armv7l: 'f6a33f234184d2dae8646449940234d749deefffb7148a141ac09a402a054e22',
+       i686: '883bce06a7813a3640258c2d1f9f81bac128330a34726691d8c5e76959525e40',
+     x86_64: '561c5a0e8f4b0cd4d9b7e1f7c2b53901e687d3be91e0dfdcb93f3c2184f61dbc',
   })
 
-  depends_on 'pkgconfig' => :build
-  depends_on 'renderproto'
   depends_on 'libx11'
 
   def self.build

--- a/packages/libxres.rb
+++ b/packages/libxres.rb
@@ -3,25 +3,24 @@ require 'package'
 class Libxres < Package
   description 'X.org X-Resource extension client library'
   homepage 'http://www.x.org'
-  version '1.2.0'
+  version '1.2.0-0'
   source_url 'https://www.x.org/archive/individual/lib/libXres-1.2.0.tar.gz'
   source_sha256 '5b62feee09f276d74054787df030fceb41034de84174abec6d81c591145e043a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxres-1.2.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxres-1.2.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxres-1.2.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxres-1.2.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxres-1.2.0-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxres-1.2.0-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxres-1.2.0-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxres-1.2.0-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '64bdfcb01f7beb55c24020aa027d93c7423e849402434069860a11464526c82e',
-     armv7l: '64bdfcb01f7beb55c24020aa027d93c7423e849402434069860a11464526c82e',
-       i686: '8d062a5ca2f946ec4fa9fea1f5f92a0baa48acecf1a7e68af4ca140237e6b1fa',
-     x86_64: '7f2546d9a4670bc694f0155a0c89aef6f2aaa74d09e022ac512c8900d340dfad',
+    aarch64: 'd6de2abe84e9f020add008da76bdb2e35e98438d799f64c3f8cf93df39a0319c',
+     armv7l: 'd6de2abe84e9f020add008da76bdb2e35e98438d799f64c3f8cf93df39a0319c',
+       i686: '042a57a7fbc0ce1c3f07c76f2a0a3bd3009f8f8e5b3c8c346fa87eed38fa051e',
+     x86_64: '4c765244df508377ed52517cb56a572a76b319b68e9bb88074870f1530f922d1',
   })
 
   depends_on 'libxext'
-  depends_on 'resourceproto'
   depends_on 'libx11'
   
   def self.build

--- a/packages/libxscrnsaver.rb
+++ b/packages/libxscrnsaver.rb
@@ -3,27 +3,25 @@ require 'package'
 class Libxscrnsaver < Package
   description 'X.org the X11 Screen Saver extension client library'
   homepage 'http://www.x.org'
-  version '1.2.2'
+  version '1.2.2-0'
   source_url 'https://www.x.org/archive//individual/lib/libXScrnSaver-1.2.2.tar.gz'
   source_sha256 'e12ba814d44f7b58534c0d8521e2d4574f7bf2787da405de4341c3b9f4cc8d96'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxscrnsaver-1.2.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxscrnsaver-1.2.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxscrnsaver-1.2.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxscrnsaver-1.2.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxscrnsaver-1.2.2-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxscrnsaver-1.2.2-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxscrnsaver-1.2.2-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxscrnsaver-1.2.2-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'e9e071ec1e54fee2879ed3fd5388f5e510812f0e7593efdeeaa407df96bcec70',
-     armv7l: 'e9e071ec1e54fee2879ed3fd5388f5e510812f0e7593efdeeaa407df96bcec70',
-       i686: 'df9518c09b515b59d34361ee293d21b8593d5565b0571920503689e2dfa30d1f',
-     x86_64: '9c4d17416463a70659c83f143de43a15cd867c3af57c234b882987d79f30a06d',
+    aarch64: '43bdc049d82141406115751ad9afc49521833fa777a8a693f2f1aaebedc04ccc',
+     armv7l: '43bdc049d82141406115751ad9afc49521833fa777a8a693f2f1aaebedc04ccc',
+       i686: '1f71684bc973876d66354aae4c9942d706fee619995b47d67bfa38528aca6ca0',
+     x86_64: '74dfe48f8e6375d8d45996b645a8cb5b82fb57253580840ef5461f6c60239a7f',
   })
 
   depends_on 'libx11'
   depends_on 'libxext'
-  depends_on 'xextproto'
-  depends_on 'scrnsaverproto'
   
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libxt.rb
+++ b/packages/libxt.rb
@@ -3,27 +3,25 @@ require 'package'
 class Libxt < Package
   description 'X.org X Toolkit Library'
   homepage 'http://www.x.org'
-  version '1.1.5'
+  version '1.1.5-0'
   source_url 'https://www.x.org/archive/individual/lib/libXt-1.1.5.tar.gz'
   source_sha256 'b59bee38a9935565fa49dc1bfe84cb30173e2e07e1dcdf801430d4b54eb0caa3'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxt-1.1.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxt-1.1.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxt-1.1.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxt-1.1.5-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxt-1.1.5-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxt-1.1.5-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxt-1.1.5-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxt-1.1.5-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'ee8648d4f454ef7fa606d52ed8d2cce97c5e3abff2dcfd74a12b873b41cf9bea',
-     armv7l: 'ee8648d4f454ef7fa606d52ed8d2cce97c5e3abff2dcfd74a12b873b41cf9bea',
-       i686: 'e14ffe76c72168b6221571cb0346ff9e067f3715c083772bb4fa2dd609b88162',
-     x86_64: '0b177148872f51a9e26cdb188c745600034d455c42a6efb151fbd5816e86dabc',
+    aarch64: '168593f2dd1628c1816c4504beec2fc997932b28b1fc0e2ddb9043d1400f5523',
+     armv7l: '168593f2dd1628c1816c4504beec2fc997932b28b1fc0e2ddb9043d1400f5523',
+       i686: '70220d5f6b186bf700907b8b2a92665608f24944dfab22cc9b077a3dd6b18437',
+     x86_64: 'ccc5cd728842864ab67d48a85420ba8eb05c19d3a1beb9a5e6ac473ed7a5c9e0',
   })
 
-  depends_on 'kbproto'
   depends_on 'libsm'
   depends_on 'libx11'
-  depends_on 'util_macros'  
   
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libxv.rb
+++ b/packages/libxv.rb
@@ -3,27 +3,25 @@ require 'package'
 class Libxv < Package
   description 'X.org X Window System video extension library'
   homepage 'http://www.x.org'
-  version '1.0.11'
+  version '1.0.11-0'
   source_url 'https://www.x.org/archive/individual/lib/libXv-1.0.11.tar.gz'
   source_sha256 'c4112532889b210e21cf05f46f0f2f8354ff7e1b58061e12d7a76c95c0d47bb1'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxv-1.0.11-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxv-1.0.11-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxv-1.0.11-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxv-1.0.11-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxv-1.0.11-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxv-1.0.11-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxv-1.0.11-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxv-1.0.11-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'de4608c1e342f9fc192238daccbc75ec33e777bf0a618d196dca079cbe079a63',
-     armv7l: 'de4608c1e342f9fc192238daccbc75ec33e777bf0a618d196dca079cbe079a63',
-       i686: '50fd60825ca1d54958153c0a68d5595a040c15d8d4ad3b84edb0511da0d5a9ed',
-     x86_64: '9b7da69a2936fdc07509824391a795840f7c2bc77b7b8b7de32f7a51a0232c21',
+    aarch64: '23314bc66eeaa5e85199bebc283053bcb0de85d9361b4f2a98fa673982f11295',
+     armv7l: '23314bc66eeaa5e85199bebc283053bcb0de85d9361b4f2a98fa673982f11295',
+       i686: '09c4a2428a623c2c81c5093fd893709f2cf11bab451314ca625729163d60d17d',
+     x86_64: '8f3ee446b50d160561283024caff13c7103074e366b65351f69b16c59e41b95d',
   })
 
-  depends_on 'videoproto'
   depends_on 'libxext'
   depends_on 'libx11'
-  depends_on 'xextproto'
   
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libxxf86dga.rb
+++ b/packages/libxxf86dga.rb
@@ -3,24 +3,23 @@ require 'package'
 class Libxxf86dga < Package
   description 'X.org the client library for the XFree86-DGA extension'
   homepage 'http://www.x.org'
-  version '1.1'
+  version '1.1-0'
   source_url 'https://www.x.org/archive/individual/lib/libXxf86dga-1.1.tar.gz'
   source_sha256 'b3b7eab9b0b55d41526a5abf9a0b4e104cf2114e6b8adf7c7807b92e848c7d73'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86dga-1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86dga-1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86dga-1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86dga-1.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86dga-1.1-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86dga-1.1-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86dga-1.1-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86dga-1.1-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '9b1dceb66e38c7d3cbba0ef6f7c915faaa621603468de3247ff29bb63ddb4c36',
-     armv7l: '9b1dceb66e38c7d3cbba0ef6f7c915faaa621603468de3247ff29bb63ddb4c36',
-       i686: 'dcc91190359b1e3612b0802e497efd60d1a6ab097b761e45573cfbde99699431',
-     x86_64: '35aa2f2e5f8f4a93bb271cb6c4cb0d50dccfdd9d521f45e9bfdb2368b98bdbb2',
+    aarch64: '7640083a2883a0e14b77add34fb9dbaf3d7c941526d31485f38e89b0ce8f9f6b',
+     armv7l: '7640083a2883a0e14b77add34fb9dbaf3d7c941526d31485f38e89b0ce8f9f6b',
+       i686: '74ec3a332764fc434cdbfb2892da93b7b4aad159478b631f340414258d6da540',
+     x86_64: 'b744b0b6d078a6bed7c71e903c652f17fdf7fd5bb0b84cecae9c475a8e845401',
   })
 
-  depends_on 'xf86dgaproto'
   depends_on 'libxext'
   depends_on 'libx11'
    

--- a/packages/libxxf86vm.rb
+++ b/packages/libxxf86vm.rb
@@ -3,24 +3,23 @@ require 'package'
 class Libxxf86vm < Package
   description 'X.org the client library for the XFree86-VidMode X extension.'
   homepage 'http://www.x.org'
-  version '1.1.4'
+  version '1.1.4-0'
   source_url 'https://www.x.org/archive//individual/lib/libXxf86vm-1.1.4.tar.gz'
   source_sha256 '5108553c378a25688dcb57dca383664c36e293d60b1505815f67980ba9318a99'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86vm-1.1.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86vm-1.1.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86vm-1.1.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86vm-1.1.4-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86vm-1.1.4-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86vm-1.1.4-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86vm-1.1.4-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxxf86vm-1.1.4-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '414cf54c14e966e49268737d45796b5c9422494d74e0fbd685bb80fa4b8e1dfc',
-     armv7l: '414cf54c14e966e49268737d45796b5c9422494d74e0fbd685bb80fa4b8e1dfc',
-       i686: '2581b7cea2747dc9f82f0b25beb57afdcbdd9378da59e45f7a7e2c75816184e6',
-     x86_64: '5288bf141f7688eacd7c622d22adf7e24090685c584f25e2c6e7d29d06b8650e',
+    aarch64: '62379cfc00fd66e76b81b93be0e79d68b2749fa79f162addc3745c2ecd452019',
+     armv7l: '62379cfc00fd66e76b81b93be0e79d68b2749fa79f162addc3745c2ecd452019',
+       i686: '81582f8aa29eebd0e83f186e1679fba7706e286deb0bf09d887496fc1a6d6c97',
+     x86_64: 'a841de7f515f3eff18afc1bc746e2b9c7f6146108fa6ddc9d76439d3d20374ed',
   })
 
-  depends_on 'xf86vidmodeproto'
   depends_on 'libxext'
   depends_on 'libx11'
   

--- a/packages/xorg_proto.rb
+++ b/packages/xorg_proto.rb
@@ -1,40 +1,38 @@
 require 'package'
 
 class Xorg_proto < Package
-  is_fake
+  description 'The xorgproto package provides the header files required to build the X Window system, and to allow other applications to build against the installed X Window system.'
+  homepage 'https://www.x.org/'
+  version '2018.4'
+  source_url 'https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2018.4.tar.bz2'
+  source_sha256 'fee885e0512899ea5280c593fdb2735beb1693ad170c22ebcc844470eec415a0'
 
-  depends_on 'applewmproto'
-  depends_on 'bigreqsproto'
-  depends_on 'compositeproto'
-  depends_on 'damageproto'
-  depends_on 'dmxproto'
-  depends_on 'dri2proto'
-  depends_on 'dri3proto'
-  depends_on 'fixesproto'
-  depends_on 'fontcacheproto'
-  depends_on 'fontsproto'
-  depends_on 'glproto'
-  depends_on 'inputproto'
-  depends_on 'kbproto'
-  depends_on 'presentproto'
-  depends_on 'printproto'
-  depends_on 'randrproto'
-  depends_on 'recordproto'
-  depends_on 'renderproto'
-  depends_on 'resourceproto'
-  depends_on 'scrnsaverproto'
-  depends_on 'trapproto'
-  depends_on 'videoproto'
-  depends_on 'windowswmproto'
-  depends_on 'xcmiscproto'
-  depends_on 'xextproto'
-  depends_on 'xf86driproto'
-  depends_on 'xf86vidmodeproto'
-  depends_on 'xf86rushproto'
-  depends_on 'xf86dgaproto'
-  depends_on 'xf86bigfontproto'
-  depends_on 'xineramaproto'
-  depends_on 'xproto'
-  depends_on 'xproxymanagementproto'
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2018.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2018.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2018.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2018.4-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '92f1d6ea6ef2c905f2ae1749c57e0d6b962145f9936ce726b64624af4e835549',
+     armv7l: '92f1d6ea6ef2c905f2ae1749c57e0d6b962145f9936ce726b64624af4e835549',
+       i686: 'f9b2d6bd821fbac154f818ebe43eb5c5b07b4bfacb8ab66a141c7e7fcd6feaef',
+     x86_64: '1285c5962d32f9ca776261cd0a7ccf78b8fda8878d11032673932892c98e5b88',
+  })
+
+  def self.build
+    system "./configure",
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           "--datadir=#{CREW_LIB_PREFIX}",   # install *.pc in #{CREW_LIB_PREFIX}/pkgconfig
+           "--enable-strict-compilation",
+           "--enable-specs"
+    system "make"
+  end
   
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+  
+
 end


### PR DESCRIPTION
1. Combine all xorg protocols in a single package
2. Remove related dependencies (old protocols) with new compact one in xorg library packages and recompile them.

#889 #1825 