### PR TITLE
Update php from 5.6.39-7.3.0 to 5.6.40-7.3.1

### DIFF
--- a/packages/libzip.rb
+++ b/packages/libzip.rb
@@ -1,0 +1,47 @@
+require 'package'
+
+class Libzip < Package
+  description 'libzip is a C library for reading, creating, and modifying zip archives.'
+  homepage 'https://libzip.org/'
+  version '1.5.1'
+  source_url 'https://libzip.org/download/libzip-1.5.1.tar.xz'
+  source_sha256 '04ea35b6956c7b3453f1ed3f3fe40e3ddae1f43931089124579e8384e79ed372'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libzip-1.5.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libzip-1.5.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libzip-1.5.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libzip-1.5.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'd219497c9fb7451c26c93dd9379808fbbd936317e765be63beafb8d91db2a84d',
+     armv7l: 'd219497c9fb7451c26c93dd9379808fbbd936317e765be63beafb8d91db2a84d',
+       i686: 'd286172ecf333bed71e0bd1c7713cbbefb5a5434e2592ee5e67cd881bccb5784',
+     x86_64: '4d1fa9fad684b7e4aa92885e247e963ac7ad1a1c85fd7a35cec728491a2e72cc',
+  })
+
+  depends_on 'bz2'
+
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             "-DCMAKE_INSTALL_LIBDIR=#{ARCH_LIB}",
+             '-DCMAKE_BUILD_TYPE=Release ..'
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    end
+  end
+
+  def self.check
+    Dir.chdir 'build' do
+      system "make", "check"
+    end
+  end
+end

--- a/packages/php.rb
+++ b/packages/php.rb
@@ -3,34 +3,34 @@ require 'package'
 class Php < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.39-7.3.0'
+  version '5.6.40-7.3.1'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
-    abort "Php version #{phpver} already installed.".lightgreen unless "#{phpver}" == ""
+    abort "PHP version #{phpver} already installed.".lightgreen unless "#{phpver}" == ""
     puts
-    puts "Enter the php version to install:"
-    puts "5.6 = PHP 5.6.39"
+    puts "Enter the PHP version to install:"
+    puts "5.6 = PHP 5.6.40"
     puts "7.0 = PHP 7.0.33"
-    puts "7.1 = PHP 7.1.25"
-    puts "7.2 = PHP 7.2.13"
-    puts "7.3 = PHP 7.3.0"
+    puts "7.1 = PHP 7.1.26"
+    puts "7.2 = PHP 7.2.14"
+    puts "7.3 = PHP 7.3.1"
     puts "  0 = Cancel"
 
     while version = STDIN.gets.chomp
       case version
       when '5.6'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '5a0be4837ee67281c647a74b98e9d893dda07266bfc542ef1b87b5143791fb19',
-           armv7l: '5a0be4837ee67281c647a74b98e9d893dda07266bfc542ef1b87b5143791fb19',
-             i686: '383ac377bd617182bbca5a41ddac52105bbccd3754268ca0c4d04556848965a7',
-           x86_64: 'fe93b5fd684e10bac3b6e74c8a4150c9231e6febfe80061917130a94b6f1e094',
+          aarch64: '2c856f39c5bea81c5ffd1b0fc57a5046c9987cf44304e1b4b7a9b3f5c8249f6f',
+           armv7l: '2c856f39c5bea81c5ffd1b0fc57a5046c9987cf44304e1b4b7a9b3f5c8249f6f',
+             i686: '0fe21893525eeb70f2d7f075738e57f9d8edb5ead85e8c5b09de188b244c6a34',
+           x86_64: '26b5cc993b96db0bb251db8b5ed54d1b2f25c6c8f81b91e50bef35b4fc62d9ad',
         })
         $ver = 5
         break
@@ -51,46 +51,46 @@ class Php < Package
         break
       when '7.1'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.25-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.25-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.25-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.25-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.26-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.26-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.26-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.26-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '41ff2144c2e1d6d87412736eedfbd267362a817e164eb226aac2a5332bff8871',
-           armv7l: '41ff2144c2e1d6d87412736eedfbd267362a817e164eb226aac2a5332bff8871',
-             i686: 'd3a2555f4127ba4837a819070314a2987b21c3053b10565a09c05c19ce296715',
-           x86_64: '3d73d6e75bcef3a42dfa7bbaf458021753b1fb1c0b6329dbd1cab6e1f4f0bdc6',
+          aarch64: '4f3026fe98f4ab68ec2e0029abc52c00d8bd61632ec700aa03242c1cf7ac5252',
+           armv7l: '4f3026fe98f4ab68ec2e0029abc52c00d8bd61632ec700aa03242c1cf7ac5252',
+             i686: 'dc4a8ab10ade19c80018e1f815f9053b88dee6c5dc5d363e55181f8e59719469',
+           x86_64: '0fa31104c75e229ae7988c193657df32f2c9d4dca8154d0f3b8a4081aeb2fa17',
         })
         $ver = 7
         break
       when '7.2'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.14-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.14-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.14-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.14-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '1eba303d85b10189ca84d7004dba52dfbf77599e972d41350c9d5b0d109c0868',
-           armv7l: '1eba303d85b10189ca84d7004dba52dfbf77599e972d41350c9d5b0d109c0868',
-             i686: 'dca4240c6530c0b05956259bf352fdfbf4de96993a1e87bea518b98e3338e54e',
-           x86_64: '816e2a00a31b200b668cfe4da1a4ad5a015e478d4f2af6b5c41a47875c6f6e25',
+          aarch64: 'dc076b2e07da99b8ae26dd75b74e0dd39e23a6df8e82dfc2060b8a03f884ddd7',
+           armv7l: 'dc076b2e07da99b8ae26dd75b74e0dd39e23a6df8e82dfc2060b8a03f884ddd7',
+             i686: 'e75f54e42bb686ab2f8c49bd9c4cf080d507bc5e780515523453482667421fc1',
+           x86_64: 'a13f6063587b19f9cc64dd9fcd9f96149033f184476c9282a38da7e855f4d900',
         })
         $ver = 7
         break
       when '7.3'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.0-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.0-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.0-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.0-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.1-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.1-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.1-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.1-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '96537d016c335816a0540c6e96bee856bc7d81fc7ed5fcdb5bd9abffb5b3f3b6',
-           armv7l: '96537d016c335816a0540c6e96bee856bc7d81fc7ed5fcdb5bd9abffb5b3f3b6',
-             i686: '2ab4ff20cd0feac5515788cc59477b61d35d7cab4f499f02df41eaed3f15fb91',
-           x86_64: 'c58287f53287258d2ce073f69a318cceed8cae541cdb3ff0a31998153df3c439',
+          aarch64: '49214ca99d98c7ff9a17a97a96df976d2b20f406ac0737a8d22ae16a3486774b',
+           armv7l: '49214ca99d98c7ff9a17a97a96df976d2b20f406ac0737a8d22ae16a3486774b',
+             i686: '58481f39c04d98d199e8864a5c28a68e45f94daa87ba3cfbdb8d8663733d096f',
+           x86_64: 'b2fce9ddd14abb740e180bd1c0deeb46fe93f0c236a78dd0ee3f93da896b7b51',
         })
         $ver = 7
         break
@@ -107,8 +107,13 @@ class Php < Package
   depends_on 'libgcrypt'
   depends_on 'libpng'
   depends_on 'libxslt'
+  depends_on 'libzip'
   depends_on 'curl'
+  depends_on 'exif'
+  depends_on 'freetype'
   depends_on 'pcre'
+  depends_on 'tidy'
+  depends_on 'unixodbc'
 
   def self.postinstall
     puts

--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -3,31 +3,39 @@ require 'package'
 class Php5 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.39'
-  source_url 'http://php.net/distributions/php-5.6.39.tar.xz'
-  source_sha256 '8147576001a832ff3d03cb2980caa2d6b584a10624f87ac459fcd3948c6e4a10'
+  version '5.6.40'
+  source_url 'http://php.net/distributions/php-5.6.40.tar.xz'
+  source_sha256 '1369a51eee3995d7fbd1c5342e5cc917760e276d561595b6052b21ace2656d1c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.39-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5a0be4837ee67281c647a74b98e9d893dda07266bfc542ef1b87b5143791fb19',
-     armv7l: '5a0be4837ee67281c647a74b98e9d893dda07266bfc542ef1b87b5143791fb19',
-       i686: '383ac377bd617182bbca5a41ddac52105bbccd3754268ca0c4d04556848965a7',
-     x86_64: 'fe93b5fd684e10bac3b6e74c8a4150c9231e6febfe80061917130a94b6f1e094',
+    aarch64: '2c856f39c5bea81c5ffd1b0fc57a5046c9987cf44304e1b4b7a9b3f5c8249f6f',
+     armv7l: '2c856f39c5bea81c5ffd1b0fc57a5046c9987cf44304e1b4b7a9b3f5c8249f6f',
+       i686: '0fe21893525eeb70f2d7f075738e57f9d8edb5ead85e8c5b09de188b244c6a34',
+     x86_64: '26b5cc993b96db0bb251db8b5ed54d1b2f25c6c8f81b91e50bef35b4fc62d9ad',
   })
 
   depends_on 'readline7'
   depends_on 'libgcrypt'
   depends_on 'libpng'
   depends_on 'libxslt'
+  depends_on 'libzip'
   depends_on 'curl'
+  depends_on 'exif'
+  depends_on 'freetype'
   depends_on 'pcre'
+  depends_on 'tidy'
+  depends_on 'unixodbc'
 
   def self.patch
+    # Fix for tidy
+    system "sed -i 's,buffio.h,tidybuffio.h,' ext/tidy/tidy.c"
+    # Configuration
     system "sed -i 's,;pid = run/php-fpm.pid,pid = #{CREW_PREFIX}/tmp/run/php-fpm.pid,' sapi/fpm/php-fpm.conf.in"
     system "sed -i 's,;error_log = log/php-fpm.log,error_log = #{CREW_PREFIX}/log/php-fpm.log,' sapi/fpm/php-fpm.conf.in"
     system "sed -i 's,include=@php_fpm_sysconfdir@/php-fpm.d,include=#{CREW_PREFIX}/etc/php-fpm.d,' sapi/fpm/php-fpm.conf.in"
@@ -55,17 +63,32 @@ class Php5 < Package
       --sbindir=#{CREW_PREFIX}/bin \
       --with-config-file-path=#{CREW_PREFIX}/etc \
       --with-libdir=#{ARCH_LIB} \
+      --with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype \
+      --enable-exif \
       --enable-fpm \
+      --enable-ftp \
       --enable-mbstring \
       --enable-opcache \
+      --enable-pcntl \
+      --enable-sockets \
+      --enable-shared \
+      --enable-shmop \
+      --enable-zip \
+      --with-bz2 \
       --with-curl \
       --with-gd \
-      --with-xsl \
+      --with-gettext \
+      --with-gmp \
+      --with-libzip \
       --with-mysqli \
       --with-openssl \
       --with-pdo-mysql \
+      --with-pear \
       --with-pcre-regex \
       --with-readline \
+      --with-tidy \
+      --with-unixODBC \
+      --with-xsl \
       --with-zlib"
     system 'make'
   end

--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -3,31 +3,37 @@ require 'package'
 class Php7 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.2.13'
-  source_url 'https://php.net/distributions/php-7.2.13.tar.xz'
-  source_sha256 '14b0429abdb46b65c843e5882c9a8c46b31dfbf279c747293b8ab950c2644a4b'
+  version '7.2.14'
+  source_url 'https://php.net/distributions/php-7.2.14.tar.xz'
+  source_sha256 'ee3f1cc102b073578a3c53ba4420a76da3d9f0c981c02b1664ae741ca65af84f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.13-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.14-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1eba303d85b10189ca84d7004dba52dfbf77599e972d41350c9d5b0d109c0868',
-     armv7l: '1eba303d85b10189ca84d7004dba52dfbf77599e972d41350c9d5b0d109c0868',
-       i686: 'dca4240c6530c0b05956259bf352fdfbf4de96993a1e87bea518b98e3338e54e',
-     x86_64: '816e2a00a31b200b668cfe4da1a4ad5a015e478d4f2af6b5c41a47875c6f6e25',
+    aarch64: 'dc076b2e07da99b8ae26dd75b74e0dd39e23a6df8e82dfc2060b8a03f884ddd7',
+     armv7l: 'dc076b2e07da99b8ae26dd75b74e0dd39e23a6df8e82dfc2060b8a03f884ddd7',
+       i686: 'e75f54e42bb686ab2f8c49bd9c4cf080d507bc5e780515523453482667421fc1',
+     x86_64: 'a13f6063587b19f9cc64dd9fcd9f96149033f184476c9282a38da7e855f4d900',
   })
 
   depends_on 'readline7'
   depends_on 'libgcrypt'
   depends_on 'libpng'
   depends_on 'libxslt'
+  depends_on 'libzip'
   depends_on 'curl'
+  depends_on 'exif'
+  depends_on 'freetype'
   depends_on 'pcre'
+  depends_on 'tidy'
+  depends_on 'unixodbc'
 
   def self.patch
+    # Configuration
     system "sed -i 's,;pid = run/php-fpm.pid,pid = #{CREW_PREFIX}/tmp/run/php-fpm.pid,' sapi/fpm/php-fpm.conf.in"
     system "sed -i 's,;error_log = log/php-fpm.log,error_log = #{CREW_PREFIX}/log/php-fpm.log,' sapi/fpm/php-fpm.conf.in"
     system "sed -i 's,include=@php_fpm_sysconfdir@/php-fpm.d,include=#{CREW_PREFIX}/etc/php-fpm.d,' sapi/fpm/php-fpm.conf.in"
@@ -53,17 +59,32 @@ class Php7 < Package
       --sbindir=#{CREW_PREFIX}/bin \
       --with-config-file-path=#{CREW_PREFIX}/etc \
       --with-libdir=#{ARCH_LIB} \
+      --with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype \
+      --enable-exif \
       --enable-fpm \
+      --enable-ftp \
       --enable-mbstring \
       --enable-opcache \
+      --enable-pcntl \
+      --enable-sockets \
+      --enable-shared \
+      --enable-shmop \
+      --enable-zip \
+      --with-bz2 \
       --with-curl \
       --with-gd \
-      --with-xsl \
+      --with-gettext \
+      --with-gmp \
+      --with-libzip \
       --with-mysqli \
       --with-openssl \
       --with-pdo-mysql \
+      --with-pear \
       --with-pcre-regex \
       --with-readline \
+      --with-tidy \
+      --with-unixODBC \
+      --with-xsl \
       --with-zlib"
     system 'make'
   end


### PR DESCRIPTION
- Add more dependencies and configure options
- Fix for tidy support
- Add libzip dependency
- Update php7 to 7.1.26
- Update php7 to 7.2.14
- Update php7 to 7.3.1
- Add pre-built binaries

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64