### PR TITLE
Add ibmonitor package and perl module dependencies

### DIFF
--- a/packages/ibmonitor.rb
+++ b/packages/ibmonitor.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Ibmonitor < Package
+  description 'ibmonitor is an interactive bandwidth monitor console application.'
+  homepage 'http://ibmonitor.sourceforge.net/'
+  version '1.4'
+  source_url 'http://downloads.sourceforge.net/project/ibmonitor/ibmonitor/v1.4/ibmonitor-1.4.tar.gz'
+  source_sha256 '331dac4553b5c336d1db3d35176ecebeaf15b39ad0432372cba583324a222e28'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ibmonitor-1.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ibmonitor-1.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ibmonitor-1.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ibmonitor-1.4-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '22735764b4c6c9d973dffa60110c138f6a0b1cc2d9a7dae43f87d02f47c0028c',
+     armv7l: '22735764b4c6c9d973dffa60110c138f6a0b1cc2d9a7dae43f87d02f47c0028c',
+       i686: 'c3b22b076844102544be601716e5225021c411ae31487551e0adc03dbabe2c5a',
+     x86_64: '1c56681a1f5c22ccd9bb42a0610937e0097371503ac1d8dd599c7cf945948009',
+  })
+
+  depends_on 'filecmd'
+  depends_on 'perl_read_key'
+  depends_on 'perl_term_ansicolor'
+  depends_on 'perl_time_hires'
+
+  def self.build
+    system "sed -i 's,/usr/bin,#{CREW_PREFIX}/bin,' ibmonitor"
+  end
+
+  def self.install
+    system "install -Dm755 ibmonitor #{CREW_DEST_PREFIX}/bin/ibmonitor"
+  end
+end

--- a/packages/perl_term_ansicolor.rb
+++ b/packages/perl_term_ansicolor.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Perl_term_ansicolor < Package
+  description 'Character mode terminal access for Perl Term::ANSIColor'
+  homepage 'https://www.eyrie.org/~eagle/software/ansicolor/'
+  version '4.06'
+  source_url 'https://github.com/rra/ansicolor/archive/release/4.06.tar.gz'
+  source_sha256 '0cf6f25ac82ccc0aff2bcfdec23879469626db80f0f50105ec5100236a6830cf'
+
+  def self.build
+    system "perl", "Makefile.PL"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/perl_time_hires.rb
+++ b/packages/perl_time_hires.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Perl_time_hires < Package
+  description 'High resolution alarm, sleep, gettimeofday, interval timers Time::HiRes'
+  homepage 'https://metacpan.org/release/Time-HiRes'
+  version '1.9758'
+  source_url 'https://cpan.metacpan.org/authors/id/J/JH/JHI/Time-HiRes-1.9758.tar.gz'
+  source_sha256 '5bfa145bc11e70a8e337543b1084a293743a690691b568493455dedf58f34b1e'
+
+  def self.build
+    system "perl", "Makefile.PL"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
ibmonitor is an interactive linux console application which shows
bandwidth consumed and total data transferred on all interfaces.

Its main features are:
- Shows received, transmitted and total bandwidth of each interface
- Calculates and displays the combined value of all interfaces
- Displays total data transferred per interface in KB/MB/GB
- Values can be displayed in Kbits/sec(Kbps) and/or KBytes/sec(KBps)
- Can show maximum bandwidth consumed on each interface since start of utility
- Can show average bandwidth consumption on each interface since start of utility
- The output with all features (max, avg and display in Kbps and KBps) easily fits on a 80x24 console or xterm
- Can interactively change its output display format depending on key pressed by user.
