### PR TITLE
Add qtbase, qtchooser, qttools and qtx11extras packages

### DIFF
--- a/packages/qtbase.rb
+++ b/packages/qtbase.rb
@@ -1,0 +1,63 @@
+require 'package'
+
+class Qtbase < Package
+  description 'Qt Base (Core, Gui, Widgets, Network, ...)'
+  homepage 'https://github.com/qt/qtbase'
+  version '5.12.3'
+  source_url 'http://download.qt.io/official_releases/qt/5.12/5.12.3/submodules/qtbase-everywhere-src-5.12.3.tar.xz'
+  source_sha256 'fddfd8852ef7503febeed67b876d1425160869ae2b1ae8e10b3fb0fedc5fe701'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtbase-5.12.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtbase-5.12.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtbase-5.12.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtbase-5.12.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '1d03332f2eb04d0f74d35ac1120c5d8cc2fa28b13c12649ec1778dba6fde0f6d',
+     armv7l: '1d03332f2eb04d0f74d35ac1120c5d8cc2fa28b13c12649ec1778dba6fde0f6d',
+       i686: '60cfbe8822c86ca48c0fa847744b7d4aa8829e31fc18396b7a6cd9b6bd047b3a',
+     x86_64: '58a2294909587a37caf520df334bee992fa4fcc793985a90ff1eb18fa96e3ab9',
+  })
+
+  depends_on 'alsa_plugins'
+  depends_on 'cups'
+  depends_on 'ffmpeg'
+  depends_on 'fontconfig'
+  depends_on 'freetds'
+  depends_on 'gstreamer'
+  depends_on 'harfbuzz'
+  depends_on 'jsoncpp'
+  depends_on 'pcre2'
+  depends_on 'lcms'
+  depends_on 'libevent'
+  depends_on 'libinput'
+  depends_on 'libjpeg'
+  depends_on 'libvpx'
+  depends_on 'protobuf'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}/share/Qt-5",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '-verbose',
+           '-release',
+           '-opensource',
+           '-confirm-license',
+           '-inotify',
+           '-system-pcre',
+           '-system-zlib',
+           '-system-libpng',
+           '-system-libjpeg',
+           '-system-freetype'
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "INSTALL_ROOT=#{CREW_DEST_DIR}", 'install'
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    Dir.chdir "#{CREW_DEST_PREFIX}/share/Qt-5/bin" do
+      system "find . -type f -exec ln -s #{CREW_PREFIX}/share/Qt-5/bin/{} #{CREW_DEST_PREFIX}/bin/{} \\;"
+    end
+  end
+end

--- a/packages/qtchooser.rb
+++ b/packages/qtchooser.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Qtchooser < Package
+  description 'a wrapper used to select between Qt development binary versions'
+  homepage 'https://www.qt.io/'
+  version '66'
+  source_url 'http://download.qt.io/official_releases/qtchooser/qtchooser-66.tar.xz'
+  source_sha256 'b22c21df135d48fc775d26d771170c2c70555704d4625605383be2cd149c7cea'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtchooser-66-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtchooser-66-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtchooser-66-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtchooser-66-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '7dcd1b8095c0f9cba9b10c2ffbaf3fa9c633dd00342acce2070a06fe4df991e0',
+     armv7l: '7dcd1b8095c0f9cba9b10c2ffbaf3fa9c633dd00342acce2070a06fe4df991e0',
+       i686: 'be579452bceef673e4563576451f05d1b94e6ee622841181d33e8e28e1f827d9',
+     x86_64: 'ddcf92c0c4e7ced912f58b42948a205cd90575567248ae33f16a64bafe402553',
+  })
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    Dir.chdir 'src/qtchooser' do
+      system "make", "prefix=#{CREW_PREFIX}", "INSTALL_ROOT=#{CREW_DEST_DIR}", "install"
+    end
+    system "install -Dm644 doc/qtchooser.1 #{CREW_DEST_PREFIX}/share/man/man1/qtchooser.1"
+  end
+end

--- a/packages/qtcreator.rb
+++ b/packages/qtcreator.rb
@@ -1,9 +1,9 @@
 require 'package'
 
-class Qt < Package
+class Qtcreator < Package
   description 'Qt is a comprehensive cross-platform framework and toolkit that helps you create and build native applications and user interfaces for all the screens of your end user.'
   homepage 'https://info.qt.io/download-qt-for-application-development'
-  version '5.12.3'
+  version '4.9.1'
   source_url 'http://download.qt.io/official_releases/qt/5.12/5.12.3/md5sums.txt'
   source_sha256 '7562395316ed1cfea7c6276bb80b4de14cab34475ced3ae7549eedf6e94da5d9'
 
@@ -61,17 +61,17 @@ class Qt < Package
     end
     case ARCH
     when 'i686'
-      system 'wget http://download.qt.io/official_releases/online_installers/qt-unified-linux-x86-online.run'
-      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('qt-unified-linux-x86-online.run') ) == 'b9dfef211d3122ab2f1b1e96aa7e2357ebdeb068c750eeb423b9396a3f55d619'
-      system "install -Dm755 qt-unified-linux-x86-online.run #{CREW_PREFIX}/tmp/qt-unified-linux-x86-online.run"
-      system "#{CREW_PREFIX}/tmp/qt-unified-linux-x86-online.run --script qt-installer-script.qs"
-      system "rm -f #{CREW_PREFIX}/tmp/qt-unified-linux-x86-online.run"
+      system 'wget http://qtmirror.ics.com/pub/qtproject/archive/online_installers/2.0/qt-unified-linux-x86-2.0.5-2-online.run'
+      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('qt-unified-linux-x86-2.0.5-2-online.run') ) == 'b9dfef211d3122ab2f1b1e96aa7e2357ebdeb068c750eeb423b9396a3f55d619'
+      system "install -Dm755 qt-unified-linux-x86-2.0.5-2-online.run #{CREW_PREFIX}/tmp/qt-unified-linux-x86-2.0.5-2-online.run"
+      system "#{CREW_PREFIX}/tmp/qt-unified-linux-x86-2.0.5-2-online.run --script qt-installer-script.qs"
+      system "rm -f #{CREW_PREFIX}/tmp/qt-unified-linux-x86-2.0.5-2-online.run"
     when 'x86_64'
-      system 'wget http://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run'
-      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('qt-unified-linux-x64-online.run') ) == 'a90c2f1cfb38bf9ab6f8757837c757342fcafdc8ca339e0288d7ac80c5e48de7'
-      system "install -Dm755 qt-unified-linux-x64-online.run #{CREW_PREFIX}/tmp/qt-unified-linux-x64-online.run"
-      system "#{CREW_PREFIX}/tmp/qt-unified-linux-x64-online.run --script qt-installer-script.qs"
-      system "rm -f #{CREW_PREFIX}/tmp/qt-unified-linux-x64-online.run"
+      system 'wget http://qt.mirror.constant.com/archive/online_installers/3.1/qt-unified-linux-x64-3.1.1-online.run'
+      abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('qt-unified-linux-x64-3.1.1-online.run') ) == '931ee9506128e778a0167341a55b9ea76b46d695e8e8f0d9a1ecd58987b53488'
+      system "install -Dm755 qt-unified-linux-x64-3.1.1-online.run #{CREW_PREFIX}/tmp/qt-unified-linux-x64-3.1.1-online.run"
+      system "#{CREW_PREFIX}/tmp/qt-unified-linux-x64-3.1.1-online.run --script qt-installer-script.qs"
+      system "rm -f #{CREW_PREFIX}/tmp/qt-unified-linux-x64-3.1.1-online.run"
     end
     case ARCH
     when 'i686', 'x86_64'

--- a/packages/qttools.rb
+++ b/packages/qttools.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Qttools < Package
+  description 'Qt Tools'
+  homepage 'https://github.com/qt/qttools'
+  version '5.12.3'
+  source_url 'http://download.qt.io/official_releases/qt/5.12/5.12.3/submodules/qttools-everywhere-src-5.12.3.tar.xz'
+  source_sha256 'c9e92d2f0d369e44bb1a60e9fa6d970f8d9893d653212305e04be5e6daec2cd8'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.12.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.12.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.12.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.12.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '6ffa4d4c83e99e789c5aa62503d8efca8c65297a2ef3f5727fe15ee4bacd07b4',
+     armv7l: '6ffa4d4c83e99e789c5aa62503d8efca8c65297a2ef3f5727fe15ee4bacd07b4',
+       i686: '2483850b80bf9e529e5dd2b5213d2d926f02eb173e154ef2554d88497d8f1b6f',
+     x86_64: 'e4d70c3744ce933a2628cc81c0193d34bbacfc41e540cdabdf903ecc3e69f2c1',
+  })
+
+  depends_on 'qtbase'
+  depends_on 'sommelier'
+
+  def self.build
+    system 'qmake && make'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}"
+    system "cp -a lib/* #{CREW_DEST_LIB_PREFIX}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'bin', "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'examples', "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'include', "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'mkspecs', "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'plugins', "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'src/linguist/phrasebooks', "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    Dir.chdir "#{CREW_DEST_PREFIX}/share/Qt-5/bin" do
+      system "find . -type f -exec ln -s #{CREW_PREFIX}/share/Qt-5/bin/{} #{CREW_DEST_PREFIX}/bin/{} \\;"
+    end
+  end
+end

--- a/packages/qtx11extras.rb
+++ b/packages/qtx11extras.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Qtx11extras < Package
+  description 'Provides classes for developing for the X11 platform.'
+  homepage 'https://www.qt.io/'
+  version '5.12.3'
+  source_url 'http://download.qt.io/official_releases/qt/5.12/5.12.3/submodules/qtx11extras-everywhere-src-5.12.3.tar.xz'
+  source_sha256 '85e3ae5177970c2d8656226d7535d0dff5764c100e55a79a59161d80754ba613'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f88300f9d8d06dd02a44570832881dcc79e40a41e41a3e418122512eacce6f99',
+     armv7l: 'f88300f9d8d06dd02a44570832881dcc79e40a41e41a3e418122512eacce6f99',
+       i686: 'a2151e5240dafae30e73e7b2998b7b4c216478d780e4534540f48f817f5ee3a4',
+     x86_64: 'd0f65e142afaad622feb7fc8f25c04f3aed698677634115106ad4be3a3f75671',
+  })
+
+  depends_on 'qtbase'
+
+  def self.build
+    system 'qmake && make'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}"
+    system "cp -a lib/* #{CREW_DEST_LIB_PREFIX}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'include', "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'mkspecs', "#{CREW_DEST_PREFIX}/share/Qt-5"
+  end
+end


### PR DESCRIPTION
Qt is a cross-platform application development framework for desktop, embedded and mobile. Supported Platforms include Linux, OS X, Windows, VxWorks, QNX, Android, iOS, BlackBerry, Sailfish OS and others.

Qt is not a programming language on its own. It is a framework written in C++. A preprocessor, the MOC (Meta-Object Compiler), is used to extend the C++ language with features like signals and slots. Before the compilation step, the MOC parses the source files written in Qt-extended C++ and generates standard compliant C++ sources from them. Thus the framework itself and applications/libraries using it can be compiled by any standard compliant C++ compiler like Clang, GCC, ICC, MinGW and MSVC.

See https://wiki.qt.io/About_Qt.

- Replace qt package with qtcreator
- Update qtcreator from 4.8.0 to 4.9.1
- Add pre-built binaries
- Tested on all architectures