### PR TITLE
Add pre-built binaries for kakoune and quakespasm

### DIFF
--- a/packages/kakoune.rb
+++ b/packages/kakoune.rb
@@ -7,6 +7,19 @@ class Kakoune < Package
   version 'v2018.09.04'
   source_url 'https://github.com/mawww/kakoune/releases/download/v2018.09.04/kakoune-2018.09.04.tar.bz2'
   source_sha256 '7a31c9f08c261c5128d1753762721dd7b7fe4bb4e9a3c368c9d768c72a1472e1'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/kakoune-v2018.09.04-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/kakoune-v2018.09.04-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/kakoune-v2018.09.04-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/kakoune-v2018.09.04-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'a4304ec155e6c375c841451df07d60b19ed288b0abc9f99b46a6de52a2b40321',
+     armv7l: 'a4304ec155e6c375c841451df07d60b19ed288b0abc9f99b46a6de52a2b40321',
+       i686: 'd602be65796ba2ec9b13a105910225469e9ba0b73c32459169b1e8ea8784ce13',
+     x86_64: 'daed7d68e53f1f2751dc6a9a59c3efaab0a89651ff690b2cb5ac8be02e4d95f1',
+  })
   
   depends_on 'ncurses'  => :build
   depends_on 'asciidoc' => :build

--- a/packages/quakespasm.rb
+++ b/packages/quakespasm.rb
@@ -7,6 +7,19 @@ class Quakespasm < Package
   source_url 'https://sourceforge.net/projects/quakespasm/files/Source/quakespasm-0.93.1.tgz'
   source_sha256 'ed3ee6ba7e3d9454c7620757cc166e13d892f1167c7b74bef4f067e350d835ae'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/quakespasm-0.93.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/quakespasm-0.93.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/quakespasm-0.93.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/quakespasm-0.93.1-1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'a75901d94ad4475d297ddd09ec4f32b75c7b6d1120f5fdfb5d18e068d7517824',
+     armv7l: 'a75901d94ad4475d297ddd09ec4f32b75c7b6d1120f5fdfb5d18e068d7517824',
+       i686: '4f475052feca47e669afbd81d11882ca54143c2bffcd1765a8ab1c46b2a3f8ef',
+     x86_64: '16afe97af889bd2c5c4f8e4c835fd044c3313f76e91bb584f27a44740c454e17',
+  })
+
   depends_on 'libglu'
   depends_on 'libsdl'
   depends_on 'libvorbis'


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64