### PR TITLE
Add tkdiff package

### DIFF
--- a/packages/tkdiff.rb
+++ b/packages/tkdiff.rb
@@ -1,0 +1,15 @@
+require 'package'
+
+class Tkdiff < Package
+  description 'TkDiff is a graphical front end to the diff program.'
+  homepage 'https://tkdiff.sourceforge.io/'
+  version '4.3.5'
+  source_url 'https://downloads.sourceforge.net/project/tkdiff/tkdiff/4.3.5/tkdiff-4-3-5.zip'
+  source_sha256 '29d7f0b815d06b0ab6653baa9b6b7c213801ce6a976724ae843bf9735cbbde7e'
+
+  depends_on 'tk'
+
+  def self.install
+    system "install -Dm755 tkdiff #{CREW_DEST_PREFIX}/bin/tkdiff"
+  end
+end

--- a/tools/needs_binaries.sh
+++ b/tools/needs_binaries.sh
@@ -12,7 +12,7 @@ exclusions+=' qt.rb sl.rb spark.rb stack.rb sublime_merge.rb sublime_text.rb the
 exclusions+=' neofetch.rb perl_gcstring_linebreak.rb perl_io_socket_ssl.rb perl_locale_gettext.rb perl_locale_messages.rb perl_module_build.rb'
 exclusions+=' perl_read_key.rb perl_sgmls.rb perl_term_ansicolor.rb perl_text_charwidth.rb perl_text_unidecode.rb perl_text_wrapi18n.rb'
 exclusions+=' perl_time_hires.rb perl_unicode_eastasianwidth.rb perl_xml_parser.rb perl_xml_sax_parserfactory.rb perl_xml_simple.rb'
-exclusions+=' leiningen.rb v2ray.rb'
+exclusions+=' leiningen.rb tkdiff.rb v2ray.rb'
 if [[ "${arch}" == 'aarch64' || "${arch}" == 'armv7l' ]]; then
   exclusions+=' az.rb cf.rb clisp.rb dropbox.rb freebasic.rb miniconda3.rb misctools.rb oci.rb wkhtmltox.rb xorg_intel_driver.rb xorg_vmmouse_driver.rb'
 fi


### PR DESCRIPTION
TkDiff is a graphical front end to the diff program. It provides a side-by-side view of the differences between two text files, along with several innovative features such as diff bookmarks, a graphical map of differences for quick navigation, and a facility for slicing diff regions to achieve exactly the merge output desired.  See https://tkdiff.sourceforge.io/.  Tested on all architectures.  Depends on #3393 