### PR TITLE
Add pre-built binaries for mandb and nginx

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -3,13 +3,21 @@ require 'package'
 class Mandb < Package
   description 'mandb is used to initialise or manually update index database caches that are usually maintained by man.'
   homepage 'http://savannah.nongnu.org/projects/man-db'
-  version '2.8.6'
+  version '2.8.6.1'
   source_url 'https://download.savannah.gnu.org/releases/man-db/man-db-2.8.6.tar.xz'
   source_sha256 'a8baebeb1e1de770a08bbbb0bd50f4c00a2ed7fed07aafd917c7ddf92178a955'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.8.6.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.8.6.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.8.6.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.8.6.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '4ab54543270e692f94ac50235b1518824aa1bdb09a45745991848e9c30dc6469',
+     armv7l: '4ab54543270e692f94ac50235b1518824aa1bdb09a45745991848e9c30dc6469',
+       i686: 'c8378e0ca6622c336bf3e8cfab8a85aff1f49a498008221a06be74dc5509311d',
+     x86_64: '5d830ca395acb5b7ab78fef4e44669bc1c5066196d139bcfcabd91c5b51055a8',
   })
 
   def self.build

--- a/packages/nginx.rb
+++ b/packages/nginx.rb
@@ -8,8 +8,16 @@ class Nginx < Package
   source_sha256 '62854b365e66670ef4f1f8cc79124f914551444da974207cd5fe22d85710e555'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nginx-1.17.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nginx-1.17.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nginx-1.17.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nginx-1.17.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f67f978ee52a403fb628c0d4128c01a0b556974d4a573afd1ae3f3228c5e3f72',
+     armv7l: 'f67f978ee52a403fb628c0d4128c01a0b556974d4a573afd1ae3f3228c5e3f72',
+       i686: '04adfd5c84292dfeb788a982d970373b786ec511710083bb0f1611bcb359a630',
+     x86_64: '25c755241869d55397734f97bc1ee96ad36fd028315f5ffd151eabda7c66de5e',
   })
 
   depends_on 'pcre'


### PR DESCRIPTION
@cstrouse: I tested on all architectures and now `mandb -c` segfaults.  Also, there are 2 nginx files that get added to the files manifest but are not installed.  You can find from `crew files nginx`:
```
du: cannot access '/lib/systemd/system/man-db.service': No such file or directory
du: cannot access '/lib/systemd/system/man-db.timer': No such file or directory
```
The mandb executable has always been a bit flaky but this latest update killed it completely.  I think we can work on these issues later since everything else seems to work fine.  The mandb package is in core so we need the binaries, otherwise, users see mandb compile from source during crew install.