### PR TITLE
Add nftables package and supporting library

### DIFF
--- a/packages/libnftnl.rb
+++ b/packages/libnftnl.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Libnftnl < Package
+  description 'libnftnl is a userspace library providing a low-level netlink programming interface (API) to the in-kernel nf_tables subsystem.'
+  homepage 'https://netfilter.org/projects/libnftnl/'
+  version '1.1.1'
+  source_url 'https://netfilter.org/projects/libnftnl/files/libnftnl-1.1.1.tar.bz2'
+  source_sha256 '5d6a65413f27ec635eedf6aba033f7cf671d462a2afeacc562ba96b19893aff2'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libnftnl-1.1.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libnftnl-1.1.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libnftnl-1.1.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libnftnl-1.1.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '98505655c55453a9f6bddddf1fd3f917ea3a98ed3f5e05f1fa609301fedb180c',
+     armv7l: '98505655c55453a9f6bddddf1fd3f917ea3a98ed3f5e05f1fa609301fedb180c',
+       i686: '0f1d6dca8c4dbf11856085d5572d45a66e86c422aeb278d68bd4c1e1af7c7675',
+     x86_64: 'a0482c543920370b4fc428b50b48c4071efd60c2ecb83fdaae4d8e77bea70b92',
+  })
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/nftables.rb
+++ b/packages/nftables.rb
@@ -1,0 +1,52 @@
+require 'package'
+
+class Nftables < Package
+  description 'nftables replaces the popular {ip,ip6,arp,eb}tables.'
+  homepage 'https://netfilter.org/projects/nftables/'
+  version '0.9.0'
+  source_url 'https://netfilter.org/projects/nftables/files/nftables-0.9.0.tar.bz2'
+  source_sha256 'ad8181b5fcb9ca572f444bed54018749588522ee97e4c21922648bb78d7e7e91'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nftables-0.9.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nftables-0.9.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nftables-0.9.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nftables-0.9.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '5245548bfb5081d7a25291d3cc82052ace323d235eba1a73638cff83152e5a06',
+     armv7l: '5245548bfb5081d7a25291d3cc82052ace323d235eba1a73638cff83152e5a06',
+       i686: '5129603a7f40d072f8746430f6b1b14e0f77b50b3495154de7408c49ca891c87',
+     x86_64: '60cb68a70ecc066d7c6b92617db9f38593692f056c3620a3a42c7df0dd6a2ae7',
+  })
+
+  depends_on 'help2man'
+  depends_on 'jansson'
+  depends_on 'libmnl'
+  depends_on 'libnftnl'
+  depends_on 'readline'
+
+  def self.build
+    system "LIBS=\"-lncurses\" ./configure \
+           --prefix=#{CREW_PREFIX} \
+           --libdir=#{CREW_LIB_PREFIX} \
+           --disable-man-doc \
+           --with-json \
+           --with-mini-gmp"
+    system 'make'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/man/man1"
+    system "touch #{CREW_DEST_PREFIX}/man/man1/nft.1.gz"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.postinstall
+    system "help2man -n 'userspace command line tool for nftables' -s 1 -N --no-discard-stderr '#{CREW_PREFIX}/sbin/nft -h' > nft.1"
+    system "sed -i 's,Usage:,nft,g' nft.1"
+    system "sed -i 's,USAGE:,NFT,g' nft.1"
+    system "gzip -9 nft.1"
+    system "install -m644 nft.1.gz #{CREW_PREFIX}/man/man1/nft.1.gz"
+  end
+end


### PR DESCRIPTION
nftables replaces the popular {ip,ip6,arp,eb}tables. This software provides a new in-kernel packet classification framework that is based on a network-specific Virtual Machine (VM) and a new nft userspace command line tool. nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure, the connection tracking system, NAT, userspace queueing and logging subsystem.  See https://netfilter.org/projects/nftables/.