### PR TITLE
Fix install for fortune and sl

### DIFF
--- a/packages/fortune.rb
+++ b/packages/fortune.rb
@@ -15,6 +15,6 @@ class Fortune < Package
   end
 
   def self.install
-    system "install -Dm755 fortune #{CREW_DEST_PREFIX}/bin/"
+    system "install -Dm755 fortune #{CREW_DEST_PREFIX}/bin/fortune"
   end
 end

--- a/packages/sl.rb
+++ b/packages/sl.rb
@@ -13,6 +13,6 @@ class Sl < Package
   end
 
   def self.install
-    system "install -Dm755 sl #{CREW_DEST_PREFIX}/bin/"
+    system "install -Dm755 sl #{CREW_DEST_PREFIX}/bin/sl"
   end
 end


### PR DESCRIPTION
Fixes install: target '/usr/local/tmp/crew/dest/usr/local/bin/' is not a directory: No such file or directory
sl failed to install: `install -Dm755 sl /usr/local/tmp/crew/dest/usr/local/bin/` exited with 1