### PR TITLE
Change clang to clc in TiLP packages

### DIFF
--- a/packages/libticables2.rb
+++ b/packages/libticables2.rb
@@ -18,8 +18,8 @@ class Libticables2 < Package
   def self.build
     system 'autoreconf -i'
     system "/usr/bin/env",
-      "CC=clang -fuse-ld=lld",
-      "CXX=clang++ -fuse-ld=lld",
+      "CC=clc -fuse-ld=lld",
+      "CXX=clc++ -fuse-ld=lld",
       "./configure",
       "--prefix=#{CREW_PREFIX}",
       "--enable-libusb10",

--- a/packages/libticalcs2.rb
+++ b/packages/libticalcs2.rb
@@ -17,8 +17,8 @@ class Libticalcs2 < Package
   def self.build
     system 'autoreconf -i'
     system "/usr/bin/env",
-      "CC=clang -fuse-ld=lld",
-      "CXX=clang++ -fuse-ld=lld",
+      "CC=clc -fuse-ld=lld",
+      "CXX=clc++ -fuse-ld=lld",
       "./configure",
       "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libticonv.rb
+++ b/packages/libticonv.rb
@@ -17,8 +17,8 @@ class Libticonv < Package
   def self.build
     system 'autoreconf -i'
     system "/usr/bin/env",
-      "CC=clang -fuse-ld=lld",
-      "CXX=clang++ -fuse-ld=lld",
+      "CC=clc -fuse-ld=lld",
+      "CXX=clc++ -fuse-ld=lld",
       "./configure",
       "--enable-iconv",
       "--prefix=#{CREW_PREFIX}",

--- a/packages/libtifiles2.rb
+++ b/packages/libtifiles2.rb
@@ -18,8 +18,8 @@ class Libtifiles2 < Package
   def self.build
     system 'autoreconf -i'
     system "/usr/bin/env",
-      "CC=clang -fuse-ld=lld",
-      "CXX=clang++ -fuse-ld=lld",
+      "CC=clc -fuse-ld=lld",
+      "CXX=clc++ -fuse-ld=lld",
       "./configure",
       "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}"

--- a/packages/tilp2.rb
+++ b/packages/tilp2.rb
@@ -25,8 +25,8 @@ class Tilp2 < Package
   def self.build
     system 'autoreconf -i'
     system "/usr/bin/env",
-           "CC=clang -fuse-ld=lld",
-           "CXX=clang++ -fuse-ld=lld",
+           "CC=clc -fuse-ld=lld",
+           "CXX=clc++ -fuse-ld=lld",
            "./configure",
            "--prefix=#{CREW_PREFIX}",
            "--without-kde",


### PR DESCRIPTION
Fixes #3022 
Version bump not required as same compiler is used.