### PR TITLE
Add enscript package and libpth dependency

### DIFF
--- a/packages/enscript.rb
+++ b/packages/enscript.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Enscript < Package
+  description 'GNU Enscript is a free replacement for Adobe\'s enscript program.'
+  homepage 'https://www.gnu.org/software/enscript/'
+  version '1.6.6'
+  source_url 'https://ftpmirror.gnu.org/enscript/enscript-1.6.6.tar.gz'
+  source_sha256 '6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/enscript-1.6.6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/enscript-1.6.6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/enscript-1.6.6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/enscript-1.6.6-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '316ed484d08cfbe16632937379a05366b9841e986e351fd3d4061f474e046725',
+     armv7l: '316ed484d08cfbe16632937379a05366b9841e986e351fd3d4061f474e046725',
+       i686: '4332bbf72b8622a2ecbc84e58f55b1515ce66c3d678c69c1f28402cfc6e2a7e3',
+     x86_64: '638519de1bdfc08816d511f8ad468213d78293a77a26295630a0266b664582c9',
+  })
+
+  depends_on 'libpth'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/libpth.rb
+++ b/packages/libpth.rb
@@ -1,0 +1,34 @@
+require 'package'
+
+class Libpth < Package
+  description 'Pth is a very portable POSIX/ANSI-C based library for Unix platforms'
+  homepage 'https://www.gnu.org/software/pth/'
+  version '2.0.7'
+  source_url 'https://ftpmirror.gnu.org/pth/pth-2.0.7.tar.gz'
+  source_sha256 '72353660c5a2caafd601b20e12e75d865fd88f6cf1a088b306a3963f0bc77232'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpth-2.0.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpth-2.0.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpth-2.0.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpth-2.0.7-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '6df029d8c9a59cc6bfba3308d362589b5d32e72fecc282dfb6e05e67fac6c387',
+     armv7l: '6df029d8c9a59cc6bfba3308d362589b5d32e72fecc282dfb6e05e67fac6c387',
+       i686: '49344c2b2eafe8f4490b94bed951b8e7eb31bb45c358d21f531fcd9741e412c6',
+     x86_64: 'b82687dc8d4525dd8deee18576ae9ffbb149c2a7a378de68db60fd12de3f6b12',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--enable-optimize'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Pth is a very portable POSIX/ANSI-C based library for Unix platforms which provides non-preemptive priority-based scheduling for multiple threads of execution (aka ``multithreading'') inside event-driven applications. All threads run in the same address space of the server application, but each thread has it's own individual program-counter, run-time stack, signal mask and errno variable.

See https://www.gnu.org/software/pth/.

GNU Enscript is a free replacement for Adobe's enscript program.

GNU Enscript converts ASCII files to PostScript, HTML, or RTF and stores generated output to a file or sends it directly to the printer. It includes features for `pretty-printing' (language-sensitive code highlighting) in several programming languages.

Enscript can be easily extended to handle different output media and it has many options that can be used to customize printouts.

See https://www.gnu.org/software/enscript/.