### PR TITLE
Add pre-built binaries for gdb, lzo, lzop and xhost

### DIFF
--- a/packages/gdb.rb
+++ b/packages/gdb.rb
@@ -8,8 +8,16 @@ class Gdb < Package
   source_sha256 '0a6a432907a03c5c8eaad3c3cffd50c00a40c3a5e3c4039440624bae703f2202'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gdb-8.2.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gdb-8.2.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gdb-8.2.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gdb-8.2.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '9bd4500d8af36782c5e047e15aef059fc0562e0f1c7acc391692d6287d88276a',
+     armv7l: '9bd4500d8af36782c5e047e15aef059fc0562e0f1c7acc391692d6287d88276a',
+       i686: '2078a79d604628c270576be8fb96e8ccaa087ef207e3f6d14356c606898027e8',
+     x86_64: '95fe8fac708e2c28b4c8c8453bfbd7d85d5fe795d80ceaf86ff255d574b2c5b1',
   })
 
   depends_on 'texinfo'

--- a/packages/lzo.rb
+++ b/packages/lzo.rb
@@ -8,10 +8,16 @@ class Lzo < Package
   source_sha256 'c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/lzo-2.10-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/lzo-2.10-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/lzo-2.10-1-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/lzo-2.10-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     x86_64: '6427640990d44d3e8d9c16856a40de6442624e821e64dc8441373bbcd34f71f1',
+    aarch64: '8909723551598aea2da661c6e327d42ede4eedef60351113b2ee7923e45523d4',
+     armv7l: '8909723551598aea2da661c6e327d42ede4eedef60351113b2ee7923e45523d4',
+       i686: 'cec4de5d184f57d18660b4ea8a8ca5f69a8d80cc620e79dedc617f9fab04d63f',
+     x86_64: '04c5e6c4405569793a8681869376ee5144258ced7c39eb06742f891fed741ff7',
   })
 
   def self.build

--- a/packages/lzop.rb
+++ b/packages/lzop.rb
@@ -8,10 +8,16 @@ class Lzop < Package
   source_sha256 '7e72b62a8a60aff5200a047eea0773a8fb205caf7acbe1774d95147f305a2f41'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/lzop-1.04-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/lzop-1.04-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/lzop-1.04-1-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/lzop-1.04-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     x86_64: 'e690057fbe1ab77e71f9ee73bb0d5cd75a410f8f773869f75745622776b9dcaf',
+    aarch64: '12444f80e88a657a9b03aa3567c9c69fd8778c0e178f26c79e82b56f7028efbb',
+     armv7l: '12444f80e88a657a9b03aa3567c9c69fd8778c0e178f26c79e82b56f7028efbb',
+       i686: '270dc22baf06be6742378ace4a6605f2270c36907eab53a78bd9554d72b4e3bc',
+     x86_64: 'ad20f5a37b0f564cf2a06c1e516ecbacf5d13d4dcec0cc678eb07364ff5cd2e9',
   })
 
   depends_on 'lzo'

--- a/packages/xhost.rb
+++ b/packages/xhost.rb
@@ -2,16 +2,22 @@ require 'package'
 
 class Xhost < Package
   description 'Server access control program for X'
-  homepage 'https://www.x.org/archive/X11R6.8.1/doc/xhost.1.html'
+  homepage 'https://github.com/freedesktop/xorg-xhost'
   version '1.0.7'
   source_url 'https://www.x.org/releases/individual/app/xhost-1.0.7.tar.bz2'
   source_sha256 '93e619ee15471f576cfb30c663e18f5bc70aca577a63d2c2c03f006a7837c29a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xhost-1.0.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xhost-1.0.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xhost-1.0.7-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xhost-1.0.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     x86_64: 'a9efe55993274542bd7cf8f9cc5dd9cd4899396c5218728fb844379b1873334d',
+    aarch64: '6bc7b1b1ac3da2a29d255dc12116d8fb7558b7a951c39694e793a17de3118f0f',
+     armv7l: '6bc7b1b1ac3da2a29d255dc12116d8fb7558b7a951c39694e793a17de3118f0f',
+       i686: '6b52588ce97148da0b44ca76a7934b9f921834fe3d3bc3165c9085a46fb20d87',
+     x86_64: '81710af7e1d0a9193739e8fd4f87b469be75ceadf364f5628504927a7f715ab2',
   })
 
   depends_on 'xorg_lib'


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64

- xhost freezes on i686 but that is not really surprising