### PR TITLE
Add pre-built binaries for nasm and ndisc6

### DIFF
--- a/packages/nasm.rb
+++ b/packages/nasm.rb
@@ -8,8 +8,16 @@ class Nasm < Package
   source_sha256 '084482a7708c46ef6ab480488d29092cf9d4d5b9e8a5d0ba58d69eee1758f358'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.14rc16-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.14rc16-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.14rc16-chromeos-x86_64.tar.xz',
+    i686: 'file:///home/chronos/user/chromebrew/release/i686/nasm-2.14rc16-chromeos-i686.tar.xz'
   })
   binary_sha256 ({
+    aarch64: '167d71028afc02c296a27fb8a145f873986da262cc1e954dac80644fd57e4fc8',
+     armv7l: '167d71028afc02c296a27fb8a145f873986da262cc1e954dac80644fd57e4fc8',
+     x86_64: '7aed39d25a05f43613950f27d0033dfa890804c9398ab7549c70ba951c2355d1',
+       i686: '87728c542fe6322b64bcadb9aaea25779c53d6059c8062d40d770d0593daf2c0',
   })
 
   def self.build

--- a/packages/ndisc6.rb
+++ b/packages/ndisc6.rb
@@ -8,11 +8,17 @@ class Ndisc6 < Package
   source_sha256 '0f41d6caf5f2edc1a12924956ae8b1d372e3b426bd7b11eed7d38bc974eec821'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ndisc6-1.0.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ndisc6-1.0.3-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ndisc6-1.0.3-chromeos-x86_64.tar.xz',
+    i686: 'file:///home/chronos/user/chromebrew/release/i686/ndisc6-1.0.3-chromeos-i686.tar.xz'
   })
   binary_sha256 ({
+    aarch64: '72e919fab7d493afad497ec83786a905a96b7bd69802b5502890c9c5e4152127',
+     armv7l: '72e919fab7d493afad497ec83786a905a96b7bd69802b5502890c9c5e4152127',
+     x86_64: '7b73aa83893ad65101f439e85b6effed2776015ab0628ac436220fd57e00746b',
+       i686: '2e588596a6ad9f99e3552761d3e51fbfc66ec574381406c4fa946aedf74362c5',
   })
-  
-  depends_on 'perl'
 
   def self.build
     system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}", "--disable-suid-install"


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64