### PR TITLE
Update code from 1.25 to 1.25.1

### DIFF
--- a/packages/code.rb
+++ b/packages/code.rb
@@ -3,13 +3,13 @@ require 'package'
 class Code < Package
   description 'Visual Studio Code is a source code editor developed by Microsoft for Windows, Linux and macOS.'
   homepage 'https://code.visualstudio.com/'
-  version '1.25'
+  version '1.25.1'
   case ARCH
   when 'x86_64'
-    source_url 'https://go.microsoft.com/fwlink/?LinkID=620884'
+    source_url 'https://vscode-update.azurewebsites.net/1.25.1/linux-x64/stable'
     source_sha256 '5856bbebf38aa05d584da4722869bbe507cf123f69f7ffab5f1532d73dbf3438'
   when 'i686'
-    source_url 'https://go.microsoft.com/fwlink/?LinkID=620885'
+    source_url 'https://vscode-update.azurewebsites.net/1.25.1/linux-ia32/stable'
     source_sha256 'af6adc2e2500e50bfebe7ee7b97d661b6e774a590136bf5f89334132a5b292e2'
   else
     source_url 'https://raw.githubusercontent.com/Microsoft/vscode/1.25.1/README.md'
@@ -32,7 +32,7 @@ class Code < Package
       system "mkdir", "-p", "#{CREW_DEST_PREFIX}/share/code"
       system "mkdir", "-p", "#{CREW_DEST_PREFIX}/bin"
       system "cp", "-rpa", ".", "#{CREW_DEST_PREFIX}/share/code/"
-      system "ln", "-s", "#{CREW_PREFIX}/share/code/bin/code", "#{CREW_DEST_PREFIX}/bin"
+      system "ln", "-s", "#{CREW_PREFIX}/share/code/bin/code", "#{CREW_DEST_PREFIX}/bin/code"
     else
       puts
       puts 'Visual Studio Code is currently not supported on ARM and AArch64.'.lightred


### PR DESCRIPTION
Resolves #2603.

Still have an issue with the display on both i686 and x86_64:
```
$ code --verbose
(code:9186): Gtk-WARNING **: 20:30:59.812: cannot open display: :0
```