### PR TITLE
Add pre-built binaries for aws and nano packages

### DIFF
--- a/packages/aws.rb
+++ b/packages/aws.rb
@@ -8,8 +8,16 @@ class Aws < Package
   source_sha256 '7c785969c320d8f00c5f4b6daee9e7f1377ec0de045ff811a645b709f534fd82'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.25-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.25-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.25-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.25-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'dd174dfed432e64ade0c43b7ca8750ae16c3b220672fc05780902774fb1500fe',
+     armv7l: 'dd174dfed432e64ade0c43b7ca8750ae16c3b220672fc05780902774fb1500fe',
+       i686: '539e4ca588ed1e08e40fc43545c3571f0918ca1535edd51d003a78f414705463',
+     x86_64: 'a4b818f502f67f96ff727736304cef7db926384ee3baf4405890033480d6c110',
   })
 
   depends_on 'python3'

--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -8,8 +8,16 @@ class Nano < Package
   source_sha256 '14c02ca40a5bc61c580ce2f9cb7f9fc72d5ccc9da17ad044f78f6fb3fdb7719e'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'b104f51c34448e5f20b6f0ab1a446ba85701464e40ed96484ecadeb2fb09c9cb',
+     armv7l: 'b104f51c34448e5f20b6f0ab1a446ba85701464e40ed96484ecadeb2fb09c9cb',
+       i686: 'd187d05f68885e4ce3afb3726d5ab684d4a97f2c67ea3d1b917893db64120fa8',
+     x86_64: '492bc56f517c1c0c4cc52bdfc210b8b6cd1f072e3da5605f406c99d4be7e11ac',
   })
 
   depends_on 'filecmd'


### PR DESCRIPTION
Tested binaries on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64