### PR TITLE
Add llvm dependency to gimp

### DIFF
--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -29,6 +29,7 @@ class Gimp < Package
   depends_on 'libmng'
   depends_on 'libtiff'
   depends_on 'libwmf'
+  depends_on 'llvm'
   depends_on 'aalib'
   depends_on 'mypaint_brushes'
   depends_on 'openexr'


### PR DESCRIPTION
Fixes: gimp: error while loading shared libraries: libomp.so: cannot open shared object file: No such file or directory