### PR TITLE
Add pre-built binaries for acl, heroku and r packages

### DIFF
--- a/packages/acl.rb
+++ b/packages/acl.rb
@@ -8,8 +8,16 @@ class Acl < Package
   source_sha256 '06be9865c6f418d851ff4494e12406568353b891ffe1f596b34693c387af26c7'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/acl-2.2.53-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/acl-2.2.53-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/acl-2.2.53-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/acl-2.2.53-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '63d5600ce26933fc49b5fea4a9ab37f1dac8546c9a2bee6d0525ced6b98c03bb',
+     armv7l: '63d5600ce26933fc49b5fea4a9ab37f1dac8546c9a2bee6d0525ced6b98c03bb',
+       i686: 'a6859cfa0dc95c84304e49e90bbabc19f99a88daf962c58ff83914acd87f151e',
+     x86_64: 'bcf1563988e765aaa8a7ed3969b677a035571bad41c5e12935ebc1745e9fcdd0',
   })
 
   depends_on 'attr'

--- a/packages/heroku.rb
+++ b/packages/heroku.rb
@@ -8,8 +8,16 @@ class Heroku < Package
   source_sha256 '7afe83110494a958bccd2be5ea83b6f86f9abd2b7bf7e4530137f706a4e08ff5'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/heroku-7.16.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/heroku-7.16.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/heroku-7.16.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/heroku-7.16.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'e81447458cee23759364b05ed301cc89d89ea6db14ef9198272a1b010340570e',
+     armv7l: 'e81447458cee23759364b05ed301cc89d89ea6db14ef9198272a1b010340570e',
+       i686: 'c3a8485f2f6427ca86e4ca4bf81d74a8e401e8c05627ebbd77d1bc04fa2c9554',
+     x86_64: 'da7204aacb05c99e034a4f2a9c95e9e44b2493bf9c0717126ab00af6948edb5b',
   })
 
   depends_on 'yarn'

--- a/packages/r.rb
+++ b/packages/r.rb
@@ -8,26 +8,31 @@ class R < Package
   source_sha256 '0463bff5eea0f3d93fa071f79c18d0993878fd4f2e18ae6cf22c1639d11457ed'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.5.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.5.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.5.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/r-3.5.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '983840999a1c53a65cee42ba0a0fcef1cb4c61833d8de078beae5ba83300c908',
+     armv7l: '983840999a1c53a65cee42ba0a0fcef1cb4c61833d8de078beae5ba83300c908',
+       i686: 'd6e8403d9001e8412ad3c17c9422816ab594c1eb2b2576ad0dbb49c27af02cf9',
+     x86_64: 'bd46cf97defc2d200e1bf94c0a157040a5f86cc56ffc99e85b6abe5e875f9e50',
   })
 
   # depends_on 'gfortran'       # require gfortran enabled gcc
   depends_on 'pcre'             # need to use pcre not pcre2
-  depends_on 'zlibpkg'
   depends_on 'xzutils'
   depends_on 'bz2'
   depends_on 'curl'
-  depends_on 'openssl'
   depends_on 'readline7'
-  depends_on 'icu4c'
 
   def self.build
     system './configure',
       "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}",
       '--with-x=no', # X is not available
-	  '--enable-R-shlib'
+      '--enable-R-shlib'
     system 'make'
   end
 


### PR DESCRIPTION
Tested binaries on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64