### PR TITLE
Add txt2regex package

### DIFF
--- a/packages/txt2regex.rb
+++ b/packages/txt2regex.rb
@@ -1,0 +1,13 @@
+require 'package'
+
+class Txt2regex < Package
+  description 'Regex wizard for the terminal, written in Bash'
+  homepage 'http://aurelio.net/projects/txt2regex/'
+  version '0.8'
+  source_url 'https://github.com/aureliojargas/txt2regex/archive/v0.8.tar.gz'
+  source_sha256 '31a83516db6c88c07a3d5440136d4fe3928090f0d8b59cb127ca611d6bb9dda9'
+
+  def self.install
+    system "install -Dm755 txt2regex.sh #{CREW_DEST_PREFIX}/bin/txt2regex"
+  end
+end


### PR DESCRIPTION
Txt2regex is a Regular Expression Wizard that converts human sentences to regexes. In a simple interactive console interface, the user answer questions and the program build the regexes for more than 20 programs, like Vim, Emacs, Perl, PHP, Python, Procmail and OpenOffice.org. It is a Shell Script 100% written with Bash builtin commands. No compilation or extra commands are needed, just download and run.  See http://aurelio.net/projects/txt2regex/.