### PR TITLE
Upgrade gemacs to 26.3 and generate glib compiled schemas

### DIFF
--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -3,25 +3,19 @@ require 'package'
 class Gemacs < Package
   description 'An extensible, customizable, free/libre text editor - and more.'
   homepage 'http://www.gnu.org/software/emacs/'
-  version '26.2'
-  source_url 'https://ftpmirror.gnu.org/emacs/emacs-26.2.tar.xz'
-  source_sha256 '151ce69dbe5b809d4492ffae4a4b153b2778459de6deb26f35691e1281a9c58e'
+  version '26.3'
+  source_url 'https://ftpmirror.gnu.org/emacs/emacs-26.3.tar.xz'
+  source_sha256 '4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'cf400dc1a499f64c25c5fd08cb954305f62bba1f65bfaddeea799205d59fe506',
-     armv7l: 'cf400dc1a499f64c25c5fd08cb954305f62bba1f65bfaddeea799205d59fe506',
-       i686: 'd0b38c6c09d92c73dd0c02aff134b364ef1a05ff2e530a04b83e53aa62fed95c',
-     x86_64: '120a8438b8ab8fda338f38151a2846528ba41a06923e294ed43b2c090c86a113',
   })
 
   depends_on 'emacs'
   depends_on 'giflib'
+  depends_on 'libjpeg'
+  depends_on 'libpng'
   depends_on 'libtiff'
   depends_on 'imagemagick6'
   depends_on 'sommelier'
@@ -42,6 +36,6 @@ class Gemacs < Package
 
   def self.install
     system "install -Dm755 src/emacs #{CREW_DEST_PREFIX}/bin/gemacs"
-    system "install -Dm755 src/emacs-26.2.1 #{CREW_DEST_PREFIX}/bin/gemacs-26.2.1"
+    system "install -Dm755 src/emacs-26.3.1 #{CREW_DEST_PREFIX}/bin/gemacs-26.3.1"
   end
 end

--- a/packages/gsettings_desktop_schemas.rb
+++ b/packages/gsettings_desktop_schemas.rb
@@ -35,10 +35,12 @@ class Gsettings_desktop_schemas < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install" # the steps required to install the package
-    
+  end
+
+  def self.postinstall
     # The package is installed using a “DESTDIR” method, #{CREW_PREFIX}/share/glib-2.0/schemas/gschemas.compiled was not updated/created.
     # Generate gschemas.compiled
-    system "glib-compile-schemas #{CREW_DEST_PREFIX}/share/glib-2.0/schemas"
+    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
   end
 
 end


### PR DESCRIPTION
Fixes #3581 
Needed to modify the `gsettings_desktop_schemas` since latest command of install wasn't executed.