### PR TITLE
Update emacs and gemacs to 26.2 and use gtk+ v3 instead of lucid

### DIFF
--- a/packages/emacs.rb
+++ b/packages/emacs.rb
@@ -3,25 +3,20 @@ require 'package'
 class Emacs < Package
   description 'An extensible, customizable, free/libre text editor - and more.'
   homepage 'http://www.gnu.org/software/emacs/'
-  version '26.1-1'
-  source_url 'https://ftp.gnu.org/gnu/emacs/emacs-26.1.tar.xz'
-  source_sha256 '1cf4fc240cd77c25309d15e18593789c8dbfba5c2b44d8f77c886542300fd32c'
+  version '26.2'
+  source_url 'https://ftp.gnu.org/gnu/emacs/emacs-26.2.tar.xz'
+  source_sha256 '151ce69dbe5b809d4492ffae4a4b153b2778459de6deb26f35691e1281a9c58e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-26.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-26.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-26.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-26.1-1-chromeos-x86_64.tar.xz',
+    
   })
   binary_sha256 ({
-    aarch64: 'f932a0b4ef4e33e230abd07d39ba12e6661304b2baaddacc5f03470d355dd021',
-     armv7l: 'f932a0b4ef4e33e230abd07d39ba12e6661304b2baaddacc5f03470d355dd021',
-       i686: 'd5b9fed4b9f42e04da7b326d339e23a1b6cf0367885a413e5dfbff4f90c9feef',
-     x86_64: '20adfa13c8b999da71d4efe1c6e86521ad83481e1d593bdcab20eac5c2cb589e',
+    
   })
 
   depends_on 'lcms'
   depends_on 'libjpeg'
+  depends_on 'libpng'
 
   def self.build
     system "./configure \

--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -3,27 +3,23 @@ require 'package'
 class Gemacs < Package
   description 'An extensible, customizable, free/libre text editor - and more.'
   homepage 'http://www.gnu.org/software/emacs/'
-  version '26.1'
-  source_url 'https://ftp.gnu.org/gnu/emacs/emacs-26.1.tar.xz'
-  source_sha256 '1cf4fc240cd77c25309d15e18593789c8dbfba5c2b44d8f77c886542300fd32c'
+  version '26.2'
+  source_url 'https://ftp.gnu.org/gnu/emacs/emacs-26.2.tar.xz'
+  source_sha256 '151ce69dbe5b809d4492ffae4a4b153b2778459de6deb26f35691e1281a9c58e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.1-chromeos-x86_64.tar.xz',
+
   })
   binary_sha256 ({
-    aarch64: '4ded760607b64f706cc83b92042609845f8213a697bc82a931f04ddcf1c94a17',
-     armv7l: '4ded760607b64f706cc83b92042609845f8213a697bc82a931f04ddcf1c94a17',
-       i686: 'f8c514abd49a4a8aefa6235918d442d75d1a722e9558cd741246769cfeb9c8da',
-     x86_64: '7d646d49bec0acf2c7eb79ff589c6f311537233565f43646dafa927de1adbb8c',
+
   })
 
   depends_on 'emacs'
   depends_on 'giflib'
   depends_on 'libjpeg'
+  depends_on 'libpng'
   depends_on 'libtiff'
+  depends_on 'imagemagick6'
   depends_on 'sommelier'
 
   def self.build
@@ -31,10 +27,11 @@ class Gemacs < Package
             --prefix=#{CREW_PREFIX} \
             --localstatedir=#{CREW_PREFIX}/share \
             --with-x=yes \
-            --with-x-toolkit=lucid \
+            --with-x-toolkit=gtk3 \
             --with-gif=yes \
-            --without-makeinfo \
-            --without-selinux"
+	    --with-jpeg=yes \
+	    --with-png=yes \
+	    --with-rsvg=yes" 
     system 'make'
   end
 
@@ -42,6 +39,6 @@ class Gemacs < Package
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     system "rm -rf #{CREW_DEST_DIR}"
     system "install -Dm755 src/emacs #{CREW_DEST_PREFIX}/bin/gemacs"
-    system "install -Dm755 src/emacs-26.1.1 #{CREW_DEST_PREFIX}/bin/gemacs-26.1.1"
+    system "install -Dm755 src/emacs-26.2.1 #{CREW_DEST_PREFIX}/bin/gemacs-26.2.1"
   end
 end

--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -14,10 +14,8 @@ class Gemacs < Package
 
   })
 
-  depends_on 'lcms'
+  depends_on 'emacs'
   depends_on 'giflib'
-  depends_on 'libjpeg'
-  depends_on 'libpng'
   depends_on 'libtiff'
   depends_on 'imagemagick6'
   depends_on 'sommelier'
@@ -36,7 +34,6 @@ class Gemacs < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     system "install -Dm755 src/emacs #{CREW_DEST_PREFIX}/bin/gemacs"
     system "install -Dm755 src/emacs-26.2.1 #{CREW_DEST_PREFIX}/bin/gemacs-26.2.1"
   end

--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -14,7 +14,7 @@ class Gemacs < Package
 
   })
 
-  depends_on 'emacs'
+  depends_on 'lcms'
   depends_on 'giflib'
   depends_on 'libjpeg'
   depends_on 'libpng'
@@ -37,7 +37,6 @@ class Gemacs < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    system "rm -rf #{CREW_DEST_DIR}"
     system "install -Dm755 src/emacs #{CREW_DEST_PREFIX}/bin/gemacs"
     system "install -Dm755 src/emacs-26.2.1 #{CREW_DEST_PREFIX}/bin/gemacs-26.2.1"
   end


### PR DESCRIPTION
Fixes #3253 

I previously had troubles with menu-bar fonts using emacs and gemacs 26.1 compiled with lucid. I managed to have a full running emacs and gemacs using 26.2 and gtk+ v3 which allows to display images and manage fonts in a functional way.