### PR TITLE
Update python27 to 2.7.16

### DIFF
--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -3,21 +3,13 @@ require 'package'
 class Python27 < Package
   description 'Python is a programming language that lets you work quickly and integrate systems more effectively.'
   homepage 'https://www.python.org/'
-  version '2.7.15'
-  source_url 'https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tar.xz'
-  source_sha256 '22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574'
+  version '2.7.16'
+  source_url 'https://www.python.org/ftp/python/2.7.16/Python-2.7.16.tar.xz'
+  source_sha256 'f222ef602647eecb6853681156d32de4450a2c39f4de93bd5b20235f2e660ed7'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.15-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.15-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.15-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.15-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '712ea676f522e01f37ec2d9ee7fff973fa12df20b8d1822d32d07241800fe0e6',
-     armv7l: '712ea676f522e01f37ec2d9ee7fff973fa12df20b8d1822d32d07241800fe0e6',
-       i686: 'a0aacd3f53d38d929d278e85384a41049e402e5d42c8a6df560aa1d64d5bf684',
-     x86_64: 'f1f81eaf334c05e6895213a78b8f56b2077b56a3ddf03daea65df403b91bd798',
   })
 
   depends_on 'bz2' => :build


### PR DESCRIPTION
Preparation for #3463 

OpenSSL 1.1.1 support with backwards-compatibility

binaries will need to be upgraded when moving to OpenSSL 1.1.1