### PR TITLE
Add sane packages

### DIFF
--- a/packages/sane_backends.rb
+++ b/packages/sane_backends.rb
@@ -1,0 +1,34 @@
+require 'package'
+
+class Sane_backends < Package
+  description 'Scanner Access Now Easy - Backends'
+  homepage 'http://www.sane-project.org/'
+  version '1.0.27'
+  source_url 'https://gitlab.com/sane-project/backends/-/archive/RELEASE_1_0_27/backends-RELEASE_1_0_27.tar.bz2'
+  source_sha256 '6a4034a9d29255bb40cf5a19f3d85dd7ba4fe6452eb9b1ae4385bc8175493ec4'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sane_backends-1.0.27-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sane_backends-1.0.27-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sane_backends-1.0.27-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sane_backends-1.0.27-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '88808a041b13f2cc49fcc997e79ee2976010613d4961a552022b5a1d9887fd98',
+     armv7l: '88808a041b13f2cc49fcc997e79ee2976010613d4961a552022b5a1d9887fd98',
+       i686: '890abd21b508d9efc1a91e7738f00b58589110c536b79b9df8c3ee12b5f39e4c',
+     x86_64: 'b585e6efcc75a0d54dc1468d6e9fa00445af1a5ceb01752dc11d7ad65a101efc',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/sane_frontends.rb
+++ b/packages/sane_frontends.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Sane_frontends < Package
+  description 'Scanner Access Now Easy - Frontends'
+  homepage 'http://www.sane-project.org/'
+  version 'c3e739'
+  source_url 'https://gitlab.com/sane-project/frontends/-/archive/c3e739702f965f635319e0407c5a1e0b17dd7b42/frontends-c3e739702f965f635319e0407c5a1e0b17dd7b42.tar.bz2'
+  source_sha256 'eb38d1ff3cc074a5db2538c523e654db1946f6e96593e252e433467ebab8a525'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sane_frontends-c3e739-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sane_frontends-c3e739-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sane_frontends-c3e739-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sane_frontends-c3e739-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '2867edb5d4a2ce0d6dca6ce7794d407900b9e3841fe42dd722a6fabdbddd8021',
+     armv7l: '2867edb5d4a2ce0d6dca6ce7794d407900b9e3841fe42dd722a6fabdbddd8021',
+       i686: '6bc6e0a417fe5aed435c1acee5796729a241ff6584930c66f49ebd65f8fc1ad7',
+     x86_64: '7404a4f07aeaee09f4610faafa40251f6f22c93b92cce5eeed267305dd9e8576',
+  })
+
+  depends_on 'sane_backends'
+  depends_on 'sommelier'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
SANE stands for "Scanner Access Now Easy" and is an application programming interface (API) that provides standardized access to any raster image scanner hardware (flatbed scanner, hand-held scanner, video- and still-cameras, frame-grabbers, etc.). The SANE API is public domain and its discussion and development is open to everybody.  See http://www.sane-project.org/intro.html.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64