### PR TITLE
[php74] Activate zip and gd2 module

### DIFF
--- a/packages/php74.rb
+++ b/packages/php74.rb
@@ -3,7 +3,7 @@ require 'package'
 class Php74 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.4.1'
+  version '7.4.1-1'
   source_url 'https://www.php.net/distributions/php-7.4.1.tar.xz'
   source_sha256 '561bb866bdd509094be00f4ece7c3543ec971c4d878645ee81437e291cffc762'
 
@@ -13,16 +13,8 @@ class Php74 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'fa52e200025cdac6033c8a406be7a396ed442e13f0d8d8f88c93e3c819a5b56e',
-     armv7l: 'fa52e200025cdac6033c8a406be7a396ed442e13f0d8d8f88c93e3c819a5b56e',
-       i686: '51f58cc9434a8e3de6857803eec81cfb5d21fb45655f202b09e8c10167dd4367',
-     x86_64: '0d5be4983d24e0c543996208533922c70c95b75f4ac796c66ea0c01def96bf71',
   })
 
   depends_on 'libgcrypt'
@@ -86,10 +78,10 @@ class Php74 < Package
            '--enable-shared',
            '--enable-shmop',
            '--enable-sockets',
-           '--enable-zip',
+           '--with-zip',
            '--with-bz2',
            '--with-curl',
-           '--with-gd',
+           '--enable-gd',
            '--with-gettext',
            '--with-gmp',
            '--with-libzip',


### PR DESCRIPTION
Compilation options have changed with php74 to activate zip and gd modules (did not test the other ones)