### PR TITLE
Add const command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,18 @@ Usage
 
 Where available commands are:
 
-  * build [build package(s) from source and store the archive and checksum in the current working directory]
-  * download [download package(s) to `CREW_BREW_DIR` (`/usr/local/tmp/crew` by default), but don't install]
-  * files [display installed files of package(s).]
-  * help [get information about command usage]
-  * install [install package(s) along with dependencies after prompting for confirmation]
-  * list [available or installed packages]
-  * remove [remove package(s)]
-  * search [look for a package]
-  * update [update crew itself]
-  * upgrade [update all or specific package(s)]
-  * whatprovides [regex search for package(s) that contains file(s)]
+  * build - `build package(s) from source and store the archive and checksum in the current working directory`
+  * const - `display constant(s)`
+  * download - `download package(s) to CREW_BREW_DIR (/usr/local/tmp/crew by default), but don't install`
+  * files - `display installed files of package(s)`
+  * help - `get information about command usage`
+  * install - `install package(s) along with dependencies after prompting for confirmation`
+  * list - `available or installed packages`
+  * remove - `remove package(s)`
+  * search - `look for package(s)`
+  * update - `update crew itself`
+  * upgrade - `update all or specific package(s)`
+  * whatprovides - `regex search for package(s) that contains file(s)`
 
 Available packages are listed in the [packages directory](https://github.com/skycocker/chromebrew/tree/master/packages).
 

--- a/crew
+++ b/crew
@@ -22,6 +22,7 @@ Chromebrew - Package manager for Chrome OS http://skycocker.github.io/chromebrew
 Usage:
   crew build [-k|--keep] [-v|--verbose] <name> ...
   crew download [-v|--verbose] <name> ...
+  crew const [<name> ...]
   crew files <name> ...
   crew help [<command>]
   crew install [-k|--keep] [-s|--build-from-source] [-v|--verbose] <name> ...
@@ -173,6 +174,10 @@ def help (pkgName)
     puts "Build package(s) from source and place the archive and checksum in the current working directory."
     puts "If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain."
     puts "If `-v` or `--verbose` is present, extra information will be displayed."
+  when "const"
+    puts "Display constant(s)."
+    puts "Usage: crew const [<const1> <const2> ...]"
+    puts "If no constants are provided, all constants will be displayed."
   when "download"
     puts "Download package(s)."
     puts "Usage: crew download [-v|--verbose] <package1> [<package2> ...]"
@@ -226,6 +231,36 @@ def help (pkgName)
     puts "The <pattern> is a search string which can contain regular expressions."
   else
     puts "Available commands: build, download, files, install, list ,remove, search, update, upgrade, whatprovides"
+  end
+end
+
+def const (var)
+  if var
+    value = eval(var)
+    puts "#{var}=#{value}"
+  else
+    vars = [
+      'ARCH',
+      'ARCH_LIB',
+      'CHROMEOS_RELEASE',
+      'CREW_BREW_DIR',
+      'CREW_CONFIG_PATH',
+      'CREW_DEST_DIR',
+      'CREW_DEST_LIB_PREFIX',
+      'CREW_DEST_PREFIX',
+      'CREW_LIB_PATH',
+      'CREW_LIB_PREFIX',
+      'CREW_NOT_COMPRESS',
+      'CREW_NOT_STRIP',
+      'CREW_NPROC',
+      'CREW_PREFIX',
+      'CREW_VERSION',
+      'USER'
+    ]
+    vars.each { |var|
+      value = eval(var)
+      puts "#{var}=#{value}"
+    }
   end
 end
 
@@ -829,6 +864,16 @@ def download_command (args)
     @pkgName = name
     search @pkgName
     download
+  end
+end
+
+def const_command (args)
+  unless args["<name>"].empty?
+    args["<name>"].each do |name|
+      const name
+    end
+  else
+    const nil
   end
 end
 


### PR DESCRIPTION
This command will print all or the specified constant to display.
```
$ crew const
ARCH=x86_64
ARCH_LIB=lib64
CHROMEOS_RELEASE=66
CREW_BREW_DIR=/usr/local/tmp/crew/
CREW_CONFIG_PATH=/usr/local/etc/crew/
CREW_DEST_DIR=/usr/local/tmp/crew/dest
CREW_DEST_LIB_PREFIX=/usr/local/tmp/crew/dest/usr/local/lib64
CREW_DEST_PREFIX=/usr/local/tmp/crew/dest/usr/local
CREW_LIB_PATH=/usr/local/lib/crew/
CREW_LIB_PREFIX=/usr/local/lib64
CREW_NOT_COMPRESS=
CREW_NOT_STRIP=
CREW_NPROC=2
CREW_PREFIX=/usr/local
CREW_VERSION=0.4.3
USER=chronos
$ crew const ARCH
ARCH=x86_64
$ crew const USER
USER=chronos
```