### PR TITLE
Update nss and nspr packages

### DIFF
--- a/packages/nspr.rb
+++ b/packages/nspr.rb
@@ -3,21 +3,21 @@ require 'package'
 class Nspr < Package
   description 'Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc-like functions.'
   homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR'
-  version '4.20'
-  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_42_RTM/src/nss-3.42-with-nspr-4.20.tar.gz'
-  source_sha256 '59a0f6f4209b4066702c20c75d6b5531c92b6b3a7bc938b56aa3891c808860dd'
+  version '4.22'
+  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_46_RTM/src/nss-3.46-with-nspr-4.22.tar.gz'
+  source_sha256 '3d4197196e870ab2dccc6ee497e0ec83f45ea070fee929dd931491c024d69f31'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.20-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.20-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.20-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.20-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.22-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.22-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.22-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nspr-4.22-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '26aeff4a3365e980c18d543bddd9d5b2fc6f33a599ba66cb22e1c47538c34ac2',
-     armv7l: '26aeff4a3365e980c18d543bddd9d5b2fc6f33a599ba66cb22e1c47538c34ac2',
-       i686: 'c8356ba7dd10bc68bebc4ca67988f234d095fc1823999a1bc2135f81aa29586b',
-     x86_64: '3632fc729b387d06d9f4b551278f120c56549af288dcd1d78267a5df140fe031',
+    aarch64: 'c271570497b6730a6161c8beca6dc3ebb19a882674cc547deb57ec5f175498ad',
+     armv7l: 'c271570497b6730a6161c8beca6dc3ebb19a882674cc547deb57ec5f175498ad',
+       i686: '743e748f70b5844d95f722426fc0d504a3475153bfc393b6bbb9ce17bf967383',
+     x86_64: 'f49b5ca3842230a3542bbe2986fa2c644c9b89a6cb7c220cfe3ec10b67dc15ad',
   })
 
   def self.build

--- a/packages/nss.rb
+++ b/packages/nss.rb
@@ -3,21 +3,21 @@ require 'package'
 class Nss < Package
   description 'Network Security Services (NSS) is a set of libraries designed to support cross-platform development of security-enabled client and server applications.'
   homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS'
-  version '3.42'
-  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_42_RTM/src/nss-3.42-with-nspr-4.20.tar.gz'
-  source_sha256 '59a0f6f4209b4066702c20c75d6b5531c92b6b3a7bc938b56aa3891c808860dd'
+  version '3.46'
+  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_46_RTM/src/nss-3.46-with-nspr-4.22.tar.gz'
+  source_sha256 '3d4197196e870ab2dccc6ee497e0ec83f45ea070fee929dd931491c024d69f31'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.42-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.42-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.42-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.42-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.46-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.46-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.46-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.46-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '9181501ed99d339989be2aaa11fe69cc0a5317b13bfadf95e6924d497e8d13c7',
-     armv7l: '9181501ed99d339989be2aaa11fe69cc0a5317b13bfadf95e6924d497e8d13c7',
-       i686: '69644e80b3127dcfc4a20e3353dd194297c427c9a37bbbbae1a9482c9cb45961',
-     x86_64: 'b7444bf704022a0bf2f6efe785bbf65b5ed12479a0c1d03e89500b1d19652e00',
+    aarch64: '70857c150acf4e50ab20f1108c89c1be22189953ecbcabb13816d92d7473854f',
+     armv7l: '70857c150acf4e50ab20f1108c89c1be22189953ecbcabb13816d92d7473854f',
+       i686: '7693bc01a39e8a15a7f1a5c5be28194cdd65c2592155401952d14a8376b80ac5',
+     x86_64: '5d15892323a46a0d4c4cf709f615e2243adb1ade44d7118773b3a057cf11aa9a',
   })
 
   depends_on 'gyp' => :build


### PR DESCRIPTION
Update nspr from 4.20 to 4.22 and nss from 3.42 to 3.46.  Tested on all architectures.