### PR TITLE
[Gimp] Update to 2.10.14

### DIFF
--- a/packages/babl.rb
+++ b/packages/babl.rb
@@ -3,33 +3,28 @@ require 'package'
 class Babl < Package
   description 'babl is a dynamic, any to any, pixel format translation library.'
   homepage 'http://gegl.org/babl/'
-  version '0.1.56'
-  source_url 'https://download.gimp.org/pub/babl/0.1/babl-0.1.56.tar.bz2'
-  source_sha256 '8ad26ca717ec3c74e261f454dd6bb316333a39fd1f87db4ac44706a860dc4d28'
+  version '0.1.72'
+  source_url 'https://download.gimp.org/pub/babl/0.1/babl-0.1.72.tar.xz'
+  source_sha256 '64e111097b1fa22f6c9bf044e341a9cd9ee1372c5acfa0b452e7a86fb37c6a42'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.56-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.56-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.56-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.56-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '42a003545e08b7a59cfeaad87600d5144935e3b2ba7adeb18477ba9b30c50d4c',
-     armv7l: '42a003545e08b7a59cfeaad87600d5144935e3b2ba7adeb18477ba9b30c50d4c',
-       i686: '8fe7d7375039a79441f0d4b365cfdd6391bb8bea12ec40d7ece2a8274c437b54',
-     x86_64: '70b20df01d205cb2bb3209321b15336f3d1d4917ce784d5826610cc775d8c523',
   })
 
   def self.build
-    system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system 'meson',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '_build'
+    system 'ninja -v -C _build'
+  end
+  
+  def self.check
+    system 'ninja -C _build test'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-  end
-
-  def self.check
-    system "make", "check"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
   end
 end

--- a/packages/gegl.rb
+++ b/packages/gegl.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gegl < Package
   description 'GEGL (Generic Graphics Library) is a data flow based image processing framework, providing floating point processing and non-destructive image processing capabilities to GNU Image Manipulation Program and other projects.'
   homepage 'http://gegl.org/'
-  version '0.4.8'
-  source_url 'https://download.gimp.org/pub/gegl/0.4/gegl-0.4.8.tar.bz2'
-  source_sha256 '719468eec56ac5b191626a0cb6238f3abe9117e80594890c246acdc89183ae49'
+  version '0.4.18'
+  source_url 'https://download.gimp.org/pub/gegl/0.4/gegl-0.4.18.tar.xz'
+  source_sha256 'c946dfb45beb7fe0fb95b89a25395b449eda2b205ba3e8a1ffb1ef992d9eca64'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'ab2f5a9ab05edc387fa5ff9b548ae25acf5085afdfef655c79787912a3593d81',
-     armv7l: 'ab2f5a9ab05edc387fa5ff9b548ae25acf5085afdfef655c79787912a3593d81',
-       i686: '9fbfc23e510a0b1534625ddbdac465716f5da41c9f7fa8e816264d192d2653ed',
-     x86_64: 'c00defcb1a8e58fbf7e9c7c94e8bfd684abb36281453252b0103b300034fa843',
   })
 
   depends_on 'babl'
@@ -32,19 +24,18 @@ class Gegl < Package
   depends_on 'vala'
 
   def self.build
-    system './configure',
+    system 'meson',
            "--prefix=#{CREW_PREFIX}",
            "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-maintainer-mode',
-           '--disable-docs'
-    system 'make'
+           '_build'
+    system 'ninja -v -C _build'
   end
-
+  
   def self.check
-    system "make check"
+    system 'ninja -C _build test'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
   end
 end

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -3,21 +3,13 @@ require 'package'
 class Gimp < Package
   description 'GIMP is a cross-platform image editor available for GNU/Linux, OS X, Windows and more operating systems.'
   homepage 'https://www.gimp.org/'
-  version '2.10.6'
-  source_url 'https://download.gimp.org/pub/gimp/v2.10/gimp-2.10.6.tar.bz2'
-  source_sha256 '4ec8071f828e918384cf7bc7d1219210467c84655123f802bc55a8bf2415101f'
+  version '2.10.14'
+  source_url 'https://download.gimp.org/pub/gimp/v2.10/gimp-2.10.14.tar.bz2'
+  source_sha256 'df9b0f11c2078eea1de3ebc66529a5d3854c5e28636cd25a8dd077bd9d6ddc54'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.6-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.6-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.6-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f237f502445c1dbd8aa88c1e5bb2bd74efaf53bb20712edce62f30436b24253d',
-     armv7l: 'f237f502445c1dbd8aa88c1e5bb2bd74efaf53bb20712edce62f30436b24253d',
-       i686: '7edecd8e91873795fc234d2000f2ac03392f5ce6947492d36bc9df582d7dd015',
-     x86_64: '8d2400b5806a22e5afc39b1ec1571a7fdba416dded25a77baa7192c32e0c2c64',
   })
 
   depends_on 'ghostscript'
@@ -38,6 +30,8 @@ class Gimp < Package
   depends_on 'shared_mime_info'
   depends_on 'xdg_base'
   depends_on 'sommelier'
+  depends_on 'gegl'
+  depends_on 'babl'
 
   def self.build
     system './configure',

--- a/packages/hugo.rb
+++ b/packages/hugo.rb
@@ -3,18 +3,18 @@ require 'package'
 class Hugo < Package
   description 'Hugo is one of the most popular open-source static site generators.'
   homepage 'https://gohugo.io'
-  version '0.62.0'
+  version '0.61.0'
 
   case ARCH
   when 'aarch64','armv7l'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.62.0/hugo_0.62.0_Linux-ARM.tar.gz'
-    source_sha256 'fac4116c82ed7e4bc385fa03c33de074a02acde29b1a0817e87561fa62e8f951'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_0.61.0_Linux-ARM.tar.gz'
+    source_sha256 'e33342d907a6744f4f90b96e99b700a3a72e424d1c94594e2d774fa2b43da52f'
   when 'i686'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.62.0/hugo_0.62.0_Linux-32bit.tar.gz'
-    source_sha256 'd3091184ebb3ce449c421f2aae49f5a0b29e66599d103a23ead13e3cab90d7f2'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_0.61.0_Linux-32bit.tar.gz'
+    source_sha256 '39469894c2b337b9d906ae798ce3b3326c9d4dc8fad79d429b8f5e6ccc5ddd4f'
   when 'x86_64'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.62.0/hugo_0.62.0_Linux-64bit.tar.gz'
-    source_sha256 '1c3f999320ae30f9b648f6f72305b126be7fd4bab9cb7edf74253c0cbe892c87'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_0.61.0_Linux-64bit.tar.gz'
+    source_sha256 '873e4a0fb39cbf17258ebd5ab54577652580ce7421b440f30e5cae9eafc731e4'
   end
 
   binary_url ({

--- a/packages/hugo.rb
+++ b/packages/hugo.rb
@@ -3,18 +3,18 @@ require 'package'
 class Hugo < Package
   description 'Hugo is one of the most popular open-source static site generators.'
   homepage 'https://gohugo.io'
-  version '0.61.0'
+  version '0.62.0'
 
   case ARCH
   when 'aarch64','armv7l'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_0.61.0_Linux-ARM.tar.gz'
-    source_sha256 'e33342d907a6744f4f90b96e99b700a3a72e424d1c94594e2d774fa2b43da52f'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.62.0/hugo_0.62.0_Linux-ARM.tar.gz'
+    source_sha256 'fac4116c82ed7e4bc385fa03c33de074a02acde29b1a0817e87561fa62e8f951'
   when 'i686'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_0.61.0_Linux-32bit.tar.gz'
-    source_sha256 '39469894c2b337b9d906ae798ce3b3326c9d4dc8fad79d429b8f5e6ccc5ddd4f'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.62.0/hugo_0.62.0_Linux-32bit.tar.gz'
+    source_sha256 'd3091184ebb3ce449c421f2aae49f5a0b29e66599d103a23ead13e3cab90d7f2'
   when 'x86_64'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_0.61.0_Linux-64bit.tar.gz'
-    source_sha256 '873e4a0fb39cbf17258ebd5ab54577652580ce7421b440f30e5cae9eafc731e4'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.62.0/hugo_0.62.0_Linux-64bit.tar.gz'
+    source_sha256 '1c3f999320ae30f9b648f6f72305b126be7fd4bab9cb7edf74253c0cbe892c87'
   end
 
   binary_url ({

--- a/packages/jsonc3.rb
+++ b/packages/jsonc3.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Jsonc3 < Package
+  description 'JSON-C implements a reference counting object model that allows you to easily construct JSON objects in C, output them as JSON formatted strings and parse JSON formatted strings back into the C representation of JSON objects.'
+  homepage 'https://github.com/json-c/json-c/wiki'
+  version '0.13-nodoc'
+  source_url 'https://s3.amazonaws.com/json-c_releases/releases/json-c-0.13-nodoc.tar.gz'
+  source_sha256 '8572760646e9d23ee68f967ca62fa134a97b931665fd9af562192b7788c95a06'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/jsonc-0.13-nodoc-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/jsonc-0.13-nodoc-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/jsonc-0.13-nodoc-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/jsonc-0.13-nodoc-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '7a7202d506c9ed3580b02f37e7aae42ecb665e240fa45d09d16cb9c4de501745',
+     armv7l: '7a7202d506c9ed3580b02f37e7aae42ecb665e240fa45d09d16cb9c4de501745',
+       i686: 'c9305143aec228f737b3fc952ccd22ae0e139174b7bd46e8f25ef06b2bdf2131',
+     x86_64: 'ecfa4db7850b31558d70ac0d92f372c4fd1082fcd04130a51b4520f591bcb5fb',
+  })
+
+  depends_on "autoconf" => :build
+
+  def self.build
+    system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
Needs to update `babl` and `gegl`  which have to be built using `meson` / `ninja` (maybe should be added as build dependencies, or `meson` and `ninja` should be added to the chromebrew core since more and more packages seem to rely upon these two tools).

I had to add an old version of `jsonc` to get `libjson-c.so.3`. Maybe I should rename it ...