### PR TITLE
Update openldap from 2.4.45 to 2.4.48

### DIFF
--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -2,31 +2,37 @@ require 'package'
 
 class Openldap < Package
   description 'OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.'
-  homepage 'http://www.openldap.org/'
-  version '2.4.45'
-  source_url 'ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/openldap-2.4.45.tgz'
-  source_sha256 'cdd6cffdebcd95161a73305ec13fc7a78e9707b46ca9f84fb897cd5626df3824'
+  homepage 'https://www.openldap.org/'
+  version '2.4.48'
+  source_url 'ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/openldap-2.4.48.tgz'
+  source_sha256 'd9523ffcab5cd14b709fcf3cb4d04e8bc76bb8970113255f372bc74954c6074d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openldap-2.4.45-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openldap-2.4.45-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openldap-2.4.45-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openldap-2.4.45-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openldap-2.4.48-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openldap-2.4.48-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openldap-2.4.48-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openldap-2.4.48-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '65b8d0db561c4c5732a2a499cd1703a2126ce8debf13abe81de066f3ba968954',
-     armv7l: '65b8d0db561c4c5732a2a499cd1703a2126ce8debf13abe81de066f3ba968954',
-       i686: '35b5e0d15baf20ccdf0d1f3b0693f4c42742c60ffaec631dc015133abf1272bb',
-     x86_64: '89922907122e587d9107cfaa4ce7b0657ff2590507db92d97905096c28170d99',
+    aarch64: '3114faa85e552c365ebf8956ab443d2c9d6908afd87df1ee51babc82c1a36332',
+     armv7l: '3114faa85e552c365ebf8956ab443d2c9d6908afd87df1ee51babc82c1a36332',
+       i686: 'b3926bcf814981ac31a2e0d6b9a392ab46760edbaae6aaa0f760b2b29f2fe61a',
+     x86_64: 'b666c84259fd202178018520f2b9bd4d657ea2e18c85c62836b9f1ba8a222158',
   })
 
+  depends_on 'libcyrussasl'
+
   def self.build
-    system "./configure --disable-slapd --prefix=#{CREW_PREFIX}"
-    system "make"
-    system "make depend"
+    system './configure',
+           "--build=#{CREW_BUILD}",
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-slapd'
+    system 'make'
+    system 'make depend'
   end
 
   def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
Abstracts the library directory.  Tested on all architectures.  Depends on #3509.