### PR TITLE
Rebuild curl binaries against libressl

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,21 +3,21 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.haxx.se/'
-  version '7.66.0'
+  version '7.66.0-1'
   source_url 'https://curl.haxx.se/download/curl-7.66.0.tar.xz'
   source_sha256 'dbb48088193016d079b97c5c3efde8efa56ada2ebf336e8a97d04eb8e2ed98c1'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.66.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '135488fd75e5127645d4ffe07d67e635229e5bfdb238852e5d8af9c10fd5f15d',
-     armv7l: '135488fd75e5127645d4ffe07d67e635229e5bfdb238852e5d8af9c10fd5f15d',
-       i686: 'c03cb9fe9b2d30e106a96a686ce79e367281cea8296241c6151938fcecde27e0',
-     x86_64: 'aa67936bd49b3722c356c5fd5137f5b3b350f6085a8da19d70e03ee58f428e60',
+    aarch64: 'd3fa586deef7030c2bdd3c3e477391c276b34276d5dddbf755cf4785a56ec482',
+     armv7l: 'd3fa586deef7030c2bdd3c3e477391c276b34276d5dddbf755cf4785a56ec482',
+       i686: '76dfc54131f9ad33fdc6fba5ffc74eabd730322ba88cfdf10ded79b304c1ce22',
+     x86_64: 'bee317b81814d931317a7539cd86678e28b3de46508aa09ad7a5aa648ba761ff',
   })
 
   depends_on 'groff' => :build


### PR DESCRIPTION
Fixes #3640.  Tested on all architectures.