### PR TITLE
Add gnome_doc_utils package and dependency

### DIFF
--- a/packages/gnome_doc_utils.rb
+++ b/packages/gnome_doc_utils.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Gnome_doc_utils < Package
+  description 'Gnome Documentation Utilities'
+  homepage 'https://github.com/GNOME/gnome-doc-utils'
+  version '0.20.10'
+  source_url 'https://ftp.gnome.org/pub/gnome/sources/gnome-doc-utils/0.20/gnome-doc-utils-0.20.10.tar.xz'
+  source_sha256 'cb0639ffa9550b6ddf3b62f3b1add92fb92ab4690d351f2353cffe668be8c4a6'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_doc_utils-0.20.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_doc_utils-0.20.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_doc_utils-0.20.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_doc_utils-0.20.10-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'be5d308c26af775dcebf0fe9a3e17905d31fa983b4d6c1c590ceba5a50b89504',
+     armv7l: 'be5d308c26af775dcebf0fe9a3e17905d31fa983b4d6c1c590ceba5a50b89504',
+       i686: '51793e4e7769e1a0abc40351893c8aa5bd75f63f8202cf59b8002c48b0fe3be1',
+     x86_64: '7d42545db45cd71173b27f329526932d1fc24e00494dfd704f51f11804676986',
+  })
+
+  depends_on 'rarian'
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/rarian.rb
+++ b/packages/rarian.rb
@@ -1,0 +1,34 @@
+require 'package'
+
+class Rarian < Package
+  description 'Documentation metadata library based on the proposed Freedesktop.org spec.'
+  homepage 'https://rarian.freedesktop.org/'
+  version '0.8.1'
+  source_url 'https://ftp.gnome.org/pub/gnome/sources/rarian/0.8/rarian-0.8.1.tar.bz2'
+  source_sha256 'aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rarian-0.8.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rarian-0.8.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rarian-0.8.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rarian-0.8.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '0432d2e342be1d21b788bd906d12312faae65f9badef502c9cbcfe74c56aabf3',
+     armv7l: '0432d2e342be1d21b788bd906d12312faae65f9badef502c9cbcfe74c56aabf3',
+       i686: 'f8feef1bf91eb6fc6c503f8b088dcb23da53de683809d941e793fbeaaf87bb00',
+     x86_64: '3ececd8ac3dce371c40d1b32c10b538821a2b74edff336d9c041f8fcab4ac09c',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Gnome Documentation Utilities.  See https://github.com/GNOME/gnome-doc-utils.  Depends on rarian (included).

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64