### PR TITLE
Add pre-built binaries for collectl, libssh2, libunbound, perf and python27

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -56,8 +56,8 @@ case "${ARCH}" in
   sha256s+=('cfa05a46d37d49479047f205e3d4ab2a8c11f953ed91e11465a1195ff2d95d01')
   urls+=('https://dl.bintray.com/chromebrew/chromebrew/git-2.23.0-chromeos-armv7l.tar.xz')
   sha256s+=('b89d3e83fe9c797c69b4ec90c6f88004270437fbdd4fd378a6a31d66ee7cb276')
-  urls+=('https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.8.1-chromeos-armv7l.tar.xz')
-  sha256s+=('d8fae766d77818ef95ae8a993bda0c03730d773cfb8392ceaaf6c8697206409c')
+  urls+=('https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.9.0-chromeos-armv7l.tar.xz')
+  sha256s+=('497e146e4d769aa85b0d547889784d7552e2aadbbaa448df5bbe9515cd94c182')
   ;;
 "armv7l")
   if ! type "xz" > /dev/null; then
@@ -72,8 +72,8 @@ case "${ARCH}" in
   sha256s+=('cfa05a46d37d49479047f205e3d4ab2a8c11f953ed91e11465a1195ff2d95d01')
   urls+=('https://dl.bintray.com/chromebrew/chromebrew/git-2.23.0-chromeos-armv7l.tar.xz')
   sha256s+=('b89d3e83fe9c797c69b4ec90c6f88004270437fbdd4fd378a6a31d66ee7cb276')
-  urls+=('https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.8.1-chromeos-armv7l.tar.xz')
-  sha256s+=('d8fae766d77818ef95ae8a993bda0c03730d773cfb8392ceaaf6c8697206409c')
+  urls+=('https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.9.0-chromeos-armv7l.tar.xz')
+  sha256s+=('497e146e4d769aa85b0d547889784d7552e2aadbbaa448df5bbe9515cd94c182')
   ;;
 "i686")
   urls+=('https://dl.bintray.com/chromebrew/chromebrew/gcc8-8.3.0-chromeos-i686.tar.xz')
@@ -84,8 +84,8 @@ case "${ARCH}" in
   sha256s+=('b080cd1e667dd9efba1a4392c7c177f5b8292f1b6fc29e862634b7ad41d29ab5')
   urls+=('https://dl.bintray.com/chromebrew/chromebrew/git-2.23.0-chromeos-i686.tar.xz')
   sha256s+=('b02bb5d57315a2c620ecf177ac19fdadf03139136d7bc864e86b08d26e08472b')
-  urls+=('https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.8.1-chromeos-i686.tar.xz')
-  sha256s+=('ccdea94d6dcc0bdd27b364cd99f53e9aba6f90f0b8272a5f3856bf2a9a32beb6')
+  urls+=('https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.9.0-chromeos-i686.tar.xz')
+  sha256s+=('dd2172bf82e3ffc1cfd06463108a36de55ba5e4bc2eb283852b54a737e087fe4')
   ;;
 "x86_64")
   urls+=('https://dl.bintray.com/chromebrew/chromebrew/gcc8-8.3.0-chromeos-x86_64.tar.xz')
@@ -96,8 +96,8 @@ case "${ARCH}" in
   sha256s+=('7ac97b03fff5d1befecb26ac471daa239c2c23ab1bc774a5366e6c46d1bb9ad3')
   urls+=('https://dl.bintray.com/chromebrew/chromebrew/git-2.23.0-chromeos-x86_64.tar.xz')
   sha256s+=('a67df6819289a4acb87e07c9f84300c1856c9116691318bf440cab7f8eb044e6')
-  urls+=('https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.8.1-chromeos-x86_64.tar.xz')
-  sha256s+=('1025b413f30c5ac27bfa340e41cb437bf19311e72b95030f64020e25be4cda31')
+  urls+=('https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.9.0-chromeos-x86_64.tar.xz')
+  sha256s+=('d02623da747ecc95acdba69a056220ef579b01dae82a0cbfec2aa96c2ea8e914')
   ;;
 esac
 

--- a/packages/collectl.rb
+++ b/packages/collectl.rb
@@ -8,11 +8,17 @@ class Collectl < Package
   source_sha256 '2187264d974b36a653c8a4b028ac6eeab23e1885f8b2563a33f06358f39889f1'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/collectl-4.3.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/collectl-4.3.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/collectl-4.3.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/collectl-4.3.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'c7dfcb941c97ae272b888d9c6257f931285ce51d453c08bc53cfcfb419b02486',
+     armv7l: 'c7dfcb941c97ae272b888d9c6257f931285ce51d453c08bc53cfcfb419b02486',
+       i686: '9df81b18774e4f086d53b646da72a3fb3c2dd0abc574b2d71728d77857dc80b2',
+     x86_64: '3726cff22c73deab81018a66b27e75696db94ab3de9a40239407077f07a885b3',
   })
-
-  depends_on 'perl'
 
   def self.build
     system "sed -i 's,/usr/bin/perl,#{CREW_PREFIX}/bin/perl,' colmux"
@@ -24,6 +30,6 @@ class Collectl < Package
   end
 
   def self.install
-    system "./INSTALL"
+    system './INSTALL'
   end
 end

--- a/packages/libssh2.rb
+++ b/packages/libssh2.rb
@@ -8,8 +8,16 @@ class Libssh2 < Package
   source_sha256 'd5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.9.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.9.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.9.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libssh2-1.9.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '497e146e4d769aa85b0d547889784d7552e2aadbbaa448df5bbe9515cd94c182',
+     armv7l: '497e146e4d769aa85b0d547889784d7552e2aadbbaa448df5bbe9515cd94c182',
+       i686: 'dd2172bf82e3ffc1cfd06463108a36de55ba5e4bc2eb283852b54a737e087fe4',
+     x86_64: 'd02623da747ecc95acdba69a056220ef579b01dae82a0cbfec2aa96c2ea8e914',
   })
 
   def self.patch

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -8,8 +8,16 @@ class Libunbound < Package
   source_sha256 '3d3e25fb224025f0e732c7970e5676f53fd1764c16d6a01be073a13e42954bb0'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.9.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.9.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.9.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libunbound-1.9.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd8951bc3aea52562d64b899ec99e8e12ed4a53b186b2631557ff182da14724f0',
+     armv7l: 'd8951bc3aea52562d64b899ec99e8e12ed4a53b186b2631557ff182da14724f0',
+       i686: '2fc4b02d55f38c63ae4a4070774b50ebe17a724a9ba3232321a1f82f135210ea',
+     x86_64: '47007cc2efc1962ea0e6b5eb03c2e768faa95af16f92e7e7de52cb2638c211cd',
   })
 
   def self.build
@@ -23,10 +31,10 @@ class Libunbound < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
-    system "make", "test"
+    system 'make', 'test'
   end
 end

--- a/packages/perf.rb
+++ b/packages/perf.rb
@@ -7,6 +7,19 @@ class Perf < Package
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perf-4.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perf-4.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perf-4.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perf-4.14-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '87c533c2b45a9beec0ef975b4a3f110e42a6d03def1820dfd3190fb3f767e710',
+     armv7l: '87c533c2b45a9beec0ef975b4a3f110e42a6d03def1820dfd3190fb3f767e710',
+       i686: '9786bce0863320385c3dd96534c681e5eae26d593851bde4278d30aa4dedec22',
+     x86_64: '95e550bc751bd655a0d885104ec0f88aad533b8450af35438802f0a848b768be',
+  })
+
   # Reuse linux sources if they're already installed
   depends_on 'linux_sources' => :build
 

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -8,8 +8,16 @@ class Python27 < Package
   source_sha256 '4d43f033cdbd0aa7b7023c81b0e986fd11e653b5248dac9144d508f11812ba41'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.17-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.17-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.17-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.17-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '753d3df25a3353384c6d938a907305825d5f6d8eda3189a18de877c3d5dc6075',
+     armv7l: '753d3df25a3353384c6d938a907305825d5f6d8eda3189a18de877c3d5dc6075',
+       i686: 'a3c9214188a6648ade671337591b93a4e8b53e733442a6db6bbd366559605928',
+     x86_64: '671417cd3cdc21f4196fb7515beeb8c3a1d4fbc302cf4a3094a504ab71291fd4',
   })
 
   depends_on 'bz2' => :build


### PR DESCRIPTION
Tested on all architectures.