### PR TITLE
Update leveldb from 1.20 to 1.22

### DIFF
--- a/packages/leveldb.rb
+++ b/packages/leveldb.rb
@@ -3,34 +3,33 @@ require 'package'
 class Leveldb < Package
   description 'LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.'
   homepage 'https://leveldb.googlecode.com/'
-  version '1.20-1'
-  source_url 'https://github.com/google/leveldb/archive/v1.20.tar.gz'
-  source_sha256 'f5abe8b5b209c2f36560b75f32ce61412f39a2922f7045ae764a2c23335b6664'
+  version '1.22'
+  source_url 'https://github.com/google/leveldb/archive/1.22.tar.gz'
+  source_sha256 '55423cac9e3306f4a9502c738a001e4a339d1a38ffbee7572d4a07d5d63949b2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/leveldb-1.20-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/leveldb-1.20-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/leveldb-1.20-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/leveldb-1.20-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '78469e16d2864c8f544710f8dca294bada2528be5f7db2a8a87dcd6e3567b625',
-     armv7l: '78469e16d2864c8f544710f8dca294bada2528be5f7db2a8a87dcd6e3567b625',
-       i686: '08e120b94bc11785ba2bc78418c2e76211e606939873d7b7d4f55a2c3baef049',
-     x86_64: '2f81ee50689c02e67f608f717d4956aee5106bea929c0498eb2b751f8c46b512',
   })
 
+  depends_on 'snappy'
+
   def self.build
-    system 'make'
+    FileUtils.mkdir 'build'
+    FileUtils.cd('build') do
+      system "cmake .. -DCMAKE_BUILD_TYPE=Release \
+                       -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
+                       -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX} \
+                       -DBUILD_SHARED_LIBS=1"
+      system 'make'
+    end
   end
 
   def self.install
-    system "mkdir", "-p", "#{CREW_DEST_PREFIX}/include"
-    system "mkdir", "-p", "#{CREW_DEST_LIB_PREFIX}"
-    system "cp", "-R", "include/leveldb", "#{CREW_DEST_PREFIX}/include"
-    system "cp", "out-static/libleveldb.a", "#{CREW_DEST_LIB_PREFIX}"
-    system "cp", "out-shared/libleveldb.so.1.20", "#{CREW_DEST_LIB_PREFIX}"
-    system "cp", "-P", "out-shared/libleveldb.so.1", "#{CREW_DEST_LIB_PREFIX}"
-    system "cp", "-P", "out-shared/libleveldb.so", "#{CREW_DEST_LIB_PREFIX}"
+    system "make -C build DESTDIR=#{CREW_DEST_DIR} install"
+  end
+
+  def self.check
+    system 'make -C build test'
   end
 end

--- a/packages/snappy.rb
+++ b/packages/snappy.rb
@@ -1,0 +1,29 @@
+require 'package'
+
+class Snappy < Package
+  description 'Snappy, a fast compressor/decompressor.'
+  homepage 'https://github.com/google/snappy'
+  version '1.1.7'
+  source_url 'https://github.com/google/snappy/archive/1.1.7.tar.gz'
+  source_sha256 '3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  def self.build
+    FileUtils.mkdir 'build'
+    FileUtils.cd('build') do
+      system "cmake .. -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
+                       -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX} \
+                       -DBUILD_SHARED_LIBS=ON \
+                       -DSNAPPY_BUILD_TESTS=OFF" # Tests don't work on ARM
+      system 'make'
+    end
+  end
+
+  def self.install
+    system "make -C build DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end


### PR DESCRIPTION
Leveldb has switched to CMake and the package has been updated to
reflect that. Google's snappy compression library is required as a
dependency and has been added as a new package.

Tested on ARM.