### PR TITLE
Updated tilp package and split dependencies.

### DIFF
--- a/packages/libticables2.rb
+++ b/packages/libticables2.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Libticables2 < Package
+  description 'Libticables2 offers the library used to connect to and perform read/write operations on TI Calculators via. USB.'
+  homepage 'http://lpg.ticalc.org/prj_tilp/'
+  version '1.3.5'
+  source_url 'https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/libticables2-1.3.5.tar.bz2'
+  source_sha256 '0c6fb6516e72ccab081ddb3aecceff694ed93aec689ddd2edba9c7c7406c4522'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'libusb'
+  depends_on 'libtifiles2'
+
+  def self.build
+    system 'autoreconf -i'
+    system "/usr/bin/env",
+      "CC=clang -fuse-ld=lld",
+      "CXX=clang++ -fuse-ld=lld",
+      "./configure",
+      "--prefix=#{CREW_PREFIX}",
+      "--enable-libusb10",
+      "--disable-libusb",
+      "--libdir=#{CREW_LIB_PREFIX}"
+    system 'sed -i "s,tests,,g" Makefile'
+    system 'make'
+  end
+
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/libticalcs2.rb
+++ b/packages/libticalcs2.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Libticalcs2 < Package
+  description 'Libticalcs2 offers the library used to properly manipulate files on TI calculators.'
+  homepage 'http://lpg.ticalc.org/prj_tilp/'
+  version '1.1.9'
+  source_url 'https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/libticalcs2-1.1.9.tar.bz2'
+  source_sha256 '76780788bc309b647f97513d38dd5f01611c335a72855e0bd10c7bdbf2e38921'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'libticables2'
+
+  def self.build
+    system 'autoreconf -i'
+    system "/usr/bin/env",
+      "CC=clang -fuse-ld=lld",
+      "CXX=clang++ -fuse-ld=lld",
+      "./configure",
+      "--prefix=#{CREW_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}"
+    system 'sed -i "s,tests,,g" Makefile'
+    system 'make'
+  end
+
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/libticonv.rb
+++ b/packages/libticonv.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Libticonv < Package
+  description 'Libticonv offers support for performing operations on TI calculators involving charsets.'
+  homepage 'http://lpg.ticalc.org/prj_tilp/'
+  version '1.1.5'
+  source_url 'https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/libticonv-1.1.5.tar.bz2'
+  source_sha256 '316da6a73bf26b266dd23443882abc4c9fe7013edc3a53e5e301d525c2060878'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'glib'
+
+  def self.build
+    system 'autoreconf -i'
+    system "/usr/bin/env",
+      "CC=clang -fuse-ld=lld",
+      "CXX=clang++ -fuse-ld=lld",
+      "./configure",
+      "--enable-iconv",
+      "--prefix=#{CREW_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}"
+    system 'sed -i "s,tests,,g" Makefile'
+    system 'make'
+  end
+
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/libtifiles2.rb
+++ b/packages/libtifiles2.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Libtifiles2 < Package
+  description 'Libtifiles2 offers the library used to properly manipulate files on TI calculators.'
+  homepage 'http://lpg.ticalc.org/prj_tilp/'
+  version '1.1.7'
+  source_url 'https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/libtifiles2-1.1.7.tar.bz2'
+  source_sha256 '9ac63b49e97b09b30b37bbc84aeb15fa7967bceb944e56141c5cd5a528acc982'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'libticonv'
+  depends_on 'libarchive'
+
+  def self.build
+    system 'autoreconf -i'
+    system "/usr/bin/env",
+      "CC=clang -fuse-ld=lld",
+      "CXX=clang++ -fuse-ld=lld",
+      "./configure",
+      "--prefix=#{CREW_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}"
+    system 'sed -i "s,tests,,g" Makefile'
+    system 'make'
+  end
+
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/tilp.rb
+++ b/packages/tilp.rb
@@ -1,67 +1,12 @@
-require 'package' 
+require 'package'
+
 class Tilp < Package
   description 'TiLP is a linking program for Texas Instruments\' graphing calculators.'
   homepage 'http://lpg.ticalc.org/prj_tilp/'
-  version '1.19'
-  source_url 'https://www.ticalc.org/pub/unix/tilp.tar.gz'
-  source_sha256 '6ba834f7fdbbce9818ccaa864222aed2d1688b210e9ff2c59576d1fde5159cd7'
+  version '1.18'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tilp-1.19-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tilp-1.19-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tilp-1.19-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tilp-1.19-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'db30e53d1c32e60d62238c7185059692ae43f7514026f965cb4e3f64b8f11c95',
-     armv7l: 'db30e53d1c32e60d62238c7185059692ae43f7514026f965cb4e3f64b8f11c95',
-       i686: 'f21fa9762e55d14383c96d9ea25fc22d69aeb26fdaacdbfc7482132d29872f83',
-     x86_64: '607e83053d566f29a5daf692d01fe5fc66d371e176aa89bc97a4c75cdcbe3c90',
-  })
+  is_fake
 
-  depends_on 'libarchive'
-  depends_on 'libglade'
-  depends_on 'libusb'
+  depends_on 'tilp2'
 
-  def self.install
-    system 'wget http://lpg.ticalc.org/prj_tilp/download/install_tilp.sh'
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('install_tilp.sh') ) == '6baf4b79100a938c2c36218d50c30a39c2beec17490784e3623d4aeebe9931ee'
-    system "sed -i '243iif [ \"x\$LIBDIR\" = \"x\" ]; then' install_tilp.sh"
-    system "sed -i '250ifi' install_tilp.sh"
-    system "PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} SRCDIR=#{CREW_DEST_PREFIX}/share bash install_tilp.sh"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include"
-    FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}/pkgconfig"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/appdata"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/applications"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/locale/de/LC_MESSAGES"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/locale/fr/LC_MESSAGES"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/mime/packages"
-    system "cp #{CREW_PREFIX}/bin/gfm #{CREW_DEST_PREFIX}/bin"
-    system "cp #{CREW_PREFIX}/bin/tilp #{CREW_DEST_PREFIX}/bin"
-    system "cp -r #{CREW_PREFIX}/include/tilp2 #{CREW_DEST_PREFIX}/include"
-    system "cp #{CREW_LIB_PREFIX}/libticables2.so* #{CREW_DEST_LIB_PREFIX}"
-    system "cp #{CREW_LIB_PREFIX}/libticalcs2.so* #{CREW_DEST_LIB_PREFIX}"
-    system "cp #{CREW_LIB_PREFIX}/libticonv.so* #{CREW_DEST_LIB_PREFIX}"
-    system "cp #{CREW_LIB_PREFIX}/libtifiles2.so* #{CREW_DEST_LIB_PREFIX}"
-    system "cp #{CREW_LIB_PREFIX}/pkgconfig/ticables2.pc #{CREW_DEST_LIB_PREFIX}/pkgconfig"
-    system "cp #{CREW_LIB_PREFIX}/pkgconfig/ticalcs2.pc #{CREW_DEST_LIB_PREFIX}/pkgconfig"
-    system "cp #{CREW_LIB_PREFIX}/pkgconfig/ticonv.pc #{CREW_DEST_LIB_PREFIX}/pkgconfig"
-    system "cp #{CREW_LIB_PREFIX}/pkgconfig/tifiles2.pc #{CREW_DEST_LIB_PREFIX}/pkgconfig"
-    system "cp #{CREW_PREFIX}/share/appdata/gfm.appdata.xml #{CREW_DEST_PREFIX}/share/appdata"
-    system "cp #{CREW_PREFIX}/share/appdata/tilp.appdata.xml #{CREW_DEST_PREFIX}/share/appdata"
-    system "cp #{CREW_PREFIX}/share/applications/gfm.desktop #{CREW_DEST_PREFIX}/share/applications"
-    system "cp #{CREW_PREFIX}/share/applications/tilp.desktop #{CREW_DEST_PREFIX}/share/applications"
-    system "cp -r #{CREW_PREFIX}/share/gfm #{CREW_DEST_PREFIX}/share"
-    system "cp #{CREW_PREFIX}/share/locale/de/LC_MESSAGES/libticalcs2.mo #{CREW_DEST_PREFIX}/share/locale/de/LC_MESSAGES"
-    system "cp #{CREW_PREFIX}/share/locale/de/LC_MESSAGES/tilp2.mo #{CREW_DEST_PREFIX}/share/locale/de/LC_MESSAGES"
-    system "cp #{CREW_PREFIX}/share/locale/fr/LC_MESSAGES/gfm.mo #{CREW_DEST_PREFIX}/share/locale/fr/LC_MESSAGES"
-    system "cp #{CREW_PREFIX}/share/locale/fr/LC_MESSAGES/libticables2.mo #{CREW_DEST_PREFIX}/share/locale/fr/LC_MESSAGES"
-    system "cp #{CREW_PREFIX}/share/locale/fr/LC_MESSAGES/libticalcs2.mo #{CREW_DEST_PREFIX}/share/locale/fr/LC_MESSAGES"
-    system "cp #{CREW_PREFIX}/share/locale/fr/LC_MESSAGES/libtifiles2.mo #{CREW_DEST_PREFIX}/share/locale/fr/LC_MESSAGES"
-    system "cp #{CREW_PREFIX}/share/locale/fr/LC_MESSAGES/tilp2.mo #{CREW_DEST_PREFIX}/share/locale/fr/LC_MESSAGES"
-    system "cp #{CREW_PREFIX}/share/mime/packages/tilp.xml #{CREW_DEST_PREFIX}/share/mime/packages"
-    system "cp -r #{CREW_PREFIX}/share/tilp2 #{CREW_DEST_PREFIX}/share"
-    system "rm -rf #{CREW_DEST_PREFIX}/share/tilp"
-  end
 end

--- a/packages/tilp2.rb
+++ b/packages/tilp2.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Tilp2 < Package
+  description 'TiLP 2 is a linking program for Texas Instruments\' graphing calculators.'
+  homepage 'http://lpg.ticalc.org/prj_tilp/'
+  version '1.18'
+  source_url 'https://sourceforge.net/projects/tilp/files/tilp2-linux/tilp2-1.18/tilp2-1.18.tar.bz2'
+  source_sha256 '7b3ab363eeb52504d6ef5811c5d264f8016060bb7bd427be5a064c2ed7384e47'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'libticalcs2'
+  depends_on 'libglade'
+  depends_on 'sommelier'
+
+  def self.build
+    system "wget https://github.com/JL2210/patches/raw/04eeee244059b41e0f0f4bf60f38fc4b6cb1e480/tilp2-1.18-autoconf.patch"
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('tilp2-1.18-autoconf.patch') ) == 'dedba5bbd1ceb9cf819ea62c156377b6e4eb4b167f33e2c4c8823c2684fa352b'
+    system 'patch -Np1 -i tilp2-1.18-autoconf.patch'
+    system 'autoreconf -i'
+    system "CC='clang -fuse-ld=lld -L#{CREW_LIB_PREFIX} -lusb-1.0' CXX='clang++ -fuse-ld=lld -L#{CREW_LIB_PREFIX} -lusb-1.0' ./configure --prefix=#{CREW_PREFIX} --without-kde --enable-libusb10 --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+    system 'make install'
+  end
+
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end


### PR DESCRIPTION
Fixes #2489 

Updates Tilp package, uses Autoconf, and splits dependencies into separate packages.