### PR TITLE
Add ck4up package

### DIFF
--- a/packages/ck4up.rb
+++ b/packages/ck4up.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Ck4up < Package
+  description 'Check for Updates, a utility to monitor web pages for updates'
+  homepage 'http://jue.li/crux/ck4up'
+  version '1.4'
+  source_url 'http://jue.li/crux/ck4up/ck4up-1.4.tar.gz'
+  source_sha256 '37f2f981cfdb6811a906e5520cb27203cb5ecb725d2180aaac59d377c1ac9fbf'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+  end
+
+  def self.install
+    system 'make', "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.postinstall
+    puts
+    puts "A configuration file is required to use ck4up.".lightblue
+    puts "By default it looks for ~/.ck4up/ck4up.conf".lightblue
+    puts
+  end
+end


### PR DESCRIPTION
Ck4up is a small command-line utility primarily intended for CRUX ports
maintainers to watch http and ftp sites for updates, but may also be useful for
others.

Tested on ARM. HTTPS is not available on homepage or for the downloads.