### PR TITLE
Update bison, cmake and filecmd packages

### DIFF
--- a/packages/bison.rb
+++ b/packages/bison.rb
@@ -3,21 +3,21 @@ require 'package'
 class Bison < Package
   description 'Bison is a general-purpose parser generator that converts an annotated context-free grammar into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables.'
   homepage 'http://www.gnu.org/software/bison/'
-  version '3.1'
-  source_url 'https://ftpmirror.gnu.org/bison/bison-3.1.tar.xz'
-  source_sha256 '7c2464ad6cb7b513b2c350a092d919327e1f63d12ff024836acbb504475da5c6'
+  version '3.2.3'
+  source_url 'https://ftpmirror.gnu.org/gnu/bison/bison-3.2.3.tar.xz'
+  source_sha256 '3cb07a84ff698b205ea244e36eccb4979dd4e10f2120ebbf58c5f1f700023f29'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.2.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.2.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.2.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.2.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '20ca51ab529fdddad6f00cd32e0e5b8f2824be4f150d3337403ae6050825b0d3',
-     armv7l: '20ca51ab529fdddad6f00cd32e0e5b8f2824be4f150d3337403ae6050825b0d3',
-       i686: '1c14341e113a500e651383a5197e422d09cc56714bbb00e44f2f217f3ca7c1c8',
-     x86_64: 'ce6e119ab793ec25b80af20b14243f408430a28172f4b23dbc23cca8b6811cae',
+    aarch64: '4cdc57fdbba01e5b1854c9c2ca84b616835575b5c73232528688b414162a333a',
+     armv7l: '4cdc57fdbba01e5b1854c9c2ca84b616835575b5c73232528688b414162a333a',
+       i686: '120e83f2906a36d6ce31c4b8ecb1ef7bab63d987b3392a5613b49bc655420178',
+     x86_64: '141fd756fb765dda1d110033360be9b4e582ed002d3f6bf895f8df9e5890d43b',
   })
 
   def self.build

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,29 +3,28 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  version '3.12.2'
-  source_url 'https://cmake.org/files/v3.12/cmake-3.12.2.tar.gz'
-  source_sha256 '0f97485799e51a7070cc11494f3e02349b0fc3a24cc12b082e737bf67a0581a4'
+  version '3.13.2'
+  source_url 'https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz'
+  source_sha256 'c925e7d2c5ba511a69f43543ed7b4182a7d446c274c7480d0e42cd933076ae25'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cmake-3.12.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cmake-3.12.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cmake-3.12.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cmake-3.12.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cmake-3.13.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cmake-3.13.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cmake-3.13.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cmake-3.13.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '8c69b2eb83e6591925ba720049e18418ccb58d8fa217285159fb9a0d5caf4788',
-     armv7l: '8c69b2eb83e6591925ba720049e18418ccb58d8fa217285159fb9a0d5caf4788',
-       i686: '753b5f083571e63727f4706b6bd453cf07db7dff7c4853bfcad1a03c179922c5',
-     x86_64: 'bd60b37bb2f1df504af1e73577be7980c9cbc6aa4fb15e46143e25f1ef1e8aea',
+    aarch64: 'c51a1a850e928be59e5c3ad5ab708fc1511001597f03413a3861e7bb5b42603d',
+     armv7l: 'c51a1a850e928be59e5c3ad5ab708fc1511001597f03413a3861e7bb5b42603d',
+       i686: 'b6362623145ffd0060d56db8b08f9a17b913c7e8a9012b9cd54d7924ab0fea84',
+     x86_64: '266148894803c26d92a0aef1126b3cfe8c025e4d3336a3338e81f63f41c63241',
   })
 
   def self.build
     if Dir.exist? "#{CREW_PREFIX}/include/ncursesw"
       system 'sed -i "51s,$,\n  set(CURSES_INCLUDE_PATH ' + "#{CREW_PREFIX}/include/ncursesw" + ')," Modules/FindCurses.cmake'
     end
-    system './bootstrap',
-      "--prefix=#{CREW_PREFIX}"
+    system "./bootstrap --prefix=#{CREW_PREFIX}"
     system 'make'
   end
 

--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -3,21 +3,21 @@ require 'package'
 class Filecmd < Package
   description 'file command determines the file type.'
   homepage 'ftp://ftp.astron.com/pub/file'
-  version '5.34'
-  source_url 'ftp://ftp.astron.com/pub/file/file-5.34.tar.gz'
-  source_sha256 'f15a50dbbfa83fec0bd1161e8e191b092ec832720e30cd14536e044ac623b20a'
+  version '5.35'
+  source_url 'ftp://ftp.astron.com/pub/file/file-5.35.tar.gz'
+  source_sha256 '30c45e817440779be7aac523a905b123cba2a6ed0bf4f5439e1e99ba940b5546'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filecmd-5.34-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filecmd-5.34-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/filecmd-5.34-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filecmd-5.34-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filecmd-5.35-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filecmd-5.35-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/filecmd-5.35-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filecmd-5.35-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '4468657f5add5e6f6b3d92eb48f9e3b15daa27700ba6f53465497dea1d2d6a2a',
-     armv7l: '4468657f5add5e6f6b3d92eb48f9e3b15daa27700ba6f53465497dea1d2d6a2a',
-       i686: '6422e05633b289b5e7a25f9c1d553f98a95cd71bdf809c81bbd8a2e485a11d55',
-     x86_64: '0662f414ad1da35ea0664cdf79d85f4b758c2d3a4442bd5c11620afb5647d4d1',
+    aarch64: '1b18c244b4f38a931cb3647782325e34b1345d7ecbb4aca03294cc7a9a066052',
+     armv7l: '1b18c244b4f38a931cb3647782325e34b1345d7ecbb4aca03294cc7a9a066052',
+       i686: '39efe5224d49ff887a7aac593b0532e7fb8e4618418342d438383030a69eee68',
+     x86_64: '277f3393963a2c5c897f02c46832d15bea5a3b994e422f8a8278e81d9997115c',
   })
 
   def self.build


### PR DESCRIPTION
- Update bison from 3.1 to 3.2.3
- Update cmake from 3.12.2 to 3.13.2
- Update filecmd from 5.34 to 5.35

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64