### PR TITLE
Added lines to readline to fix fdisk

### DIFF
--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -34,7 +34,7 @@ class Readline < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    system "mv", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6.old"
+    system "rm", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6"
     system "ln", "-s", "/#{ARCH_LIB}/libreadline.so.6", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6"
   end
 end

--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -8,16 +8,8 @@ class Readline < Package
   source_sha256 '56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '7b70ee08258af2bd190b30639306aa4d0b71273cfb702a4ae75003317f19702f',
-     armv7l: '7b70ee08258af2bd190b30639306aa4d0b71273cfb702a4ae75003317f19702f',
-       i686: '572baf2f2bba47d719714fc97709bc3932abab4bf1a9d838bb47ccd0f1fa4395',
-     x86_64: 'f235ee73feba6d2c0bb085042db9462225cda1a18f190a47116417cc6993e716',
   })
 
   depends_on 'buildessential' => :build
@@ -42,5 +34,7 @@ class Readline < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "mv", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6.old"
+    system "ln", "-s", "/#{ARCH_LIB}/libreadline.so.6", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6"
   end
 end

--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -34,7 +34,8 @@ class Readline < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    system "rm", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6"
+    system "rm", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6.3"
     system "ln", "-s", "/#{ARCH_LIB}/libreadline.so.6", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6"
+    system "ln", "-s", "/#{ARCH_LIB}/libreadline.so.6.3", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6.3"
   end
 end


### PR DESCRIPTION
Fixed issue where executing fdisk after installing readline gave the error:
 ```
libreadline.so.s: error: /usr/local/lib(64)/libreadline.so.6: undefined symbol: UP
```
Using system libreadline.so.6 now