### PR TITLE
Add pre-built binaries for attr, avocado and go

### DIFF
--- a/packages/attr.rb
+++ b/packages/attr.rb
@@ -8,8 +8,16 @@ class Attr < Package
   source_sha256 '5ead72b358ec709ed00bbf7a9eaef1654baad937c001c044fe8b74c57f5324e7'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/attr-2.4.48-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/attr-2.4.48-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/attr-2.4.48-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/attr-2.4.48-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '9ba6aafd2ac91a3b9534ed8780ad40b8f88d1b549281455fecefd700f7d8a734',
+     armv7l: '9ba6aafd2ac91a3b9534ed8780ad40b8f88d1b549281455fecefd700f7d8a734',
+       i686: 'db2b92875ead6a24c93708af44ca35aff9257269c33add3c94f04aa97b1dbf9b',
+     x86_64: '876f464fc3b2185e2076569d06ccf5df957405ce78b92c49a779582d30ee75a4',
   })
 
   depends_on 'gettext'

--- a/packages/avocado.rb
+++ b/packages/avocado.rb
@@ -8,8 +8,16 @@ class Avocado < Package
   source_sha256 'bf1434d61754f389771dc38beb66a62ee6cca95f5224b17eb2a4ca2f7abf22ab'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-64.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-64.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-64.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-64.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'a2659851c10f6b1d57bf55c6e15f035183a256951422004bff486eb1ec338222',
+     armv7l: 'a2659851c10f6b1d57bf55c6e15f035183a256951422004bff486eb1ec338222',
+       i686: 'd7c93778bdc3f7eeffca15e38fa2208f5dac6a2bce16aa6caee97aebf0dce375',
+     x86_64: '223c4eccb8c646453f633ebb6b6c8b23bf52535ba4895999a029db7c92329ca3',
   })
 
   depends_on 'xdg_base'

--- a/packages/go.rb
+++ b/packages/go.rb
@@ -7,6 +7,19 @@ class Go < Package
   source_url 'https://dl.google.com/go/go1.11.1.src.tar.gz'
   source_sha256 '558f8c169ae215e25b81421596e8de7572bd3ba824b79add22fba6e284db1117'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.11.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.11.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.11.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.11.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '3a2c84b284794c22dfcf18181e0daa7db64c697b5b08bc357d96c5dda4234f4c',
+     armv7l: '3a2c84b284794c22dfcf18181e0daa7db64c697b5b08bc357d96c5dda4234f4c',
+       i686: 'c9abb02e4ff93d2ed181079a43387e6222667c5aaf36cd865159f19db9bcb424',
+     x86_64: '5bccebc7b426d01ddfb9919b9ac7e2ab3e47776a131a21da70a54d2639c361c0',
+  })
+
   # Tests requires perl
   depends_on 'perl' => :build
   # go is required to build versions of go > 1.4


### PR DESCRIPTION
Tested binaries on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64