### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: bash
+services:
+  - docker
+
+before_install:
+  - docker pull brunux/chromeos
+
+script:
+  # Workaround sudo prompting for password by editing existing chronos entry
+  - docker run -it
+               -v $PWD:/travis
+               brunux/chromeos
+               /bin/sh -c "
+      grep chronos /etc/sudoers > /tmp/sudoers.new;
+      sed s/chronos/ALL/ /tmp/sudoers.new > /etc/sudoers;
+      sudo -u chronos bash /travis/install.sh;
+    "

--- a/install.sh
+++ b/install.sh
@@ -184,6 +184,9 @@ for i in $(seq 0 $((${#urls[@]} - 1))); do
   update_device_json "${name}" "${version}"
 done
 
+# workaround https://github.com/skycocker/chromebrew/issues/3305
+sudo ldconfig > /dev/null 2> /dev/null || true
+
 # create symlink to 'crew' in ${CREW_PREFIX}/bin/
 rm -f "${CREW_PREFIX}/bin/crew"
 ln -s "../lib/crew/crew" "${CREW_PREFIX}/bin/"


### PR DESCRIPTION
Fixes #3353

## Description
Adds automated testing using Travis CI, which looks like this when enabled:
https://travis-ci.org/jayvdb/chromebrew/builds/558588401

It only tests the `install.sh` , using docker image `brunux/chromeos`, but that test environment will allow more QA to be added.