### PR TITLE
Remove linux_sources binaries

### DIFF
--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -7,19 +7,6 @@ class Linux_sources < Package
   source_url 'https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.14.tar.xz'
   source_sha256 'f81d59477e90a130857ce18dc02f4fbe5725854911db1e7ba770c7cd350f96a7'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/linux_sources-4.14-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/linux_sources-4.14-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/linux_sources-4.14-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/linux_sources-4.14-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '7dfea20067015e59a2b4b1006b0beddaa6873a01470cee8007647d990da5bf57',
-     armv7l: '7dfea20067015e59a2b4b1006b0beddaa6873a01470cee8007647d990da5bf57',
-       i686: 'fae80d1d113eb4e2d9bc84daee4b398c2064730234df74b09edfc85fb9a696b4',
-     x86_64: '3051229ae81224a038795eecd6d21dfd9dad2c5f8711137016bb8a4bb28852c9',
-  })
-
   def self.install
     linux_src_dir = CREW_DEST_PREFIX + '/src/linux'
     pdir = 'chromiumos-overlay/sys-kernel/linux-headers/files'

--- a/tools/needs_binaries.sh
+++ b/tools/needs_binaries.sh
@@ -12,7 +12,7 @@ exclusions+=' qt.rb sl.rb spark.rb stack.rb sublime_merge.rb sublime_text.rb the
 exclusions+=' neofetch.rb perl_gcstring_linebreak.rb perl_io_socket_ssl.rb perl_locale_gettext.rb perl_locale_messages.rb perl_module_build.rb'
 exclusions+=' perl_read_key.rb perl_sgmls.rb perl_term_ansicolor.rb perl_text_charwidth.rb perl_text_unidecode.rb perl_text_wrapi18n.rb'
 exclusions+=' perl_time_hires.rb perl_unicode_eastasianwidth.rb perl_xml_parser.rb perl_xml_sax_parserfactory.rb perl_xml_simple.rb'
-exclusions+=' leiningen.rb v2ray.rb'
+exclusions+=' leiningen.rb v2ray.rb linux_sources.rb'
 if [[ "${arch}" == 'aarch64' || "${arch}" == 'armv7l' ]]; then
   exclusions+=' az.rb cf.rb clisp.rb dropbox.rb freebasic.rb miniconda3.rb misctools.rb oci.rb wkhtmltox.rb xorg_intel_driver.rb xorg_vmmouse_driver.rb'
 fi


### PR DESCRIPTION
This is pointless, as it literally just copies the patched files.

It's better to just download the sources and patch them on the fly, and it should reduce server load on Bintray.