### PR TITLE
Revert "Fixes #3205: only expand real archives"

### DIFF
--- a/crew
+++ b/crew
@@ -441,20 +441,25 @@ def download
 end
 
 def unpack (meta)
-  extract_dir = "#{meta[:filename]}.dir"
+  extract_dir = meta[:filename]+ '.dir'
   target_dir = nil
   Dir.chdir CREW_BREW_DIR do
-    Dir.mkdir("#{extract_dir}") unless Dir.exist?("#{extract_dir}")
-    case File.basename meta[:filename]
-    when /\.zip$/i
-      puts "Unpacking archive using 'unzip', this may take a while..."
-      _verbopt = @opt_verbose ? 'v' : 'qq'
-      system "unzip", _verbopt, "-d", "#{extract_dir}", meta[:filename]
-    when /\.(tar(\.(gz|bz2|xz))?|tgz|tbz)$/i
-      puts "Unpacking archive using 'tar', this may take a while..."
-      _verbopt = @opt_verbose ? 'v' : ''
-      system "tar", "x#{_verbopt}f", meta[:filename], "-C", "#{extract_dir}"
-   end
+    puts "Unpacking archive, this may take a while..."
+    Dir.mkdir(extract_dir) unless Dir.exist?(extract_dir)
+    case File.extname meta[:filename]
+    when '.zip'
+      if @opt_verbose then
+        system "unzip", "-v", "-d", "#{extract_dir}", meta[:filename]
+      else
+        system "unzip", "-qq", "-d", "#{extract_dir}", meta[:filename]
+      end
+    else
+      if @opt_verbose then
+        system "tar", "xvf", meta[:filename], "-C", "#{extract_dir}"
+      else
+        system "tar", "xf", meta[:filename], "-C", "#{extract_dir}"
+      end
+    end
     if meta[:source] == true
       # Check the number of directories in the archive
       entries = Dir["#{extract_dir}/*"]


### PR DESCRIPTION
This has been causing issues ever since it was merged,
including but not limited to: screwing up `.zip` files,
not unpacking `.tar.lz` files, and other bugs.