### PR TITLE
Add pre-built binaries for cras, iniparser, ladspa and sbc packages

### DIFF
--- a/packages/cras.rb
+++ b/packages/cras.rb
@@ -7,6 +7,17 @@ class Cras < Package
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/adhd/+/refs/heads/stabilize-12249.B/cras/README?format=TEXT'
   source_sha256 'b65b959f4ad842a219a637413b8702676378a0b5d18b5e413c78c211b3fb133c'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-12249.B-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-12249.B-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-12249.B-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '88dde49090fbd16244b5c3fd260634e2b1852ea53a37e3aa3d71d64ae1b20551',
+     armv7l: '88dde49090fbd16244b5c3fd260634e2b1852ea53a37e3aa3d71d64ae1b20551',
+     x86_64: 'c37202a1909d5c593ad39c929ab4d6e7ac3cfcb51daaea032698644f59bb5d51',
+  })
+
   depends_on 'alsa_lib'
   depends_on 'ladspa'
   depends_on 'iniparser'

--- a/packages/iniparser.rb
+++ b/packages/iniparser.rb
@@ -7,6 +7,19 @@ class Iniparser < Package
   source_url 'https://github.com/ndevilla/iniparser/archive/v4.1.tar.gz'
   source_sha256 '960daa800dd31d70ba1bacf3ea2d22e8ddfc2906534bf328319495966443f3ae'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/iniparser-4.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/iniparser-4.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/iniparser-4.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/iniparser-4.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '712e6e63ea2aa696666a53ba354a5108f158241ce806f1eda5b27a577cc7bd58',
+     armv7l: '712e6e63ea2aa696666a53ba354a5108f158241ce806f1eda5b27a577cc7bd58',
+       i686: 'e48a36dd2464e406f43e301bcee25592b225f7eb7a7ab90bbfbfa2ea19c2ad86',
+     x86_64: '9a00066ad86da206832d1c9c024fa83e0cb0da923332581342a32dcc748254dd',
+  })
+
   def self.patch
     # Fix buffer overflow vulnerabilities
     system 'wget', 'https://github.com/ndevilla/iniparser/commit/a249509544972d60f5077bfde554af480bd82594.patch'

--- a/packages/ladspa.rb
+++ b/packages/ladspa.rb
@@ -7,6 +7,19 @@ class Ladspa < Package
   source_url 'https://www.ladspa.org/download/ladspa_sdk_1.15.tgz'
   source_sha256 '4229959b09d20c88c8c86f4aa76427843011705df22d9c28b38359fd1829fded'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ladspa-1.15-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ladspa-1.15-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ladspa-1.15-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ladspa-1.15-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '3aa308850f574ef1151a8bddfb1056775b81752a0e33e9da37eb1884c0261223',
+     armv7l: '3aa308850f574ef1151a8bddfb1056775b81752a0e33e9da37eb1884c0261223',
+       i686: 'bd9075f52a19d34a86f0674e9c33a14587006939760145ed1588937795e31315',
+     x86_64: 'c1f1d2875ea96794b51bd542768687ec3c8514abec0c3f9600a8dbb967a2df83',
+  })
+
   def self.patch
     Dir.chdir('src') do
       system 'sed', '-i', '-e', "s,/usr,\$(DESTDIR)#{CREW_PREFIX},g", '-e', "s,lib,#{ARCH_LIB},", 'Makefile'

--- a/packages/sbc.rb
+++ b/packages/sbc.rb
@@ -7,6 +7,19 @@ class Sbc < Package
   source_url 'https://www.kernel.org/pub/linux/bluetooth/sbc-1.4.tar.xz'
   source_sha256 '518bf46e6bb3dc808a95e1eabad26fdebe8a099c1e781c27ed7fca6c2f4a54c9'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sbc-1.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sbc-1.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sbc-1.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sbc-1.4-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fe3e9e33021a107111cfe96762cf5e56fb4d664b241aedf5f98fd9d81bd1ba72',
+     armv7l: 'fe3e9e33021a107111cfe96762cf5e56fb4d664b241aedf5f98fd9d81bd1ba72',
+       i686: '6945685b5ddb903ab5545fd45f08b9ea08c75ea51741b3480f4e57bce749a2cc',
+     x86_64: '539322bcdf3fe77c47f834e24c5d03ce42098f141e2820ddeb2e0aaa1d6dcec8',
+  })
+
   depends_on 'libsndfile'
 
   def self.build


### PR DESCRIPTION
Build successful for every architecture except i686 but that is expected since CRAS is a recent addition to ChromeOS.

```
make[1]: *** [Makefile:4705: dsp/libcrasserver_la-dsp_util.lo] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/usr/local/tmp/crew/README.dir/cras/src'
make: *** [Makefile:458: all-recursive] Error 1
cras failed to build: `make V=0 -j4` exited with 2
```
This shouldn't hold back a merge of this PR, however.