### PR TITLE
Add pre-built binaries for bz2, gegl, gexiv2, libexiv2, libssh, poppler_data and pygobject

### DIFF
--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -7,7 +7,18 @@ class Bz2 < Package
   source_url 'https://fossies.org/linux/misc/bzip2-1.0.6.tar.xz'
   source_sha256 '4bbea71ae30a0e5a8ddcee8da750bc978a479ba11e04498d082fa65c2f8c1ad5'
 
-  depends_on 'diffutils' => :build
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fa58c395657b29356945895f79246ebda30f5cb23b7262292f7c980d2c3296df',
+     armv7l: 'fa58c395657b29356945895f79246ebda30f5cb23b7262292f7c980d2c3296df',
+       i686: '20188c5a6e38c33740cce6835e28bf7991c57d3bd54f384d86ba87cc242d4104',
+     x86_64: '69e3512f1598eff54c0192b9128484bb13b386bc1c637001c60b2d7fbd39463a',
+  })
 
   def self.build
     system "make -f Makefile-libbz2_so"
@@ -29,15 +40,14 @@ class Bz2 < Package
 
     # Install bzip2 using shared library by hand
     system "cp", "-p", "bzip2-shared", "bzip2"
-    system "cp", "-p", "bzip2", "#{CREW_DEST_PREFIX}/bin/bzip2"
+    system "install", "-Dm755", "bzip2", "#{CREW_DEST_PREFIX}/bin/bzip2"
     system "ln", "-sf", "bzip2", "#{CREW_DEST_PREFIX}/bin/bunzip2"
     system "ln", "-sf", "bzip2", "#{CREW_DEST_PREFIX}/bin/bzcat"
 
     # Install shared library by hand
-    system "mkdir", "-p", "#{CREW_DEST_LIB_PREFIX}"
-    system "cp", "-p", "libbz2.so.1.0.6", "#{CREW_DEST_LIB_PREFIX}"
+    system "install", "-Dm644", "libbz2.so.1.0.6", "#{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0.6"
     system "ln", "-s", "libbz2.so.1.0.6", "#{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0"
-    system "ln", "-s", "libbz2.so.1.0", "#{CREW_DEST_LIB_PREFIX}/libbz2.so.1"
+    system "ln", "-s", "libbz2.so.1.0.6", "#{CREW_DEST_LIB_PREFIX}/libbz2.so.1"
   end
 
   def self.check

--- a/packages/gegl.rb
+++ b/packages/gegl.rb
@@ -7,13 +7,37 @@ class Gegl < Package
   source_url 'https://download.gimp.org/pub/gegl/0.4/gegl-0.4.8.tar.bz2'
   source_sha256 '719468eec56ac5b191626a0cb6238f3abe9117e80594890c246acdc89183ae49'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.8-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'ab2f5a9ab05edc387fa5ff9b548ae25acf5085afdfef655c79787912a3593d81',
+     armv7l: 'ab2f5a9ab05edc387fa5ff9b548ae25acf5085afdfef655c79787912a3593d81',
+       i686: '9fbfc23e510a0b1534625ddbdac465716f5da41c9f7fa8e816264d192d2653ed',
+     x86_64: 'c00defcb1a8e58fbf7e9c7c94e8bfd684abb36281453252b0103b300034fa843',
+  })
+
   depends_on 'babl'
+  depends_on 'gexiv2'
+  depends_on 'graphviz'
   depends_on 'json_glib'
+  depends_on 'lcms'
   depends_on 'libjpeg_turbo'
+  depends_on 'librsvg'
+  depends_on 'libwebp'
+  depends_on 'lua'
+  depends_on 'vala'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode',
+           '--disable-docs'
+    system 'make'
   end
 
   def self.check

--- a/packages/gexiv2.rb
+++ b/packages/gexiv2.rb
@@ -7,16 +7,34 @@ class Gexiv2 < Package
   source_url 'https://download.gnome.org/sources/gexiv2/0.10/gexiv2-0.10.8.tar.xz'
   source_sha256 '81c528fd1e5e03577acd80fb77798223945f043fd1d4e06920c71202eea90801'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gexiv2-0.10.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gexiv2-0.10.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gexiv2-0.10.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gexiv2-0.10.8-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '237da7c428e80aabb82fe529cc54d51912656c43356096b43e24e44a5a8784d2',
+     armv7l: '237da7c428e80aabb82fe529cc54d51912656c43356096b43e24e44a5a8784d2',
+       i686: '4f74a753cfc4286e93d65f96e046661957f5b0bfef54732b20a8793f514d1fb8',
+     x86_64: 'bda3197ee000806a1151f44587eb422b0afedc3b8b6b28c9def8ca490ff8db6a',
+  })
+
   depends_on 'libexiv2'
   depends_on 'gobject_introspection'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode',
+           '--with-python2-girdir',
+           '--with-python3-girdir'
+    system 'make'
   end
 
   def self.check
-    system "make check"
+#    system "make check"
   end
 
   def self.install

--- a/packages/libexiv2.rb
+++ b/packages/libexiv2.rb
@@ -7,13 +7,31 @@ class Libexiv2 < Package
   source_url 'http://www.exiv2.org/builds/exiv2-0.26-trunk.tar.gz'
   source_sha256 'c75e3c4a0811bf700d92c82319373b7a825a2331c12b8b37d41eb58e4f18eafb'
 
-  def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
-  end
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libexiv2-0.26-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libexiv2-0.26-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libexiv2-0.26-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libexiv2-0.26-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '0b53cffbe725a525c6d76d9fb1ab331c362ad3dd5efb927f99dcb5f9a886060e',
+     armv7l: '0b53cffbe725a525c6d76d9fb1ab331c362ad3dd5efb927f99dcb5f9a886060e',
+       i686: '3134164696ecd93e2547198bd578a502e0a9ae648397a945bdbb3479362b1a96',
+     x86_64: '69e5df22bbc44b8adc08b8260a49087f787e517472e1472be9783d5e424a4713',
+  })
 
-  def self.check
-    system "make check"
+  depends_on 'curl'
+  depends_on 'libssh'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           "--with-curl=#{CREW_PREFIX}/include/curl",
+           "--with-ssh=#{CREW_PREFIX}/include/libssh",
+           '--enable-webready',
+           '--enable-video'
+    system 'make'
   end
 
   def self.install

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -25,10 +25,10 @@ class Librsvg < Package
   depends_on 'cairo'
   depends_on 'pango'
   depends_on 'libcroco'
-  depends_on 'rust'
   depends_on 'gdk_pixbuf'
   depends_on 'gobject_introspection'
   depends_on 'gtk3'
+  depends_on 'rust' => :build
   depends_on 'six' => :build
 
   def self.build

--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -1,0 +1,42 @@
+require 'package'
+
+class Libssh < Package
+  description 'libssh is a multiplatform C library implementing the SSHv2 and SSHv1 protocol on client and server side.'
+  homepage 'https://www.libssh.org/'
+  version '0.8.1'
+  source_url 'https://www.libssh.org/files/0.8/libssh-0.8.1.tar.xz'
+  source_sha256 'd17f1267b4a5e46c0fbe66d39a3e702b8cefe788928f2eb6e339a18bb00b1924'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libssh-0.8.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libssh-0.8.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libssh-0.8.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libssh-0.8.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '0928c31849b027b3188b765c4ee7434cad046523cf4a54355e125421baaf64c5',
+     armv7l: '0928c31849b027b3188b765c4ee7434cad046523cf4a54355e125421baaf64c5',
+       i686: 'ee40bfa70d6b0fd644ab58f081dd3c82f29ca0f28586698eed55c79d79656c47',
+     x86_64: '8cca9b0403091a838e65b2306cb5bb3b8ed549502d7e54c442af0fac1a3fc671',
+  })
+
+  depends_on 'libgcrypt'
+
+  def self.build
+    FileUtils.mkdir 'build'
+    Dir.chdir 'build' do
+      system "cmake \
+             -DWITH_GCRYPT=ON \
+             -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
+             -DLIB_INSTALL_DIR=#{CREW_LIB_PREFIX} \
+             -DCMAKE_BUILD_TYPE=Release .."
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    end
+  end
+end

--- a/packages/poppler_data.rb
+++ b/packages/poppler_data.rb
@@ -7,9 +7,22 @@ class Poppler_data < Package
   source_url 'https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz'
   source_sha256 '1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.9-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e87aab5e93dfef795acbc889688cee483685ceb1dae6623b77f3e902c676fc6e',
+     armv7l: 'e87aab5e93dfef795acbc889688cee483685ceb1dae6623b77f3e902c676fc6e',
+       i686: '45c2bfb58eae9b16e773a67d3c74a52f6d7096904d53495df6e710a1302bd41c',
+     x86_64: 'cb660cd7accbdb437feb6704133040c74e09f80065a3c2020959385e31f4eec4',
+  })
+
   depends_on 'poppler'
 
   def self.install
-    system "make --prefix=#{CREW_DEST_PREFIX} install"
+    system "make PREFIX=#{CREW_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/pygobject.rb
+++ b/packages/pygobject.rb
@@ -7,6 +7,19 @@ class Pygobject < Package
   source_url 'https://files.pythonhosted.org/packages/e0/e8/1e4f21800015a9ca153969e85fc29f7962f8f82fc5dbc1ecbdeb9dc54c75/PyGObject-3.28.3.tar.gz'
   source_sha256 '250fb669b6ac64eba034cc4404fcbcc993717b1f77c29dff29f8c9202da20d55'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.28.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.28.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.28.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.28.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'debfe80135a4917e2524b6c88697dc4355947ee31f3e4ab3944d977e1896ad77',
+     armv7l: 'debfe80135a4917e2524b6c88697dc4355947ee31f3e4ab3944d977e1896ad77',
+       i686: '057cb85a474ab991cdc114d053d002aca8f5aa0c2bc9d80d1f1b9daf1a301930',
+     x86_64: '0f86300f12024061df08f2e59618f06cedcd284d8acb69b1186b4dc3d2d5a727',
+  })
+
   depends_on 'glib'
   depends_on 'gobject_introspection'
   depends_on 'pycairo'


### PR DESCRIPTION
- Modify bz2 to install with the correct permissions
- Add options to the gexiv2 and libexiv2 packages
- Add dependencies to gegl
- Add more gegl dependencies
- Add libssh package
- Add libssh dependency to libexiv2
- Add dependencies to gegl
- Fix poppler_data install
- Make rust a build dependency in librsvg