### PR TITLE
Add pngcheck package

### DIFF
--- a/packages/pngcheck.rb
+++ b/packages/pngcheck.rb
@@ -1,0 +1,22 @@
+require 'package'
+
+class Pngcheck < Package
+  description 'pngcheck verifies the integrity of PNG, JNG and MNG files'
+  homepage 'http://www.libpng.org/pub/png/apps/pngcheck.html'
+  version '2.3.0'
+  source_url 'https://prdownloads.sourceforge.net/project/png-mng/pngcheck/2.3.0/pngcheck-2.3.0.tar.gz'
+  source_sha256 '77f0a039ac64df55fbd06af6f872fdbad4f639d009bbb5cd5cbe4db25690f35f'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system "gcc -O -DUSE_ZLIB -I#{CREW_PREFIX}/include -o pngcheck pngcheck.c -L#{CREW_LIB_PREFIX} -lz"
+  end
+
+  def self.install
+    system "install -Dm755 pngcheck #{CREW_DEST_PREFIX}/bin/pngcheck"
+  end
+end


### PR DESCRIPTION
pngcheck verifies the integrity of PNG, JNG and MNG files (by checking the internal 32-bit CRCs [checksums] and decompressing the image data); it can optionally dump almost all of the chunk-level information in the image in human-readable form. For example, it can be used to print the basic statistics about an image (dimensions, bit depth, etc.); to list the color and transparency info in its palette (assuming it has one); or to extract the embedded text annotations. This is a command-line program with batch capabilities.  See http://www.libpng.org/pub/png/apps/pngcheck.html.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64