### PR TITLE
Add pre-built binaries for bdwgc, libatomic_ops, neofetch and tinycc packages

### DIFF
--- a/packages/bdwgc.rb
+++ b/packages/bdwgc.rb
@@ -8,8 +8,16 @@ class Bdwgc < Package
   source_sha256 '436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bdwgc-8.0.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bdwgc-8.0.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bdwgc-8.0.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bdwgc-8.0.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '876731fcfc8923fb084dceaed37bb98c6a74db13b526b38a3b3b6fa8dd5393c9',
+     armv7l: '876731fcfc8923fb084dceaed37bb98c6a74db13b526b38a3b3b6fa8dd5393c9',
+       i686: 'be933d4e732ba200b3c3c0bea9c163552cabe118d157d02b713e21dbc896eac2',
+     x86_64: '3195a44840152f6e67ca5f8f27118186af4422d7ab145e0276aa0af4dfd84378',
   })
 
   depends_on 'libatomic_ops'

--- a/packages/libatomic_ops.rb
+++ b/packages/libatomic_ops.rb
@@ -8,8 +8,16 @@ class Libatomic_ops < Package
   source_sha256 '587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libatomic_ops-7.6.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libatomic_ops-7.6.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libatomic_ops-7.6.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libatomic_ops-7.6.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '0844abb0df05ad6c0f9b72b0cbb5e20bb51e4d8c8e9889e44a146aa38693d3ff',
+     armv7l: '0844abb0df05ad6c0f9b72b0cbb5e20bb51e4d8c8e9889e44a146aa38693d3ff',
+       i686: 'bf9998a0696908b73023aec0c8cfa08f25d083184355958d96b3f8655f510293',
+     x86_64: 'f5a1470043d79aca3925da878ff395d3bdcad179d3ed308f4aea4e0f55cf348c',
   })
 
   def self.build

--- a/packages/neofetch.rb
+++ b/packages/neofetch.rb
@@ -7,6 +7,19 @@ class Neofetch < Package
   source_url 'https://github.com/dylanaraps/neofetch/archive/6.0.0.tar.gz'
   source_sha256 '264a7689561bb498f97f10231959bdd8f7c873671bac2ffb660de9a5863b1c76'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/neofetch-6.0.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/neofetch-6.0.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/neofetch-6.0.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/neofetch-6.0.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '4913ca13f21e57c9d7410a4bb1265efd43d7c4aedda8429ad5a5f6fe7b6f8bc2',
+     armv7l: '4913ca13f21e57c9d7410a4bb1265efd43d7c4aedda8429ad5a5f6fe7b6f8bc2',
+       i686: '4865152e558fc7b45c945fb54a65486f80afd80efff80fcee4922b3962496d2e',
+     x86_64: '4c8f2e53031f299c5933d5442d7caafc6647bfd4eaa3f97434d93c9387c3a757',
+  })
+
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", "PREFIX=#{CREW_PREFIX}", 'install'
   end

--- a/packages/tinycc.rb
+++ b/packages/tinycc.rb
@@ -8,8 +8,16 @@ class Tinycc < Package
   source_sha256 'de23af78fca90ce32dff2dd45b3432b2334740bb9bb7b05bf60fdbfc396ceb9c'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tinycc-0.9.27-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tinycc-0.9.27-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tinycc-0.9.27-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tinycc-0.9.27-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '029ba25378599e4fe2f4b17d1106f33dc0638fba4a993053eb75de8790a1fafc',
+     armv7l: '029ba25378599e4fe2f4b17d1106f33dc0638fba4a993053eb75de8790a1fafc',
+       i686: 'b403d10c7ee490f1769fef31a83cb75a0dbb26befc75a25fd290e796bdd45798',
+     x86_64: 'cff32a0b7312e376565d3b380e8d933c6e979caa940e64bc12872f6e2673c6be',
   })
 
   def self.patch


### PR DESCRIPTION
Tested on all architectures.