### PR TITLE
Add docx2txt package

### DIFF
--- a/packages/docx2txt.rb
+++ b/packages/docx2txt.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Docx2txt < Package
+  description 'docx2txt is a perl based command line utility to convert Microsoft Office(Tm) Docx documents to equivalent Text documents.'
+  homepage 'http://docx2txt.sourceforge.net/'
+  version '1.4'
+  source_url 'http://downloads.sourceforge.net/project/docx2txt/docx2txt/v1.4/docx2txt-1.4.tgz'
+  source_sha256 'b297752910a404c1435e703d5aedb4571222bd759fa316c86ad8c8bbe58c6d1b'
+
+  def self.install
+    system "sed -i 's,/etc,#{CREW_PREFIX}/etc,' docx2txt.pl"
+    system "install -Dm644 docx2txt.config #{CREW_DEST_PREFIX}/etc/docx2txt.config"
+    system "install -Dm755 docx2txt.pl #{CREW_DEST_PREFIX}/bin/docx2txt.pl"
+    system "install -Dm755 docx2txt.sh #{CREW_DEST_PREFIX}/bin/docx2txt"
+  end
+end


### PR DESCRIPTION
docx2txt is a perl based command line utility to convert Microsoft Office(Tm) Docx documents to equivalent Text documents. Latest version supports following features during text extraction.

- Character conversions (" ' < & > - ... fraction and some mathematical symbols etc.); currency characters are converted to respective names like Euro.
- Capitalisation of text blocks.
- Center and right justification of text fitting in a line of (configurable) 80 columns.
- Horizontal ruler, line breaks, paragraphs separation, tabs
- Indicating hyperlinked text along with the hyperlink. (configurable)
- Handling (bullet, decimal, letter, roman) lists along with (attempt at) indentation.

See http://docx2txt.sourceforge.net/.