### PR TITLE
Add pre-built binaries for packages g-x

### DIFF
--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -8,8 +8,16 @@ class Gvim < Package
   source_sha256 '7e6ad44dbb8fda0aca91c22fa0dcaed2d845cf00c26d6d3df3bfaa38c9da222a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1.0648-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1.0648-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1.0648-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1.0648-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'c45090038eea4923238023236849b34366da1e6b9a50db3dc6ef8b409c4c075d',
+     armv7l: 'c45090038eea4923238023236849b34366da1e6b9a50db3dc6ef8b409c4c075d',
+       i686: 'a7e9a2c05d77784b6da46ee40b7bbc8365a0ea4840b1979e05abe4cbc69aa1c6',
+     x86_64: '7e6c36e7602a62d615899cdc3230aacea3a08c908f1927ba2f44ff31bd09fe4f',
   })
 
   depends_on 'python27' => :build

--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -8,8 +8,16 @@ class Libdrm < Package
   source_sha256 '0d561acf7bb4cc59dc82415100e6c1a44860e8c380e00f9592923e3cd08db393'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.96-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.96-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.96-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.96-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '80eb0b1bdf0217ed2f7af5d023c4bfe45619a8d52aceab7aa7dde65d0362b736',
+     armv7l: '80eb0b1bdf0217ed2f7af5d023c4bfe45619a8d52aceab7aa7dde65d0362b736',
+       i686: '4d8ad13d4ff5b4cc8037be4835de73dffb0be56be0e93a3431d886701ef43d77',
+     x86_64: 'ecdc554b5bb6dd8fbf16862803e6b4ce78cec9f4a71fe6809e731363abd5fb12',
   })
 
   depends_on 'libpciaccess'

--- a/packages/libva.rb
+++ b/packages/libva.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Libva < Package
+  description 'Libva is an implementation for VA-API (VIdeo Acceleration API)'
+  homepage 'https://01.org/linuxmedia'
+  version '2.3.0'
+  source_url 'https://github.com/intel/libva/releases/download/2.3.0/libva-2.3.0.tar.bz2'
+  source_sha256 '60840e50da6932ee2111e15fc8911180ff8a0d6f18bb9cc6ba8c1030098fdce4'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.3.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.3.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.3.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.3.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '867f6254b17be1fa9fec487767d559b097577ff7984efed98bb9c81af2190552',
+     armv7l: '867f6254b17be1fa9fec487767d559b097577ff7984efed98bb9c81af2190552',
+       i686: 'b517990ffb952a847de93c2fe9ba9221776bb26e83218e82dfdb86f4ab3ea972',
+     x86_64: '2bb0f970dc79c3f4a1046f6b1ef6b30c2bd10e3b5a86d17efdb5eb1ac35f2dbf',
+  })
+
+  depends_on 'libdrm'
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/libvdpau.rb
+++ b/packages/libvdpau.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Libvdpau < Package
+  description 'VDPAU is the Video Decode and Presentation API for UNIX. It provides an interface to video decode acceleration and presentation hardware present in modern GPUs.'
+  homepage 'https://www.freedesktop.org/wiki/Software/VDPAU/'
+  version '1.1.1'
+  source_url 'https://gitlab.freedesktop.org/vdpau/libvdpau/uploads/5635163f040f2eea59b66d0181cf664b/libvdpau-1.1.1.tar.bz2'
+  source_sha256 '857a01932609225b9a3a5bf222b85e39b55c08787d0ad427dbd9ec033d58d736'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.1.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.1.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.1.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.1.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '7294f6d6e5658a671f2c200b927ce8af3eec5e29be48617ccd159b7cb4be4e0f',
+     armv7l: '7294f6d6e5658a671f2c200b927ce8af3eec5e29be48617ccd159b7cb4be4e0f',
+       i686: '0f1e80786ef70a10d1a75b0f22e038183eaf4e56c5f83f8db1ad42f9fad57a14',
+     x86_64: '2fd6efe5954f031570115bf0c32e03baf9418162e8f61df544f36231e902e3e1',
+  })
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -3,16 +3,25 @@ require 'package'
 class Mesa < Package
   description 'Open-source implementation of the OpenGL specification'
   homepage 'https://www.mesa3d.org'
-  version '18.3.1'
+  version '18.3.1-1'
   source_url 'https://mesa.freedesktop.org/archive/mesa-18.3.1.tar.xz'
   source_sha256 '5b1f827d28684a25f6657289f8b7d47ac56395988c7ac23e0ec9a62b644bdc63'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-18.3.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-18.3.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-18.3.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-18.3.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd51c117379b69128d7c0e6f9a0554c8d4f9666cf3fb13b5ecdd0897214873192',
+     armv7l: 'd51c117379b69128d7c0e6f9a0554c8d4f9666cf3fb13b5ecdd0897214873192',
+       i686: '2568b9ad11f52b1554c5720f4b513c26a5ded8d141e97ee01b1eede13e2052bb',
+     x86_64: '7d633a3f7e772fc527ec70ab01d8a53126e1ccee204c5c1fb58efdc8ff438b39',
   })
 
-  depends_on 'libdrm'
+  depends_on 'libva'
+  depends_on 'libvdpau'
   depends_on 'wayland'
   depends_on 'elfutils'
   depends_on 'llvm'
@@ -22,11 +31,14 @@ class Mesa < Package
   end
 
   def self.build
-    system "pip uninstall -y Mako MarkupSafe || :"
-    system "pip install --prefix \"#{CREW_PREFIX}\" --root \"#{CREW_DEST_DIR}\" Mako==1.0.7"
-    system "pip install --prefix \"#{CREW_PREFIX}\" Mako==1.0.7"
+    system "pip3 uninstall -y Mako MarkupSafe || :"
+    system "pip3 install --prefix \"#{CREW_PREFIX}\" --root \"#{CREW_DEST_DIR}\" Mako==1.0.7"
+    system "pip3 install --prefix \"#{CREW_PREFIX}\" Mako==1.0.7"
     case ARCH
-    when 'i686', 'x86_64'
+    when 'i686'
+      gallium_drivers = 'i915,nouveau,pl111,svga,swrast,vc4,virgl'
+      dri_drivers = 'i915,i965,nouveau,radeon,r200,swrast'
+    when 'x86_64'
       gallium_drivers = 'i915,nouveau,r300,r600,radeonsi,pl111,svga,swrast,swr,vc4,virgl'
       dri_drivers = 'i915,i965,nouveau,radeon,r200,swrast'
     when 'aarch64', 'armv7l'

--- a/packages/twm.rb
+++ b/packages/twm.rb
@@ -8,8 +8,16 @@ class Twm < Package
   source_sha256 '6449eadca16ce0f0d900605b0cc020b95f40619261b7beccfb46bcc1836445d7'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/twm-1.0.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/twm-1.0.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/twm-1.0.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/twm-1.0.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'e5b66bf042c287bf844da9a0ac2cff8c0af7d679ddcb83bea15b4b9a580534bf',
+     armv7l: 'e5b66bf042c287bf844da9a0ac2cff8c0af7d679ddcb83bea15b4b9a580534bf',
+       i686: '3abf216bc7c9a2e8f8f43ea263c46fe6c7e366d37e6195ac256c0123de5ce37c',
+     x86_64: '2db77d9f08c7c9090e7bc663b00f4c052442addd01fd614220603ec555e16af9',
   })
 
   depends_on 'xorg_server'

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -8,8 +8,16 @@ class Vim < Package
   source_sha256 '7e6ad44dbb8fda0aca91c22fa0dcaed2d845cf00c26d6d3df3bfaa38c9da222a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1.0648-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1.0648-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1.0648-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1.0648-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '3ad8a65a09ee223bd7ac08026617eb1738ea9f00263a588840d3bc94f804aec6',
+     armv7l: '3ad8a65a09ee223bd7ac08026617eb1738ea9f00263a588840d3bc94f804aec6',
+       i686: '9e94cb4b28b8b7e6a3cd70081d85b4a2950209aa085611aa5def722f9ae585fa',
+     x86_64: '03d46bc71c2785601e95b5e898b198dac56fae7810907d0beab0f08fe7c576f2',
   })
 
   depends_on 'python27' => :build

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -8,8 +8,16 @@ class Vim_runtime < Package
   source_sha256 '7e6ad44dbb8fda0aca91c22fa0dcaed2d845cf00c26d6d3df3bfaa38c9da222a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.1.0648-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.1.0648-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.1.0648-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.1.0648-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '68534f604cec1223f0de74c964fde11d15313967f33a485be03f0bda09e1b87b',
+     armv7l: '68534f604cec1223f0de74c964fde11d15313967f33a485be03f0bda09e1b87b',
+       i686: 'e0acbd72d697053d891f9dddc3d1b6325370af50d115c70a983ab959d7d5d230',
+     x86_64: '1eaf66995f199d6360391a9aacb0d5ab997954c21862c36502991544c08a4efc',
   })
 
   depends_on 'python27' => :build

--- a/packages/xauth.rb
+++ b/packages/xauth.rb
@@ -8,8 +8,16 @@ class Xauth < Package
   source_sha256 '5afe42ce3cdf4f60520d1658d2b17face45c74050f39af45dccdc95e73fafc4d'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xauth-1.0.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xauth-1.0.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xauth-1.0.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xauth-1.0.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'a246881cf30bade98de08a011f285ea48df3f0e6a6ba0f25d354b46867f45d2e',
+     armv7l: 'a246881cf30bade98de08a011f285ea48df3f0e6a6ba0f25d354b46867f45d2e',
+       i686: '89f58dee1108c4cf687e9936c741313d1c2eae5aee0bf73163c12a0bc1c32037',
+     x86_64: '6a8217ce647c238127d64380e7dc64b5fc0b0763b9ebe8165b40204ef815aff9',
   })
 
   depends_on 'xorg_lib'

--- a/packages/xclock.rb
+++ b/packages/xclock.rb
@@ -8,8 +8,16 @@ class Xclock < Package
   source_sha256 '23ceeca94e3e20a6c26a703ac7f789066d4517f8d2cb717ae7cb28a617d97dd0'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xclock-1.0.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xclock-1.0.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xclock-1.0.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xclock-1.0.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '589fb2e417aead9724d278e8f675bcd5d6f53d717fdd9d5b208e9a69ad3e0cfc',
+     armv7l: '589fb2e417aead9724d278e8f675bcd5d6f53d717fdd9d5b208e9a69ad3e0cfc',
+       i686: '24bac5e6ab7b90d6eb070e587e6e473cfcab04f46b47dc1801d5bfcac6467d3f',
+     x86_64: '51318c17142f85d70173ce506a2f04a8b66ee8382e821e782e07548076051a1c',
   })
 
   depends_on 'xorg_lib'

--- a/packages/xinit.rb
+++ b/packages/xinit.rb
@@ -8,15 +8,22 @@ class Xinit < Package
   source_sha256 '230835eef2f5978a1e1344928168119373f6df1d0a32c09515e545721ee582ef'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xinit-1.4.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xinit-1.4.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xinit-1.4.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xinit-1.4.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '571b3b0688bb7013a186dc577d6a6ea5b036f08b398a42528512c8990b03f51b',
+     armv7l: '571b3b0688bb7013a186dc577d6a6ea5b036f08b398a42528512c8990b03f51b',
+       i686: '3feebdbc9b9138d8acc6cfcf36459581f6bae6e8e8f26fdbcf6945f66c66743c',
+     x86_64: '943fd77aebd9dc370ca8ba637493e39d4e92e018dcea4b03a0d69566be64cb34',
   })
 
+  depends_on 'twm'
+  depends_on 'xauth'
   depends_on 'xclock'
   depends_on 'xterm'
-  depends_on 'xauth'
-  depends_on 'twm'
-  depends_on 'xorg_server'
 
   def self.build
     system "./configure",

--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -8,10 +8,17 @@ class Xorg_server < Package
   source_sha256 '1b3ce466c12cacbe2252b3ad5b0ed561972eef9d09e75900d65fb1e21f9201de'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '5603c3ad8211c77b9af761cb9ca78493b7a9a4f877197e619235e2892ffba8cc',
+     armv7l: '5603c3ad8211c77b9af761cb9ca78493b7a9a4f877197e619235e2892ffba8cc',
+       i686: 'cbec00ee50d01ccb2cdae94c2e62a254c6687a8f282ca7af24b625825dfb2958',
+     x86_64: 'daeac28c7d97ef2eaff50439cbb83299cf9df6c27a3ec816ffe55b2680b0053b',
   })
-
 
   depends_on 'pixman'
   depends_on 'mesa'
@@ -29,7 +36,8 @@ class Xorg_server < Package
   depends_on 'font_util'
   depends_on 'libxkbcommon'
   depends_on 'xkbcomp'
-  
+  depends_on 'glproto'
+
   def self.build
     system "./configure",
              "--prefix=#{CREW_PREFIX}",
@@ -50,4 +58,3 @@ class Xorg_server < Package
     system "ln", "-sf", "Xwayland", "#{CREW_DEST_PREFIX}/bin/X"
   end
 end
-


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64

- Added packages libva and libvdpau as dependencies of mesa.
- Most gui apps are still not working on i686 but that is somewhat expected.
- The gvim package needs work.  It will not start.  New issue pending.