### PR TITLE
Add HOME to the list of crew constants

### DIFF
--- a/crew
+++ b/crew
@@ -261,6 +261,7 @@ def const (var)
       'CREW_NPROC',
       'CREW_PREFIX',
       'CREW_VERSION',
+      'HOME',
       'USER'
     ]
     vars.each { |var|

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.1.0'
+CREW_VERSION = '1.1.1'
 
 ARCH = `uname -m`.strip
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end


### PR DESCRIPTION
The `HOME` constant will appear in the list of `crew const` output.