### PR TITLE
Vim 8.1.2225

### DIFF
--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -3,24 +3,15 @@ require 'package'
 class Gvim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (with advanced features, such as a GUI)'
   homepage 'http://www.vim.org/'
-  version '8.1.1915'
-  source_url 'https://github.com/vim/vim/archive/v8.1.1915.tar.gz'
-  source_sha256 '508bcffd340497d6279fb2d5aa98ff43190cf7983a87fe4838fb780446f900a9'
+  version '8.1.2225'
+  source_url 'https://github.com/vim/vim/archive/v8.1.2225.tar.gz'
+  source_sha256 'a88cf5fb07701d92ea79a3cc8f6e020e6b9bf07c0dfa72f0dde8a65f87e30f2d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1.1915-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1.1915-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1.1915-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.1.1915-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b31573015a9c31dd256555db8d75634e40cdfe79f3141540558887c6fe29b851',
-     armv7l: 'b31573015a9c31dd256555db8d75634e40cdfe79f3141540558887c6fe29b851',
-       i686: '655cf5e0076da4b7d52d7ecfe87f02b5b2ba48d1b5366652ebd08fa0288b546d',
-     x86_64: '07be8e948923b2c2b81acd1ee343da7c4f221825ee3dc14bea488149cc5fef18',
   })
 
-  depends_on 'python27' => :build
   depends_on 'python3' => :build
   depends_on 'vim_runtime'
   depends_on 'gtk3'
@@ -47,7 +38,6 @@ class Gvim < Package
               "--enable-cscope",
               "--enable-fontset",
               "--enable-perlinterp=dynamic",
-              "--enable-pythoninterp=dynamic",
               "--enable-python3interp=dynamic",
               "--enable-rubyinterp=dynamic",
               "--disable-selinux"

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -12,6 +12,7 @@ class Gvim < Package
   binary_sha256 ({
   })
 
+  depends_on 'python27' => :build
   depends_on 'python3' => :build
   depends_on 'vim_runtime'
   depends_on 'gtk3'
@@ -38,6 +39,7 @@ class Gvim < Package
               "--enable-cscope",
               "--enable-fontset",
               "--enable-perlinterp=dynamic",
+              "--enable-pythoninterp=dynamic",
               "--enable-python3interp=dynamic",
               "--enable-rubyinterp=dynamic",
               "--disable-selinux"

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -3,9 +3,9 @@ require 'package'
 class Vim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.'
   homepage 'http://www.vim.org/'
-  version '8.1.1915'
-  source_url 'https://github.com/vim/vim/archive/v8.1.1915.tar.gz'
-  source_sha256 '508bcffd340497d6279fb2d5aa98ff43190cf7983a87fe4838fb780446f900a9'
+  version '8.1.2225'
+  source_url 'https://github.com/vim/vim/archive/v8.1.2225.tar.gz'
+  source_sha256 'a88cf5fb07701d92ea79a3cc8f6e020e6b9bf07c0dfa72f0dde8a65f87e30f2d'
 
   if ARGV[0] == 'install'
     gvim = `which gvim 2> /dev/null`.chomp
@@ -13,16 +13,8 @@ class Vim < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1.1915-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1.1915-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1.1915-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.1.1915-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '7e9139cbb1940f272ea3414facfbe34e37f59e476868d8ceb7fe2419ac1261e1',
-     armv7l: '7e9139cbb1940f272ea3414facfbe34e37f59e476868d8ceb7fe2419ac1261e1',
-       i686: 'a3714ab96726d3630f6903b535b4af5808fdcc1101aabf08b0d79544d676e984',
-     x86_64: 'b5eeeb48785b05e94227747138b72b8ea48502b32aa0b6b7559e6582fab85a99',
   })
 
   depends_on 'python27' => :build

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -17,7 +17,6 @@ class Vim < Package
   binary_sha256 ({
   })
 
-  depends_on 'python27' => :build
   depends_on 'python3' => :build
   depends_on 'vim_runtime'
 
@@ -42,7 +41,6 @@ class Vim < Package
               "--enable-cscope",
               "--enable-fontset",
               "--enable-perlinterp=dynamic",
-              "--enable-pythoninterp=dynamic",
               "--enable-python3interp=dynamic",
               "--enable-rubyinterp=dynamic",
               "--disable-selinux"

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -17,6 +17,7 @@ class Vim < Package
   binary_sha256 ({
   })
 
+  depends_on 'python27' => :build
   depends_on 'python3' => :build
   depends_on 'vim_runtime'
 
@@ -41,6 +42,7 @@ class Vim < Package
               "--enable-cscope",
               "--enable-fontset",
               "--enable-perlinterp=dynamic",
+              "--enable-pythoninterp=dynamic",
               "--enable-python3interp=dynamic",
               "--enable-rubyinterp=dynamic",
               "--disable-selinux"

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -3,24 +3,15 @@ require 'package'
 class Vim_runtime < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (shared runtime)'
   homepage 'http://www.vim.org/'
-  version '8.1.1915'
-  source_url 'https://github.com/vim/vim/archive/v8.1.1915.tar.gz'
-  source_sha256 '508bcffd340497d6279fb2d5aa98ff43190cf7983a87fe4838fb780446f900a9'
+  version '8.1.2225'
+  source_url 'https://github.com/vim/vim/archive/v8.1.2225.tar.gz'
+  source_sha256 'a88cf5fb07701d92ea79a3cc8f6e020e6b9bf07c0dfa72f0dde8a65f87e30f2d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.1.1915-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.1.1915-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.1.1915-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.1.1915-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '84e607539c05688d675e8d283180f9035c494daf63cc7d34928eafc918f4430b',
-     armv7l: '84e607539c05688d675e8d283180f9035c494daf63cc7d34928eafc918f4430b',
-       i686: 'fd6b087f6651ca377859c1f158356cf4df808e3afb66754f73d1095b19444851',
-     x86_64: '0e9a254b9ccce8f8ced83a025800f980de2ba4dc17967afc69458d420d5f68c6',
   })
 
-  depends_on 'python27' => :build
   depends_on 'python3' => :build
 
   def self.patch
@@ -44,7 +35,6 @@ class Vim_runtime < Package
               "--enable-cscope",
               "--enable-fontset",
               "--enable-perlinterp=dynamic",
-              "--enable-pythoninterp=dynamic",
               "--enable-python3interp=dynamic",
               "--enable-rubyinterp=dynamic",
               "--disable-selinux"

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -12,6 +12,7 @@ class Vim_runtime < Package
   binary_sha256 ({
   })
 
+  depends_on 'python27' => :build
   depends_on 'python3' => :build
 
   def self.patch
@@ -35,6 +36,7 @@ class Vim_runtime < Package
               "--enable-cscope",
               "--enable-fontset",
               "--enable-perlinterp=dynamic",
+              "--enable-pythoninterp=dynamic",
               "--enable-python3interp=dynamic",
               "--enable-rubyinterp=dynamic",
               "--disable-selinux"


### PR DESCRIPTION
Fixes #3588 
Removing python27 dependency is optional. I think it should be but what about backward compatibility ?