### PR TITLE
Remove unnecessary sections of all packages that operate on files in $HOME

### DIFF
--- a/packages/asciinema.rb
+++ b/packages/asciinema.rb
@@ -3,21 +3,21 @@ require 'package'
 class Asciinema < Package
   description 'Terminal session recorder'
   homepage 'https://asciinema.org/'
-  version '2.0.1-1'
+  version '2.0.1-2'
   source_url 'https://github.com/asciinema/asciinema/archive/v2.0.1.tar.gz'
   source_sha256 '7087b247dae36d04821197bc14ebd4248049592b299c9878d8953c025ac802e4'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/asciinema-2.0.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/asciinema-2.0.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/asciinema-2.0.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/asciinema-2.0.1-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/asciinema-2.0.1-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/asciinema-2.0.1-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/asciinema-2.0.1-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/asciinema-2.0.1-2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1b68a9d19e2f7f129b92f53b9c273e4a69f284539d82f216f108bbf49143d2d2',
-     armv7l: '1b68a9d19e2f7f129b92f53b9c273e4a69f284539d82f216f108bbf49143d2d2',
-       i686: 'f81954e9851f5b839cbee7f58d6b723d8028f2dcc6b2bdf0f6838521a592dc62',
-     x86_64: 'f048f3f93709373d8b21456c829eccdb8f1059136e1b0371b04bc8fa4ef42046',
+    aarch64: '6b5ea0249de2ca8b44e974316799eba90b7190c43720ba2b9625cec134085318',
+     armv7l: '6b5ea0249de2ca8b44e974316799eba90b7190c43720ba2b9625cec134085318',
+       i686: '699f103391c9d5925dcc2b85ffa4d15348249e0ca033234c904bcec2ebd3c16c',
+     x86_64: '550a06b4dbdd3662852bc78036fc632e2407f5a47d582489b3d539f11b7ac259',
   })
 
   depends_on 'xdg_base'
@@ -63,9 +63,7 @@ idle_time_limit = 1' > config"
   def self.install
     system "python3 setup.py install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"
     system "install -Dm644 config #{CREW_DEST_HOME}/.config/asciinema/config"
-    system "install -Dm644 config $HOME/.config/asciinema/config"
     system "touch #{CREW_DEST_HOME}/.config/asciinema/install-id"
-    system "touch $HOME/.config/asciinema/install-id"
   end
 
   def self.postinstall

--- a/packages/avocado.rb
+++ b/packages/avocado.rb
@@ -3,21 +3,21 @@ require 'package'
 class Avocado < Package
   description 'Avocado is a next generation testing framework inspired by Autotest and modern development tools such as git.'
   homepage 'http://avocado-framework.github.io/'
-  version '64.0'
-  source_url 'https://github.com/avocado-framework/avocado/archive/64.0.tar.gz'
-  source_sha256 'bf1434d61754f389771dc38beb66a62ee6cca95f5224b17eb2a4ca2f7abf22ab'
+  version '67.0'
+  source_url 'https://github.com/avocado-framework/avocado/archive/67.0.tar.gz'
+  source_sha256 'ae96466e2c19da3c6044ae59e05b235f6d211cfc4de8cbecfcaf0b59dc61332a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-64.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-64.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-64.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-64.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-67.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-67.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-67.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/avocado-67.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'a2659851c10f6b1d57bf55c6e15f035183a256951422004bff486eb1ec338222',
-     armv7l: 'a2659851c10f6b1d57bf55c6e15f035183a256951422004bff486eb1ec338222',
-       i686: 'd7c93778bdc3f7eeffca15e38fa2208f5dac6a2bce16aa6caee97aebf0dce375',
-     x86_64: '223c4eccb8c646453f633ebb6b6c8b23bf52535ba4895999a029db7c92329ca3',
+    aarch64: 'c97be359f822af9643b4f86d6a93a8aa265effb8c1deac27af29a744601164cf',
+     armv7l: 'c97be359f822af9643b4f86d6a93a8aa265effb8c1deac27af29a744601164cf',
+       i686: '71b3af54c49600bf58255368944300017cef12af75b2c2775515719dd5a40a7a',
+     x86_64: '4946b467cfb4366ac950edbdd57b3d45780a560659f50677e45c95095e101500',
   })
 
   depends_on 'xdg_base'
@@ -25,11 +25,34 @@ class Avocado < Package
   depends_on 'setuptools'
 
   def self.install
-    system "pip3 install -r requirements.txt --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
-    system "python3 setup.py install --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
-    system "mkdir -p $HOME/.config/avocado"
-    system "ln -sf #{CREW_PREFIX}/etc/avocado/avocado.conf $HOME/.config/avocado/avocado.conf"
-    system "mkdir -p #{CREW_DEST_HOME}/.config/avocado"
-    system "ln -sf #{CREW_PREFIX}/etc/avocado/avocado.conf #{CREW_DEST_HOME}/.config/avocado/avocado.conf"
+    system "pip install avocado-framework --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
+    system "chmod +x #{CREW_DEST_PREFIX}/bin/avocado"
+    system "chmod +x #{CREW_DEST_PREFIX}/bin/avocado-rest-client"
+    avocado_home = "#{CREW_DEST_HOME}/.config/avocado"
+    system "mkdir -p #{avocado_home}/data"
+    system "touch #{avocado_home}/data/empty"
+    system "mkdir -p #{avocado_home}/job-results"
+    system "touch #{avocado_home}/job-results/empty"
+    Dir.chdir "#{avocado_home}" do
+      avocado_lib = "#{CREW_PREFIX}/lib/python2.7/site-packages/avocado/etc/avocado"
+      system "ln -sf #{avocado_lib}/avocado.conf avocado.conf"
+      system "ln -sf #{avocado_lib}/conf.d conf.d"
+      system "ln -sf #{avocado_lib}/scripts scripts"
+      system "ln -sf #{avocado_lib}/sysinfo sysinfo"
+    end
+    Dir.chdir "#{CREW_DEST_PREFIX}/lib/python2.7/site-packages/avocado/etc/avocado" do
+      system "sed -i 's,/etc,~/.config,' avocado.conf"
+      system "sed -i 's,/var/lib,~/.config,' avocado.conf"
+      system "sed -i 's,/usr/share/doc,~/.config,' avocado.conf"
+      system "sed -i 's,~/avocado,~/.config/avocado,' avocado.conf"
+      system "sed -i 's,/usr/bin,#{CREW_PREFIX}/bin,' conf.d/gdb.conf"
+      system "sed -i 's,/etc,~/.config,' conf.d/jobscripts.conf"
+    end
+  end
+
+  def self.postinstall
+    puts
+    puts "To configure avocado, edit ~/.config/avocado/avocado.conf".lightblue
+    puts
   end
 end

--- a/packages/broadway.rb
+++ b/packages/broadway.rb
@@ -3,7 +3,7 @@ require 'package'
 class Broadway < Package
   description 'Run GTK applications in a browser window.'
   homepage 'https://developer.gnome.org/gtk3/stable/gtk-broadway.html'
-  version 'gtk3.22-2'
+  version 'gtk3.22-3'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
@@ -52,7 +52,6 @@ class Broadway < Package
     system "install -Dm755 initbroadway #{CREW_DEST_PREFIX}/bin/initbroadway"
     system "install -Dm755 stopbroadway #{CREW_DEST_PREFIX}/bin/stopbroadway"
     system "install -Dm644 .broadway.env #{CREW_DEST_HOME}/.broadway.env"
-    system "cp .broadway.env ~/"
   end
 
   def self.postinstall

--- a/packages/dia.rb
+++ b/packages/dia.rb
@@ -3,21 +3,19 @@ require 'package'
 class Dia < Package
   description 'Dia Diagram Editor is free Open Source drawing software for Windows, Mac OS X and Linux.'
   homepage 'http://dia-installer.de/'
-  version '0.97.2'
+  version '0.97.2-1'
   source_url 'https://github.com/GNOME/dia/archive/DIA_0_97_2.tar.gz'
   source_sha256 '13437d52f2c5cfdae7ecde8bd5ed0a53a388b0331698236d0ec63453b8a13016'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-1-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dia-0.97.2-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f351da33d3d4196bd3748f4315df3f3bcfdf648de47c90dfd941a15876707fba',
-     armv7l: 'f351da33d3d4196bd3748f4315df3f3bcfdf648de47c90dfd941a15876707fba',
-       i686: 'ce3cc2776d9d45f976d1076ef38f9fcf58010fae70d3ab961b8aa25b380cb4ff',
-     x86_64: '95d55abe7ebceaae87a0474bd453a923be63cc6b64ed2df3e7fea779e0365789',
+    aarch64: '55db6bb7d6703818578e1a8977b5020d3e83cb5fb3ac568f8d797deaf200c3b6',
+     armv7l: '55db6bb7d6703818578e1a8977b5020d3e83cb5fb3ac568f8d797deaf200c3b6',
+     x86_64: '6c8f42b5f5da58ebfca61c328ef621e7462b1f624c5a0d7001de7eac325ba2bc',
   })
 
   depends_on 'optipng' => :build
@@ -50,15 +48,10 @@ class Dia < Package
   end
 
   def self.install
-    FileUtils.mkdir_p "#CREW_DEST_HOME}/.dia"
-    system "touch #CREW_DEST_HOME}/.dia/persistence"
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-  end
-
-  def self.postinstall
     # Fix dia_renderer_set_size: assertion 'irenderer != NULL' failed.  See https://bugs.launchpad.net/ubuntu/+source/dia/+bug/1102960/comments/11.
     system 'wget https://bugs.launchpad.net/ubuntu/+source/dia/+bug/1102960/+attachment/3552916/+files/persistence'
     abort 'Checksum mismatch :/ try again' unless Digest::SHA256.hexdigest( File.read('persistence') ) == '53cb6e49892bd60870fb31780052e46d9e47c5b19f87db1651760d10d3fe66e7'
-    system "install -Dm644 persistence #{ENV['HOME']}/.dia/persistence"
+    system "install -Dm644 persistence #{CREW_DEST_HOME}/.dia/persistence"
   end
 end

--- a/packages/google_cloud_sdk.rb
+++ b/packages/google_cloud_sdk.rb
@@ -3,15 +3,15 @@ require 'package'
 class Google_cloud_sdk < Package
   description 'Command-line interface for Google Cloud Platform products and services'
   homepage 'https://cloud.google.com/sdk/'
-  version '220.0.0'
+  version '228.0.0'
 
   case ARCH
   when 'i686'
-    source_url 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-220.0.0-linux-x86.tar.gz'
-    source_sha256 'd347562e5a076330f96506285c01e9c9f6e594524c54e02842da7e63bdfe264d'
+    source_url 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-228.0.0-linux-x86.tar.gz'
+    source_sha256 '24f5909f3928384150883a8e33447f3a6881a846fedacdd2dbe5af308e915f76'
   when 'x86_64'
-    source_url 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-220.0.0-linux-x86_64.tar.gz'
-    source_sha256 'a2205e35b11136004d52d47774762fbec9145bf0bda74ca506f52b71452c570e'
+    source_url 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-228.0.0-linux-x86_64.tar.gz'
+    source_sha256 'e4876cedf2af338a0c853f4cf97aa88e18173117ed4f59c93c9d25239ac3ade3'
   end
 
   binary_url ({
@@ -23,14 +23,13 @@ class Google_cloud_sdk < Package
   depends_on 'xdg_base'
 
   def self.install
-    FileUtils.mkdir_p "#{ENV['HOME']}/.config/gcloud"
     FileUtils.mkdir_p "#{CREW_DEST_HOME}/.config/gcloud"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/google_cloud_sdk"
-    system "cp -r . #{CREW_DEST_PREFIX}/share/google_cloud_sdk"
+    system "cp -a . #{CREW_DEST_PREFIX}/share/google_cloud_sdk"
     FileUtils.cd("#{CREW_DEST_PREFIX}/share/google_cloud_sdk") do
       system "./install.sh \
               --usage-reporting false \
-              --rc-path $HOME/.bashrc \
+              --rc-path #{ENV['HOME']}/.bashrc \
               --quiet"
     end
     system "mkdir -p #{CREW_DEST_PREFIX}/bin"

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -3,21 +3,21 @@ require 'package'
 class Gvim < Package
   description 'gVim is a highly configurable text editor built to make creating and changing any kind of text very efficient.'
   homepage 'http://www.vim.org/'
-  version '8.1'
+  version '8.1-1'
   source_url 'ftp://ftp.vim.org/pub/vim/unix/vim-8.1.tar.bz2'
   source_sha256 '8b69fbd01c877dd8ecbbeca1dc66e5e927228d631ac4c2174b9307eb5c827c86'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '38214e7c175c449f2f0918436de73442972b7e7207fa81a9baf98050393dccd1',
-     armv7l: '38214e7c175c449f2f0918436de73442972b7e7207fa81a9baf98050393dccd1',
-       i686: '898790d171557a46128eae1df18e8121c22c78a3a114f7b651c19883cd4852e5',
-     x86_64: '366e9f29c198cfe34737ff6f644c928e124880455178e52b0d2c1c45c8121c8a',
+    aarch64: 'fdda85b0be941d9043acf35f166b7c95457ab96d04c8a3c82b96c7bc6314f99e',
+     armv7l: 'fdda85b0be941d9043acf35f166b7c95457ab96d04c8a3c82b96c7bc6314f99e',
+       i686: 'dcf0668bbabdd5623ed6481c3e1503a52df398771fe3c9fa64a1f58d1cb0ed95',
+     x86_64: 'd8fb8c1ee73295d0e7646235c012f1785c38a67c46db18846faf33b89384cdfc',
   })
 
   depends_on 'vim'
@@ -67,7 +67,6 @@ class Gvim < Package
     FileUtils.mkdir_p "#{CREW_DEST_HOME}"
     system "touch #{configdir}/gvimrc #{configdestdir}/gvimrc"
     system "ln -s #{configdir}/gvimrc #{CREW_DEST_HOME}/.gvimrc"
-    system "ln -sf #{configdir}/gvimrc $HOME/.gvimrc"
   end
 
   def self.postinstall

--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -3,16 +3,24 @@ require 'package'
 class Nano < Package
   description 'Nano\'s ANOther editor, an enhanced free Pico clone.'
   homepage 'https://www.nano-editor.org/'
-  version '3.2'
+  version '3.2-1'
   source_url 'https://www.nano-editor.org/dist/v3/nano-3.2.tar.xz'
   source_sha256 'd12773af3589994b2e4982c5792b07c6240da5b86c5aef2103ab13b401fe6349'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.2-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.2-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.2-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-3.2-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'db96c75313fda53faea0e9a0ee4690f9f24079fc457c48e09626ac1651ee18ca',
+     armv7l: 'db96c75313fda53faea0e9a0ee4690f9f24079fc457c48e09626ac1651ee18ca',
+       i686: '0715e4858cd3eecfaaee253d7a720f35b57bfb25f9cb0c1f845f65f69fbfe4be',
+     x86_64: '1c7fef9ce6e3d4a3a1e77824dba8f8ac3f96bcb6c581faf8ae5092186923e091',
   })
 
-  depends_on 'filecmd'
+  depends_on 'xdg_base'
 
   def self.patch
     system "sed -i '/SIGWINCH/d' src/nano.c"
@@ -23,24 +31,7 @@ class Nano < Package
            "--prefix=#{CREW_PREFIX}",
            "--enable-utf8"
     system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-strip'
-    system "mkdir -pv #{CREW_DEST_HOME}"
-    system "touch #{CREW_DEST_HOME}/.nanorc"
-  end
-
-  def self.postinstall
-    puts
-    puts "Personal configuration file is located in $HOME/.nanorc".lightblue
-    puts
-    puts "To make nano your default editor, execute this:".lightblue
-    puts
-    puts "echo 'EDITOR=nano' >> ~/.bashrc".lightblue
-    puts "source ~/.bashrc".lightblue
-    puts
-    open("#{ENV['HOME']}/.nanorc", 'w') { |f|
+    open('nanorc', 'w') { |f|
       f << "set constantshow\n"
       f << "set fill 72\n"
       f << "set historylog\n"
@@ -53,5 +44,23 @@ class Nano < Package
       f << "set smooth\n"
       f << "set suspend\n"
     }
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-strip'
+    system "install -Dm644 nanorc #{CREW_DEST_HOME}/.nanorc"
+    # Fix Unable to create directory /home/chronos/user/.local/share/nano/: No such file or directory
+    FileUtils.mkdir_p "#{CREW_DEST_HOME}/.local/share"
+    system "ln -sf #{CREW_PREFIX}/share/nano #{CREW_DEST_HOME}/.local/share/nano"
+  end
+
+  def self.postinstall
+    puts
+    puts "Personal configuration file is located in $HOME/.nanorc".lightblue
+    puts
+    puts "To make nano your default editor, execute the following:".lightblue
+    puts
+    puts "echo 'EDITOR=#{CREW_PREFIX}/bin/nano' >> ~/.bashrc && source ~/.bashrc".lightblue
+    puts
   end
 end

--- a/packages/powerline_fonts.rb
+++ b/packages/powerline_fonts.rb
@@ -3,21 +3,21 @@ require 'package'
 class Powerline_fonts < Package
   description 'Patched fonts for Powerline users.'
   homepage 'https://github.com/powerline/fonts'
-  version '1.1'
-  source_url 'https://codeload.github.com/powerline/fonts/tar.gz/2015-12-04?dummy=/'
+  version '2015-12-04'
+  source_url 'https://github.com/powerline/fonts/archive/2015-12-04.tar.gz'
   source_sha256 '3a0b73abca6334b5e6bddefab67f6eb1b2fac1231817d95fc79126c8998c4844'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/powerline_fonts-1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/powerline_fonts-1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/powerline_fonts-1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/powerline_fonts-1.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/powerline_fonts-2015-12-04-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/powerline_fonts-2015-12-04-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/powerline_fonts-2015-12-04-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/powerline_fonts-2015-12-04-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '12dbb3c203ce8605b729a2782268ee564ac44dc0855820a57388e9cf7878b0b3',
-     armv7l: '12dbb3c203ce8605b729a2782268ee564ac44dc0855820a57388e9cf7878b0b3',
-       i686: '71722a9389f4e0cfa0efebdd588fc5497108d52fe887958a24a710c9f450bdee',
-     x86_64: 'd393b1c392bd70949bbc77aff791a52781aa044d9c8951eca442fc3b66d90246',
+    aarch64: 'f8a9f001b5e1fb43795a6f3c1ac430ae1a1cae8f192f43b416d694518fea8050',
+     armv7l: 'f8a9f001b5e1fb43795a6f3c1ac430ae1a1cae8f192f43b416d694518fea8050',
+       i686: '3c0ef20d744105d0e5c7a43f644c83986bfb1f5a90342115afe7730328482b68',
+     x86_64: 'ef0fbbbbafa3c82924d3547654d7456e64787b2847f996f6d946e0f05b3943b5',
   })
 
   def self.install

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,13 +3,21 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 and Wayland programs to the built-in ChromeOS wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/containers/sommelier'
-  version '1382ce084cc'
+  version '1382ce084cc4'
   source_url 'https://chromium.googlesource.com/chromiumos/containers/sommelier/+/0.20/README?format=TEXT'
   source_sha256 'b58d799b16d20abf92369fe0749c73f7398996f0afa9933517051778a8bb16c3'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce084cc4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce084cc4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce084cc4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sommelier-1382ce084cc4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '4d0c30b98a82340e43e3e8f32d9914e1726465b3c8ca961c0f764aaa967f8cd7',
+     armv7l: '4d0c30b98a82340e43e3e8f32d9914e1726465b3c8ca961c0f764aaa967f8cd7',
+       i686: '20fb398592c4a8368fd2292faaa599632f5df717d30a8c27cd2a67631563e0dd',
+     x86_64: '29813316bbb6421f5a54ca45ccb52d0ab88f2a4c84bb84b823bb08fc50dd8216',
   })
 
   depends_on 'mesa'
@@ -69,7 +77,6 @@ class Sommelier < Package
       system "install -Dm755 initsommelier #{CREW_DEST_PREFIX}/bin/initsommelier"
       system "install -Dm755 stopsommelier #{CREW_DEST_PREFIX}/bin/stopsommelier"
       system "install -Dm644 .sommelier.env #{CREW_DEST_HOME}/.sommelier.env"
-      system "cp .sommelier.env ~/"
     end
   end
 

--- a/packages/stack.rb
+++ b/packages/stack.rb
@@ -3,18 +3,18 @@ require 'package'
 class Stack < Package
   description 'The Haskell Tool Stack - Stack is a cross-platform program for developing Haskell projects. It is aimed at Haskellers both new and experienced.'
   homepage 'https://docs.haskellstack.org/en/stable/README/'
-  version '1.9.0.1'
+  version '1.9.3'
 
   case ARCH
   when 'aarch64', 'armv7l'
-    source_url 'https://github.com/commercialhaskell/stack/releases/download/v1.9.0.1/stack-1.9.0.1-linux-arm.tar.gz'
-    source_sha256 'd5401e11e5419ff8f30a88dcec8864c66067b01f36b3e32e279b48335b0ffd70'
+    source_url 'https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-arm.tar.gz'
+    source_sha256 '96394b616e29b3bd2479a3712e2c0c375a7cfd748b613f7c6c3186d7ae92977b'
   when 'i686'
-    source_url 'https://github.com/commercialhaskell/stack/releases/download/v1.9.0.1/stack-1.9.0.1-linux-i386.tar.gz'
-    source_sha256 '8e7802340d8c820a89bb0c670b635e2286f48fb8175f89e7205fee92408715bb'
+    source_url 'https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-i386.tar.gz'
+    source_sha256 'c7a45fcf782fcc9b2bbac38f9e1b41afec5e940c6e26936a51652f246e226505'
   when 'x86_64'
-    source_url 'https://github.com/commercialhaskell/stack/releases/download/v1.9.0.1/stack-1.9.0.1-linux-x86_64.tar.gz'
-    source_sha256 '92e7b2c8cf607c8554cefb168fbb31f45eb8b08f8021d33af9bc11971abed0d3'
+    source_url 'https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz'
+    source_sha256 'e2363728e5818ccc68db9371c15af892a9a1fc86d808d0a9a77257f13696e946'
   end
 
   binary_url ({
@@ -23,13 +23,10 @@ class Stack < Package
   })
 
   def self.install
-    FileUtils.mkdir "#{ENV['HOME']}/.stack"
     FileUtils.mkdir_p "#{CREW_DEST_HOME}/.stack"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/stack"
     system "install -Dm755 stack #{CREW_DEST_PREFIX}/bin/stack"
-    system "echo 'local-bin-path: #{CREW_PREFIX}/bin' > #{ENV['HOME']}/.stack/config.yaml"
-    system "echo 'local-programs-path: #{CREW_PREFIX}/share/stack' >> #{ENV['HOME']}/.stack/config.yaml"
-    system "cp #{ENV['HOME']}/.stack/config.yaml #{CREW_DEST_HOME}/.stack"
+    system "echo 'local-bin-path: #{CREW_PREFIX}/bin' > #{CREW_DEST_HOME}/.stack/config.yaml"
+    system "echo 'local-programs-path: #{CREW_PREFIX}/share/stack' >> #{CREW_DEST_HOME}/.stack/config.yaml"
   end
 
   def self.postinstall

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -3,21 +3,21 @@ require 'package'
 class Vim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.'
   homepage 'http://www.vim.org/'
-  version '8.1'
+  version '8.1-1'
   source_url 'ftp://ftp.vim.org/pub/vim/unix/vim-8.1.tar.bz2'
   source_sha256 '8b69fbd01c877dd8ecbbeca1dc66e5e927228d631ac4c2174b9307eb5c827c86'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b8a982519a4f0b01410e42a5bb5ed915fca1847d10aca1d17cd7c85c9ef1f8d8',
-     armv7l: 'b8a982519a4f0b01410e42a5bb5ed915fca1847d10aca1d17cd7c85c9ef1f8d8',
-       i686: '18fa5898517801da4307f60e4e8ed1e74cd6ee46820f49a8c2cac0ee0458e1c9',
-     x86_64: '89c090299914ffe373e3d25f42be5e85b888696da4bdb0d21256157cc00cf9ee',
+    aarch64: '7dea736a534604b7356a2056097b13bb67804a9b7281ffae6d8462daa4596096',
+     armv7l: '7dea736a534604b7356a2056097b13bb67804a9b7281ffae6d8462daa4596096',
+       i686: '67422ff9eed379c72a8ce63ee214a5141aee420f187752838efc9c4ade8ffce9',
+     x86_64: '6ebd581a5d978985b1eb8c5fe12fafb8e659e94a311a46a047f0eab2d6e4251b',
   })
 
   depends_on 'python3'
@@ -65,9 +65,7 @@ class Vim < Package
     FileUtils.mkdir_p "#{configdir}" unless Dir.exists? "#{configdir}"
     system "ln -s #{configdir} #{CREW_DEST_HOME}/.vim"
     system "ln -s #{configdir}/vimrc #{CREW_DEST_HOME}/.vimrc"
-    system "ln -sf #{configdir} $HOME/.vim"
     system "touch #{configdir}/vimrc #{configdestdir}/vimrc"
-    system "ln -sf #{configdir}/vimrc $HOME/.vimrc"
   end
 
   def self.postinstall

--- a/packages/xdg_base.rb
+++ b/packages/xdg_base.rb
@@ -3,18 +3,18 @@ require 'package'
 class Xdg_base < Package
   description 'XDG Base Directory Specification Configuration'
   homepage 'https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html'
-  version '0.7-1'
+  version '0.7-2'
   source_url 'https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html'
   source_sha256 '342289ad33b48b8f643278f74cafa182f4471d490b82dc5e442e2e720fa4080f'
 
   def self.preinstall
     # Save any previous configuration, if it exists.
     if Dir.exists? "$HOME/.config"
-      system "cp -r $HOME/.config #{CREW_PREFIX} && rm -rf $HOME/.config"
+      system "cp -a $HOME/.config #{CREW_PREFIX} && rm -rf $HOME/.config"
     end
     if Dir.exists? "$HOME/.local"
       system "mkdir -p #{CREW_PREFIX}/.config" unless Dir.exists? "#{CREW_PREFIX}/.config"
-      system "cp -r $HOME/.local/* #{CREW_PREFIX}/.config && rm -rf $HOME/.local"
+      system "cp -a $HOME/.local/. #{CREW_PREFIX}/.config && rm -rf $HOME/.local"
     end
   end
 
@@ -25,8 +25,6 @@ class Xdg_base < Package
     system "mkdir -p #{CREW_DEST_PREFIX}/.config"
     system "ln -s #{CREW_PREFIX}/.config #{CREW_DEST_HOME}/.config"
     system "ln -s #{CREW_PREFIX}/.config #{CREW_DEST_HOME}/.local"
-    system "ln -sf #{CREW_PREFIX}/.config $HOME/.config"
-    system "ln -sf #{CREW_PREFIX}/.config $HOME/.local"
   end
 
   def self.postinstall


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64

Unable to build dia on i686 so rather than mess with it, I decided since we're dropping support for gui apps, it was OK to exclude the pre-built binaries.  FWIW, gvim did not behave either even though the pre-built binaries generated fine.  We'll likely see fewer and fewer pre-built binaries for i686 gui apps in the future.