### PR TITLE
Add autosetup package

### DIFF
--- a/packages/autosetup.rb
+++ b/packages/autosetup.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Autosetup < Package
+  description 'autosetup is a tool, similar to autoconf, to configure a build system'
+  homepage 'http://msteveb.github.io/autosetup/'
+  version '0.6.7'
+  source_url 'https://github.com/msteveb/autosetup/archive/v0.6.7.tar.gz'
+  source_sha256 'a8f852e10374261bf96bd19f03fac667b7332ff6ceef858e5199112d1f2782ce'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'tcl'
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system "./autosetup --sysinstall=#{CREW_DEST_PREFIX}"
+  end
+end


### PR DESCRIPTION
autosetup is a tool, similar to autoconf, to configure a build system for the appropriate environment, according to the system capabilities and the user-selected options.

autosetup is designed to be light-weight, fast, simple and flexible.

Notable features include:

- Easily check for headers, functions, types for C/C++
- Easily support user configuration options
- Can generate files based on templates, such as Makefile.in => Makefile
- Can generate header files based on checked features
- Excellent support for cross compilation
- Replacement for autoconf in many situations
- Runs with either Tcl 8.5+, Jim Tcl or just a C compiler (using the included Jim Tcl source code!)
- autosetup is intended to be distributed with projects - no version mismatch issues

See http://msteveb.github.io/autosetup/.