### PR TITLE
Add pre-built binaries for dpkg

### DIFF
--- a/packages/dpkg.rb
+++ b/packages/dpkg.rb
@@ -8,8 +8,16 @@ class Dpkg < Package
   source_sha256 'f8f2ae2cf8065b81239db960b3794099ec607c94a125cec61c986f68f9861b71'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dpkg-1.19.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dpkg-1.19.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/dpkg-1.19.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dpkg-1.19.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '2fb0d2ada4de00332e73a4fabd754101ee21c3c23b1b9dffee4dd57ea4923228',
+     armv7l: '2fb0d2ada4de00332e73a4fabd754101ee21c3c23b1b9dffee4dd57ea4923228',
+       i686: '82386ba68f525549b60144dd00b7b3eea92ab59747138ec4351fedcf645a01f1',
+     x86_64: 'ae5431150d307fc1cbf5635192bd6cb22f82d7fc60d3f7263b169dd4283205dd',
   })
 
   depends_on 'bz2'

--- a/packages/dpkg.rb
+++ b/packages/dpkg.rb
@@ -4,8 +4,13 @@ class Dpkg < Package
   description 'A medium-level package manager for Debian'
   homepage 'https://anonscm.debian.org/git/dpkg/'
   version '1.19.2'
-  source_url 'http://http.debian.net/debian/pool/main/d/dpkg/dpkg_1.19.2.tar.xz'
+  source_url 'https://deb.debian.org/debian/pool/main/d/dpkg/dpkg_1.19.2.tar.xz'
   source_sha256 'f8f2ae2cf8065b81239db960b3794099ec607c94a125cec61c986f68f9861b71'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
 
   depends_on 'bz2'
   depends_on 'xzutils'


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64