### PR TITLE
Update ninja and meson packages

### DIFF
--- a/packages/meson.rb
+++ b/packages/meson.rb
@@ -3,21 +3,21 @@ require 'package'
 class Meson < Package
   description 'The Meson Build System'
   homepage 'http://mesonbuild.com/'
-  version '0.48.2'
-  source_url 'https://github.com/mesonbuild/meson/releases/download/0.48.2/meson-0.48.2.tar.gz'
-  source_sha256 '39ead8bfd0dc9c7b0af15e23ea975c864600bf871fba279c9918625bb9a85506'
+  version '0.51.1'
+  source_url 'https://github.com/mesonbuild/meson/releases/download/0.51.1/meson-0.51.1.tar.gz'
+  source_sha256 'f27b7a60f339ba66fe4b8f81f0d1072e090a08eabbd6aa287683b2c2b9dd2d82'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/meson-0.48.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/meson-0.48.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/meson-0.48.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/meson-0.48.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/meson-0.51.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/meson-0.51.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/meson-0.51.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/meson-0.51.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '9a5f1420003ee72848c76d9c9a53bbce10a30484e48e7a76a88d224fe3d6a81f',
-     armv7l: '9a5f1420003ee72848c76d9c9a53bbce10a30484e48e7a76a88d224fe3d6a81f',
-       i686: 'f875c2151456f44b7b2ada00e3e09676ce3457f3234c8b5f0b956a62222720cb',
-     x86_64: '96406f75738f1ae81fb382016988b577f6e3c610bfd7bde48b60033333b44e3a',
+    aarch64: '6173c80dfccf2978adcc3a67470a12177f1ff8678dcffc6c1bfff3fe1ffb9978',
+     armv7l: '6173c80dfccf2978adcc3a67470a12177f1ff8678dcffc6c1bfff3fe1ffb9978',
+       i686: '009b3313c5c22c5208ba9597ef6e7796df0c3a3cf74484f5abca4f0b168bf54a',
+     x86_64: '5da9467ea3d2a9e05870fa5a584904a4d533a296852d7b20407fe430fee620a0',
   })
 
   depends_on 'ninja'

--- a/packages/ninja.rb
+++ b/packages/ninja.rb
@@ -3,24 +3,25 @@ require 'package'
 class Ninja < Package
   description 'a small build system with a focus on speed'
   homepage 'https://ninja-build.org'
-  version '1.7.2'
-  source_url 'https://github.com/ninja-build/ninja/archive/v1.7.2.tar.gz'
-  source_sha256 '2edda0a5421ace3cf428309211270772dd35a91af60c96f93f90df6bc41b16d9'
+  version '1.9.0'
+  source_url 'https://github.com/ninja-build/ninja/archive/v1.9.0.tar.gz'
+  source_sha256 '5d7ec75828f8d3fd1a0c2f31b5b0cea780cdfe1031359228c428c1a48bfcd5b9'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.7.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.7.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.7.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.7.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.9.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.9.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.9.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ninja-1.9.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3ff2fc875e7fce5f69880d0db463afe580aa2c963c36e07301348b3ea597f469',
-     armv7l: '3ff2fc875e7fce5f69880d0db463afe580aa2c963c36e07301348b3ea597f469',
-       i686: '45c4ea8662459b4846c09bf440982b3431162556b6d955268ebd2d7e5d2ba157',
-     x86_64: '1dbb0af40656a2dda2d2e0c157f3860ee8ea9b79edff4a28b90f34d08d3f81d5',
+    aarch64: 'b9f89afdefe5747802c7ccd5184775c2a18f8f66f380cf68213c3c86833f0822',
+     armv7l: 'b9f89afdefe5747802c7ccd5184775c2a18f8f66f380cf68213c3c86833f0822',
+       i686: 'c1a6a31fec8fd4185ab6c7e478f7cc935c3f836c7e399f2a74725946e9d23d98',
+     x86_64: 'a1b8db9d11211ece355c2d4d7a1fecffb719d0d47b1c5c48276a2cb22f505f62',
   })
 
   depends_on 'python3'
+  depends_on 're2c'
   depends_on 'unzip'
 
   def self.build


### PR DESCRIPTION
- Update meson from 0.48.2 to 0.51.1
- Update ninja from 1.7.2 to 1.9.0
- Tested on all architectures