### PR TITLE
Fix library path for vidstab on x86_64

### DIFF
--- a/packages/vidstab.rb
+++ b/packages/vidstab.rb
@@ -3,25 +3,29 @@ require 'package'
 class Vidstab < Package
   description 'Transcode video stabilization plugin.'
   homepage 'http://public.hronopik.de/vid.stab/'
-  version '1.1.0'
+  version '1.1.0-1'
   source_url 'https://github.com/georgmartius/vid.stab/archive/v1.1.0.tar.gz'
   source_sha256 '14d2a053e56edad4f397be0cb3ef8eb1ec3150404ce99a426c4eb641861dc0bb'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vidstab-1.1.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vidstab-1.1.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vidstab-1.1.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vidstab-1.1.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vidstab-1.1.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vidstab-1.1.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vidstab-1.1.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vidstab-1.1.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bce661392dce20dd457aac266b8fd54d9baab87d817f5975ab6705950b77a272',
-     armv7l: 'bce661392dce20dd457aac266b8fd54d9baab87d817f5975ab6705950b77a272',
-       i686: '68014e89423663b16267d08d5cb2342356f81eeb92cad863a6a97d8b536466d8',
-     x86_64: '3557c98666d254d12bd738595ea6147dea7f7b354a24bd246832084fe1bcddb6',
+    aarch64: '1f8dad35414c0ee16576445473791d9012ff3910d3a491b40d820adc05438eb2',
+     armv7l: '1f8dad35414c0ee16576445473791d9012ff3910d3a491b40d820adc05438eb2',
+       i686: '36dc191071129b11a10eed98042c06b17dd2d41dccbddc0995da11a5a6fdb7d8',
+     x86_64: 'c722ad0d35766647406425bd512bf05058909045634b75ec42450fe3b42e4592',
   })
 
   def self.build
-    system "cmake . -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}"
+    if ARCH == 'x86_64'
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DLIB_SUFFIX=64"
+    else
+      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}"
+    end
     system 'make'
   end
 


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64