### PR TITLE
Fix broadway/sommelier interoperability

### DIFF
--- a/packages/broadway.rb
+++ b/packages/broadway.rb
@@ -3,7 +3,7 @@ require 'package'
 class Broadway < Package
   description 'Run GTK applications in a browser window.'
   homepage 'https://developer.gnome.org/gtk3/stable/gtk-broadway.html'
-  version 'gtk3.22'
+  version 'gtk3.22-1'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
@@ -15,66 +15,65 @@ class Broadway < Package
   depends_on 'gtk3'
 
   def self.build
-    system "echo '#!/bin/bash' > startbroadwayd"
-    system "echo >> startbroadwayd"
-    system "echo '  BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> startbroadwayd"
-    system "echo '  if [ -z \"\${BROADWAYD}\" ]; then' >> startbroadwayd"
-    system "echo '    broadwayd \${BROADWAY_DISPLAY} &>/dev/null &' >> startbroadwayd"
-    system "echo '    sleep 3' >> startbroadwayd"
-    system "echo '  fi' >> startbroadwayd"
-    system "echo '  BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> startbroadwayd"
-    system "echo '  if [ ! -z \"\${BROADWAYD}\" ]; then' >> startbroadwayd"
-    system "echo '    echo \"broadwayd process \${BROADWAYD} is running\"' >> startbroadwayd"
-    system "echo '  else' >> startbroadwayd"
-    system "echo '    echo \"broadwayd failed to start\"' >> startbroadwayd"
-    system "echo '    exit 1' >> startbroadwayd"
-    system "echo '  fi' >> startbroadwayd"
-    system "echo '#!/bin/bash' > stopbroadwayd"
-    system "echo >> stopbroadwayd"
-    system "echo '  BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> stopbroadwayd"
-    system "echo '  if [ ! -z \"\${BROADWAYD}\" ]; then' >> stopbroadwayd"
-    system "echo '    pkill broadwayd' >> stopbroadwayd"
-    system "echo '    sleep 3' >> stopbroadwayd"
-    system "echo '  fi' >> stopbroadwayd"
-    system "echo '  BROADWAYD=\$(pidof broadwayd 2> /dev/null)' >> stopbroadwayd"
-    system "echo '  if [ -z \"\${BROADWAYD}\" ]; then' >> stopbroadwayd"
-    system "echo '    echo \"broadwayd process stopped\"' >> stopbroadwayd"
-    system "echo '  else' >> stopbroadwayd"
-    system "echo '    echo \"broadwayd process \${BROADWAYD} is running\"' >> stopbroadwayd"
-    system "echo '    exit 1' >> stopbroadwayd"
-    system "echo '  fi' >> stopbroadwayd"
+    system "echo 'GDK_BACKEND=broadway' > .broadway.env"
+    system "echo 'XDG_RUNTIME_DIR=/var/run/chrome' >> .broadway.env"
+    system "echo 'BROADWAY_DISPLAY=:5' >> .broadway.env"
+    system "echo '#!/bin/bash' > initbroadway"
+    system "echo 'source ~/.broadway.env' >> initbroadway"
+    system "echo 'BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> initbroadway"
+    system "echo 'if [ -z \"\${BROADWAYD}\" ]; then' >> initbroadway"
+    system "echo '  [ -f #{CREW_PREFIX}/bin/stopsommelier ] && stopsommelier' >> initbroadway"
+    system "echo '  broadwayd \${BROADWAY_DISPLAY} &' >> initbroadway"
+    system "echo '  sleep 3' >> initbroadway"
+    system "echo 'fi' >> initbroadway"
+    system "echo 'BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> initbroadway"
+    system "echo 'if [ ! -z \"\${BROADWAYD}\" ]; then' >> initbroadway"
+    system "echo '  echo \"broadwayd process \${BROADWAYD} is running\"' >> initbroadway"
+    system "echo 'else' >> initbroadway"
+    system "echo '  echo \"broadwayd failed to start\"' >> initbroadway"
+    system "echo '  exit 1' >> initbroadway"
+    system "echo 'fi' >> initbroadway"
+    system "echo '#!/bin/bash' > stopbroadway"
+    system "echo >> stopbroadway"
+    system "echo 'BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> stopbroadway"
+    system "echo 'if [ ! -z \"\${BROADWAYD}\" ]; then' >> stopbroadway"
+    system "echo '  pkill broadwayd' >> stopbroadway"
+    system "echo '  sleep 3' >> stopbroadway"
+    system "echo 'fi' >> stopbroadway"
+    system "echo 'BROADWAYD=\$(pidof broadwayd 2> /dev/null)' >> stopbroadway"
+    system "echo 'if [ -z \"\${BROADWAYD}\" ]; then' >> stopbroadway"
+    system "echo '  echo \"broadwayd process stopped\"' >> stopbroadway"
+    system "echo 'else' >> stopbroadway"
+    system "echo '  echo \"broadwayd process \${BROADWAYD} is running\"' >> stopbroadway"
+    system "echo '  exit 1' >> stopbroadway"
+    system "echo 'fi' >> stopbroadway"
   end
 
   def self.install
-    system "install -Dm755 startbroadwayd #{CREW_DEST_PREFIX}/bin/startbroadwayd"
-    system "install -Dm755 stopbroadwayd #{CREW_DEST_PREFIX}/bin/stopbroadwayd"
+    system "install -Dm755 initbroadway #{CREW_DEST_PREFIX}/bin/initbroadway"
+    system "install -Dm755 stopbroadway #{CREW_DEST_PREFIX}/bin/stopbroadway"
+    system "install -Dm644 .broadway.env #{CREW_DEST_HOME}/.broadway.env"
+    system "cp .broadway.env ~/"
   end
 
   def self.postinstall
     puts
     puts "To complete the installation, execute the following:".lightblue
     puts "echo '# Broadway environment variables + daemon' >> ~/.bashrc".lightblue
-    puts "echo 'if [[ -z \"\${GDK_BACKEND}\" ]]; then' >> ~/.bashrc".lightblue
-    puts "echo '  export GDK_BACKEND=broadway' >> ~/.bashrc".lightblue
-    puts "echo 'fi' >> ~/.bashrc".lightblue
-    puts "echo 'if [[ -z \"\${XDG_RUNTIME_DIR}\" ]]; then' >> ~/.bashrc".lightblue
-    puts "echo '  export XDG_RUNTIME_DIR=/var/run/chrome' >> ~/.bashrc".lightblue
-    puts "echo 'fi' >> ~/.bashrc".lightblue
-    puts "echo 'export BROADWAY_DISPLAY=:5' >> ~/.bashrc".lightblue
-    puts "echo 'startbroadwayd' >> ~/.bashrc".lightblue
+    puts "echo '# See https://developer.gnome.org/gtk3/stable/gtk-broadway.html' >> ~/.bashrc".lightblue
+    puts "echo 'alias startbroadway=\"source ~/.broadway.env && initbroadway\"' >> ~/.bashrc".lightblue
+    puts "echo 'startbroadway' >> ~/.bashrc".lightblue
     puts "source ~/.bashrc".lightblue
     puts
-    puts "To start the broadwayd daemon, run 'startbroadwayd'".lightblue
-    puts "To stop the broadwayd daemon, run 'stopbroadwayd'".lightblue
+    puts "To start the broadwayd daemon, run 'startbroadway'".lightblue
+    puts "To stop the broadwayd daemon, run 'stopbroadway'".lightblue
     puts
-    puts "Please be aware that gtk applications may not work without the broadwayd daemon running.".orange
-    puts "Broadway may also not work if Sommelier is installed; If you have any issues, run these commands:".orange
-    puts
-    puts "sed -i 's,^export GDK_BACKEND=wayland,#&,g' ~/.bashrc".orange
-    puts "unset GDK_BACKEND && source ~/.bashrc".orange
+    puts "To adjust environment variables, edit ~/.broadway.env".lightblue
     puts
     puts "Navigate your browser to http://127.0.0.1:8085 while the broadwayd".lightblue
     puts "daemon is running to run GTK applications in the browser window.".lightblue
+    puts
+    puts "Please be aware that gtk applications may not work without the broadwayd daemon running.".orange
     puts
   end
 end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,21 +3,21 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 and Wayland programs to the built-in ChromeOS wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/containers/sommelier'
-  version '1382ce08'
+  version '1382ce084'
   source_url 'https://chromium.googlesource.com/chromiumos/containers/sommelier/+/0.20/README?format=TEXT'
   source_sha256 'b58d799b16d20abf92369fe0749c73f7398996f0afa9933517051778a8bb16c3'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce08-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce08-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce08-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce08-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce084-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce084-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce084-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce084-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '90274ae7d2b2eb0dcc1d87d2f88af6cb01420df30ded001a7671f5fc4739b2b1',
-     armv7l: '90274ae7d2b2eb0dcc1d87d2f88af6cb01420df30ded001a7671f5fc4739b2b1',
-       i686: 'a063a6fe5da3dd7f9f38b389c0ac89c1077fbb1e800cdcfb0d4b8379a0982df2',
-     x86_64: 'c798a59b652619398ed781f9dc726d27da3898dba6a34f5c5ddeee67904871d1',
+    aarch64: '2352711cfdbca58c120a21ea57e805974de2a7dc35fcfa766a9790c9376ecb65',
+     armv7l: '2352711cfdbca58c120a21ea57e805974de2a7dc35fcfa766a9790c9376ecb65',
+       i686: '426f4e0e2173e1d6ff7c4bb98c9016ef1170df7a0860726cb13617d72eb3a9bc',
+     x86_64: '20a615a422293813c1e7843fa85aca1534ba16ede7b63b3f4030d056881d3e86',
   })
 
   depends_on 'mesa'
@@ -32,21 +32,28 @@ class Sommelier < Package
       system "sed -i 's,/lib/,/#{ARCH_LIB}/,g' Makefile"
       system "sed -i 's,-I.,-I. -I#{CREW_PREFIX}/include/pixman-1,g' Makefile"
       system "make PREFIX=#{CREW_PREFIX} SYSCONFDIR=#{CREW_PREFIX}/etc"
+      system "echo 'GDK_BACKEND=wayland' > .sommelier.env"
+      system "echo 'CLUTTER_BACKEND=wayland' >> .sommelier.env"
+      system "echo 'XDG_RUNTIME_DIR=/var/run/chrome' >> .sommelier.env"
+      system "echo 'WAYLAND_DISPLAY=wayland-0' >> .sommelier.env"
+      system "echo 'DISPLAY=:0' >> .sommelier.env"
+      system "echo 'SCALE=1' >> .sommelier.env"
       system "echo '#!/bin/bash' > sommelierd"
       system "echo 'sommelier -X --x-display=\$DISPLAY --scale=\$SCALE --no-exit-with-child /bin/sh -c \"#{CREW_PREFIX}/etc/sommelierrc\"' >> sommelierd"
-      system "echo '#!/bin/bash' > startsommelier"
-      system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> startsommelier"
-      system "echo 'if [ -z \"\$SOMM\" ]; then' >> startsommelier"
-      system "echo '  #{CREW_PREFIX}/sbin/sommelierd &' >> startsommelier"
-      system "echo '  sleep 3' >> startsommelier"
-      system "echo 'fi' >> startsommelier"
-      system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> startsommelier"
-      system "echo 'if [ ! -z \"\$SOMM\" ]; then' >> startsommelier"
-      system "echo '  echo \"sommelier process \$SOMM is running\"' >> startsommelier"
-      system "echo 'else' >> startsommelier"
-      system "echo '  echo \"sommelier failed to start\"' >> startsommelier"
-      system "echo '  exit 1' >> startsommelier"
-      system "echo 'fi' >> startsommelier"
+      system "echo '#!/bin/bash' > initsommelier"
+      system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> initsommelier"
+      system "echo 'if [ -z \"\$SOMM\" ]; then' >> initsommelier"
+      system "echo '  [ -f #{CREW_PREFIX}/bin/stopbroadway ] && stopbroadway' >> initsommelier"
+      system "echo '  #{CREW_PREFIX}/sbin/sommelierd &' >> initsommelier"
+      system "echo '  sleep 3' >> initsommelier"
+      system "echo 'fi' >> initsommelier"
+      system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> initsommelier"
+      system "echo 'if [ ! -z \"\$SOMM\" ]; then' >> initsommelier"
+      system "echo '  echo \"sommelier process \$SOMM is running\"' >> initsommelier"
+      system "echo 'else' >> initsommelier"
+      system "echo '  echo \"sommelier failed to start\"' >> initsommelier"
+      system "echo '  exit 1' >> initsommelier"
+      system "echo 'fi' >> initsommelier"
       system "echo '#!/bin/bash' > stopsommelier"
       system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> stopsommelier"
       system "echo 'if [ ! -z \"\$SOMM\" ]; then' >> stopsommelier"
@@ -67,8 +74,10 @@ class Sommelier < Package
     Dir.chdir ("sommelier") do
       system "make", "PREFIX=#{CREW_PREFIX}", "SYSCONFDIR=#{CREW_PREFIX}/etc", "DESTDIR=#{CREW_DEST_DIR}", "install"
       system "install -Dm755 sommelierd #{CREW_DEST_PREFIX}/sbin/sommelierd"
-      system "install -Dm755 startsommelier #{CREW_DEST_PREFIX}/bin/startsommelier"
+      system "install -Dm755 initsommelier #{CREW_DEST_PREFIX}/bin/initsommelier"
       system "install -Dm755 stopsommelier #{CREW_DEST_PREFIX}/bin/stopsommelier"
+      system "install -Dm644 .sommelier.env #{CREW_DEST_HOME}/.sommelier.env"
+      system "cp .sommelier.env ~/"
     end
   end
 
@@ -77,26 +86,26 @@ class Sommelier < Package
     puts "To complete the installation, execute the following:".lightblue
     puts "echo '# Sommelier environment variables + daemon' >> ~/.bashrc".lightblue
     puts "echo '# See https://github.com/dnschneid/crouton/wiki/Sommelier-(A-more-native-alternative-to-xiwi)' >> ~/.bashrc".lightblue
-    puts "echo 'export GDK_BACKEND=wayland' >> ~/.bashrc".lightblue
-    puts "echo 'export CLUTTER_BACKEND=wayland' >> ~/.bashrc".lightblue
-    puts "echo 'export XDG_RUNTIME_DIR=/var/run/chrome' >> ~/.bashrc".lightblue
-    puts "echo 'export WAYLAND_DISPLAY=wayland-0' >> ~/.bashrc".lightblue
-    puts "echo 'export DISPLAY=:0' >> ~/.bashrc".lightblue
-    puts "echo 'export SCALE=1' >> ~/.bashrc".lightblue
     puts "echo 'if [ ! -d /tmp/.X11-unix ]; then' >> ~/.bashrc".lightblue
     puts "echo 'mkdir /tmp/.X11-unix' >> ~/.bashrc".lightblue
     puts "echo 'fi' >> ~/.bashrc".lightblue
     puts "echo 'sudo chmod -R 1777 /tmp/.X11-unix' >> ~/.bashrc".lightblue
     puts "echo 'sudo chown root:root /tmp/.X11-unix' >> ~/.bashrc".lightblue
+    puts "echo 'alias startsommelier=\"source ~/.sommelier.env && initsommelier\"' >> ~/.bashrc".lightblue
     puts "echo 'startsommelier' >> ~/.bashrc".lightblue
     puts "source ~/.bashrc".lightblue
     puts
     puts "To start the sommelier daemon, run 'startsommelier'".lightblue
     puts "To stop the sommelier daemon, run 'stopsommelier'".lightblue
     puts
+    puts "To adjust environment variables, edit ~/.sommelier.env".lightblue
+    puts
     puts "You may need to adjust the SCALE environment variable to get the correct screen size.".lightblue
     puts
     puts "Please be aware that gui applications may not work without the sommelier daemon running.".orange
+    puts
+    puts "If you are upgrading from an earlier version of sommelier, edit ~/.bashrc".orange
+    puts "and remove the former 'Sommelier environment variables + daemon' section.".orange
     puts
   end
 end


### PR DESCRIPTION
The broadway and sommelier window managers cannot run simultaneously so this fix prevents one from running while the other is running.  It also introduces an elegant way to switch the GDK_BACKEND environment variable value as needed.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64