### PR TITLE
Removed broken binaries for mosh (#2335)

### DIFF
--- a/packages/mosh.rb
+++ b/packages/mosh.rb
@@ -7,19 +7,6 @@ class Mosh < Package
   source_url 'https://mosh.org/mosh-1.3.2.tar.gz'
   source_sha256 'da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '3d73351c544564df8129057bd2004c77259d9a4c86edb31abae929a99fa4d381',
-     armv7l: '3d73351c544564df8129057bd2004c77259d9a4c86edb31abae929a99fa4d381',
-       i686: '33b8add3d09107e5dfe7b07c1a8a7972e04e1e5cb772a96f8f465a079184a901',
-     x86_64: '7644ad75af42f77b989c0e0d8513a1d9635a74ca9bf2953abc422d643fa27052',
-  })
-
   depends_on 'protobuf'
 
   def self.build


### PR DESCRIPTION
Fixes #2335 

## Description
The current mosh packages fails to run, with error: `mosh-client: symbol lookup error: mosh-client: undefined symbol: _ZN6google8protobuf2io22LazyStringOutputStreamC1EPNS0_14ResultCallbackIPSsEE`. Installing from source works properly, so removing `binary_url` fixes this problem. 

## Addtional information
I don't have non x86_64 environments to test, so I'd leave it to others to contribute binaries.
