### PR TITLE
Add pre-built binaries for ansible, ant, aria2, aws and libcyrussasl

### DIFF
--- a/packages/ansible.rb
+++ b/packages/ansible.rb
@@ -8,8 +8,16 @@ class Ansible < Package
   source_sha256 '8e9403e755ce8ef27b6066cdd7a4c567aa80ebe2fd90d0ff8efa0a725d246986'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ansible-2.8.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ansible-2.8.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ansible-2.8.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ansible-2.8.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '0f98e84a4761b65b27d666496d9c73a20c94994072af69faa1b29e189b51b37a',
+     armv7l: '0f98e84a4761b65b27d666496d9c73a20c94994072af69faa1b29e189b51b37a',
+       i686: '19569f4ab9b9b11a753a88cd12eb2650266931b91443679c49a119eeeb52932d',
+     x86_64: 'da437a69b68b9fa6a24d449cec83e09141dcb8f28a8098de01d0b652bfebc2b3',
   })
 
   depends_on 'setuptools'

--- a/packages/ant.rb
+++ b/packages/ant.rb
@@ -8,8 +8,16 @@ class Ant < Package
   source_sha256 'c8d68b396d9e44b49668bafe0c82f8c89497915254b5395d73d6f6e41d7a0e25'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ant-1.10.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ant-1.10.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ant-1.10.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ant-1.10.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '8c8f4cf7c36b17cee645c7e7b97ba96d56a61f423471ec90bfe5538c635d7c06',
+     armv7l: '8c8f4cf7c36b17cee645c7e7b97ba96d56a61f423471ec90bfe5538c635d7c06',
+       i686: '6cd682307210e3164e22a59cda0719d68476e8c3303e5fa1d262ca5a83753720',
+     x86_64: '4d135fc9b5b3e76f9fc614dfd93a781451d9b0901281a2b8dd6a20a28d76bc62',
   })
 
   depends_on 'jdk8'

--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -8,8 +8,16 @@ class Aria2 < Package
   source_sha256 '3a44a802631606e138a9e172a3e9f5bcbaac43ce2895c1d8e2b46f30487e77a3'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.34.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.34.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.34.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.34.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'bc492c8c31baf9b8e90719f640196b720277343198d4e3b11e7c9a4acae2b5ce',
+     armv7l: 'bc492c8c31baf9b8e90719f640196b720277343198d4e3b11e7c9a4acae2b5ce',
+       i686: '85e56222a315543f6aedb0f744538f3969ed632cbb3aff2c67c8bcfbb341d580',
+     x86_64: '17b8d40ca1a21416cff6fce22621e5720ee7c1643cad4e2822802926fa99ac5d',
   })
 
   depends_on 'c_ares'

--- a/packages/aws.rb
+++ b/packages/aws.rb
@@ -8,8 +8,16 @@ class Aws < Package
   source_sha256 'c0c503379ec30e576d6c88b15c9d9a820fc085c15b14744291081ab55f3d855c'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.241-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.241-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.241-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.241-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '5315d84b871a81dc802025cf2db6b1ac97e640323a51d7e35daf7284241b34c9',
+     armv7l: '5315d84b871a81dc802025cf2db6b1ac97e640323a51d7e35daf7284241b34c9',
+       i686: '10c882927ae6c671e0514cb2181c00281fcecfff02b455f9678b410652d93c46',
+     x86_64: '56eb8eac88fa39637e9f74dbceb6389462f85736f9a7ac996d99903f8068de44',
   })
 
   depends_on 'six'

--- a/packages/libcyrussasl.rb
+++ b/packages/libcyrussasl.rb
@@ -8,8 +8,16 @@ class Libcyrussasl < Package
   source_sha256 '26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcyrussasl-2.1.27-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcyrussasl-2.1.27-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcyrussasl-2.1.27-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcyrussasl-2.1.27-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '281ac03fa4841ff2bd2395e960a9803791fac3ccfa0bf70ec7b8f79088c25817',
+     armv7l: '281ac03fa4841ff2bd2395e960a9803791fac3ccfa0bf70ec7b8f79088c25817',
+       i686: 'dbce3fbbf6efedd4c9266c14163022ca9a1da22386f55eeffe6074c341a5bac0',
+     x86_64: '46241ea5cf5e0181649e91edb183128669d5ab5bc13a938493ba1158a5189743',
   })
 
   depends_on 'diffutils' => :build


### PR DESCRIPTION
Tested on all architectures.