### PR TITLE
Faster dep checks

### DIFF
--- a/crew
+++ b/crew
@@ -627,41 +627,28 @@ end
 
 def expand_dependencies
   @dependencies = []
-  @dontRecheck = []
-
   def push_dependencies
     if @pkg.is_binary?(@device[:architecture]) ||
        (!@pkg.in_upgrade && !@pkg.build_from_source && @device[:installed_packages].any? { |pkg| pkg[:name] == @pkg.name })
       # retrieve name of dependencies that doesn't contain :build tag
       check_deps = @pkg.dependencies.select {|k, v| !v.include?(:build)}.map {|k, v| k}
-    elsif @pkg.is_fake?
-      # retrieve name of all dependencies
-      check_deps = @pkg.dependencies.map {|k, v| k}
     else
       # retrieve name of all dependencies
       check_deps = @pkg.dependencies.map {|k, v| k}
     end
-
-    # remove a dependent package which is equal to the target
-    check_deps.select! {|name| @pkgName != name}
-
-    # add new dependencies at the beginning of array
-    @dependencies = check_deps.clone.concat(@dependencies)
-
     # check all dependencies recursively
     check_deps.each do |dep|
-      # skip a dependency if it's been checked already
-      next if @dontRecheck.include?(dep)
-      search dep, true
-      push_dependencies
-      # Remember dep so we can skip it from now on
-      @dontRecheck << dep
+      # build unique dependencies list
+      unless @dependencies.include?(dep) || dep == @pkgName
+        @dependencies << dep
+        search dep, true
+        push_dependencies
+      end
     end
   end
-
   push_dependencies
-
-  @dependencies.uniq
+  # resolve_dependencies needs expand_dependencies to return @dependencies
+  return @dependencies
 end
 
 def resolve_dependencies

--- a/crew
+++ b/crew
@@ -627,6 +627,7 @@ end
 
 def expand_dependencies
   @dependencies = []
+  @dontRecheck = []
 
   def push_dependencies
     if @pkg.is_binary?(@device[:architecture]) ||
@@ -649,8 +650,12 @@ def expand_dependencies
 
     # check all dependencies recursively
     check_deps.each do |dep|
+      # skip a dependency if it's been checked already
+      next if @dontRecheck.include?(dep)
       search dep, true
       push_dependencies
+      # Remember dep so we can skip it from now on
+      @dontRecheck << dep
     end
   end
 


### PR DESCRIPTION
## Description
Keep track of the names of dependencies that have already been checked
in the `expand_dependencies`/`push_dependencies loop`. A quick and dirty way
to break out of dependency cycles and speed up the dependency resolution
step in general.

## Addtional information
This PR would merge the branch `dpgettings:faster-dep-checks` which uses arrays to store the names of dependencies that have already been checked. This is an alternative to #3105 which would merge `dpgettings:prevent-repeat-dep-checks`, a different branch that accomplishes the same thing as `dpgettings:faster-dep-checks` but which uses the `Set` class to store dependency names. 

The only noticeable functional difference between the two versions is the order of a package's final dependency list, which is often different; the deps named on the list are exactly the same for every current package. In the end, the performance gain due to the use of `Set` vs arrays is negligible.