### PR TITLE
Add wireless_tools package

### DIFF
--- a/packages/wireless_tools.rb
+++ b/packages/wireless_tools.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Wireless_tools < Package
+  description 'Wireless Tools for Linux'
+  homepage 'https://github.com/HewlettPackard/wireless-tools'
+  version '2.9'
+  source_url 'https://github.com/HewlettPackard/wireless-tools/archive/v29.tar.gz'
+  source_sha256 '69c5face9ac9d3273042436408a9a057d3416a814253dedeaaef210fcbc42d40'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    Dir.chdir ("wireless_tools") do
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir ("wireless_tools") do
+      system "make", "INSTALL_MAN=#{CREW_DEST_PREFIX}/share/man", "INSTALL_LIB=#{CREW_DEST_LIB_PREFIX}", "PREFIX=#{CREW_DEST_PREFIX}", "install"
+    end
+  end
+end


### PR DESCRIPTION
The Wireless Tools (WT) interface is a set of tools allowing to manipulate Wireless Extensions. They use a textual interface and are rather crude, but aim to support the full Wireless Extension pack. There are many other tools you can use with Wireless Extensions, however Wireless Tools is the reference implementation.