### PR TITLE
Add pre-built binaries for gzip

### DIFF
--- a/packages/gzip.rb
+++ b/packages/gzip.rb
@@ -8,8 +8,16 @@ class Gzip < Package
   source_sha256 '8425ccac99872d544d4310305f915f5ea81e04d0f437ef1a230dc9d1c819d7c0'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gzip-1.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gzip-1.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gzip-1.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gzip-1.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f06dff71bad212d9a9032bb2d2ede8e8d749a6d629404d0c60a70fe34485fd04',
+     armv7l: 'f06dff71bad212d9a9032bb2d2ede8e8d749a6d629404d0c60a70fe34485fd04',
+       i686: '16c9345b17e82ce949db29462142fbd06dd38d647321e046c9626cd08b6766d1',
+     x86_64: '70e752fbb1b545a0fa3189571d3179a46eaa2331485475aaa349420407529422',
   })
 
   def self.build


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64