### PR TITLE
Add cpputest package

### DIFF
--- a/packages/cpputest.rb
+++ b/packages/cpputest.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Cpputest < Package
+  description 'Unit testing and mocking framework for C/C++.'
+  homepage 'https://cpputest.github.io/'
+  version '3.8'
+  source_url 'https://github.com/cpputest/cpputest/archive/v3.8.tar.gz'
+  source_sha256 '2b95bb4a568f680cdcca678345a2c41c028275471c2ed7bf0b6f6f1f689c3b76'
+
+  def self.build                   # the steps required to build the package
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
+    system "make"
+  end
+
+  def self.install                 # the steps required to install the package
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check                   # the steps required to check if the package was built ok
+    system "make", "check"
+  end
+end
+


### PR DESCRIPTION
This is a request to add cpputest package to chromebrew.

CppUTest is a C /C++ based unit xUnit test framework for unit testing and for
test-driving your code. It is written in C++ but is used in C and C++ projects
and frequently used in embedded systems.

CppUTest's core design principles:

* Simple to use and small
* Portable to old and new platforms
* Build with Test-driven Development in mind

WWW: https://cpputest.github.io/