### PR TITLE
Rebuild alsa_plugins with libav support

### DIFF
--- a/packages/alsa_plugins.rb
+++ b/packages/alsa_plugins.rb
@@ -3,24 +3,25 @@ require 'package'
 class Alsa_plugins < Package
   description 'alsa-plugins contains plugins for various ALSA needs (e.g. Jack).'
   homepage 'https://www.alsa-project.org/main/index.php/Main_Page'
-  version '1.1.7'
+  version '1.1.7-1'
   source_url 'ftp://ftp.alsa-project.org/pub/plugins/alsa-plugins-1.1.7.tar.bz2'
   source_sha256 'a74b405ab6d9e346e6908a853d5e7631cc61038d9b265bc7f37fab16e827da47'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.7-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.7-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.7-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.7-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.7-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.7-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.7-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1abb05f8e9fd533ee3d334b3572903cd191393a8ce96d4fb3158574580874571',
-     armv7l: '1abb05f8e9fd533ee3d334b3572903cd191393a8ce96d4fb3158574580874571',
-       i686: 'caa7cb34ef9b3817cd045e4bd528f02662f32ff9c5b613ffefc3e169d934e062',
-     x86_64: '7cba5116274f0988618eceeb11e9cfebef90805e1ba6aec2b402c486ca68dbd9',
+    aarch64: '5a0c67e36abf9d2dfc3d7da7b53c7ed14734e8545fc44fb77073bfbc0f8592fa',
+     armv7l: '5a0c67e36abf9d2dfc3d7da7b53c7ed14734e8545fc44fb77073bfbc0f8592fa',
+       i686: '7cb449d186acc168056cbfaf63b4c4942abc14475ce9d5f2b1fd6671f7226b3d',
+     x86_64: '00d5ec8f220e64b9f4197b4897326192c963da616541d4787723a3969f2a129a',
   })
 
   depends_on 'alsa_lib'
+  depends_on 'libav'
   depends_on 'pulseaudio'
 
   def self.build


### PR DESCRIPTION
Depends on #2805.
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64