### PR TITLE
[libsoxr] upgrade to 0.1.3 and fix wrong libdir

### DIFF
--- a/packages/libsoxr.rb
+++ b/packages/libsoxr.rb
@@ -7,8 +7,6 @@ class Libsoxr < Package
   source_url 'https://sourceforge.net/projects/soxr/files/soxr-0.1.3-Source.tar.xz'
   source_sha256 'b111c15fdc8c029989330ff559184198c161100a59312f5dc19ddeb9b5a15889'
 
-  depends_on 'cmake' => :build
-
   def self.build
     if ARCH == "x86_64"
       system "cmake",

--- a/packages/libsoxr.rb
+++ b/packages/libsoxr.rb
@@ -3,28 +3,32 @@ require 'package'
 class Libsoxr < Package
   description 'High quality, one-dimensional sample-rate conversion library.'
   homepage 'https://sourceforge.net/projects/soxr/'
-  version '0.1.2'
-  source_url 'https://sourceforge.net/projects/soxr/files/soxr-0.1.2-Source.tar.xz'
-  source_sha256 '54e6f434f1c491388cd92f0e3c47f1ade082cc24327bdc43762f7d1eefe0c275'
+  version '0.1.3'
+  source_url 'https://sourceforge.net/projects/soxr/files/soxr-0.1.3-Source.tar.xz'
+  source_sha256 'b111c15fdc8c029989330ff559184198c161100a59312f5dc19ddeb9b5a15889'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoxr-0.1.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsoxr-0.1.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsoxr-0.1.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoxr-0.1.2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '9b979e95816ba9c0fd130226805721f146c500920f5af49ab3cbc92a357510d4',
-     armv7l: '9b979e95816ba9c0fd130226805721f146c500920f5af49ab3cbc92a357510d4',
-       i686: 'f826d9131cdaa905e20dbfe6e887545ff836f542992e990b94a8eef4299f90ce',
-     x86_64: 'db89700429e41819e2e16076fd501d9824df24a4c14982513347aa7144031e42',
-  })
-
-  depends_on 'cmake'
+  depends_on 'cmake' => :build
 
   def self.build
-    system "cmake ."
+    if ARCH == "x86_64"
+      system "cmake",
+             "-DPREFIX=#{CREW_PREFIX}",
+             "-DLIB_SUFFIX=64",
+             "-DBUILD_SHARED_LIBS=ON",
+             "-DCMAKE_C_FLAGS=-g -O2 -fPIC",
+             "."
+    else
+      system "cmake",
+             "-DPREFIX=#{CREW_PREFIX}",
+             "-DBUILD_SHARED_LIBS=ON",
+             "-DCMAKE_C_FLAGS=-g -O2 -fPIC",
+             "."
+    end
     system "make"
+  end
+  
+  def self.check
+    system "make check"
   end
 
   def self.install


### PR DESCRIPTION
fix wrong libdir on x86_64. #2240 #1981

Tested on x86_64. Should work for rest architectures.