### PR TITLE
Add pre-built binaries for gstreamer packages

### DIFF
--- a/packages/gst_plugins_base.rb
+++ b/packages/gst_plugins_base.rb
@@ -8,9 +8,15 @@ class Gst_plugins_base < Package
   source_sha256 'ca6139490e48863e7706d870ff4e8ac9f417b56f3b9e4b3ce490c13b09a77461'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.14.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.14.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.14.4-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.14.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f829a4e5e8c59fc70a35e66664a7e82b780f2a6e5dc0be140c53fa986c260706',
+     armv7l: 'f829a4e5e8c59fc70a35e66664a7e82b780f2a6e5dc0be140c53fa986c260706',
+       i686: '84400b9d962da80378a8bd3d99bb6e2ceb642f31735a4aa2011b28347c4e69ef',
      x86_64: 'f858e5ccb578bcff6db1cdd143727b8feec5cf153d0b438af4925827e6fabcc1',
   })
 

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -8,9 +8,15 @@ class Gstreamer < Package
   source_sha256 'f94f6696c5f05a3b3a9183e39c5f5c0b779f75a04c0efa497e7920afa985ffc7'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.14.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.14.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.14.4-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.14.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd0d13f431c7dd2300538c99fa7346eb731a82e71ee637caa93ef5181c3c7cff4',
+     armv7l: 'd0d13f431c7dd2300538c99fa7346eb731a82e71ee637caa93ef5181c3c7cff4',
+       i686: '88cdb5e2d96c18da5e8168897309e463617888a0227fa1994c62a6dbdba054c7',
      x86_64: 'ffef3b7e782be4821276a5f75c4b75e096a145901193b962b3e94b6ac63252ca',
   })
 


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686