### PR TITLE
Add openexr and supporting ilmbase packages

### DIFF
--- a/packages/ilmbase.rb
+++ b/packages/ilmbase.rb
@@ -1,0 +1,34 @@
+require 'package'
+
+class Ilmbase < Package
+  description 'Supporting libraries for OpenEXR'
+  homepage 'http://www.openexr.com/'
+  version '2.3.0'
+  source_url 'https://github.com/openexr/openexr/releases/download/v2.3.0/ilmbase-2.3.0.tar.gz'
+  source_sha256 '456978d1a978a5f823c7c675f3f36b0ae14dba36638aeaa3c4b0e784f12a3862'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ilmbase-2.3.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ilmbase-2.3.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ilmbase-2.3.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ilmbase-2.3.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '2409254e52175a62f82fba8cc1362f9cbb03ab473e0a23be82616346ac3fb63c',
+     armv7l: '2409254e52175a62f82fba8cc1362f9cbb03ab473e0a23be82616346ac3fb63c',
+       i686: '4dcff79fad721cd25e2a4ce9fbad88627b3aab051f638cbbfe3444069b5e538b',
+     x86_64: '76a019fd719ce2bc922396ca3ff5297f45fdbedf29a509fdcc853e36a61b17f5',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/openexr.rb
+++ b/packages/openexr.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Openexr < Package
+  description 'OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications.'
+  homepage 'http://www.openexr.com/'
+  version '2.3.0'
+  source_url 'https://github.com/openexr/openexr/releases/download/v2.3.0/openexr-2.3.0.tar.gz'
+  source_sha256 'fd6cb3a87f8c1a233be17b94c74799e6241d50fc5efd4df75c7a4b9cf4e25ea6'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openexr-2.3.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openexr-2.3.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openexr-2.3.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openexr-2.3.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'd2c0cda2100a6928c13ee79bd605be4c0457f11b289fe7970ac4fdee18d4653b',
+     armv7l: 'd2c0cda2100a6928c13ee79bd605be4c0457f11b289fe7970ac4fdee18d4653b',
+       i686: '71fb7e679140b71ada434125e1d3f2d475806fa1bb08d476f196b5999ec04c4c',
+     x86_64: '4db94a6aa538bdfb6ab6b41f24d03afab0b81c827d64b2b4bf44d004a8c72d15',
+  })
+
+  depends_on 'ilmbase'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications.  See http://www.openexr.com/.  Also includes the ilmbase package which provides the supporting libraries for OpenEXR.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64