### PR TITLE
Add audio players and supporting libraries

### DIFF
--- a/packages/flac.rb
+++ b/packages/flac.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Flac < Package
+  description 'FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality.'
+  homepage 'https://xiph.org/flac/'
+  version '1.3.2'
+  source_url 'https://ftp.osuosl.org/pub/xiph/releases/flac/flac-1.3.2.tar.xz'
+  source_sha256 '91cfc3ed61dc40f47f050a109b08610667d73477af6ef36dcad31c31a4a8d53f'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/flac-1.3.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/flac-1.3.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/flac-1.3.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/flac-1.3.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'adbc9e93a8d301f82c6cb9ede5392c787bd3994eaf1a963df9c36298f137e08b',
+     armv7l: 'adbc9e93a8d301f82c6cb9ede5392c787bd3994eaf1a963df9c36298f137e08b',
+       i686: '37d96f3aa15558f3bf2f2191db3b9c346785bc5d16a99027c5332f4fc2374681',
+     x86_64: 'f8868c2bcc493dcc7cf51d72531bf6e0be420d883b314847f20eed37251e251b',
+  })
+
+  depends_on 'libogg'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/libdb.rb
+++ b/packages/libdb.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Libdb < Package
+  description 'Berkeley DB is a family of embedded key-value database libraries providing scalable high-performance data management services to applications.'
+  homepage 'http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html'
+  version '6.2.32'
+  source_url 'https://download.oracle.com/berkeley-db/db-6.2.32.tar.gz'
+  source_sha256 'a9c5e2b004a5777aa03510cfe5cd766a4a3b777713406b02809c17c8e0e7a8fb'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libdb-6.2.32-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libdb-6.2.32-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libdb-6.2.32-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libdb-6.2.32-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'af75254a46b10c045b118c915e3b4021bd7a0158cb8069061ae82a715a732e10',
+     armv7l: 'af75254a46b10c045b118c915e3b4021bd7a0158cb8069061ae82a715a732e10',
+       i686: '0229c9ae467fd512120034336b24af89e7f8a58d8f7eaca09c9cccee8916844b',
+     x86_64: '507cc3f213d01122b5214302b7433c9a9926b0f9f57551aeee1f9fcca8c90d2e',
+  })
+
+  def self.build
+    Dir.chdir 'build_unix' do
+      system "../dist/configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build_unix' do
+      system "make", "docdir=#{CREW_PREFIX}/share/doc/db-6.2.32", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    end
+  end
+end

--- a/packages/libid3tag.rb
+++ b/packages/libid3tag.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Libid3tag < Package
+  description 'libid3tag is a library for reading and (eventually) writing ID3 tags'
+  homepage 'https://www.underbit.com/products/mad/'
+  version '0.15.1b'
+  source_url 'ftp://ftp.mars.org/pub/mpeg/libid3tag-0.15.1b.tar.gz'
+  source_sha256 '63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libid3tag-0.15.1b-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libid3tag-0.15.1b-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libid3tag-0.15.1b-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libid3tag-0.15.1b-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '614d3daa64a65218669d392862e0adb52d6a97e29e0964e83519a0f43e2e7ae0',
+     armv7l: '614d3daa64a65218669d392862e0adb52d6a97e29e0964e83519a0f43e2e7ae0',
+       i686: '2572d5b5926bff440114e0bf3542f1ad308d990761792f9206a30b5ddfc070e7',
+     x86_64: '49449a7a53c03eaa8293427db604db65954123c4e1fdbe1207aae80d934da070',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/libmad.rb
+++ b/packages/libmad.rb
@@ -1,0 +1,34 @@
+require 'package'
+
+class Libmad < Package
+  description 'MAD is a high-quality MPEG audio decoder.'
+  homepage 'https://www.underbit.com/products/mad/'
+  version '0.15.1b'
+  source_url 'ftp://ftp.mars.org/pub/mpeg/libmad-0.15.1b.tar.gz'
+  source_sha256 'bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libmad-0.15.1b-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libmad-0.15.1b-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libmad-0.15.1b-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libmad-0.15.1b-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'd4694b736be240c5f8a979fa6e4bdab8620a53178b156ebde91eba46897512f4',
+     armv7l: 'd4694b736be240c5f8a979fa6e4bdab8620a53178b156ebde91eba46897512f4',
+       i686: 'fc86b5ff463282571c274db18c96891b479e23fa959dcdee881f7a7c8ff4a198',
+     x86_64: '502ea142d67c8d4d3cce64c7945c07c529cbda4e4efe0dd3aa770c29b168bd46',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system "sed -i 's,-fforce-mem ,,' Makefile"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/madplay.rb
+++ b/packages/madplay.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Madplay < Package
+  description 'Decode and play MPEG audio files'
+  homepage 'https://www.underbit.com/products/mad/'
+  version '0.15.2b'
+  source_url 'ftp://ftp.mars.org/pub/mpeg/madplay-0.15.2b.tar.gz'
+  source_sha256 '5a79c7516ff7560dffc6a14399a389432bc619c905b13d3b73da22fa65acede0'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/madplay-0.15.2b-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/madplay-0.15.2b-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/madplay-0.15.2b-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/madplay-0.15.2b-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'd13a87ad6db7d64ad099815c35bf34b05724068699283abe79d7bceff1831df3',
+     armv7l: 'd13a87ad6db7d64ad099815c35bf34b05724068699283abe79d7bceff1831df3',
+       i686: '140e4c39b9cb08c6fe453012fa737cc1895494711705ab0c42d0e503f1a018c8',
+     x86_64: 'e24353e4a61f0b8d5e4a8fda4bc2d5a3d3e94f55147aa666e2f271b1e7671900',
+  })
+
+  depends_on 'libmad'
+  depends_on 'libid3tag'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/moc.rb
+++ b/packages/moc.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Moc < Package
+  description 'music on console'
+  homepage 'http://moc.daper.net/'
+  version '2.5.2'
+  source_url 'http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.2.tar.bz2'
+  source_sha256 'f3a68115602a4788b7cfa9bbe9397a9d5e24c68cb61a57695d1c2c3ecf49db08'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/moc-2.5.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/moc-2.5.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/moc-2.5.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/moc-2.5.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fd25d8ee963c5a4dc02b01d432ad69dfdea09f2ab05fa78da0d0e1fcf5fbc96d',
+     armv7l: 'fd25d8ee963c5a4dc02b01d432ad69dfdea09f2ab05fa78da0d0e1fcf5fbc96d',
+       i686: '08101077400e2ff57ba6b9b37fce21e9f460511a610bd90fb818c633b70cecf1',
+     x86_64: '9103ec69198179f32c47efbf422bad69c81621c789c6018279fa1b1e130c4ec6',
+  })
+
+  depends_on 'flac'
+  depends_on 'libdb'
+  depends_on 'libmad'
+  depends_on 'libid3tag'
+  depends_on 'libsndfile'
+  depends_on 'libvorbis'
+  depends_on 'popt'
+  depends_on 'speex'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-debug'
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
- flac: FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality.  See https://xiph.org/flac/.
- libdb: Berkeley DB is a family of embedded key-value database libraries providing scalable high-performance data management services to applications.  See http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html.
- libid3tag: libid3tag is a library for reading and (eventually) writing ID3 tags.  See https://www.underbit.com/products/mad/.
- libmad: MAD is a high-quality MPEG audio decoder.  See https://www.underbit.com/products/mad/.
- madplay: Decode and play MPEG audio files.  See https://www.underbit.com/products/mad/.
- moc: music on console.  See http://moc.daper.net/.