### PR TITLE
Misc. Nano fixes

### DIFF
--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -3,24 +3,20 @@ require 'package'
 class Nano < Package
   description 'Nano\'s ANOther editor, an enhanced free Pico clone.'
   homepage 'https://www.nano-editor.org/'
-  version '3.1'
+  version '3.1-1'
   source_url 'https://www.nano-editor.org/dist/v3/nano-3.1.tar.xz'
   source_sha256 '14c02ca40a5bc61c580ce2f9cb7f9fc72d5ccc9da17ad044f78f6fb3fdb7719e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b104f51c34448e5f20b6f0ab1a446ba85701464e40ed96484ecadeb2fb09c9cb',
-     armv7l: 'b104f51c34448e5f20b6f0ab1a446ba85701464e40ed96484ecadeb2fb09c9cb',
-       i686: 'd187d05f68885e4ce3afb3726d5ab684d4a97f2c67ea3d1b917893db64120fa8',
-     x86_64: '492bc56f517c1c0c4cc52bdfc210b8b6cd1f072e3da5605f406c99d4be7e11ac',
   })
 
   depends_on 'filecmd'
+
+  def self.patch
+    system "sed -i '/SIGWINCH/d' src/nano.c"
+  end
 
   def self.build
     system "./configure",
@@ -38,6 +34,11 @@ class Nano < Package
   def self.postinstall
     puts
     puts "Personal configuration file is located in $HOME/.nanorc".lightblue
+    puts
+    puts "To make nano your default editor, execute this:".lightblue
+    puts
+    puts "echo 'EDITOR=nano' >> ~/.bashrc".lightblue
+    puts "source ~/.bashrc"
     puts
     open("#{ENV['HOME']}/.nanorc", 'w') { |f|
       f << "set constantshow\n"

--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -38,7 +38,7 @@ class Nano < Package
     puts "To make nano your default editor, execute this:".lightblue
     puts
     puts "echo 'EDITOR=nano' >> ~/.bashrc".lightblue
-    puts "source ~/.bashrc"
+    puts "source ~/.bashrc".lightblue
     puts
     open("#{ENV['HOME']}/.nanorc", 'w') { |f|
       f << "set constantshow\n"


### PR DESCRIPTION
Fixes:
Issues where `nano`'s screen flickers ( Blocks `SIGWINCH` interrupts in `src/nano.c` )
Issue where `git commit` tries to run `/bin/nano` instead of `/usr/local/bin/nano`
Issue where `nano` is not the default editor

Tested on i686