### PR TITLE
Fix dependency loops and update gcc7 and gcc8 packages

### DIFF
--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -21,7 +21,6 @@ class Cairo < Package
   })
 
   depends_on 'libpng'
-  depends_on 'librsvg'
   depends_on 'lzo'
   depends_on 'pixman'
   depends_on 'mesa'

--- a/packages/gcc7.rb
+++ b/packages/gcc7.rb
@@ -3,28 +3,16 @@ require 'package'
 class Gcc7 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '7.4.0'
+  version '7.4.0-1'
   source_url 'https://ftpmirror.gnu.org/gcc/gcc-7.4.0/gcc-7.4.0.tar.xz'
   source_sha256 'eddde28d04f334aec1604456e536416549e9b1aa137fc69204e65eb0c009fe51'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc7-7.4.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcc7-7.4.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcc7-7.4.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc7-7.4.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '07126320a193d947aeac51f1827ff954c322a8f43014f3cff146715b72f9d7f8',
-     armv7l: '07126320a193d947aeac51f1827ff954c322a8f43014f3cff146715b72f9d7f8',
-       i686: '72cd956d055ad418b052dab407ec3a2b16663b09c396073a23bd12828fcf03c3',
-     x86_64: '6cce57e98836ccc3c6773df1627bca2102b4f89c7abf64dc47f7b97120b0e01b',
   })
 
-  depends_on 'unzip' => :build
-  depends_on 'gawk' => :build
   depends_on 'dejagnu' => :build # for test
-  depends_on 'gcc8' => :build # gcc version 8.2.0
-  depends_on 'icu4c' => :build # icu version 62.1
   depends_on 'python27' => :build
   depends_on 'python3' => :build
 
@@ -36,125 +24,91 @@ class Gcc7 < Package
   depends_on 'glibc'
 
   def self.build
-    # previous compile issue
-    # #{CREW_PREFIX}/bin/ld: cannot find crti.o: No such file or directory
-    # #{CREW_PREFIX}/bin/ld: cannot find /usr/lib64/libc_nonshared.a
-    ENV["LIBRARY_PATH"] = "#{CREW_LIB_PREFIX}"   # fix x86_64 issues
-    system "mkdir -p objdir"
-    Dir.chdir("objdir") do
+    ENV['LIBRARY_PATH'] = CREW_LIB_PREFIX   # fix x86_64 issues
+    FileUtils.mkdir('build')
+    Dir.chdir('build') do
       case ARCH
         when 'armv7l', 'aarch64'
-          system "../configure",
-                 "--prefix=#{CREW_PREFIX}",
+          system '../configure',
+                 '--target=armv7l-cros-linux-gnueabihf',
+                 '--build=armv7l-cros-linux-gnueabihf',
+                 '--host=armv7l-cros-linux-gnueabihf',
                  "--libdir=#{CREW_LIB_PREFIX}",
-                 "--build=armv7l-cros-linux-gnueabihf",
-                 "--host=armv7l-cros-linux-gnueabihf",
-                 "--target=armv7l-cros-linux-gnueabihf",
-                 "--enable-checking=release",
-                 "--disable-multilib",
-                 "--enable-threads=posix",
-                 "--disable-bootstrap",
-                 "--disable-werror",
-                 "--disable-libmpx",
-                 "--enable-static",
-                 "--enable-shared",
-                 "--program-suffix=-7.3",
-                 "--with-arch=armv7-a",
-                 "--with-tune=cortex-a15",
-                 "--with-fpu=neon",
-                 "--with-float=hard",
-                 "--with-default-libstdcxx-abi=gcc4-compatible"
-        when 'x86_64'
-          system "../configure",
+                 '--enable-checking=release',
                  "--prefix=#{CREW_PREFIX}",
-                 "--libdir=#{CREW_LIB_PREFIX}",
+                 '--enable-languages=all',
+                 '--enable-threads=posix',
+                 '--with-tune=cortex-a15',
+                 '--program-suffix=-7.4',
+                 '--with-arch=armv7-a',
+                 '--with-float=hard',
+                 '--disable-libmpx',
+                 '--enable-static',
+                 '--enable-shared',
+                 '--with-fpu=neon'
+        when 'x86_64', 'i686'
+          system '../configure',
+                 "--target=#{ARCH}-cros-linux-gnu",
                  "--build=#{ARCH}-cros-linux-gnu",
                  "--host=#{ARCH}-cros-linux-gnu",
-                 "--target=#{ARCH}-cros-linux-gnu",
-                 "--enable-checking=release",
-                 "--disable-multilib",
-                 "--enable-threads=posix",
-                 "--disable-bootstrap",
-                 "--disable-werror",
-                 "--disable-libmpx",
-                 "--enable-static",
-                 "--enable-shared",
-                 "--program-suffix=-7.3",
-                 "--with-arch-64=x86-64",
-                 "--with-default-libstdcxx-abi=gcc4-compatible"
-        when 'i686'
-          system "../configure",
-                 "--prefix=#{CREW_PREFIX}",
                  "--libdir=#{CREW_LIB_PREFIX}",
-                 "--build=#{ARCH}-cros-linux-gnu",
-                 "--host=#{ARCH}-cros-linux-gnu",
-                 "--target=#{ARCH}-cros-linux-gnu",
-                 "--enable-checking=release",
-                 "--disable-multilib",
-                 "--enable-threads=posix",
-                 "--disable-bootstrap",
-                 "--disable-werror",
-                 "--disable-libmpx",
-                 "--enable-static",
-                 "--enable-shared",
-                 "--program-suffix=-7.3",
-                 "--with-arch-32=i686",
-                 "--with-default-libstdcxx-abi=gcc4-compatible"
+                 '--enable-checking=release',
+                 "--prefix=#{CREW_PREFIX}",
+                 '--enable-languages=all',
+                 '--enable-threads=posix',
+                 '--program-suffix=-7.4',
+                 '--with-arch-64=x86-64',
+                 '--with-arch-32=i686',
+                 '--disable-multilib',
+                 '--disable-libmpx',
+                 '--enable-static',
+                 '--enable-shared'
       end
-      # Comment: --with-default-libstdcxx-abi=gcc-compatible
-      #          Use this switch if we are upgrading from GCC version prior to 5.1.0
-      #          We do not want to recompile all the libraries written in C++
-
-      system "make"
+      system 'make'
     end
   end
 
-  # preserve for check, skip check for current version
   def self.check
-    Dir.chdir("objdir") do
-      #system "ulimit -s 32768"
-      #system "make -k check -j8"
-      #system "../contrib/test_summary"
+    Dir.chdir('build') do
+      system 'ulimit -s 32768'
+      system 'make -k check'
+      system '../contrib/test_summary'
     end
   end
 
   def self.install
-    Dir.chdir("objdir") do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    Dir.chdir('build') do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-strip'
 
-      # http://www.linuxfromscratch.org/lfs/view/development/chapter06/gcc.html#contents-gcc
-      # move a misplaced file
-      # The installation stage puts some files used by gdb under the #{CREW_LIB_PREFIX} directory. This generates spurious error messages when performing ldconfig. This command moves the files to another location.
-      system "mkdir -pv #{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib"
-      system "mv -v #{CREW_DEST_LIB_PREFIX}/*gdb.py #{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib"
+      FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/gdb/auto-load/#{CREW_LIB_PREFIX}")
+      FileUtils.mv(Dir.glob("#{CREW_DEST_LIB_PREFIX}/*gdb.py"), "#{CREW_DEST_PREFIX}/share/gdb/auto-load/#{CREW_LIB_PREFIX}")
 
-      # Install Binary File Descriptor library (BFD)
-      system "install -v -dm755 #{CREW_DEST_LIB_PREFIX}/bfd-plugins"
+      FileUtils.mkdir_p("#{CREW_DEST_LIB_PREFIX}/bfd-plugins")
 
       # Add a compatibility symlink to enable building programs with Link Time Optimization (LTO)
-      system "ln -sfv #{CREW_PREFIX}/libexec/gcc/$(gcc -dumpmachine)/7.3.0/liblto_plugin.so #{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
+      FileUtils.ln_s("../../libexec/gcc/$(gcc -dumpmachine)/7.4.0/liblto_plugin.so", "#{CREW_DEST_LIB_PREFIX}/bfd-plugins/")
 
       # Make symbolic links
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-7.3 #{CREW_DEST_PREFIX}/bin/cc"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-7.3 #{CREW_DEST_PREFIX}/bin/gcc"
-      system "ln -sv #{CREW_PREFIX}/bin/c++-7.3 #{CREW_DEST_PREFIX}/bin/c++"
-      system "ln -sv #{CREW_PREFIX}/bin/g++-7.3 #{CREW_DEST_PREFIX}/bin/g++"
-      system "ln -sv #{CREW_PREFIX}/bin/cpp-7.3 #{CREW_DEST_PREFIX}/bin/cpp"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-ar-7.3 #{CREW_DEST_PREFIX}/bin/gcc-ar"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-nm-7.3 #{CREW_DEST_PREFIX}/bin/gcc-nm"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-ranlib-7.3 #{CREW_DEST_PREFIX}/bin/gcc-ranlib"
-      system "ln -sv #{CREW_PREFIX}/bin/gcov-7.3 #{CREW_DEST_PREFIX}/bin/gcov"
-      system "ln -sv #{CREW_PREFIX}/bin/gcov-dump-7.3 #{CREW_DEST_PREFIX}/bin/gcov-dump"
-      system "ln -sv #{CREW_PREFIX}/bin/gcov-tool-7.3 #{CREW_DEST_PREFIX}/bin/gcov-tool"
-      system "ln -sv #{CREW_PREFIX}/bin/gfortran-7.3 #{CREW_DEST_PREFIX}/bin/gfortran"
+      FileUtils.ln_s('gcc', "#{CREW_DEST_PREFIX}/bin/cc")
+      FileUtils.ln_s('gcc-7.4', "#{CREW_DEST_PREFIX}/bin/gcc")
+      FileUtils.ln_s('c++-7.4', "#{CREW_DEST_PREFIX}/bin/c++")
+      FileUtils.ln_s('g++-7.4', "#{CREW_DEST_PREFIX}/bin/g++")
+      FileUtils.ln_s('cpp-7.4', "#{CREW_DEST_PREFIX}/bin/cpp")
+      FileUtils.ln_s('gcc-ar-7.4', "#{CREW_DEST_PREFIX}/bin/gcc-ar")
+      FileUtils.ln_s('gcc-nm-7.4', "#{CREW_DEST_PREFIX}/bin/gcc-nm")
+      FileUtils.ln_s('gcc-ranlib-7.4', "#{CREW_DEST_PREFIX}/bin/gcc-ranlib")
+      FileUtils.ln_s('gcov-7.4', "#{CREW_DEST_PREFIX}/bin/gcov")
+      FileUtils.ln_s('gcov-dump-7.4', "#{CREW_DEST_PREFIX}/bin/gcov-dump")
+      FileUtils.ln_s('gcov-tool-7.4', "#{CREW_DEST_PREFIX}/bin/gcov-tool")
+      FileUtils.ln_s('gfortran-7.4', "#{CREW_DEST_PREFIX}/bin/gfortran")
 
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-c++-7.3 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-c++"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-g++-7.3 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-g++"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gcc-7.3 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ar-7.3 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ar"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gcc-nm-7.3 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-nm"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ranlib-7.3 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ranlib"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gfortran-7.3 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gfortran"
+      FileUtils.ln_s("$(gcc -dumpmachine)-c++-7.4", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-c++")
+      FileUtils.ln_s("$(gcc -dumpmachine)-g++-7.4", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-g++")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gcc-7.4", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gcc-ar-7.4", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ar")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gcc-nm-7.4", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-nm")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gcc-ranlib-7.4", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ranlib")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gfortran-7.4", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gfortran")
     end
   end
 end

--- a/packages/gcc8.rb
+++ b/packages/gcc8.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gcc8 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '8.2.0'
+  version '8.2.0-1'
   source_url 'https://ftpmirror.gnu.org/gcc/gcc-8.2.0/gcc-8.2.0.tar.xz'
   source_sha256 '196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080'
 
@@ -20,11 +20,7 @@ class Gcc8 < Package
      x86_64: '6d982f3c35acd3a738e176a3f3b8c4ea093c7be86882153a7711841cf0c80737',
   })
 
-  depends_on 'unzip' => :build
-  depends_on 'gawk' => :build
   depends_on 'dejagnu' => :build # for test
-  depends_on 'gcc7' => :build # gcc version 7.4.0
-  depends_on 'icu4c' => :build # icu version 62.1
   depends_on 'python27' => :build
   depends_on 'python3' => :build
 
@@ -33,7 +29,6 @@ class Gcc8 < Package
   depends_on 'mpfr'
   depends_on 'mpc'
   depends_on 'isl'
-  depends_on 'cloog'
   depends_on 'glibc'
 
   def self.patch
@@ -43,67 +38,45 @@ class Gcc8 < Package
   end
 
   def self.build
-    # previous compile issue
-    # /usr/local/bin/ld: cannot find crti.o: No such file or directory
-    # /usr/local/bin/ld: cannot find /usr/lib64/libc_nonshared.a
-    ENV["LIBRARY_PATH"] = "#{CREW_LIB_PREFIX}"   # fix x86_64 issues
-    system "mkdir -p objdir"
-    Dir.chdir("objdir") do
+    ENV['LIBRARY_PATH'] = CREW_LIB_PREFIX   # fix x86_64 issues
+    FileUtils.mkdir('build')
+    Dir.chdir('build') do
       case ARCH
         when 'armv7l', 'aarch64'
-          system "../configure",
-                 "--prefix=#{CREW_PREFIX}",
+          system '../configure',
+                 '--target=armv7l-cros-linux-gnueabihf',
+                 '--build=armv7l-cros-linux-gnueabihf',
+                 '--host=armv7l-cros-linux-gnueabihf',
                  "--libdir=#{CREW_LIB_PREFIX}",
-                 "--build=armv7l-cros-linux-gnueabihf",
-                 "--host=armv7l-cros-linux-gnueabihf",
-                 "--target=armv7l-cros-linux-gnueabihf",
-                 "--enable-checking=release",
-                 "--disable-multilib",
-                 "--enable-threads=posix",
-                 "--disable-bootstrap",
-                 "--disable-werror",
-                 "--disable-libmpx",
-                 "--enable-static",
-                 "--enable-shared",
-                 "--program-suffix=-8.2",
-                 "--with-arch=armv7-a",
-                 "--with-tune=cortex-a15",
-                 "--with-fpu=neon",
-                 "--with-float=hard"
-        when 'x86_64'
-          system "../configure",
+                 '--enable-checking=release',
                  "--prefix=#{CREW_PREFIX}",
-                 "--libdir=#{CREW_LIB_PREFIX}",
+                 '--enable-languages=all',
+                 '--enable-threads=posix',
+                 '--with-tune=cortex-a15',
+                 '--program-suffix=-8.2',
+                 '--with-arch=armv7-a',
+                 '--with-float=hard',
+                 '--disable-libmpx',
+                 '--enable-static',
+                 '--enable-shared',
+                 '--with-fpu=neon'
+        when 'x86_64', 'i686'
+          system '../configure',
+                 "--target=#{ARCH}-cros-linux-gnu",
                  "--build=#{ARCH}-cros-linux-gnu",
                  "--host=#{ARCH}-cros-linux-gnu",
-                 "--target=#{ARCH}-cros-linux-gnu",
-                 "--enable-checking=release",
-                 "--disable-multilib",
-                 "--enable-threads=posix",
-                 "--disable-bootstrap",
-                 "--disable-werror",
-                 "--disable-libmpx",
-                 "--enable-static",
-                 "--enable-shared",
-                 "--program-suffix=-8.2",
-                 "--with-arch-64=x86-64"
-        when 'i686'
-          system "../configure",
-                 "--prefix=#{CREW_PREFIX}",
                  "--libdir=#{CREW_LIB_PREFIX}",
-                 "--build=#{ARCH}-cros-linux-gnu",
-                 "--host=#{ARCH}-cros-linux-gnu",
-                 "--target=#{ARCH}-cros-linux-gnu",
-                 "--enable-checking=release",
-                 "--disable-multilib",
-                 "--enable-threads=posix",
-                 "--disable-bootstrap",
-                 "--disable-werror",
-                 "--disable-libmpx",
-                 "--enable-static",
-                 "--enable-shared",
-                 "--program-suffix=-8.2",
-                 "--with-arch-32=i686"
+                 '--enable-checking=release',
+                 "--prefix=#{CREW_PREFIX}",
+                 '--enable-languages=all',
+                 '--enable-threads=posix',
+                 '--program-suffix=-8.2',
+                 '--with-arch-64=x86-64',
+                 '--with-arch-32=i686',
+                 '--disable-multilib',
+                 '--disable-libmpx',
+                 '--enable-static',
+                 '--enable-shared'
       end
       system 'make'
     end
@@ -111,50 +84,46 @@ class Gcc8 < Package
 
   # preserve for check, skip check for current version
   def self.check
-    Dir.chdir("objdir") do
-      #system "ulimit -s 32768"
-      #system "make -k check -j8"
-      #system "../contrib/test_summary"
+    Dir.chdir('build') do
+      system 'ulimit -s 32768'
+      system 'make -k check'
+      system '../contrib/test_summary'
     end
   end
 
   def self.install
-    Dir.chdir("objdir") do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    Dir.chdir('build') do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-strip'
 
-      # http://www.linuxfromscratch.org/lfs/view/development/chapter06/gcc.html#contents-gcc
-      # move a misplaced file
-      # The installation stage puts some files used by gdb under the /usr/local/lib(64) directory. This generates spurious error messages when performing ldconfig. This command moves the files to another location.
-      system "mkdir -pv #{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib"
-      system "mv -v #{CREW_DEST_LIB_PREFIX}/*gdb.py #{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib"
+      FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/gdb/auto-load/#{CREW_LIB_PREFIX}")
+      FileUtils.mv(Dir.glob("#{CREW_DEST_LIB_PREFIX}/*gdb.py"), "#{CREW_DEST_PREFIX}/share/gdb/auto-load/#{CREW_LIB_PREFIX}")
 
-      # Install Binary File Descriptor library (BFD)
-      system "install -v -dm755 #{CREW_DEST_LIB_PREFIX}/bfd-plugins"
+      FileUtils.mkdir_p("#{CREW_DEST_LIB_PREFIX}/bfd-plugins")
 
       # Add a compatibility symlink to enable building programs with Link Time Optimization (LTO)
-      system "ln -sfv #{CREW_PREFIX}/libexec/gcc/$(gcc -dumpmachine)/8.2.0/liblto_plugin.so #{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
+      FileUtils.ln_s("../../libexec/gcc/$(gcc -dumpmachine)/8.2.0/liblto_plugin.so", "#{CREW_DEST_LIB_PREFIX}/bfd-plugins/")
 
       # Make symbolic links
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-8.2 #{CREW_DEST_PREFIX}/bin/cc"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-8.2 #{CREW_DEST_PREFIX}/bin/gcc"
-      system "ln -sv #{CREW_PREFIX}/bin/c++-8.2 #{CREW_DEST_PREFIX}/bin/c++"
-      system "ln -sv #{CREW_PREFIX}/bin/g++-8.2 #{CREW_DEST_PREFIX}/bin/g++"
-      system "ln -sv #{CREW_PREFIX}/bin/cpp-8.2 #{CREW_DEST_PREFIX}/bin/cpp"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-ar-8.2 #{CREW_DEST_PREFIX}/bin/gcc-ar"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-nm-8.2 #{CREW_DEST_PREFIX}/bin/gcc-nm"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-ranlib-8.2 #{CREW_DEST_PREFIX}/bin/gcc-ranlib"
-      system "ln -sv #{CREW_PREFIX}/bin/gcov-8.2 #{CREW_DEST_PREFIX}/bin/gcov"
-      system "ln -sv #{CREW_PREFIX}/bin/gcov-dump-8.2 #{CREW_DEST_PREFIX}/bin/gcov-dump"
-      system "ln -sv #{CREW_PREFIX}/bin/gcov-tool-8.2 #{CREW_DEST_PREFIX}/bin/gcov-tool"
-      system "ln -sv #{CREW_PREFIX}/bin/gfortran-8.2 #{CREW_DEST_PREFIX}/bin/gfortran"
+      FileUtils.ln_s('gcc', "#{CREW_DEST_PREFIX}/bin/cc")
+      FileUtils.ln_s('gcc-8.2', "#{CREW_DEST_PREFIX}/bin/gcc")
+      FileUtils.ln_s('c++-8.2', "#{CREW_DEST_PREFIX}/bin/c++")
+      FileUtils.ln_s('g++-8.2', "#{CREW_DEST_PREFIX}/bin/g++")
+      FileUtils.ln_s('cpp-8.2', "#{CREW_DEST_PREFIX}/bin/cpp")
+      FileUtils.ln_s('gcc-ar-8.2', "#{CREW_DEST_PREFIX}/bin/gcc-ar")
+      FileUtils.ln_s('gcc-nm-8.2', "#{CREW_DEST_PREFIX}/bin/gcc-nm")
+      FileUtils.ln_s('gcc-ranlib-8.2', "#{CREW_DEST_PREFIX}/bin/gcc-ranlib")
+      FileUtils.ln_s('gcov-8.2', "#{CREW_DEST_PREFIX}/bin/gcov")
+      FileUtils.ln_s('gcov-dump-8.2', "#{CREW_DEST_PREFIX}/bin/gcov-dump")
+      FileUtils.ln_s('gcov-tool-8.2', "#{CREW_DEST_PREFIX}/bin/gcov-tool")
+      FileUtils.ln_s('gfortran-8.2', "#{CREW_DEST_PREFIX}/bin/gfortran")
 
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-c++-8.2 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-c++"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-g++-8.2 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-g++"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gcc-8.2 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ar-8.2 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ar"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gcc-nm-8.2 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-nm"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ranlib-8.2 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ranlib"
-      system "ln -sv #{CREW_PREFIX}/bin/$(gcc -dumpmachine)-gfortran-8.2 #{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gfortran"
+      FileUtils.ln_s("$(gcc -dumpmachine)-c++-8.2", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-c++")
+      FileUtils.ln_s("$(gcc -dumpmachine)-g++-8.2", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-g++")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gcc-8.2", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gcc-ar-8.2", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ar")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gcc-nm-8.2", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-nm")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gcc-ranlib-8.2", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gcc-ranlib")
+      FileUtils.ln_s("$(gcc -dumpmachine)-gfortran-8.2", "#{CREW_DEST_PREFIX}/bin/$(gcc -dumpmachine)-gfortran")
     end
   end
 end

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -21,7 +21,6 @@ class Llvm < Package
   })
 
   depends_on 'python27' => :build # for test suite
-  depends_on 'graphviz' => :build
   depends_on 'sphinx' => :build
   depends_on 'libedit'
   depends_on 'libtirpc'


### PR DESCRIPTION
`librsvg` is not used in Cairo, and `llvm` can build without GraphViz.

Includes an update to gcc 7 and 8 that uses more Ruby than shell and enables all languages.
Changes `/usr/lib` to `#{CREW_LIB_PREFIX}`.
Uses `Dir.glob` instead of asterisks.
Changes symlinks for gcc 7 from `7.3` to `7.4`.
Makes gcc 7 similar to gcc 8.
Removes unneeded dependencies.