### PR TITLE
Remove dpkg from the needs_binaries.sh exclusions list

### DIFF
--- a/tools/needs_binaries.sh
+++ b/tools/needs_binaries.sh
@@ -6,8 +6,8 @@ fi
 cd ../packages
 arch=$(uname -m)
 exclusions="antlr4.rb asciinema.rb autosetup.rb cabal.rb code.rb composer.rb crew_profile.rb cros_resize.rb"
-exclusions+=" docx2txt.rb dpkg.rb dr.rb far.rb fpc.rb freedos.rb ghc.rb julia.rb kr.rb libtinfo.rb lsb_release.rb"
-exclusions+=" mysqltuner.rb nodebrew.rb nvm.rb oc.rb spark.rb stack.rb thefuck.rb txt2regex.rb uwsgi.rb xdg_base.rb yarn.rb"
+exclusions+=" docx2txt.rb dr.rb far.rb fpc.rb freedos.rb ghc.rb julia.rb kr.rb libtinfo.rb lsb_release.rb yarn.rb"
+exclusions+=" mysqltuner.rb nodebrew.rb nvm.rb oc.rb spark.rb stack.rb thefuck.rb txt2regex.rb uwsgi.rb xdg_base.rb"
 if [[ "$arch" == "aarch64" || "$arch" == "armv7l" ]]; then
   exclusions+=" az.rb cbase.rb cf.rb clisp.rb dmidecode.rb dropbox.rb freebasic.rb google_cloud_sdk.rb lldb.rb mesa.rb"
   exclusions+=" miniconda3.rb misctools.rb oci.rb qt.rb wkhtmltox.rb xorg_intel_driver.rb xorg_vmmouse_driver.rb"


### PR DESCRIPTION
Makes it so needs_binaries.sh will output `dpkg.rb` when `dpkg` needs binaries.
Fixes #2799 