### PR TITLE
Add support for ARM

### DIFF
--- a/packages/julia.rb
+++ b/packages/julia.rb
@@ -3,14 +3,17 @@ require 'package'
 class Julia < Package
   description 'Julia is a flexible dynamic language, appropriate for scientific and numerical computing'
   homepage 'https://julialang.org/'
-  version '1.0.1'
+  version '1.0.4'
   case ARCH
   when 'x86_64'
-    source_url 'https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.1-linux-x86_64.tar.gz'
+    source_url 'https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.4-linux-x86_64.tar.gz'
     source_sha256 '9ffbcf7f4a111e13415954caccdd1ce90b5c835cee9f62d6ac708f5b752c87dd'
   when 'i686'
-    source_url 'https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.1-linux-i686.tar.gz'
+    source_url 'https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.4-linux-i686.tar.gz'
     source_sha256 'e2ce5fa564242c2dbb836f9493166ce6eaaec8f46db9861b4cdad047497dd4c4'
+  when 'armv7l', 'aarch64'
+   source_url 'https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/julia-1.0.4-linux-armv7l.tar.gz'
+   source_sha256 '2e742f4ddf5ac21779b6943ef210d73dc02f1c6de23836b352336a3dcbb18ae6'
   end
 
   binary_url ({


### PR DESCRIPTION
This adds ARM support using the project's binary release. It also updates the
package from 1.0.1 to 1.0.4.

Note that to update to the current non-LTS release we would need to build out
own armv7l binaries as they only release 64-bit versions.

Tested on Samsung Chromebook Plus V1 (ARM).