### PR TITLE
Remove sommelier dependency from zvbi

### DIFF
--- a/packages/zvbi.rb
+++ b/packages/zvbi.rb
@@ -20,6 +20,8 @@ class Zvbi < Package
      x86_64: 'df144f5bf127aad35537b7874fbeddf60847e2d8e956bea44fdd4d6b1ab4eece',
   })
 
+  depends_on 'libpng'
+
   def self.build
     system './configure',
            "--prefix=#{CREW_PREFIX}",

--- a/packages/zvbi.rb
+++ b/packages/zvbi.rb
@@ -20,14 +20,11 @@ class Zvbi < Package
      x86_64: 'df144f5bf127aad35537b7874fbeddf60847e2d8e956bea44fdd4d6b1ab4eece',
   })
 
-  depends_on 'sommelier'
-
   def self.build
     system './configure',
            "--prefix=#{CREW_PREFIX}",
            "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-maintainer-mode',
-           '--with-x'
+           '--disable-maintainer-mode'
     system 'make'
   end
 


### PR DESCRIPTION
This doesn't actually do anything; it's just an artifact from old Autotools. Should be safe to just remove.