### PR TITLE
Fix issue where gcc8 depends on gcc7 and vice versa

### DIFF
--- a/packages/gcc7.rb
+++ b/packages/gcc7.rb
@@ -23,7 +23,6 @@ class Gcc7 < Package
   depends_on 'unzip' => :build
   depends_on 'gawk' => :build
   depends_on 'dejagnu' => :build # for test
-  depends_on 'gcc8' => :build # gcc version 8.2.0
   depends_on 'icu4c' => :build # icu version 62.1
   depends_on 'python27' => :build
   depends_on 'python3' => :build

--- a/packages/gcc8.rb
+++ b/packages/gcc8.rb
@@ -23,7 +23,6 @@ class Gcc8 < Package
   depends_on 'unzip' => :build
   depends_on 'gawk' => :build
   depends_on 'dejagnu' => :build # for test
-  depends_on 'gcc7' => :build # gcc version 7.4.0
   depends_on 'icu4c' => :build # icu version 62.1
   depends_on 'python27' => :build
   depends_on 'python3' => :build


### PR DESCRIPTION
This issue causes any and all packages installed with `-S`
to depend on a version of GCC that's not installed.
It also breaks the dual-versioning support scheme.