### PR TITLE
Update GTK packages (gtk2, gtk3, gnome_icon_theme)

### DIFF
--- a/packages/gnome_icon_theme.rb
+++ b/packages/gnome_icon_theme.rb
@@ -3,33 +3,21 @@ require 'package'
 class Gnome_icon_theme < Package
   description 'GNOME Icon Theme'
   homepage 'https://ftp.gnome.org/pub/GNOME/sources/gnome-icon-theme/'
-  version '3.12.0'
+  version '3.12.0-1'
   source_url 'https://ftp.gnome.org/pub/GNOME/sources/gnome-icon-theme/3.12/gnome-icon-theme-3.12.0.tar.xz'
   source_sha256 '359e720b9202d3aba8d477752c4cd11eced368182281d51ffd64c8572b4e503a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_icon_theme-3.12.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_icon_theme-3.12.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_icon_theme-3.12.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_icon_theme-3.12.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '69df3dead88dd49730c8ba282b473a2052ec910a4fb8259f132066d6d55d9c67',
-     armv7l: '69df3dead88dd49730c8ba282b473a2052ec910a4fb8259f132066d6d55d9c67',
-       i686: '0ab623d3e86efa317be11c0774e5c42486796a94be09b49110aaed207e91045e',
-     x86_64: '43f0676b7b5a59eab61f54b3e4213f27e7397c591c77d738349f1cb971886ffd',
   })
 
-  depends_on 'gtk3'
   depends_on 'icon_naming_utils'
 
-  def self.patch
-    # Fixes error when building .po files
-    system "sed -i 's,SUBDIRS = po,SUBDIRS =,' Makefile.in"
-  end
-
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX}"
+    system "./configure",
+           "--prefix=#{CREW_PREFIX}",
+           "--enable-icon-mapping"
     system 'make'
   end
 

--- a/packages/gtk2.rb
+++ b/packages/gtk2.rb
@@ -1,38 +1,33 @@
 require 'package'
 
 class Gtk2 < Package
-  description 'Gtk+ 2.24 graphical user interface library.'
+  description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://www.gtk.org/'
-  version '2.24'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/gtk+/2.24/gtk+-2.24.32.tar.xz'
+  version '2.24.32'
+  source_url 'https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.32.tar.xz'
   source_sha256 'b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd3c7e104ceeb13827016447cfe6f3db5a5c3a8a50fc8be54f67e1893700bd388',
-     armv7l: 'd3c7e104ceeb13827016447cfe6f3db5a5c3a8a50fc8be54f67e1893700bd388',
-       i686: '9d961a6437d896cd1dbde21ebe4a20967ad0267621fbbb7d80cb36309fd7f232',
-     x86_64: '96e236c0057e01ac2790ec5881349a2fa4b6c0821fa3d9ae477a1471f0c1d1af',
   })
 
   depends_on 'gtk_doc'
   depends_on 'atk'
   depends_on 'pango'
-  depends_on 'cairo'
   depends_on 'gdk_pixbuf'
+  depends_on 'cups'
   depends_on 'six' => :build
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "./configure",
+           "--with-gdktarget=x11",
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" # the steps required to install the package
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
   end
 end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -1,47 +1,50 @@
 require 'package'
 
 class Gtk3 < Package
-  description 'Gtk3 is a cross-platform widget toolkit for creating graphical user interfaces.'
+  description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk3/3.0/'
-  version '3.22.29-0'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/gtk+/3.22/gtk+-3.22.29.tar.xz'
-  source_sha256 'a07d64b939fcc034a066b7723fdf9b24e92c9cfb6a8497593f3471fe56fbbbf8'
+  version '3.24.3'
+  source_url 'https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.3.tar.xz'
+  source_sha256 '5708fa534d964b1fb9a69d15758729d51b9a438471d4612dc153f595904803bd'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.22.29-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.22.29-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.22.29-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.22.29-0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bdf7541925c1708e2517346b2138cccd81fabd6a73e3d2eb5d2bc27817b9d90e',
-     armv7l: 'bdf7541925c1708e2517346b2138cccd81fabd6a73e3d2eb5d2bc27817b9d90e',
-       i686: '7cae5db165ff66b908163272e0aac0f361238e0eaed6f04c91ab3f0ebbee2b7b',
-     x86_64: 'f55a4969e7f0ddbeed5586455864d3b83345c1f6b0ef4c2b6fcb000046d56e9d',
   })
 
-  depends_on 'xorg_lib'
   depends_on 'gdk_pixbuf'
+  depends_on 'json_glib'
   depends_on 'libepoxy'
   depends_on 'graphene'
   depends_on 'libxkbcommon'
   depends_on 'at_spi2_atk'
+  depends_on 'gobject_introspection'
+  depends_on 'cups'
+  depends_on 'gnome_icon_theme'
+  depends_on 'hicolor_icon_theme'
+  depends_on 'shared_mime_info'
   depends_on 'six' => :build
 
   def self.build
     system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--enable-broadway-backend",
+           "--enable-cups",
+           "--disable-debug",
            "--enable-x11-backend",
-           "--enable-wayland-backend"
+           "--enable-introspection",
+           "--prefix=#{CREW_PREFIX}",
+           "--enable-wayland-backend",
+           "--enable-broadway-backend",
+           "--libdir=#{CREW_LIB_PREFIX}"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.postinstall
     # generate schemas
-    system "mkdir -p #{CREW_DEST_PREFIX}/share/glib-2.0/schemas"
-    system "glib-compile-schemas #{CREW_DEST_PREFIX}/share/glib-2.0/schemas"
+    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
+    system "update-mime-database #{CREW_PREFIX}/share/mime"
   end
 end


### PR DESCRIPTION
Removes unneeded dependency `gtk3` from `gnome_icon_theme` and switches the dependencies.
Should fix most issues for missing image box in place of image.
