### PR TITLE
Add filezilla package and dependencies

### DIFF
--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Filezilla < Package
+  description 'FileZilla Client is a free FTP solution.'
+  homepage 'https://filezilla-project.org/'
+  version '1.6.3'
+  source_url 'https://download.filezilla-project.org/client/FileZilla_3.38.1_src.tar.bz2'
+  source_sha256 '1a86becc4a8bb70ff316522217818364028b95224fc728e3bb676ebee98d0cde'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-1.6.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-1.6.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-1.6.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-1.6.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '1d00ac0692973757937dfc29a9feed883b28e211ed700bda64d360e21d0cf5c8',
+     armv7l: '1d00ac0692973757937dfc29a9feed883b28e211ed700bda64d360e21d0cf5c8',
+       i686: '7157a9d2aa5899fcd9a21148f56daa3b01e70623d1d55d1256abf4e4043797f4',
+     x86_64: '683cb597524c179fff8e0f2748a296d633c8429cdb948eaab70069609b2379f3',
+  })
+
+  depends_on 'dbus'
+  depends_on 'gnome_icon_theme'
+  depends_on 'hicolor_icon_theme'
+  depends_on 'libfilezilla'
+  depends_on 'libidn2'
+  depends_on 'sqlite'
+  depends_on 'wxwidgets'
+  depends_on 'xdg_utils'
+  depends_on 'sommelier'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode',
+           '--with-pugixml=builtin'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/libfilezilla.rb
+++ b/packages/libfilezilla.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Libfilezilla < Package
+  description 'libfilezilla is a small and modern C++ library, offering some basic functionality to build high-performing, platform-independent programs.'
+  homepage 'https://lib.filezilla-project.org/'
+  version '0.15.1'
+  source_url 'https://download.filezilla-project.org/libfilezilla/libfilezilla-0.15.1.tar.bz2'
+  source_sha256 '2048c4128f3bf37a2a4ece17c8bea5455f3d7414fe2e060afcf2a8b00a87f49f'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.15.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.15.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.15.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.15.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '9f0c812627b00d80513fd6efa9f26151f7fd91be28277f387fe8f950fe59d7ac',
+     armv7l: '9f0c812627b00d80513fd6efa9f26151f7fd91be28277f387fe8f950fe59d7ac',
+       i686: '85e40754a5dcb32e2f77b2bd95e0e25d1a8319e9a8bb09688596b44c279ba715',
+     x86_64: '607e93feabe4f830aa05379bd1a1b9930f6253ba9ab3bede5ee56f60ac542de5',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/wxwidgets.rb
+++ b/packages/wxwidgets.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Wxwidgets < Package
+  description 'wxWidgets is a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base.'
+  homepage 'https://www.wxwidgets.org/'
+  version '3.0.4'
+  source_url 'https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.4/wxWidgets-3.0.4.tar.bz2'
+  source_sha256 '96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.4-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f4ccfde2ce01be971af64b1a76cce5b8748352c30ac67d51085dba02d8d60060',
+     armv7l: 'f4ccfde2ce01be971af64b1a76cce5b8748352c30ac67d51085dba02d8d60060',
+       i686: '2b0024005566d7d45de96f2fe8a417859cbccd2f9061039adfcd782e0165426d',
+     x86_64: 'c24c461c76af35ce55fe34b442d31ed090afe45c971902287c44d8d77f332e22',
+  })
+
+  depends_on 'gtk3'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/xdg_utils.rb
+++ b/packages/xdg_utils.rb
@@ -1,0 +1,39 @@
+require 'package'
+
+class Xdg_utils < Package
+  description 'xdg-utils is a set of tools that allows applications to easily integrate with the desktop environment of the user, regardless of the specific desktop environment that the user runs.'
+  homepage 'https://www.freedesktop.org/wiki/Software/xdg-utils/'
+  version '1.1.3'
+  source_url 'https://portland.freedesktop.org/download/xdg-utils-1.1.3.tar.gz'
+  source_sha256 'd798b08af8a8e2063ddde6c9fa3398ca81484f27dec642c5627ffcaa0d4051d9'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xdg_utils-1.1.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xdg_utils-1.1.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xdg_utils-1.1.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xdg_utils-1.1.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '047179b2eed1133b4694e22ccf3bdec32840162ec267db88e7f2b4f72b7cb757',
+     armv7l: '047179b2eed1133b4694e22ccf3bdec32840162ec267db88e7f2b4f72b7cb757',
+       i686: '4e362f4e1f5d0425b8f51188bf2800125cd7e8c395bbb41f529111a6c8795235',
+     x86_64: '2cf6a0564337993c470a8fcbaf9a9f588a0b1171ddd8fcfe42d3568625bca7b4',
+  })
+
+  depends_on 'help2man' => :build
+
+  def self.build
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/man/man1"
+    system "./configure --prefix=#{CREW_PREFIX}"
+    system "sed -i 's,html man scripts,scripts,' scripts/Makefile"
+    system "sed -i '65,71d' scripts/Makefile"
+    system "sed -i '63imv \$\$x.in \$\$x; \\\\' scripts/Makefile"
+    system "sed -i '64ihelp2man -N --no-discard-stderr \$\$x > \$\$x.1; \\\\' scripts/Makefile"
+    system "sed -i '65igzip -9 \$\$x.1; \\\\' scripts/Makefile"
+    system "sed -i '66iinstall -Dm755 \$\$x.1.gz #{CREW_DEST_PREFIX}/share/man/man1/\$\$x.1.gz; \\\\' scripts/Makefile"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
FileZilla Client is a free FTP solution and not only supports FTP, but also FTP over TLS (FTPS) and SFTP.  It is open source software distributed free of charge under the terms of the GNU General Public License.  See https://filezilla-project.org/.  Dependencies include libfilezilla, wxwidgets and xdg_utils.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64

Caveats:
- The i686 build of filezilla does not launch.  This has been a general issue with most of the gui apps tested lately which makes it increasingly difficult to support this architecture moving forward.  Most command line apps still work well, however.  We should probably think about supporting only cli apps on i686.
- The man pages for xdg_utils are useless but this doesn't prevent filezilla from working since the executables are fine.  The i686 man pages work fine, however.  Go figure?