### PR TITLE
Add pre-built binaries for libbsd and libseccomp

### DIFF
--- a/packages/libbsd.rb
+++ b/packages/libbsd.rb
@@ -8,8 +8,16 @@ class Libbsd < Package
   source_sha256 '34b8adc726883d0e85b3118fa13605e179a62b31ba51f676136ecb2d0bc1a887'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libbsd-0.10.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libbsd-0.10.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libbsd-0.10.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libbsd-0.10.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '37a763df2252323db210cdb3ea216adaa5e04702975de7b3e13164d7b89f7b85',
+     armv7l: '37a763df2252323db210cdb3ea216adaa5e04702975de7b3e13164d7b89f7b85',
+       i686: '0cc3fad8e96ddf9cd0c501a48043f76c8e2d25a8ce2114912cefe0f39633a14c',
+     x86_64: '1eaed035917e2d3656a3e708777cc18f3f350ec495185bae77c3a8f7e254da52',
   })
 
   def self.build

--- a/packages/libseccomp.rb
+++ b/packages/libseccomp.rb
@@ -8,8 +8,16 @@ class Libseccomp < Package
   source_sha256 '36aa502c0461ae9efc6c93ec2430d6badd9bf91ecbe73806baf7b7c6f687ab4f'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libseccomp-2.4.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libseccomp-2.4.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libseccomp-2.4.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libseccomp-2.4.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'c857c381ba1cd7bc53d0c760d33b308dd0e8b24893828745ac2d9697f4098266',
+     armv7l: 'c857c381ba1cd7bc53d0c760d33b308dd0e8b24893828745ac2d9697f4098266',
+       i686: 'e29d38e68b4a4043ef55a39a07b9dcb42429c6fdefedc50842cce784e0670fe7',
+     x86_64: 'fb72ad86487e84775255ad3c231e4517f490094cfed05da2d22274e2f1006257',
   })
 
   def self.build


### PR DESCRIPTION
Tested on all architectures using filezilla and gimp after restarting sommelier.