### PR TITLE
Update Dart.rb to solve issues with pub

### DIFF
--- a/packages/dart.rb
+++ b/packages/dart.rb
@@ -39,5 +39,6 @@ class Dart < Package
     system "cp -r bin/ #{CREW_DEST_PREFIX}"
     system "cp -r lib/* #{CREW_DEST_LIB_PREFIX}"
     system "cp -r include/ #{CREW_DEST_PREFIX}"
+    system "cp version /usr/local/version" # This stops 'pub get' from throwing errors
   end
 end

--- a/packages/dart.rb
+++ b/packages/dart.rb
@@ -39,6 +39,6 @@ class Dart < Package
     system "cp -r bin/ #{CREW_DEST_PREFIX}"
     system "cp -r lib/* #{CREW_DEST_LIB_PREFIX}"
     system "cp -r include/ #{CREW_DEST_PREFIX}"
-    system "cp version /usr/local/version" # This stops 'pub get' from throwing errors
+    system "cp version #{CREW_DEST_PREFIX}" # This stops 'pub get' from throwing errors
   end
 end


### PR DESCRIPTION
# Fixes
`pub get` now requires a file called *version* in `/usr/local/`
