### PR TITLE
Update linux_sources and linuxheaders to Chrome OS version and apply patches

### DIFF
--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -3,12 +3,21 @@ require 'package'
 class Linux_sources < Package
   description 'Sources for the Linux kernel'
   homepage 'https://kernel.org/'
-  version '3.18'
-  source_url 'https://www.kernel.org/pub/linux/kernel/v3.x/linux-3.18.tar.xz'
-  source_sha256 'becc413cc9e6d7f5cc52a3ce66d65c3725bc1d1cc1001f4ce6c32b69eb188cbd'
+  version '4.14'
+  source_url 'https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.14.tar.xz'
+  source_sha256 'f81d59477e90a130857ce18dc02f4fbe5725854911db1e7ba770c7cd350f96a7'
 
   def self.install
     linux_src_dir = CREW_DEST_PREFIX + '/src/linux'
+    pdir = 'chromiumos-overlay/sys-kernel/linux-headers/files'
+    # Download Linux kernel header patches
+    system 'git', 'clone', '--depth=1', '-b', 'release-R75-12105.B',
+           'https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay.git'
+    # Remove a/ and b/ path prefixes on patches so they can be applied with -Np0
+    system "sed -i -e 's,a/,,g' -e 's,b/,,g' #{pdir}/*.patch"
+    system "for file in #{pdir}/*.patch; do patch -Np0 -i \${file}; done"
+    # Remove Chromium OS overlay so it isn't included in the source tree
+    FileUtils.rm_rf 'chromiumos-overlay'
     FileUtils.mkdir_p(linux_src_dir)
     FileUtils.cp_r('.', linux_src_dir)
     Dir.chdir(linux_src_dir) do

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -7,6 +7,19 @@ class Linux_sources < Package
   source_url 'https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.14.tar.xz'
   source_sha256 'f81d59477e90a130857ce18dc02f4fbe5725854911db1e7ba770c7cd350f96a7'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/linux_sources-4.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/linux_sources-4.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/linux_sources-4.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/linux_sources-4.14-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '7dfea20067015e59a2b4b1006b0beddaa6873a01470cee8007647d990da5bf57',
+     armv7l: '7dfea20067015e59a2b4b1006b0beddaa6873a01470cee8007647d990da5bf57',
+       i686: 'fae80d1d113eb4e2d9bc84daee4b398c2064730234df74b09edfc85fb9a696b4',
+     x86_64: '3051229ae81224a038795eecd6d21dfd9dad2c5f8711137016bb8a4bb28852c9',
+  })
+
   def self.install
     linux_src_dir = CREW_DEST_PREFIX + '/src/linux'
     pdir = 'chromiumos-overlay/sys-kernel/linux-headers/files'

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -7,6 +7,17 @@ class Linuxheaders < Package
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-4.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-4.14-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-4.14-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '4960ced072202049c4f90350ebfa6b13a3fe6750ae8a1f0d79c63ad976b66391',
+     armv7l: '4960ced072202049c4f90350ebfa6b13a3fe6750ae8a1f0d79c63ad976b66391',
+     x86_64: '1cbc54cf8c1af9996039c5aec487ed3f047c9c870341b08418c0d93fb40233a0',
+  })
+
   depends_on 'linux_sources' => :build
 
   def self.install

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -10,11 +10,13 @@ class Linuxheaders < Package
   binary_url ({
     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-4.14-chromeos-armv7l.tar.xz',
      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-4.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-3.18-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-4.14-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
     aarch64: '4960ced072202049c4f90350ebfa6b13a3fe6750ae8a1f0d79c63ad976b66391',
      armv7l: '4960ced072202049c4f90350ebfa6b13a3fe6750ae8a1f0d79c63ad976b66391',
+       i686: 'df0178926e599e8a6bb54a74c7c7cda734751e007a2bbb2e59f17a8fb3d4489f',
      x86_64: '1cbc54cf8c1af9996039c5aec487ed3f047c9c870341b08418c0d93fb40233a0',
   })
 

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -3,22 +3,9 @@ require 'package'
 class Linuxheaders < Package
   description 'Linux headers for Chrome OS.'
   homepage 'https://kernel.org/'
-  version '3.18'
+  version '4.14'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-3.18-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-3.18-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-3.18-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/linuxheaders-3.18-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '7dd6d546dea319d014e92662d256c4554d0f2e5b4cd740eefde02913b3513831',
-     armv7l: '7dd6d546dea319d014e92662d256c4554d0f2e5b4cd740eefde02913b3513831',
-       i686: 'df0178926e599e8a6bb54a74c7c7cda734751e007a2bbb2e59f17a8fb3d4489f',
-     x86_64: '02d89a6f204239541e719818a4ed1696e2aa70e9c3861f437712723c1278344e',
-  })
 
   depends_on 'linux_sources' => :build
 


### PR DESCRIPTION
Allows for Sommelier to be updated to a version that circumvents the broken pipe errors.