### PR TITLE
Add dia package and dependency

### DIFF
--- a/packages/dia.rb
+++ b/packages/dia.rb
@@ -1,0 +1,64 @@
+require 'package'
+
+class Dia < Package
+  description 'Dia Diagram Editor is free Open Source drawing software for Windows, Mac OS X and Linux.'
+  homepage 'http://dia-installer.de/'
+  version '0.97.2'
+  source_url 'https://github.com/GNOME/dia/archive/DIA_0_97_2.tar.gz'
+  source_sha256 '13437d52f2c5cfdae7ecde8bd5ed0a53a388b0331698236d0ec63453b8a13016'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f351da33d3d4196bd3748f4315df3f3bcfdf648de47c90dfd941a15876707fba',
+     armv7l: 'f351da33d3d4196bd3748f4315df3f3bcfdf648de47c90dfd941a15876707fba',
+       i686: 'ce3cc2776d9d45f976d1076ef38f9fcf58010fae70d3ab961b8aa25b380cb4ff',
+     x86_64: '95d55abe7ebceaae87a0474bd453a923be63cc6b64ed2df3e7fea779e0365789',
+  })
+
+  depends_on 'optipng' => :build
+  depends_on 'cairo'
+  depends_on 'gtk2'
+  depends_on 'libart'
+  depends_on 'libpng'
+  depends_on 'libwmf'
+  depends_on 'six'
+  depends_on 'swig1'
+  depends_on 'sommelier'
+
+  def self.patch
+    # Fix broken images.  See http://archscientist.altervista.org/blog/how-to-solve-libpng-error-idat-invalid-distance-too-far-back/.
+    system "find app/pixmaps -iname '\*.png' -exec echo {} > /tmp/pngfiles.txt \\;"
+    system 'cat /tmp/pngfiles.txt | xargs -n 1 -P 3 optipng -quiet -force -fix'
+    system 'rm -f /tmp/pngfiles.txt'
+  end
+
+  def self.build
+    system './autogen.sh'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode',
+           '--without-python',
+           '--with-cairo',
+           '--with-swig'
+    system 'make'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#CREW_DEST_HOME}/.dia"
+    system "touch #CREW_DEST_HOME}/.dia/persistence"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.postinstall
+    # Fix dia_renderer_set_size: assertion 'irenderer != NULL' failed.  See https://bugs.launchpad.net/ubuntu/+source/dia/+bug/1102960/comments/11.
+    system 'wget https://bugs.launchpad.net/ubuntu/+source/dia/+bug/1102960/+attachment/3552916/+files/persistence'
+    abort 'Checksum mismatch :/ try again' unless Digest::SHA256.hexdigest( File.read('persistence') ) == '53cb6e49892bd60870fb31780052e46d9e47c5b19f87db1651760d10d3fe66e7'
+    system "install -Dm644 persistence #{ENV['HOME']}/.dia/persistence"
+  end
+end

--- a/packages/swig1.rb
+++ b/packages/swig1.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Swig1 < Package
+  description 'Simplified Wrapper and Interface Generator'
+  homepage 'http://www.swig.org'
+  version '1.3.40'
+  source_url 'https://prdownloads.sourceforge.net/project/swig/swig/swig-1.3.40/swig-1.3.40.tar.gz'
+  source_sha256 '1945b3693bcda6777bd05fef1015a0ad1a4604cde4a4a0a368b61ccfd143ac09'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/swig1-1.3.40-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/swig1-1.3.40-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/swig1-1.3.40-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/swig1-1.3.40-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'bff62d68c6c6ab5c57ffb994153b506711cc8eca0b50a29c80736617d2baae68',
+     armv7l: 'bff62d68c6c6ab5c57ffb994153b506711cc8eca0b50a29c80736617d2baae68',
+       i686: '3d878e0d24a378f6deb27cb2760363d82a0c81273ccd12091d863c6080588225',
+     x86_64: '7c2e070c4325546cd74ff4219a5737b020f43c23f3bcaf49b302551962361215',
+  })
+
+  depends_on 'pcre'
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Dia Diagram Editor is free Open Source drawing software for Windows, Mac OS X and Linux.  See http://dia-installer.de/.  Depends on swig1 (included).

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64

The i686 build does not launch successfully.
