### PR TITLE
Fix gettext package

### DIFF
--- a/packages/dpkg.rb
+++ b/packages/dpkg.rb
@@ -9,7 +9,6 @@ class Dpkg < Package
 
   depends_on 'bz2'
   depends_on 'xzutils'
-  depends_on 'icu4c' => :build
 
   def self.build
     system "git clone https://salsa.debian.org/dpkg-team/dpkg.git"

--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -23,6 +23,7 @@ class Gettext < Package
   depends_on 'diffutils' => :build
   depends_on 'ncurses'
   depends_on 'libxml2'
+  depends_on 'icu4c'
 
   def self.build
     system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic"


### PR DESCRIPTION
Explanation:
```chronos@localhost ~/git/JL2210/chromebrew $ xgettext
xgettext: error while loading shared libraries: libicui18n.so.60: cannot open shared object file: No such file or directory
chronos@localhost ~/git/JL2210/chromebrew $ crew install icu4c
icu4c: ICU is a mature, widely used set of C/C++ and Java libraries providing Unicode and Globalization support for software applications.
http://site.icu-project.org/
version 60.1
Precompiled binary available, downloading...
Archive downloaded
Unpacking archive, this may take awhile...
Installing...
Performing post-install...
Icu4c installed!
chronos@localhost ~/git/JL2210/chromebrew $ xgettext
xgettext: no input file given
Try 'xgettext --help' for more information.
chronos@localhost ~/git/JL2210/chromebrew $ 
```