### PR TITLE
Add fpc package

### DIFF
--- a/packages/fpc.rb
+++ b/packages/fpc.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Fpc < Package
+  description 'Free Pascal is a 32, 64 and 16 bit professional Pascal compiler.'
+  homepage 'https://www.freepascal.org/'
+  version '3.0.4'
+  case ARCH
+  when 'i686'
+    source_url 'http://downloads.sourceforge.net/project/freepascal/Linux/3.0.4/fpc-3.0.4.i386-linux.tar'
+    source_sha256 'aa6da9a58d155bbaa71aaa7f414d64b02b3e450dc23eed7c161eac6d547fae17'
+  when 'x86_64'
+    source_url 'http://downloads.sourceforge.net/project/freepascal/Linux/3.0.4/fpc-3.0.4.x86_64-linux.tar'
+    source_sha256 '7e965baf13c9822a0ff39e7bbfa040bd5599e94d0f3338f1ac4efa989081fd77'
+  end
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system "sed -i 's,PREFIX=\"\$HOME/fpc-\$VERSION\",PREFIX=#{CREW_DEST_PREFIX},' install.sh"
+    system "sed -i '264,272d' install.sh"
+  end
+
+  def self.install
+    system './install.sh'
+  end
+
+  def self.postinstall
+    puts
+    puts "Type 'fp' to start.".lightblue
+    puts
+  end
+end


### PR DESCRIPTION
Free Pascal is a 32, 64 and 16 bit professional Pascal compiler. It can target many processor architectures: Intel x86 (including 8086), AMD64/x86-64, PowerPC, PowerPC64, SPARC, ARM, AArch64, MIPS and the JVM. Supported operating systems include Linux, FreeBSD, Haiku, Mac OS X/iOS/iPhoneSimulator/Darwin, DOS (16 and 32 bit), Win32, Win64, WinCE, OS/2, MorphOS, Nintendo GBA, Nintendo DS, Nintendo Wii, Android, AIX and AROS. Additionally, support for the Motorola 68k architecture is available in the development versions.  See https://freepascal.org/.