### PR TITLE
Add kcov package

### DIFF
--- a/packages/kcov.rb
+++ b/packages/kcov.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Kcov < Package
+  description 'Kcov is a code coverage tester for compiled programs, Python scripts and shell scripts.'
+  homepage 'http://simonkagstrom.github.io/kcov/'
+  version 'v36'
+  source_url 'https://github.com/SimonKagstrom/kcov/archive/v36.tar.gz'
+  source_sha256 '29ccdde3bd44f14e0d7c88d709e1e5ff9b448e735538ae45ee08b73c19a2ea0b'
+
+  depends_on 'curl'
+
+  def self.build
+    system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
+  end
+end

--- a/packages/kcov.rb
+++ b/packages/kcov.rb
@@ -8,17 +8,23 @@ class Kcov < Package
   source_sha256 '29ccdde3bd44f14e0d7c88d709e1e5ff9b448e735538ae45ee08b73c19a2ea0b'
 
   depends_on 'curl'
+  depends_on 'elfutils'
 
   def self.build
-    system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}"
-    system "make"
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             '-DCMAKE_BUILD_TYPE=Release',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '..'
+      system 'make'
+    end
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
   end
 
-  def self.check
-    system "make", "check"
-  end
 end


### PR DESCRIPTION
This is a request to add kcov to chromebrew.

Kcov is a code coverage tester for compiled programs, Python scripts and shell scripts. It allows collecting code coverage information from executables without special command-line arguments, and continuously produces output from long-running applications.

The main features of kcov are:
* Supports both compiled (ELF / Mach-O) binaries, Python programs and shell scripts (sh/bash)
* Collects code coverage information from binaries directly - no compilation options
* HTML and Cobertura XML output without processing steps
* With Cobertura output, kcov coverage data can be easily integrated in the Jenkins continuous integration server.
* kcov can upload coverage data automatically to coveralls.io, with easy integration into travis-ci.org.
* Shared libraries linked to the application (or opened through dlopen) are transparently covered
* kcov can accumulate data from multiple runs of the same program
* kcov also accumulates data from multiple programs, so that common source code can be analyzed in total
* kcov generates an updated web page every second, so long-running programs can be watched "live"
* kcov allows output to be sorted, either by coverage percentage or filename
* kcov allows specifying paths to include and exclude in the coverage, thereby limiting noise from system header files etc
* kcov allows multiple program coverage to be kept in a single HTML output directory, and will automatically add more programs as they are run
* build-id is automatically used to find source code, when applicable