### PR TITLE
Add gnucobol package

### DIFF
--- a/packages/gnucobol.rb
+++ b/packages/gnucobol.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Gnucobol < Package
+  description 'GnuCOBOL (formerly OpenCOBOL) is a free COBOL compiler.'
+  homepage 'https://open-cobol.sourceforge.io/'
+  version '3.0-rc1'
+  source_url 'http://downloads.sourceforge.net/project/open-cobol/gnu-cobol/3.0/gnucobol-3.0-rc1.tar.gz'
+  source_sha256 'e55aeea6b1f77e763b4cd4b520c78eb06da7671b4dcc76463fd0237dbf2e4816'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnucobol-3.0-rc1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnucobol-3.0-rc1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnucobol-3.0-rc1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnucobol-3.0-rc1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '414d959994a7816b3afca483ebbff70306ea9f5577e702957806f76f1d714718',
+     armv7l: '414d959994a7816b3afca483ebbff70306ea9f5577e702957806f76f1d714718',
+       i686: '5a881e05b716742c8f5e590f542a9b7eee411c38ff946e5896d843e21bb021ef',
+     x86_64: '00e04366fab756136bba0bcb07a285c1bda4d218b5f6555e0bc67583fb051963',
+  })
+
+  depends_on 'libdb'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
GnuCOBOL (formerly OpenCOBOL) is a free COBOL compiler. cobc translates COBOL source to executable using intermediate C, designated C compiler and linker. OpenCOBOL 1.1 became GNU Cobol 1.1 in 2013. GnuCOBOL 2.2 is the latest, version 3.0 is on its way. A programmer's guide, by Gary Cutler and Vincent Coen, is indexed at https://open-cobol.sourceforge.io together with more documentation. OpenCOBOL was written by Keisuke Nishida and Roger While, from 2001 to 2012. GnuCOBOL is also authored by Simon Sobisch, Ron Norman, Edward Hart, Sergey Kashyrin, Dave Pitts and Brian Tiffin. Others listed in the AUTHORS and THANKS files. Copyright 2001-2018 Free Software Foundation, Inc. This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the FSF; either version 3, or (at your option) any later version. The libcob run time support source tree is licensed LGPL.  See https://open-cobol.sourceforge.io/.