### PR TITLE
Add mcelog package

### DIFF
--- a/packages/mcelog.rb
+++ b/packages/mcelog.rb
@@ -1,0 +1,27 @@
+require 'package'
+
+class Mcelog < Package
+  description 'logs and accounts machine checks (in particular memory, IO, and CPU hardware errors) on modern x86 Linux systems.'
+  homepage 'https://www.mcelog.org/'
+  version '162'
+  source_url 'https://git.kernel.org/pub/scm/utils/cpu/mce/mcelog.git/snapshot/mcelog-162.tar.gz'
+  source_sha256 '875e98572e86240ea319ab1f69ee6d744eb8b73ac5d700e474f6410d0f52d3fc'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.patch
+    system "sed -i 's,prefix := /usr,prefix := #{CREW_PREFIX},' Makefile"
+    system "sed -i 's,etcprefix :=,etcprefix := #{CREW_PREFIX},' Makefile"
+  end
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
mcelog logs and accounts machine checks (in particular memory, IO, and CPU hardware errors) on modern x86 Linux systems.

mcelog is required by both 32bit x86 Linux kernels (since 2.6.30) and 64bit Linux kernels (since early 2.6 kernel releases) to log machine checks and should run on all Linux systems that need error handling.