### PR TITLE
Add kakoune package

### DIFF
--- a/packages/kakoune.rb
+++ b/packages/kakoune.rb
@@ -7,20 +7,20 @@ class Kakoune < Package
   version 'v2018.09.04'
   source_url 'https://github.com/mawww/kakoune/releases/download/v2018.09.04/kakoune-2018.09.04.tar.bz2'
   source_sha256 '7a31c9f08c261c5128d1753762721dd7b7fe4bb4e9a3c368c9d768c72a1472e1'
-
+  
   depends_on 'ncurses'  => :build
   depends_on 'asciidoc' => :build
   depends_on 'libxslt'  => :build
 
   def self.build
     Dir.chdir("src") do
-      system "make", "debug=no"
+      system "make", "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", "debug=no"
     end
   end
 
   def self.install
     Dir.chdir("src") do
-      system "make", "install", "DESTDIR=#{CREW_DEST_DIR}", "debug=no"
+      system "make", "install", "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", "debug=no"
     end
   end
 end

--- a/packages/kakoune.rb
+++ b/packages/kakoune.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Kakoune < Package
+  # TODO prebuild version
+  description 'mawww\'s experiment for a better code editor'
+  homepage 'http://kakoune.org/'
+  version 'v2018.09.04'
+  source_url 'https://github.com/mawww/kakoune/releases/download/v2018.09.04/kakoune-2018.09.04.tar.bz2'
+  source_sha256 '7a31c9f08c261c5128d1753762721dd7b7fe4bb4e9a3c368c9d768c72a1472e1'
+
+  depends_on 'ncurses'  => :build
+  depends_on 'asciidoc' => :build
+  depends_on 'libxslt'  => :build
+
+  def self.build
+    Dir.chdir("src") do
+      system "make", "debug=no"
+    end
+  end
+
+  def self.install
+    Dir.chdir("src") do
+      system "make", "install", "DESTDIR=#{CREW_DEST_DIR}", "debug=no"
+    end
+  end
+end


### PR DESCRIPTION
Kakoune is a text editor, similar to vim.
Official repo: https://github.com/mawww/kakoune
Official website: http://kakoune.org

(let GitHub automatically close an issue when this pull request gets merged)

Works properly on all targets.

I have not researched much about how crew does prebuilt binaries. It looks like I have to upload them somewhere (bintray?) or set up a script to build them automatically. Is this correct?