### PR TITLE
Add pre-built binaries for leveldb, nanomsg, nim and snappy

### DIFF
--- a/packages/leveldb.rb
+++ b/packages/leveldb.rb
@@ -8,8 +8,16 @@ class Leveldb < Package
   source_sha256 '55423cac9e3306f4a9502c738a001e4a339d1a38ffbee7572d4a07d5d63949b2'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/leveldb-1.22-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/leveldb-1.22-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/leveldb-1.22-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/leveldb-1.22-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '362de886138261f127b60e31644ac80c627d9aba40e027c9d92978337c327915',
+     armv7l: '362de886138261f127b60e31644ac80c627d9aba40e027c9d92978337c327915',
+       i686: '1722af2fe019a295d63f72cb56fa75a69cc618a90e6013aef8d1a3572cc6c3de',
+     x86_64: 'a9a4f292b4d9ae782a7763b03cf62ae2bdd12944f5ccd82e5fd4c0780d74bdca',
   })
 
   depends_on 'snappy'

--- a/packages/nanomsg.rb
+++ b/packages/nanomsg.rb
@@ -8,8 +8,16 @@ class Nanomsg < Package
   source_sha256 '218b31ae1534ab897cb5c419973603de9ca1a5f54df2e724ab4a188eb416df5a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nanomsg-1.1.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nanomsg-1.1.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nanomsg-1.1.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nanomsg-1.1.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '70871fc6e26bbb62ed2924c9f368f9dae4395a7c03306ccfd00d01fcae196c03',
+     armv7l: '70871fc6e26bbb62ed2924c9f368f9dae4395a7c03306ccfd00d01fcae196c03',
+       i686: 'fed0e57269bae6898436d906b38cc36751aa1abd3c786810168ad9f673d002c8',
+     x86_64: 'fbe6018ba37354fb102a78ec63c0aef7a36f0e1e34b0bf19355e3e912df498c2',
   })
 
   def self.build

--- a/packages/nim.rb
+++ b/packages/nim.rb
@@ -7,6 +7,19 @@ class Nim < Package
   source_url 'https://nim-lang.org/download/nim-1.0.4.tar.xz'
   source_sha256 '89841545a14475911bb84616bcd5a1b93a3268e1a6a0089f54642e405eeaaee0'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nim-1.0.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nim-1.0.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nim-1.0.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nim-1.0.4-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '920e361cd01578ee262ad33aa0f3504d75f497faf076929a8086040e02d1d272',
+     armv7l: '920e361cd01578ee262ad33aa0f3504d75f497faf076929a8086040e02d1d272',
+       i686: '519c6781965966f6ed12c619c21893cf51ea34b99ef4f5c987887b3b68ae594a',
+     x86_64: '9e9c318e33f264eee54e70d490048c84d3629fec6820d73f7b863713534cbd62',
+  })
+
   depends_on 'pcre'
 
   def self.build
@@ -21,5 +34,7 @@ class Nim < Package
   def self.install
     system 'sed -i "s,/usr/local,' + CREW_DEST_PREFIX + ',g" install.sh'
     system "sh install.sh #{CREW_DEST_PREFIX}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.ln_s "#{CREW_PREFIX}/nim/bin/nim", "#{CREW_DEST_PREFIX}/bin/nim"
   end
 end

--- a/packages/snappy.rb
+++ b/packages/snappy.rb
@@ -8,8 +8,16 @@ class Snappy < Package
   source_sha256 '3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/snappy-1.1.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/snappy-1.1.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/snappy-1.1.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/snappy-1.1.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '3ea4b27d211d42908d27ab51d5c35ad3ed4fc19300a6714040e3b2f97e9d106a',
+     armv7l: '3ea4b27d211d42908d27ab51d5c35ad3ed4fc19300a6714040e3b2f97e9d106a',
+       i686: '98d7365e20a8f9f20a93697ea99955dd8a2e1f2411e314dd0d86f51a0e07a391',
+     x86_64: '45695bc3b76470fb98ca385eb7cf0fcb9e08f79492474ea65ee690c4b4ed5474',
   })
 
   def self.build


### PR DESCRIPTION
Tested on all architectures.