### PR TITLE
Update aws cli from 1.16.241 to 1.16.252

### DIFF
--- a/packages/aws.rb
+++ b/packages/aws.rb
@@ -3,27 +3,19 @@ require 'package'
 class Aws < Package
   description 'The AWS CLI is an open source tool built on top of the AWS SDK for Python (Boto) that provides commands for interacting with AWS services.'
   homepage 'https://aws.amazon.com/documentation/cli/'
-  version '1.16.241'
-  source_url 'https://github.com/aws/aws-cli/archive/1.16.241.tar.gz'
-  source_sha256 'c0c503379ec30e576d6c88b15c9d9a820fc085c15b14744291081ab55f3d855c'
+  version '1.16.252'
+  source_url 'https://github.com/aws/aws-cli/archive/1.16.252.tar.gz'
+  source_sha256 'dfe2021ac11641aa30bf0245f1be9ffcca54af5af6d66a1ed64a96b7bdf43690'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.241-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.241-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.241-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.241-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5315d84b871a81dc802025cf2db6b1ac97e640323a51d7e35daf7284241b34c9',
-     armv7l: '5315d84b871a81dc802025cf2db6b1ac97e640323a51d7e35daf7284241b34c9',
-       i686: '10c882927ae6c671e0514cb2181c00281fcecfff02b455f9678b410652d93c46',
-     x86_64: '56eb8eac88fa39637e9f74dbceb6389462f85736f9a7ac996d99903f8068de44',
   })
 
   depends_on 'six'
 
   def self.build
-    system "sed -i 's,-e git://github.com/boto/botocore.git@develop#egg=botocore,botocore==1.12.105,' requirements.txt"
+    system "sed -i 's,-e git://github.com/boto/botocore.git@develop#egg=botocore,botocore==1.12.242,' requirements.txt"
     system "sed -i 's,-e git://github.com/boto/s3transfer.git@develop#egg=s3transfer,s3transfer==0.2.0,' requirements.txt"
     system "sed -i 's,-e git://github.com/boto/jmespath.git@develop#egg=jmespath,jmespath==0.9.4,' requirements.txt"
   end

--- a/packages/six.rb
+++ b/packages/six.rb
@@ -3,21 +3,13 @@ require 'package'
 class Six < Package
   description 'Six is a Python 2 and 3 compatibility library.'
   homepage 'https://github.com/benjaminp/six'
-  version '1.11.0'
-  source_url 'https://github.com/benjaminp/six/archive/1.11.0.tar.gz'
-  source_sha256 '927dc6fcfccd4e32e1ce161a20bf8cda39d8c9d5f7a845774486907178f69bd4'
+  version '1.12.0'
+  source_url 'https://github.com/benjaminp/six/archive/1.12.0.tar.gz'
+  source_sha256 '0ce7aef70d066b8dda6425c670d00c25579c3daad8108b3e3d41bef26003c852'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.11.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.11.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.11.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.11.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '2eccdbb14fcef16c0a1d0c84e3ed80d49225ddc188d2d8ee7116a0572a9ba277',
-     armv7l: '2eccdbb14fcef16c0a1d0c84e3ed80d49225ddc188d2d8ee7116a0572a9ba277',
-       i686: '022a175322383509ac825b5727cd544af2c4b9e3b8f2a65b2c7c231cde13590f',
-     x86_64: '9b3e2de8109ab192bd6b5522619fd6fe4b39b44beb0d89b45091d82805123b2c',
   })
 
   depends_on 'python3'


### PR DESCRIPTION
In addition to upgrading the AWS CLI package this also requires bumping the
expected version of botocore and updating the six package.

Tested on ARM.