### PR TITLE
Add pre-built binaries for bacon, musl, nmap and sqlite

### DIFF
--- a/packages/bacon.rb
+++ b/packages/bacon.rb
@@ -8,8 +8,16 @@ class Bacon < Package
   source_sha256 '2ecd99b478dca48fc0421b19165b35e2cd57b84253b2b494c610233151324bc6'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.2b3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.2b3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.2b3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.2b3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '24e02e1ac6dadbd7f36ee689c9c1ec012e871f488cece03cc3d975d91ae0301d',
+     armv7l: '24e02e1ac6dadbd7f36ee689c9c1ec012e871f488cece03cc3d975d91ae0301d',
+       i686: '48721711a984c4f8cd4a6279586b2872292b29ed7be404415c7b37ea663f823d',
+     x86_64: 'c11e702b654b1fc9f3503c815d75b3f87b92240952611688daf0355e935b77fc',
   })
 
   def self.build

--- a/packages/musl.rb
+++ b/packages/musl.rb
@@ -8,8 +8,16 @@ class Musl < Package
   source_sha256 '8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/musl-1.1.23-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/musl-1.1.23-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/musl-1.1.23-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/musl-1.1.23-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd4fdc8b8d4bbe495283cfcaa0bf3574439d972dfbe4a1e1aa28927cc672f2089',
+     armv7l: 'd4fdc8b8d4bbe495283cfcaa0bf3574439d972dfbe4a1e1aa28927cc672f2089',
+       i686: 'cb4834f91df4afcbe7eccaf85abbbf4c80afa15d7e6ea9a220889c42e719ee8f',
+     x86_64: '1d65413f0d246a3a350c354c03080e007a831552678d24ca4e125b515793bef8',
   })
 
   def self.build

--- a/packages/nmap.rb
+++ b/packages/nmap.rb
@@ -8,8 +8,16 @@ class Nmap < Package
   source_sha256 'fcfa5a0e42099e12e4bf7a68ebe6fde05553383a682e816a7ec9256ab4773faa'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nmap-7.80-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nmap-7.80-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nmap-7.80-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nmap-7.80-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '05f6f7b8303f7249e0ce26650f13bd051d0d5665d321be0ff59f6ce51cff57fe',
+     armv7l: '05f6f7b8303f7249e0ce26650f13bd051d0d5665d321be0ff59f6ce51cff57fe',
+       i686: 'f40786b4937b7d3a6b6ddc67afb4a004ba577f865d9d922fa0982ebb871b1451',
+     x86_64: '624e3f64733244d3f987b5dfbd72a52acef314fa481857cc1ad4f92d621d2f3a',
   })
 
   def self.build

--- a/packages/sqlite.rb
+++ b/packages/sqlite.rb
@@ -8,8 +8,16 @@ class Sqlite < Package
   source_sha256 '8e7c1e2950b5b04c5944a981cb31fffbf9d2ddda939d536838ebc854481afd5b'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlite-3.29.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sqlite-3.29.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sqlite-3.29.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlite-3.29.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '9d9adb320dfdaaed8cf896f4338b0a78e75f0aa0d01d2c0480ff2c18dc4ed66f',
+     armv7l: '9d9adb320dfdaaed8cf896f4338b0a78e75f0aa0d01d2c0480ff2c18dc4ed66f',
+       i686: '18e1aaaa527230edc785c7637e8088fb8f10bf6aee8911ace8bd1d350e727ed7',
+     x86_64: '71b432b2d4c2a030f2739754998ebeca05942625b93ef8ba96c4d00957feaf58',
   })
 
   depends_on 'libedit'


### PR DESCRIPTION
Tested on all architectures.