### PR TITLE
Add bash_completion support for git

### DIFF
--- a/packages/bash_completion_git.rb
+++ b/packages/bash_completion_git.rb
@@ -1,0 +1,16 @@
+require 'package'
+
+class Bash_completion_git < Package
+  description 'Adds completion for git to package bash_completion'
+  homepage 'https://github.com/git/git'
+  version '2.21'
+  source_url 'https://raw.githubusercontent.com/git/git/8104ec994ea3849a968b4667d072fedd1e688642/contrib/completion/git-completion.bash'
+  source_sha256 '54bfe8b6a61062c462d15d6c483ece622d3716ad7806fdc40c4d0f576cae67cd'
+
+  depends_on 'bash_completion'
+
+  def self.install
+    system 'cp', "#{CREW_BREW_DIR}/git-completion.bash", './git'
+    system 'install', '-Dm644', 'git', "#{CREW_DEST_PREFIX}/share/bash-completion/completions/git"
+  end
+end


### PR DESCRIPTION
### For some reason git seems not be worthy for upstream bash_completion.

Though trivial it my first package submission :). 

### Issues
I went through `crew` and the Package class, however it seems there is no easy way around tar? 
