### PR TITLE
Update R package.

### DIFF
--- a/packages/r.rb
+++ b/packages/r.rb
@@ -3,21 +3,13 @@ require 'package'
 class R < Package
   description 'R is a free software environment for statistical computing and graphics.'
   homepage 'https://www.r-project.org/'
-  version '3.4.3-1'
-  source_url 'https://cran.r-project.org/src/base/R-3/R-3.4.3.tar.gz'
-  source_sha256 '7a3cb831de5b4151e1f890113ed207527b7d4b16df9ec6b35e0964170007f426'
+  version '3.5.1'
+  source_url 'https://cran.r-project.org/src/base/R-3/R-3.5.1.tar.gz'
+  source_sha256 '0463bff5eea0f3d93fa071f79c18d0993878fd4f2e18ae6cf22c1639d11457ed'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.4.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.4.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.4.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.4.3-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'cfbe1876271be723e1477c325830917fa45acb5e36187bbcb3d8ce835668357e',
-     armv7l: 'cfbe1876271be723e1477c325830917fa45acb5e36187bbcb3d8ce835668357e',
-       i686: '7d69683c6b3c9ce41718652eccc1b4ddb4cba42fee7060c00a06d3afdf25ebca',
-     x86_64: 'b70dbd51af3b9c1676bc4e9c3d90ff4169556a6937f81a51252c7be81b365f05',
   })
 
   # depends_on 'gfortran'       # require gfortran enabled gcc
@@ -27,14 +19,15 @@ class R < Package
   depends_on 'bz2'
   depends_on 'curl'
   depends_on 'openssl'
-  depends_on 'readline'
+  depends_on 'readline7'
   depends_on 'icu4c'
 
   def self.build
     system './configure',
       "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}",
-      '--with-x=no' # X is not available
+      '--with-x=no', # X is not available
+	  '--enable-R-shlib'
     system 'make'
   end
 


### PR DESCRIPTION
Enable shlib to fix #2196 and updated the package to use readline7 since readline6 fails during installation. Oh and bumped the version number to the current release.