### PR TITLE
Add pre-built binaries for ant

### DIFF
--- a/packages/ant.rb
+++ b/packages/ant.rb
@@ -8,16 +8,22 @@ class Ant < Package
   source_sha256 'ec7c704e22a2b0167e1ff35cc3d4198267e6489f142aa3e9da1b7fe6e39ff53d'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ant-1.10.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ant-1.10.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ant-1.10.5-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ant-1.10.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     x86_64: '569b2e3a067b1a9a6b683ae6b7916130c2e3eafaf626d0e90805fc30d7695d09',
+    aarch64: '80c3117cc17432043a67a73fcc9119a08c5ca4c26c530f6f181a10da03659a70',
+     armv7l: '80c3117cc17432043a67a73fcc9119a08c5ca4c26c530f6f181a10da03659a70',
+       i686: 'a6fb4227c591d591d61d2f61df39bcf989bcfdb6281554da7a051d392c7594f0',
+     x86_64: 'df3d7a6d91af51068b9fbcbec1851f3a22a10edca341a6791262fced0a7deb36',
   })
 
   depends_on 'jdk8'
 
   def self.build
-    system "./build.sh"
+    system "JAVA_HOME=#{CREW_PREFIX}/share/jdk8 ./build.sh"
   end
 
   def self.install


### PR DESCRIPTION
Set JAVA_HOME for build.sh.  Fixes #2842.