### PR TITLE
Update php from 5.6.38-7.2.12 to 5.6.39-7.3.0

### DIFF
--- a/packages/php.rb
+++ b/packages/php.rb
@@ -3,78 +3,94 @@ require 'package'
 class Php < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.38-7.2.12'
+  version '5.6.39-7.3.0'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
     abort "Php version #{phpver} already installed.".lightgreen unless "#{phpver}" == ""
     puts
     puts "Enter the php version to install:"
-    puts "5.6 = PHP 5.6.38"
-    puts "7.0 = PHP 7.0.32"
-    puts "7.1 = PHP 7.1.24"
-    puts "7.2 = PHP 7.2.12"
+    puts "5.6 = PHP 5.6.39"
+    puts "7.0 = PHP 7.0.33"
+    puts "7.1 = PHP 7.1.25"
+    puts "7.2 = PHP 7.2.13"
+    puts "7.3 = PHP 7.3.0"
     puts "  0 = Cancel"
 
     while version = STDIN.gets.chomp
       case version
       when '5.6'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.38-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.38-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.38-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.38-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '6fa6a12b50a565c1934f2556011aa9107058adc7af2b8cf44567d3c324c34ce7',
-           armv7l: '6fa6a12b50a565c1934f2556011aa9107058adc7af2b8cf44567d3c324c34ce7',
-             i686: '7e652da5133743cc170a1bd2ecc2ecc9c2f14ff66580cfc7e84c5daba96922f3',
-           x86_64: 'ce5b6e291a502f632a125ada7693f423cab96ed137bd52ac3a0538523b3caf01',
+          aarch64: '5a0be4837ee67281c647a74b98e9d893dda07266bfc542ef1b87b5143791fb19',
+           armv7l: '5a0be4837ee67281c647a74b98e9d893dda07266bfc542ef1b87b5143791fb19',
+             i686: '383ac377bd617182bbca5a41ddac52105bbccd3754268ca0c4d04556848965a7',
+           x86_64: 'fe93b5fd684e10bac3b6e74c8a4150c9231e6febfe80061917130a94b6f1e094',
         })
         $ver = 5
         break
       when '7.0'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.32-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.32-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.32-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.32-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: 'b381413c87bc2d262ea443b2acdbcd90ba2c2840b6423954548f845aa08264e0',
-           armv7l: 'b381413c87bc2d262ea443b2acdbcd90ba2c2840b6423954548f845aa08264e0',
-             i686: 'fa06779f527ee0e50ae3b0f13b0e09eea916786443fef769b231f603eaa9192d',
-           x86_64: 'df3a185813a7c7bd1512c430d047d8e8c947b296b5ddbd74777e7e457703261f',
+          aarch64: '0f265657ebc48ef210a5058e619a5819b34cde3c87ed1d8bd16795425acee36d',
+           armv7l: '0f265657ebc48ef210a5058e619a5819b34cde3c87ed1d8bd16795425acee36d',
+             i686: 'b61e1dc6dd810e57d0737a555000933efbc04e421643a775361cbf191afa1188',
+           x86_64: 'b58ecb0ba8ba6b8310a7c9060e5ff5f64c3fdc11e23285fab4cebbda6704e5c9',
         })
         $ver = 7
         break
       when '7.1'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.24-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.24-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.24-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.24-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.25-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.25-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.25-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.25-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '9b0598def745f33db755791721c594ccf3cace3de54f8d24c32df07aac616e28',
-           armv7l: '9b0598def745f33db755791721c594ccf3cace3de54f8d24c32df07aac616e28',
-             i686: '60c31d2303610d96a1c9530ca8b442d978289b3b4e50961267ef0eafc3d8981e',
-           x86_64: 'd8b7494f19c04967553f5601804ad7864d3ec47204e6bc23ab4d6ffa2fc6e980',
+          aarch64: '41ff2144c2e1d6d87412736eedfbd267362a817e164eb226aac2a5332bff8871',
+           armv7l: '41ff2144c2e1d6d87412736eedfbd267362a817e164eb226aac2a5332bff8871',
+             i686: 'd3a2555f4127ba4837a819070314a2987b21c3053b10565a09c05c19ce296715',
+           x86_64: '3d73d6e75bcef3a42dfa7bbaf458021753b1fb1c0b6329dbd1cab6e1f4f0bdc6',
         })
         $ver = 7
         break
       when '7.2'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.12-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.12-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.12-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.12-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '09132b4326e34418695af2566c356591048583b1c286b1235aac3a1030431161',
-           armv7l: '09132b4326e34418695af2566c356591048583b1c286b1235aac3a1030431161',
-             i686: '206b65c8b6051dbabbc4c97f08c95d79bea8e9a35f7eca671dacdee7eaf3cffb',
-           x86_64: '156a3d95387a2ea0bf6367935b71b63c281e1d663370d3ba2848717db956e3f3',
+          aarch64: '1eba303d85b10189ca84d7004dba52dfbf77599e972d41350c9d5b0d109c0868',
+           armv7l: '1eba303d85b10189ca84d7004dba52dfbf77599e972d41350c9d5b0d109c0868',
+             i686: 'dca4240c6530c0b05956259bf352fdfbf4de96993a1e87bea518b98e3338e54e',
+           x86_64: '816e2a00a31b200b668cfe4da1a4ad5a015e478d4f2af6b5c41a47875c6f6e25',
+        })
+        $ver = 7
+        break
+      when '7.3'
+        binary_url ({
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.0-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.0-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.0-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.0-chromeos-x86_64.tar.xz',
+        })
+        binary_sha256 ({
+          aarch64: '96537d016c335816a0540c6e96bee856bc7d81fc7ed5fcdb5bd9abffb5b3f3b6',
+           armv7l: '96537d016c335816a0540c6e96bee856bc7d81fc7ed5fcdb5bd9abffb5b3f3b6',
+             i686: '2ab4ff20cd0feac5515788cc59477b61d35d7cab4f499f02df41eaed3f15fb91',
+           x86_64: 'c58287f53287258d2ce073f69a318cceed8cae541cdb3ff0a31998153df3c439',
         })
         $ver = 7
         break

--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -3,21 +3,21 @@ require 'package'
 class Php5 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.38'
-  source_url 'http://php.net/distributions/php-5.6.38.tar.xz'
-  source_sha256 'c2fac47dc6316bd230f0ea91d8a5498af122fb6a3eb43f796c9ea5f59b04aa1e'
+  version '5.6.39'
+  source_url 'http://php.net/distributions/php-5.6.39.tar.xz'
+  source_sha256 '8147576001a832ff3d03cb2980caa2d6b584a10624f87ac459fcd3948c6e4a10'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.38-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.38-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.38-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.38-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '6fa6a12b50a565c1934f2556011aa9107058adc7af2b8cf44567d3c324c34ce7',
-     armv7l: '6fa6a12b50a565c1934f2556011aa9107058adc7af2b8cf44567d3c324c34ce7',
-       i686: '7e652da5133743cc170a1bd2ecc2ecc9c2f14ff66580cfc7e84c5daba96922f3',
-     x86_64: 'ce5b6e291a502f632a125ada7693f423cab96ed137bd52ac3a0538523b3caf01',
+    aarch64: '5a0be4837ee67281c647a74b98e9d893dda07266bfc542ef1b87b5143791fb19',
+     armv7l: '5a0be4837ee67281c647a74b98e9d893dda07266bfc542ef1b87b5143791fb19',
+       i686: '383ac377bd617182bbca5a41ddac52105bbccd3754268ca0c4d04556848965a7',
+     x86_64: 'fe93b5fd684e10bac3b6e74c8a4150c9231e6febfe80061917130a94b6f1e094',
   })
 
   depends_on 'readline7'

--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -3,21 +3,21 @@ require 'package'
 class Php7 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.2.12'
-  source_url 'https://php.net/distributions/php-7.2.12.tar.xz'
-  source_sha256 '989c04cc879ee71a5e1131db867f3c5102f1f7565f805e2bb8bde33f93147fe1'
+  version '7.2.13'
+  source_url 'https://php.net/distributions/php-7.2.13.tar.xz'
+  source_sha256 '14b0429abdb46b65c843e5882c9a8c46b31dfbf279c747293b8ab950c2644a4b'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.12-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.12-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.12-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '09132b4326e34418695af2566c356591048583b1c286b1235aac3a1030431161',
-     armv7l: '09132b4326e34418695af2566c356591048583b1c286b1235aac3a1030431161',
-       i686: '206b65c8b6051dbabbc4c97f08c95d79bea8e9a35f7eca671dacdee7eaf3cffb',
-     x86_64: '156a3d95387a2ea0bf6367935b71b63c281e1d663370d3ba2848717db956e3f3',
+    aarch64: '1eba303d85b10189ca84d7004dba52dfbf77599e972d41350c9d5b0d109c0868',
+     armv7l: '1eba303d85b10189ca84d7004dba52dfbf77599e972d41350c9d5b0d109c0868',
+       i686: 'dca4240c6530c0b05956259bf352fdfbf4de96993a1e87bea518b98e3338e54e',
+     x86_64: '816e2a00a31b200b668cfe4da1a4ad5a015e478d4f2af6b5c41a47875c6f6e25',
   })
 
   depends_on 'readline7'


### PR DESCRIPTION
New 7.30 version released.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64