### PR TITLE
Update Vdev package

### DIFF
--- a/packages/vdev.rb
+++ b/packages/vdev.rb
@@ -25,20 +25,20 @@ class Vdev < Package
   end
 
   def self.build
-    system "make LIBDIR=#{CREW_LIB_PREFIX}"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} -C vdevd OS=LINUX"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} -C example"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} -C hwdb"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} -C libudev-compat"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} -C fs"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} -C vdevd OS=LINUX"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} -C example"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} -C hwdb"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} -C libudev-compat"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} -C fs"
   end
 
   def self.install
-    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C vdevd OS=LINUX install"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C example install"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C hwdb install"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C libudev-compat install"
-    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C fs install"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C vdevd OS=LINUX install"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C example install"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C hwdb install"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C libudev-compat install"
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C fs install"
   end
 end

--- a/packages/vdev.rb
+++ b/packages/vdev.rb
@@ -3,44 +3,42 @@ require 'package'
 class Vdev < Package
   description 'A device-file manager for *nix'
   homepage 'https://github.com/jcnelson/vdev'
-  version 'ceb7a6'
+  version 'ceb7a6c'
   source_url 'https://github.com/jcnelson/vdev/archive/ceb7a6c4f44dec542dc1c3c3d5abd27dec7f3e0e.tar.gz'
   source_sha256 'dbf561890aa70a8619506d166803a72d0c2a5b7590226feef784ec623bcb4739'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6-chromeos-x86_64.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6c-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bf9bd2fdde42e0897e6aab47a18e2f2649b6dbd01de14bf6165c55c2a716e133',
-     armv7l: 'bf9bd2fdde42e0897e6aab47a18e2f2649b6dbd01de14bf6165c55c2a716e133',
-       i686: '8bb09676d68f9b00da89f0e9bc9499bc5d38332081cbbc698266f74644af89e1',
-     x86_64: '45e3ca2fe33ec0dce519ad5053b63fefc4c50a38ce5fb842faca3ec941006f61',
+     x86_64: '826658f93e7a9c31eda6adfc1d96f9e1ded2c8becf4bbc0a8315ba4e6a77da3f',
   })
 
-  depends_on 'glibc'
   depends_on 'fuse'
   depends_on 'libpstat'
   depends_on 'fskit'
   depends_on 'lvm2'
 
+  def self.patch
+    system "sed -i 's,-fstack-protector -fstack-protector-all ,,g' buildconf.mk libudev-compat/Makefile"
+    system "sed -i 's,attr/xattr.h,sys/xattr.h,g' fs/fs.h"
+  end
+
   def self.build
-    system "make"
-    system "make -C vdevd OS=LINUX"
-    system "make -C example"
-    system "make -C hwdb"
-    system "make -C libudev-compat"
-    system "make -C fs"
+    system "make LIBDIR=#{CREW_LIB_PREFIX}"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} -C vdevd OS=LINUX"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} -C example"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} -C hwdb"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} -C libudev-compat"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} -C fs"
   end
 
   def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
-    system "make DESTDIR=#{CREW_DEST_DIR} -C vdevd OS=LINUX install"
-    system "make DESTDIR=#{CREW_DEST_DIR} -C example install"
-    system "make DESTDIR=#{CREW_DEST_DIR} -C hwdb install"
-    system "make DESTDIR=#{CREW_DEST_DIR} -C libudev-compat install"
-    system "make DESTDIR=#{CREW_DEST_DIR} -C fs install"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C vdevd OS=LINUX install"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C example install"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C hwdb install"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C libudev-compat install"
+    system "make LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} -C fs install"
   end
 end


### PR DESCRIPTION
Depends on #2826 

Updates fskit package for compatibility with attr 2.4.48
Uses proper lib directory `#{CREW_LIB_PREFIX}`

Tested on:
- [x] x86_64