### PR TITLE
Change clc++ script to search in lib64 for libraries

### DIFF
--- a/packages/glfw.rb
+++ b/packages/glfw.rb
@@ -10,7 +10,12 @@ class Glfw < Package                 # The first character of the class name mus
   depends_on 'cmake' => :build      # packages with "=> :build" are only required if you're building from source 
 
   def self.build                   # the steps required to build the package
-    system "cmake","-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}", "-DCMAKE_LIB_SUFFIX=64"
+    case ARCH
+    with 'x86_64'
+      system "cmake","-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}", "-DCMAKE_LIB_SUFFIX=64"
+    else
+      system "cmake","-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}"
+    end
     system "make"
   end
 

--- a/packages/glfw.rb
+++ b/packages/glfw.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Glfw < Package                 # The first character of the class name must be upper case
+  description 'GLFW is a multi-platform library for OpenGL, OpenGL ES, Vulkan, window and input '
+  homepage 'http://www.glfw.org/'
+  version '3.2.1'
+  source_url 'https://github.com/glfw/glfw/archive/3.2.1.zip'
+  source_sha256 '0c623f65a129c424d0fa45591694fde3719ad4a0955d4835182fda71b255446f'   # Use the command "sha256sum"
+
+  depends_on 'cmake' => :build      # packages with "=> :build" are only required if you're building from source 
+
+  def self.build                   # the steps required to build the package
+    system "cmake","-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}"
+    system "make"
+  end
+
+  def self.install                 # the steps required to install the package
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check                   # the steps required to check if the package was built ok
+    system "make", "check"
+  end
+end

--- a/packages/glfw.rb
+++ b/packages/glfw.rb
@@ -10,7 +10,7 @@ class Glfw < Package                 # The first character of the class name mus
   depends_on 'cmake' => :build      # packages with "=> :build" are only required if you're building from source 
 
   def self.build                   # the steps required to build the package
-    system "cmake","-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}"
+    system "cmake","-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}", "-DCMAKE_LIB_SUFFIX=64"
     system "make"
   end
 

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -283,7 +283,8 @@ clang -B \${gnuc_lib} -L \${gnuc_lib} \"\$@\"' > clc"
 cxx_sys=#{CREW_PREFIX}/include/c++/#{gcc_ver}
 cxx_inc=#{CREW_PREFIX}/include/c++/#{gcc_ver}/x86_64-cros-linux-gnu
 gnuc_lib=#{CREW_PREFIX}/lib/gcc/x86_64-cros-linux-gnu/#{gcc_ver}
-clang++ -cxx-isystem \${cxx_sys} -I \${cxx_inc} -B \${gnuc_lib} -L \${gnuc_lib} \"\$@\"' > clc++"
+gnuc_lib64=#{CREW_PREFIX}/lib64/gcc/x86_64-cros-linux-gnu/#{gcc_ver}
+clang++ -cxx-isystem \${cxx_sys} -I \${cxx_inc} -B \${gnuc_lib} -B \${gnuc_lib654} -L \${gnuc_lib} -L \${gnuc_lib64} \"\$@\"' > clc++"
         system "cmake",
                "-DCURSES_INCLUDE_PATH='#{CREW_PREFIX}/include/ncursesw'",
                "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",


### PR DESCRIPTION

Works properly:
- [x] x86_64

This changes the clc++ script (only when building from source) to include the lib64 folder. This fixes a bug when using clang++. This will also probably have to be fixed on bin-tray as well.