### PR TITLE
Add CREW_BUILD constant

### DIFF
--- a/crew
+++ b/crew
@@ -254,6 +254,7 @@ def const (var)
       'ARCH_LIB',
       'CHROMEOS_RELEASE',
       'CREW_BREW_DIR',
+      'CREW_BUILD',
       'CREW_CONFIG_PATH',
       'CREW_DEST_DIR',
       'CREW_DEST_HOME',

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.2.4'
+CREW_VERSION = '1.2.5'
 
 ARCH = `uname -m`.strip
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
@@ -45,3 +45,5 @@ CREW_NOT_STRIP = ENV["CREW_NOT_STRIP"]
 USER = `whoami`.chomp
 
 CHROMEOS_RELEASE = `grep CHROMEOS_RELEASE_CHROME_MILESTONE= /etc/lsb-release | cut -d'=' -f2`.chomp
+
+CREW_BUILD = `gcc -dumpmachine`


### PR DESCRIPTION
This should fix the issue with source builds on aarch64 (aka armv8) architecture.  We just need to remember to include `--build=#{CREW_BUILD}` from now on as a new configure option.