### PR TITLE
Add pre-built binaries for eudev, libsdl, libsdl2 and xterm

### DIFF
--- a/packages/eudev.rb
+++ b/packages/eudev.rb
@@ -8,8 +8,16 @@ class Eudev < Package
   source_sha256 'ce2fda4dea129bbcf824c947aab23504bcd26911481b47dbaf10646f723083a4'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/eudev-3.2.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/eudev-3.2.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/eudev-3.2.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/eudev-3.2.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '27be58c328302b73da3627c3415515be0cc592fbabce38bcff5f5da6ccdf1837',
+     armv7l: '27be58c328302b73da3627c3415515be0cc592fbabce38bcff5f5da6ccdf1837',
+       i686: '20a8f053b84bce5fa389a0a1cca5648fd34ab92f06cbe440aecdea2ef4dbc0ab',
+     x86_64: 'ad95ed97aedd8939ed8c06c5773d923de025544d10e41627758a82cd5ee0d1cc',
   })
 
   depends_on 'libxslt'

--- a/packages/libsdl.rb
+++ b/packages/libsdl.rb
@@ -8,8 +8,16 @@ class Libsdl < Package
   source_sha256 'd6d316a793e5e348155f0dd93b979798933fb98aa1edebcc108829d6474aad00'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl-1.2.15-3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl-1.2.15-3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl-1.2.15-3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl-1.2.15-3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd3c4bf0e39075db7dc30b794733682209dec0a0a23df611b73e7f3fffb69f85c',
+     armv7l: 'd3c4bf0e39075db7dc30b794733682209dec0a0a23df611b73e7f3fffb69f85c',
+       i686: '913282020e94cf12b60f03e67786dacf34378daf848cdc0f52693efa418e154b',
+     x86_64: '528be8eff53afff1c1cd7973ecda09fc68adbcbea0c22453764ebf0cb7ce0a59',
   })
 
   depends_on 'xwayland'

--- a/packages/libsdl2.rb
+++ b/packages/libsdl2.rb
@@ -8,8 +8,16 @@ class Libsdl2 < Package
   source_sha256 '255186dc676ecd0c1dbf10ec8a2cc5d6869b5079d8a38194c2aecdff54b324b1'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl2-2.0.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl2-2.0.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl2-2.0.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsdl2-2.0.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '8d317956cc1a196d8f5d1a84993abda2c04091afabf71ade3229f9077082b99f',
+     armv7l: '8d317956cc1a196d8f5d1a84993abda2c04091afabf71ade3229f9077082b99f',
+       i686: 'd1a410a9aa771feb91da30f7cab69a38aa88b8cb3a18a16653c30f4b4f9ae6da',
+     x86_64: '4a7cf8e0c57bb8485eb1cade392ca919aff3e71b811464adf6a51e1f98488a00',
   })
 
   depends_on 'xwayland'

--- a/packages/xterm.rb
+++ b/packages/xterm.rb
@@ -8,8 +8,16 @@ class Xterm < Package
   source_sha256 '63a07dfa2b5d501a9e1da0e05772bff7ad431ac2065127c77eebe392ef33cb44'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xterm-341-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xterm-341-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xterm-341-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xterm-341-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'b0c2289b1f2a2927d3bd133059705407e6418bc595a59aca522eaf9bd92e9e00',
+     armv7l: 'b0c2289b1f2a2927d3bd133059705407e6418bc595a59aca522eaf9bd92e9e00',
+       i686: '0803e8b84a900c5344bc2aa4f2586e8795bf6feb517bc7b75dae69c9438d5eef',
+     x86_64: 'c93930b998ed21cccde94dc81c2aa5e0f91d986d9f193c4c61ca2714d10a8956',
   })
 
   depends_on 'pcre'


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64