### PR TITLE
bump emacs to 26.1, enable x11 via lucid

### DIFF
--- a/packages/emacs.rb
+++ b/packages/emacs.rb
@@ -3,35 +3,21 @@ require 'package'
 class Emacs < Package
   description 'An extensible, customizable, free/libre text editor - and more.'
   homepage 'http://www.gnu.org/software/emacs/'
-  version '25.3'
-  source_url 'https://ftp.gnu.org/gnu/emacs/emacs-25.3.tar.xz'
-  source_sha256 '253ac5e7075e594549b83fd9ec116a9dc37294d415e2f21f8ee109829307c00b'
-  
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-25.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-25.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-25.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-25.3-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '9efee852141ebcb349ec99766739ef2babbb6d7b83d66725e32b74d406ab2e49',
-     armv7l: '9efee852141ebcb349ec99766739ef2babbb6d7b83d66725e32b74d406ab2e49',
-       i686: '0f3710bd6cc4c1f0d6cf727328c94c829197dbae8423f8069bd08556ac68bbab',
-     x86_64: 'd135d3f0ffd2cc536fe30fb8b1b002b63e086b4a2f6b56ebd89e451803372040',
-  })
+  version '26.1'
+  source_url 'https://ftp.gnu.org/gnu/emacs/emacs-26.1.tar.xz'
+  source_sha256 '1cf4fc240cd77c25309d15e18593789c8dbfba5c2b44d8f77c886542300fd32c'
 
-  depends_on "zlibpkg" => :build
-  depends_on "diffutils" => :build
-  depends_on "m4" => :build
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "ncurses"
+  depends_on 'libjpeg'
+  depends_on 'libtiff'
+  depends_on 'sommelier'
 
   def self.build
     system "./configure \
             --prefix=#{CREW_PREFIX} \
             --localstatedir=#{CREW_PREFIX}/share \
-            --with-x=no \
+            --with-x=yes \
+            --with-x-toolkit=lucid \
+            --with-gif=no \
             --without-makeinfo \
             --without-selinux"
     system 'make'


### PR DESCRIPTION
## Description
- bump Emacs to 26.1
- enable emacs X11 (via lucid toolkit) which makes the GUI work via sommelier

## Addtional information
I removed the sha's for the binaries.

Works properly:
- [x] x86_64
- [ ] aarch64 (reasons why it doesn't) - didn't test
