### PR TITLE
Fix crew to resolve `libtool: link: '*.la' is not a valid libtool archive` and `du: cannot access '*.la': No such file or directory` issue

### DIFF
--- a/crew
+++ b/crew
@@ -435,7 +435,18 @@ end
 def build_and_preconfigure (target_dir)
   Dir.chdir target_dir do
     puts "Building from source, this may take a while..."    
-    
+
+    # Rename *.la files temporily to *.la_tmp to avoid
+    # libtool: link: '*.la' is not a valid libtool archive.
+    # See https://gnunet.org/faq-la-files and
+    # https://stackoverflow.com/questions/42963653/libquadmath-la-is-not-a-valid-libtool-archive-when-configuring-openmpi-with-g
+    puts "Rename all *.la files to *.la_tmp".lightblue
+    if @opt_verbose then
+      system "find #{CREW_LIB_PREFIX} -type f -name *.la -print0 | xargs --null -I{} mv {} {}_tmp"
+    else
+      system "find #{CREW_LIB_PREFIX} -type f -name *.la -print0 | xargs --null -I{} mv {} {}_tmp"
+    end
+
     @pkg.in_build = true
     @pkg.preinstall
     @pkg.patch
@@ -449,6 +460,15 @@ def build_and_preconfigure (target_dir)
     end
     puts "Preconfiguring package..."
     @pkg.install
+
+    # Rename all *.la_tmp back to *.la to avoid
+    # cannot access '*.la': No such file or directory
+    puts "Rename all *.la_tmp files back to *.la".lightblue
+    if @opt_verbose then
+      system "find #{CREW_LIB_PREFIX} -type f -name '*.la_tmp' -exec sh -c 'mv \"$1\" \"${1%.la_tmp}.la\"' _  {} \\;"
+    else
+      system "find #{CREW_LIB_PREFIX} -type f -name '*.la_tmp' -exec sh -c 'mv \"$1\" \"${1%.la_tmp}.la\"' _  {} \\;"
+    end
   end
 end
 
@@ -480,15 +500,6 @@ def prepare_package (destdir)
     compress_doc "#{destdir}#{CREW_PREFIX}/info"
     compress_doc "#{destdir}#{CREW_PREFIX}/share/man"
     compress_doc "#{destdir}#{CREW_PREFIX}/share/info"
-
-    # Remove /usr/local/lib(64)/*.la to resolve any "can not find /usr/local/lib(64)/*.la" compile errors when building the packages.
-    # https://gnunet.org/faq-la-files
-    # https://stackoverflow.com/questions/42963653/libquadmath-la-is-not-a-valid-libtool-archive-when-configuring-openmpi-with-g
-    if @opt_verbose then
-      system "find #{destdir}#{CREW_LIB_PREFIX} -type f -name *.la -delete"
-    else
-      system "find #{destdir}#{CREW_LIB_PREFIX} -type f -name *.la -delete"
-    end
 
     # create directory list
     system "find . -type f > ../filelist"


### PR DESCRIPTION
This solves a two-fold problem.  Sometimes when compiling a package, you may encounter the issue below:
```
libtool: link: '*.la' is not a valid libtool archive
```
However, if you delete all the '*.la' files, you will encounter the issue below:
```
du: cannot access '*.la': No such file or directory
```
This PR attempts to solve both of those issues.  Sorry @lovedheart if I didn't understand when you mentioned this earlier.  I was busy with a client issue at that time.