### PR TITLE
Update php packages

### DIFF
--- a/packages/php.rb
+++ b/packages/php.rb
@@ -3,7 +3,7 @@ require 'package'
 class Php < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.40-7.3.3'
+  version '5.6.40-7.3.4'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -12,85 +12,85 @@ class Php < Package
     puts "Enter the PHP version to install:"
     puts "5.6 = PHP 5.6.40"
     puts "7.0 = PHP 7.0.33"
-    puts "7.1 = PHP 7.1.27"
-    puts "7.2 = PHP 7.2.16"
-    puts "7.3 = PHP 7.3.3"
+    puts "7.1 = PHP 7.1.28"
+    puts "7.2 = PHP 7.2.17"
+    puts "7.3 = PHP 7.3.4"
     puts "  0 = Cancel"
 
     while version = STDIN.gets.chomp
       case version
       when '5.6'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-1-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-1-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-1-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-1-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '2c856f39c5bea81c5ffd1b0fc57a5046c9987cf44304e1b4b7a9b3f5c8249f6f',
-           armv7l: '2c856f39c5bea81c5ffd1b0fc57a5046c9987cf44304e1b4b7a9b3f5c8249f6f',
-             i686: '0fe21893525eeb70f2d7f075738e57f9d8edb5ead85e8c5b09de188b244c6a34',
-           x86_64: '26b5cc993b96db0bb251db8b5ed54d1b2f25c6c8f81b91e50bef35b4fc62d9ad',
+          aarch64: 'c70edbf5ed87c65852ebae34aa83273e810b6727e630b7416d2ee68d56722398',
+           armv7l: 'c70edbf5ed87c65852ebae34aa83273e810b6727e630b7416d2ee68d56722398',
+             i686: '58320b4a5e73dbc5d028bc0969f28fd606e7aa6b2367aa2cf8b61fc043ce8740',
+           x86_64: '5e7f5461af3627f086a84bc62a26de7cdc907493244fbecd65be02c6ad9869bb',
         })
         $ver = 5
         break
       when '7.0'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-1-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-1-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-1-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.0.33-1-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '0f265657ebc48ef210a5058e619a5819b34cde3c87ed1d8bd16795425acee36d',
-           armv7l: '0f265657ebc48ef210a5058e619a5819b34cde3c87ed1d8bd16795425acee36d',
-             i686: 'b61e1dc6dd810e57d0737a555000933efbc04e421643a775361cbf191afa1188',
-           x86_64: 'b58ecb0ba8ba6b8310a7c9060e5ff5f64c3fdc11e23285fab4cebbda6704e5c9',
+          aarch64: '4b1a64041ce564014c9318ec4697796c783caac0689489c21f90d41d338dc753',
+           armv7l: '4b1a64041ce564014c9318ec4697796c783caac0689489c21f90d41d338dc753',
+             i686: 'adce0459926b85882ee5d2dd5801a4d062eec3f63abf893a12da9a30a8b4d738',
+           x86_64: 'a55e3ee6889347fe5065ccb2d16fd19e783c612661a8985f0040e1a5443b5368',
         })
         $ver = 7
         break
       when '7.1'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.27-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.27-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.27-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.27-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.28-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.28-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.28-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.1.28-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '19e231864e33ac1f7d676ad88d042b87998f7b29bf659dd6f8f5c977a3a7d5b8',
-           armv7l: '19e231864e33ac1f7d676ad88d042b87998f7b29bf659dd6f8f5c977a3a7d5b8',
-             i686: '4810da96a1325ad9a3f1212a86636625ed0ea2b07db0ec47af420e5002e16376',
-           x86_64: '70e8e4ea5c7d407e63b4a4acabd450cec8844ea488bea7ec843f72ada2280d4c',
+          aarch64: '9ea62e3401003510c4ac490859d1f68a8e5464eed9eb80b2ef46d58931b88808',
+           armv7l: '9ea62e3401003510c4ac490859d1f68a8e5464eed9eb80b2ef46d58931b88808',
+             i686: 'e1039b896be6b3abbaebac5a21bb99b07cc7525305362a1fb0727d736cf321be',
+           x86_64: '27bf2057cb6b9d060f50f76c06f50c09c08c7f9d754f95d5e2b2d64bcd513750',
         })
         $ver = 7
         break
       when '7.2'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.16-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.16-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.16-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.16-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.17-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.17-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.17-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.17-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: '369005b949a43d6c2206e92d3cf9509f3adcc82aedc183282cdaae75531c1af0',
-           armv7l: '369005b949a43d6c2206e92d3cf9509f3adcc82aedc183282cdaae75531c1af0',
-             i686: '565ee9d8e5eb4dc6a4c7b5f20a5f879a63d4493d60af0fcbc12e58b2502cd886',
-           x86_64: 'e88d57c9ae18d50f3e91bc4973efb2f5d253cfdd764da894305254e20ab91b4d',
+          aarch64: 'aba9f4b68ac33a105bb135d71a40bc7f777aa27d6f8199ed3f8fa52dd2e7caf8',
+           armv7l: 'aba9f4b68ac33a105bb135d71a40bc7f777aa27d6f8199ed3f8fa52dd2e7caf8',
+             i686: '1a43bd9bade0d298840eb2cc4f6f84ad060b5ba36da3dba50d9170fcee803cec',
+           x86_64: '828c4a9f5960e7fd9bce9b7dccc4256520120deb36ac9aa8c6ffb4a947836ee1',
         })
         $ver = 7
         break
       when '7.3'
         binary_url ({
-          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.3-chromeos-armv7l.tar.xz',
-           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.3-chromeos-armv7l.tar.xz',
-             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.3-chromeos-i686.tar.xz',
-           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.3-chromeos-x86_64.tar.xz',
+          aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.4-chromeos-armv7l.tar.xz',
+           armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.4-chromeos-armv7l.tar.xz',
+             i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.4-chromeos-i686.tar.xz',
+           x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.4-chromeos-x86_64.tar.xz',
         })
         binary_sha256 ({
-          aarch64: 'a453903edea22a488a4277ee58c6a3e1adfaa2e9536545c10d8199651c98bc54',
-           armv7l: 'a453903edea22a488a4277ee58c6a3e1adfaa2e9536545c10d8199651c98bc54',
-             i686: 'bcc55c2ba85eae16af280990edf5067d38fef46e892682a2234b1b76af7f32b1',
-           x86_64: '5bc9a88a0f5349565922796b9cd1aaa6a95ade072691cb6d0847094fa26c8a55',
+          aarch64: 'c947e49208bf12a9ff30fc271d049c3207bee9f66b79f4b1baaf11c82b88255c',
+           armv7l: 'c947e49208bf12a9ff30fc271d049c3207bee9f66b79f4b1baaf11c82b88255c',
+             i686: '9549a8c69b3c3a31a47d29c188d41fbe3566682f8780bf357c4be3123a674b03',
+           x86_64: '483cc2241d4aec2d4d236dc5383096db99c4d2c53b65399503edf455499de2ca',
         })
         $ver = 7
         break
@@ -103,7 +103,6 @@ class Php < Package
     end
   end
 
-  depends_on 'readline7'
   depends_on 'libgcrypt'
   depends_on 'libxslt'
   depends_on 'libzip'

--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -3,24 +3,23 @@ require 'package'
 class Php5 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.40'
+  version '5.6.40-1'
   source_url 'http://php.net/distributions/php-5.6.40.tar.xz'
   source_sha256 '1369a51eee3995d7fbd1c5342e5cc917760e276d561595b6052b21ace2656d1c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php5-5.6.40-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '2c856f39c5bea81c5ffd1b0fc57a5046c9987cf44304e1b4b7a9b3f5c8249f6f',
-     armv7l: '2c856f39c5bea81c5ffd1b0fc57a5046c9987cf44304e1b4b7a9b3f5c8249f6f',
-       i686: '0fe21893525eeb70f2d7f075738e57f9d8edb5ead85e8c5b09de188b244c6a34',
-     x86_64: '26b5cc993b96db0bb251db8b5ed54d1b2f25c6c8f81b91e50bef35b4fc62d9ad',
+    aarch64: 'c70edbf5ed87c65852ebae34aa83273e810b6727e630b7416d2ee68d56722398',
+     armv7l: 'c70edbf5ed87c65852ebae34aa83273e810b6727e630b7416d2ee68d56722398',
+       i686: '58320b4a5e73dbc5d028bc0969f28fd606e7aa6b2367aa2cf8b61fc043ce8740',
+     x86_64: '5e7f5461af3627f086a84bc62a26de7cdc907493244fbecd65be02c6ad9869bb',
   })
 
-  depends_on 'readline7'
   depends_on 'libgcrypt'
   depends_on 'libpng'
   depends_on 'libxslt'
@@ -53,43 +52,43 @@ class Php5 < Package
   end
 
   def self.build
-    system "./configure \
-      --prefix=#{CREW_PREFIX} \
-      --docdir=#{CREW_PREFIX}/doc \
-      --infodir=#{CREW_PREFIX}/info \
-      --libdir=#{CREW_LIB_PREFIX} \
-      --localstatedir=#{CREW_PREFIX}/tmp \
-      --mandir=#{CREW_PREFIX}/man \
-      --sbindir=#{CREW_PREFIX}/bin \
-      --with-config-file-path=#{CREW_PREFIX}/etc \
-      --with-libdir=#{ARCH_LIB} \
-      --with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype \
-      --enable-exif \
-      --enable-fpm \
-      --enable-ftp \
-      --enable-mbstring \
-      --enable-opcache \
-      --enable-pcntl \
-      --enable-sockets \
-      --enable-shared \
-      --enable-shmop \
-      --enable-zip \
-      --with-bz2 \
-      --with-curl \
-      --with-gd \
-      --with-gettext \
-      --with-gmp \
-      --with-libzip \
-      --with-mysqli \
-      --with-openssl \
-      --with-pdo-mysql \
-      --with-pear \
-      --with-pcre-regex \
-      --with-readline \
-      --with-tidy \
-      --with-unixODBC \
-      --with-xsl \
-      --with-zlib"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--docdir=#{CREW_PREFIX}/doc",
+           "--infodir=#{CREW_PREFIX}/info",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           "--localstatedir=#{CREW_PREFIX}/tmp",
+           "--mandir=#{CREW_PREFIX}/man",
+           "--sbindir=#{CREW_PREFIX}/bin",
+           "--with-config-file-path=#{CREW_PREFIX}/etc",
+           "--with-libdir=#{ARCH_LIB}",
+           "--with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype",
+           '--enable-exif',
+           '--enable-fpm',
+           '--enable-ftp',
+           '--enable-mbstring',
+           '--enable-opcache',
+           '--enable-pcntl',
+           '--enable-sockets',
+           '--enable-shared',
+           '--enable-shmop',
+           '--enable-zip',
+           '--with-bz2',
+           '--with-curl',
+           '--with-gd',
+           '--with-gettext',
+           '--with-gmp',
+           '--with-libzip',
+           '--with-mysqli',
+           '--with-openssl',
+           '--with-pdo-mysql',
+           '--with-pear',
+           '--with-pcre-regex',
+           '--with-readline',
+           '--with-tidy',
+           '--with-unixODBC',
+           '--with-xsl',
+           '--with-zlib'
     system 'make'
   end
 

--- a/packages/php7.rb
+++ b/packages/php7.rb
@@ -3,24 +3,23 @@ require 'package'
 class Php7 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.2.16'
-  source_url 'https://php.net/distributions/php-7.2.16.tar.xz'
-  source_sha256 '7d91ed3c1447c6358a3d53f84599ef854aca4c3622de7435e2df115bf196e482'
+  version '7.3.4'
+  source_url 'https://php.net/distributions/php-7.3.4.tar.xz'
+  source_sha256 '6fe79fa1f8655f98ef6708cde8751299796d6c1e225081011f4104625b923b83'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.16-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.16-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.16-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.2.16-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php7-7.3.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '369005b949a43d6c2206e92d3cf9509f3adcc82aedc183282cdaae75531c1af0',
-     armv7l: '369005b949a43d6c2206e92d3cf9509f3adcc82aedc183282cdaae75531c1af0',
-       i686: '565ee9d8e5eb4dc6a4c7b5f20a5f879a63d4493d60af0fcbc12e58b2502cd886',
-     x86_64: 'e88d57c9ae18d50f3e91bc4973efb2f5d253cfdd764da894305254e20ab91b4d',
+    aarch64: 'c947e49208bf12a9ff30fc271d049c3207bee9f66b79f4b1baaf11c82b88255c',
+     armv7l: 'c947e49208bf12a9ff30fc271d049c3207bee9f66b79f4b1baaf11c82b88255c',
+       i686: '9549a8c69b3c3a31a47d29c188d41fbe3566682f8780bf357c4be3123a674b03',
+     x86_64: '483cc2241d4aec2d4d236dc5383096db99c4d2c53b65399503edf455499de2ca',
   })
 
-  depends_on 'readline7'
   depends_on 'libgcrypt'
   depends_on 'libxslt'
   depends_on 'libzip'


### PR DESCRIPTION
- Update php7 from 7.1.27 to 7.1.28
- Update php7 from 7.2.16 to 7.2.17
- Update php7 from 7.3.3 to 7.3.4
- Recompile php5 and php7 for the new readline version
- Add pre-built binaries
- Tested on all architectures

Depends on #3238.