### PR TITLE
Update optipng from 0.7.6-1 to 0.7.7

### DIFF
--- a/packages/optipng.rb
+++ b/packages/optipng.rb
@@ -3,25 +3,24 @@ require 'package'
 class Optipng < Package
   description 'OptiPNG is a PNG optimizer that recompresses image files to a smaller size, without losing any information.'
   homepage 'http://optipng.sourceforge.net/'
-  version '0.7.6-1'
-  source_url 'http://prdownloads.sourceforge.net/optipng/optipng-0.7.6.tar.gz'
-  source_sha256 '4870631fcbd3825605f00a168b8debf44ea1cda8ef98a73e5411eee97199be80'
+  version '0.7.7'
+  source_url 'https://prdownloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.7/optipng-0.7.7.tar.gz'
+  source_sha256 '4f32f233cef870b3f95d3ad6428bfe4224ef34908f1b42b0badf858216654452'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/optipng-0.7.6-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/optipng-0.7.6-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/optipng-0.7.6-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/optipng-0.7.6-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/optipng-0.7.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/optipng-0.7.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/optipng-0.7.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/optipng-0.7.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'cbec93e41fa2aaf0c5ff8b56a532236f88ba16f7dd4c56bfa8f04e67a801f224',
-     armv7l: 'cbec93e41fa2aaf0c5ff8b56a532236f88ba16f7dd4c56bfa8f04e67a801f224',
-       i686: '1f5b21f33c91191c1aa53d387948b9dd83bb38ee196b94439dd91b3a05602c5d',
-     x86_64: '15a053ff2d6728d49f9c33301963a342aa385c94184be494a15f3d14daa7928f',
+    aarch64: '1601aa1f127fdb2eacad1c0faa347c405722e208387fea068a9566d11373c92f',
+     armv7l: '1601aa1f127fdb2eacad1c0faa347c405722e208387fea068a9566d11373c92f',
+       i686: '6ce2f78ccb3a4d33cb15843735ee93ef42f7862f448cbf2fdb2515e5e355b364',
+     x86_64: 'cc4c62f535d32680b40ec79f8334b1d046032ff773596cc87f2c127128b032d3',
   })
 
   depends_on 'libpng'
-  depends_on 'zlibpkg'
 
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --with-system-libpng" # Bundled libpng doesn't work on armv7l


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64