### PR TITLE
Updated nano

### DIFF
--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -3,21 +3,13 @@ require 'package'
 class Nano < Package
   description 'Nano\'s ANOther editor, an enhanced free Pico clone.'
   homepage 'https://www.nano-editor.org/'
-  version '2.9.5'
-  source_url 'https://www.nano-editor.org/dist/v2.9/nano-2.9.5.tar.xz'
-  source_sha256 '7b8d181cb57f42fa86a380bb9ad46abab859b60383607f731b65a9077f4b4e19'
+  version '3.0'
+  source_url 'https://www.nano-editor.org/dist/v3/nano-3.0.tar.xz'
+  source_sha256 'e0a5bca354514e64762c987c200a8758b05e7bcced3b00b3e48ea0a2d383c8a0'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-2.9.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nano-2.9.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nano-2.9.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-2.9.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '127c08b4f613b9beb34f73334b201345eaa6375951da4a9f672fa1f710a519a3',
-     armv7l: '127c08b4f613b9beb34f73334b201345eaa6375951da4a9f672fa1f710a519a3',
-       i686: 'fd5962055dffc82f039023f7f454873abe76bfa53f51ce87d2e648f813cb8862',
-     x86_64: 'd8d56d3e5cc9e5db5ac312454231886dd327fecc122fb9d91231427eaa294cd8',
   })
 
   depends_on 'filecmd'
@@ -31,8 +23,8 @@ class Nano < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-strip'
-    system "mkdir -pv #{CREW_DEST_DIR}$HOME"
-    system "touch #{CREW_DEST_DIR}$HOME/.nanorc"
+    system "mkdir -pv #{CREW_DEST_HOME}"
+    system "touch #{CREW_DEST_HOME}/.nanorc"
   end
 
   def self.postinstall
@@ -40,12 +32,10 @@ class Nano < Package
     puts "Personal configuration file is located in $HOME/.nanorc".lightblue
     puts
     open("#{ENV['HOME']}/.nanorc", 'w') { |f|
-      f << "set autoindent\n"
       f << "set constantshow\n"
       f << "set fill 72\n"
       f << "set historylog\n"
       f << "set multibuffer\n"
-      f << "set nohelp\n"
       f << "set nowrap\n"
       f << "set positionlog\n"
       f << "set historylog\n"


### PR DESCRIPTION
GNU nano 3.0 "Water Flowing Underground" speeds up the
reading of a file by seventy percent, roughly doubles the
speed of handling ASCII text, changes the way words at line
boundaries are deleted, makes <Ctrl+Delete> wipe the next
word and <Ctrl+Shift+Delete> the preceding word, binds M-Q
to 'findprevious' by default (the Tabs-to-Spaces toggle is
placed on M-O, and the More-Space toggle is fully removed),
makes an external spell check undoable, shows the correct
number of lines on the status bar when opening multiple
files, removes the 'formatter' command, removes the
'searchagain' bindable function (M-W is now bound to
'findnext' by default), moves the No-Convert toggle to the
Insert menu, removes the Backup and New-Buffer toggles from
the main menu (they remain in the Write-Out and Insert
menus, respectively), is more precise in what it accepts as
a rebindable key name, ignores any presses of <Esc> before
a valid command keystroke, recognizes some more escape
sequences for modified editing-pad keys, does not hide
rcfile error messages on a Linux console, renames the
bindable functions 'copytext' to 'copy' and 'uncut' to
'paste', and avoids a possible hang during a Full-Justify.