### PR TITLE
Add modemmanager package and dependencies

### DIFF
--- a/packages/libmbim.rb
+++ b/packages/libmbim.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Libmbim < Package
+  description 'libmbim is a glib-based library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol.'
+  homepage 'https://www.freedesktop.org/wiki/Software/libmbim/'
+  version '1.16.2'
+  source_url 'https://www.freedesktop.org/software/libmbim/libmbim-1.16.2.tar.xz'
+  source_sha256 'eb494fee2c200daf4f5cc8a40061d24a3dfafe8c59151c95c6a826fd96dcb262'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libmbim-1.16.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libmbim-1.16.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libmbim-1.16.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libmbim-1.16.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '20e7289ee6494836d2ae1ae555fcd8dcdaaaf17fbd4c60036d0729b548885007',
+     armv7l: '20e7289ee6494836d2ae1ae555fcd8dcdaaaf17fbd4c60036d0729b548885007',
+       i686: 'f05206366153c334dacc0320633b8dcb2b4ef331a2ac99d710084a7a19b52f2f',
+     x86_64: '8e85d643f339222cede9361db492333709a4c5e0f135aff659c996d51020abff',
+  })
+
+  depends_on 'glib'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/libqmi.rb
+++ b/packages/libqmi.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Libqmi < Package
+  description 'libqmi is a glib-based library for talking to WWAN modems and devices which speak the Qualcomm MSM Interface (QMI) protocol.'
+  homepage 'https://www.freedesktop.org/wiki/Software/libqmi/'
+  version '1.20.2'
+  source_url 'https://www.freedesktop.org/software/libqmi/libqmi-1.20.2.tar.xz'
+  source_sha256 'c73459ca8bfe1213f8047858d4946fc1f58e164d4f488a7a6904edee25e2ca44'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libqmi-1.20.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libqmi-1.20.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libqmi-1.20.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libqmi-1.20.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '30dc112b0c02bec117a00a1a72684d34b4db6e5c60f5ffdbdcac7701b962e23d',
+     armv7l: '30dc112b0c02bec117a00a1a72684d34b4db6e5c60f5ffdbdcac7701b962e23d',
+       i686: 'a9e7760a7345e09368cfe8655923e27f8fc534179bbc003afef6eb18c5fa1533',
+     x86_64: 'e52b18b3f21c9cbe69609e0c0c351ac8e7231c6ac29792d9f360451724818019',
+  })
+
+  depends_on 'libgudev'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/modemmanager.rb
+++ b/packages/modemmanager.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Modemmanager < Package
+  description 'ModemManager is a DBus-activated daemon which controls mobile broadband (2G/3G/4G) devices and connections.'
+  homepage 'https://www.freedesktop.org/wiki/Software/ModemManager/'
+  version '1.8.2'
+  source_url 'https://www.freedesktop.org/software/ModemManager/ModemManager-1.8.2.tar.xz'
+  source_sha256 '96f2a5f0ed15532b4c4c185b756fdc0326e7c2027cea26a1264f91e098260f80'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/modemmanager-1.8.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/modemmanager-1.8.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/modemmanager-1.8.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/modemmanager-1.8.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fafa7f2a98d6d68491db64205063c636a24662a8097c303d73e0b2ab660d0800',
+     armv7l: 'fafa7f2a98d6d68491db64205063c636a24662a8097c303d73e0b2ab660d0800',
+       i686: '18c4897f2fa06868b3b39c1b06c7351ef42f05629c33011f17c837d9c6206593',
+     x86_64: 'bb5304352a96304749c0f969e24dde97e2c58a307f73ed53882afdb293648f55',
+  })
+
+  depends_on 'libmbim'
+  depends_on 'libqmi'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
ModemManager is a DBus-activated daemon which controls mobile broadband (2G/3G/4G) devices and connections. Whether built-in devices, USB dongles, bluetooth-paired telephones, or professional RS232/USB devices with external power supplies, ModemManager is able to prepare and configure the modems and setup connections with them.  See https://www.freedesktop.org/wiki/Software/ModemManager/.  Depends on libmbim and libqmi (included).

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64