### PR TITLE
Add support for HTTP/2 in curl

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,26 +3,27 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.haxx.se/'
-  version '7.64.0'
-  source_url 'https://curl.haxx.se/download/curl-7.64.0.tar.xz'
-  source_sha256 '2f2f13fa34d44aa29cb444077ad7dc4dc6d189584ad552e0aaeb06e608af6001'
+  version '7.64.1'
+  source_url 'https://curl.haxx.se/download/curl-7.64.1.tar.xz'
+  source_sha256 '9252332a7f871ce37bfa7f78bdd0a0e3924d8187cc27cb57c76c9474a7168fb3'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.64.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.64.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.64.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.64.0-chromeos-x86_64.tar.xz',
+    aarch64: '',
+     armv7l: '',
+       i686: '',
+     x86_64: '',
   })
   binary_sha256 ({
-    aarch64: 'e3123c63a71a6a326f722c4c43d0c2f872e6dd98f2a5aa48eed5e7a5f2cebd4d',
-     armv7l: 'e3123c63a71a6a326f722c4c43d0c2f872e6dd98f2a5aa48eed5e7a5f2cebd4d',
-       i686: '63ae5ac6beaf62b07efb626e73f66e6ee60e650242cc1d56f874c780b3110411',
-     x86_64: '68b0f48be8feefe01582c7fe05ef549d0fd63b581ab5d2821226f5d04c6c3dbe',
+    aarch64: '',
+     armv7l: '',
+       i686: '',
+     x86_64: '',
   })
 
   depends_on 'groff' => :build
   depends_on 'brotli'
   depends_on 'libmetalink'
+  depends_on 'libnghttp2'
   depends_on 'libtirpc'
   depends_on 'openldap'
   depends_on 'rtmpdump'
@@ -39,6 +40,7 @@ class Curl < Package
       '--disable-static',
       '--disable-debug',
       '--with-libssh2',
+      '--with-nghttp2',
       '--with-brotli',
       '--enable-ldap',
       '--with-ssl'
@@ -49,7 +51,4 @@ class Curl < Package
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
-  def self.check
-#    system 'make', 'test'
-  end
 end

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Libnghttp2 < Package
+  description 'library implementing HTTP/2 protocol'
+  homepage 'https://nghttp2.org/'
+  version '1.38.0'
+  source_url 'https://github.com/nghttp2/nghttp2/releases/download/v1.38.0/nghttp2-1.38.0.tar.xz'
+  source_sha256 'ef75c761858241c6b4372fa6397aa0481a984b84b7b07c4ec7dc2d7b9eee87f8'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system './configure',
+      "--prefix=#{CREW_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+end


### PR DESCRIPTION
## Description
Add support for HTTP/2 protocol in curl

## Additional information

Works properly:
- [x] x86_64

I didn't put the binary versions as I can't push to bintray. AlsoI removed the sha256 of curl binaries to remember to change them when curl is recompiled.