### PR TITLE
Add pre-built binaries for lha, libmetalink, xmessage and xprop

### DIFF
--- a/packages/lha.rb
+++ b/packages/lha.rb
@@ -8,8 +8,16 @@ class Lha < Package
   source_sha256 'b081f600fd34ab99d5ddf085d0667bc4fa3e44362843935236592ddd999f084f'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/lha-6f6cbc1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/lha-6f6cbc1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/lha-6f6cbc1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/lha-6f6cbc1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '8fa5dd3a57a9da3ffe245f1417f746da3c6d712e4436dcad67a71ec34e1c2e94',
+     armv7l: '8fa5dd3a57a9da3ffe245f1417f746da3c6d712e4436dcad67a71ec34e1c2e94',
+       i686: '8b5d6ed5ffb6118b36ab7a1ab93519003694fc18b5203ca4f885447aa023965b',
+     x86_64: 'e1894e33a4ed0932a493d049007e8d4ac70d94ec5e46247a04d448f23bf32c5d',
   })
 
   def self.patch

--- a/packages/libmetalink.rb
+++ b/packages/libmetalink.rb
@@ -9,8 +9,16 @@ class Libmetalink < Package
   source_sha256 '86312620c5b64c694b91f9cc355eabbd358fa92195b3e99517504076bf9fe33a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '29e31d4461af785016c7fc39dad45479e943488cdcf60a77ed06bb09ec61ea82',
+     armv7l: '29e31d4461af785016c7fc39dad45479e943488cdcf60a77ed06bb09ec61ea82',
+       i686: 'd289f088f022b0ebd91585afb9a8f12f5ffd2ad86efacfdf13aaffdfb0cb9634',
+     x86_64: '26c796170ae70679c0cc6ba510b5fd94594e2436b8ae14733226e6b294762fc3',
   })
 
   depends_on 'libxml2'

--- a/packages/xmessage.rb
+++ b/packages/xmessage.rb
@@ -7,6 +7,19 @@ class Xmessage < Package
   source_url 'https://www.x.org/releases/individual/app/xmessage-1.0.5.tar.bz2'
   source_sha256 '373dfb81e7a6f06d3d22485a12fcde6e255d58c6dee1bbaeb00c7d0caa9b2029'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xmessage-1.0.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xmessage-1.0.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xmessage-1.0.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xmessage-1.0.5-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '6df6c32406b06cc78f207c28b3a8cec0c41fe98a7566bf7d73e53553c55a4ccc',
+     armv7l: '6df6c32406b06cc78f207c28b3a8cec0c41fe98a7566bf7d73e53553c55a4ccc',
+       i686: '9af874eed48fcad769c3eea3382448c26958b101af58f0708eefab8454d3eeed',
+     x86_64: '1ccd1102b9debf4c9a7b7ca877b2010622ac013cc551fb0d7d9b3a772355ac80',
+  })
+
   depends_on 'xorg_lib'
 
   def self.build

--- a/packages/xprop.rb
+++ b/packages/xprop.rb
@@ -7,6 +7,19 @@ class Xprop < Package
   source_url 'https://x.org/releases/individual/app/xprop-1.2.3.tar.bz2'
   source_sha256 'd22afb28c86d85fff10a50156a7d0fa930c80ae865d70b26d805fd28a17a521b'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xprop-1.2.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xprop-1.2.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xprop-1.2.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xprop-1.2.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '12aec4691f07cb0d55bd31441b02a5d496c15c7ffccce46866506669833de899',
+     armv7l: '12aec4691f07cb0d55bd31441b02a5d496c15c7ffccce46866506669833de899',
+       i686: '40d86af58fce14adf2bf12605a7935345c759a03513d590e63b50c5198d60b95',
+     x86_64: 'aaeb4ab85d29869250c52958035df3e0317d168f42ce3577b5edee1a2c9aa484',
+  })
+
   depends_on 'xorg_lib'
 
   def self.build


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64