### PR TITLE
Add kbd package and dependency

### DIFF
--- a/packages/kbd.rb
+++ b/packages/kbd.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Kbd < Package
+  description 'The kbd project contains tools for managing Linux console'
+  homepage 'http://kbd-project.org/'
+  version '2.0.4'
+  source_url 'https://github.com/legionus/kbd/archive/2.0.4.tar.gz'
+  source_sha256 '18f45ee8790ddb18363fcb98d60e715528b1c04aa4501bd69111609d43240d3e'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/kbd-2.0.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/kbd-2.0.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/kbd-2.0.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/kbd-2.0.4-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '0c53c9ac9dfae25f7ddbc308db92cff85b5343e594cfb5e9f73058340eda1401',
+     armv7l: '0c53c9ac9dfae25f7ddbc308db92cff85b5343e594cfb5e9f73058340eda1401',
+       i686: '448eb6055759318a5e87bbcf37e57bf636aaaa941b69c245f7db09d5b20c5720',
+     x86_64: '7e16b148b66c8466ec6dc2685da62c83feb09a915e21ed0b5b7fb5d9be0e14a1',
+  })
+
+  depends_on 'linux_pam'
+
+  def self.build
+    system './autogen.sh'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           '--disable-static'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/linux_pam.rb
+++ b/packages/linux_pam.rb
@@ -1,0 +1,38 @@
+require 'package'
+
+class Linux_pam < Package
+  description 'Linux PAM (Pluggable Authentication Modules for Linux) project'
+  homepage 'https://github.com/linux-pam/linux-pam'
+  version '1.3.1'
+  source_url 'https://github.com/linux-pam/linux-pam/releases/download/v1.3.1/Linux-PAM-1.3.1.tar.xz'
+  source_sha256 'eff47a4ecd833fbf18de9686632a70ee8d0794b79aecb217ebd0ce11db4cd0db'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/linux_pam-1.3.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/linux_pam-1.3.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/linux_pam-1.3.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/linux_pam-1.3.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fa843f1976fe0305311b857ff803945c40d1953edb191333f7f258924585aff7',
+     armv7l: 'fa843f1976fe0305311b857ff803945c40d1953edb191333f7f258924585aff7',
+       i686: '166142b8ccd0b24b39d7c6e0105d94b3a9eb7cb66af2a5b702024c5c0fcb9a5a',
+     x86_64: 'f2536e7e91c5154744e78630dc53d3ce767c00baf05d0fa998f15f848b6dc561',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--enable-static'
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include/security"
+    Dir.chdir "#{CREW_DEST_PREFIX}/include" do
+      system "find . -type f -exec ln -s #{CREW_PREFIX}/include/{} #{CREW_DEST_PREFIX}/include/security/{} \\;"
+    end
+  end
+end


### PR DESCRIPTION
The kbd project contains tools for managing Linux console (Linux console, virtual terminals, keyboard, etc.) – mainly, what they do is loading console fonts and keyboard maps.  See http://kbd-project.org/.  Depends on linux_pam (included).

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64