### PR TITLE
Add sysfsutils package

### DIFF
--- a/packages/sysfsutils.rb
+++ b/packages/sysfsutils.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Sysfsutils < Package
+  description 'Libsysfs provides a stable programming interface to sysfs and eases querying system devices and their attributes.'
+  homepage 'https://github.com/Distrotech/sysfsutils'
+  version '2.1.0'
+  source_url 'http://http.debian.net/debian/pool/main/s/sysfsutils/sysfsutils_2.1.0+repack.orig.tar.gz'
+  source_sha256 'e865de2c1f559fff0d3fc936e660c0efaf7afe662064f2fb97ccad1ec28d208a'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/sysfsutils.rb
+++ b/packages/sysfsutils.rb
@@ -1,10 +1,10 @@
 require 'package'
 
 class Sysfsutils < Package
-  description 'Libsysfs provides a stable programming interface to sysfs and eases querying system devices and their attributes.'
-  homepage 'https://github.com/Distrotech/sysfsutils'
+  description 'These are a set of utilites built upon sysfs, a new virtual filesystem in Linux kernel versions 2.5+ that exposes a system\'s device tree. The current version of sysfsutils includes libsysfs and systool.'
+  homepage 'http://linux-diag.sourceforge.net/Sysfsutils.html'
   version '2.1.0'
-  source_url 'http://http.debian.net/debian/pool/main/s/sysfsutils/sysfsutils_2.1.0+repack.orig.tar.gz'
+  source_url 'https://sourceforge.net/projects/linux-diag/files/sysfsutils/2.1.0/sysfsutils-2.1.0.tar.gz'
   source_sha256 'e865de2c1f559fff0d3fc936e660c0efaf7afe662064f2fb97ccad1ec28d208a'
 
   binary_url ({


### PR DESCRIPTION
This package's purpose is to provide a set of utilities for interfacing
with sysfs, a virtual filesystem in Linux kernel versions 2.5+ that
provides a tree of system devices. While a filesystem is a very useful
interface, we've decided to provide a stable programming interface
that will hopefully make it easier for applications to query system devices
and their attributes.

Tested on x86_64