### PR TITLE
Rearrange crew dependency install order

### DIFF
--- a/crew
+++ b/crew
@@ -659,7 +659,20 @@ def resolve_dependencies
 
   return if @dependencies.empty?
 
+
   puts "The following packages also need to be installed: "
+
+  i = 0
+  last_deps = []
+  last_packages = ["curl", "gtk3", "sommelier"]
+  @dependencies.each do |dep|
+    if last_packages.include?(dep)
+      @dependencies.delete_at(i)
+      last_deps.push(dep)
+    end
+    i += 1
+  end
+  @dependencies.concat last_deps.sort
 
   @dependencies.each do |dep|
     print dep + " "

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.2.3'
+CREW_VERSION = '1.2.4'
 
 ARCH = `uname -m`.strip
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end


### PR DESCRIPTION
- Fixes issue when curl is installed before brotli or libmetalink
- Fixes issue when gtk3 is installed before shared_mime_info
- Fixes issue when sommelier is installed before other dependencies and the postinstall message is missed
- Bump crew version

Fixes #3174.