### PR TITLE
Add pre-built binaries for osl, rng_tools and sysfsutils

### DIFF
--- a/packages/osl.rb
+++ b/packages/osl.rb
@@ -8,8 +8,16 @@ class Osl < Package
   source_sha256 'eee5cd9bf5b3b8491f95f681cfaa987344f0fb3d7499f5d8e19e3ce75e0c5ed0'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/osl-0.9.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/osl-0.9.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/osl-0.9.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/osl-0.9.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '171bd5dfa05cc568a97a4fb4d88ad483f3d4a147df7c2e6da3561e9d61f845a7',
+     armv7l: '171bd5dfa05cc568a97a4fb4d88ad483f3d4a147df7c2e6da3561e9d61f845a7',
+       i686: '8c4a682433e1b332055cac4c152d0b03687d0fc2ccde8ed9e39da3fa3f284600',
+     x86_64: '70d5a0b54a59fa9c32cdeb22b9f02198cff7d319b4c8a78688ee992959f49371',
   })
 
   def self.build

--- a/packages/rng_tools.rb
+++ b/packages/rng_tools.rb
@@ -8,8 +8,16 @@ class Rng_tools < Package
   source_sha256 '5fecd904f7d01262b3209ff78dd3b9594aac8daa41badd5a1e6438658e80c36e'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rng_tools-6.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rng_tools-6.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rng_tools-6.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rng_tools-6.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd24c4b10672a24a8fee318a3eabe9f6124da04ffc8099243c88f30dddf29eb90',
+     armv7l: 'd24c4b10672a24a8fee318a3eabe9f6124da04ffc8099243c88f30dddf29eb90',
+       i686: '645bf08eaa22ffc84d9603bad4a22ef754d81b95cc44fa1cbc3ebe951e8b1fcf',
+     x86_64: 'df9504bf42632204e92fb4b97ac0b863c7e8cbb7d5592ec9ab7c4224071b711b',
   })
 
   depends_on 'curl'

--- a/packages/sysfsutils.rb
+++ b/packages/sysfsutils.rb
@@ -8,8 +8,16 @@ class Sysfsutils < Package
   source_sha256 'e865de2c1f559fff0d3fc936e660c0efaf7afe662064f2fb97ccad1ec28d208a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sysfsutils-2.1.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sysfsutils-2.1.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sysfsutils-2.1.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sysfsutils-2.1.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f5cce4169a5647744a583823b0ea095f531574a0fcb11a584207dd871bfef43e',
+     armv7l: 'f5cce4169a5647744a583823b0ea095f531574a0fcb11a584207dd871bfef43e',
+       i686: '6f7d32bd3a199f8febb2101b368c36da43c5c6363570e020dd66774386ab0288',
+     x86_64: '81876c5c17b99ad08b662f0b560021a419c3a441be485963fab688e7fbde6a0b',
   })
 
   def self.build


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64