### PR TITLE
Update julia from 1.0.0-1 to 1.0.1

### DIFF
--- a/packages/julia.rb
+++ b/packages/julia.rb
@@ -3,19 +3,14 @@ require 'package'
 class Julia < Package
   description 'Julia is a flexible dynamic language, appropriate for scientific and numerical computing'
   homepage 'https://julialang.org/'
-  version '1.0.0-1'
+  version '1.0.1'
   case ARCH
   when 'x86_64'
-    source_url 'https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.0-linux-x86_64.tar.gz'
-    source_sha256 'bea4570d7358016d8ed29d2c15787dbefaea3e746c570763e7ad6040f17831f3'
+    source_url 'https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.1-linux-x86_64.tar.gz'
+    source_sha256 '9ffbcf7f4a111e13415954caccdd1ce90b5c835cee9f62d6ac708f5b752c87dd'
   when 'i686'
-    source_url 'https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.0-linux-i686.tar.gz'
-    source_sha256 'c8c607a7682bfe08b5511aac616c3b393038e52edf4dbaac5e69727c4f1eaa8b'
-  when 'aarch64', 'armv7l'
-    source_url 'https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/julia-1.0.0-linux-armv7l.tar.gz'
-    source_sha256 '61e855e93c3bfe5e4f486a54a4c45194f4b020922e56af5fc104ff3fd3d8e41a'
-  else
-    puts "#{ARCH} architecture not supported.".lightred
+    source_url 'https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.1-linux-i686.tar.gz'
+    source_sha256 'e2ce5fa564242c2dbb836f9493166ce6eaaec8f46db9861b4cdad047497dd4c4'
   end
 
   binary_url ({


### PR DESCRIPTION
Tested on:
- [x] i686
- [x] x86_64

Binary builds for armv7l have been dropped.