### PR TITLE
Add spacefm package and dependency

### DIFF
--- a/packages/ffmpegthumbnailer.rb
+++ b/packages/ffmpegthumbnailer.rb
@@ -1,0 +1,42 @@
+require 'package'
+
+class Ffmpegthumbnailer < Package
+  description 'FFmpegthumbnailer is a lightweight video thumbnailer that can be used by file managers to create thumbnails for your video files.'
+  homepage 'https://github.com/dirkvdb/ffmpegthumbnailer'
+  version '2.2.0'
+  source_url 'https://github.com/dirkvdb/ffmpegthumbnailer/releases/download/2.2.0/ffmpegthumbnailer-2.2.0.tar.bz2'
+  source_sha256 'e5c31299d064968198cd378f7488e52cd5e738fac998eea780bc77d7f32238c2'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpegthumbnailer-2.2.0-chromeos-aarch64.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpegthumbnailer-2.2.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpegthumbnailer-2.2.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpegthumbnailer-2.2.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '747253e634463bd56136959ba3d9af7a2471dab0b6ea25942c2393e63c8c2a32',
+     armv7l: 'd87b2c125e50ecc2556594995889eba190dff239f3e3d9707f7cb73dc4a6adc8',
+       i686: 'e47f302bf25775143bd1e7b0a62af36dfe734d7f9766c5e9a13c4eee54b69701',
+     x86_64: '61cb62cb5162ebae8ab981bf14e0187cef4529ebf100f68c4ddf2ba15b39de31',
+  })
+
+  depends_on 'ffmpeg'
+
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      if ARCH == 'x86_64'
+        system "cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_GIO=ON -DENABLE_THUMBNAILER=ON -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DLIB_SUFFIX=64"
+      else
+        system "cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_GIO=ON -DENABLE_THUMBNAILER=ON -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}"
+      end
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    end
+  end
+end

--- a/packages/spacefm.rb
+++ b/packages/spacefm.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Spacefm < Package
+  description 'SpaceFM is a multi-panel tabbed file and desktop manager for Linux with built-in VFS, udev- or HAL-based device manager, customisable menu system, and bash-GTK integration.'
+  homepage 'https://ignorantguru.github.io/spacefm/'
+  version '1.0.6'
+  source_url 'https://github.com/IgnorantGuru/spacefm/archive/1.0.6.tar.gz'
+  source_sha256 'fedea9fcad776e0af4b8d90c5a1c86684a9c96ef1cdd4e959530ce93bdebe7c9'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/spacefm-1.0.6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/spacefm-1.0.6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/spacefm-1.0.6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/spacefm-1.0.6-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'a761365160878900f94ad9c964631d2ad29ba0afc3f8d237313f97b9baf60fe0',
+     armv7l: 'a761365160878900f94ad9c964631d2ad29ba0afc3f8d237313f97b9baf60fe0',
+       i686: '555b7b3a04b73d4aa46ed0551cb6d9577b7e9a1bbe98b0d6ef04b0dedcb94c4a',
+     x86_64: '9a347033bb9eb459beddbc793b86f9462f523a28e45250072def822e91adcdf7',
+  })
+
+  depends_on 'gtk3'
+  depends_on 'ffmpegthumbnailer'
+  depends_on 'hicolor_icon_theme'
+  depends_on 'desktop_file_utilities'
+  depends_on 'shared_mime_info'
+  depends_on 'sommelier'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
SpaceFM is a multi-panel tabbed file and desktop manager for Linux with built-in VFS, udev- or HAL-based device manager, customisable menu system, and bash-GTK integration. SpaceFM aims to provide a stable, capable file manager with significant customisation capabilities.  See http://ignorantguru.github.io/spacefm/.  Depends on ffmpegthumbnailer (included).  Resolves #2904.  This is a better option than Dolphin, Nautilus or Nemo since it doesn't depend on a specific desktop environment like Cinnamon, GNOME or KDE.  Looks like it has more features also.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64

Able to launch on i686 but doesn't exit gracefully.