### PR TITLE
Update ffmpeg from 4.0 to 4.1

### DIFF
--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -3,21 +3,21 @@ require 'package'
 class Ffmpeg < Package
   description 'A complete, cross-platform solution to record, convert and stream audio and video.'
   homepage 'https://ffmpeg.org/'
-  version '4.0'
-  source_url 'https://ffmpeg.org/releases/ffmpeg-4.0.tar.xz'
-  source_sha256 'ed945daf40b124e77a685893cc025d086f638bc703183460aff49508edb3a43f'
+  version '4.1'
+  source_url 'https://ffmpeg.org/releases/ffmpeg-4.1.tar.xz'
+  source_sha256 'a38ec4d026efb58506a99ad5cd23d5a9793b4bf415f2c4c2e9c1bb444acd1994'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bd6d8edae2aa12f149e7d514e56378fa18bd427f610ce3e4d9bf68884a3c8dc7',
-     armv7l: 'bd6d8edae2aa12f149e7d514e56378fa18bd427f610ce3e4d9bf68884a3c8dc7',
-       i686: '34dfd0ed8773bde7066f4454cec9316ed02753ca84a9303bfd958924df415f08',
-     x86_64: '84811eca1f3f2b47537e8c9bfe3f0611247e6797cd1e64797bd5d68a9bcf1ea6',
+    aarch64: 'd480cd8f729607f54029425d63adde1c67b83fb14fe815887354aa9077bb48d3',
+     armv7l: 'd480cd8f729607f54029425d63adde1c67b83fb14fe815887354aa9077bb48d3',
+       i686: '1b22147d3cc89bcd4fae816495f38a74556f5b45aaaf107ca77e09d56980ceda',
+     x86_64: '84dd40e9f141b6fe15915e0e3ff9a42450281d82d69b11da2d86a403fc27ce48',
   })
 
   depends_on 'gnutls'


### PR DESCRIPTION
Depends on #2855 for x86_64.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64