### PR TITLE
Add pre-built binaries for bz2, gdbm and openssl

### DIFF
--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -7,6 +7,19 @@ class Bz2 < Package
   source_url 'https://fossies.org/linux/misc/bzip2-1.0.6.tar.xz'
   source_sha256 '4bbea71ae30a0e5a8ddcee8da750bc978a479ba11e04498d082fa65c2f8c1ad5'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'abfa979b02b0f587c65b7bebb1bc97ba9eda57aec1cb5f3657b6d4f92b90ee65',
+     armv7l: 'abfa979b02b0f587c65b7bebb1bc97ba9eda57aec1cb5f3657b6d4f92b90ee65',
+       i686: '426ec6778bb285ac377f43581a06391ca5a23b533dcfc02cc5c3e03d4239af9f',
+     x86_64: '3ec7418e132350c4989ff2a6856b320d68fbec02913043a6c19f2c025732217f',
+  })
+
   def self.build
     system "make -f Makefile-libbz2_so"
   end

--- a/packages/gdbm.rb
+++ b/packages/gdbm.rb
@@ -8,8 +8,16 @@ class Gdbm < Package
   source_sha256 '86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.18.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.18.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.18.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.18.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'b7d1eefc792b5250b4a1e1c6cf7845cb965944c5f2f4468b63201e6dc7374d66',
+     armv7l: 'b7d1eefc792b5250b4a1e1c6cf7845cb965944c5f2f4468b63201e6dc7374d66',
+       i686: '60deef61ee53f9aab9a94767a8902ee29920302e113ca115567f3b2d428ae582',
+     x86_64: 'b52cde5502c9bf35fe485776d976d1a44a872e2ffee8964297ac2fe3ef0d064e',
   })
 
   depends_on 'readline7'

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -55,10 +55,6 @@ class Mandb < Package
 
   def self.postinstall
     puts
-    puts "To finish the installation, set the default MANPATH environment variable:".lightblue
-    puts "echo \"export MANPATH=#{CREW_PREFIX}/man:$MANPATH\" >> ~/.bashrc".lightblue
-    puts "source ~/.bashrc".lightblue
-    puts
     puts "To create the man databases and get apropos working, type 'mandb -c'.".lightblue
     puts
   end

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -7,6 +7,19 @@ class Openssl < Package
   source_url 'https://github.com/openssl/openssl/archive/OpenSSL_1_0_2p.tar.gz'
   source_sha256 '95ca65a25bdd41e127e5f4054539e8532a46be602b43b44af7c7100172e7cd50'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.0.2p-1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '9d2a1bdeac0d26ec7a22a91e017064edf1799f1783ebb7bce89e92e95b68f043',
+     armv7l: '9d2a1bdeac0d26ec7a22a91e017064edf1799f1783ebb7bce89e92e95b68f043',
+       i686: '0329163f9f9c78433d8b3d22d5a94eccc067ff557810c0fc85d4a8090cacb494',
+     x86_64: 'b61308c6d0cddb3a6e0713e9d47b95382b1c5f0f9495766cec1afa6a07ccf56c',
+  })
+
   depends_on 'bc' => :build             # required for `make test`
 
   def self.build
@@ -47,10 +60,10 @@ class Openssl < Package
     system "rm", "-rf", "#{CREW_DEST_DIR}/etc"
 
     # compress man pages
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man1"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man3"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man5"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/man/man7"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man1"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man3"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man5"
+    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man7"
   end
 
   def self.check


### PR DESCRIPTION
Fixes #3123.

Tested on:
- [x] aarch64
- [x] armv7l
- [x] i686
- [x] x86_64