### PR TITLE
Add libvpx, nspr and nss packages

### DIFF
--- a/packages/libvpx.rb
+++ b/packages/libvpx.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Libvpx < Package
+  description 'VP8/VP9 Codec SDK'
+  homepage 'http://www.webmproject.org/code/'
+  version '1.8.0'
+  source_url 'https://github.com/webmproject/libvpx/archive/v1.8.0.tar.gz'
+  source_sha256 '86df18c694e1c06cc8f83d2d816e9270747a0ce6abe316e93a4f4095689373f6'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libvpx-1.8.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libvpx-1.8.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libvpx-1.8.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libvpx-1.8.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '33b8d61c591e0f0dfb0770c4ad9227e4a8f8dbf608a68561ad99813063a6934a',
+     armv7l: '33b8d61c591e0f0dfb0770c4ad9227e4a8f8dbf608a68561ad99813063a6934a',
+       i686: 'afc67c6dbc8c12fa6bd2d7a91e34518119dce03e45e8e8554b4beb670a54b71b',
+     x86_64: '9d4aba4937495ec10fe02e6255689280019a30b8db4fbb11826be7c896e1e40c',
+  })
+
+  def self.build
+    Dir.chdir 'build' do
+      system '../configure',
+             "--prefix=#{CREW_PREFIX}",
+             "--libdir=#{CREW_LIB_PREFIX}",
+             '--enable-vp8',
+             '--enable-vp9',
+             '--enable-shared',
+             '--disable-static'
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    end
+  end
+end

--- a/packages/nspr.rb
+++ b/packages/nspr.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Nspr < Package
+  description 'Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc-like functions.'
+  homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR'
+  version '4.20'
+  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_42_RTM/src/nss-3.42-with-nspr-4.20.tar.gz'
+  source_sha256 '59a0f6f4209b4066702c20c75d6b5531c92b6b3a7bc938b56aa3891c808860dd'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.20-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.20-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.20-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.20-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '26aeff4a3365e980c18d543bddd9d5b2fc6f33a599ba66cb22e1c47538c34ac2',
+     armv7l: '26aeff4a3365e980c18d543bddd9d5b2fc6f33a599ba66cb22e1c47538c34ac2',
+       i686: 'c8356ba7dd10bc68bebc4ca67988f234d095fc1823999a1bc2135f81aa29586b',
+     x86_64: '3632fc729b387d06d9f4b551278f120c56549af288dcd1d78267a5df140fe031',
+  })
+
+  def self.build
+    Dir.chdir 'nspr' do
+      case ARCH
+      when 'x86_64'
+        system './configure',
+               "--prefix=#{CREW_PREFIX}",
+               "--libdir=#{CREW_LIB_PREFIX}",
+               '--enable-64bit'
+      else
+        system './configure',
+               "--prefix=#{CREW_PREFIX}",
+               "--libdir=#{CREW_LIB_PREFIX}"
+     end
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'nspr' do
+      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    end
+  end
+end

--- a/packages/nss.rb
+++ b/packages/nss.rb
@@ -1,0 +1,39 @@
+require 'package'
+
+class Nss < Package
+  description 'Network Security Services (NSS) is a set of libraries designed to support cross-platform development of security-enabled client and server applications.'
+  homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS'
+  version '3.42'
+  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_42_RTM/src/nss-3.42-with-nspr-4.20.tar.gz'
+  source_sha256 '59a0f6f4209b4066702c20c75d6b5531c92b6b3a7bc938b56aa3891c808860dd'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.42-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.42-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.42-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.42-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '9181501ed99d339989be2aaa11fe69cc0a5317b13bfadf95e6924d497e8d13c7',
+     armv7l: '9181501ed99d339989be2aaa11fe69cc0a5317b13bfadf95e6924d497e8d13c7',
+       i686: '69644e80b3127dcfc4a20e3353dd194297c427c9a37bbbbae1a9482c9cb45961',
+     x86_64: 'b7444bf704022a0bf2f6efe785bbf65b5ed12479a0c1d03e89500b1d19652e00',
+  })
+
+  depends_on 'gyp' => :build
+  depends_on 'meson' => :build
+  depends_on 'nspr'
+  depends_on 'sqlite'
+
+  def self.build
+    Dir.chdir 'nss' do
+      system "CPPFLAGS='-I#{CREW_PREFIX}/include/nspr' ./build.sh --opt --gcc --system-nspr --system-sqlite"
+    end
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}"
+    system "mv dist/Release/lib dist/Release/#{ARCH_LIB}" unless "#{ARCH_LIB}" == "lib"
+    system "cp -a dist/Release/* #{CREW_DEST_PREFIX}"
+  end
+end


### PR DESCRIPTION
- libvpx is a webm VP8/VP9 Codec SDK.  See http://www.webmproject.org/code/.
- Network Security Services (NSS) is a set of libraries designed to support cross-platform development of security-enabled client and server applications.  See https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS.
- Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc-like functions.  See https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR.

Tested on all architectures.