### PR TITLE
Remove CRLFs and replace with LFs in all packages

### DIFF
--- a/packages/libdmx.rb
+++ b/packages/libdmx.rb
@@ -22,7 +22,7 @@ class Libdmx < Package
 
   depends_on 'libxext'
   depends_on 'libx11'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libfs.rb
+++ b/packages/libfs.rb
@@ -20,10 +20,9 @@ class Libfs < Package
      x86_64: '98f7cc48a3a2406ea1d110b051b3f18f5682b2096cfdb7f4f4f9c4b2255f2f42',
   })
 
-
   depends_on 'xorg_proto'
   depends_on 'libxtrans'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libice.rb
+++ b/packages/libice.rb
@@ -23,7 +23,7 @@ class Libice < Package
   depends_on 'libxtrans'
   depends_on 'libx11'
   depends_on 'libbsd'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libsm.rb
+++ b/packages/libsm.rb
@@ -22,7 +22,7 @@ class Libsm < Package
 
   depends_on 'libice'
   depends_on 'libx11'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxaw.rb
+++ b/packages/libxaw.rb
@@ -23,7 +23,7 @@ class Libxaw < Package
   depends_on 'libxmu'
   depends_on 'libxpm'
   depends_on 'libx11'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxfont2.rb
+++ b/packages/libxfont2.rb
@@ -24,7 +24,7 @@ class Libxfont2 < Package
   depends_on 'libfontenc'
   depends_on 'libx11'
   depends_on 'freetype'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxft.rb
+++ b/packages/libxft.rb
@@ -21,12 +21,12 @@ class Libxft < Package
   })
 
   depends_on 'libxrender'
-  depends_on 'libx11' 
+  depends_on 'libx11'
   depends_on 'fontconfig'
   depends_on 'util_macros'
   depends_on 'zlibpkg'
   depends_on 'harfbuzz'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxmu.rb
+++ b/packages/libxmu.rb
@@ -23,8 +23,8 @@ class Libxmu < Package
   depends_on 'libxt'
   depends_on 'libxext'
   depends_on 'util_macros'
-  depends_on 'libx11' 
-  
+  depends_on 'libx11'
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxpm.rb
+++ b/packages/libxpm.rb
@@ -23,7 +23,7 @@ class Libxpm < Package
   depends_on 'libx11'
   depends_on 'util_macros'
   depends_on 'gettext'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxrandr.rb
+++ b/packages/libxrandr.rb
@@ -22,7 +22,7 @@ class Libxrandr < Package
 
   depends_on 'libxrender'
   depends_on 'libx11'
-   
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxres.rb
+++ b/packages/libxres.rb
@@ -22,7 +22,7 @@ class Libxres < Package
 
   depends_on 'libxext'
   depends_on 'libx11'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxt.rb
+++ b/packages/libxt.rb
@@ -22,7 +22,7 @@ class Libxt < Package
 
   depends_on 'libsm'
   depends_on 'libx11'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxv.rb
+++ b/packages/libxv.rb
@@ -22,7 +22,7 @@ class Libxv < Package
 
   depends_on 'libxext'
   depends_on 'libx11'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxvmc.rb
+++ b/packages/libxvmc.rb
@@ -22,7 +22,7 @@ class Libxvmc < Package
 
   depends_on 'libxv'
   depends_on 'libx11'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxxf86dga.rb
+++ b/packages/libxxf86dga.rb
@@ -22,7 +22,7 @@ class Libxxf86dga < Package
 
   depends_on 'libxext'
   depends_on 'libx11'
-   
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/libxxf86vm.rb
+++ b/packages/libxxf86vm.rb
@@ -22,7 +22,7 @@ class Libxxf86vm < Package
 
   depends_on 'libxext'
   depends_on 'libx11'
-  
+
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"

--- a/packages/xorg_lib.rb
+++ b/packages/xorg_lib.rb
@@ -3,10 +3,10 @@ require 'package'
 class Xorg_lib < Package
   description 'A collection of xorg libraries.'
   homepage ''
-  version '0.1-0'  
-  
+  version '0.1-0'
+
   is_fake
- 
+
   depends_on 'libxtrans'
   depends_on 'libx11'
   depends_on 'libxext'
@@ -21,7 +21,7 @@ class Xorg_lib < Package
   depends_on 'libxcursor'
   depends_on 'libxrender'
   depends_on 'libxfixes'
-  
+
   # new
   depends_on 'libdmx'
   depends_on 'libfs'
@@ -41,5 +41,4 @@ class Xorg_lib < Package
   depends_on 'libxxf86vm'
   depends_on 'libxcomposite'
   depends_on 'libxscrnsaver'
-  
 end


### PR DESCRIPTION
This PR fixes the result of building packages in Windows which should never be used as a development environment for Chromebrew...ever. :)