### PR TITLE
Update php packages

### DIFF
--- a/packages/php.rb
+++ b/packages/php.rb
@@ -3,7 +3,7 @@ require 'package'
 class Php < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.40-7.4.1'
+  version '5.6.40-7.4.2'
 
   is_fake
 
@@ -15,9 +15,9 @@ class Php < Package
     puts "  5.6 = PHP 5.6.40"
     puts "  7.0 = PHP 7.0.33"
     puts "  7.1 = PHP 7.1.33"
-    puts "  7.2 = PHP 7.2.26"
-    puts "  7.3 = PHP 7.3.13"
-    puts "  7.4 = PHP 7.4.1"
+    puts "  7.2 = PHP 7.2.27"
+    puts "  7.3 = PHP 7.3.14"
+    puts "  7.4 = PHP 7.4.2"
     puts "    0 = Cancel"
 
     while version = STDIN.gets.chomp

--- a/packages/php72.rb
+++ b/packages/php72.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php72 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.2.26'
-  source_url 'https://php.net/distributions/php-7.2.26.tar.xz'
-  source_sha256 '1dd3bc875e105f5c9d21fb4dc240670bd2c22037820ff03890f5ab883c88b78d'
+  version '7.2.27'
+  source_url 'https://php.net/distributions/php-7.2.27.tar.xz'
+  source_sha256 '7bd0fb9e3b63cfe53176d1f3565cd686f90b3926217158de5ba57091f49e4c32'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -13,16 +13,16 @@ class Php72 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.26-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.26-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.26-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.26-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bb0369a0541a9d232a9120e0c8aba4c1e1e1ce3447386ca686674a0fd682dad0',
-     armv7l: 'bb0369a0541a9d232a9120e0c8aba4c1e1e1ce3447386ca686674a0fd682dad0',
-       i686: 'f9b36ad6c59341dbf0e838a1ed5a7f574c8423851d6a7c797ec33b0ae6960af7',
-     x86_64: 'bd1290df89dabfedd37cbf48297491230cc23d43bdb1c222714117b9d3696cfd',
+    aarch64: '200c2376c4dcd3435a8813d13ff14dcd9dd28b849822841c40a2ef1d27516d0f',
+     armv7l: '200c2376c4dcd3435a8813d13ff14dcd9dd28b849822841c40a2ef1d27516d0f',
+       i686: 'aa8177e8f6e9f58d07b35a68c83103552d585aaa4ec2abbcbe34b7b067a6b493',
+     x86_64: '18c012beea8876a2d4820698ba0ab533cbea191c32a048f9d93457cfda4fbcf5',
   })
 
   depends_on 'libgcrypt'

--- a/packages/php73.rb
+++ b/packages/php73.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php73 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.3.13'
-  source_url 'https://php.net/distributions/php-7.3.13.tar.xz'
-  source_sha256 '57ac55fe442d2da650abeb9e6fa161bd3a98ba6528c029f076f8bba43dd5c228'
+  version '7.3.14'
+  source_url 'https://php.net/distributions/php-7.3.14.tar.xz'
+  source_sha256 'cc05dd373ca5d36652800762f65c10e828a17de35aaf246262e3efa99d00cdb0'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -13,16 +13,16 @@ class Php73 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.13-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.13-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.13-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.13-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '4f4dd5605013e5057a97ada6c470e6deb4caf72396112fe13539907bc4fb9849',
-     armv7l: '4f4dd5605013e5057a97ada6c470e6deb4caf72396112fe13539907bc4fb9849',
-       i686: '556d246ccb45c65744d73c4fe45e52b474e9d0b40e5a4e1a1c399d40fb5133f2',
-     x86_64: '5e64b330ec9404b659f53d161c272e80a4d00a16a8e73e8e6273600e866ecc03',
+    aarch64: '0155c17c10baa03c36e9e43ab9249b994eda6477a210d8bce7a40ac23c623a4d',
+     armv7l: '0155c17c10baa03c36e9e43ab9249b994eda6477a210d8bce7a40ac23c623a4d',
+       i686: '03efd2ecd997bf5e0d8e4a3ed7a16bcbf29d4cee7c43d4277775c22902ba9f31',
+     x86_64: '9247dc95950d33454a41a4477513b2e0ec48b20dcb59a510472714925a1be0d2',
   })
 
   depends_on 'libgcrypt'

--- a/packages/php74.rb
+++ b/packages/php74.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php74 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.4.1'
-  source_url 'https://www.php.net/distributions/php-7.4.1.tar.xz'
-  source_sha256 '561bb866bdd509094be00f4ece7c3543ec971c4d878645ee81437e291cffc762'
+  version '7.4.2'
+  source_url 'https://www.php.net/distributions/php-7.4.2.tar.xz'
+  source_sha256 '98284deac017da0d426117ecae7599a1f1bf62ae3911e8bc16c4403a8f4bdf13'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -13,24 +13,28 @@ class Php74 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'fa52e200025cdac6033c8a406be7a396ed442e13f0d8d8f88c93e3c819a5b56e',
-     armv7l: 'fa52e200025cdac6033c8a406be7a396ed442e13f0d8d8f88c93e3c819a5b56e',
-       i686: '51f58cc9434a8e3de6857803eec81cfb5d21fb45655f202b09e8c10167dd4367',
-     x86_64: '0d5be4983d24e0c543996208533922c70c95b75f4ac796c66ea0c01def96bf71',
+    aarch64: '1772f9875a24d504c367a3aaef3574906c746babccf0e951da5e0f016e72175c',
+     armv7l: '1772f9875a24d504c367a3aaef3574906c746babccf0e951da5e0f016e72175c',
+       i686: 'f5c0e82ece2a9d9c2fa259f644eca699e6eacedf6566fdd7f7b8fce9416d2510',
+     x86_64: '9ce8fb964eca402de3072e061e8bc48e4cf6438abd72031299f5db2f30156304',
   })
 
+  depends_on 'aspell_en'
+  depends_on 'libedit'
   depends_on 'libgcrypt'
+  depends_on 'libsodium'
   depends_on 'libwebp'
   depends_on 'libxslt'
   depends_on 'libzip'
   depends_on 'curl'
   depends_on 'exif'
+  depends_on 'freetds'
   depends_on 'freetype'
   depends_on 'pcre'
   depends_on 're2c'
@@ -77,31 +81,50 @@ class Php74 < Package
            "--with-png-dir=#{CREW_LIB_PREFIX}",
            "--with-webp-dir=#{CREW_LIB_PREFIX}",
            "--with-xpm-dir=#{CREW_LIB_PREFIX}",
+           '--enable-bcmath',
+           '--enable-calendar',
+           '--enable-dba=shared',
            '--enable-exif',
            '--enable-fpm',
            '--enable-ftp',
+           '--enable-gd',
+           '--enable-intl',
            '--enable-mbstring',
+           '--enable-mysqlnd',
            '--enable-opcache',
            '--enable-pcntl',
            '--enable-shared',
            '--enable-shmop',
+           '--enable-soap',
            '--enable-sockets',
-           '--enable-zip',
+           '--enable-sysvmsg',
            '--with-bz2',
            '--with-curl',
-           '--with-gd',
+           '--with-ffi',
+           '--with-freetype',
+           '--with-gdbm',
            '--with-gettext',
            '--with-gmp',
-           '--with-libzip',
+           '--with-jpeg',
+           '--with-kerberos',
+           '--with-ldap',
+           '--with-ldap-sasl',
+           '--with-libedit',
            '--with-mysqli',
            '--with-openssl',
-           '--with-pcre-regex',
+           '--with-pdo-dblib',
            '--with-pdo-mysql',
            '--with-pear',
+           '--with-pspell',
            '--with-readline',
+           '--with-sodium',
            '--with-tidy',
            '--with-unixODBC',
+           '--with-webp',
+           '--with-xmlrpc',
+           '--with-xpm',
            '--with-xsl',
+           '--with-zip',
            '--with-zlib'
     system 'make'
   end


### PR DESCRIPTION
Update php 7.2.26 to 7.2.27

Update php 7.3.13 to 7.3.14

Update php 7.4.1 to 7.4.2

Add pre-built binaries

Tested on all architectures.  Fixes #3768.