### PR TITLE
Update dpkg package

### DIFF
--- a/packages/dpkg.rb
+++ b/packages/dpkg.rb
@@ -3,20 +3,20 @@ require 'package'
 class Dpkg < Package
   description 'A medium-level package manager for Debian'
   homepage 'https://anonscm.debian.org/git/dpkg/'
-  version '1.18.25'
-  source_url 'https://salsa.debian.org/dpkg-team/dpkg/-/archive/1.18.25/dpkg-1.18.25.tar.gz'
-  source_sha256 '93470770161bb15fd7988da1890aecda322e19c3fc858d6cb8f33417e5fe01e9'
+  version '1.19.1'
+  source_url 'http://http.debian.net/debian/pool/main/d/dpkg/dpkg_1.19.1.tar.xz'
+  source_sha256 'ae3978a6b7bddc3e3196804ae0d49ea008c84a8a7a60b7d212af1e1d469e7ccf'
 
   depends_on 'bz2'
   depends_on 'xzutils'
 
   def self.build
-    system "git clone https://salsa.debian.org/dpkg-team/dpkg.git -b 1.18.25"
-    Dir.chdir ("dpkg") do
-      system "autoreconf -i -f"
-      system "./configure --libdir=#{CREW_LIB_PREFIX} --prefix=#{CREW_PREFIX}"
-      system "make"
-    end
+    system "/usr/bin/env",
+           "PERL_LIBDIR=#{CREW_PREFIX}/lib/perl5/site_perl/",
+           "./configure",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           "--prefix=#{CREW_PREFIX}"
+    system "make"
   end
 
   def self.preinstall
@@ -26,32 +26,18 @@ class Dpkg < Package
   end
 
   def self.install
-    Dir.chdir ("dpkg") do
-      system "make install DESTDIR=#{CREW_DEST_DIR}"
-      system "mkdir -p #{CREW_DEST_PREFIX}/usr/"
-      system "ln -s #{CREW_PREFIX} #{CREW_DEST_PREFIX}/usr/local"
-      system "mkdir -p #{CREW_DEST_PREFIX}/var/lib/dpkg/"
-      system "touch #{CREW_DEST_PREFIX}/var/lib/dpkg/status"
-      system "mkdir -p #{CREW_DEST_PREFIX}/lib/perl5/site_perl/"
-      system "ln -s #{CREW_PREFIX}/Dpkg.pm #{CREW_DEST_PREFIX}/lib/perl5/site_perl/"
-      system "ln -s #{CREW_PREFIX}/Dpkg/ #{CREW_DEST_PREFIX}/lib/perl5/site_perl/"
-    end
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
     Dir.chdir ("#{CREW_DEST_PREFIX}/bin") do
       system 'mv dpkg dpkg-run'
       system "echo '#!/bin/bash' > dpkg"
-      system "echo 'dpkg-run --force-not-root --force-depends --root=#{CREW_PREFIX} \"$@\"' >> dpkg"
+      system "echo 'dpkg-run --force-not-root --force-depends \"$@\"' >> dpkg"
       system 'chmod a+x dpkg'
-    end
-    Dir.chdir ("#{CREW_DEST_PREFIX}") do
-      # This will make dpkg run without root
-      system "sudo", "chown", "-R", "#{USER}:#{USER}", "./var/lib/dpkg"
     end
   end
 
   def self.postinstall
     if File.exists? "#{CREW_PREFIX}/var/lib/dpkg/status.old" then
-      system "cat #{CREW_PREFIX}/var/lib/dpkg/status.old >> #{CREW_PREFIX}/var/lib/dpkg/status"
-      system "rm #{CREW_PREFIX}/var/lib/dpkg/status.old"
+      system "mv #{CREW_PREFIX}/var/lib/dpkg/status.old #{CREW_PREFIX}/var/lib/dpkg/status"
     end
   end
 end


### PR DESCRIPTION
Update dpkg to 1.19.1
Tested on x86_64
Version 1.19.1 of dpkg resolves po errors of previous version.
Safe for pre-compiled binaries.