### PR TITLE
Update google_cloud_sdk from 228.0.0 to 236.0.0

### DIFF
--- a/packages/google_cloud_sdk.rb
+++ b/packages/google_cloud_sdk.rb
@@ -3,15 +3,15 @@ require 'package'
 class Google_cloud_sdk < Package
   description 'Command-line interface for Google Cloud Platform products and services'
   homepage 'https://cloud.google.com/sdk/'
-  version '228.0.0'
+  version '236.0.0'
 
   case ARCH
   when 'i686'
-    source_url 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-228.0.0-linux-x86.tar.gz'
-    source_sha256 '24f5909f3928384150883a8e33447f3a6881a846fedacdd2dbe5af308e915f76'
+    source_url 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-236.0.0-linux-x86.tar.gz'
+    source_sha256 '6ea8595dff4926318e408879ef2ac46329b470d6ed76010ae19bfa6aaad5cdee'
   when 'x86_64'
-    source_url 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-228.0.0-linux-x86_64.tar.gz'
-    source_sha256 'e4876cedf2af338a0c853f4cf97aa88e18173117ed4f59c93c9d25239ac3ade3'
+    source_url 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-236.0.0-linux-x86_64.tar.gz'
+    source_sha256 'cfa7ff7c67d58d5b1bd2ae623a007c23d94937d8bc898b7933c647c660860659'
   end
 
   binary_url ({


### PR DESCRIPTION
Works on my chromebook `x86_64`, not sure about `aarch64`
