### PR TITLE
Change arm64 to arm in code.rb

### DIFF
--- a/packages/code.rb
+++ b/packages/code.rb
@@ -24,8 +24,8 @@ class Code < Package
   depends_on 'sommelier'
 
   case ARCH
-  when 'aarch64', 'armv7l'
-    @arch = 'arm64'
+  when 'armv7l', 'aarch64'
+    @arch = 'arm'
   when 'i686'
     @arch = 'ia32'
   when 'x86_64'


### PR DESCRIPTION
#3391 changed arm to arm64 in Code, which breaks the ARM builds. Change this back and restore order.

Error:  
![error](https://user-images.githubusercontent.com/38843657/63055945-fc6e7980-beb4-11e9-8591-2e7386d8d1c3.png)

Details on the Discord server.
