### PR TITLE
Added crew_profile as an optional package.

### DIFF
--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -9,11 +9,13 @@ class Crew_profile < Package
 
   depends_on "xdg_base"
 
+  ENV['HOME'] = '/home/chronos/user'
+
   def self.install
     system "mkdir", "-p", "#{CREW_DEST_PREFIX}/etc"
     system "mkdir", "-p", "#{CREW_DEST_HOME}"
-    system "touch", "$HOME/.profile" # To not overwrite already installed configuration
-    system "ln", "-s", "$HOME/.profile", "#{CREW_DEST_PREFIX}/etc/profile"
+    system "touch", "#{HOME}/.profile" # To not overwrite already installed configuration
+    system "ln", "-s", "#{HOME}/.profile", "#{CREW_DEST_PREFIX}/etc/profile"
   end
 
   def self.postinstall

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -9,13 +9,11 @@ class Crew_profile < Package
 
   depends_on "xdg_base"
 
-  HOME = "/home/chronos/user"
-
   def self.install
     system "mkdir", "-p", "#{CREW_DEST_PREFIX}/etc"
     system "mkdir", "-p", "#{CREW_DEST_HOME}"
-    system "touch", "#{HOME}/.profile" # To not overwrite already installed configuration
-    system "ln", "-s", "#{HOME}/.profile", "#{CREW_DEST_PREFIX}/etc/profile"
+    system "touch", "$HOME/.profile" # To not overwrite already installed configuration
+    system "ln", "-s", "$HOME/.profile", "#{CREW_DEST_PREFIX}/etc/profile"
   end
 
   def self.postinstall

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -9,12 +9,10 @@ class Crew_profile < Package
 
   depends_on "xdg_base"
 
-  ENV['HOME'] = '/home/chronos/user'
-
   def self.install
     system "mkdir", "-p", "#{CREW_DEST_PREFIX}/etc"
     system "mkdir", "-p", "#{CREW_DEST_HOME}"
-    system "ln", "-s", "#{HOME}/.profile", "#{CREW_DEST_PREFIX}/etc/profile"
+    system "ln", "-s", "#{ENV['HOME']}/.profile", "#{CREW_DEST_PREFIX}/etc/profile"
   end
 
   def self.postinstall

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -11,7 +11,8 @@ class Crew_profile < Package
 
   def self.install
     system "mkdir", "-p", "#{CREW_DEST_PREFIX}/etc"
-    system "touch", "#{CREW_DEST_PREFIX}/etc/profile"
+    system "touch", "#{CREW_DEST_HOME}/.profile"
+    system "ln", "-s", "#{CREW_DEST_HOME}/.profile", "#{CREW_PREFIX}/etc/profile"
   end
 
   def self.postinstall

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -9,10 +9,13 @@ class Crew_profile < Package
 
   depends_on "xdg_base"
 
+  HOME = "/home/chronos/user"
+
   def self.install
     system "mkdir", "-p", "#{CREW_DEST_PREFIX}/etc"
-    system "touch", "#{CREW_DEST_HOME}/.profile"
-    system "ln", "-s", "#{CREW_DEST_HOME}/.profile", "#{CREW_PREFIX}/etc/profile"
+    system "mkdir", "-p", "#{CREW_DEST_HOME}"
+    system "touch", "#{HOME}/.profile" # To not overwrite already installed configuration
+    system "ln", "-s", "#{HOME}/.profile", "#{CREW_DEST_PREFIX}/etc/profile"
   end
 
   def self.postinstall

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -38,10 +38,10 @@ class Crew_profile < Package
     puts
     puts "For Fish, execute this:".lightblue
     puts
-    puts "echo \"if [ -f #{CREW_PREFIX}/etc/profile ]; then\" >> ~/.config/fish/config.fish".lightblue
+    puts "echo \"if [ -f #{CREW_PREFIX}/etc/profile ]\" >> ~/.config/fish/config.fish".lightblue
     puts "echo \"  # Source crew profile\" >> ~/.config/fish/config.fish".lightblue
     puts "echo \"  source #{CREW_PREFIX}/etc/profile\" >> ~/.config/fish/config.fish".lightblue
-    puts "echo \"fi\" >> ~/.config/fish/config.fish".lightblue
+    puts "echo \"end\" >> ~/.config/fish/config.fish".lightblue
     puts "source ~/.config/fish/config.fish".lightblue
     puts
     puts "Works with Bash, Zsh, and Fish".lightblue

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -3,7 +3,7 @@ require 'package'
 class Crew_profile < Package
   description 'A profile for Chromebrew, to be used instead of ~/.*rc'
   homepage 'https://github.com/skycocker/chromebrew'
-  version '0.4.3'
+  version "#{CREW_VERSION}"
   source_url 'https://github.com/skycocker/chromebrew/raw/511ee9cb3138e113df74ddf0dee057ef5d9a46fd/README.md'
   source_sha256 '27b201cec82d903a1856972e6d7ff1ac58a67c761d729ecd7fd14f24fa9d9901'
 

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -12,6 +12,7 @@ class Crew_profile < Package
   def self.install
     system "mkdir", "-p", "#{CREW_DEST_PREFIX}/etc"
     system "touch", "#{CREW_DEST_PREFIX}/etc/profile"
+  end
 
   def self.postinstall
     puts

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -23,7 +23,7 @@ class Crew_profile < Package
     puts
     puts "To create your very own Crew profile, please execute this:".lightblue
     puts
-    puts "touch ~/.profile"
+    puts "touch ~/.profile".lightblue
     puts
     puts "For Bash, execute this:".lightblue
     puts

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Crew_profile < Package
+  description 'A profile for Chromebrew, to be used instead of ~/.*rc'
+  homepage 'https://github.com/skycocker/chromebrew'
+  version '0.4.3'
+  source_url 'https://github.com/skycocker/chromebrew/raw/511ee9cb3138e113df74ddf0dee057ef5d9a46fd/README.md'
+  source_sha256 '27b201cec82d903a1856972e6d7ff1ac58a67c761d729ecd7fd14f24fa9d9901'
+
+  depends_on "xdg_base"
+
+  def self.install
+    system "mkdir", "-p", "#{CREW_DEST_PREFIX}/etc"
+    system "touch", "#{CREW_DEST_PREFIX}/etc/profile"
+
+  def self.postinstall
+    puts
+    puts "To create your very own Crew profile, please execute this:".lightblue
+    puts
+    puts "echo \"if [ -f #{CREW_PREFIX}/etc/profile ]; then\" >> ~/.bashrc".lightblue
+    puts "echo \"  # Source crew profile\" >> ~/.bashrc".lightblue
+    puts "echo \"  source #{CREW_PREFIX}/etc/profile\" >> ~/.bashrc".lightblue
+    puts "echo \"fi\" >> ~/.bashrc".lightblue
+    puts "source ~/.bashrc".lightblue
+    puts
+    puts "For Zsh, execute this:".lightblue
+    puts
+    puts "echo \"if [ -f #{CREW_PREFIX}/etc/profile ]; then\" >> ~/.zshrc".lightblue
+    puts "echo \"  # Source crew profile\" >> ~/.zshrc".lightblue
+    puts "echo \"  source #{CREW_PREFIX}/etc/profile\" >> ~/.zshrc".lightblue
+    puts "echo \"fi\" >> ~/.zshrc".lightblue
+    puts "source ~/.zshrc".lightblue
+    puts
+    puts "For Fish, execute this:".lightblue
+    puts
+    puts "echo \"if [ -f #{CREW_PREFIX}/etc/profile ]; then\" >> ~/.config/fish/config.fish".lightblue
+    puts "echo \"  # Source crew profile\" >> ~/.config/fish/config.fish".lightblue
+    puts "echo \"  source #{CREW_PREFIX}/etc/profile\" >> ~/.config/fish/config.fish".lightblue
+    puts "echo \"fi\" >> ~/.config/fish/config.fish".lightblue
+    puts "source ~/.config/fish/config.fish".lightblue
+    puts
+    puts "Works with Bash, Zsh, and Fish".lightblue
+    puts
+  end
+end

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -3,7 +3,7 @@ require 'package'
 class Crew_profile < Package
   description 'A profile for Chromebrew, to be used instead of ~/.*rc'
   homepage 'https://github.com/skycocker/chromebrew'
-  version "#{CREW_VERSION}"
+  version "1"
   source_url 'https://github.com/skycocker/chromebrew/raw/511ee9cb3138e113df74ddf0dee057ef5d9a46fd/README.md'
   source_sha256 '27b201cec82d903a1856972e6d7ff1ac58a67c761d729ecd7fd14f24fa9d9901'
 
@@ -17,6 +17,8 @@ class Crew_profile < Package
   end
 
   def self.postinstall
+    puts
+    puts "Works with Bash, Zsh, and Fish".lightblue
     puts
     puts "To create your very own Crew profile, please execute this:".lightblue
     puts
@@ -41,8 +43,6 @@ class Crew_profile < Package
     puts "echo \"  source #{CREW_PREFIX}/etc/profile\" >> ~/.config/fish/config.fish".lightblue
     puts "echo \"end\" >> ~/.config/fish/config.fish".lightblue
     puts "source ~/.config/fish/config.fish".lightblue
-    puts
-    puts "Works with Bash, Zsh, and Fish".lightblue
     puts
   end
 end

--- a/packages/crew_profile.rb
+++ b/packages/crew_profile.rb
@@ -14,7 +14,6 @@ class Crew_profile < Package
   def self.install
     system "mkdir", "-p", "#{CREW_DEST_PREFIX}/etc"
     system "mkdir", "-p", "#{CREW_DEST_HOME}"
-    system "touch", "#{HOME}/.profile" # To not overwrite already installed configuration
     system "ln", "-s", "#{HOME}/.profile", "#{CREW_DEST_PREFIX}/etc/profile"
   end
 
@@ -23,6 +22,10 @@ class Crew_profile < Package
     puts "Works with Bash, Zsh, and Fish".lightblue
     puts
     puts "To create your very own Crew profile, please execute this:".lightblue
+    puts
+    puts "touch ~/.profile"
+    puts
+    puts "For Bash, execute this:".lightblue
     puts
     puts "echo \"if [ -f #{CREW_PREFIX}/etc/profile ]; then\" >> ~/.bashrc".lightblue
     puts "echo \"  # Source crew profile\" >> ~/.bashrc".lightblue


### PR DESCRIPTION
Does support bash, zsh, and fish, but not all 3 at the same time.

Adds a new file, `#{CREW_PREFIX}/etc/profile`, that is sourced after the shell starts.