### PR TITLE
Fix bz2 and openssl manpages.

### DIFF
--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -3,22 +3,9 @@ require 'package'
 class Bz2 < Package
   description 'bzip2 is a freely available, patent free, high-quality data compressor.'
   homepage 'http://www.bzip.org/'
-  version '1.0.6-2'
+  version '1.0.6-3'
   source_url 'https://fossies.org/linux/misc/bzip2-1.0.6.tar.xz'
   source_sha256 '4bbea71ae30a0e5a8ddcee8da750bc978a479ba11e04498d082fa65c2f8c1ad5'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'c46ed5a6a89650f945fd627caad1778ee8a6c14abf98e1c7c1497c634210ab0c',
-     armv7l: 'c46ed5a6a89650f945fd627caad1778ee8a6c14abf98e1c7c1497c634210ab0c',
-       i686: 'e014d6cf82a39221aa5657244dc2b8af6a693c77fbfacd0653c01eb8fd393514',
-     x86_64: '03750d307fca3c0ea2829ba357196373630400299fd519da6963f266cd10a091',
-  })
 
   def self.build
     system "make -f Makefile-libbz2_so"
@@ -49,6 +36,10 @@ class Bz2 < Package
     system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0"
     system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1"
     system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so"
+
+    # Move manpages
+    system "mkdir -p #{CREW_DEST_PREFIX}/share"
+    system "mv #{CREW_DEST_PREFIX}/man #{CREW_DEST_PREFIX}/share/"
   end
 
   def self.check

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -38,7 +38,7 @@ class Bz2 < Package
     system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so"
 
     # Move manpages
-    system "mkdir -p #{CREW_DEST_PREFIX}/share"
+    FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share")
     system "mv #{CREW_DEST_PREFIX}/man #{CREW_DEST_PREFIX}/share/"
   end
 

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -40,7 +40,7 @@ class Openssl < Package
     system "find #{CREW_DEST_PREFIX} -name 'lib*.a' -print | xargs rm"
 
     # move man to #{CREW_PREFIX}/share/man
-    system "mkdir", "-p", "#{CREW_DEST_PREFIX}/share"
+    FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share")
     system "mv", "#{CREW_DEST_DIR}/etc/ssl/man", "#{CREW_DEST_PREFIX}/share/man"
 
     # remove all files under /etc/ssl (use system's /etc/ssl as is)

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,7 +3,7 @@ require 'package'
 class Openssl < Package
   description 'OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.'
   homepage 'https://www.openssl.org/'
-  version '1.0.2p'
+  version '1.0.2p-2'
   source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2p.tar.gz'
   source_sha256 '95ca65a25bdd41e127e5f4054539e8532a46be602b43b44af7c7100172e7cd50'
 

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -7,19 +7,6 @@ class Openssl < Package
   source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2p.tar.gz'
   source_sha256 '95ca65a25bdd41e127e5f4054539e8532a46be602b43b44af7c7100172e7cd50'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'e7d69e95badd39e35c3d607386319e03a5db364ddd2be6a359a21661a764b587',
-     armv7l: 'e7d69e95badd39e35c3d607386319e03a5db364ddd2be6a359a21661a764b587',
-       i686: '587cc2a7d1eca05eaf9abc3c8e468be2264eb167a87d5a63c12bc46617696196',
-     x86_64: '1e23e83b900b3a472dca44a6d88c7860119904f39cfde09a81f8d6caae01f42b',
-  })
-
   depends_on 'bc' => :build             # required for `make test`
 
   def self.build
@@ -52,8 +39,9 @@ class Openssl < Package
     system "make", "INSTALL_PREFIX=#{CREW_DEST_DIR}", "install"
     system "find #{CREW_DEST_PREFIX} -name 'lib*.a' -print | xargs rm"
 
-    # move man to #{CREW_PREFIX}/man
-    system "mv", "#{CREW_DEST_DIR}/etc/ssl/man", "#{CREW_DEST_PREFIX}/man"
+    # move man to #{CREW_PREFIX}/share/man
+    system "mkdir", "-p", "#{CREW_DEST_PREFIX}/share"
+    system "mv", "#{CREW_DEST_DIR}/etc/ssl/man", "#{CREW_DEST_PREFIX}/share/man"
 
     # remove all files under /etc/ssl (use system's /etc/ssl as is)
     system "rm", "-rf", "#{CREW_DEST_DIR}/etc"

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,7 +3,7 @@ require 'package'
 class Openssl < Package
   description 'OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.'
   homepage 'https://www.openssl.org/'
-  version '1.0.2p-2'
+  version '1.0.2p-1'
   source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2p.tar.gz'
   source_sha256 '95ca65a25bdd41e127e5f4054539e8532a46be602b43b44af7c7100172e7cd50'
 


### PR DESCRIPTION
Fixes #3002.
OpenSSL will be updated separately, for now this just solves the manpage issue.