### PR TITLE
Add ladspa package

### DIFF
--- a/packages/ladspa.rb
+++ b/packages/ladspa.rb
@@ -1,0 +1,27 @@
+require 'package'
+
+class Ladspa < Package
+  description 'Linux Audio Developer\'s Simple Plugin API'
+  homepage 'https://www.ladspa.org/'
+  version '1.15'
+  source_url 'https://www.ladspa.org/download/ladspa_sdk_1.15.tgz'
+  source_sha256 '4229959b09d20c88c8c86f4aa76427843011705df22d9c28b38359fd1829fded'
+
+  def self.patch
+    Dir.chdir('src') do
+      system 'sed', '-i', '-e', "s,/usr,\$(DESTDIR)#{CREW_PREFIX},g", '-e', "s,lib,#{ARCH_LIB},", 'Makefile'
+    end
+  end
+
+  def self.build
+    Dir.chdir('src') do
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir('src') do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
+  end
+end


### PR DESCRIPTION
LADSPA is a standard that allows software audio processors and effects to be plugged into a wide range of audio synthesis and recording packages.

For instance, it allows a developer to write a reverb program and bundle it into a LADSPA "plugin library." Ordinary users can then use this reverb within any LADSPA-friendly audio application. Most major audio applications on Linux support LADSPA.

Yet another dependency for CRAS.