### PR TITLE
Add re6stnet package

### DIFF
--- a/packages/re6stnet.rb
+++ b/packages/re6stnet.rb
@@ -27,7 +27,7 @@ class Re6stnet < Package
     system "mkdir -p #{CREW_DEST_PREFIX}/opt/ "
     system "cp -r #{@re6st_dir} #{CREW_DEST_DIR}#{@re6st_dir}"
     system "rm -rf #{CREW_DEST_DIR}#{@re6st_dir}/download-cache"
-    system "ln -fs #{@grande_dir}/bin/grandenet #{CREW_PREFIX}/sbin/grandenet"
+    system "ln -fs #{@re6st_dir}/bin/grandenet #{CREW_PREFIX}/sbin/grandenet"
     system "ln -fs #{@re6st_dir}/bin/re6stnet #{CREW_PREFIX}/sbin/re6stnet"
     system "ln -fs #{@re6st_dir}/bin/re6st-conf #{CREW_PREFIX}/bin/re6st-conf"
     system "ln -fs #{@re6st_dir}/bin/re6st-registry #{CREW_PREFIX}/bin/re6st-registry"

--- a/packages/re6stnet.rb
+++ b/packages/re6stnet.rb
@@ -2,15 +2,15 @@ require 'package'
 class Re6stnet < Package
   description 'Resilient, Scalable, IPv6 Network'
   homepage 'https://re6st.nexedi.com/'
-  version '0.501'
-  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=bac2e5bb857dfe5a72fef58575e36e5629018569'
-  source_sha256 'dd8d8e211a7eeb32eab3556b08b233969d77a4468a59c620dffd8db80f7d26fd'
+  version '0.509'
+  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=5cb542c266b398fd2a36d16c9f8cb1fb9fc1d567'
+  source_sha256 '6872b0275ff11d264241e098133b2f490a04273dfb1db5bf91547ceb0c320763'
 
   binary_url ({
-    x86_64: 'https://softinst62285.host.vifib.net/public/re6stnet-0.501-chromeos-x86_64.tar.xz',
+    x86_64: 'https://softinst105421.host.vifib.net/public/re6stnet-0.509-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    x86_64: '39e86454e8e11ba9672145a2fa5ab4754c1c739a9062f2019e6a2f066787e064',
+    x86_64: '506d8e7f959bbe05c6e68672b5e488ecfc4e87a3782aafe73a4621b34a6cf0c8',
   })
 
   depends_on 'python27' => :build

--- a/packages/re6stnet.rb
+++ b/packages/re6stnet.rb
@@ -3,8 +3,8 @@ class Re6stnet < Package
   description 'Resilient, Scalable, IPv6 Network'
   homepage 'https://re6st.nexedi.com/'
   version '0.501'
-  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive?sha=master'
-  source_sha256 '056a94304282f9e073b85370be0b77c5f42a16fe0365602e921679d1287137fa'
+  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=ec195cec46f7ed4893bbc8462266d28cec886dad'
+  source_sha256 '62fb68e53aa1f60ed073efad192e06298746922331fe84f6cd3d0f68c5dd4941'
 
   binary_url ({
     x86_64: 'https://softinst62285.host.vifib.net/public/re6stnet-0.501-chromeos-x86_64.tar.xz',
@@ -24,16 +24,16 @@ class Re6stnet < Package
   end
 
   def self.install
-    system "mkdir -p #{CREW_DEST_DIR}#{CREW_PREFIX}/opt/ "
+    system "mkdir -p #{CREW_DEST_PREFIX}/opt/ "
     system "cp -r #{@re6st_dir} #{CREW_DEST_DIR}#{@re6st_dir}"
     system "rm -rf #{CREW_DEST_DIR}#{@re6st_dir}/download-cache"
+    system "ln -fs #{@grande_dir}/bin/grandenet #{CREW_PREFIX}/sbin/grandenet"
+    system "ln -fs #{@re6st_dir}/bin/re6stnet #{CREW_PREFIX}/sbin/re6stnet"
+    system "ln -fs #{@re6st_dir}/bin/re6st-conf #{CREW_PREFIX}/bin/re6st-conf"
+    system "ln -fs #{@re6st_dir}/bin/re6st-registry #{CREW_PREFIX}/bin/re6st-registry"
   end
 
   def self.postinstall
-    system "ln -fs #{@re6st_dir}/bin/grandenet #{CREW_PREFIX}/bin/grandenet"
-    system "ln -fs #{@re6st_dir}/bin/re6stnet #{CREW_PREFIX}/bin/re6stnet"
-    system "ln -fs #{@re6st_dir}/bin/re6st-conf #{CREW_PREFIX}/bin/re6st-conf"
-    system "ln -fs #{@re6st_dir}/bin/re6st-registry #{CREW_PREFIX}/bin/re6st-registry"
-    puts "To initiate re6stnet, run /usr/local/bin/grandenet with superuser priviliges"
+    puts "To initiate re6stnet, run #{CREW_PREFIX}/sbin/grandenet"
   end
 end

--- a/packages/re6stnet.rb
+++ b/packages/re6stnet.rb
@@ -3,24 +3,26 @@ class Re6stnet < Package
   description 'Resilient, Scalable, IPv6 Network'
   homepage 'https://re6st.nexedi.com/'
   version '0.509'
-  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=5cb542c266b398fd2a36d16c9f8cb1fb9fc1d567'
-  source_sha256 '6872b0275ff11d264241e098133b2f490a04273dfb1db5bf91547ceb0c320763'
+  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=1bc16d97519af4329b01514634e648db0a7be333'
+  source_sha256 '02e90c41ed7511216b7ab283d8b7893882a3349d7c383e7b983561299972a9ce'
 
   binary_url ({
     x86_64: 'https://softinst105421.host.vifib.net/public/re6stnet-0.509-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    x86_64: '506d8e7f959bbe05c6e68672b5e488ecfc4e87a3782aafe73a4621b34a6cf0c8',
+    x86_64: 'b9b8cc48e5a7a1fa202a89c8807d4aa63a8db79353ab6dc992608b608130a52b',
   })
 
   depends_on 'python27' => :build
   depends_on 'filecmd' => :build
   depends_on 'libiconv' => :build
+  depends_on 'glibc'
 
   @re6st_dir = 	"#{CREW_PREFIX}/opt/re6st"
 
   def self.build
     system "mkdir -p #{@re6st_dir}/bin && cp buildout.cfg #{@re6st_dir} && cp bin/grandenet #{@re6st_dir}/bin"
+    system "gcc shill_wrapper.c -o #{@re6st_dir}/bin/shill_wrapper -ldl -Wall -fPIC -pie"
     system "SSL_CERT_DIR=/etc/ssl/certs ./bin/buildout buildout:directory=#{@re6st_dir}"
   end
 

--- a/packages/re6stnet.rb
+++ b/packages/re6stnet.rb
@@ -1,0 +1,39 @@
+require 'package'
+class Re6stnet < Package
+  description 'Resilient, Scalable, IPv6 Network'
+  homepage 'https://re6st.nexedi.com/'
+  version '0.501'
+  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive?sha=master'
+  source_sha256 '056a94304282f9e073b85370be0b77c5f42a16fe0365602e921679d1287137fa'
+
+  binary_url ({
+    x86_64: 'https://softinst62285.host.vifib.net/public/re6stnet-0.501-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    x86_64: '39e86454e8e11ba9672145a2fa5ab4754c1c739a9062f2019e6a2f066787e064',
+  })
+
+  depends_on 'python27' => :build
+  depends_on 'filecmd' => :build
+
+  @re6st_dir = 	"#{CREW_PREFIX}/opt/re6st"
+
+  def self.build
+    system "mkdir -p #{@re6st_dir}/bin && cp buildout.cfg #{@re6st_dir} && cp bin/grandenet #{@re6st_dir}/bin"
+    system "SSL_CERT_DIR=/etc/ssl/certs ./bin/buildout buildout:directory=#{@re6st_dir}"
+  end
+
+  def self.install
+    system "mkdir -p #{CREW_DEST_DIR}#{CREW_PREFIX}/opt/ "
+    system "cp -r #{@re6st_dir} #{CREW_DEST_DIR}#{@re6st_dir}"
+    system "rm -rf #{CREW_DEST_DIR}#{@re6st_dir}/download-cache"
+  end
+
+  def self.postinstall
+    system "ln -fs #{@re6st_dir}/bin/grandenet #{CREW_PREFIX}/bin/grandenet"
+    system "ln -fs #{@re6st_dir}/bin/re6stnet #{CREW_PREFIX}/bin/re6stnet"
+    system "ln -fs #{@re6st_dir}/bin/re6st-conf #{CREW_PREFIX}/bin/re6st-conf"
+    system "ln -fs #{@re6st_dir}/bin/re6st-registry #{CREW_PREFIX}/bin/re6st-registry"
+    puts "To initiate re6stnet, run /usr/local/bin/grandenet with superuser priviliges"
+  end
+end

--- a/packages/re6stnet.rb
+++ b/packages/re6stnet.rb
@@ -3,8 +3,8 @@ class Re6stnet < Package
   description 'Resilient, Scalable, IPv6 Network'
   homepage 'https://re6st.nexedi.com/'
   version '0.501'
-  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=02992c9ae6c0ac16a6a024cc23400b331e70b67f'
-  source_sha256 'c2c6744c2d5bf731ca60ce7f32d70ef1fda7c7a2cbf583d4521b9bc4121b32b8'
+  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=64b11f4eb4fe1f1f07861f8060546414dfcf949f'
+  source_sha256 '5e1815347175d982a0184f22a0d913f8efc992b2ed74b73c92a543299d9f89e3'
 
   binary_url ({
     x86_64: 'https://softinst62285.host.vifib.net/public/re6stnet-0.501-chromeos-x86_64.tar.xz',

--- a/packages/re6stnet.rb
+++ b/packages/re6stnet.rb
@@ -21,7 +21,8 @@ class Re6stnet < Package
   @re6st_dir = 	"#{CREW_PREFIX}/opt/re6st"
 
   def self.build
-    system "mkdir -p #{@re6st_dir}/bin && cp buildout.cfg #{@re6st_dir} && cp bin/grandenet #{@re6st_dir}/bin"
+    system "mkdir -p #{@re6st_dir}/bin && cp buildout.cfg #{@re6st_dir}"
+    system "cp bin/grandenet #{@re6st_dir}/bin && cp bin/shill.sh #{@re6st_dir}/bin"
     system "gcc shill_wrapper.c -o #{@re6st_dir}/bin/shill_wrapper -ldl -Wall -fPIC -pie"
     system "SSL_CERT_DIR=/etc/ssl/certs ./bin/buildout buildout:directory=#{@re6st_dir}"
   end
@@ -31,6 +32,8 @@ class Re6stnet < Package
     system "cp -r #{@re6st_dir} #{CREW_DEST_DIR}#{@re6st_dir}"
     system "rm -rf #{CREW_DEST_DIR}#{@re6st_dir}/download-cache"
     system "ln -fs #{@re6st_dir}/bin/grandenet #{CREW_PREFIX}/sbin/grandenet"
+    system "ln -fs #{@re6st_dir}/bin/shill.sh #{CREW_PREFIX}/sbin/shill.sh"
+    system "ln -fs #{@re6st_dir}/bin/shill_wrapper #{CREW_PREFIX}/sbin/shill_wrapper"
     system "ln -fs #{@re6st_dir}/bin/re6stnet #{CREW_PREFIX}/sbin/re6stnet"
     system "ln -fs #{@re6st_dir}/bin/re6st-conf #{CREW_PREFIX}/bin/re6st-conf"
     system "ln -fs #{@re6st_dir}/bin/re6st-registry #{CREW_PREFIX}/bin/re6st-registry"

--- a/packages/re6stnet.rb
+++ b/packages/re6stnet.rb
@@ -3,8 +3,8 @@ class Re6stnet < Package
   description 'Resilient, Scalable, IPv6 Network'
   homepage 'https://re6st.nexedi.com/'
   version '0.501'
-  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=64b11f4eb4fe1f1f07861f8060546414dfcf949f'
-  source_sha256 '5e1815347175d982a0184f22a0d913f8efc992b2ed74b73c92a543299d9f89e3'
+  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=bac2e5bb857dfe5a72fef58575e36e5629018569'
+  source_sha256 'dd8d8e211a7eeb32eab3556b08b233969d77a4468a59c620dffd8db80f7d26fd'
 
   binary_url ({
     x86_64: 'https://softinst62285.host.vifib.net/public/re6stnet-0.501-chromeos-x86_64.tar.xz',

--- a/packages/re6stnet.rb
+++ b/packages/re6stnet.rb
@@ -3,8 +3,8 @@ class Re6stnet < Package
   description 'Resilient, Scalable, IPv6 Network'
   homepage 'https://re6st.nexedi.com/'
   version '0.501'
-  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=ec195cec46f7ed4893bbc8462266d28cec886dad'
-  source_sha256 '62fb68e53aa1f60ed073efad192e06298746922331fe84f6cd3d0f68c5dd4941'
+  source_url 'https://lab.nexedi.com/nexedi/chromebrew-buildout-re6st/repository/archive.tar.bz2?ref=02992c9ae6c0ac16a6a024cc23400b331e70b67f'
+  source_sha256 'c2c6744c2d5bf731ca60ce7f32d70ef1fda7c7a2cbf583d4521b9bc4121b32b8'
 
   binary_url ({
     x86_64: 'https://softinst62285.host.vifib.net/public/re6stnet-0.501-chromeos-x86_64.tar.xz',
@@ -15,6 +15,7 @@ class Re6stnet < Package
 
   depends_on 'python27' => :build
   depends_on 'filecmd' => :build
+  depends_on 'libiconv' => :build
 
   @re6st_dir = 	"#{CREW_PREFIX}/opt/re6st"
 


### PR DESCRIPTION
## Description
Provides version 0.501 of [Re6st](https://re6st.nexedi.com/), a resilient and scalable IPv6 network which runs on top of an existing IPv4 network, along with the `grandenet` script to run it on Chromebooks.

## Addtional information
The build process downloads a few dependencies, whose required versions are different from what the Chromebrew provided packages are, using [Buildout](http://www.buildout.org), and keeps them into its own directory under `#{CREW_PREFIX}/opt/re6st`, where the package is built in the first place to avoid libraries pointing to the incorrect path. Any suggestions to improve this workflow would be welcome

Works properly:
- [x] x86_64
- [ ] aarch64 (untested for lack of hardware)
