### PR TITLE
Fix Broadway and Sommelier packages

### DIFF
--- a/packages/broadway.rb
+++ b/packages/broadway.rb
@@ -3,7 +3,7 @@ require 'package'
 class Broadway < Package
   description 'Run GTK applications in a browser window.'
   homepage 'https://developer.gnome.org/gtk3/stable/gtk-broadway.html'
-  version 'gtk3.22-1'
+  version 'gtk3.22-2'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
@@ -15,36 +15,32 @@ class Broadway < Package
   depends_on 'gtk3'
 
   def self.build
-    system "echo 'GDK_BACKEND=broadway' > .broadway.env"
-    system "echo 'XDG_RUNTIME_DIR=/var/run/chrome' >> .broadway.env"
-    system "echo 'BROADWAY_DISPLAY=:5' >> .broadway.env"
+    system "echo 'export GDK_BACKEND=broadway' > .broadway.env"
+    system "echo 'export XDG_RUNTIME_DIR=/var/run/chrome' >> .broadway.env"
+    system "echo 'export BROADWAY_DISPLAY=:5' >> .broadway.env"
     system "echo '#!/bin/bash' > initbroadway"
+    system "echo >> initbroadway"
     system "echo 'source ~/.broadway.env' >> initbroadway"
+    system "echo >> initbroadway"
     system "echo 'BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> initbroadway"
     system "echo 'if [ -z \"\${BROADWAYD}\" ]; then' >> initbroadway"
     system "echo '  [ -f #{CREW_PREFIX}/bin/stopsommelier ] && stopsommelier' >> initbroadway"
-    system "echo '  broadwayd \${BROADWAY_DISPLAY} &' >> initbroadway"
+    system "echo '  broadwayd \${BROADWAY_DISPLAY} &>/dev/null &' >> initbroadway"
     system "echo '  sleep 3' >> initbroadway"
     system "echo 'fi' >> initbroadway"
     system "echo 'BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> initbroadway"
-    system "echo 'if [ ! -z \"\${BROADWAYD}\" ]; then' >> initbroadway"
-    system "echo '  echo \"broadwayd process \${BROADWAYD} is running\"' >> initbroadway"
-    system "echo 'else' >> initbroadway"
-    system "echo '  echo \"broadwayd failed to start\"' >> initbroadway"
+    system "echo 'if [ -z \"\${BROADWAYD}\" ]; then' >> initbroadway"
     system "echo '  exit 1' >> initbroadway"
     system "echo 'fi' >> initbroadway"
     system "echo '#!/bin/bash' > stopbroadway"
     system "echo >> stopbroadway"
     system "echo 'BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> stopbroadway"
     system "echo 'if [ ! -z \"\${BROADWAYD}\" ]; then' >> stopbroadway"
-    system "echo '  pkill broadwayd' >> stopbroadway"
+    system "echo '  pkill broadwayd &>/dev/null' >> stopbroadway"
     system "echo '  sleep 3' >> stopbroadway"
     system "echo 'fi' >> stopbroadway"
-    system "echo 'BROADWAYD=\$(pidof broadwayd 2> /dev/null)' >> stopbroadway"
-    system "echo 'if [ -z \"\${BROADWAYD}\" ]; then' >> stopbroadway"
-    system "echo '  echo \"broadwayd process stopped\"' >> stopbroadway"
-    system "echo 'else' >> stopbroadway"
-    system "echo '  echo \"broadwayd process \${BROADWAYD} is running\"' >> stopbroadway"
+    system "echo 'BROADWAYD=\$(pidof broadwayd 2>/dev/null)' >> stopbroadway"
+    system "echo 'if [ ! -z \"\${BROADWAYD}\" ]; then' >> stopbroadway"
     system "echo '  exit 1' >> stopbroadway"
     system "echo 'fi' >> stopbroadway"
   end
@@ -53,7 +49,6 @@ class Broadway < Package
     system "install -Dm755 initbroadway #{CREW_DEST_PREFIX}/bin/initbroadway"
     system "install -Dm755 stopbroadway #{CREW_DEST_PREFIX}/bin/stopbroadway"
     system "install -Dm644 .broadway.env #{CREW_DEST_HOME}/.broadway.env"
-    system "cp .broadway.env ~/"
   end
 
   def self.postinstall

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -24,39 +24,33 @@ class Sommelier < Package
       system "sed -i 's,/lib/,/#{ARCH_LIB}/,g' Makefile"
       system "sed -i 's,-I.,-I. -I#{CREW_PREFIX}/include/pixman-1,g' Makefile"
       system "make PREFIX=#{CREW_PREFIX} SYSCONFDIR=#{CREW_PREFIX}/etc"
-      system "echo 'GDK_BACKEND=wayland' > .sommelier.env"
-      system "echo 'CLUTTER_BACKEND=wayland' >> .sommelier.env"
-      system "echo 'XDG_RUNTIME_DIR=/var/run/chrome' >> .sommelier.env"
-      system "echo 'WAYLAND_DISPLAY=wayland-0' >> .sommelier.env"
-      system "echo 'DISPLAY=:0' >> .sommelier.env"
-      system "echo 'SCALE=1' >> .sommelier.env"
+      system "echo 'export GDK_BACKEND=wayland' > .sommelier.env"
+      system "echo 'export CLUTTER_BACKEND=wayland' >> .sommelier.env"
+      system "echo 'export XDG_RUNTIME_DIR=/var/run/chrome' >> .sommelier.env"
+      system "echo 'export WAYLAND_DISPLAY=wayland-0' >> .sommelier.env"
+      system "echo 'export DISPLAY=:0' >> .sommelier.env"
+      system "echo 'export SCALE=1' >> .sommelier.env"
       system "echo '#!/bin/bash' > sommelierd"
-      system "echo 'sommelier -X --x-display=\$DISPLAY --scale=\$SCALE --no-exit-with-child /bin/sh -c \"#{CREW_PREFIX}/etc/sommelierrc\"' >> sommelierd"
+      system "echo 'sommelier -X --x-display=\$DISPLAY --scale=\$SCALE --no-exit-with-child /bin/sh -c \"#{CREW_PREFIX}/etc/sommelierrc\" &>/dev/null' >> sommelierd"
       system "echo '#!/bin/bash' > initsommelier"
-      system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> initsommelier"
+      system "echo 'SOMM=\$(pidof sommelier 2>/dev/null)' >> initsommelier"
       system "echo 'if [ -z \"\$SOMM\" ]; then' >> initsommelier"
       system "echo '  [ -f #{CREW_PREFIX}/bin/stopbroadway ] && stopbroadway' >> initsommelier"
       system "echo '  #{CREW_PREFIX}/sbin/sommelierd &' >> initsommelier"
       system "echo '  sleep 3' >> initsommelier"
       system "echo 'fi' >> initsommelier"
-      system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> initsommelier"
-      system "echo 'if [ ! -z \"\$SOMM\" ]; then' >> initsommelier"
-      system "echo '  echo \"sommelier process \$SOMM is running\"' >> initsommelier"
-      system "echo 'else' >> initsommelier"
-      system "echo '  echo \"sommelier failed to start\"' >> initsommelier"
+      system "echo 'SOMM=\$(pidof sommelier 2>/dev/null)' >> initsommelier"
+      system "echo 'if [ -z \"\$SOMM\" ]; then' >> initsommelier"
       system "echo '  exit 1' >> initsommelier"
       system "echo 'fi' >> initsommelier"
       system "echo '#!/bin/bash' > stopsommelier"
-      system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> stopsommelier"
+      system "echo 'SOMM=\$(pidof sommelier 2>/dev/null)' >> stopsommelier"
       system "echo 'if [ ! -z \"\$SOMM\" ]; then' >> stopsommelier"
-      system "echo '  sudo killall sommelier' >> stopsommelier"
+      system "echo '  sudo killall sommelier &>/dev/null' >> stopsommelier"
       system "echo '  sleep 3' >> stopsommelier"
       system "echo 'fi' >> stopsommelier"
-      system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> stopsommelier"
-      system "echo 'if [ -z \"\$SOMM\" ]; then' >> stopsommelier"
-      system "echo '  echo \"sommelier process stopped\"' >> stopsommelier"
-      system "echo 'else' >> stopsommelier"
-      system "echo '  echo \"sommelier process \$SOMM is running\"' >> stopsommelier"
+      system "echo 'SOMM=\$(pidof sommelier 2>/dev/null)' >> stopsommelier"
+      system "echo 'if [ ! -z \"\$SOMM\" ]; then' >> stopsommelier"
       system "echo '  exit 1' >> stopsommelier"
       system "echo 'fi' >> stopsommelier"
     end
@@ -69,7 +63,6 @@ class Sommelier < Package
       system "install -Dm755 initsommelier #{CREW_DEST_PREFIX}/bin/initsommelier"
       system "install -Dm755 stopsommelier #{CREW_DEST_PREFIX}/bin/stopsommelier"
       system "install -Dm644 .sommelier.env #{CREW_DEST_HOME}/.sommelier.env"
-      system "cp .sommelier.env ~/"
     end
   end
 
@@ -79,10 +72,10 @@ class Sommelier < Package
     puts "echo '# Sommelier environment variables + daemon' >> ~/.bashrc".lightblue
     puts "echo '# See https://github.com/dnschneid/crouton/wiki/Sommelier-(A-more-native-alternative-to-xiwi)' >> ~/.bashrc".lightblue
     puts "echo 'if [ ! -d /tmp/.X11-unix ]; then' >> ~/.bashrc".lightblue
-    puts "echo 'mkdir /tmp/.X11-unix' >> ~/.bashrc".lightblue
+    puts "echo '  mkdir /tmp/.X11-unix' >> ~/.bashrc".lightblue
+    puts "echo '  sudo chmod -R 1777 /tmp/.X11-unix' >> ~/.bashrc".lightblue
+    puts "echo '  sudo chown root:root /tmp/.X11-unix' >> ~/.bashrc".lightblue
     puts "echo 'fi' >> ~/.bashrc".lightblue
-    puts "echo 'sudo chmod -R 1777 /tmp/.X11-unix' >> ~/.bashrc".lightblue
-    puts "echo 'sudo chown root:root /tmp/.X11-unix' >> ~/.bashrc".lightblue
     puts "echo 'alias startsommelier=\"source ~/.sommelier.env && initsommelier\"' >> ~/.bashrc".lightblue
     puts "echo 'startsommelier' >> ~/.bashrc".lightblue
     puts "source ~/.bashrc".lightblue


### PR DESCRIPTION
Silences broadway and sommelier daemons (for certain cases in which output from ~/.bashrc is undesirable) 
Exports needed environment variables
Moves `chmod` and `chown` to `if` statement in Sommelier
@uberhacker, think before closing.