### PR TITLE
Add yad package

### DIFF
--- a/packages/rgb.rb
+++ b/packages/rgb.rb
@@ -1,0 +1,34 @@
+require 'package'
+
+class Rgb < Package
+  description 'X color name database'
+  homepage 'https://gitlab.freedesktop.org/xorg/app/rgb'
+  version '1.0.6'
+  source_url 'https://gitlab.freedesktop.org/xorg/app/rgb/-/archive/rgb-1.0.6/rgb-rgb-1.0.6.tar.bz2'
+  source_sha256 'ad054b6cc040ee52610fcb7a895cf00351fda4e703f7ce7f474c1bf7577ecfca'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rgb-1.0.6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rgb-1.0.6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rgb-1.0.6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rgb-1.0.6-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '383f3eb09ad356d72aec226b445f8b69f33f64ddc51279e84e046fcec83a293a',
+     armv7l: '383f3eb09ad356d72aec226b445f8b69f33f64ddc51279e84e046fcec83a293a',
+       i686: 'f0cf3ee49517e01bd7d97bf017b48253f19bb6dd304ab4b59f6612db57756fe1',
+     x86_64: '021c3ce30ac996c8bfbcda435612a1d5d0a449f96ff1ae88f0b5c7903b7ca141',
+  })
+
+  def self.build
+    system './autogen.sh'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/yad.rb
+++ b/packages/yad.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Yad < Package
+  description 'display graphical dialogs from shell scripts or command line.'
+  homepage 'https://sourceforge.net/projects/yad-dialog/'
+  version '0.40.0'
+  source_url 'https://prdownloads.sourceforge.net/project/yad-dialog/yad-0.40.0.tar.xz'
+  source_sha256 'c2d0b7d1b6d3a0877299faa00db75d58c974f81fce72d520a3a84e67d1d60ef4'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yad-0.40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yad-0.40.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yad-0.40.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yad-0.40.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '9e95ee3627b04922ddd447649e69ea54c9dc43e7138319bd1588a4f8b58b51af',
+     armv7l: '9e95ee3627b04922ddd447649e69ea54c9dc43e7138319bd1588a4f8b58b51af',
+       i686: '6099dc7626511aa2c8e7dc55d0ed4ac516f165a5bd6c28a9b2170ca798aad445',
+     x86_64: '1fdac4030f16b26ff16102a570c6d2ec58a5228fd8f89752e4e6da58555a6604',
+  })
+
+  depends_on 'gtk3'
+  depends_on 'rgb'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode',
+           '--enable-gio',
+           '--enable-icon-browser',
+           '--with-gtk=gtk3',
+           "--with-rgb=#{CREW_PREFIX}/share/X11/rgb.txt"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
yad displays graphical dialogs from shell scripts or command line.  See https://sourceforge.net/projects/yad-dialog/.  Depends on rgb (included).

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64
