### PR TITLE
Move *.la file removal to prepare_package function

### DIFF
--- a/crew
+++ b/crew
@@ -436,16 +436,6 @@ def build_and_preconfigure (target_dir)
   Dir.chdir target_dir do
     puts "Building from source, this may take a while..."    
     
-    # Remove /usr/local/lib64/*.la to resolve any "can not find /usr/local/*.la" compile errors when building the packages (only needed for x86_64).
-    # https://gnunet.org/faq-la-files
-    # https://stackoverflow.com/questions/42963653/libquadmath-la-is-not-a-valid-libtool-archive-when-configuring-openmpi-with-g
-    
-    # Since pkgconfig is recompiled, the *.la problem appear also for i686 and armv7l. Remove any .la files to resolve it.
-    if @opt_verbose then
-      system "rm -rvf #{CREW_LIB_PREFIX}/*.la"
-    else
-      system "rm -rf #{CREW_LIB_PREFIX}/*.la"
-    end
     @pkg.in_build = true
     @pkg.preinstall
     @pkg.patch
@@ -490,6 +480,15 @@ def prepare_package (destdir)
     compress_doc "#{destdir}#{CREW_PREFIX}/info"
     compress_doc "#{destdir}#{CREW_PREFIX}/share/man"
     compress_doc "#{destdir}#{CREW_PREFIX}/share/info"
+
+    # Remove /usr/local/lib(64)/*.la to resolve any "can not find /usr/local/lib(64)/*.la" compile errors when building the packages.
+    # https://gnunet.org/faq-la-files
+    # https://stackoverflow.com/questions/42963653/libquadmath-la-is-not-a-valid-libtool-archive-when-configuring-openmpi-with-g
+    if @opt_verbose then
+      system "rm -rvf #{destdir}#{CREW_LIB_PREFIX}/*.la"
+    else
+      system "rm -rf #{destdir}#{CREW_LIB_PREFIX}/*.la"
+    end
 
     # create directory list
     system "find . -type f > ../filelist"


### PR DESCRIPTION
Fixes #2261.  This only applies to newly compiled packages.  Any existing pre-built binaries will need to be recreated to remove *.la files.