### PR TITLE
Add pre-built binaries for ck4up, gambit, jansson and libcheck

### DIFF
--- a/packages/ck4up.rb
+++ b/packages/ck4up.rb
@@ -8,8 +8,16 @@ class Ck4up < Package
   source_sha256 '37f2f981cfdb6811a906e5520cb27203cb5ecb725d2180aaac59d377c1ac9fbf'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ck4up-1.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ck4up-1.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ck4up-1.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ck4up-1.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '04faf368ecc2291d8b0177488f1d4d26441dd2e147c27d848c7e1f719eac9238',
+     armv7l: '04faf368ecc2291d8b0177488f1d4d26441dd2e147c27d848c7e1f719eac9238',
+       i686: '08be206b7492b1517afb7d857b00bf22dbf8443f3dc52cb6b98134bb678483b3',
+     x86_64: '5bb33449474861c134b780586c215e8429457312577535502b96c5343a8a0541',
   })
 
   def self.build

--- a/packages/gambit.rb
+++ b/packages/gambit.rb
@@ -8,19 +8,27 @@ class Gambit < Package
   source_sha256 'a5e4e5c66a99b6039fa7ee3741ac80f3f6c4cff47dc9e0ff1692ae73e13751ca'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gambit-4.9.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gambit-4.9.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gambit-4.9.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gambit-4.9.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '0e2b98c6d0a60f3715c6e554a4b95018cd6d665c4709892da9eafc74fd84ebd5',
+     armv7l: '0e2b98c6d0a60f3715c6e554a4b95018cd6d665c4709892da9eafc74fd84ebd5',
+       i686: '08bc6d954969ec3f4d3a985d9460647f4667b33609f98fe3ff6b705e09ab8260',
+     x86_64: 'baa93bfbb278ac2560fbf56cb3e6339f2bf633105986b3d23f2e343eedf632e0',
   })
 
   def self.build
     system './configure',
              "--prefix=#{CREW_PREFIX}",
              "--libdir=#{CREW_LIB_PREFIX}/gambit",
-             '--enable-gcc-opts',
-             '--enable-single-host',
              '--enable-openssl',
-             '--enable-interpreter-name=gsi-gambit',
-             '--enable-compiler-name=gsc-gambit'
+             '--enable-single-host',
+             '--enable-multiple-versions',
+             '--enable-compiler-name=gsc-gambit',
+             '--enable-interpreter-name=gsi-gambit'
     system 'make'
   end
 

--- a/packages/jansson.rb
+++ b/packages/jansson.rb
@@ -8,14 +8,24 @@ class Jansson < Package
   source_sha256 '76260d30e9bbd0ef392798525e8cd7fe59a6450c54ca6135672e3cd6a1642941'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/jansson-2.12-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/jansson-2.12-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/jansson-2.12-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/jansson-2.12-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '1268da5b1e8fb780fa300e2435992978ad3ca1dca671fcb157591795b219cee3',
+     armv7l: '1268da5b1e8fb780fa300e2435992978ad3ca1dca671fcb157591795b219cee3',
+       i686: '1a5b9a9099cb64e5b097090bc17a0ae3b225c66815dd06f3db0a32d4adedac03',
+     x86_64: '3cb0754c45a3997f7c41cc0d941964c4ec55f12e28792712ececc2d5f41a42e4',
   })
 
   def self.build
-    system "cmake . -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}"
-           #"-DJANSSON_INSTALL_CMAKE_DIR=#{ARCH_LIB}/cmake/jansson",
-           #"-DJANSSON_INSTALL_LIB_DIR=#{ARCH_LIB}"
+    system 'autoreconf -i'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
   end
 
   def self.install

--- a/packages/libcheck.rb
+++ b/packages/libcheck.rb
@@ -8,8 +8,16 @@ class Libcheck < Package
   source_sha256 'c4336b31447acc7e3266854f73ec188cdb15554d0edd44739631da174a569909'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcheck-0.13.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcheck-0.13.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcheck-0.13.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcheck-0.13.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '71a129c63ce759b17a6a9ce7c30eecadb633a24242170d9a6646a9c45c64eac4',
+     armv7l: '71a129c63ce759b17a6a9ce7c30eecadb633a24242170d9a6646a9c45c64eac4',
+       i686: '48d3bea93e956e8089ba520a48761d40148be6009aa4d93f801e4f6627e75755',
+     x86_64: '9522b0a5173a563716f2f435d1ef26e61f39eebea16c6ece97aea037a5db9ba3',
   })
 
   def self.build


### PR DESCRIPTION
Change configure options for gambit and jansson.  Tested on all architectures.
Fixes #3646.