### PR TITLE
fixes #2339 where the cd into the extracted cargo directory is lost h…

### DIFF
--- a/packages/kr.rb
+++ b/packages/kr.rb
@@ -28,8 +28,10 @@ class Kr < Package
 
     system "curl -Ls https://github.com/koute/cargo-web/archive/#{cargo_web_version}.zip -o cargo-web.zip"
     abort "Checksum mismatch. :/  Try again.".lightred unless Digest::SHA256.hexdigest( File.read("cargo-web.zip") ) == "#{cargo_web_sha256}"
-    system "unzip cargo-web.zip && cd cargo-web-#{cargo_web_version}"
-    system "cargo build --release && cargo install"
+    system "unzip cargo-web.zip"
+    FileUtils.cd("cargo-web-#{cargo_web_version}") do
+      system "cargo build --release && cargo install"
+    end
 
     system "mkdir -p #{Dir.pwd}/go/src"
     system "go get github.com/kryptco/kr"


### PR DESCRIPTION
…en running the build

Fixes #2339 

## Description
The issue was caused by breaking the long line I had previously into smaller lines and not correctly testing it. The problem is that I would cd into a directory in one system call and then try to do the build in that directory but the cd context is not preserved between system calls.

Works properly:
- [x] x86_64
