### PR TITLE
Add pre-built binaries for curl, nano, powerstat and python27

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -8,8 +8,16 @@ class Curl < Package
   source_sha256 'dbb48088193016d079b97c5c3efde8efa56ada2ebf336e8a97d04eb8e2ed98c1'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '135488fd75e5127645d4ffe07d67e635229e5bfdb238852e5d8af9c10fd5f15d',
+     armv7l: '135488fd75e5127645d4ffe07d67e635229e5bfdb238852e5d8af9c10fd5f15d',
+       i686: 'c03cb9fe9b2d30e106a96a686ce79e367281cea8296241c6151938fcecde27e0',
+     x86_64: 'aa67936bd49b3722c356c5fd5137f5b3b350f6085a8da19d70e03ee58f428e60',
   })
 
   depends_on 'groff' => :build

--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -8,8 +8,16 @@ class Nano < Package
   source_sha256 '2af222e0354848ffaa3af31b5cd0a77917e9cb7742cd073d762f3c32f0f582c7'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-4.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nano-4.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nano-4.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nano-4.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd90750f2218b77a4ddaf02915c8d06ff4f32868273a2709eb2906949c9bea3c6',
+     armv7l: 'd90750f2218b77a4ddaf02915c8d06ff4f32868273a2709eb2906949c9bea3c6',
+       i686: '61e9a1790d99f2f8edcceea2bd10ae8a092166e4da9f648ff1a1083360f9bdda',
+     x86_64: '29e8f79fa4e1d93a14373249036428859d7a2e80c319854bb2266f441634a1a6',
   })
 
   depends_on 'xdg_base'

--- a/packages/powerstat.rb
+++ b/packages/powerstat.rb
@@ -8,8 +8,16 @@ class Powerstat < Package
   source_sha256 '679305b3a6d2cc9820d19247e9acc1fb2fa48e96a65bc253b358ba5b0a985de3'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.20-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.20-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.20-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.20-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '40781457dd33d5bbf4372dec0b0f23544e04c8545b54a6734e135ca3502c0e65',
+     armv7l: '40781457dd33d5bbf4372dec0b0f23544e04c8545b54a6734e135ca3502c0e65',
+       i686: 'a64eb0f7eef06b749f0ca89905e731102763e6bd1f7373a708664da5978df748',
+     x86_64: 'b345616591b185396594420bb43f193b56c450a964c847302ef5e72538ec7d5e',
   })
 
   def self.build

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -8,8 +8,16 @@ class Python27 < Package
   source_sha256 'f222ef602647eecb6853681156d32de4450a2c39f4de93bd5b20235f2e660ed7'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.16-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.16-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.16-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.16-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '16265a3e01624006c7446d4e0f59ff8b497f351bad14d3d326e17511c2711095',
+     armv7l: '16265a3e01624006c7446d4e0f59ff8b497f351bad14d3d326e17511c2711095',
+       i686: 'b098571da5c664c9e777d48b0f50ef9c3bf4ffd1aebf5edcdad48ef60a940d6c',
+     x86_64: '4987e4e3fd77e1db8233c2d2652174c519001b6ab2cd2989c3329268e093d701',
   })
 
   depends_on 'bz2' => :build


### PR DESCRIPTION
Tested on all architectures.