### PR TITLE
Add libjpeg dependency to emacs

### DIFF
--- a/packages/emacs.rb
+++ b/packages/emacs.rb
@@ -21,6 +21,7 @@ class Emacs < Package
   })
 
   depends_on 'lcms'
+  depends_on 'libjpeg'
 
   def self.build
     system "./configure \


### PR DESCRIPTION
## Description
`emacs` requires `libjpeg.so.9` provided by libjpeg, which is not installed by default. This PR adds `libjpeg` as a dependency.