### PR TITLE
Update libfilezilla from 0.15.1 to 0.18.0 and filezilla from 3.39.0 to 3.43.0

### DIFF
--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -3,21 +3,21 @@ require 'package'
 class Filezilla < Package
   description 'FileZilla Client is a free FTP solution.'
   homepage 'https://filezilla-project.org/'
-  version '3.39.0'
-  source_url 'https://download.filezilla-project.org/client/FileZilla_3.39.0_src.tar.bz2'
-  source_sha256 'fb515e93775e5ad94ff2755b39605b62b3e8fcfc1125757f411d8f580d16444f'
+  version '3.43.0'
+  source_url 'https://download.filezilla-project.org/client/FileZilla_3.43.0_src.tar.bz2'
+  source_sha256 '6fe652c360682f860abe2dc2e196bddca6260242cefe6fe779d42c327c01258e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.39.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.39.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.39.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.39.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.43.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.43.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.43.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.43.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '7da4e0d6fc406bfd0e321ebd9058a2346ac50c182c62b201355be1c65f80e3f1',
-     armv7l: '7da4e0d6fc406bfd0e321ebd9058a2346ac50c182c62b201355be1c65f80e3f1',
-       i686: 'd6a0fd020e660b70bd64f1068c349e5cbe01e99255b9d931ad36d3b5c0937d06',
-     x86_64: 'b3cd0a4569aa2396003683e824381f9856d1353fb79b47564f8887644b0cc170',
+    aarch64: 'fdef2404efb7251ba6c9b3675d6f7364b57272cc8c431e8de69761224bae5f9d',
+     armv7l: 'fdef2404efb7251ba6c9b3675d6f7364b57272cc8c431e8de69761224bae5f9d',
+       i686: '652990bad986fc083e5d9137bf9df6bba7479ca8ec255a9250c34680b5676610',
+     x86_64: '3fe771c921d4738d0c82d33bfd0aeea1405009ce0ea7d126603801f40abec1ee',
   })
 
   depends_on 'dbus'

--- a/packages/libfilezilla.rb
+++ b/packages/libfilezilla.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libfilezilla < Package
   description 'libfilezilla is a small and modern C++ library, offering some basic functionality to build high-performing, platform-independent programs.'
   homepage 'https://lib.filezilla-project.org/'
-  version '0.15.1'
-  source_url 'https://download.filezilla-project.org/libfilezilla/libfilezilla-0.15.1.tar.bz2'
-  source_sha256 '2048c4128f3bf37a2a4ece17c8bea5455f3d7414fe2e060afcf2a8b00a87f49f'
+  version '0.18.0'
+  source_url 'https://download.filezilla-project.org/libfilezilla/libfilezilla-0.18.0.tar.bz2'
+  source_sha256 '577a663b5dcf7f44e76a4208f11d6e7c4325c8f45fe15be8588de86eb75f9f3c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.15.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.15.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.15.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.15.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.18.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.18.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.18.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.18.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '9f0c812627b00d80513fd6efa9f26151f7fd91be28277f387fe8f950fe59d7ac',
-     armv7l: '9f0c812627b00d80513fd6efa9f26151f7fd91be28277f387fe8f950fe59d7ac',
-       i686: '85e40754a5dcb32e2f77b2bd95e0e25d1a8319e9a8bb09688596b44c279ba715',
-     x86_64: '607e93feabe4f830aa05379bd1a1b9930f6253ba9ab3bede5ee56f60ac542de5',
+    aarch64: 'd35b79ea3d8d2854986c3880bf6b39792914b7c90a8e41c3dc8af1616a897ca9',
+     armv7l: 'd35b79ea3d8d2854986c3880bf6b39792914b7c90a8e41c3dc8af1616a897ca9',
+       i686: '58437bfb3359931446837389c2116d3d4f997069d1a39a901ce6bfc47ef652e5',
+     x86_64: '87dd446e4984dedb2ffb7f704a3458a29c64fd8cba33d49ac7bdd3241d53bc7a',
   })
 
   def self.build


### PR DESCRIPTION
Tested on all architectures.  Fixes #2999.  Fixes #3380.  Depends on #3397.