### PR TITLE
Fixed invalid environment variable CREW_LIB_DIR in fakeroot

### DIFF
--- a/packages/fakeroot.rb
+++ b/packages/fakeroot.rb
@@ -11,7 +11,7 @@ class Fakeroot < Package
   
   def self.build
     system "./bootstrap"
-    system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_DIR}"
+    system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 


### PR DESCRIPTION
I accidentally had --libdir as CREW_LIB_DIR instead of CREW_LIB_PREFIX. I fixed this in this pull request. Sorry for not checking about that before I made the first one.