### PR TITLE
Gcc fix

### DIFF
--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -3,25 +3,10 @@ require 'package'
 class Gcc < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '4.9.4-1'
+  version '7.3.0'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew-cross/gcc-4.9.4-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew-cross/gcc-4.9.4-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew-cross/gcc-4.9.4-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew-cross/gcc-4.9.4-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'ecb047a9f52ea6b24313d4329b00236b6880e12df684e52e34e9664127d447c6',
-     armv7l: 'ecb047a9f52ea6b24313d4329b00236b6880e12df684e52e34e9664127d447c6',
-       i686: '9a8b20b58a564c9557c74b2b2769ddc68c110211588356b71c533aac6d54431b',
-     x86_64: '1ae1f58ca4b9fee3b0f68856e5d49b2feeb90e259e8d885f339c9aa8091f27c8',
-  })
+  is_fake
 
-  depends_on 'binutils'
-  depends_on 'gmp'
-  depends_on 'mpfr'
-  depends_on 'mpc'
-  depends_on 'isl'
-  depends_on 'glibc'
+  depends_on 'gcc7'
+
 end


### PR DESCRIPTION
Removes gcc 4 entirely and creates dependency from gcc to gcc7.  GCC 4 is deprecated, and also depends on cloog, breaking some packages. This kills two birds with one stone. Thanks, @superloach, for finding this out.