### PR TITLE
Add feh package and dependency

### DIFF
--- a/packages/feh.rb
+++ b/packages/feh.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Feh < Package
+  description 'feh is an X11 image viewer aimed mostly at console users.'
+  homepage 'https://feh.finalrewind.org/'
+  version '3.1.1'
+  source_url 'https://feh.finalrewind.org/feh-3.1.1.tar.bz2'
+  source_sha256 '61d0242e3644cf7c5db74e644f0e8a8d9be49b7bd01034265cc1ebb2b3f9c8eb'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.1.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.1.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.1.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.1.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '3078205c170c198443f34de67e203553706e37d2e0e6922a6da19eab2a6fc01b',
+     armv7l: '3078205c170c198443f34de67e203553706e37d2e0e6922a6da19eab2a6fc01b',
+       i686: '607aa603469570597246fbb5e4947546eede0cc86856b3da93ad366b1d038ce2',
+     x86_64: '4183106490b301341bb7d8c4cf37f6071e61231580c5d2d6ff1e108874c681f7',
+  })
+
+  depends_on 'curl'
+  depends_on 'gtk3'
+  depends_on 'imlib2'
+  depends_on 'sommelier'
+
+  def self.build
+    system "sed -i 's,gtk-update-icon-cache,gtk-update-icon-cache -t,g' Makefile"
+    system 'make'
+  end
+
+  def self.install
+    system "make",
+           "PREFIX=#{CREW_PREFIX}",
+           "ICON_PREFIX=#{CREW_DEST_PREFIX}/share/icons",
+           "DESTDIR=#{CREW_DEST_DIR}",
+           "install",
+           "app=1"
+  end
+end

--- a/packages/imlib2.rb
+++ b/packages/imlib2.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Imlib2 < Package
+  description 'library that does image file loading and saving as well as rendering, manipulation, arbitrary polygon support, etc.'
+  homepage 'https://sourceforge.net/projects/enlightenment/'
+  version '1.5.1'
+  source_url 'https://downloads.sourceforge.net/enlightenment/imlib2-1.5.1.tar.bz2'
+  source_sha256 'fa4e57452b8843f4a70f70fd435c746ae2ace813250f8c65f977db5d7914baae'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.5.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.5.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.5.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.5.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '6f0ba9fab8919ca237a7e6cf685b2bda016392f10b8f65dbb8c290dd376de9a2',
+     armv7l: '6f0ba9fab8919ca237a7e6cf685b2bda016392f10b8f65dbb8c290dd376de9a2',
+       i686: 'aadf78515aa8456ea66f8fe294ad15031dcbe4f2696c6ed56f7810ff0b5c3976',
+     x86_64: '03cb7e8861fadc3724814bce639898416e09eb73a5fd5ac6e1ab76769434a171',
+  })
+
+  depends_on 'freetype'
+  depends_on 'giflib'
+  depends_on 'libid3tag'
+  depends_on 'libjpeg_turbo'
+  depends_on 'libtiff'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-static'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
feh is an X11 image viewer aimed mostly at console users. Unlike most other viewers, it does not have a fancy GUI, but simply displays images. It is controlled via commandline arguments and configurable key/mouse actions.  See https://feh.finalrewind.org/.  Depends on imlib2 (included).

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64