### PR TITLE
Add faultstat package

### DIFF
--- a/packages/faultstat.rb
+++ b/packages/faultstat.rb
@@ -2,7 +2,7 @@ require 'package'
 
 class Faultstat < Package
   description 'Faultstat measures page fault activity and swap utilization of processes'
-  homepage 'http://kernel.ubuntu.com/~cking/faultstat/'
+  homepage 'https://kernel.ubuntu.com/~cking/faultstat/'
   version '0.01.01'
   source_url 'https://kernel.ubuntu.com/~cking/tarballs/faultstat/faultstat-0.01.01.tar.xz'
   source_sha256 '81218818fe7498411797289bdd0967e82665d2065407be8b5335eaf2959b8991'
@@ -18,6 +18,6 @@ class Faultstat < Package
 
   def self.install
     system "install -Dm755 faultstat #{CREW_DEST_PREFIX}/bin/faultstat"
-    system "install -Dm644 faultstat.8 #{CREW_DEST_PREFIX}/man/man8/faultstat.8"
+    system "install -Dm644 faultstat.8 #{CREW_DEST_PREFIX}/share/man/man8/faultstat.8"
   end
 end

--- a/packages/faultstat.rb
+++ b/packages/faultstat.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Faultstat < Package
+  description 'Faultstat measures page fault activity and swap utilization of processes'
+  homepage 'http://kernel.ubuntu.com/~cking/faultstat/'
+  version '0.01.01'
+  source_url 'https://kernel.ubuntu.com/~cking/tarballs/faultstat/faultstat-0.01.01.tar.xz'
+  source_sha256 '81218818fe7498411797289bdd0967e82665d2065407be8b5335eaf2959b8991'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    system "CPPFLAGS=-I#{CREW_PREFIX}/include/ncurses make" 
+  end
+
+  def self.install
+    system "install -Dm755 faultstat #{CREW_DEST_PREFIX}/bin/faultstat"
+    system "install -Dm644 faultstat.8 #{CREW_DEST_PREFIX}/man/man8/faultstat.8"
+  end
+end


### PR DESCRIPTION
Faultstat measures page fault activity and swap utilization of processes. This is another useful utility for kernel developers from the talented Colin King. Tested on ARM.