### PR TITLE
Add pre-built binaries for a52 and ragel

### DIFF
--- a/packages/a52.rb
+++ b/packages/a52.rb
@@ -7,6 +7,19 @@ class A52 < Package
   source_url 'http://liba52.sourceforge.net/files/a52dec-0.7.4.tar.gz'
   source_sha256 'a21d724ab3b3933330194353687df82c475b5dfb997513eef4c25de6c865ec33'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/a52-0.7.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/a52-0.7.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/a52-0.7.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/a52-0.7.4-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '7f504acf9550dea90992fba392d7aedc43d872dd2bcba37cb08e369432a99e95',
+     armv7l: '7f504acf9550dea90992fba392d7aedc43d872dd2bcba37cb08e369432a99e95',
+       i686: '74340244a1e15054e0764f12fc36e7cae7b3d1ed44c7203555afa67500da5a43',
+     x86_64: 'eb8a838b7b5284354f0e033f098e6c2270ea20eccf51df3ea5a93be6b2a4d56d',
+  })
+
   def self.build
     system "./bootstrap"
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/ragel.rb
+++ b/packages/ragel.rb
@@ -7,6 +7,19 @@ class Ragel < Package
   source_url 'https://www.colm.net/files/ragel/ragel-6.10.tar.gz'
   source_sha256 '5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ragel-6.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ragel-6.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ragel-6.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ragel-6.10-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '2efdeff57b498308def95b8fb8ac9efdc232909b245d0a8522a4259f82d9767c',
+     armv7l: '2efdeff57b498308def95b8fb8ac9efdc232909b245d0a8522a4259f82d9767c',
+       i686: '238950153c3a07bd9465f20918b26bc9986fc45ce97936d739a8bf25edcf7de6',
+     x86_64: 'dcb064549487d9ba7916e83ff4676673b9f2b01a437cd31d162c34a8b5fe1597',
+  })
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64