### PR TITLE
Update packages a-r

### DIFF
--- a/packages/arduino_ide.rb
+++ b/packages/arduino_ide.rb
@@ -1,4 +1,4 @@
-ENV["CREW_NOT_STRIP"] = "true"
+ENV['CREW_NOT_STRIP'] = 'true'
 
 require 'package'
 
@@ -17,13 +17,21 @@ class Arduino_ide < Package
 
   description 'Arduino is an open-source physical computing platform based on a simple I/O board and a development environment that implements the Processing/Wiring language.'
   homepage 'https://www.arduino.cc/'
-  version '1.8.9'
-  source_url "https://github.com/arduino/Arduino/releases/download/#{@version}/arduino-#{@version}.tar.xz"
-  source_sha256 '49e9c3a3a04c8dae8c2ffbfd39cf83b77d4908a09e29c2b3bfa4697c59ea1bf2'
+  version '1.8.10'
+  source_url 'https://github.com/arduino/Arduino/releases/download/1.8.10/arduino-1.8.10.tar.xz'
+  source_sha256 '862e4b100d5214ca51d501edcc095467d7a4e3dc39b306146001da8b0c63343e'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/arduino_ide-1.8.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/arduino_ide-1.8.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/arduino_ide-1.8.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/arduino_ide-1.8.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'cf323df5db4b7b3d225199539f185cdd66bb7d86705b8eec5125d1538508bf9b',
+     armv7l: 'cf323df5db4b7b3d225199539f185cdd66bb7d86705b8eec5125d1538508bf9b',
+       i686: '9755e405993c3608fa7ff631eab47b0ab25af9b043f369ebf96d512e4a0b0375',
+     x86_64: 'f3a6d2ae75065565c1891d09b4e5556647be4dd6e5a04d8345b5a3b0d1183792',
   })
 
   depends_on 'xzutils'
@@ -33,14 +41,14 @@ class Arduino_ide < Package
 
   def self.build
     Dir.chdir("build") do
-      system "env",
+      system 'env',
              "JAVA_HOME=#{CREW_PREFIX}/share/jdk8",
-             "ant",
-             "-Djava.net.preferIPv4Stack=true",
+             'ant',
+             '-Djava.net.preferIPv4Stack=true',
              "-Dversion=#{@version}",
              "-Dplatform=#{@platform}",
-             "clean",
-             "dist"
+             'clean',
+             'dist'
       system "echo '#!/bin/bash' > arduino"
       system "echo >> arduino"
       system "echo 'echo \"Enabling Arduino write access...\"' >> arduino"
@@ -54,11 +62,11 @@ class Arduino_ide < Package
   def self.install
     Dir.chdir("build") do
       FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
-      system "tar", "xpf", "linux/arduino-#{@version}-#{@platform}.tar.xz", "-C", "#{CREW_DEST_PREFIX}/share/"
-      system "install", "-Dm755", "arduino", "#{CREW_DEST_PREFIX}/bin/arduino"
-      system "ln", "-s", "../share/arduino-#{@version}/arduino-builder", "#{CREW_DEST_PREFIX}/bin"
+      system "tar xpf linux/arduino-#{@version}-#{@platform}.tar.xz -C #{CREW_DEST_PREFIX}/share/"
+      system "install -Dm755 arduino #{CREW_DEST_PREFIX}/bin/arduino"
+      FileUtils.ln_s "../share/arduino-#{@version}/arduino-builder", "#{CREW_DEST_PREFIX}/bin"
     end
   end
 end
 
-ENV["CREW_NOT_STRIP"] = ""
+ENV['CREW_NOT_STRIP'] = ''

--- a/packages/chibi_scheme.rb
+++ b/packages/chibi_scheme.rb
@@ -8,14 +8,24 @@ class Chibi_scheme < Package
   source_sha256 '8a077859b123216c123c243db391b0fe4c0cf73978c7cdd7b8ea853a48192756'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/chibi_scheme-0.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/chibi_scheme-0.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/chibi_scheme-0.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/chibi_scheme-0.8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'c5ce68d2b060f78644b9b95d4c4bf900aec0787d5461d78ff4ccfca556d63e16',
+     armv7l: 'c5ce68d2b060f78644b9b95d4c4bf900aec0787d5461d78ff4ccfca556d63e16',
+       i686: '3c397e24bac2b7ebaaf822fd43ef5f2f44e2f3e2a3e469dbdfa70e3c51a13560',
+     x86_64: 'b6c3320b5e3bd52980bfc8882b9117ad851ea2351dfa23a84fd108a470bbc3c4',
   })
 
-
-  def self.build
+  def self.patch
     system 'sed -i -e \'/LDCONFIG/d\' Makefile'
     system 'sed -i \'/^IMAGE_FILES =/c\IMAGE_FILES =\' Makefile' # wasn't able to override via CLI
+  end
+
+  def self.build
     system 'make', '-j1', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}"
   end
 

--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -2,14 +2,22 @@ require 'package'
 
 class Gemacs < Package
   description 'An extensible, customizable, free/libre text editor - and more.'
-  homepage 'http://www.gnu.org/software/emacs/'
+  homepage 'https://www.gnu.org/software/emacs/'
   version '26.3'
   source_url 'https://ftpmirror.gnu.org/emacs/emacs-26.3.tar.xz'
   source_sha256 '4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '45bae4cffee76691bf89478032d4ac68faf331b263696b6236b3cdcaa9ae8eee',
+     armv7l: '45bae4cffee76691bf89478032d4ac68faf331b263696b6236b3cdcaa9ae8eee',
+       i686: '2980639d04f3d911773b3a97f0a99e604eb38f5155beabafb3d02cb033ce3a93',
+     x86_64: '3e3becfa06271d8b9a13aacdbc0a9f3aeade8ddfa7991f1a24c4f6b8bdc30a89',
   })
 
   depends_on 'emacs'

--- a/packages/mcelog.rb
+++ b/packages/mcelog.rb
@@ -3,13 +3,21 @@ require 'package'
 class Mcelog < Package
   description 'logs and accounts machine checks (in particular memory, IO, and CPU hardware errors) on modern x86 Linux systems.'
   homepage 'https://www.mcelog.org/'
-  version '162'
-  source_url 'https://git.kernel.org/pub/scm/utils/cpu/mce/mcelog.git/snapshot/mcelog-162.tar.gz'
-  source_sha256 '875e98572e86240ea319ab1f69ee6d744eb8b73ac5d700e474f6410d0f52d3fc'
+  version '165'
+  source_url 'https://git.kernel.org/pub/scm/utils/cpu/mce/mcelog.git/snapshot/mcelog-165.tar.gz'
+  source_sha256 'a18fdef9cfe2dfaefa09087c616c376a301dc87b1fa14a37476d97370962c668'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mcelog-165-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mcelog-165-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mcelog-165-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mcelog-165-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '5d9cf717ea6e8f1008b061468130164e14794588d1bf5610d01563cf48182c9b',
+     armv7l: '5d9cf717ea6e8f1008b061468130164e14794588d1bf5610d01563cf48182c9b',
+       i686: '9d5f57770c2189457f402992ef0fa08ccf26d9db677ec725177589ec92b32118',
+     x86_64: 'cbe973fe9210ca821f3bda8e2f0f98249ab8fa4043fcf30fdb7ef5a1c234362b',
   })
 
   def self.patch
@@ -22,6 +30,6 @@ class Mcelog < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/rsu_client.rb
+++ b/packages/rsu_client.rb
@@ -3,9 +3,22 @@ require 'package'
 class Rsu_client < Package
   description 'RSU-Client is a RuneScape Client Launcher written for the now Legacy client and now OldSchool.'
   homepage 'https://github.com/rsu-client/rsu-client'
-  version '4.3.7'
-  source_url 'https://github.com/rsu-client/rsu-client/archive/v4.3.7.tar.gz'
-  source_sha256 '7cc589de111baad956c0c41a4d7f1b45168886bf623dd3886d07fa3d1dfd604c'
+  version '4.3.8'
+  source_url 'https://github.com/rsu-client/rsu-client/archive/v4.3.8.tar.gz'
+  source_sha256 'a84d27f2775ceef3bf0f715504ba41f3776c5374b61f9820993a26f350e4fa3d'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rsu_client-4.3.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rsu_client-4.3.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rsu_client-4.3.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rsu_client-4.3.8-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '740174a97f6f60b8fde6cc6458934ecb1605fa66d40c4ee04b095316b8fa4e7e',
+     armv7l: '740174a97f6f60b8fde6cc6458934ecb1605fa66d40c4ee04b095316b8fa4e7e',
+       i686: '17999feafa2539689e57454b9825d9f436baca894125383405f5c5e93421d70e',
+     x86_64: '535a8a5339b57fe5929b6b1ff4fc40c8c93039ecf43006c2323c0d65502ed899',
+  })
 
   depends_on 'jdk8'
   depends_on 'p7zip'
@@ -25,13 +38,13 @@ class Rsu_client < Package
   end
 
   def self.build
-    system 'cpan install Archive::Extract exit'
+    system 'cpan -f -i Archive::Extract'
   end
 
   def self.install
-    system 'mkdir', '-p', "#{CREW_DEST_PREFIX}/share"
-    system 'cp', '-a', 'runescape', "#{CREW_DEST_PREFIX}/share/"
-    system 'mkdir', '-p', "#{CREW_DEST_PREFIX}/bin"
-    system 'ln', '-s', "#{CREW_PREFIX}/share/runescape/runescape", "#{CREW_DEST_PREFIX}/bin/runescape"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
+    FileUtils.cp_r 'runescape', "#{CREW_DEST_PREFIX}/share/"
+    FileUtils.ln_s "#{CREW_PREFIX}/share/runescape/runescape", "#{CREW_DEST_PREFIX}/bin/runescape"
   end
 end


### PR DESCRIPTION
- Add self.patch section to chibi_scheme
- Change home from http to https for gemacs
- Update arduino_ide from 1.8.9 to 1.8.10
- Update mcelog from 162 to 165
- Update rsu_client from 4.3.7 to 4.3.8
- Add pre-built binaries

Fixes #3124.  Tested on all architectures.