### PR TITLE
Change from libjpeg to libjpeg_turbo dependency in gdk_pixbuf

### DIFF
--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -25,7 +25,7 @@ class Gdk_pixbuf < Package
   depends_on 'gobject_introspection'
   depends_on 'jasper'
   depends_on 'libtiff'
-  depends_on 'libjpeg'
+  depends_on 'libjpeg_turbo'
   depends_on 'six'
   depends_on 'sommelier'
 


### PR DESCRIPTION
Fixes #3681.