### PR TITLE
Add progress bar to crew

### DIFF
--- a/crew
+++ b/crew
@@ -422,9 +422,9 @@ def download
   end
   Dir.chdir CREW_BREW_DIR do
     if @opt_verbose then
-      system('curl', '-v', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
+      system('curl', '-v', '--progress-bar', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
     else
-      system('curl', '-s', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
+      system('curl', '--progress-bar', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
     end
     abort 'Checksum mismatch. :/ Try again.'.lightred unless
       Digest::SHA256.hexdigest( File.read("./#{filename}") ) == sha256sum


### PR DESCRIPTION
Fixes #2981 

Uses `--progress-bar` option in CUrl to display progress bar when downloading files.