### PR TITLE
Add libcdio package and dependency

### DIFF
--- a/packages/libcddb.rb
+++ b/packages/libcddb.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Libcddb < Package
+  description 'Libcddb is a C library to access data on a CDDB server (freedb.org).'
+  homepage 'http://libcddb.sourceforge.net/'
+  version '1.3.2'
+  source_url 'https://prdownloads.sourceforge.net/project/libcddb/libcddb/1.3.2/libcddb-1.3.2.tar.bz2'
+  source_sha256 '35ce0ee1741ea38def304ddfe84a958901413aa829698357f0bee5bb8f0a223b'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcddb-1.3.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcddb-1.3.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcddb-1.3.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcddb-1.3.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '4f3c225000eeafdaa9129b944d4763c40f823eb195aeafc6996698f651db7d46',
+     armv7l: '4f3c225000eeafdaa9129b944d4763c40f823eb195aeafc6996698f651db7d46',
+       i686: 'ba523bc37fbcd2278171754f58c042bc9b7d81438857b73803c44d34288a21d8',
+     x86_64: 'e98cba9508a10e2a7388e1aea34d49b1387bd029bc35c152abeafae4b54f65f6',
+  })
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/libcdio.rb
+++ b/packages/libcdio.rb
@@ -1,0 +1,38 @@
+require 'package'
+
+class Libcdio < Package
+  description 'The GNU Compact Disc Input and Control library (libcdio) contains a library for CD-ROM and CD image access.'
+  homepage 'http://www.gnu.org/software/libcdio/'
+  version '2.0.0'
+  source_url 'https://ftp.gnu.org/gnu/libcdio/libcdio-2.0.0.tar.gz'
+  source_sha256 '1b481b5da009bea31db875805665974e2fc568e2b2afa516f4036733657cf958'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcdio-2.0.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcdio-2.0.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcdio-2.0.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcdio-2.0.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '96fe10d82e1165af8ddf59512c0f5e47adbebab38fcdb9741e687fc591075e98',
+     armv7l: '96fe10d82e1165af8ddf59512c0f5e47adbebab38fcdb9741e687fc591075e98',
+       i686: '0f4cd7753e6ba8c5304769fbebdd7c9603ed8841c1085e50d79f1ee9091f2857',
+     x86_64: 'b3e6ab517eaae30320ffbdc3f6874b250f59783dfb35708590e6fd22782e89ac',
+  })
+
+  depends_on 'libcddb'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--without-cdda-player',
+           '--disable-maintainer-mode',
+           '--disable-static'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
The GNU Compact Disc Input and Control library (libcdio) contains a library for CD-ROM and CD image access.  See http://www.gnu.org/software/libcdio/.  Depends on libcddb (included).

Libcddb is a C library to access data on a CDDB server (freedb.org).  See http://libcddb.sourceforge.net/.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64