### PR TITLE
Fix manpages

### DIFF
--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -7,19 +7,6 @@ class Bz2 < Package
   source_url 'https://fossies.org/linux/misc/bzip2-1.0.6.tar.xz'
   source_sha256 '4bbea71ae30a0e5a8ddcee8da750bc978a479ba11e04498d082fa65c2f8c1ad5'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'c46ed5a6a89650f945fd627caad1778ee8a6c14abf98e1c7c1497c634210ab0c',
-     armv7l: 'c46ed5a6a89650f945fd627caad1778ee8a6c14abf98e1c7c1497c634210ab0c',
-       i686: 'e014d6cf82a39221aa5657244dc2b8af6a693c77fbfacd0653c01eb8fd393514',
-     x86_64: '03750d307fca3c0ea2829ba357196373630400299fd519da6963f266cd10a091',
-  })
-
   def self.build
     system "make -f Makefile-libbz2_so"
   end

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -51,9 +51,8 @@ class Bz2 < Package
     system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so"
 
     # Move manpages
-    system "mkdir -p #{CREW_DEST_PREFIX}/share/man/"
-    system "cp -a #{CREW_DEST_PREFIX}/man/* #{CREW_DEST_PREFIX}/share/man/"
-    system "rm -rf #{CREW_DEST_PREFIX}/man"
+    system "mkdir -p #{CREW_DEST_PREFIX}/share"
+    system "mv #{CREW_DEST_PREFIX}/man #{CREW_DEST_PREFIX}/share/"
   end
 
   def self.check

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -49,6 +49,11 @@ class Bz2 < Package
     system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0"
     system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1"
     system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so"
+
+    # Move manpages
+    system "mkdir -p #{CREW_DEST_PREFIX}/share/man/"
+    system "cp -a #{CREW_DEST_PREFIX}/man/* #{CREW_DEST_PREFIX}/share/man/"
+    system "rm -rf #{CREW_DEST_PREFIX}/man"
   end
 
   def self.check

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -3,7 +3,7 @@ require 'package'
 class Bz2 < Package
   description 'bzip2 is a freely available, patent free, high-quality data compressor.'
   homepage 'http://www.bzip.org/'
-  version '1.0.6-2'
+  version '1.0.6-3'
   source_url 'https://fossies.org/linux/misc/bzip2-1.0.6.tar.xz'
   source_sha256 '4bbea71ae30a0e5a8ddcee8da750bc978a479ba11e04498d082fa65c2f8c1ad5'
 

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -52,9 +52,8 @@ class Openssl < Package
     system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man7"
 
     # Move manpages
-    system "mkdir -p #{CREW_DEST_PREFIX}/share/man/"
-    system "cp -a #{CREW_DEST_PREFIX}/man/* #{CREW_DEST_PREFIX}/share/man/"
-    system "rm -rf #{CREW_DEST_PREFIX}/man"
+    system "mkdir -p #{CREW_DEST_PREFIX}/share"
+    system "mv #{CREW_DEST_PREFIX}/man #{CREW_DEST_PREFIX}/share/"
   end
 
   def self.check

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,9 +3,9 @@ require 'package'
 class Openssl < Package
   description 'OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.'
   homepage 'https://www.openssl.org/'
-  version '1.0.2p-2'
-  source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2p.tar.gz'
-  source_sha256 '95ca65a25bdd41e127e5f4054539e8532a46be602b43b44af7c7100172e7cd50'
+  version '1.0.2q'
+  source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2q.tar.gz'
+  source_sha256 'a8531541d93bb4486bc07abdc0018c4d759643d6e30dfc514c5939364b3230ca'
 
   depends_on 'bc' => :build             # required for `make test`
 

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,22 +3,9 @@ require 'package'
 class Openssl < Package
   description 'OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.'
   homepage 'https://www.openssl.org/'
-  version '1.0.2p'
+  version '1.0.2p-2'
   source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2p.tar.gz'
   source_sha256 '95ca65a25bdd41e127e5f4054539e8532a46be602b43b44af7c7100172e7cd50'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'e7d69e95badd39e35c3d607386319e03a5db364ddd2be6a359a21661a764b587',
-     armv7l: 'e7d69e95badd39e35c3d607386319e03a5db364ddd2be6a359a21661a764b587',
-       i686: '587cc2a7d1eca05eaf9abc3c8e468be2264eb167a87d5a63c12bc46617696196',
-     x86_64: '1e23e83b900b3a472dca44a6d88c7860119904f39cfde09a81f8d6caae01f42b',
-  })
 
   depends_on 'bc' => :build             # required for `make test`
 

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -39,21 +39,18 @@ class Openssl < Package
     system "make", "INSTALL_PREFIX=#{CREW_DEST_DIR}", "install"
     system "find #{CREW_DEST_PREFIX} -name 'lib*.a' -print | xargs rm"
 
-    # move man to #{CREW_PREFIX}/man
-    system "mv", "#{CREW_DEST_DIR}/etc/ssl/man", "#{CREW_DEST_PREFIX}/man"
+    # move man to #{CREW_PREFIX}/share/man
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
+    system "mv", "#{CREW_DEST_DIR}/etc/ssl/man", "#{CREW_DEST_PREFIX}/share/man"
 
     # remove all files under /etc/ssl (use system's /etc/ssl as is)
     system "rm", "-rf", "#{CREW_DEST_DIR}/etc"
 
     # compress man pages
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man1"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man3"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man5"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man7"
-
-    # Move manpages
-    system "mkdir -p #{CREW_DEST_PREFIX}/share"
-    system "mv #{CREW_DEST_PREFIX}/man #{CREW_DEST_PREFIX}/share/"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man1"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man3"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man5"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man7"
   end
 
   def self.check

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,9 +3,22 @@ require 'package'
 class Openssl < Package
   description 'OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.'
   homepage 'https://www.openssl.org/'
-  version '1.0.2q'
-  source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2q.tar.gz'
-  source_sha256 'a8531541d93bb4486bc07abdc0018c4d759643d6e30dfc514c5939364b3230ca'
+  version '1.0.2p'
+  source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2p.tar.gz'
+  source_sha256 '95ca65a25bdd41e127e5f4054539e8532a46be602b43b44af7c7100172e7cd50'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e7d69e95badd39e35c3d607386319e03a5db364ddd2be6a359a21661a764b587',
+     armv7l: 'e7d69e95badd39e35c3d607386319e03a5db364ddd2be6a359a21661a764b587',
+       i686: '587cc2a7d1eca05eaf9abc3c8e468be2264eb167a87d5a63c12bc46617696196',
+     x86_64: '1e23e83b900b3a472dca44a6d88c7860119904f39cfde09a81f8d6caae01f42b',
+  })
 
   depends_on 'bc' => :build             # required for `make test`
 
@@ -39,18 +52,17 @@ class Openssl < Package
     system "make", "INSTALL_PREFIX=#{CREW_DEST_DIR}", "install"
     system "find #{CREW_DEST_PREFIX} -name 'lib*.a' -print | xargs rm"
 
-    # move man to #{CREW_PREFIX}/share/man
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
-    system "mv", "#{CREW_DEST_DIR}/etc/ssl/man", "#{CREW_DEST_PREFIX}/share/man"
+    # move man to #{CREW_PREFIX}/man
+    system "mv", "#{CREW_DEST_DIR}/etc/ssl/man", "#{CREW_DEST_PREFIX}/man"
 
     # remove all files under /etc/ssl (use system's /etc/ssl as is)
     system "rm", "-rf", "#{CREW_DEST_DIR}/etc"
 
     # compress man pages
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man1"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man3"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man5"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man7"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man1"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man3"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man5"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man7"
   end
 
   def self.check

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,28 +3,24 @@ require 'package'
 class Openssl < Package
   description 'OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.'
   homepage 'https://www.openssl.org/'
-  version '1.0.2o'
-  source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2o.tar.gz'
-  source_sha256 'fd8bff81636c262ff82cb22286957d73213f899c1a80a3ec712c7ae80761ea9b'
+  version '1.0.2p'
+  source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2p.tar.gz'
+  source_sha256 '95ca65a25bdd41e127e5f4054539e8532a46be602b43b44af7c7100172e7cd50'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2o-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2o-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2o-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2o-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b7500bdbfd231f726182b415bbd3b27194e617df455f6f42bdd0e0822cf39a60',
-     armv7l: 'b7500bdbfd231f726182b415bbd3b27194e617df455f6f42bdd0e0822cf39a60',
-       i686: 'e6633187ec8ba10f13c4b4e2af0643f78409bcd84c596744289d47d9afdef664',
-     x86_64: '45caf4d45bc65e494f7b77d1d454f0aff516a2f76656e00efa335cf38bcf7055',
+    aarch64: 'e7d69e95badd39e35c3d607386319e03a5db364ddd2be6a359a21661a764b587',
+     armv7l: 'e7d69e95badd39e35c3d607386319e03a5db364ddd2be6a359a21661a764b587',
+       i686: '587cc2a7d1eca05eaf9abc3c8e468be2264eb167a87d5a63c12bc46617696196',
+     x86_64: '1e23e83b900b3a472dca44a6d88c7860119904f39cfde09a81f8d6caae01f42b',
   })
 
-  depends_on 'compressdoc' => :build
-  depends_on 'perl' => :build
   depends_on 'bc' => :build             # required for `make test`
-  depends_on 'diffutils' => :build      # required for `make test`
-  depends_on 'zlibpkg' => :build
 
   def self.build
     options="shared zlib-dynamic"
@@ -56,7 +52,7 @@ class Openssl < Package
     system "make", "INSTALL_PREFIX=#{CREW_DEST_DIR}", "install"
     system "find #{CREW_DEST_PREFIX} -name 'lib*.a' -print | xargs rm"
 
-    # move man to /usr/local/man
+    # move man to #{CREW_PREFIX}/man
     system "mv", "#{CREW_DEST_DIR}/etc/ssl/man", "#{CREW_DEST_PREFIX}/man"
 
     # remove all files under /etc/ssl (use system's /etc/ssl as is)
@@ -67,6 +63,11 @@ class Openssl < Package
     system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man3"
     system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man5"
     system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man7"
+
+    # Move manpages
+    system "mkdir -p #{CREW_DEST_PREFIX}/share/man/"
+    system "cp -a #{CREW_DEST_PREFIX}/man/* #{CREW_DEST_PREFIX}/share/man/"
+    system "rm -rf #{CREW_DEST_PREFIX}/man"
   end
 
   def self.check


### PR DESCRIPTION
Move manpages from `/usr/local/man` to `/usr/local/share/man`
Fixes #3002 