### PR TITLE
Fix CREW_DEST_HOME constant

### DIFF
--- a/crew
+++ b/crew
@@ -584,9 +584,9 @@ def install_package (pkgdir)
     strip_find_files "find . -type f ! -iname '*\.bz2' ! -iname '*\.gz' ! -iname '*\.lha' ! -iname '*\.lz' ! -iname '*\.rar' ! -iname '*\.tar' ! -iname '*\.tgz' ! -iname '*\.xz' ! -iname '*\.zip' -perm /111 -print | sed -e '/lib.*\.a$/d' -e '/lib.*\.so/d'"
 
     if @opt_verbose then
-      system "tar cvf - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
+      system "tar cvf - ./usr ./home | (cd /; tar xp --keep-directory-symlink -f -)"
     else
-      system "tar cf - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
+      system "tar cf - ./usr ./home | (cd /; tar xp --keep-directory-symlink -f -)"
     end
   end
 end

--- a/install.sh
+++ b/install.sh
@@ -108,10 +108,10 @@ function extract_install () {
 
     #extract and install
     echo "Extracting $1 (this may take a while)..."
-    rm -rf ./usr
+    rm -rf ./usr ./home
     tar -xf $2
     echo "Installing $1 (this may take a while)..."
-    tar cf - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)
+    tar cf - ./usr ./home | (cd /; tar xp --keep-directory-symlink -f -)
     mv ./dlist $CREW_CONFIG_PATH/meta/$1.directorylist
     mv ./filelist $CREW_CONFIG_PATH/meta/$1.filelist
 }

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.0.4'
+CREW_VERSION = '1.0.5'
 
 ARCH = `uname -m`.strip
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end


### PR DESCRIPTION
Fixes CREW_DEST_HOME constant and packages files in `#{ENV['HOME']}`. Also fixes `install.sh` if any packages in the install script ever need files in `#{ENV['HOME']}`. Bumps `crew` version.