### PR TITLE
Add scrot package and giblib dependency

### DIFF
--- a/packages/giblib.rb
+++ b/packages/giblib.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Giblib < Package
+  description 'giblib is a simple library which wraps imlib2.'
+  homepage 'http://freshmeat.sourceforge.net/projects/giblib/'
+  version '1.2.4'
+  source_url 'https://deb.debian.org/debian/pool/main/g/giblib/giblib_1.2.4.orig.tar.gz'
+  source_sha256 'e437756ce3ded019946fb3d979991cda7604bc345dbb1338b17655caff65a3d3'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/giblib-1.2.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/giblib-1.2.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/giblib-1.2.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/giblib-1.2.4-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'cd6fb66f5d4c31c8bd10016bd1aa3d520989527b8f9415a7feb3e3f517781db2',
+     armv7l: 'cd6fb66f5d4c31c8bd10016bd1aa3d520989527b8f9415a7feb3e3f517781db2',
+       i686: 'a972ff625fe3cbaeaed1a156ee95147692e24b091eef76e7ced14f626d556ec3',
+     x86_64: '6e2fbfb1686cc25d21d36e0d62ca61333d923a1d528d21d870241de4428d6ceb',
+  })
+
+  depends_on 'imlib2'
+  
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/scrot.rb
+++ b/packages/scrot.rb
@@ -1,0 +1,39 @@
+require 'package'
+
+class Scrot < Package
+  description 'scrot, an acronym for (SCReen shOT) is a simple, freely distributed and open source command-line screen capture utility'
+  homepage 'https://github.com/resurrecting-open-source-projects/scrot'
+  version '1.2'
+  source_url 'https://github.com/resurrecting-open-source-projects/scrot/archive/1.2.tar.gz'
+  source_sha256 'e9b41d4cb9b5ab3747d6718c4eb51d5aaf35b6cac23c9ff68af15fc1c9ce187c'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/scrot-1.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/scrot-1.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/scrot-1.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/scrot-1.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'bbb19fc3f64dd778da3a3a79658cb22da4d435ebd6319ba0d6dce5117d8790cc',
+     armv7l: 'bbb19fc3f64dd778da3a3a79658cb22da4d435ebd6319ba0d6dce5117d8790cc',
+       i686: '2b1720613f82c66ab60473bf454375c6b3a73019a5e7f10dd6af0327f51dd777',
+     x86_64: 'a80847e67860885dadcb12c0dce773dee599293240a3365932268ac77d98e75b',
+  })
+
+  depends_on 'autoconf_archive' => :build
+  depends_on 'giblib'
+  depends_on 'libxcursor'
+  depends_on 'libxfixes'
+
+  def self.build
+    system './autogen.sh'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end


### PR DESCRIPTION
scrot, an acronym for (SCReen shOT) is a simple, freely distributed and open source command-line screen capture utility.  giblib is a simple library which wraps imlib2.  Tested on all architectures.  Fixes #3686.