### PR TITLE
Update Readline package

### DIFF
--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -1,44 +1,43 @@
 require 'package'
 
 class Readline < Package
+
+  @patchlevel = 8
+
   description 'The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in.'
   homepage 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
-  version '6.3p8-1'
+  version '6.3p8-2'
   source_url 'https://ftpmirror.gnu.org/gnu/readline/readline-6.3.tar.gz'
   source_sha256 '56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/readline-6.3p8-2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bb0ad30615c12e9559fcc7158a87d76cda4f216b4ccd79e0434064cd071e197c',
-     armv7l: 'bb0ad30615c12e9559fcc7158a87d76cda4f216b4ccd79e0434064cd071e197c',
-       i686: 'a3015ee22758606e1bb85e4add62335bb6ce36da2cb99805da051609b04843c6',
-     x86_64: '77227d45ffa89f861ddbc7dba8433c0a8401333ab527d11c0c809f81de53d567',
+    aarch64: '83218261c09120972d87c9710a251e22e1456fc19bd6bf4d0d111e445f9496a7',
+     armv7l: '83218261c09120972d87c9710a251e22e1456fc19bd6bf4d0d111e445f9496a7',
+       i686: 'cae31632449c2e5530f02d74377d2d61772bf4793fb8aea14e00550f7c9f18da',
+     x86_64: '0b6095eabde0211a03f4af71e1497ba06cad8c20a075425d1fae69f0948ce27a',
   })
 
   def self.build
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-001 -P readline-6.3-patches"
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-002 -P readline-6.3-patches"
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-003 -P readline-6.3-patches"
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-004 -P readline-6.3-patches"
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-005 -P readline-6.3-patches"
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-006 -P readline-6.3-patches"
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-007 -P readline-6.3-patches"
-    system "wget -r -N -nd --no-parent ftp://ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-008 -P readline-6.3-patches"
-    # system "for i in readline-6.3-patches/*.sig; do gpg $i; done"
-    system "for i in readline-6.3-patches/readline63-???; do patch < $i; done"
-
-    system "CC='gcc' ./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --disable-static --with-curses"
+    system "wget --recursive --no-parent https://ftp.gnu.org/gnu/readline/readline-6.3-patches/"
+    system "bash -c \"for (( N = 1; N <= #{@patchlevel}; N++ )); do \
+              patch -Np0 -i ftp.gnu.org/gnu/readline/readline-6.3-patches/readline63-00\\\${N}; \
+            done\""
+    system "./configure",
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           "--disable-static",
+           "--with-curses"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}"
     system "ln", "-sf", "/#{ARCH_LIB}/libreadline.so.6.3", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6"
     system "ln", "-sf", "/#{ARCH_LIB}/libreadline.so.6.3", "#{CREW_DEST_LIB_PREFIX}/libreadline.so.6.3"
     system "ln", "-sf", "/#{ARCH_LIB}/libreadline.so.6.3", "#{CREW_DEST_LIB_PREFIX}/libreadline.so"


### PR DESCRIPTION
Updates readline package to 6.3p8-2 and uses new versioning scheme seen in readline 7.0p5.