### PR TITLE
Add pre-built binaries for packages f-v

### DIFF
--- a/packages/fskit.rb
+++ b/packages/fskit.rb
@@ -8,10 +8,16 @@ class Fskit < Package
   source_sha256 'fe682890ebab9226d65fc6ebfb8b3619c0d5a93e3161787cea9d01ad23d3a83a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fskit-dd9a8d-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fskit-dd9a8d-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fskit-dd9a8d-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fskit-dd9a8d-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     x86_64: '22c2b4d3adb6a374f267983ff164a6ad63f9aa762f47921c99eebe01031438a6',
+    aarch64: '0efdae023da0bae9937978163a17248ba26ad6a29af52c7dbbcd98fbb17ae2d0',
+     armv7l: '0efdae023da0bae9937978163a17248ba26ad6a29af52c7dbbcd98fbb17ae2d0',
+       i686: '65c827cd622753d13d1dda7f26dbe437365c8af6285754873db16d7d980d72e2',
+     x86_64: 'd4cc3783a929b3cb95652bad97dfe9cb0797aa431b3db2daecb829f34980f1db',
   })
 
   depends_on 'attr'

--- a/packages/iptables.rb
+++ b/packages/iptables.rb
@@ -9,15 +9,15 @@ class Iptables < Package
 
   binary_url ({
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/iptables-1.6.1-1-chromeos-x86_64.tar.xz',
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/iptables-1.6.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/iptables-1.6.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/iptables-1.6.1-chromeos-i686.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/iptables-1.6.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/iptables-1.6.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/iptables-1.6.1-1-chromeos-i686.tar.xz',
   })
   binary_sha256 ({
-     x86_64: '249bf764fc6bf31d7fdf7e926af710ced35650d16c701ee7ba3cc90e5c441446',
-    aarch64: '4a72a30c1e6d29706a68473a8814461912f04c408e2738edb963667ad9e3a591',
-     armv7l: '4a72a30c1e6d29706a68473a8814461912f04c408e2738edb963667ad9e3a591',
-       i686: '4289bf6ce4a37636ce84bc47dbe5ceb96c1bc6ea5f08991ca018b3e40ad3fefc',
+     x86_64: 'db40420fd3c926cf252232c19f4c07c35769ed2fa496350e88a4ff2a0422edee',
+    aarch64: '72c2d7c0c065ac6b4d3f98463e8accde960b67e9584c9c9a82043d71f5ef9dcd',
+     armv7l: '72c2d7c0c065ac6b4d3f98463e8accde960b67e9584c9c9a82043d71f5ef9dcd',
+       i686: '7c9eedcc3dd9e2657bdfbf0efcebe5e39762a36def97c3b531c93913c1ec29a0',
   })
 
   def self.build

--- a/packages/nethack4.rb
+++ b/packages/nethack4.rb
@@ -8,10 +8,12 @@ class Nethack4 < Package
   source_sha256 'b143a86b5e1baf55c663ae09c2663b169d265e95ac43154982296a1887d05f15'
 
   binary_url ({
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nethack4-4.3.0-beta2-1-chromeos-x86_64.tar.xz',
+      i686: 'https://dl.bintray.com/chromebrew/chromebrew/nethack4-4.3.0-beta2-1-chromeos-i686.tar.xz',
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nethack4-4.3.0-beta2-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     x86_64: '76fead3fb952f1b03b6bc11350657e91d975325dd48c8f3063dca35d53b836bf',
+      i686: '6d350da249e839266caf16d1f1c67ea39bdf504eb078cdad727aad08581aecfa',
+    x86_64: 'f433701d17fb8ac9c1d6ab57f3038ae27e3fe3999ea00e821f296647f622ec99',
   })
 
   depends_on 'buildessential'

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -8,10 +8,16 @@ class Python3 < Package
   source_sha256 'fa7e2b8e8c9402f192ad56dc4f814089d1c4466c97d780f5e5acc02c04243d6d'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.7.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.7.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.7.1-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.7.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     x86_64: '3e414c4a01b4f47c75f900435a29b5325900975f525ae905a5d1d073cdb8f332',
+    aarch64: 'c6ad3a008510f5cbafc94d23e2470fe350b75bd4dcce4c20bce69d5ba3dc7f15',
+     armv7l: 'c6ad3a008510f5cbafc94d23e2470fe350b75bd4dcce4c20bce69d5ba3dc7f15',
+       i686: '51c94f7be089b8515bb03eacb5812c4080f93201565406d438fb2cd9e2a4cb50',
+     x86_64: '434f8f1156f89cb15dcbbdbf3a6e0448c931e5f5480dc1c5550694f014aab315',
   })
 
   depends_on 'bz2'

--- a/packages/vdev.rb
+++ b/packages/vdev.rb
@@ -8,10 +8,16 @@ class Vdev < Package
   source_sha256 'dbf561890aa70a8619506d166803a72d0c2a5b7590226feef784ec623bcb4739'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6c-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6c-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6c-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vdev-ceb7a6c-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     x86_64: '826658f93e7a9c31eda6adfc1d96f9e1ded2c8becf4bbc0a8315ba4e6a77da3f',
+    aarch64: '087ab4f0a4b12f0fe49c8e0031e8af37b2b4e645cd71def45c212177716eaebb',
+     armv7l: '087ab4f0a4b12f0fe49c8e0031e8af37b2b4e645cd71def45c212177716eaebb',
+       i686: '7a9730d9c87a269e8f41adad59d55232b583614c7f11b9ce5472ed6fee7f4314',
+     x86_64: 'f8384c3a8b057e48d13889a9ce8433b16d44f74a6750273323a53aa782bf24be',
   })
 
   depends_on 'fuse'


### PR DESCRIPTION
Fixes #2829.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64