### PR TITLE
Update crew to allow aarch64 to build armv7l binaries

### DIFF
--- a/crew
+++ b/crew
@@ -28,7 +28,7 @@ Usage:
   crew install [-k|--keep] [-s|--build-from-source] [-S|--recursive-build] [-v|--verbose] <name> ...
   crew list (available|installed)
   crew postinstall <name> ...
-  crew reinstall [-v|--verbose] <name> ...
+  crew reinstall [-k|--keep] [-s|--build-from-source] [-S|--recursive-build] [-v|--verbose] <name> ...
   crew remove [-v|--verbose] <name> ...
   crew search [-v|--verbose] [<name> ...]
   crew update
@@ -65,7 +65,7 @@ rescue Docopt::Exit => e
     end
     if ARGV[0] != '-h' and ARGV[0] != '--help' then
       puts "Could not understand \"crew #{ARGV.join(' ')}\".".lightred
-      cmds = ["build", "download", "files", "help", "install", "list", "remove", "search", "update", "upgrade", "whatprovides"]
+      cmds = ["build", "const", "download", "files", "help", "install", "list", "postinstall", "reinstall", "remove", "search", "update", "upgrade", "whatprovides"]
       # Looking for similar commands
       if not cmds.include?(ARGV[0]) then
         similar = cmds.select {|word| edit_distance(ARGV[0], word) < 4}
@@ -204,7 +204,10 @@ def help (pkgName)
     puts "The package(s) must be currently installed."
   when "reinstall"
     puts "Remove and install package(s)."
-    puts "Usage: crew reinstall [-v|--verbose] <package1> [<package2> ...]"
+    puts "Usage: crew reinstall [-k|--keep] [-s|--build-from-source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]"
+    puts "If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain."
+    puts "If `-s` or `--build-from-source` is present, the package(s) will be compiled instead of installed via binary."
+    puts "If `-S` or `--recursive-build` is present, the package(s), including all dependencies, will be compiled instead of installed via binary."
     puts "If `-v` or `--verbose` is present, extra information will be displayed."
   when "remove"
     puts "Remove package(s)."
@@ -240,7 +243,7 @@ def help (pkgName)
     puts "Usage: crew whatprovides <pattern> ..."
     puts "The <pattern> is a search string which can contain regular expressions."
   else
-    puts "Available commands: build, const, download, files, install, list, postinstall, reinstall ,remove, search, update, upgrade, whatprovides"
+    puts "Available commands: build, const, download, files, help, install, list, postinstall, reinstall ,remove, search, update, upgrade, whatprovides"
   end
 end
 
@@ -265,6 +268,7 @@ def const (var)
       'CREW_NOT_COMPRESS',
       'CREW_NOT_STRIP',
       'CREW_NPROC',
+      'CREW_OPTIONS',
       'CREW_PREFIX',
       'CREW_VERSION',
       'HOME',
@@ -283,7 +287,7 @@ def files (pkgName)
   if File.exists? "#{filelist}"
     system "sort #{filelist}"
     lines = `wc -l "#{filelist}"`.strip.split(' ')[0].to_i
-    size = `du -ch $(cat #{filelist}) | tail -1 | cut -f 1`
+    size = `cat #{filelist} | xargs -I {} du -b '{}' | awk '{ print; total += $1 }; END { print total }' | numfmt --suffix B --to=si | tail -1`
     puts "Total found: #{lines}".lightgreen
     puts "Disk usage: #{size}".lightgreen
   else
@@ -451,7 +455,7 @@ def unpack (meta)
       puts "Unpacking archive using 'unzip', this may take a while..."
       _verbopt = @opt_verbose ? '-v' : '-qq'
       system "unzip", _verbopt, "-d", "#{extract_dir}", meta[:filename]
-    when /\.(tar(\.(gz|bz2|xz|lz))?|tgz|tbz)$/i
+    when /\.(tar(\.(gz|bz2|xz|lz))?|tgz|tbz|txz)$/i
       puts "Unpacking archive using 'tar', this may take a while..."
       _verbopt = @opt_verbose ? 'v' : ''
       system "tar", "x#{_verbopt}f", meta[:filename], "-C", "#{extract_dir}"
@@ -546,12 +550,12 @@ def prepare_package (destdir)
     compress_doc "#{destdir}#{CREW_PREFIX}/share/man"
     compress_doc "#{destdir}#{CREW_PREFIX}/share/info"
 
-    # create directory list
+    # create file list
     system "find . -type f > ../filelist"
     system "find . -type l >> ../filelist"
     system "cut -c2- ../filelist > filelist"
 
-    # create file list
+    # create directory list
     system "find . -type d > ../dlist"
     system "cut -c2- ../dlist > dlistcut"
     system "tail -n +2 dlistcut > dlist"
@@ -808,7 +812,12 @@ def build_package (pwd)
 end
 
 def archive_package (pwd)
-  pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
+  arch = "#{@device[:architecture]}"
+  case arch
+  when 'aarch64'
+    arch = 'armv7l'
+  end
+  pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{arch}.tar.xz"
   Dir.chdir CREW_DEST_DIR do
     if @opt_verbose then
       system "tar cJvf #{pwd}/#{pkg_name} *"
@@ -950,7 +959,8 @@ def reinstall_command (args)
     remove name
     @pkgName = name
     search @pkgName
-    install
+    @pkg.build_from_source = true if @opt_src or @opt_recursive
+    resolve_dependencies_and_install
   end
 end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,10 +1,10 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.2.9'
+CREW_VERSION = '1.3.3'
 
 ARCH = `uname -m`.strip
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
-LIBC_VERSION = if File.exists? "/#{ARCH_LIB}/libc-2.27.so" then '2.27' else '2.23' end
+LIBC_VERSION = if File.exist? "/#{ARCH_LIB}/libc-2.27.so" then '2.27' else '2.23' end
 
 if ENV['CREW_PREFIX'].to_s == ''
   CREW_PREFIX = '/usr/local'
@@ -46,4 +46,12 @@ USER = `whoami`.chomp
 
 CHROMEOS_RELEASE = `grep CHROMEOS_RELEASE_CHROME_MILESTONE= /etc/lsb-release | cut -d'=' -f2`.chomp
 
-CREW_BUILD = `gcc -dumpmachine`
+case ARCH
+when 'aarch64', 'armv7l'
+  CREW_BUILD = 'armv7l-cros-linux-gnueabihf'
+when 'i686'
+  CREW_BUILD = 'i686-cros-linux-gnu'
+when 'x86_64'
+  CREW_BUILD = 'x86_64-cros-linux-gnu'
+end
+CREW_OPTIONS = "--prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --build=#{CREW_BUILD} --host=#{CREW_BUILD} --target=#{CREW_BUILD}"

--- a/packages/alpine.rb
+++ b/packages/alpine.rb
@@ -1,0 +1,51 @@
+require 'package'
+
+class Alpine < Package
+  description 'The continuation of the Alpine email client from University of Washington.'
+  homepage 'http://alpine.x10host.com/alpine'
+  version '2.22'
+  source_url 'http://alpine.x10host.com/alpine/release/src/alpine-2.22.tar.xz'
+  source_sha256 '849567c1b6f71fde3aaa1c97cf0577b12a525d9e22c0ea47797c4bf1cd2bbfdb'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alpine-2.22-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alpine-2.22-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alpine-2.22-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alpine-2.22-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '3856cd6cb2d2073b4cf022e5d2db54ed65ba2f7ab53545c4cd476d894a343d89',
+     armv7l: '3856cd6cb2d2073b4cf022e5d2db54ed65ba2f7ab53545c4cd476d894a343d89',
+       i686: '32701e3edcc3cab4a409d66cb9747c799b1265b46cb531e093b2472660f34f48',
+     x86_64: '4277b6583b8e753da09a95ea7912d69666d45dae5a9db91b18abf1a7bbcca155',
+  })
+
+  depends_on 'hunspell_en_us'
+  depends_on 'openldap'
+  depends_on 'tcl'
+
+  def self.patch
+    # Fixes ./configure: line 8156: /usr/bin/file: No such file or directory
+    system 'filefix'
+  end
+
+  def self.build
+    system "./configure",
+    "--prefix=#{CREW_PREFIX}",
+    "--libdir=#{CREW_LIB_PREFIX}",
+    "--with-ssl-dir=/etc/ssl",
+    "--with-ssl-include-dir=#{CREW_PREFIX}/include",
+    "--with-ssl-lib-dir=#{CREW_LIB_PREFIX}", "--disable-nls",
+    "--with-system-pinerc=#{CREW_PREFIX}/etc/alpine.d/pine.conf",
+    "--with-system-fixed-pinerc=#{CREW_PREFIX}/etc/alpine/pine.conf.fixed"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
+  end
+end

--- a/packages/alsa_lib.rb
+++ b/packages/alsa_lib.rb
@@ -3,21 +3,21 @@ require 'package'
 class Alsa_lib < Package
   description 'The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionality to the Linux operating system.'
   homepage 'https://www.alsa-project.org/main/index.php/Main_Page'
-  version '1.1.8'
-  source_url 'ftp://ftp.alsa-project.org/pub/lib/alsa-lib-1.1.8.tar.bz2'
-  source_sha256 '3cdc3a93a6427a26d8efab4ada2152e64dd89140d981f6ffa003e85be707aedf'
+  version '1.2.2'
+  source_url 'ftp://ftp.alsa-project.org/pub/lib/alsa-lib-1.2.2.tar.bz2'
+  source_sha256 'd8e853d8805574777bbe40937812ad1419c9ea7210e176f0def3e6ed255ab3ec'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_lib-1.1.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_lib-1.1.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_lib-1.1.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_lib-1.1.8-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_lib-1.2.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_lib-1.2.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_lib-1.2.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_lib-1.2.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd94c01b609084242a81ba4c2427434cbc1a6ae47964906f153226b14ec23e2fb',
-     armv7l: 'd94c01b609084242a81ba4c2427434cbc1a6ae47964906f153226b14ec23e2fb',
-       i686: '2ed364d08fd327fc73d9d885fc0612c9e15c6af0de3864f6aab8e2b640b9a851',
-     x86_64: '8fbcdb011920f27fabec31ef9e2057ccbdb26ae14ba3ac468a83c6ca767bf7cc',
+    aarch64: 'f20836e7392c095c013f60d797f4baafeb45cbca294a8c18f65f3e4b6254f177',
+     armv7l: 'f20836e7392c095c013f60d797f4baafeb45cbca294a8c18f65f3e4b6254f177',
+       i686: 'fb5eac7b44ff2281f11c6ca0868111d082d52c426bf233b096db43966fc77411',
+     x86_64: '69c2ad1f9f67af8573f63f79c2e44072d521aad1497ebf1197c668d22fddfec4',
   })
 
   depends_on 'python3'
@@ -25,11 +25,11 @@ class Alsa_lib < Package
   def self.build
     system './configure',
            '--without-debug',
-           '--enable-mixer-pymods',
+           '--disable-maintainer-mode',
            "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
-           '--with-pythonlibs=-lpython3.7m'
-           "--with-pythonincludes=-I#{CREW_PREFIX}/include/python3.7m"
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--with-pythonlibs=-lpython3.8',
+           "--with-pythonincludes=-I#{CREW_PREFIX}/include/python3.8"
     system 'make'
   end
 

--- a/packages/alsa_plugins.rb
+++ b/packages/alsa_plugins.rb
@@ -3,21 +3,21 @@ require 'package'
 class Alsa_plugins < Package
   description 'alsa-plugins contains plugins for various ALSA needs (e.g. Jack).'
   homepage 'https://www.alsa-project.org/main/index.php/Main_Page'
-  version '1.1.8'
-  source_url 'ftp://ftp.alsa-project.org/pub/plugins/alsa-plugins-1.1.8.tar.bz2'
-  source_sha256 '7f77df171685ccec918268477623a39db4d9f32d5dc5e76874ef2467a2405994'
+  version '1.2.2'
+  source_url 'ftp://ftp.alsa-project.org/pub/plugins/alsa-plugins-1.2.2.tar.bz2'
+  source_sha256 '1c0f06450c928d711719686c9dbece2d480184f36fab11b8f0534cb7b41e337d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.1.8-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.2.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.2.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.2.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_plugins-1.2.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '223803ef01f3365babc184abad7f257ac664db4599294e1538d01a8af8794907',
-     armv7l: '223803ef01f3365babc184abad7f257ac664db4599294e1538d01a8af8794907',
-       i686: '8e9c4a2a69727f1e7872022fb24f97f6f6ec41f83eaa81b3298104dbaab477da',
-     x86_64: '590df0d75d5680b5da817feedb7f163ce5e7a4c60809adab298168dda09697b9',
+    aarch64: '6dfe0afc4137d689eda0c4693aac4016e66e9da74ccaf540ebd12cb2fd704103',
+     armv7l: '6dfe0afc4137d689eda0c4693aac4016e66e9da74ccaf540ebd12cb2fd704103',
+       i686: '2e363fbae56a4dc05af716316f6465b36655663a5953437af4c996e22eece8bc',
+     x86_64: '2c0108843697c8711160defebbf6db421a2b6fe1aa582b9567e8cbb9b124bf02',
   })
 
   depends_on 'dbus'
@@ -34,7 +34,11 @@ class Alsa_plugins < Package
     system 'make'
   end
 
+  def self.check
+    system 'make', 'check'
+  end
+
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/alsa_tools.rb
+++ b/packages/alsa_tools.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Alsa_tools < Package
+  description 'The Advanced Linux Sound Architecture (ALSA) - tools'
+  homepage 'https://github.com/alsa-project/alsa-tools'
+  version '1.2.2'
+  source_url 'https://github.com/alsa-project/alsa-tools/archive/v1.2.2.tar.gz'
+  source_sha256 '7242cfb3493461b2a28c9c3a6a69dbc2e9ee236a5dc46400cbb0d1d87c27b453'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_tools-1.2.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_tools-1.2.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_tools-1.2.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_tools-1.2.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '13e8a8e05816e7b33369a3dfa62805d74a31899aac172f2d895e181c002e163c',
+     armv7l: '13e8a8e05816e7b33369a3dfa62805d74a31899aac172f2d895e181c002e163c',
+       i686: '1ca6fa11e786e0d277ff15532de6b58f9a1bba5198163fc7d773ecddbabe4574',
+     x86_64: '9078e54a91c60bb12d5f8087239cf21b24b033f04991e095f22502d663a5d77c',
+  })
+
+  depends_on 'alsa_lib'
+  depends_on 'fltk'
+  depends_on 'gtk2'
+
+  def self.patch
+    # Make sure automake can be found.
+    system "find -name gitcompile -exec sed -i 's,/usr/local/share/automake,#{CREW_PREFIX}/share/automake-1.16,' {} +"
+    # Take out things that won't build.
+    system "sed -i 's,ld10k1 qlo10k1,,' Makefile"
+    system "sed -i 's,usx2yloader,,' Makefile"
+    system "sed -i 's,hdspmixer,,' Makefile" if ARCH != 'x86_64'
+  end
+
+  def self.build
+    system "GITCOMPILE_ARGS='--prefix=#{CREW_PREFIX}' make all"
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/alsa_utils.rb
+++ b/packages/alsa_utils.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Alsa_utils < Package
+  description 'The Advanced Linux Sound Architecture (ALSA) - utilities'
+  homepage 'https://github.com/alsa-project/alsa-utils'
+  version '1.2.2'
+  source_url 'https://github.com/alsa-project/alsa-utils/archive/v1.2.2.tar.gz'
+  source_sha256 '9da1ce4f12a4dd56d55cd5a8f6ae7d56ac91397c3d37fdfcd737adeeb34fce1c'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_utils-1.2.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_utils-1.2.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_utils-1.2.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_utils-1.2.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'cff8b1579f0d7b918ac5f9bfb7dd3e6bfb4f4beff4eb28eae425add13b1c0ee2',
+     armv7l: 'cff8b1579f0d7b918ac5f9bfb7dd3e6bfb4f4beff4eb28eae425add13b1c0ee2',
+       i686: '27c3a3394bcadf2751fbeb755b269cedbd078349638b64e3febdf1ef7c468ad9',
+     x86_64: '31deca395175c3c5fde640609bb635a1a35a329fe840c63fd2c280462e82d7d7',
+  })
+
+  depends_on 'alsa_lib'
+
+  def self.build
+    system "./gitcompile --prefix=#{CREW_PREFIX}"
+  end
+
+  def self.check
+    # This takes several hours to run!
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/android_studio.rb
+++ b/packages/android_studio.rb
@@ -3,9 +3,12 @@ require 'package'
 class Android_studio < Package
   description 'Android Studio is the official IDE for Android development.'
   homepage 'https://developer.android.com/studio'
-  version '3.4.1.0'
-  source_url 'https://dl.google.com/dl/android/studio/ide-zips/3.4.1.0/android-studio-ide-183.5522156-linux.tar.gz'
-  source_sha256 '60488b63302fef657367105d433321de248f1fb692d06dba6661efec434b9478'
+  version '3.5.3.0'
+  case ARCH
+  when 'x86_64'
+    source_url 'https://dl.google.com/dl/android/studio/ide-zips/3.5.3.0/android-studio-ide-191.6010548-linux.tar.gz'
+    source_sha256 'af630d40f276b0d169c6ac8c7663a989f562b0ac48a1d3f0d720f5b6472355db'
+  end
 
   depends_on 'jdk8'
   depends_on 'xdg_base'
@@ -23,11 +26,11 @@ class Android_studio < Package
     FileUtils.cd(CREW_DEST_PREFIX + '/bin') do
       FileUtils.ln_s(CREW_PREFIX + '/share/android-studio/bin/studio.sh', 'studio')
     end
-    FileUtils.mkdir_p(CREW_DEST_PREFIX + '/.config/.AndroidStudio3.4')
+    FileUtils.mkdir_p(CREW_DEST_PREFIX + '/.config/.AndroidStudio3.5')
     FileUtils.mkdir_p(CREW_DEST_PREFIX + '/.config/Android')
     FileUtils.mkdir_p(CREW_DEST_HOME)
     FileUtils.cd(CREW_DEST_HOME) do
-      FileUtils.ln_sf(CREW_PREFIX + '/.config/.AndroidStudio3.4/', '.AndroidStudio3.4')
+      FileUtils.ln_sf(CREW_PREFIX + '/.config/.AndroidStudio3.5/', '.AndroidStudio3.5')
       FileUtils.ln_sf(CREW_PREFIX + '/.config/Android/', 'Android')
     end
   end
@@ -40,7 +43,7 @@ class Android_studio < Package
     puts 'settings, SDK and tools, execute the following:'.lightblue
     puts 'crew remove android_studio'.lightblue
     puts "rm -rf #{CREW_PREFIX}/.config/Android".lightblue
-    puts "rm -rf #{CREW_PREFIX}/.config/.AndroidStudio3.3".lightblue
+    puts "rm -rf #{CREW_PREFIX}/.config/.AndroidStudio3.5".lightblue
     puts
   end
 end

--- a/packages/arping.rb
+++ b/packages/arping.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Arping < Package
+  description 'ARP Ping'
+  homepage 'https://github.com/ThomasHabets/arping'
+  version '2.21'
+  source_url 'https://github.com/ThomasHabets/arping/archive/arping-2.21.tar.gz'
+  source_sha256 '7bf550571aa1d4a2b00878bb2f6fb857a09d30bf65411c90d62afcd86755bd81'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/arping-2.21-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/arping-2.21-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/arping-2.21-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/arping-2.21-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e85f871e84dce5360c1b50eccaa3ae5a1beaea9f89120cf0da19ffcabcf19fa1',
+     armv7l: 'e85f871e84dce5360c1b50eccaa3ae5a1beaea9f89120cf0da19ffcabcf19fa1',
+       i686: 'b808583d44c865ac023986b02e4c1ad8d9fbdbd12540775f620953b01a810e50',
+     x86_64: '46c5c7e174bb800bb317e09df6f77448040c7aeda137a23e2b8ed85ecb852fcb',
+  })
+
+  depends_on 'libpcap'
+  depends_on 'libnet'
+
+  def self.build
+    system './bootstrap.sh'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/atom.rb
+++ b/packages/atom.rb
@@ -3,7 +3,7 @@ require 'package'
 class Atom < Package
   description 'The hackable text editor'
   homepage 'https://atom.io/'
-  version '1.42.0'
+  version '1.43.0'
   case ARCH
   when 'x86_64'
     source_url 'file:///dev/null'
@@ -11,10 +11,10 @@ class Atom < Package
   end
 
   binary_url ({
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/atom-1.42.0-chromeos-x86_64.tar.xz'
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/atom-1.43.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    x86_64: '7835a7ba3e5a0cd9a02beb36e94fe41605535ab5fd073aa24306c1c60b087084'
+    x86_64: '435736336fa7d108a318b11ebe92fc7266abf0b14ee59fd8d2890a722483cb01',
   })
 
   depends_on 'alien' => :build
@@ -25,8 +25,8 @@ class Atom < Package
 
   def self.build
     system "wget https://github.com/atom/atom/releases/download/v#{version}/atom-amd64.deb"
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('atom-amd64.deb') ) == '5e9a487da9d7d6530be61d4af2454b0bcfc907537447cf9d0423766e91282ac7'
-    system "alien -t -c atom-amd64.deb"
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('atom-amd64.deb') ) == 'ce3af452301b6ad45ee0abf340e497f8778f6fae114be9e455a305045ab3a037'
+    system "alien -tc atom-amd64.deb"
     system "tar xvf atom-#{version}.tgz"
   end
 

--- a/packages/automake.rb
+++ b/packages/automake.rb
@@ -3,21 +3,21 @@ require 'package'
 class Automake < Package
   description 'Automake is a tool for automatically generating Makefile.in files compliant with the GNU Coding Standards.'
   homepage 'http://www.gnu.org/software/automake/'
-  version '1.16.1'
-  source_url 'https://ftpmirror.gnu.org/automake/automake-1.16.1.tar.xz'
-  source_sha256 '5d05bb38a23fd3312b10aea93840feec685bdf4a41146e78882848165d3ae921'
+  version '1.16.2'
+  source_url 'https://ftpmirror.gnu.org/automake/automake-1.16.2.tar.xz'
+  source_sha256 'ccc459de3d710e066ab9e12d2f119bd164a08c9341ca24ba22c9adaa179eedd0'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/automake-1.16.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/automake-1.16.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/automake-1.16.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/automake-1.16.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/automake-1.16.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/automake-1.16.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/automake-1.16.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/automake-1.16.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '83961e48a99575d70e225d4d0b89b71eae90dd7308fb6a5e8234831afdb87134',
-     armv7l: '83961e48a99575d70e225d4d0b89b71eae90dd7308fb6a5e8234831afdb87134',
-       i686: '46cc913feaf2b7ad6490967361fc36ee69181deb0481c9287d9949fcfe45b579',
-     x86_64: '3f9ff866f29e8b15b99e2b807e2c7f75d8091d551f25ab5480b60703c3612ba6',
+    aarch64: '3f318d4d4873a656e805ee7a60f9d442922f6e2f0efffd7c6639f43f98d727a3',
+     armv7l: '3f318d4d4873a656e805ee7a60f9d442922f6e2f0efffd7c6639f43f98d727a3',
+       i686: '4df8a089bfeef4610ad7a1e6eb303fbd8e49182252522dc2a2ddac4aa173c648',
+     x86_64: 'b24ad3589d0ea2ad97f213157ccca85a965d268cf128dabf9e5d11243d77babc',
   })
 
   depends_on 'autoconf'

--- a/packages/aws.rb
+++ b/packages/aws.rb
@@ -3,29 +3,29 @@ require 'package'
 class Aws < Package
   description 'The AWS CLI is an open source tool built on top of the AWS SDK for Python (Boto) that provides commands for interacting with AWS services.'
   homepage 'https://aws.amazon.com/documentation/cli/'
-  version '1.16.268'
-  source_url 'https://github.com/aws/aws-cli/archive/1.16.268.tar.gz'
-  source_sha256 'fde1ad4206fe92b27277ba6a21ff3879a0a390ee29679d2b4c9bfb47a7c7ce78'
+  version '1.17.13'
+  source_url 'https://github.com/aws/aws-cli/archive/1.17.13.tar.gz'
+  source_sha256 '4dc8ff38ca67341021f6e2971084d7ed8b87968443e089e758b5531f1381205f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.268-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.268-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.268-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.16.268-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.17.13-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.17.13-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.17.13-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aws-1.17.13-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1e34d559b3d0025a4ffa8d06d729970b32647b2fd06d7c25fd75afb434718964',
-     armv7l: '1e34d559b3d0025a4ffa8d06d729970b32647b2fd06d7c25fd75afb434718964',
-       i686: 'be9cc4591ee69024f10408adf76ab953022f2a271205489dab98c3d2067f450f',
-     x86_64: '0ec34be425dc06028ab9423d1c0a3914f796e440e76d84e0fe3c436f8bb509d5',
+    aarch64: '8f291de2ee2c9766dedb1b60ef178fdf4fa7554e3a305c6035decbce2661fb91',
+     armv7l: '8f291de2ee2c9766dedb1b60ef178fdf4fa7554e3a305c6035decbce2661fb91',
+       i686: 'ba5feb2b679177d47da9c08b482990be1259559bfa0cc005acfcaf429412a0f0',
+     x86_64: '1a52ec06dd1e471b64e14f27a14a783ca7488bb6016b245b20ef29d4cbceb833',
   })
 
+  depends_on 'setuptools' => :build
   depends_on 'six'
 
   def self.build
-    system "sed -i 's,-e git://github.com/boto/botocore.git@develop#egg=botocore,botocore==1.13.4,' requirements.txt"
-    system "sed -i 's,-e git://github.com/boto/s3transfer.git@develop#egg=s3transfer,s3transfer==0.2.0,' requirements.txt"
-    system "sed -i 's,-e git://github.com/boto/jmespath.git@develop#egg=jmespath,jmespath==0.9.4,' requirements.txt"
+    system "sed -i 's,-e git://github.com/boto/botocore.git@develop#egg=botocore,botocore==1.14.13,' requirements.txt"
+    system "sed -i 's,-e git://github.com/boto/s3transfer.git@develop#egg=s3transfer,s3transfer==0.3.3,' requirements.txt"
   end
 
   def self.install

--- a/packages/bacon.rb
+++ b/packages/bacon.rb
@@ -3,21 +3,21 @@ require 'package'
 class Bacon < Package
   description 'BaCon is a free BASIC to C translator for Unix-based systems.'
   homepage 'http://www.basic-converter.org/'
-  version '3.9.2b3'
-  source_url 'https://basic-converter.org/stable/bacon-3.9.2b3.tar.gz'
-  source_sha256 '2ecd99b478dca48fc0421b19165b35e2cd57b84253b2b494c610233151324bc6'
+  version '3.9.3'
+  source_url 'https://basic-converter.org/stable/bacon-3.9.3.tar.gz'
+  source_sha256 '7f907f4ede68704eefd076733f617438c4baba98e9a1e8676ea1a00c4f8476ae'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.2b3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.2b3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.2b3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.2b3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '24e02e1ac6dadbd7f36ee689c9c1ec012e871f488cece03cc3d975d91ae0301d',
-     armv7l: '24e02e1ac6dadbd7f36ee689c9c1ec012e871f488cece03cc3d975d91ae0301d',
-       i686: '48721711a984c4f8cd4a6279586b2872292b29ed7be404415c7b37ea663f823d',
-     x86_64: 'c11e702b654b1fc9f3503c815d75b3f87b92240952611688daf0355e935b77fc',
+    aarch64: 'e3688910dbee42cea250706e85b73dc6970aceabb25b855f0d7729ee07421f66',
+     armv7l: 'e3688910dbee42cea250706e85b73dc6970aceabb25b855f0d7729ee07421f66',
+       i686: 'ed8ac51c3a7f75e27cca79c1fe050f65aa6a188a2b58898961df43a7855d60db',
+     x86_64: '4a5ac4797556651820de1081d7be92726d1c01be68f4945f4bc2e78790a1f599',
   })
 
   def self.build

--- a/packages/bison.rb
+++ b/packages/bison.rb
@@ -3,21 +3,21 @@ require 'package'
 class Bison < Package
   description 'Bison is a general-purpose parser generator that converts an annotated context-free grammar into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables.'
   homepage 'http://www.gnu.org/software/bison/'
-  version '3.5'
-  source_url 'https://ftpmirror.gnu.org/gnu/bison/bison-3.5.tar.xz'
-  source_sha256 '55e4a023b1b4ad19095a5f8279f0dc048fa29f970759cea83224a6d5e7a3a641'
+  version '3.5.3'
+  source_url 'https://ftpmirror.gnu.org/gnu/bison/bison-3.5.3.tar.xz'
+  source_sha256 '2bf85b5f88a5f2fa8069aed2a2dfc3a9f8d15a97e59c713e3906e5fdd982a7c4'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.5-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.5.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.5.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.5.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bison-3.5.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1a81b867d451925f47e43af13c6b270cae838511d5ae88cdbcdc6b1e95e04489',
-     armv7l: '1a81b867d451925f47e43af13c6b270cae838511d5ae88cdbcdc6b1e95e04489',
-       i686: 'af29f98f0888cb0d00e53edcacd4084a36e2f81bd119655d4e7a96eb9637b4f5',
-     x86_64: 'ac8aa34ea566a028fa22d85b51cbda6fb0436a4608646b6b479707e8826a5009',
+    aarch64: '1ff70ed7db74cadbb20d0e17a6d631bd256caf3549c0932c347eba3edf1f2a53',
+     armv7l: '1ff70ed7db74cadbb20d0e17a6d631bd256caf3549c0932c347eba3edf1f2a53',
+       i686: '091fc0b760316ca632cce4240b1fa910c1528a953d1328d5edb5e05239a8e875',
+     x86_64: '1e810c55fec98830af9089b773150efdc5a1d9a9380bf885b4ae6bf8261111d9',
   })
 
   def self.build

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -3,21 +3,21 @@ require 'package'
 class Bz2 < Package
   description 'bzip2 is a freely available, patent free, high-quality data compressor.'
   homepage 'http://www.bzip.org/'
-  version '1.0.6-3'
-  source_url 'https://fossies.org/linux/misc/bzip2-1.0.6.tar.xz'
-  source_sha256 '4bbea71ae30a0e5a8ddcee8da750bc978a479ba11e04498d082fa65c2f8c1ad5'
+  version '1.0.8'
+  source_url 'https://fossies.org/linux/misc/bzip2-1.0.8.tar.gz'
+  source_sha256 'ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.6-3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'abfa979b02b0f587c65b7bebb1bc97ba9eda57aec1cb5f3657b6d4f92b90ee65',
-     armv7l: 'abfa979b02b0f587c65b7bebb1bc97ba9eda57aec1cb5f3657b6d4f92b90ee65',
-       i686: '426ec6778bb285ac377f43581a06391ca5a23b533dcfc02cc5c3e03d4239af9f',
-     x86_64: '3ec7418e132350c4989ff2a6856b320d68fbec02913043a6c19f2c025732217f',
+    aarch64: '11fbd7bb0897446cfda34be28db698ecdcbfbcb70e23311fe405edf1aa9abec4',
+     armv7l: '11fbd7bb0897446cfda34be28db698ecdcbfbcb70e23311fe405edf1aa9abec4',
+       i686: '82f0c8f531c14cef34d9b2a7b1c3a8f1783d43fad87a3da19a12da91abf03857',
+     x86_64: '418cff679b9753a9f247a77bf0d61994fc73ee473e6eaed49cd8aa4a159166a7',
   })
 
   def self.build
@@ -45,10 +45,10 @@ class Bz2 < Package
     system "ln -sf bzip2 #{CREW_DEST_PREFIX}/bin/bzcat"
 
     # Install shared library by hand
-    system "install -Dm644 libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0.6"
-    system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0"
-    system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1"
-    system "ln -s libbz2.so.1.0.6 #{CREW_DEST_LIB_PREFIX}/libbz2.so"
+    system "install -Dm644 libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0.8"
+    system "ln -s libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0"
+    system "ln -s libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1"
+    system "ln -s libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so"
 
     # Move manpages
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share")

--- a/packages/chrpath.rb
+++ b/packages/chrpath.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Chrpath < Package
+  description 'Change or delete the rpath or runpath in ELF files'
+  homepage 'https://directory.fsf.org/project/chrpath/'
+  version '0.16'
+  source_url 'http://ftp.debian.org/debian/pool/main/c/chrpath/chrpath_0.16.orig.tar.gz'
+  source_sha256 'bb0d4c54bac2990e1bdf8132f2c9477ae752859d523e141e72b3b11a12c26e7b'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/chrpath-0.16-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/chrpath-0.16-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/chrpath-0.16-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/chrpath-0.16-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '90a116020875ffc085d1da9352d6fadb08cedf5e50e73b296380e00d061d82f1',
+     armv7l: '90a116020875ffc085d1da9352d6fadb08cedf5e50e73b296380e00d061d82f1',
+       i686: 'af52c7da43448bb4ea99e96dd28534627cfc1665273fcfa5ecbba6093956f91c',
+     x86_64: '620cedb1453b3b30fa23d036708956dbadbf8dda7f1afd470c8bcfe2bba56f07',
+  })
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/codium.rb
+++ b/packages/codium.rb
@@ -3,20 +3,17 @@ require 'package'
 class Codium < Package
   description 'VSCodium is Open Source Software Binaries of VSCode with a community-driven default configuration.'
   homepage 'https://vscodium.com/'
-  version '1.41.1'
-  source_url 'https://github.com/VSCodium/vscodium/releases/download/1.41.1/VSCodium-linux-x64-1.41.1.tar.gz'
-  source_sha256 '3d50cedad289730301ddbb6cc5f754753e3fc58b0c812da5390b2871c0639c58'
-
-  binary_url ({
-  })
-  binary_sha256 ({
-  })
-
-  if ARGV[0] == 'install' || ARGV[0] == 'upgrade'
-    abort "#{ARCH} architecture not supported.".lightred unless ARCH == 'x86_64'
+  version '1.43.1-1'
+  case ARCH
+  when 'aarch64', 'armv7l'
+    source_url 'https://github.com/VSCodium/vscodium/releases/download/1.43.1/VSCodium-linux-arm-1.43.1.tar.gz'
+    source_sha256 '9284f85c832441b20462843acaa69da9b1efd8407a5818c78e415e39f13f9cb7'
+    @arch = 'arm'
+  when 'x86_64'
+    source_url 'https://github.com/VSCodium/vscodium/releases/download/1.43.1/VSCodium-linux-x64-1.43.1.tar.gz'
+    source_sha256 '5a8c67b3da103baaa843797d4dc487c167c9068ae99181d8f483baf632ef5975'
+    @arch = 'x64'
   end
-
-  @arch = 'x64'
 
   depends_on 'gtk2'
   depends_on 'libsecret'
@@ -25,16 +22,16 @@ class Codium < Package
   depends_on 'sommelier'
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/VSCodium-linux-#{@arch}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/VSCodium-linux-#{@arch}"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/VSCodium-linux-#{@arch}"
-    FileUtils.ln_s "../share/VSCodium-linux-#{@arch}/bin/codium", "#{CREW_DEST_PREFIX}/bin/codium"
+    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/VSCodium-linux-#{@arch}"
+    FileUtils.ln_s "../VSCodium-linux-#{@arch}/bin/codium", "#{CREW_DEST_PREFIX}/bin/codium"
   end
 
   def self.postinstall
     puts
     puts 'Congratulations! You have installed VSCodium on Chrome OS!'.lightgreen
-    puts 'Now, please type \'codium\' to execute.'.lightgreen
+    puts 'Type \'codium\' to get started.'.lightgreen
     puts 'Happy coding!'.lightgreen
     puts
   end

--- a/packages/composer.rb
+++ b/packages/composer.rb
@@ -3,11 +3,11 @@ require 'package'
 class Composer < Package
   description 'Dependency Manager for PHP'
   homepage 'https://getcomposer.org/'
-  version '1.9.2-1'
-  source_url 'https://github.com/composer/composer/archive/1.9.2.tar.gz'
-  source_sha256 'bb855149a0c691c11aeb563bbe185bc0de3988c4e678c803762ee4d76dcb3436'
+  version '1.10.1'
+  source_url 'https://github.com/composer/composer/archive/1.10.1.tar.gz'
+  source_sha256 '9d19d87a63a4927c20ed8e21dc2dd472eaf86deaf529917591557945464d5573'
 
-  depends_on 'php7' unless File.exists? "#{CREW_PREFIX}/bin/php"
+  depends_on 'php' unless File.exists? "#{CREW_PREFIX}/bin/php"
   depends_on 'xdg_base'
 
   def self.preinstall
@@ -22,7 +22,8 @@ class Composer < Package
 
   def self.install
     system "php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\""
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA384.hexdigest( File.read('composer-setup.php') ) == 'c5b9b6d368201a9db6f74e2611495f369991b72d9c8cbd3ffbc63edff210eb73d46ffbfce88669ad33695ef77dc76976'
+    system 'curl -Ls -o installer.sig https://composer.github.io/installer.sig'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA384.hexdigest( File.read('composer-setup.php') ) == File.read('installer.sig')
     system "mkdir -p #{CREW_DEST_PREFIX}/bin"
     system "php composer-setup.php --install-dir=#{CREW_DEST_PREFIX}/bin --filename=composer --version=#{version}"
     system "mkdir -p #{CREW_DEST_PREFIX}/.config"

--- a/packages/cpustat.rb
+++ b/packages/cpustat.rb
@@ -3,21 +3,21 @@ require 'package'
 class Cpustat < Package
   description 'cpustat periodically dumps out the current CPU utilisation statistics of running processes.'
   homepage 'https://kernel.ubuntu.com/~cking/cpustat/'
-  version '0.02.09'
-  source_url 'https://kernel.ubuntu.com/~cking/tarballs/cpustat/cpustat-0.02.09.tar.xz'
-  source_sha256 'fe48369cf031ecf5edd77f585c66b66d3c6e71a0933230502e1a665fcc86aa8b'
+  version '0.02.10'
+  source_url 'https://kernel.ubuntu.com/~cking/tarballs/cpustat/cpustat-0.02.10.tar.xz'
+  source_sha256 'ea9ab5a970ec657496c0127e3e5d58d49ce0fe07e750b4aafcfeb4896ccd74e9'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.09-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.09-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.09-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.09-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '14b4aa6110904b31c0259f3bc6aeba5efeca97b8c8d95a6342fd1bbf2b81f426',
-     armv7l: '14b4aa6110904b31c0259f3bc6aeba5efeca97b8c8d95a6342fd1bbf2b81f426',
-       i686: '7eab479cc88afe2a1336f5a0c091bcf44751a561c911f77fce86e3b29abe2e59',
-     x86_64: 'aa9a721eaa7cd8c54306e744cf40d40db278742a9542a69956b68d3c7f42fdae',
+    aarch64: 'd8a55c174fee28fc12a5a153836696fdfc7320f5fbc106095e0d18faccc7c58e',
+     armv7l: 'd8a55c174fee28fc12a5a153836696fdfc7320f5fbc106095e0d18faccc7c58e',
+       i686: '8e215c1064acc4bc8329f801d79aa96b7d8537596e6b91c12037c5782f5b3454',
+     x86_64: '8e96b86281a64fe06adc42c18a8507f0e52ffba4368cd3acb96b4f428ad0bb0d',
   })
 
   def self.build
@@ -28,6 +28,6 @@ class Cpustat < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/depot_tools.rb
+++ b/packages/depot_tools.rb
@@ -1,0 +1,46 @@
+require 'package'
+
+class Depot_tools < Package
+  description 'Chromium uses a package of scripts, the depot_tools, to manage interaction with the Chromium source code repository and the Chromium development process.'
+  homepage 'http://dev.chromium.org/developers/how-tos/depottools'
+  version '906bfde9'
+  source_url 'file:///dev/null'
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+  depends_on 'xdg_base'
+
+  def self.install
+    system 'git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git'
+    Dir.chdir 'depot_tools' do
+      system "git checkout #{version}"
+      FileUtils.rm_rf 'man/src'
+      FileUtils.rm_rf Dir.glob('.git*')
+      system 'find -name \'*.bat\' -exec rm {} +'
+      FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/depot_tools"
+      FileUtils.mv 'man/', "#{CREW_DEST_PREFIX}/share"
+      FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/depot_tools"
+      FileUtils.mkdir_p "#{CREW_DEST_HOME}/.config/.vpython-root"
+      FileUtils.mkdir_p "#{CREW_DEST_HOME}/.config/.vpython_cipd_cache"
+      FileUtils.ln_s "#{HOME}/.config/.vpython-root/", "#{CREW_DEST_HOME}/.vpython-root"
+      FileUtils.ln_s "#{HOME}/.config/.vpython_cipd_cache/", "#{CREW_DEST_HOME}/.vpython_cipd_cache"
+    end
+  end
+
+  def self.postinstall
+    puts
+    puts "To finish the installation, execute the following:".lightblue
+    puts "echo 'export PATH=\$PATH:#{CREW_PREFIX}/share/depot_tools' >> ~/.bashrc && source ~/.bashrc".lightblue
+    puts
+    puts "To get started, type 'man depot_tools_tutorial'.".lightblue
+    puts
+    puts "To completely remove, execute the following:".lightblue
+    puts "crew remove depot_tools".lightblue
+    puts "sudo rm -rf ~/.config/.vpython*".lightblue
+    puts
+  end
+end

--- a/packages/dfu_util.rb
+++ b/packages/dfu_util.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Dfu_util < Package
+  description 'DFU is intended to download and upload firmware to/from devices connected over USB.'
+  homepage 'http://dfu-util.gnumonks.org/'
+  version '0.9'
+  source_url 'http://dfu-util.sourceforge.net/releases/dfu-util-0.9.tar.gz'
+  source_sha256 '36428c6a6cb3088cad5a3592933385253da5f29f2effa61518ee5991ea38f833'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dfu_util-0.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dfu_util-0.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/dfu_util-0.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dfu_util-0.9-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '9f15f808d4e10bce99419bd7330f17af265be7db6b21919497aa1df2b235259a',
+     armv7l: '9f15f808d4e10bce99419bd7330f17af265be7db6b21919497aa1df2b235259a',
+       i686: '9a3d7b20e130741f7182f124fac70e458ccf7293848373bfd1808b147062fe63',
+     x86_64: '0293dd440c43ca3c89f8a83c8127de0a37a1357c6515f2933f94ab1b29b5322d',
+  })
+
+  depends_on 'libusb'
+
+  def self.build
+    system "./configure \
+      --prefix=#{CREW_PREFIX} \
+      --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/docbook_xml.rb
+++ b/packages/docbook_xml.rb
@@ -5,21 +5,21 @@ require 'package'
 class Docbook_xml < Package
   description 'document type definitions for verification of XML data files against the DocBook rule set'
   homepage 'http://www.docbook.org'
-  version '4.3-1'
-  source_url 'http://www.docbook.org/xml/4.3/docbook-xml-4.3.zip'
-  source_sha256 '23068a94ea6fd484b004c5a73ec36a66aa47ea8f0d6b62cc1695931f5c143464'
+  version '5.1'
+  source_url 'https://docbook.org/xml/5.1/docbook-v5.1-os.zip'
+  source_sha256 'b3f3413654003c1e773360d7fc60ebb8abd0e8c9af8e7d6c4b55f124f34d1e7f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-4.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-4.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-4.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-4.3-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd3008b147f80217982def39e17e04ab9dd32774932322685ae54e5310c70787b',
-     armv7l: 'd3008b147f80217982def39e17e04ab9dd32774932322685ae54e5310c70787b',
-       i686: '2650849c66d4838eb91c679dcd18792583e848a11073b8f60fdc2f5c9f81a7dd',
-     x86_64: '2479e13c8b04434b51a07a96d8500a753042e08ed68dac8b692a267b44372001',
+    aarch64: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
+     armv7l: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
+       i686: '118a652d4b192525f2400ec121747b1824292b874941b04da037b4a031107148',
+     x86_64: '19aefa5a44bdd6a0ff77072f2fe45e1b032a06d9a72faeb51ac3cae2d49e992c',
   })
 
   depends_on 'docbook'
@@ -27,7 +27,7 @@ class Docbook_xml < Package
 
   def self.install
 
-    xml_version = '4.3'
+    xml_version = '5.1'
     xml_dtd = "xml-dtd-#{xml_version}"
 
     system "install -v -d -m755 #{CREW_DEST_PREFIX}/share/xml/docbook/#{xml_dtd}"

--- a/packages/ecasound.rb
+++ b/packages/ecasound.rb
@@ -1,0 +1,44 @@
+require 'package'
+
+class Ecasound < Package
+  description 'Ecasound is a software package designed for multitrack audio processing.'
+  homepage 'https://ecasound.seul.org/ecasound/'
+  version '1.0.21'
+  source_url 'https://nosignal.fi/download/ecasound-2.9.3.tar.gz'
+  source_sha256 '468bec44566571043c655c808ddeb49ae4f660e49ab0072970589fd5a493f6d4'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ecasound-1.0.21-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ecasound-1.0.21-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ecasound-1.0.21-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ecasound-1.0.21-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '8bbf7d4b25da6f034a519a8bbb213acd9e4d328c8be0ffcb1ef7973faf1932ea',
+     armv7l: '8bbf7d4b25da6f034a519a8bbb213acd9e4d328c8be0ffcb1ef7973faf1932ea',
+       i686: '1cce14a38401659698c2500e9d09aaf732c46343438601745d46cbf162fcd5cf',
+     x86_64: 'f8242a29cdc5a9a3abcabb1455a457c39ed08d195b7aa17df859f0ad845ca6d4',
+  })
+
+  depends_on 'libaudiofile'
+  depends_on 'libsndfile'
+  depends_on 'python27'
+
+  def self.patch
+    # Fix ./configure: line 8777: /usr/bin/file: No such file or directory
+    system 'filefix'
+  end
+
+  def self.build
+    system "CPPFLAGS=-I#{CREW_PREFIX}/include/readline ./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/elfutils.rb
+++ b/packages/elfutils.rb
@@ -3,27 +3,27 @@ require 'package'
 class Elfutils < Package
   description 'elfutils is a collection of utilities and libraries to read, create and modify ELF binary files, find and handle DWARF debug data, symbols, thread state and stacktraces for processes and core files on GNU/Linux.'
   homepage 'https://sourceware.org/elfutils/'
-  version '0.177'
-  source_url 'https://sourceware.org/elfutils/ftp/0.177/elfutils-0.177.tar.bz2'
-  source_sha256 'fa489deccbcae7d8c920f60d85906124c1989c591196d90e0fd668e3dc05042e'
+  version '0.178'
+  source_url 'https://sourceware.org/elfutils/ftp/0.178/elfutils-0.178.tar.bz2'
+  source_sha256 '31e7a00e96d4e9c4bda452e1f2cdac4daf8abd24f5e154dee232131899f3a0f2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/elfutils-0.177-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/elfutils-0.177-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/elfutils-0.177-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/elfutils-0.177-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/elfutils-0.178-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/elfutils-0.178-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/elfutils-0.178-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/elfutils-0.178-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '515b7c9a5e8de3b1e073b1370e24a331616530a20f91348e291bc0c92ad431d5',
-     armv7l: '515b7c9a5e8de3b1e073b1370e24a331616530a20f91348e291bc0c92ad431d5',
-       i686: 'c255e8096b05af371ea1942058f4b5e4a31ba342e6dc1e3062931eb4656e1898',
-     x86_64: '403d0304956f372da40af8b2af6e00f82ae8db203a782e9c3f48a8028d8f1b5c',
+    aarch64: 'bbb5f8ab0208492e735585d2623f29b19326b4cc7a9201fa8f04fa1144f9583e',
+     armv7l: 'bbb5f8ab0208492e735585d2623f29b19326b4cc7a9201fa8f04fa1144f9583e',
+       i686: '6213446efdfc5c588b323125a38f1c48383826831925084368a239a437dc137e',
+     x86_64: 'd34976b47335c47f8d4c88794789285971c4171d9c2aec9dae31ab9df06a5210',
   })
 
   depends_on 'xzutils'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --disable-debuginfod"
     system 'make'
   end
 

--- a/packages/epydoc.rb
+++ b/packages/epydoc.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Epydoc < Package
+  description 'Epydoc is a tool for generating API documentation for Python modules, based on their docstrings.'
+  homepage 'http://epydoc.sourceforge.net/'
+  version '3.0.1'
+  source_url 'https://downloads.sourceforge.net/project/epydoc/epydoc/3.0.1/epydoc-3.0.1.tar.gz'
+  source_sha256 'd4e5c8d90937d01b05170f592c1fa9b29e9ed0498dfe7f0eb2a3af61725b6ad1'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/epydoc-3.0.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/epydoc-3.0.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/epydoc-3.0.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/epydoc-3.0.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '8991ce352c0c8d49e7947ed3d99194dc3d8b3c6277c21ee47f44925b9377dccf',
+     armv7l: '8991ce352c0c8d49e7947ed3d99194dc3d8b3c6277c21ee47f44925b9377dccf',
+       i686: 'cff7e6d737b259381d1538acf184b7f209d857c297264fa91483c6b01033356b',
+     x86_64: '5978478fb0eadb8a0a48b76b3c96bf0baa6b6c8d31ecd97c121a4cbaeb0941dd',
+  })
+
+  depends_on 'python27'
+
+  def self.install
+    system "python setup.py install --root=#{CREW_DEST_DIR} --prefix=#{CREW_PREFIX}"
+  end
+end

--- a/packages/expat.rb
+++ b/packages/expat.rb
@@ -3,21 +3,21 @@ require 'package'
 class Expat < Package
   description 'James Clark\'s Expat XML parser library in C.'
   homepage 'https://sourceforge.net/projects/expat/'
-  version '2.2.6'
-  source_url 'https://prdownloads.sourceforge.net/project/expat/expat/2.2.6/expat-2.2.6.tar.bz2'
-  source_sha256 '17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2'
+  version '2.2.9'
+  source_url 'https://prdownloads.sourceforge.net/project/expat/expat/2.2.9/expat-2.2.9.tar.bz2'
+  source_sha256 'f1063084dc4302a427dabcca499c8312b3a32a29b7d2506653ecc8f950a9a237'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/expat-2.2.6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/expat-2.2.6-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/expat-2.2.6-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/expat-2.2.6-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/expat-2.2.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/expat-2.2.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/expat-2.2.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/expat-2.2.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '419210356fe54f15bf2e8c51e436ccffe2e240b6cfb44a12b9c999561611e418',
-     armv7l: '419210356fe54f15bf2e8c51e436ccffe2e240b6cfb44a12b9c999561611e418',
-       i686: 'bb902406002d8cee6c803dd18a567658d02e60c1fbb0dfa94a5d31a076fe2348',
-     x86_64: '9e37b6a5b6ec892b3da12fbd984685e375b3641ed53074da98bd43a7faf75161',
+    aarch64: '2bac1ab7a27c48690d47e28b5826818095932bb9210ec46b69e173a088ead177',
+     armv7l: '2bac1ab7a27c48690d47e28b5826818095932bb9210ec46b69e173a088ead177',
+       i686: '331b397c748e8bfeef19ac927236b19ea03d841e7e15788850f8a207c3ab473b',
+     x86_64: '1f339732173e08417ae6c9f12ff898020a517c345afd34682971ffa7d982a306',
   })
 
   def self.build

--- a/packages/fftw.rb
+++ b/packages/fftw.rb
@@ -1,0 +1,39 @@
+require 'package'
+
+class Fftw < Package
+  description 'FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data'
+  homepage 'http://www.fftw.org/'
+  version '3.3.8'
+  source_url 'http://www.fftw.org/fftw-3.3.8.tar.gz'
+  source_sha256 '6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f3e94c3a07e8966eafe02daa3673de462bab1fbbb0f1aefcc844ffbc53c84307',
+     armv7l: 'f3e94c3a07e8966eafe02daa3673de462bab1fbbb0f1aefcc844ffbc53c84307',
+       i686: '03800193d0be4a716331a27a948022d0a6ac94183a6b2fe0a988f5d94e3e8ff9',
+     x86_64: '47c9b73133cf16339ab6c229ba74ec73155f0fc1bf01bfd0e4e2c6ac7c46f78e',
+  })
+
+  def self.build
+    system './configure',
+           '--enable-shared=yes',
+           '--disable-maintainer-mode',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -3,14 +3,14 @@ require 'package'
 class Firefox < Package
   description 'Mozilla Firefox (or simply Firefox) is a free and open-source web browser'
   homepage 'https://www.mozilla.org/en-US/firefox/'
-  version '70.0.1'
+  version '73.0.1'
   case ARCH
-  when 'x86_64'
-    source_url 'https://archive.mozilla.org/pub/firefox/releases/70.0.1/linux-x86_64/en-US/firefox-70.0.1.tar.bz2'
-    source_sha256 'bc1ef29799f15d1fe709a430203d16c12d5ae0899f1c01ba4461062392a2e77e'
   when 'i686'
-    source_url 'https://archive.mozilla.org/pub/firefox/releases/70.0.1/linux-i686/en-US/firefox-70.0.1.tar.bz2'
-    source_sha256 '4981bae093177f3ae705bbf9119a2e9149dbfa3d931157a724fb1b294c099811'
+    source_url 'https://archive.mozilla.org/pub/firefox/releases/73.0.1/linux-i686/en-US/firefox-73.0.1.tar.bz2'
+    source_sha256 '0cf4ed94739979f5c7fce0a94152911079722cc0118edab9a8f6a573bdf06c3a'
+  when 'x86_64'
+    source_url 'https://archive.mozilla.org/pub/firefox/releases/73.0.1/linux-x86_64/en-US/firefox-73.0.1.tar.bz2'
+    source_sha256 'd5a2c93844763b2e7f7f555eab239b71442cd87205c40a8ad287c38208a2a513'
   end
 
   depends_on 'gtk3'
@@ -24,7 +24,7 @@ class Firefox < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/firefox"
-    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/firefox"
+    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/firefox"
     system "install -Dm755 firefox.sh #{CREW_DEST_PREFIX}/bin/firefox"
   end
 end

--- a/packages/fltk.rb
+++ b/packages/fltk.rb
@@ -1,0 +1,42 @@
+require 'package'
+
+class Fltk < Package
+  description 'Fast Light Toolkit or FLTK (pronounced "fulltick") is a cross-platform C++ GUI toolkit'
+  homepage 'https://www.fltk.org/'
+  version '1.3.5'
+  source_url 'https://www.fltk.org/pub/fltk/1.3.5/fltk-1.3.5-source.tar.bz2'
+  source_sha256 '2933c72400f9e7c0f4c3a81a1ce98bc9582b2a3edc44b8597ccd26e240e32c3c'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fltk-1.3.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fltk-1.3.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fltk-1.3.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fltk-1.3.5-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '98d7e8f6846f357be4b7600b016fe4f1800c8e7e08d1846227c674fa7e0a7a89',
+     armv7l: '98d7e8f6846f357be4b7600b016fe4f1800c8e7e08d1846227c674fa7e0a7a89',
+       i686: 'ee29eb618e5f09f1486e56061c5b82d1a331dba26eb0e0329020641261d6ac92',
+     x86_64: '95fabef98ee5b2fc9c7ba32ea8f62bf0193322b791f8048d4ee003d76b7c8e83',
+  })
+
+  depends_on 'sommelier'
+
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             '-DCMAKE_BUILD_TYPE=Release',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '-DOPTION_BUILD_EXAMPLES=OFF',
+             '..'
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
+  end
+end

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -3,21 +3,21 @@ require 'package'
 class Freetype < Package
   description 'FreeType is a freely available software library to render fonts.'
   homepage 'https://www.freetype.org/'
-  version '2.9.1'
-  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.gz'
-  source_sha256 'ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce'
+  version '2.10'
+  source_url 'https://namesdir.com/mirrors/nongnu/freetype/freetype-2.10.0.tar.gz'
+  source_sha256 '955e17244e9b38adb0c98df66abb50467312e6bb70eac07e49ce6bd1a20e809a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.9.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.9.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.9.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.9.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b1f0356d2f51ea825abd4d9b3204b9aa5cc3e660451c94222284f71abd73ec7d',
-     armv7l: 'b1f0356d2f51ea825abd4d9b3204b9aa5cc3e660451c94222284f71abd73ec7d',
-       i686: '757f41d0bed65abdcf8a86345a54fe6a3e69a81b9d5fb7a93d78e4612ee0d1f6',
-     x86_64: '2474ed8846e36917b2a1864416affb6de8dde1f8a61b1fc0a587ada3a7592fca',
+    aarch64: '3cdfc1eae6ee52f0d3c046e2a3bc01d8383d830ea48cb2f84db94caced32b2a9',
+     armv7l: '3cdfc1eae6ee52f0d3c046e2a3bc01d8383d830ea48cb2f84db94caced32b2a9',
+       i686: 'b3a195210ba9bc95a863956c69218b99bdcac6a276b27648ff043d5e7bf64b39',
+     x86_64: '0c761037a91633e1371974ced873e59c1f847ead4416f338119761be1bbe21c7',
   })
 
   depends_on 'expat'

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -3,21 +3,21 @@ require 'package'
 class Freetype_sub < Package
   description 'Freetype_sub is a version without harfbuzz. It is intended to handle circular dependency betwwen freetype and harfbuzz.'
   homepage 'https://www.freetype.org/'
-  version '2.9'
-  source_url 'http://download.savannah.gnu.org/releases/freetype/freetype-2.9.tar.gz'
-  source_sha256 'bf380e4d7c4f3b5b1c1a7b2bf3abb967bda5e9ab480d0df656e0e08c5019c5e6'
+  version '2.10'
+  source_url 'https://namesdir.com/mirrors/nongnu/freetype/freetype-2.10.0.tar.gz'
+  source_sha256 '955e17244e9b38adb0c98df66abb50467312e6bb70eac07e49ce6bd1a20e809a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.9-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f180b27eb703e0e7680f53ee4396a7e9cfb4093d9f29b7d16fffad6c6476c912',
-     armv7l: 'f180b27eb703e0e7680f53ee4396a7e9cfb4093d9f29b7d16fffad6c6476c912',
-       i686: '71fb1bace0552659cfc86ef6ed88bbb1ce5c618061107381618f1a1060c47397',
-     x86_64: '3ccd3b201456c5d9f2dac55311ed3f337edd230a894fae5e821072515a3d5d5f',
+    aarch64: 'b2d3c0d50a433d0ffc1fbada114b76bc4147d2a67664155ac3d91342e501d557',
+     armv7l: 'b2d3c0d50a433d0ffc1fbada114b76bc4147d2a67664155ac3d91342e501d557',
+       i686: '9bd721ac92d77e19686c6e39f283a5d434b7649483b99ea01ae562c8d1b14e45',
+     x86_64: 'b69cbd236ddc7ba3ee01719131832c174b345e12ea8df9ead43ebc1a8b622805',
   })
 
   depends_on 'expat'

--- a/packages/fribidi.rb
+++ b/packages/fribidi.rb
@@ -3,21 +3,21 @@ require 'package'
 class Fribidi < Package
   description 'GNU FriBidi is an implementation of the Unicode Bidirectional Algorithm (bidi).'
   homepage 'https://www.fribidi.org/'
-  version '1.0.1'
-  source_url 'https://github.com/fribidi/fribidi/releases/download/v1.0.1/fribidi-1.0.1.tar.bz2'
-  source_sha256 'c1b182d70590b6cdb5545bab8149de33b966800f27f2d9365c68917ed5a174e4'
+  version '1.0.9'
+  source_url 'https://github.com/fribidi/fribidi/releases/download/v1.0.9/fribidi-1.0.9.tar.xz'
+  source_sha256 'c5e47ea9026fb60da1944da9888b4e0a18854a0e2410bbfe7ad90a054d36e0c7'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fribidi-1.0.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fribidi-1.0.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fribidi-1.0.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fribidi-1.0.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fribidi-1.0.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fribidi-1.0.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fribidi-1.0.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fribidi-1.0.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd2c2acf788e0fc1c3d5330ead4bf2f184c7667847c51fe6e8da183cba9e77748',
-     armv7l: 'd2c2acf788e0fc1c3d5330ead4bf2f184c7667847c51fe6e8da183cba9e77748',
-       i686: '0b0515f77ac80bfd3cf9332b3bc5980e04e3664e9b2f5957f4f12ba48f9dd02a',
-     x86_64: 'f408ec87bb6df6e4d375ba9b90d5d79cbdef7180e6fb69bdf31610756ae31f7d',
+    aarch64: '9726846e950c5aa4ba2587a7e2a4057ca36718e606980fcef18a47990a967e5e',
+     armv7l: '9726846e950c5aa4ba2587a7e2a4057ca36718e606980fcef18a47990a967e5e',
+       i686: 'a19caf91d86c53eb02398361e93ac8afdb042e661a22222d7ca63caab92fe205',
+     x86_64: '17c2146657860ec4664fb7d247383c40859d3adf87fdf3c9f343e989cefcafb3',
   })
 
   def self.build

--- a/packages/geany.rb
+++ b/packages/geany.rb
@@ -1,0 +1,51 @@
+require 'package'
+
+class Geany < Package
+  description 'Geany is a small and lightweight Integrated Development Environment.'
+  homepage 'https://www.geany.org/'
+  version '1.36'
+  source_url 'https://download.geany.org/geany-1.36.tar.bz2'
+  source_sha256 '9184dd3dd40b7b84fca70083284bb9dbf2ee8022bf2be066bdc36592d909d53e'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/geany-1.36-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/geany-1.36-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/geany-1.36-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e89045825ce51fbb6f4705f3d408d1dada843bc54ff24ad35f18cea61b4b03b3',
+     armv7l: 'e89045825ce51fbb6f4705f3d408d1dada843bc54ff24ad35f18cea61b4b03b3',
+     x86_64: '3d99c7c90b6ea63856fd9b469cdbdb4c2f00db6a549d7f3973e5efea25b65536',
+  })
+
+  depends_on 'gtk3'
+  depends_on 'python27'
+  depends_on 'xdg_base'
+  depends_on 'sommelier'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--enable-gtk3'
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.postinstall
+    puts
+    puts "To get started, type 'geany'.".lightblue
+    puts
+    puts "To completely uninstall, execute the following:".lightblue
+    puts "crew remove geany".lightblue
+    puts "rm -rf ~/.config/geany".lightblue
+    puts
+  end
+end

--- a/packages/glew.rb
+++ b/packages/glew.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Glew < Package
+  description 'GLEW provides efficient run-time mechanisms for determining which OpenGL extensions are supported on the target platform'
+  homepage 'http://glew.sourceforge.net/'
+  version '2.1.0'
+  source_url 'https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz'
+  source_sha256 '04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glew-2.1.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glew-2.1.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glew-2.1.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glew-2.1.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '66d50f1b19c6a53fc3b30940df863e4471d9ee641310eef1965f69748d54fa98',
+     armv7l: '66d50f1b19c6a53fc3b30940df863e4471d9ee641310eef1965f69748d54fa98',
+       i686: '6cdeed1dbca32d7ca46cda937c0d5487ad2d5c2ef96916339093f838e0d0ba9e',
+     x86_64: '021f5b6b7669a7719e5b46716ce3aac75c4fd1922ec4d2f112a318867665e5c8',
+  })
+
+  depends_on 'mesa'
+
+  def self.build
+    Dir.chdir 'build' do
+      system 'cmake',
+             '-DCMAKE_BUILD_TYPE=Release',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             "-DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX}",
+             './cmake'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "GLEW_DEST=#{CREW_DEST_DIR}", 'install'
+    end
+  end
+end

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,35 +3,32 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  version '2.56.1'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/glib/2.56/glib-2.56.1.tar.xz'
-  source_sha256 '40ef3f44f2c651c7a31aedee44259809b6f03d3d20be44545cd7d177221c0b8d'
+  version '2.64.1'
+  source_url 'https://ftp.acc.umu.se/pub/gnome/sources/glib/2.64/glib-2.64.1.tar.xz'
+  source_sha256 '17967603bcb44b6dbaac47988d80c29a3d28519210b28157c2bd10997595bbc7'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.56.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.56.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.56.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.56.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.64.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.64.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.64.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.64.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'c204eac72fd82ad0aa5c58be276960f98f05ff1edca0beea76dd60ecedc8adbf',
-     armv7l: 'c204eac72fd82ad0aa5c58be276960f98f05ff1edca0beea76dd60ecedc8adbf',
-       i686: '14f14d855b87c7c062b850d91b4de2deb6d92fef8d252938631820a43d468d7c',
-     x86_64: 'fd6aea5f310ed045f3e9c132af14d11e63c5d50e04871369eb4888dfef9aee66',
+    aarch64: 'ba601edad8d81993f486184431f1951e47e8300366e7655c2ea164e923fcc056',
+     armv7l: 'ba601edad8d81993f486184431f1951e47e8300366e7655c2ea164e923fcc056',
+       i686: '532128e2b88f76fd80cad43e0804e5d6549dfe02f21579158261357c9a4be159',
+     x86_64: '9f0d347094230086b43f7535bd980d1a0efb4b9e5704e74acff9c1eb584dcd04',
   })
 
   depends_on 'util_linux'
   depends_on 'six'
 
   def self.build
-    system "./configure",
-    "--prefix=#{CREW_PREFIX}",
-    "--libdir=#{CREW_LIB_PREFIX}",
-    "--with-pcre"
-    system "make"
+    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} -Dinternal_pcre=true builddir"
+    system "ninja -C builddir"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -3,21 +3,21 @@ require 'package'
 class Gnutls < Package
   description 'GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols and technologies around them.'
   homepage 'http://gnutls.org/'
-  version '3.6.3-1'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.3.tar.xz'
-  source_sha256 'ed642b66a4ecf4851ab2d809cd1475c297b6201d8e8bd14b4d1c08b53ffca993'
+  version '3.6.12'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.12.tar.xz'
+  source_sha256 'bfacf16e342949ffd977a9232556092c47164bd26e166736cf3459a870506c4b'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.3-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.12-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.12-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.12-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnutls-3.6.12-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '7b8f451dcc136eafc149196998494173200d4c0e6e44484c6cdedfaccb1e32fe',
-     armv7l: '7b8f451dcc136eafc149196998494173200d4c0e6e44484c6cdedfaccb1e32fe',
-       i686: 'b23d185954cb6e28ff20918a54ce573700686e25193d2921acb18dd017d629ba',
-     x86_64: '70a7b1753ab61e09249f599bbad21e16e8eff71848787c8ad4e77c90582a6f1b',
+    aarch64: 'ef7aac519396162958750c83622781f8f9e4c30cee06b911271a8ae3d8cb44a4',
+     armv7l: 'ef7aac519396162958750c83622781f8f9e4c30cee06b911271a8ae3d8cb44a4',
+       i686: 'd403e4200b18dfafba3c46bdf3c95e3e59088499b8fae5e22085f65b8a99fc49',
+     x86_64: '261a3766026d916bdb4a68fd1b55a9409e52ac06e2949310371bf9a13dea3751',
   })
 
   depends_on 'zlibpkg'

--- a/packages/go.rb
+++ b/packages/go.rb
@@ -3,21 +3,13 @@ require 'package'
 class Go < Package
   description 'Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.'
   homepage 'https://golang.org/'
-  version '1.12'
-  source_url 'https://dl.google.com/go/go1.12.src.tar.gz'
-  source_sha256 '09c43d3336743866f2985f566db0520b36f4992aea2b4b2fd9f52f17049e88f2'
+  version '1.14'
+  source_url 'https://dl.google.com/go/go1.14.src.tar.gz'
+  source_sha256 '6d643e46ad565058c7a39dac01144172ef9bd476521f42148be59249e4b74389'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.12-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.12-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.12-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'ba79eb1b8d48ce92d1a31d9f173941cc55fa55ff847cc5fab36a66c1ce77938b',
-     armv7l: 'ba79eb1b8d48ce92d1a31d9f173941cc55fa55ff847cc5fab36a66c1ce77938b',
-       i686: 'a96ebc21fbe093d956e06c3f977ecadc8a0840830585eec08aecbd629250beb6',
-     x86_64: '2620b266c38b8a9dce103886346a40d66b9a8eaccf98e1cff7f0e958f2a53cb2',
   })
 
   # Tests requires perl
@@ -34,12 +26,14 @@ class Go < Package
         system "GOROOT_BOOTSTRAP=#{CREW_PREFIX}/share/go_bootstrap/go \
                 TMPDIR=#{CREW_PREFIX}/tmp \
                 GOROOT_FINAL=#{CREW_PREFIX}/share/go \
-                ./make.bash"
+                %s \
+                ./make.bash" % 'GOHOSTARCH=arm' if ARCH == 'aarch64'
       else
         system "GOROOT_BOOTSTRAP=#{CREW_PREFIX}/share/go \
                 TMPDIR=#{CREW_PREFIX}/tmp \
                 GOROOT_FINAL=#{CREW_PREFIX}/share/go \
-                ./make.bash"
+                %s \
+                ./make.bash" % 'GOHOSTARCH=arm' if ARCH == 'aarch64'
       end
     end
   end

--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -3,32 +3,32 @@ require 'package'
 class Gobject_introspection < Package
   description 'GObject introspection is a middleware layer between C libraries (using GObject) and language bindings.'
   homepage 'https://wiki.gnome.org/action/show/Projects/GObjectIntrospection'
-  version '1.52.1'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/gobject-introspection/1.52/gobject-introspection-1.52.1.tar.xz'
-  source_sha256 '2ed0c38d52fe1aa6fc4def0c868fe481cb87b532fc694756b26d6cfab29faff4'
+  version '1.64.0'
+  source_url 'https://ftp.acc.umu.se/pub/gnome/sources/gobject-introspection/1.64/gobject-introspection-1.64.0.tar.xz'
+  source_sha256 'eac05a63091c81adfdc8ef34820bcc7e7778c5b9e34734d344fc9e69ddf4fc82'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.52.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.52.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.52.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.52.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.64.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.64.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.64.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.64.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'cef6d20359ec63d73eb2f4f9446f4a2d9d10ddce89a3101bb2689dca59f1c3ec',
-     armv7l: 'cef6d20359ec63d73eb2f4f9446f4a2d9d10ddce89a3101bb2689dca59f1c3ec',
-       i686: 'a01838c57af9d90964c2cf4c9efa13f21cf639cae38e7fe0c34f2bc59797c3d6',
-     x86_64: '1579109ca32ff57a7b8dd4aeac198d09f4131998bf9127e992fb4df81f4967eb',
+    aarch64: '38781ac9905d88ebfcd5f776cdec1d7ff79b45b0f03dbf7e72e729a232175389',
+     armv7l: '38781ac9905d88ebfcd5f776cdec1d7ff79b45b0f03dbf7e72e729a232175389',
+       i686: '0244b19fa91d0524eceb40b1694ee3473d212d5cd9d3147fcb3e59406d98dbd6',
+     x86_64: '10e3f341d3bbe14d741062463bc6eb0631051db075cef3782b3273191aea098b',
   })
 
   depends_on 'glib'
   depends_on 'cairo'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
+    system "ninja -C builddir"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/gphoto.rb
+++ b/packages/gphoto.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Gphoto < Package
+  description 'The gphoto2 commandline tool for accessing and controlling digital cameras.'
+  homepage 'http://www.gphoto.org/'
+  version '2.5.23'
+  source_url 'https://github.com/gphoto/gphoto2/archive/gphoto2-2_5_23-release.tar.gz'
+  source_sha256 'dc78b7f8a88803937301d157b5b32cd45f6defcc771564438a477a7fb05f4489'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gphoto-2.5.23-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gphoto-2.5.23-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gphoto-2.5.23-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gphoto-2.5.23-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '055e881c56a7e40a0208176d08555a8992f15844aedc204f53d99db8e86e1f31',
+     armv7l: '055e881c56a7e40a0208176d08555a8992f15844aedc204f53d99db8e86e1f31',
+       i686: '72969ad37c17319ce08ca6a80d26d8cfd1bbeac71cbfbcf4ae89f582d6db0f52',
+     x86_64: '92fcfd96e8a3a8d40d5a2661d5a9b37dad019ef086b925c97a738c9879c82663',
+  })
+
+  depends_on 'libgphoto'
+  depends_on 'popt'
+
+  def self.build
+    system 'autoreconf -is'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/graphviz.rb
+++ b/packages/graphviz.rb
@@ -3,21 +3,21 @@ require 'package'
 class Graphviz < Package
   description 'Graphviz is open source graph visualization software.'
   homepage 'https://www.graphviz.org/'
-  version '2.40.1'
-  source_url 'https://gitlab.com/graphviz/graphviz/repository/67cd2e5121379a38e0801cc05cce5033f8a2a609/archive.tar.bz2'
-  source_sha256 '8dddc80b4194b17c1a5bc1cc7b5e001e9a3ec27272287dc16f278c736a29a9b9'
+  version '2.42.2'
+  source_url 'https://gitlab.com/graphviz/graphviz/-/archive/2.42.2/graphviz-2.42.2.tar.bz2'
+  source_sha256 '1daed697d9cdd7fac3b320336fa98dd3518dd211769301dc716869fc3d5409b1'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.40.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.40.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.40.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.40.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.42.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.42.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.42.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.42.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd1620cf88f88aca31001a64a26c95d02d5ee3b7109b093ea824f381f54d71ed0',
-     armv7l: 'd1620cf88f88aca31001a64a26c95d02d5ee3b7109b093ea824f381f54d71ed0',
-       i686: 'cb31be3ee6e1d74917c87ebb7a2bb2290e2a1cf1d60ef817b06a5d569b3fdcd3',
-     x86_64: 'd27c0177f7c154aacf6c69cbe0ae85c9a36a0aa2946fe32d5f4c9fd39772ce5a',
+    aarch64: '7950f9bf30b726d47e2a43b7617cd2cc01039a53faba377b5c8aa706e1b61a2f',
+     armv7l: '7950f9bf30b726d47e2a43b7617cd2cc01039a53faba377b5c8aa706e1b61a2f',
+       i686: 'dc786a500b658446e90f90e7e6b8aeb5165840f09964f12899cef19c8413a633',
+     x86_64: 'b34bab2d96832ca42aaeeddad01637f4f0bab8705f7d49ef9a2488a7164d8451',
   })
 
   depends_on 'automake' => :build
@@ -26,10 +26,11 @@ class Graphviz < Package
   depends_on 'gdk_pixbuf'
   depends_on 'libxrender'
   depends_on 'poppler'
+  depends_on 'tcl'
 
   def self.build
     system "./autogen.sh"
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} LDFLAGS='-L#{CREW_LIB_PREFIX}' --with-libgd=yes --with-gdincludedir=#{CREW_PREFIX}/include --with-gdlibdir=#{CREW_LIB_PREFIX} --enable-tcl=no --enable-lua=no --enable-perl=no --enable-io=no"
     system "make"
   end
 

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -3,21 +3,21 @@ require 'package'
 class Gvim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (with advanced features, such as a GUI)'
   homepage 'http://www.vim.org/'
-  version '8.2.0014'
-  source_url 'https://github.com/vim/vim/archive/v8.2.0014.tar.gz'
-  source_sha256 '5e433abdebf36855bcec38b4e195a1281d04309b72523a265a21288717061845'
+  version '8.2.0346'
+  source_url 'https://github.com/vim/vim/archive/v8.2.0346.tar.gz'
+  source_sha256 '418d1cbc9f53f31cb19869b6df0294ca5c377ca2824c759e3f6796edc60e5628'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.0014-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.0014-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.0014-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.0014-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.0346-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.0346-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.0346-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.0346-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '0a03d59fe6790574ae83b36aa5da4bdadd5a2c6097dcc671933323400f2e1352',
-     armv7l: '0a03d59fe6790574ae83b36aa5da4bdadd5a2c6097dcc671933323400f2e1352',
-       i686: '3a1f848861f0faccb30d95bdd4657abbdbc80b4654d13ecfb3502559ae014e91',
-     x86_64: 'ef77b6f6a7d2ab6adf04148ede4ad1682d1ab0eefd59208d729bfe9d6a2023d0',
+    aarch64: '0470196bc08f2217d4621b513797fe472aea4b426c987361739ef978ba2b654b',
+     armv7l: '0470196bc08f2217d4621b513797fe472aea4b426c987361739ef978ba2b654b',
+       i686: 'c3c8b0ae067acff18ef3167c79694cb99f91170e0091ae9ca2e5d51cfd8a8385',
+     x86_64: 'b0427f0c3fdb2cbb892be3de830515171457899ace33758538a9313f375abe9f',
   })
 
   depends_on 'python27' => :build
@@ -31,7 +31,7 @@ class Gvim < Package
     FileUtils.cd('src') do
       system "sed", "-i", "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|", "feature.h"
       system "sed", "-i", "s|^.*#define SYS_GVIMRC_FILE.*$|#define SYS_GVIMRC_FILE \"#{CREW_PREFIX}/etc/gvimrc\"|", "feature.h"
-      system "autoconf"
+      system 'autoconf'
     end
   end
 
@@ -39,23 +39,23 @@ class Gvim < Package
     system "./configure",
               "--prefix=#{CREW_PREFIX}",
               "--localstatedir=#{CREW_PREFIX}/var/lib/vim",
-              "--with-features=huge",
+              '--with-features=huge',
               "--with-compiledby='Chromebrew'",
-              "--with-x=yes",
-              "--enable-gui=gtk3",
-              "--enable-multibyte",
-              "--enable-cscope",
-              "--enable-fontset",
-              "--enable-perlinterp=dynamic",
-              "--enable-pythoninterp=dynamic",
-              "--enable-python3interp=dynamic",
-              "--enable-rubyinterp=dynamic",
-              "--disable-selinux"
+              '--with-x=yes',
+              '--enable-gui=gtk3',
+              '--enable-multibyte',
+              '--enable-cscope',
+              '--enable-fontset',
+              '--enable-perlinterp=dynamic',
+              '--enable-pythoninterp=dynamic',
+              '--enable-python3interp=dynamic',
+              '--enable-rubyinterp=dynamic',
+              '--disable-selinux'
     system "make"
   end
 
   def self.install
-    system "make", "VIMRCLOC=#{CREW_PREFIX}/etc", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "VIMRCLOC=#{CREW_PREFIX}/etc", "DESTDIR=#{CREW_DEST_DIR}", 'install'
 
     # these are provided by 'vim_runtime'
     FileUtils.rm_r "#{CREW_DEST_PREFIX}/share/vim"

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -3,21 +3,21 @@ require 'package'
 class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
-  version '1.7.6-0'
-  source_url 'https://github.com/harfbuzz/harfbuzz/releases/download/1.7.6/harfbuzz-1.7.6.tar.bz2'
-  source_sha256 'da7bed39134826cd51e57c29f1dfbe342ccedb4f4773b1c951ff05ff383e2e9b'
+  version '2.6.4'
+  source_url 'https://github.com/harfbuzz/harfbuzz/releases/download/2.6.4/harfbuzz-2.6.4.tar.xz'
+  source_sha256 '9413b8d96132d699687ef914ebb8c50440efc87b3f775d25856d7ec347c03c12'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-1.7.6-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-1.7.6-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-1.7.6-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-1.7.6-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-2.6.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-2.6.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-2.6.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-2.6.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd92567e640f2b847ff35d1dcb5e0fcabaa640cea8c709755a3fed8b1ed59a598',
-     armv7l: 'd92567e640f2b847ff35d1dcb5e0fcabaa640cea8c709755a3fed8b1ed59a598',
-       i686: '220ae1416d6fb21e9d5621d97c66e65dddd15eb63108fb4c5e3d5fe6c75e662a',
-     x86_64: '3dd360778d0ffbd12b23a9d1e2fe5d3031f8a93eb9f9618cd430dc91349bee7d',
+    aarch64: 'a8e4b59ff79cf7d445693aaf4cb3b942551d927be47436a70114e286947c5ee6',
+     armv7l: 'a8e4b59ff79cf7d445693aaf4cb3b942551d927be47436a70114e286947c5ee6',
+       i686: '10aa0c94e9a04d86ae06d9508aac0a1224942dffd2d3982aa7a7e27c14499ccf',
+     x86_64: '76d5d648508cb2a85c128d8a0a529ea0f57ff86982ddf5c1aa3fb277d76825dc',
   })
 
   depends_on 'glib'

--- a/packages/hplip.rb
+++ b/packages/hplip.rb
@@ -3,17 +3,31 @@ require 'package'
 class Hplip < Package
   description 'Print, Scan and Fax Drivers for Linux'
   homepage 'https://developers.hp.com/hp-linux-imaging-and-printing/'
-  version '3.18.7'
-  source_url 'https://sourceforge.net/projects/hplip/files/hplip/3.18.7/hplip-3.18.7.tar.gz'
-  source_sha256 '55b879e1d6d0d88c32d79486b748a21759cab404036d883be4ea9fcb55bfeb1d'
+  version '3.20.2'
+  case ARCH
+  when 'i686', 'x86_64'
+    source_url 'https://sourceforge.net/projects/hplip/files/hplip/3.20.2/hplip-3.20.2.tar.gz'
+    source_sha256 '90c49d74688b4d745a739a6db9bf8dbdfa134c24e921e31909bffe9d84f471c2'
+  end
 
   binary_url ({
+      i686: 'https://dl.bintray.com/chromebrew/chromebrew/hplip-3.20.2-chromeos-i686.tar.xz',
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/hplip-3.20.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+      i686: '3665d159fe1684d280689e09546a9f6cb0ab7be68d4e670f40c4111ae015d8b7',
+    x86_64: '05b80f04ea8ac68ffad990ed86140932f6353d25f7fd116df5190e8484385f09',
   })
 
-  depends_on 'libjpeg'
   depends_on 'cups'
+  depends_on 'dbus'
+  depends_on 'libjpeg_turbo'
+  depends_on 'sane_backends'
+
+  def self.preinstall
+    system "curl -Ls -o config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'"
+    system "curl -Ls -o config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'"
+  end
 
   def self.build
     system "sed -i 's,/usr/bin/perl,#{CREW_PREFIX}/bin/perl,g' hpijs-drv"

--- a/packages/hugo.rb
+++ b/packages/hugo.rb
@@ -3,18 +3,18 @@ require 'package'
 class Hugo < Package
   description 'Hugo is one of the most popular open-source static site generators.'
   homepage 'https://gohugo.io'
-  version '0.63.2'
+  version '0.68.1'
 
   case ARCH
   when 'aarch64','armv7l'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.63.2/hugo_0.63.2_Linux-ARM.tar.gz'
-    source_sha256 'a3b659ef0129582aa0151afa8e9727b3a740973727e3c2c4842e0814b85171bf'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.68.1/hugo_0.68.1_Linux-ARM.tar.gz'
+    source_sha256 '3d10e6630730761c6352d02ada31cefb196c42a9c0aca8a38f60d8215ff24f8b'
   when 'i686'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.63.2/hugo_0.63.2_Linux-32bit.tar.gz'
-    source_sha256 '229e297e45f890073d7a8c84c14a2ec54b0ea5d0fd9761e7339501a1f1cead07'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.68.1/hugo_0.68.1_Linux-32bit.tar.gz'
+    source_sha256 'fe6c97026bcceb6d1c6f520f98cf211e9b17f39d1f51be4a0a0537871d1e7a2e'
   when 'x86_64'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.63.2/hugo_0.63.2_Linux-64bit.tar.gz'
-    source_sha256 '9f4d259c345ae976063d8a6064b8fa589a48280ab61c24cb0d1152cf077e4724'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.68.1/hugo_0.68.1_Linux-64bit.tar.gz'
+    source_sha256 '7942cfed5b22f294cc95edbe7ac2d2fdf42a1c4ec94da4666b48256a850c9caa'
   end
 
   binary_url ({

--- a/packages/hunspell_base.rb
+++ b/packages/hunspell_base.rb
@@ -3,28 +3,29 @@ require 'package'
 class Hunspell_base < Package
   description 'Hunspell is a spell checker and morphological analyzer library'
   homepage 'http://hunspell.github.io/'
-  version '1.7.0'
+  version '1.7.0-1'
   source_url 'https://github.com/hunspell/hunspell/archive/v1.7.0.tar.gz'
   source_sha256 'bb27b86eb910a8285407cf3ca33b62643a02798cf2eef468c0a74f6c3ee6bc8a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1827aa434bd7848d03d07ddc2b76c14c052aba16643acd33f494e6d4c3d78016',
-     armv7l: '1827aa434bd7848d03d07ddc2b76c14c052aba16643acd33f494e6d4c3d78016',
-       i686: '5348ba92a0e4b784aaad1875ffdb7a824b60d975bd721f8b86994693697a0840',
-     x86_64: '83443d8cd8e21f25f346dcd6c7ada5a8a5ef0f01a1045addb43d263ab73d9136',
+    aarch64: 'e3e77aa133961b491fee9c7b139d3ae40f04a407faff775cf76a204a947a7b62',
+     armv7l: 'e3e77aa133961b491fee9c7b139d3ae40f04a407faff775cf76a204a947a7b62',
+       i686: 'd4cdc61aac3ab02d3234146364cb1c747e0c070a219197f6990f1d61877b3b13',
+     x86_64: '9f7a88d1e448094147b004a80b62ec5e9cf25b5e93ccbb363a2dddb3461ed8a2',
   })
 
   depends_on 'readline'
   
   def self.build
     system 'autoreconf -vfi'
-    system './configure',
+    system "./configure",
+           "CPPFLAGS=-I#{CREW_PREFIX}/include -I#{CREW_PREFIX}/include/ncursesw -I#{CREW_PREFIX}/include/ncurses",
            "--prefix=#{CREW_PREFIX}",
            "--include=#{CREW_PREFIX}/include",
            "--libdir=#{CREW_LIB_PREFIX}",

--- a/packages/idea.rb
+++ b/packages/idea.rb
@@ -3,9 +3,9 @@ require 'package'
 class Idea < Package
   description 'Capable and Ergonomic IDE for JVM'
   homepage 'https://www.jetbrains.com/idea/'
-  version '2019.3.1'
-  source_url 'https://download.jetbrains.com/idea/ideaIC-2019.3.1.tar.gz'
-  source_sha256 'b67cc055d7ab18b2a864d05956407ae1f910eb295e2a73e6a6aa813260930509'
+  version '2019.3.2'
+  source_url 'https://download.jetbrains.com/idea/ideaIC-2019.3.2.tar.gz'
+  source_sha256 'c38f18a2b2246b9a53fd62d454ccf67996bf59adc0b7e3843be0a9cf44637127'
 
   binary_url ({
   })

--- a/packages/jack.rb
+++ b/packages/jack.rb
@@ -1,0 +1,50 @@
+require 'package'
+
+class Jack < Package
+  description 'JACK (JACK Audio Connection Kit) refers to an API that provides a basic infrastructure for audio applications to communicate with each other and with audio hardware.'
+  homepage 'https://jackaudio.org/'
+  version '1.9.14'
+  source_url 'https://github.com/jackaudio/jack2/releases/download/v1.9.14/v1.9.14.tar.gz'
+  source_sha256 'a20a32366780c0061fd58fbb5f09e514ea9b7ce6e53b080a44b11a558a83217c'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/jack-1.9.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/jack-1.9.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/jack-1.9.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/jack-1.9.14-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '347c09ba7eb56e45ab222de5aebbc75ea6c9bbf85c59bf1da3cb33a87762a0c7',
+     armv7l: '347c09ba7eb56e45ab222de5aebbc75ea6c9bbf85c59bf1da3cb33a87762a0c7',
+       i686: '8b855311f24cb179be23371066b8f8917589af2ac364ce8a70af145f5e8b86a1',
+     x86_64: '85bb228bd5f60b72b377ca99bd22464292d3cf05f7e5e92d433482117abdeafd',
+  })
+
+  depends_on 'dbus'
+  depends_on 'alsa_lib'
+  depends_on 'libdb'
+  depends_on 'libsndfile'
+
+  def self.patch
+    # Set the correct python executable path.
+    system "sed -i 's,/usr/bin,#{CREW_PREFIX}/bin,' waf"
+  end
+
+  def self.build
+    system './waf',
+           'configure',
+           '--dbus',
+           '--classic',
+           '--db=yes',
+           '--alsa=yes',
+           '--sndfile=yes',
+           '--autostart=none',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system './waf build'
+  end
+
+  def self.install
+    system "./waf install --destdir=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/janet.rb
+++ b/packages/janet.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Janet < Package
+  description 'Janet is a functional and imperative programming language and bytecode interpreter.'
+  homepage 'https://janet-lang.org'
+  version '1.7.0'
+  source_url 'https://github.com/janet-lang/janet/archive/v1.7.0.tar.gz'
+  source_sha256 '2a119f3a79b209a858864e73ca3efda57ac044df3c89762a31480bbea386d2a3'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/janet-1.7.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/janet-1.7.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/janet-1.7.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/janet-1.7.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '6fbc239bc6374e516ca5e63e988e50a62f5396b83cc1b5ffcc37c484f436ea07',
+     armv7l: '6fbc239bc6374e516ca5e63e988e50a62f5396b83cc1b5ffcc37c484f436ea07',
+       i686: '5037e0285af569a4a660094599bb251695387fe84936bc53315a107d2d258b61',
+     x86_64: 'db58991ce4aef8d19e17abf5e944f39bb94bbb5e7b750c217de36fae71fce1b3',
+  })
+
+  def self.build
+    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/julia.rb
+++ b/packages/julia.rb
@@ -3,23 +3,18 @@ require 'package'
 class Julia < Package
   description 'Julia is a flexible dynamic language, appropriate for scientific and numerical computing'
   homepage 'https://julialang.org/'
-  version '1.0.4'
+  version '1.3.1'
   case ARCH
-  when 'x86_64'
-    source_url 'https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.4-linux-x86_64.tar.gz'
-    source_sha256 '9ffbcf7f4a111e13415954caccdd1ce90b5c835cee9f62d6ac708f5b752c87dd'
+  when 'aarch64', 'armv7l'
+   source_url 'https://julialang-s3.julialang.org/bin/linux/armv7l/1.3/julia-1.3.1-linux-armv7l.tar.gz'
+   source_sha256 '965c8fab2214f8ce1b3d449d088561a6de61be42543b48c3bbadaed5b02bf824'
   when 'i686'
-    source_url 'https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.4-linux-i686.tar.gz'
-    source_sha256 'e2ce5fa564242c2dbb836f9493166ce6eaaec8f46db9861b4cdad047497dd4c4'
-  when 'armv7l', 'aarch64'
-   source_url 'https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/julia-1.0.4-linux-armv7l.tar.gz'
-   source_sha256 '2e742f4ddf5ac21779b6943ef210d73dc02f1c6de23836b352336a3dcbb18ae6'
+    source_url 'https://julialang-s3.julialang.org/bin/linux/x86/1.3/julia-1.3.1-linux-i686.tar.gz'
+    source_sha256 '2cef14e892ac317707b39d2afd9ad57a39fb77445ffb7c461a341a4cdf34141a'
+  when 'x86_64'
+    source_url 'https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz'
+    source_sha256 'faa707c8343780a6fe5eaf13490355e8190acf8e2c189b9e7ecbddb0fa2643ad'
   end
-
-  binary_url ({
-  })
-  binary_sha256 ({
-  })
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}/julia"

--- a/packages/lftp.rb
+++ b/packages/lftp.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Lftp < Package
+  description 'LFTP is a sophisticated file transfer program for ftp/http/sftp/fish/torrent'
+  homepage 'https://lftp.yar.ru'
+  version '4.9.1'
+  source_url 'https://lftp.yar.ru/ftp/lftp-4.9.1.tar.xz'
+  source_sha256 '5969fcaefd102955dd882f3bcd8962198bc537224749ed92f206f415207a024b'
+
+  binary_url ({
+  })
+  binary_sha256 ({
+  })
+
+
+  def self.build
+    system "./configure \
+      --prefix=#{CREW_PREFIX} \
+      --libdir=#{CREW_LIB_PREFIX} \
+      --disable-nls \
+      --with-linux-crypto"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libarchive.rb
+++ b/packages/libarchive.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libarchive < Package
   description 'Multi-format archive and compression library.'
   homepage 'https://www.libarchive.org/'
-  version '3.4.0'
-  source_url 'https://www.libarchive.org/downloads/libarchive-3.4.0.tar.gz'
-  source_sha256 '8643d50ed40c759f5412a3af4e353cffbce4fdf3b5cf321cb72cacf06b2d825e'
+  version '3.4.2'
+  source_url 'https://www.libarchive.org/downloads/libarchive-3.4.2.tar.gz'
+  source_sha256 'b60d58d12632ecf1e8fad7316dc82c6b9738a35625746b47ecdcaf4aed176176'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.4.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.4.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.4.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.4.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.4.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.4.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.4.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.4.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'a1d05d75b8fa0a6addcb8c4a4c52a4eaabe2a5622b6977886a11a830f50f5791',
-     armv7l: 'a1d05d75b8fa0a6addcb8c4a4c52a4eaabe2a5622b6977886a11a830f50f5791',
-       i686: '96c199ef6abec9f36e3e75403bc8050f38fc5d983b9e8c9a6a848f287ca287a6',
-     x86_64: '183af5cc69cf24c59f1914f498ffc374fd4b800e6832e74ae6bec7afc369671b',
+    aarch64: 'd84d0e6a0a8223863a24f0357a1a21a1eed520e7115fa377267d555de18e3190',
+     armv7l: 'd84d0e6a0a8223863a24f0357a1a21a1eed520e7115fa377267d555de18e3190',
+       i686: 'b650a66234e47f1cf4e5970c483cd4cebaed61ed6a177e45ad0480b61eb50811',
+     x86_64: 'd8131fdd7605773a1f3955b2e9bc1649d67d00a1c034355f8561fb0cbb1bfe7c',
   })
 
   depends_on 'lz4'

--- a/packages/libaudiofile.rb
+++ b/packages/libaudiofile.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Libaudiofile < Package
+  description 'The Audio File Library is a C-based library for reading and writing audio files in many common formats.'
+  homepage 'https://audiofile.68k.org/'
+  version 'b62c90'
+  source_url 'https://github.com/mpruett/audiofile/archive/b62c902dd258125cac86cd2df21fc898035a43d3.tar.gz'
+  source_sha256 '808aff989a24ee3b60d3f08897d90ca45a031c95c42fe22d4fd913042c1ce307'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libaudiofile-b62c90-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libaudiofile-b62c90-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libaudiofile-b62c90-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libaudiofile-b62c90-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '4d4f7ea006f09f5777c2998775f6dd49e4ddf91ac40c3cdad09e94b5f1016ddc',
+     armv7l: '4d4f7ea006f09f5777c2998775f6dd49e4ddf91ac40c3cdad09e94b5f1016ddc',
+       i686: '0302ccfddd315e8fcbc58c2139463b03da3352dacc83a4e424130d15fdca1da1',
+     x86_64: 'f74fa54401206607f94c5c76e8ba8bcedc13b202ed64262785b2ab11d7eb87db',
+  })
+
+  depends_on 'flac'
+
+  def self.build
+    system './autogen.sh'
+    # Fix ./configure: line 7237: /usr/bin/file: No such file or directory
+    system 'filefix'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-docs'
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libdrm < Package
   description 'Cross-driver middleware for DRI protocol.'
   homepage 'https://dri.freedesktop.org'
-  version '2.4.96'
-  source_url 'https://dri.freedesktop.org/libdrm/libdrm-2.4.96.tar.bz2'
-  source_sha256 '0d561acf7bb4cc59dc82415100e6c1a44860e8c380e00f9592923e3cd08db393'
+  version '2.4.100'
+  source_url 'https://dri.freedesktop.org/libdrm/libdrm-2.4.100.tar.gz'
+  source_sha256 '6a5337c054c0c47bc16607a21efa2b622e08030be4101ef4a241c5eb05b6619b'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.96-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.96-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.96-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.96-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.100-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.100-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.100-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libdrm-2.4.100-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '80eb0b1bdf0217ed2f7af5d023c4bfe45619a8d52aceab7aa7dde65d0362b736',
-     armv7l: '80eb0b1bdf0217ed2f7af5d023c4bfe45619a8d52aceab7aa7dde65d0362b736',
-       i686: '4d8ad13d4ff5b4cc8037be4835de73dffb0be56be0e93a3431d886701ef43d77',
-     x86_64: 'ecdc554b5bb6dd8fbf16862803e6b4ce78cec9f4a71fe6809e731363abd5fb12',
+    aarch64: 'fee93a19fd4d5d628aa4f6f79e37e8104898682391079a2e82aca08254b1405e',
+     armv7l: 'fee93a19fd4d5d628aa4f6f79e37e8104898682391079a2e82aca08254b1405e',
+       i686: 'dcb2149ae24d18163ee3885113908d6ff529e1bf5c311e219e7bc4e216b53467',
+     x86_64: '88c588ff6dc9d1afa772d5ebe93f8f2a0a924f2efd229db732f25126cc482c9a',
   })
 
   depends_on 'libpciaccess'

--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libgcrypt < Package
   description 'Libgcrypt is a general purpose cryptographic library originally based on code from GnuPG.'
   homepage 'https://www.gnupg.org/related_software/libgcrypt/index.html'
-  version '1.8.1-1'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.1.tar.bz2'
-  source_sha256 '7a2875f8b1ae0301732e878c0cca2c9664ff09ef71408f085c50e332656a78b3'
+  version '1.8.5'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.5.tar.bz2'
+  source_sha256 '3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.8.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.8.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.8.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.8.1-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.8.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.8.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.8.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgcrypt-1.8.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '32e9f0384e87daaec7b030d2a4cb351f7ad62c03ef3f3f2fc26c7d69ba642eb1',
-     armv7l: '32e9f0384e87daaec7b030d2a4cb351f7ad62c03ef3f3f2fc26c7d69ba642eb1',
-       i686: 'a0661c7e1ce7467adcfbbb2b9bfe4e5522726a0d15d8a37d2ecdea55991e7380',
-     x86_64: '448844bb855035f2e5f843f5fa8108e5371b9b9e02bee0b4cf66395388836b4f',
+    aarch64: '94018f0c7542235ef7fba73a4fbcd67e415f1c5f9cc6116fa2075638c472448c',
+     armv7l: '94018f0c7542235ef7fba73a4fbcd67e415f1c5f9cc6116fa2075638c472448c',
+       i686: '7c7a857f964a2af40a45ae63d1241e40f03bbf917e609febd222e095db22c80e',
+     x86_64: '6c0cbecc94b4cd9615844e45733a0ef92f197ec6ab7a41d1733a19d168db3a3f',
   })
 
   depends_on 'libgpgerror'

--- a/packages/libgd.rb
+++ b/packages/libgd.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libgd < Package
   description 'GD is an open source code library for the dynamic creation of images by programmers.'
   homepage 'https://libgd.github.io/'
-  version '2.2.5'
-  source_url 'https://github.com/libgd/libgd/archive/gd-2.2.5.tar.gz'
-  source_sha256 '199874fdb006de0911819234104ffa84338e98e82fefbac042a58a3f8272a7df'
+  version '2.3.0'
+  source_url 'https://github.com/libgd/libgd/releases/download/gd-2.3.0/libgd-2.3.0.tar.gz'
+  source_sha256 '32590e361a1ea6c93915d2448ab0041792c11bae7b18ee812514fe08b2c6a342'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.2.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.2.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.2.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.2.5-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'e7f9d0fe0c1ea968a4c18cd47277fc80ac04bd4b53a5bb16fd7ed146d638266d',
-     armv7l: 'e7f9d0fe0c1ea968a4c18cd47277fc80ac04bd4b53a5bb16fd7ed146d638266d',
-       i686: 'f50d37624fa239829735acef46ba4c96972df68dba9cca4df480af38004e9168',
-     x86_64: 'a3497051dc1dfe8cbc764d21097288bf49a491688e4f960ac41d11c1f6d39942',
+    aarch64: 'f08ad9e3eea1b99d9c1528337d1a6fb0e764c35abcc82908acfd8d7635aa5890',
+     armv7l: 'f08ad9e3eea1b99d9c1528337d1a6fb0e764c35abcc82908acfd8d7635aa5890',
+       i686: 'ae9c98c5282c68e9f1e089281669c9e3e8a02c92a4398bb7725b9fe32ee92a65',
+     x86_64: '8e5ade77f722c7e76e8448483d1f6dc9119269173a642368f15fca9322cba14e',
   })
 
   depends_on 'cmake'

--- a/packages/libgpgerror.rb
+++ b/packages/libgpgerror.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libgpgerror < Package
   description 'Libgpg-error is a small library that defines common error values for all GnuPG components.'
   homepage 'https://www.gnupg.org/related_software/libgpg-error/index.html'
-  version '1.31'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.31.tar.bz2'
-  source_sha256 '40d0a823c9329478063903192a1f82496083b277265904878f4bc09e0db7a4ef'
+  version '1.37'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.37.tar.bz2'
+  source_sha256 'b32d6ff72a73cf79797f7f2d039e95e9c6f92f0c1450215410840ab62aea9763'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgpgerror-1.31-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgpgerror-1.31-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgpgerror-1.31-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgpgerror-1.31-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgpgerror-1.37-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgpgerror-1.37-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgpgerror-1.37-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgpgerror-1.37-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'c19b538839f596514ba033075d943eb6994649407e9bbe96129bf9fd36c76d76',
-     armv7l: 'c19b538839f596514ba033075d943eb6994649407e9bbe96129bf9fd36c76d76',
-       i686: 'be2844cda5a0149693ace020f7b186bc68e4dc0924b0e3cc795744d33654f93e',
-     x86_64: '207dab161f3d080e92b783c261a9d90b366961fd252bd49760bcb76e5af40085',
+    aarch64: 'ca41263e0992f8e969a5f7b8818af433273f4c39f88cacad9d95a227c84b5d66',
+     armv7l: 'ca41263e0992f8e969a5f7b8818af433273f4c39f88cacad9d95a227c84b5d66',
+       i686: '27e1709a936bf87a1341da43712cad6834f2ba402e897c7d659411312e38a335',
+     x86_64: '195afc96c0562686fcd14198c712f9fc77ee82d329046d914c1b754a6d04ca32',
   })
 
   def self.build

--- a/packages/libgphoto.rb
+++ b/packages/libgphoto.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Libgphoto < Package
+  description 'The libgphoto2 camera access and control library.'
+  homepage 'http://www.gphoto.org/'
+  version '2.5.23'
+  source_url 'https://github.com/gphoto/libgphoto2/archive/libgphoto2-2_5_23-release.tar.gz'
+  source_sha256 '8de52fd997aceda895abad5d8d95a888bce24a1c739079cff64dae1da7039dde'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgphoto-2.5.23-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgphoto-2.5.23-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgphoto-2.5.23-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgphoto-2.5.23-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'dfb2080fbbd42cfffdc05a6bb6d52775b807825d1b3b7ca18934c70d88beb1be',
+     armv7l: 'dfb2080fbbd42cfffdc05a6bb6d52775b807825d1b3b7ca18934c70d88beb1be',
+       i686: '9f33a1541717bf823171eef395dd8fe32aacf3804c120591e771c08034ea374a',
+     x86_64: '5993b9961a3b8dd1129186aa05370b72c3fd24cd6eaef0b33377a288be713609',
+  })
+
+  depends_on 'gtk_doc'
+  depends_on 'libexif'
+  depends_on 'libusb'
+
+  def self.build
+    system 'autoreconf --install --symlink'
+    system './configure',
+           '--with-camlibs=all,outdated',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libjpeg.rb
+++ b/packages/libjpeg.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libjpeg < Package
   description 'JPEG is a free library for image compression.'
   homepage 'http://www.ijg.org/'
-  version '9.0-c'
-  source_url 'http://www.ijg.org/files/jpegsrc.v9c.tar.gz'
-  source_sha256 '1f3a3f610f57e88ff3f1f9db530c605f3949ee6e78002552e324d493cf086ad4'
+  version '9.0-d'
+  source_url 'https://www.ijg.org/files/jpegsrc.v9d.tar.gz'
+  source_sha256 '99cb50e48a4556bc571dadd27931955ff458aae32f68c4d9c39d624693f69c32'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-c-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-c-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-c-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-c-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '46d6bf16c5b1cc601bbf7c81de56b8451ccfe15b8660a0f61a5dc882e8f68dec',
-     armv7l: '46d6bf16c5b1cc601bbf7c81de56b8451ccfe15b8660a0f61a5dc882e8f68dec',
-       i686: 'a1afb706120d5396f34536e8613e0a1c81e927d8d0dbc6d910e03563dd1be029',
-     x86_64: 'd60d7686e7f8b5808bc5f96518da10061c507d0f1da59021d2869ff1662432b6',
+    aarch64: '1d0248976ed26493bf18231df01cb42eff81792440cf6cb517679b609804a44e',
+     armv7l: '1d0248976ed26493bf18231df01cb42eff81792440cf6cb517679b609804a44e',
+       i686: '3291fe256b305b2ee3de0fe8d4c455012ba92545ef3bfd155c25d5d86b8977c4',
+     x86_64: '6c166e006cbb47be453f41f1e6e6d452df0a6b0b8f3675e29d290f20bfdcf3ef',
   })
 
   def self.build

--- a/packages/libnet.rb
+++ b/packages/libnet.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Libnet < Package
+  description 'A portable framework for low-level network packet construction'
+  homepage 'https://github.com/libnet/libnet'
+  version '1.2'
+  source_url 'https://github.com/libnet/libnet/releases/download/v1.2/libnet-1.2.tar.gz'
+  source_sha256 'caa4868157d9e5f32e9c7eac9461efeff30cb28357f7f6bf07e73933fb4edaa7'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libnet-1.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libnet-1.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libnet-1.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libnet-1.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f5470d38812054ec3e6debbcaa9f40bf8af6d466586ac5b468934308510ad60b',
+     armv7l: 'f5470d38812054ec3e6debbcaa9f40bf8af6d466586ac5b468934308510ad60b',
+       i686: '7816e92e1ade988289088c4a7732716b22747b3e4b1e8017a65e37d65c01a116',
+     x86_64: '41332bb8b21536bc8fcb14b9efb87d7caa4dff2c0942a4ef5d43a38a48e969c6',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libpciaccess.rb
+++ b/packages/libpciaccess.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libpciaccess < Package
   description 'Generic PCI access library'
   homepage 'https://x.org'
-  version '0.13-0'
-  source_url 'https://www.x.org/archive/individual/lib/libpciaccess-0.13.tar.gz'
-  source_sha256 'afdfe55b23be710751b630073127febef498af35d4a58944fccbef860315f72c'
+  version '0.16'
+  source_url 'https://www.x.org/archive/individual/lib/libpciaccess-0.16.tar.gz'
+  source_sha256 '84413553994aef0070cf420050aa5c0a51b1956b404920e21b81e96db6a61a27'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpciaccess-0.13-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpciaccess-0.13-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpciaccess-0.13-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpciaccess-0.13-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpciaccess-0.16-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpciaccess-0.16-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpciaccess-0.16-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpciaccess-0.16-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b650dc3cfc9022c9d991d6ff473db7665b218ec651a322f4607e63c55eb7edec',
-     armv7l: 'b650dc3cfc9022c9d991d6ff473db7665b218ec651a322f4607e63c55eb7edec',
-       i686: 'ab39a8afdd654ece0501efff152b379816831cf8f950afd1308cc18389b2137c',
-     x86_64: '879a01f506b6dcd404419520d814281dc732d07945ecce5089c1fe97113b20f7',
+    aarch64: '4168d9adea96e7394c3a2aee9b732134abf9ea0c749dcf1b696bbb2d19047bec',
+     armv7l: '4168d9adea96e7394c3a2aee9b732134abf9ea0c749dcf1b696bbb2d19047bec',
+       i686: 'ad555204d597c0600daeecf298240e072cdfd12b7b0a6674ca5e8cbc9f27b5eb',
+     x86_64: '1d1a2bcf5767f35e3502681aa2821fd9f81b3bf517f595657c22296163219a14',
   })
 
   def self.build

--- a/packages/libplist.rb
+++ b/packages/libplist.rb
@@ -3,26 +3,19 @@ require 'package'
 class Libplist < Package
   description 'A library to handle Apple Property List format'
   homepage 'http://www.libimobiledevice.org/'
-  version '2.0.0'
-  source_url 'http://www.libimobiledevice.org/downloads/libplist-2.0.0.tar.bz2'
-  source_sha256 '3a7e9694c2d9a85174ba1fa92417cfabaea7f6d19631e544948dc7e17e82f602'
+  version '2.1.0'
+  source_url 'https://github.com/libimobiledevice/libplist/archive/2.1.0.tar.gz'
+  source_sha256 '4b33f9af3f9208d54a3c3e1a8c149932513f451c98d1dd696fe42c06e30b7f03'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libplist-2.0.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libplist-2.0.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libplist-2.0.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libplist-2.0.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '361fcbe8e9ddd1ea0827c1fad4788b3f5dbf7c344eb0b44ad9c11e20fb0af72c',
-     armv7l: '361fcbe8e9ddd1ea0827c1fad4788b3f5dbf7c344eb0b44ad9c11e20fb0af72c',
-       i686: '1f2db0a7e401c870a8bd8a2c5b59669524e35fffbdd5f58ac8c7fa297004cb9c',
-     x86_64: '67d760c5c49508d8d89b6b81cd3480183b0fee278c59d5c20d6ccf6d483afeea',
   })
 
   depends_on 'glib'
 
   def self.build
+    system './autogen.sh CC=gcc CXX=g++'
     system './configure',
       "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}",

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libpng < Package
   description 'libpng is the official PNG reference library.'
   homepage 'http://libpng.org/pub/png/libpng.html'
-  version '1.6.36'
-  source_url 'https://downloads.sourceforge.net/project/libpng/libpng16/1.6.36/libpng-1.6.36.tar.xz'
-  source_sha256 'eceb924c1fa6b79172fdfd008d335f0e59172a86a66481e09d4089df872aa319'
+  version '1.6.37'
+  source_url 'https://downloads.sourceforge.net/project/libpng/libpng16/1.6.37/libpng-1.6.37.tar.xz'
+  source_sha256 '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.36-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.36-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.36-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.36-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '134223fd27b8f1fb39bd1f44c795d41b60b49070c9f5f8c7b582af53b090279e',
-     armv7l: '134223fd27b8f1fb39bd1f44c795d41b60b49070c9f5f8c7b582af53b090279e',
-       i686: 'd84e969b8f24fc998ed61bf4a669346216d6167ed9f9f5b026eac5acb47ea0a0',
-     x86_64: 'fe2f3ba8855fbba9c0f81a1a5d377e78be56e8895e428e19c32b497417a8bf79',
+    aarch64: '14240b27d54756682cfa2c75126cb1de443faead0232e6636f4b1e36322bb85e',
+     armv7l: '14240b27d54756682cfa2c75126cb1de443faead0232e6636f4b1e36322bb85e',
+       i686: '85d03e11ba20b635f24c6786b1f5050ee35c515d2e7b9a43464f8896945c3c13',
+     x86_64: 'bc1b016c4c947fa3fb70cc456be81b3859430579722e2189781f1403a4a96b83',
   })
 
   depends_on 'zlibpkg'

--- a/packages/libsamplerate.rb
+++ b/packages/libsamplerate.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Libsamplerate < Package
+  description 'Secret Rabbit Code (aka libsamplerate) is a Sample Rate Converter for audio.'
+  homepage 'http://www.mega-nerd.com/libsamplerate/'
+  version '0.1.9'
+  source_url 'http://www.mega-nerd.com/libsamplerate/libsamplerate-0.1.9.tar.gz'
+  source_sha256 '0a7eb168e2f21353fb6d84da152e4512126f7dc48ccb0be80578c565413444c1'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsamplerate-0.1.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsamplerate-0.1.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsamplerate-0.1.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsamplerate-0.1.9-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'cae5af051ec2d36af1e8c1acfc8fc8fd3b7d81d22492a6f2226561c78733775f',
+     armv7l: 'cae5af051ec2d36af1e8c1acfc8fc8fd3b7d81d22492a6f2226561c78733775f',
+       i686: '4f848d40fd487d9241008719b31df0dbf5257db5b9741977b5811fa691e9304e',
+     x86_64: '57c63e7f734cd31d645ec93582488f1c6fb1a14de3c8ad6b1d0cf9c9464e48bc',
+  })
+
+  depends_on 'alsa_lib'
+  depends_on 'fftw'
+  depends_on 'libsndfile'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libusb.rb
+++ b/packages/libusb.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libusb < Package
   description 'A cross-platform library that gives apps easy access to USB devices'
   homepage 'https://sourceforge.net/projects/libusb/'
-  version '1.0.21'
-  source_url 'http://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.21/libusb-1.0.21.tar.bz2'
-  source_sha256 '7dce9cce9a81194b7065ee912bcd55eeffebab694ea403ffb91b67db66b1824b'
+  version '1.0.23'
+  source_url 'https://github.com/libusb/libusb/releases/download/v1.0.23/libusb-1.0.23.tar.bz2'
+  source_sha256 'db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libusb-1.0.21-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libusb-1.0.21-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libusb-1.0.21-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libusb-1.0.21-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libusb-1.0.23-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libusb-1.0.23-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libusb-1.0.23-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libusb-1.0.23-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1ee60eca8f21386df7d8034669d189f8480e9de59bd71bc4e5631b5f5675eaf1',
-     armv7l: '1ee60eca8f21386df7d8034669d189f8480e9de59bd71bc4e5631b5f5675eaf1',
-       i686: '3269135ed3d2043a8d17415445c20386ad3df9b689cb333ecc29fb057c79ecf8',
-     x86_64: '48e8aff964b38e7ed9b70e5c1d227ff4f7c16537d3bd199e224867560b9aaa9b',
+    aarch64: '25b18e0f7bec888d717dd466c8fbbd0fe67e6bce54d052dcc52d9a004179fd0f',
+     armv7l: '25b18e0f7bec888d717dd466c8fbbd0fe67e6bce54d052dcc52d9a004179fd0f',
+       i686: 'eb3b3152a972b4849e28328a2d7d170ab7c795375def2173f77bf2a024a3dde9',
+     x86_64: 'b59a07eb8cfbb17d6d3ba7586e360b037f4ff7f96630ea4cf9ebc8a295ae7bd6',
   })
 
   depends_on 'eudev'

--- a/packages/libusbmuxd.rb
+++ b/packages/libusbmuxd.rb
@@ -3,27 +3,20 @@ require 'package'
 class Libusbmuxd < Package
   description 'USB Multiplex Daemon'
   homepage 'http://www.libimobiledevice.org/'
-  version '1.0.9'
-  source_url 'http://www.libimobiledevice.org/downloads/libusbmuxd-1.0.9.tar.bz2'
-  source_sha256 '2e3f708a3df30ad7832d2d2389eeb29f68f4e4488a42a20149cc99f4f9223dfc'
+  version '2.0.1'
+  source_url 'https://github.com/libimobiledevice/libusbmuxd/archive/2.0.1.tar.gz'
+  source_sha256 'f93faf3b3a73e283646f4d62b3421aeccf58142266b0eb22b2b13dd4b2362eb8'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libusbmuxd-1.0.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libusbmuxd-1.0.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libusbmuxd-1.0.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libusbmuxd-1.0.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd47e325523f0167e598638cc889058c4dbaae0d2277d867b1ee86cc5b2285b1b',
-     armv7l: 'd47e325523f0167e598638cc889058c4dbaae0d2277d867b1ee86cc5b2285b1b',
-       i686: '85cc5ad75e883f17e1ea5b6de634c7db4cbd390b62b0f8d75950ee494cf28eb6',
-     x86_64: 'b9b4ba031ce059483b3e72abf300534f121f37b2759352c87c87fe3595ac83b2',
   })
 
   depends_on 'glib'
   depends_on 'libplist'
 
   def self.build
+    system './autogen.sh'
     system './configure',
       "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}",

--- a/packages/libva.rb
+++ b/packages/libva.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libva < Package
   description 'Libva is an implementation for VA-API (VIdeo Acceleration API)'
   homepage 'https://01.org/linuxmedia'
-  version '2.3.0'
-  source_url 'https://github.com/intel/libva/releases/download/2.3.0/libva-2.3.0.tar.bz2'
-  source_sha256 '60840e50da6932ee2111e15fc8911180ff8a0d6f18bb9cc6ba8c1030098fdce4'
+  version '2.6.1'
+  source_url 'https://github.com/intel/libva/releases/download/2.6.1/libva-2.6.1.tar.bz2'
+  source_sha256 '6c57eb642d828af2411aa38f55dc10111e8c98976dbab8fd62e48629401eaea5'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.3.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.3.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.3.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.3.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.6.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.6.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.6.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libva-2.6.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '867f6254b17be1fa9fec487767d559b097577ff7984efed98bb9c81af2190552',
-     armv7l: '867f6254b17be1fa9fec487767d559b097577ff7984efed98bb9c81af2190552',
-       i686: 'b517990ffb952a847de93c2fe9ba9221776bb26e83218e82dfdb86f4ab3ea972',
-     x86_64: '2bb0f970dc79c3f4a1046f6b1ef6b30c2bd10e3b5a86d17efdb5eb1ac35f2dbf',
+    aarch64: '29fa0f07bfd42af85d748a7e3824ef0dc87d8c13ea39f834350ce049412fb074',
+     armv7l: '29fa0f07bfd42af85d748a7e3824ef0dc87d8c13ea39f834350ce049412fb074',
+       i686: '0023ca0203c0d44922f86d4f72fb5ab836ad99565ace968d6e5f925fc93f99d2',
+     x86_64: '67b40e1c110c7fbcf55944ff45e1bb1a39fc9bc81e95b0e52726516376f272a6',
   })
 
   depends_on 'libdrm'

--- a/packages/libvdpau.rb
+++ b/packages/libvdpau.rb
@@ -3,29 +3,29 @@ require 'package'
 class Libvdpau < Package
   description 'VDPAU is the Video Decode and Presentation API for UNIX. It provides an interface to video decode acceleration and presentation hardware present in modern GPUs.'
   homepage 'https://www.freedesktop.org/wiki/Software/VDPAU/'
-  version '1.1.1'
-  source_url 'https://gitlab.freedesktop.org/vdpau/libvdpau/uploads/5635163f040f2eea59b66d0181cf664b/libvdpau-1.1.1.tar.bz2'
-  source_sha256 '857a01932609225b9a3a5bf222b85e39b55c08787d0ad427dbd9ec033d58d736'
+  version '1.3'
+  source_url 'https://gitlab.freedesktop.org/vdpau/libvdpau/-/archive/1.3/libvdpau-1.3.tar.bz2'
+  source_sha256 'b5a52eeac9417edbc396f26c40591ba5df0cd18285f68d84614ef8f06196e50e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.1.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libvdpau-1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '7294f6d6e5658a671f2c200b927ce8af3eec5e29be48617ccd159b7cb4be4e0f',
-     armv7l: '7294f6d6e5658a671f2c200b927ce8af3eec5e29be48617ccd159b7cb4be4e0f',
-       i686: '0f1e80786ef70a10d1a75b0f22e038183eaf4e56c5f83f8db1ad42f9fad57a14',
-     x86_64: '2fd6efe5954f031570115bf0c32e03baf9418162e8f61df544f36231e902e3e1',
+    aarch64: 'b3b560d72b7877db7cad6f15d79c35ae118fc8804c64be8192b7f4a1930b138c',
+     armv7l: 'b3b560d72b7877db7cad6f15d79c35ae118fc8804c64be8192b7f4a1930b138c',
+       i686: '6f703f96ce0e186605c64550ae9ad0b43e0f3a55b3e26dbbb8074af1bb0623ba',
+     x86_64: 'd1f759f51a5888850e54415ca03983e01e960941d3859e88c8b1891fdee1afb1',
   })
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system 'make'
+    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
+    system "ninja -C builddir"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/libx11.rb
+++ b/packages/libx11.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libx11 < Package
   description 'C interface to the X window system'
   homepage 'https://x.org'
-  version '1.6.5-1'
-  source_url 'https://www.x.org/archive/individual/lib/libX11-1.6.5.tar.gz'
-  source_sha256 '3abce972ba62620611fab5b404dafb852da3da54e7c287831c30863011d28fb3'
+  version '1.6.9'
+  source_url 'https://www.x.org/archive/individual/lib/libX11-1.6.9.tar.bz2'
+  source_sha256 '9cc7e8d000d6193fa5af580d50d689380b8287052270f5bb26a5fb6b58b2bed1'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.5-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libx11-1.6.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'ff6bc290a58bee7558e7a02e587e7820b6b376d8c33254eac18e63e157c3365b',
-     armv7l: 'ff6bc290a58bee7558e7a02e587e7820b6b376d8c33254eac18e63e157c3365b',
-       i686: '0c90a7c81ef29662eab897399bd3fb7f49b7d933e2a97abe8a762e21b3eaa5c4',
-     x86_64: '566173764c75b30509d33f16efb13d59244a79274b5af833b17a2e1483e26e97',
+    aarch64: 'aa383fa7778a3ad424129ce6f0df6f793d66ba92e93910b900f460de3902acb6',
+     armv7l: 'aa383fa7778a3ad424129ce6f0df6f793d66ba92e93910b900f460de3902acb6',
+       i686: '3c44f4318aece50226c295b39ebc4f2f51d16eb4c13207135df5e11fb5005565',
+     x86_64: '6bf082987ab469c4ae7e69fe492922f2811cf6601fc1ffbbe9c62220a55265f0',
   })
 
   depends_on 'xorg_proto'

--- a/packages/libxau.rb
+++ b/packages/libxau.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libxau < Package
   description 'xau library for libX11'
   homepage 'https://x.org'
-  version '1.0.8-1'
-  source_url 'https://www.x.org/archive/individual/lib/libXau-1.0.8.tar.gz'
-  source_sha256 'c343b4ef66d66a6b3e0e27aa46b37ad5cab0f11a5c565eafb4a1c7590bc71d7b'
+  version '1.0.9'
+  source_url 'https://www.x.org/archive/individual/lib/libXau-1.0.9.tar.bz2'
+  source_sha256 'ccf8cbf0dbf676faa2ea0a6d64bcc3b6746064722b606c8c52917ed00dcb73ec'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.8-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxau-1.0.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'cddb13bfb9a81cfe5990cf1dd807c78951262bb3c2d5b8d5341da6b491d379e9',
-     armv7l: 'cddb13bfb9a81cfe5990cf1dd807c78951262bb3c2d5b8d5341da6b491d379e9',
-       i686: 'd902285f810cf1eff4bedcbd344c77997ec39631179c1d3ae2192458d58b44c8',
-     x86_64: '199a18b19af06eababe37e01a9308c11726bb6415613cc4ffde38631eaad8269',
+    aarch64: 'ef6e137ebb752f4015495c60acea0ab17efa50391f4d133e61d25859c791d452',
+     armv7l: 'ef6e137ebb752f4015495c60acea0ab17efa50391f4d133e61d25859c791d452',
+       i686: '4343e16f6c9bf01c4234a194e7478b45542c58abb0affa1032c2ae9c5abe802c',
+     x86_64: '6fe73440b9a5a242617a8a0a4e55a5c2e18fe070e6842852a89b95e23fcd1aa5',
   })
   
   depends_on 'xorg_proto'

--- a/packages/libxcb.rb
+++ b/packages/libxcb.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libxcb < Package
   description 'library for the X window system'
   homepage 'https://x.org'
-  version '1.12-0'
-  source_url 'https://www.x.org/archive/individual/xcb/libxcb-1.12.tar.gz'
-  source_sha256 '092f147149d8a6410647a848378aaae749304d5b73e028ccb8306aa8a9e26f06'
+  version '1.14'
+  source_url 'https://xcb.freedesktop.org/dist/libxcb-1.14.tar.xz'
+  source_sha256 'a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcb-1.12-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxcb-1.12-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxcb-1.12-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcb-1.12-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcb-1.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxcb-1.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxcb-1.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxcb-1.14-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '2efffcb6d5442087cd196c813756491617097f4749f7ff0ce71f71d6b70ccbf0',
-     armv7l: '2efffcb6d5442087cd196c813756491617097f4749f7ff0ce71f71d6b70ccbf0',
-       i686: 'dc4c741c4b94c0cebe7568e561bd7a739038689dcbbfa558194e5cf365f6674b',
-     x86_64: 'ec938fc5753e9d7d5d67e38c4cf561be13a873d7b4343d4a9ca60d658dc35a70',
+    aarch64: 'bc20a59bdcc53cff12a3b2d6cce84b59a53e9bc1c3d2736cd2be7f4bea3d6758',
+     armv7l: 'bc20a59bdcc53cff12a3b2d6cce84b59a53e9bc1c3d2736cd2be7f4bea3d6758',
+       i686: '2195bd9b863f56aae744c2eb3729d45340024dfcb1bf25b349024cfd232ce3e3',
+     x86_64: '73b4b21814636804c09709e4dc7fd657e097163fb1c7bc395c4cedfa30c3717c',
   })
 
   depends_on 'python27' => :build

--- a/packages/libxkbcommon.rb
+++ b/packages/libxkbcommon.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libxkbcommon < Package
   description 'Keymap handling library for toolkits and window systems'
   homepage 'http:s//xkbcommon.org'
-  version '0.9.1'
-  source_url 'https://xkbcommon.org/download/libxkbcommon-0.9.1.tar.xz'
-  source_sha256 'd4c6aabf0a5c1fc616f8a6a65c8a818c03773b9a87da9fbc434da5acd1199be0'
+  version '0.10.0'
+  source_url 'https://xkbcommon.org/download/libxkbcommon-0.10.0.tar.xz'
+  source_sha256 '57c3630cdc38fb4734cd57fa349e92244f5ae3862813e533cedbd86721a0b6f2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbcommon-0.9.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbcommon-0.9.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbcommon-0.9.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbcommon-0.9.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbcommon-0.10.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbcommon-0.10.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbcommon-0.10.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbcommon-0.10.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '92f859886c013e1e4d707c9ba5f8c24416ef90176f8c890a6bd695dc5c963072',
-     armv7l: '92f859886c013e1e4d707c9ba5f8c24416ef90176f8c890a6bd695dc5c963072',
-       i686: 'e829130c0953c012a04605ec8b81f96efc151834dd39dc76a161c373698615b9',
-     x86_64: 'ebc0379107a731b6077e8a6d6ae5d1a002671f34048c4e31423a69fcf55f6644',
+    aarch64: '342916012da771abfb4d99034b6f07d11d098e53e250976f173a2f516e5b4f99',
+     armv7l: '342916012da771abfb4d99034b6f07d11d098e53e250976f173a2f516e5b4f99',
+       i686: '30520eda6f63031b9909870502cad6ea874e2a2858a7c0e9130c2318a81b1bc4',
+     x86_64: 'b9ca070f8a5cc0a171f4ae6552e56eb4edf80826efb850d514bd523524da9643',
   })
 
   depends_on 'bison'

--- a/packages/libxkbfile.rb
+++ b/packages/libxkbfile.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libxkbfile < Package
   description 'library for the X window system'
   homepage 'https://x.org'
-  version '1.0.9-0'
-  source_url 'https://www.x.org/archive/individual/lib/libxkbfile-1.0.9.tar.gz'
-  source_sha256 '95df50570f38e720fb79976f603761ae6eff761613eb56f258c3cb6bab4fd5e3'
+  version '1.1.0'
+  source_url 'https://www.x.org/archive/individual/lib/libxkbfile-1.1.0.tar.bz2'
+  source_sha256 '758dbdaa20add2db4902df0b1b7c936564b7376c02a0acd1f2a331bd334b38c7'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbfile-1.0.9-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbfile-1.0.9-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbfile-1.0.9-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbfile-1.0.9-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbfile-1.1.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbfile-1.1.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbfile-1.1.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxkbfile-1.1.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '0da685fe99dcbbe5f69daa717ea1938d6bf6fab3149cbc50cefbd14e68e3963a',
-     armv7l: '0da685fe99dcbbe5f69daa717ea1938d6bf6fab3149cbc50cefbd14e68e3963a',
-       i686: '7be642dffe2807fc53b4b3b1dde506251ad42a2d24c94b3271db58c61a607711',
-     x86_64: '4fd10398c3b8d444dc540aa574e437401597f442f8e2837f2a2eacabc08d83ba',
+    aarch64: '667eac3dcdb3e4c79531f3263a5c98696d41650c15bd9b478f80ff77bcbb67f0',
+     armv7l: '667eac3dcdb3e4c79531f3263a5c98696d41650c15bd9b478f80ff77bcbb67f0',
+       i686: 'c2d5729b30872dcaddd114cca044f91e30fc3a2dcdb9f16f5a4177c99a66dd66',
+     x86_64: 'c3e8e8a1c2d34c36ac75eab039ab0eaca01cedd5fe8406a582cc9bdd256fec63',
   })
 
   def self.build

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.8-2'
-  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.8/libxml2-v2.9.8.tar.bz2'
-  source_sha256 '75f60530c4ff9717930ea28abcf3dfc4b213ac7617884f37637d069b01032b8a'
+  version '2.9.9'
+  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.9/libxml2-v2.9.9.tar.bz2'
+  source_sha256 'd598e907b5f3efa992b65094f7113d9d8cc87238f32e4e1ddf8beff01b60a653'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.8-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.8-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.8-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.8-2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '51646006a23ab2adcf59c464c0358b4cde2c78707d25fc736cfcabb16e37bb27',
-     armv7l: '51646006a23ab2adcf59c464c0358b4cde2c78707d25fc736cfcabb16e37bb27',
-       i686: '11b78a2921229406fcff2e8421df0a58d27ec97c7bfcc89f908583f46dafd71c',
-     x86_64: '2b1ecd272734fd960d79d75187313e581911971466ad99f360e24a5fc0e19e6a',
+    aarch64: '8f7a474b5d0f8f800faa8e585662561dc4a0db3a494b2a949e96e63becf84262',
+     armv7l: '8f7a474b5d0f8f800faa8e585662561dc4a0db3a494b2a949e96e63becf84262',
+       i686: 'b248be959d940cb499e4692973865770a74fe1e10dfd7706cca36cc3ef3a0067',
+     x86_64: 'd2a31a3c95de67b23488340deea7025cdf953700e141a629de11711d17d3794a',
   })
  
   depends_on 'zlibpkg'

--- a/packages/libxml2_python.rb
+++ b/packages/libxml2_python.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libxml2_python < Package
   description 'Libxml2 (python module) is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.8'
-  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.8.tar.gz'
-  source_sha256 '0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732'
+  version '2.9.9'
+  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.9.tar.gz'
+  source_sha256 '94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.8-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '23796c5b545d2c24568a4dc713340186990cfe3e0554832d39745f2db37cbd9f',
-     armv7l: '23796c5b545d2c24568a4dc713340186990cfe3e0554832d39745f2db37cbd9f',
-       i686: 'c79cbf58a05613a032c6d4f2707716298d181cebea0355c7dfe30cfc158fbd39',
-     x86_64: '37e3c41d54d34e190e955c7e02dc8028c3ca761065f403d1e1a24310ace15032',
+    aarch64: '05b9616edf2809cea4bfaa2a0f9b21e8455871e04f9a76f08c5472e25ab655c6',
+     armv7l: '05b9616edf2809cea4bfaa2a0f9b21e8455871e04f9a76f08c5472e25ab655c6',
+       i686: '9676158d3071ecd96bd3fc3cb0619dd137efc39b23a8c1d0c4d38990d58223ad',
+     x86_64: '54261947d04449bdeb3af3fd9c60b450fc8237defdee0076d23122786eb05934',
   })
 
   depends_on 'python27'

--- a/packages/libxslt.rb
+++ b/packages/libxslt.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libxslt < Package
   description 'Libxslt is the XSLT C library developed for the GNOME project.'
   homepage 'http://xmlsoft.org/libxslt/'
-  version '1.1.32-1'
-  source_url 'http://xmlsoft.org/sources/libxslt-1.1.32.tar.gz'
-  source_sha256 '526ecd0abaf4a7789041622c3950c0e7f2c4c8835471515fd77eec684a355460'
+  version '1.1.34'
+  source_url 'http://xmlsoft.org/sources/libxslt-1.1.34.tar.gz'
+  source_sha256 '98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxslt-1.1.32-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxslt-1.1.32-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxslt-1.1.32-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxslt-1.1.32-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxslt-1.1.34-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxslt-1.1.34-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxslt-1.1.34-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxslt-1.1.34-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '28296ca12d9a571364eb06e53711f0e1ab746c7e70f1c31a825368a4cb0b933a',
-     armv7l: '28296ca12d9a571364eb06e53711f0e1ab746c7e70f1c31a825368a4cb0b933a',
-       i686: '6c8a7b6e47087792bdad09e5e4d5cb35ae283d3bb0854692271087ec7a3b884b',
-     x86_64: 'f47fd5f5d4a975967b8d191b5dbfb97cf82f3293794d2b07766dc34bb5a7cf57',
+    aarch64: 'df33590a8edfc86f29fada7d5b44e5914651259015e8df726603a2ffdc23bd42',
+     armv7l: 'df33590a8edfc86f29fada7d5b44e5914651259015e8df726603a2ffdc23bd42',
+       i686: 'd201b063ce46e40d354c3e89472aafd54fa524bd57e70b6ab03219e4f165bd93',
+     x86_64: '2ead1e30cb028f2f299056f8eea5bfb318f7346c6a65cfa4a891672560ed26bc',
   })
 
   depends_on 'libxml2_python'

--- a/packages/libxtrans.rb
+++ b/packages/libxtrans.rb
@@ -3,21 +3,21 @@ require 'package'
 class Libxtrans < Package
   description 'transpot library for the X window system'
   homepage 'https://x.org'
-  version '1.3.5-0'
-  source_url 'https://www.x.org/archive/individual/lib/xtrans-1.3.5.tar.gz'
-  source_sha256 'b7a577c1b6c75030145e53b4793db9c88f9359ac49e7d771d4385d21b3e5945d'
+  version '1.4.0'
+  source_url 'https://www.x.org/archive/individual/lib/xtrans-1.4.0.tar.bz2'
+  source_sha256 '377c4491593c417946efcd2c7600d1e62639f7a8bbca391887e2c4679807d773'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxtrans-1.3.5-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxtrans-1.3.5-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxtrans-1.3.5-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxtrans-1.3.5-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxtrans-1.4.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxtrans-1.4.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxtrans-1.4.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxtrans-1.4.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1733f56bfe385bd68cdc430070a93f6eb6ddea511f4a994788215e00c797ca7b',
-     armv7l: '1733f56bfe385bd68cdc430070a93f6eb6ddea511f4a994788215e00c797ca7b',
-       i686: '3671105eeb2208f79fce5cdbae80722f63913d3bc13e6eb86ec41c6a5db19cf3',
-     x86_64: '63e17dadab029b422ae76939b53a0a9a38c61e654398270c34b23dd0165705db',
+    aarch64: '85980bd143e9f4e68fa5ce02ab684acf4c982b2ec1c187395136c286a46fb966',
+     armv7l: '85980bd143e9f4e68fa5ce02ab684acf4c982b2ec1c187395136c286a46fb966',
+       i686: '18c80adc947824ea4222f53d4790e1d01fb747c3c4086211c8902ef79d6d6f3b',
+     x86_64: '71e27f8f9fd0f03bd71e10def7d1efb7b7ee0f453d2579dce5acbc43dc6dcaae',
   })
 
   def self.build

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -3,21 +3,21 @@ require 'package'
 class Llvm < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, libcxxabi and openmp are included.'
   homepage 'http://llvm.org/'
-  version '9.0.0'
-  source_url 'https://releases.llvm.org/9.0.0/llvm-9.0.0.src.tar.xz'
-  source_sha256 'd6a0565cf21f22e9b4353b2eb92622e8365000a9e90a16b09b56f8157eabfe84'
+  version '10.0.0'
+  source_url 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz'
+  source_sha256 'df83a44b3a9a71029049ec101fb0077ecbbdf5fe41e395215025779099a98fdf'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-9.0.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-9.0.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-9.0.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-9.0.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-10.0.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-10.0.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-10.0.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/llvm-10.0.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'c33a3b92a7038784b4ff4231171a17cf556143f9b5d875aee64aeabc0ab458ab',
-     armv7l: 'c33a3b92a7038784b4ff4231171a17cf556143f9b5d875aee64aeabc0ab458ab',
-       i686: '2f93321ba8228faefa513fefdb2ce974874e99a24d7aaf2f672fb99791e0e3db',
-     x86_64: '1dd75d41f5188bd598bbe77a059698cc27627c4bc24602061a90f62f9cf39294',
+    aarch64: '0498ed55a9d3171c3f523c156822508f1b2a2d506ca87d6961427ae5165f6a34',
+     armv7l: '0498ed55a9d3171c3f523c156822508f1b2a2d506ca87d6961427ae5165f6a34',
+       i686: '8c4173f7de0525948ce60fed8d7fef7a3f1cb4632b650e6623eed6b4a0db7cce',
+     x86_64: 'b4751906ff72b3e4e2fcfbf3380bdc17907e3463c86ba059113369c459c7783f',
   })
 
   depends_on 'ld_default' => :build
@@ -32,10 +32,10 @@ class Llvm < Package
   def self.preinstall
 
     ############################# Download clang (tools) ###########################################
-    url_clang = "https://releases.llvm.org/#{version}/cfe-#{version}.src.tar.xz"
+    url_clang = "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/clang-#{version}.src.tar.xz"
     uri_clang = URI.parse url_clang
     filename_clang = File.basename(uri_clang.path)
-    sha256sum_clang = '7ba81eef7c22ca5da688fdf9d88c20934d2d6b40bfe150ffd338900890aa4610'
+    sha256sum_clang = '885b062b00e903df72631c5f98b9579ed1ed2790f74e5646b4234fa084eacb21'
 
     if File.exist?(filename_clang) && Digest::SHA256.hexdigest( File.read("./#{filename_clang}") ) == sha256sum_clang
       puts "Unpacking clang source code".yellow
@@ -47,16 +47,16 @@ class Llvm < Package
       puts "Clang archive downloaded".lightgreen
     end
 
-    system "tar", "xf", "cfe-#{version}.src.tar.xz", "-C", "tools"
+    system "tar", "xf", "clang-#{version}.src.tar.xz", "-C", "tools"
     puts "Clang source code unpacked".lightgreen
     system "rm -rf tools/clang"  # remove possible existing folder
-    system "mv -v tools/cfe-#{version}.src tools/clang"
+    system "mv -v tools/clang-#{version}.src tools/clang"
 
     ############################# Download lld (tools) ###########################################
-    url_lld = "https://releases.llvm.org/#{version}/lld-#{version}.src.tar.xz"
+    url_lld = "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/lld-#{version}.src.tar.xz"
     uri_lld = URI.parse url_lld
     filename_lld = File.basename(uri_lld.path)
-    sha256sum_lld = '31c6748b235d09723fb73fea0c816ed5a3fab0f96b66f8fbc546a0fcc8688f91'
+    sha256sum_lld = 'b9a0d7c576eeef05bc06d6e954938a01c5396cee1d1e985891e0b1cf16e3d708'
 
     if File.exist?(filename_lld) && Digest::SHA256.hexdigest( File.read("./#{filename_lld}") ) == sha256sum_lld
       puts "Unpacking lld source code".yellow
@@ -74,10 +74,10 @@ class Llvm < Package
     system "mv -v tools/lld-#{version}.src tools/lld"
 
     ############################# Download lldb (tools) ###########################################
-    url_lldb = "https://releases.llvm.org/#{version}/lldb-#{version}.src.tar.xz"
+    url_lldb = "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/lldb-#{version}.src.tar.xz"
     uri_lldb = URI.parse url_lldb
     filename_lldb = File.basename(uri_lldb.path)
-    sha256sum_lldb = '1e4c2f6a1f153f4b8afa2470d2e99dab493034c1ba8b7ffbbd7600de016d0794'
+    sha256sum_lldb = 'dd1ffcb42ed033f5167089ec4c6ebe84fbca1db4a9eaebf5c614af09d89eb135'
 
     if File.exist?(filename_lldb) && Digest::SHA256.hexdigest( File.read("./#{filename_lldb}") ) == sha256sum_lldb
       puts "Unpacking lldb source code".yellow
@@ -95,10 +95,10 @@ class Llvm < Package
     system "mv -v tools/lldb-#{version}.src tools/lldb"
 
     ############################# Download polly (tools) ###########################################
-    url_polly = "https://releases.llvm.org/#{version}/polly-#{version}.src.tar.xz"
+    url_polly = "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/polly-#{version}.src.tar.xz"
     uri_polly = URI.parse url_polly
     filename_polly = File.basename(uri_polly.path)
-    sha256sum_polly = 'a4fa92283de725399323d07f18995911158c1c5838703f37862db815f513d433'
+    sha256sum_polly = '35fba6ed628896fe529be4c10407f1b1c8a7264d40c76bced212180e701b4d97'
 
     if File.exist?(filename_polly) && Digest::SHA256.hexdigest( File.read("./#{filename_polly}") ) == sha256sum_polly
       puts "Unpacking polly source code".yellow
@@ -140,10 +140,10 @@ class Llvm < Package
     #end
 
     ############################# Download compiler-rt (projects) ####################################
-    url_compiler_rt = "https://releases.llvm.org/#{version}/compiler-rt-#{version}.src.tar.xz"
+    url_compiler_rt = "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/compiler-rt-#{version}.src.tar.xz"
     uri_compiler_rt = URI.parse url_compiler_rt
     filename_compiler_rt = File.basename(uri_compiler_rt.path)
-    sha256sum_compiler_rt = '56e4cd96dd1d8c346b07b4d6b255f976570c6f2389697347a6c3dcb9e820d10e'
+    sha256sum_compiler_rt = '6a7da64d3a0a7320577b68b9ca4933bdcab676e898b759850e827333c3282c75'
 
     if File.exist?(filename_compiler_rt) && Digest::SHA256.hexdigest( File.read("./#{filename_compiler_rt}") ) == sha256sum_compiler_rt
       puts "Unpacking compiler-rt source code".yellow
@@ -161,10 +161,10 @@ class Llvm < Package
     system "mv -v projects/compiler-rt-#{version}.src projects/compiler-rt"
 
     ############################# Download libcxx (procjects) ####################################
-    url_libcxx = "https://releases.llvm.org/#{version}/libcxx-#{version}.src.tar.xz"
+    url_libcxx = "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/libcxx-#{version}.src.tar.xz"
     uri_libcxx = URI.parse url_libcxx
     filename_libcxx = File.basename(uri_libcxx.path)
-    sha256sum_libcxx = '3c4162972b5d3204ba47ac384aa456855a17b5e97422723d4758251acf1ed28c'
+    sha256sum_libcxx = '270f8a3f176f1981b0f6ab8aa556720988872ec2b48ed3b605d0ced8d09156c7'
 
     if File.exist?(filename_libcxx) && Digest::SHA256.hexdigest( File.read("./#{filename_libcxx}") ) == sha256sum_libcxx
       puts "Unpacking libcxx source code".yellow
@@ -182,10 +182,10 @@ class Llvm < Package
     system "mv -v projects/libcxx-#{version}.src projects/libcxx"
 
     ############################# Download libcxxabi (procjects) ####################################
-    url_libcxxabi = "https://releases.llvm.org/#{version}/libcxxabi-#{version}.src.tar.xz"
+    url_libcxxabi = "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/libcxxabi-#{version}.src.tar.xz"
     uri_libcxxabi = URI.parse url_libcxxabi
     filename_libcxxabi = File.basename(uri_libcxxabi.path)
-    sha256sum_libcxxabi = '675041783565c906ac2f7f8b2bc5c40f14d871ecfa8ade34855aa18de95530e9'
+    sha256sum_libcxxabi = 'e71bac75a88c9dde455ad3f2a2b449bf745eafd41d2d8432253b2964e0ca14e1'
 
     if File.exist?(filename_libcxxabi) && Digest::SHA256.hexdigest( File.read("./#{filename_libcxxabi}") ) == sha256sum_libcxxabi
       puts "Unpacking libcxxabi source code".yellow
@@ -203,10 +203,10 @@ class Llvm < Package
     system "mv -v projects/libcxxabi-#{version}.src projects/libcxxabi"
 
     ############################# Download libomp (procjects) ####################################
-    url_openmp = "https://releases.llvm.org/#{version}/openmp-#{version}.src.tar.xz"
+    url_openmp = "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/openmp-#{version}.src.tar.xz"
     uri_openmp = URI.parse url_openmp
     filename_openmp = File.basename(uri_openmp.path)
-    sha256sum_openmp = '9979eb1133066376cc0be29d1682bc0b0e7fb541075b391061679111ae4d3b5b'
+    sha256sum_openmp = '3b9ff29a45d0509a1e9667a0feb43538ef402ea8cfc7df3758a01f20df08adfa'
 
     if File.exist?(filename_openmp) && Digest::SHA256.hexdigest( File.read("./#{filename_openmp}") ) == sha256sum_openmp
       puts "Unpacking openmp source code".yellow
@@ -224,10 +224,10 @@ class Llvm < Package
     system "mv -v projects/openmp-#{version}.src projects/openmp"
 
     ############################# Download libunwind (procjects) ####################################
-    url_libunwind = "https://releases.llvm.org/#{version}/libunwind-#{version}.src.tar.xz"
+    url_libunwind = "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/libunwind-#{version}.src.tar.xz"
     uri_libunwind = URI.parse url_libunwind
     filename_libunwind = File.basename(uri_libunwind.path)
-    sha256sum_libunwind = '976a8d09e1424fb843210eecec00a506b956e6c31adda3b0d199e945be0d0db2'
+    sha256sum_libunwind = '09dc5ecc4714809ecf62908ae8fe8635ab476880455287036a2730966833c626'
 
     if File.exist?(filename_libunwind) && Digest::SHA256.hexdigest( File.read("./#{filename_libunwind}") ) == sha256sum_libunwind
       puts "Unpacking libunwind source code".yellow
@@ -287,12 +287,13 @@ version=\$(gcc -dumpversion)
 cxx_sys=#{CREW_PREFIX}/include/c++/\${version}
 cxx_inc=#{CREW_PREFIX}/include/c++/\${version}/\${machine}
 gnuc_lib=#{CREW_LIB_PREFIX}/gcc/\${machine}/\${version}
-clang++ -rtlib=compiler-rt -stdlib=libc++ -cxx-isystem \${cxx_sys} -I \${cxx_inc} -B \${gnuc_lib} -L \${gnuc_lib} \"\$@\"' > clc++"
+clang++ -fPIC  -rtlib=compiler-rt -stdlib=libc++ -cxx-isystem \${cxx_sys} -I \${cxx_inc} -B \${gnuc_lib} -L \${gnuc_lib} \"\$@\"' > clc++"
       case ARCH
       when "x86_64"
         system 'cmake',
                "-DCURSES_INCLUDE_PATH='#{CREW_PREFIX}/include/ncursesw'",
                "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+               '-DCMAKE_CXX_FLAGS="-fPIC"',
                '-DCMAKE_BUILD_TYPE=Release',
                '-DLLVM_LIBDIR_SUFFIX=64',
                '-DBUILD_SHARED_LIBS=ON',
@@ -301,11 +302,12 @@ clang++ -rtlib=compiler-rt -stdlib=libc++ -cxx-isystem \${cxx_sys} -I \${cxx_inc
                '..'
                # Fix for file INSTALL cannot find ".../lib64/python2.7" error.
                # See http://lists.llvm.org/pipermail/lldb-dev/2015-June/007633.html.
-               system "sed -i '40,43d' tools/lldb/scripts/cmake_install.cmake"
+               system "sed -i '40,43d' tools/lldb/cmake_install.cmake"
       else # armv7l, aarch64 or i686
         system 'cmake',
                "-DCURSES_INCLUDE_PATH='#{CREW_PREFIX}/include/ncursesw'",
                "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+               '-DCMAKE_CXX_FLAGS="-fPIC"',
                '-DCMAKE_BUILD_TYPE=Release',
                '-DBUILD_SHARED_LIBS=ON',
                '-DLLVM_ENABLE_RTTI=ON',

--- a/packages/lua.rb
+++ b/packages/lua.rb
@@ -3,25 +3,30 @@ require 'package'
 class Lua < Package
   description 'Lua is a powerful, efficient, lightweight, embeddable scripting language.'
   homepage 'https://www.lua.org/'
-  version '5.3.5-1'
+  version '5.3.5-2'
   source_url 'https://www.lua.org/ftp/lua-5.3.5.tar.gz'
   source_sha256 '0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/lua-5.3.5-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/lua-5.3.5-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/lua-5.3.5-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/lua-5.3.5-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/lua-5.3.5-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/lua-5.3.5-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/lua-5.3.5-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/lua-5.3.5-2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'e7637922564311eddb467373ce87a1220399ee38ada304d5e66555835959e9da',
-     armv7l: 'e7637922564311eddb467373ce87a1220399ee38ada304d5e66555835959e9da',
-       i686: '7062884ea29cc4b87620ce1cb4228f81cd1427684378f50e4b539aae030d95ca',
-     x86_64: '43b7e0de02fa42251c7881884c48b6593c9c78387356e1b2ea346a4487838671',
+    aarch64: '8d7f0f8bdf7a45b010fb1c86d22a00180795705143a9572d1a86d9ceacc49a28',
+     armv7l: '8d7f0f8bdf7a45b010fb1c86d22a00180795705143a9572d1a86d9ceacc49a28',
+       i686: '29e15f8cfe77bb937f8717b90b3c6dc69097ea0d6d1685d0eb1987b9c3e5d7c0',
+     x86_64: '999525e2de56e7cdcd1b56c930acd74d3e4e20cc4a23d5936e468afd03aca118',
   })
 
   def self.build
-    system "make -C src all PLAT=linux SYSCFLAGS=\"-DLUA_USE_LINUX\" SYSLIBS=\"-Wl,-E -ldl -lreadline -lncurses\""
+    system 'make',
+      '-C', 'src',
+      'all',
+      'PLAT=linux',
+      'SYSCFLAGS=-DLUA_USE_LINUX -fPIC',
+      'SYSLIBS=-Wl,-E -ldl -lreadline -lncurses -fPIC'
   end
 
   def self.check
@@ -29,7 +34,11 @@ class Lua < Package
   end
 
   def self.install
-    system 'make', 'linux', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}",
-           "INSTALL_TOP=#{CREW_DEST_PREFIX}", 'install'
+    system 'make', 
+      'linux', 
+      "PREFIX=#{CREW_PREFIX}",
+      "LIBDIR=#{CREW_LIB_PREFIX}",
+      "INSTALL_TOP=#{CREW_DEST_PREFIX}", 
+      'install'
   end
 end

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -3,72 +3,58 @@ require 'package'
 class Mesa < Package
   description 'Open-source implementation of the OpenGL specification'
   homepage 'https://www.mesa3d.org'
-  version '18.3.1-1'
-  source_url 'https://mesa.freedesktop.org/archive/mesa-18.3.1.tar.xz'
-  source_sha256 '5b1f827d28684a25f6657289f8b7d47ac56395988c7ac23e0ec9a62b644bdc63'
+  version '20.0.2'
+  source_url 'https://mesa.freedesktop.org/archive/mesa-20.0.2.tar.xz'
+  source_sha256 'aa54f1cb669550606aab8ceb475105d15aeb814fca5a778ce70d0fd10e98e86f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-18.3.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-18.3.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-18.3.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-18.3.1-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-20.0.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-20.0.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-20.0.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-20.0.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd51c117379b69128d7c0e6f9a0554c8d4f9666cf3fb13b5ecdd0897214873192',
-     armv7l: 'd51c117379b69128d7c0e6f9a0554c8d4f9666cf3fb13b5ecdd0897214873192',
-       i686: '2568b9ad11f52b1554c5720f4b513c26a5ded8d141e97ee01b1eede13e2052bb',
-     x86_64: '7d633a3f7e772fc527ec70ab01d8a53126e1ccee204c5c1fb58efdc8ff438b39',
+    aarch64: '1032dfef942c6fba1862daf15e2f9a3f6221d68b125e11cba953f27393059004',
+     armv7l: '1032dfef942c6fba1862daf15e2f9a3f6221d68b125e11cba953f27393059004',
+       i686: 'd59403d96e51bd16af361792732e6065b58b56b71ae621884f47d30f3e2a4a1c',
+     x86_64: 'f7017c11eb0671f0ca9d0368e7c03d7668673c824af96f6238f183e72b033202',
   })
 
+  depends_on 'setuptools' => :build
   depends_on 'libva'
   depends_on 'libvdpau'
   depends_on 'wayland_protocols'
   depends_on 'elfutils'
   depends_on 'llvm'
 
-  def self.patch
-    system "wget -O- https://patchwork.freedesktop.org/patch/257229/raw | patch -Rp1"
-  end
-
   def self.build
     system "pip3 uninstall -y Mako MarkupSafe || :"
-    system "pip3 install --prefix \"#{CREW_PREFIX}\" --root \"#{CREW_DEST_DIR}\" Mako==1.0.7"
-    system "pip3 install --prefix \"#{CREW_PREFIX}\" Mako==1.0.7"
-    case ARCH
-    when 'i686'
-      gallium_drivers = 'i915,nouveau,pl111,svga,swrast,vc4,virgl'
-      dri_drivers = 'i915,i965,nouveau,radeon,r200,swrast'
-    when 'x86_64'
-      gallium_drivers = 'i915,nouveau,r300,r600,radeonsi,pl111,svga,swrast,swr,vc4,virgl'
-      dri_drivers = 'i915,i965,nouveau,radeon,r200,swrast'
-    when 'aarch64', 'armv7l'
-      gallium_drivers = 'nouveau,r300,freedreno,pl111,swrast,tegra,vc4,virgl'
-      dri_drivers = 'nouveau,radeon,r200,swrast'
-    end
-    system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--enable-shared-glapi",
-           "--with-gallium-drivers=#{gallium_drivers}",
-           "--with-dri-drivers=#{dri_drivers}",
-           "--enable-osmesa",
-           "--enable-opengl",
-           "--enable-egl",
-           "--enable-xvmc",
-           "--disable-asm",
-           "--enable-nine",
-           "--enable-gles1",
-           "--enable-gles2",
-           "--with-platforms=x11,drm,wayland",
-           "--enable-gbm",
-           "--enable-xa",
-           "--enable-glx",
-           "--enable-dri",
-           "--enable-llvm"
-    system "make"
+    system "pip3 install --prefix \"#{CREW_PREFIX}\" --root \"#{CREW_DEST_DIR}\" Mako"
+    system "pip3 install --prefix \"#{CREW_PREFIX}\" Mako"
+    system "meson",
+      "--prefix=#{CREW_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}",
+      "-Dshared-glapi=true",
+      "-Dgallium-drivers=auto",
+      "-Ddri-drivers=auto",
+      "-Dosmesa=classic",
+      "-Dopengl=true",
+      "-Degl=auto",
+      "-Dgallium-xvmc=auto",
+      "-Dgallium-nine=true",
+      "-Dgles1=auto",
+      "-Dgles2=auto",
+      "-Dplatforms=x11,drm,wayland",
+      "-Dgbm=auto",
+      "-Dgallium-xa=auto",
+      "-Dglx=auto",
+      "-Dllvm=true",
+      "builddir"
+    system "ninja -C builddir"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+
   end
 end

--- a/packages/mesa_utils.rb
+++ b/packages/mesa_utils.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Mesa_utils< Package
+  description 'Open-source implementation of the OpenGL specification - Provides tools such as glxinfo, glxgears'
+  homepage 'https://www.mesa3d.org'
+  version '8.4.0'
+  source_url 'https://mesa.freedesktop.org/archive/demos/mesa-demos-8.4.0.tar.bz2'
+  source_sha256 '01e99c94a0184e63e796728af89bfac559795fb2a0d6f506fa900455ca5fff7d'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa_utils-8.4.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mesa_utils-8.4.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mesa_utils-8.4.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa_utils-8.4.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '441d8cb0093be26118691d3f134c2fedbefea9f4b9189672d14e1954259fae34',
+     armv7l: '441d8cb0093be26118691d3f134c2fedbefea9f4b9189672d14e1954259fae34',
+       i686: '9154f4f5f1f116ebe2c6b4d601689b6651314aaca776d9e7a2c0a011dd677bf2',
+     x86_64: '2c8612ab1600e7e68a3e0f57ce59a56637c2f5ea04312dbdce172d9aeece593e',
+  })
+
+  depends_on 'mesa'
+  depends_on 'glew'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/mosh.rb
+++ b/packages/mosh.rb
@@ -3,21 +3,21 @@ require 'package'
 class Mosh < Package
   description 'Remote terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and line editing of user keystrokes.'
   homepage 'https://mosh.org/'
-  version '1.3.2-2'
+  version '1.3.2-3'
   source_url 'https://mosh.org/mosh-1.3.2.tar.gz'
   source_sha256 'da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mosh-1.3.2-3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bce0bb81f48ebe684f46f9dc3271288bd4db39563ac905e97b91ef332bf9e496',
-     armv7l: 'bce0bb81f48ebe684f46f9dc3271288bd4db39563ac905e97b91ef332bf9e496',
-       i686: '53611e546ecbcb1c6f1e5055d54b3119489a1d31756900d6c312e67687068af5',
-     x86_64: 'fb66808fe08846e07443851e0b66ec638aa2fdd18b8308bf219b05c0f02c5bce',
+    aarch64: '206acadc595fd9645a1b1f31293774c8aaaae75f6ea3f0ae766c8915a0657c75',
+     armv7l: '206acadc595fd9645a1b1f31293774c8aaaae75f6ea3f0ae766c8915a0657c75',
+       i686: 'f42e4dd4f593f47faac209e289826199849480262abd2b99faf8152396bcaae7',
+     x86_64: '9851ac9520d24cfa02881eaba610cecd4e14b7a1caffb0a2c63b18eb6c745030',
   })
 
   depends_on 'protobuf'

--- a/packages/mtr.rb
+++ b/packages/mtr.rb
@@ -1,0 +1,42 @@
+require 'package'
+
+class Mtr < Package
+  description "mtr combines the functionality of the 'traceroute' and 'ping' programs in a single network diagnostic tool."
+  homepage 'https://www.bitwizard.nl/mtr/'
+  version '0.93'
+  source_url 'ftp://ftp.bitwizard.nl/mtr/mtr-0.93.tar.gz'
+  source_sha256 '229c673d637bd7dbb96471623785a47e85da0b1944978200c949994c1e6af10d'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mtr-0.93-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mtr-0.93-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mtr-0.93-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mtr-0.93-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '10827000fd244c4a001077b013ed89d9ee156297764a59b763938e2e261d1965',
+     armv7l: '10827000fd244c4a001077b013ed89d9ee156297764a59b763938e2e261d1965',
+       i686: '6d42197636f5bc79bd63e879a4e50fa4d13c72e552d8393ac1893b2ae10bf226',
+     x86_64: '7ec1e4e20d17fa583089f1ce681c4dd373fdf9683eb36a7d14ede883a2fca0fc',
+  })
+
+  def self.build
+    system './configure',
+           '--without-gtk',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           "LDFLAGS=-Wl,-rpath,#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'sudo', 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system 'sudo', 'chown', '-R', "#{USER}:#{USER}", "#{CREW_DEST_DIR}"
+  end
+
+  def self.postinstall
+    puts
+    puts "To run, execute 'sudo mtr <domain>'".lightblue
+    puts
+  end
+end

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -3,21 +3,21 @@ require 'package'
 class Ncurses < Package
   description 'The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0 (SVr4), and more.'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '6.1-0'
-  source_url 'https://ftpmirror.gnu.org/ncurses/ncurses-6.1.tar.gz'
-  source_sha256 'aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17'
+  version '6.2'
+  source_url 'https://ftpmirror.gnu.org/ncurses/ncurses-6.2.tar.gz'
+  source_sha256 '30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.1-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.1-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.1-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.1-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'a12e70f779b2375912a5373b5f320c7b4bef8ddcba5144709e2aed67f8011afe',
-     armv7l: 'a12e70f779b2375912a5373b5f320c7b4bef8ddcba5144709e2aed67f8011afe',
-       i686: 'a89d5d79d91c8717cfecf7ebbebae6479f8cded2884798643d061605e449c1df',
-     x86_64: 'fcaf728604029920a14f27f64f498dfc8a3586bc0426ca6a890adf925e39e204',
+    aarch64: 'e040d9c065046e107be2712904f0452720724254cc36aa7f04056246967b41b5',
+     armv7l: 'e040d9c065046e107be2712904f0452720724254cc36aa7f04056246967b41b5',
+       i686: '715c277f836a8f8f6c40736c667f63913d6e8ee005b4eb258a7a156a6b6db95a',
+     x86_64: '7ac9b423de77550b4ac2fc82ce4d42fc694352d3911918ba265ca2472d595f38',
   })
 
   def self.build

--- a/packages/ocaml.rb
+++ b/packages/ocaml.rb
@@ -3,28 +3,26 @@ require 'package'
 class Ocaml < Package
   description 'OCaml is an industrial strength programming language supporting functional, imperative and object-oriented styles'
   homepage 'http://ocaml.org/'
-  version '4.06.0'
-  source_url 'https://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.xz'
-  source_sha256 '1236b5f91e1c075086d69e2d40cfab21e048b9fe38e902f707815bebbc20c5b7'
+  version '4.10.0'
+  source_url 'https://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.0.tar.gz'
+  source_sha256 '58d431dde66f5750ebe9b15d5a1c4872f80d283dec23448689b0d1a498b7e4c7'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.06.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.06.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.06.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.06.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.10.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.10.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.10.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ocaml-4.10.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '66f2bf801661c70eb4779f8075da2454b13f4b71cb3efe8680e487c54d539bb2',
-     armv7l: '66f2bf801661c70eb4779f8075da2454b13f4b71cb3efe8680e487c54d539bb2',
-       i686: 'c5942aa70696eee4c242f27a85751c7823f556eb36804f1171fde1ea64f53ba2',
-     x86_64: '3855090573fb7a460c65f2c2705d8f73cf011e79f925a30508397c9ae2376a6f',
+    aarch64: '5c473693ab61a9f70f2691b63680009bd1ddf5f237eebdaa9d3ccb02e5cba793',
+     armv7l: '5c473693ab61a9f70f2691b63680009bd1ddf5f237eebdaa9d3ccb02e5cba793',
+       i686: '9c3772682238e12d8edaf59197c8f6d0343436d0e54055490c39a4f3e67971d3',
+     x86_64: 'd2c8383d8761b1d67f244f58bf06cd3bdd49470353e0925abafa4e58906d2571',
   })
 
-  depends_on 'buildessential' => :build
-  depends_on 'gdbm'
 
   def self.build
-    system "./configure -prefix #{CREW_PREFIX} -libdir #{CREW_LIB_PREFIX} -no-graph"
+    system "./configure -prefix #{CREW_PREFIX} -libdir #{CREW_LIB_PREFIX}"
     system 'make -j1 world.opt'
   end
 

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,7 +3,7 @@ require 'package'
 class Opera < Package
   description "Opera isn't just a browser. It's an awesome browser."
   homepage 'https://www.opera.com/'
-  version '65.0.3467.69'
+  version '66.0.3515.103'
   case ARCH
   when 'x86_64'
     source_url 'file:///dev/null'
@@ -11,10 +11,10 @@ class Opera < Package
   end
 
   binary_url ({
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/opera-65.0.3467.69-chromeos-x86_64.tar.xz'
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/opera-66.0.3515.103-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    x86_64: '3c9d6056db24f8c6250c7dd382e82e7bb8758678ceb6877630457b0edb730cb1'
+    x86_64: 'b128d632850931f8c4eb49a532c7350ccdadeb1746fc8ca95c9c1f06eff2cc69',
   })
 
   depends_on 'alien' => :build
@@ -23,8 +23,8 @@ class Opera < Package
 
   def self.build
     system "wget https://get.geo.opera.com/pub/opera/desktop/#{version}/linux/opera-stable_#{version}_amd64.deb"
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("opera-stable_#{version}_amd64.deb") ) == '337af6edaa5394f914dd4e5228e75c1f3ddc1f87564f13a3c5df44fff7487026'
-    system "alien -t -c opera-stable_#{version}_amd64.deb"
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("opera-stable_#{version}_amd64.deb") ) == '6d561ef2bb8383bf3181d2e51343d94dfd1c71941da21c703d2064b3f424e9a0'
+    system "alien -tc opera-stable_#{version}_amd64.deb"
     system "tar xvf opera-stable-#{version}.tgz"
   end
 

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -3,21 +3,21 @@ require 'package'
 class Pango < Package
   description 'Pango is a library for laying out and rendering of text, with an emphasis on internationalization.'
   homepage 'http://www.pango.org/'
-  version '1.42.4'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/pango/1.42/pango-1.42.4.tar.xz'
-  source_sha256 '1d2b74cd63e8bd41961f2f8d952355aa0f9be6002b52c8aa7699d9f5da597c9d'
+  version '1.44.7'
+  source_url 'https://ftp.gnome.org/pub/gnome/sources/pango/1.44/pango-1.44.7.tar.xz'
+  source_sha256 '66a5b6cc13db73efed67b8e933584509f8ddb7b10a8a40c3850ca4a985ea1b1f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.42.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.42.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.42.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.42.4-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.44.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.44.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.44.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.44.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '071eb7577ceb4017efbb8c68fe4aab16bc247dddf66570b681de5e89a874902f',
-     armv7l: '071eb7577ceb4017efbb8c68fe4aab16bc247dddf66570b681de5e89a874902f',
-       i686: '3aad278555332b5733ef108e141ce1fd57a7d1d4c4e3ba4c15d9b6fa0a94b7d6',
-     x86_64: '10caa80ccf8d2eaef71e48dcb8f9cacf971d66450562c490043dbe35da8ab252',
+    aarch64: 'ec4d228e60636eaeae2f60a9d15d30685dfaba9b9664b633956bd2cf910f4aa1',
+     armv7l: 'ec4d228e60636eaeae2f60a9d15d30685dfaba9b9664b633956bd2cf910f4aa1',
+       i686: '6393f959ff12bafce05ba84eb60a1143bdd78cd2afdc56477d663f8ddd914db4',
+     x86_64: '535b15a6d6f7f0433b697565f1490901606803dc9af598655cb69aaf4da616b1',
   })
 
   depends_on 'harfbuzz'
@@ -29,14 +29,11 @@ class Pango < Package
   depends_on 'six'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--with-xft'
-    system 'make'
+    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
+    system "ninja -C builddir"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/pcre.rb
+++ b/packages/pcre.rb
@@ -3,21 +3,21 @@ require 'package'
 class Pcre < Package
   description 'The PCRE library is a set of functions that implement regular expression pattern matching using the same syntax and semantics as Perl 5.'
   homepage 'http://pcre.org/'
-  version '8.41'
-  source_url 'https://ftp.pcre.org/pub/pcre/pcre-8.41.tar.bz2'
-  source_sha256 'e62c7eac5ae7c0e7286db61ff82912e1c0b7a0c13706616e94a7dd729321b530'
+  version '8.44'
+  source_url 'https://ftp.pcre.org/pub/pcre/pcre-8.44.tar.bz2'
+  source_sha256 '19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.41-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.41-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.41-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.41-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.44-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.44-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.44-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.44-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b00eb9665606795130adfb074d1566273dd22cf69c9adc0bb89e6cedbfacc383',
-     armv7l: 'b00eb9665606795130adfb074d1566273dd22cf69c9adc0bb89e6cedbfacc383',
-       i686: '1f44785a94ddff3321ea0fb07fc9844b51af95ee2ad66dcf8293ff36c361c001',
-     x86_64: 'be8fb02a9f4e3d6ad1ffa09a45ee7a22042b544f26a25a079e800fb44141c311',
+    aarch64: 'b4c172b57311480be50e1f683d1df5319bd92aac6c154d0c940d35d95fc23688',
+     armv7l: 'b4c172b57311480be50e1f683d1df5319bd92aac6c154d0c940d35d95fc23688',
+       i686: '16d71a0624f07bb7cc341cbcec798a0838bbac822df307c6d4ff20a2061a8f5e',
+     x86_64: '99901d63534b07b3cfde714bfbc10b1eb19eef49fb68a8d9e498cac58a523f01',
   })
 
   def self.build

--- a/packages/pcre2.rb
+++ b/packages/pcre2.rb
@@ -3,21 +3,21 @@ require 'package'
 class Pcre2 < Package
   description 'The PCRE2 package contains a new generation of the Perl Compatible Regular Expression libraries.'
   homepage 'http://pcre.org/'
-  version '10.30'
-  source_url 'https://ftp.pcre.org/pub/pcre/pcre2-10.30.tar.gz'
-  source_sha256 'b549873a39f804480c2e6145a78adcba53e38162d90ef6ea92384f6ecf2fde76'
+  version '10.34'
+  source_url 'https://ftp.pcre.org/pub/pcre/pcre2-10.34.tar.gz'
+  source_sha256 'da6aba7ba2509e918e41f4f744a59fa41a2425c59a298a232e7fe85691e00379'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.30-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.30-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.30-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.30-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.34-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.34-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.34-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.34-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b36916b0648275dfadc42cec5c3b56210105b0f44dd07b49330f83507d3e2e2e',
-     armv7l: 'b36916b0648275dfadc42cec5c3b56210105b0f44dd07b49330f83507d3e2e2e',
-       i686: '3a6731ebebf1339f48f546f05de9cc1c9abfea9789d6a2a3bcabde3acbccc897',
-     x86_64: '3994cf0a26a2c3904851bdcb071f9348d59d57e78763459a8cea9fc4b88327b2',
+    aarch64: 'e1f117b420f4f72645cd643756a01ee712b56ce3b6367f2ec801e300e1d6e4cf',
+     armv7l: 'e1f117b420f4f72645cd643756a01ee712b56ce3b6367f2ec801e300e1d6e4cf',
+       i686: 'dafff4b147f8b3f0bffb6411fd7996bd8654823cd0a0789bc5edec723a20cb06',
+     x86_64: '4325b2825b0c425a5914c750d9837d8ad10d830156e1dc49e11f156664e9b51f',
   })
 
   depends_on 'libtool' => :build

--- a/packages/php.rb
+++ b/packages/php.rb
@@ -3,7 +3,7 @@ require 'package'
 class Php < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.40-7.4.2'
+  version '5.6.40-7.4.4'
 
   is_fake
 
@@ -15,9 +15,9 @@ class Php < Package
     puts "  5.6 = PHP 5.6.40"
     puts "  7.0 = PHP 7.0.33"
     puts "  7.1 = PHP 7.1.33"
-    puts "  7.2 = PHP 7.2.27"
-    puts "  7.3 = PHP 7.3.14"
-    puts "  7.4 = PHP 7.4.2"
+    puts "  7.2 = PHP 7.2.29"
+    puts "  7.3 = PHP 7.3.16"
+    puts "  7.4 = PHP 7.4.4"
     puts "    0 = Cancel"
 
     while version = STDIN.gets.chomp

--- a/packages/php72.rb
+++ b/packages/php72.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php72 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.2.27'
-  source_url 'https://php.net/distributions/php-7.2.27.tar.xz'
-  source_sha256 '7bd0fb9e3b63cfe53176d1f3565cd686f90b3926217158de5ba57091f49e4c32'
+  version '7.2.29'
+  source_url 'https://www.php.net/distributions/php-7.2.29.tar.xz'
+  source_sha256 'b117de74136bf4b439d663be9cf0c8e06a260c1f340f6b75ccadb609153a7fe8'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -13,20 +13,20 @@ class Php72 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.29-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.29-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.29-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.29-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '200c2376c4dcd3435a8813d13ff14dcd9dd28b849822841c40a2ef1d27516d0f',
-     armv7l: '200c2376c4dcd3435a8813d13ff14dcd9dd28b849822841c40a2ef1d27516d0f',
-       i686: 'aa8177e8f6e9f58d07b35a68c83103552d585aaa4ec2abbcbe34b7b067a6b493',
-     x86_64: '18c012beea8876a2d4820698ba0ab533cbea191c32a048f9d93457cfda4fbcf5',
+    aarch64: 'dfaf1cf9fe5bb4faec843c1f4c3d6a67b76965ead087c5e3eff899dc3c6935de',
+     armv7l: 'dfaf1cf9fe5bb4faec843c1f4c3d6a67b76965ead087c5e3eff899dc3c6935de',
+       i686: '9a13f49ecd640cc1beeb38e14496b0dabed6f7090913bf847e180fc33fc72cc5',
+     x86_64: '45805e9ec6fade956e1dcbdfe60fc7453e192cf0038a120fc189346009131421',
   })
 
   depends_on 'libgcrypt'
-  depends_on 'libwebp'
+  depends_on 'libjpeg_turbo'
   depends_on 'libxslt'
   depends_on 'libzip'
   depends_on 'curl'
@@ -69,13 +69,7 @@ class Php72 < Package
            "--sbindir=#{CREW_PREFIX}/bin",
            "--with-config-file-path=#{CREW_PREFIX}/etc",
            "--with-libdir=#{ARCH_LIB}",
-           "--with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype",
-           "--with-pcre-regex=#{CREW_LIB_PREFIX}",
-           "--with-jpeg-dir=#{CREW_LIB_PREFIX}",
            "--with-kerberos=#{CREW_LIB_PREFIX}",
-           "--with-png-dir=#{CREW_LIB_PREFIX}",
-           "--with-webp-dir=#{CREW_LIB_PREFIX}",
-           "--with-xpm-dir=#{CREW_LIB_PREFIX}",
            '--enable-exif',
            '--enable-fpm',
            '--enable-ftp',

--- a/packages/php73.rb
+++ b/packages/php73.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php73 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.3.14'
-  source_url 'https://php.net/distributions/php-7.3.14.tar.xz'
-  source_sha256 'cc05dd373ca5d36652800762f65c10e828a17de35aaf246262e3efa99d00cdb0'
+  version '7.3.16'
+  source_url 'https://www.php.net/distributions/php-7.3.16.tar.xz'
+  source_sha256 '91aaee3dbdc71b69b4f3292f9d99211172a2fa926c3f3bbdb0e85dab03dd2bcb'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -13,20 +13,20 @@ class Php73 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.16-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.16-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.16-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.16-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '0155c17c10baa03c36e9e43ab9249b994eda6477a210d8bce7a40ac23c623a4d',
-     armv7l: '0155c17c10baa03c36e9e43ab9249b994eda6477a210d8bce7a40ac23c623a4d',
-       i686: '03efd2ecd997bf5e0d8e4a3ed7a16bcbf29d4cee7c43d4277775c22902ba9f31',
-     x86_64: '9247dc95950d33454a41a4477513b2e0ec48b20dcb59a510472714925a1be0d2',
+    aarch64: 'fc1af0fc86fe4a85a917df1b153cc47bf9e03c17df21cfecc58a2beeaf8c5318',
+     armv7l: 'fc1af0fc86fe4a85a917df1b153cc47bf9e03c17df21cfecc58a2beeaf8c5318',
+       i686: '75a34b491053dc6122f52f62554a91d611facb1438fe642434c385f2c92ab60e',
+     x86_64: '5b9407524e5aa5559056a190aee703088e52ecb7a8bf505a0fceee2b4af9beef',
   })
 
   depends_on 'libgcrypt'
-  depends_on 'libwebp'
+  depends_on 'libjpeg_turbo'
   depends_on 'libxslt'
   depends_on 'libzip'
   depends_on 'curl'
@@ -69,13 +69,7 @@ class Php73 < Package
            "--sbindir=#{CREW_PREFIX}/bin",
            "--with-config-file-path=#{CREW_PREFIX}/etc",
            "--with-libdir=#{ARCH_LIB}",
-           "--with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype",
-           "--with-pcre-regex=#{CREW_LIB_PREFIX}",
-           "--with-jpeg-dir=#{CREW_LIB_PREFIX}",
            "--with-kerberos=#{CREW_LIB_PREFIX}",
-           "--with-png-dir=#{CREW_LIB_PREFIX}",
-           "--with-webp-dir=#{CREW_LIB_PREFIX}",
-           "--with-xpm-dir=#{CREW_LIB_PREFIX}",
            '--enable-exif',
            '--enable-fpm',
            '--enable-ftp',

--- a/packages/php74.rb
+++ b/packages/php74.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php74 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.4.2'
-  source_url 'https://www.php.net/distributions/php-7.4.2.tar.xz'
-  source_sha256 '98284deac017da0d426117ecae7599a1f1bf62ae3911e8bc16c4403a8f4bdf13'
+  version '7.4.4'
+  source_url 'https://www.php.net/distributions/php-7.4.4.tar.xz'
+  source_sha256 '1873c4cefdd3df9a78dcffb2198bba5c2f0464f55c9c960720c84df483fca74c'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -13,23 +13,23 @@ class Php74 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1772f9875a24d504c367a3aaef3574906c746babccf0e951da5e0f016e72175c',
-     armv7l: '1772f9875a24d504c367a3aaef3574906c746babccf0e951da5e0f016e72175c',
-       i686: 'f5c0e82ece2a9d9c2fa259f644eca699e6eacedf6566fdd7f7b8fce9416d2510',
-     x86_64: '9ce8fb964eca402de3072e061e8bc48e4cf6438abd72031299f5db2f30156304',
+    aarch64: 'e37c0e97eca8ed5b8b56d6228861cf833b4f7d0837e06c1f00672a2d2b34f6aa',
+     armv7l: 'e37c0e97eca8ed5b8b56d6228861cf833b4f7d0837e06c1f00672a2d2b34f6aa',
+       i686: 'f33f3b551c177447bda9a9ce7b6cbe5299fe387886a1c1e2124732d917b7b30f',
+     x86_64: '2398c5678b37df12e6ac4bb05d4d91ad304b5ffe5a8b1a02846aaef96c64caa9',
   })
 
   depends_on 'aspell_en'
   depends_on 'libedit'
   depends_on 'libgcrypt'
+  depends_on 'libjpeg_turbo'
   depends_on 'libsodium'
-  depends_on 'libwebp'
   depends_on 'libxslt'
   depends_on 'libzip'
   depends_on 'curl'
@@ -74,13 +74,7 @@ class Php74 < Package
            "--sbindir=#{CREW_PREFIX}/bin",
            "--with-config-file-path=#{CREW_PREFIX}/etc",
            "--with-libdir=#{ARCH_LIB}",
-           "--with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype",
-           "--with-pcre-regex=#{CREW_LIB_PREFIX}",
-           "--with-jpeg-dir=#{CREW_LIB_PREFIX}",
            "--with-kerberos=#{CREW_LIB_PREFIX}",
-           "--with-png-dir=#{CREW_LIB_PREFIX}",
-           "--with-webp-dir=#{CREW_LIB_PREFIX}",
-           "--with-xpm-dir=#{CREW_LIB_PREFIX}",
            '--enable-bcmath',
            '--enable-calendar',
            '--enable-dba=shared',
@@ -120,9 +114,7 @@ class Php74 < Package
            '--with-sodium',
            '--with-tidy',
            '--with-unixODBC',
-           '--with-webp',
            '--with-xmlrpc',
-           '--with-xpm',
            '--with-xsl',
            '--with-zip',
            '--with-zlib'

--- a/packages/platformsh.rb
+++ b/packages/platformsh.rb
@@ -3,28 +3,15 @@ require 'package'
 class Platformsh < Package
   description 'The unified tool for managing your Platform.sh services from the command line.'
   homepage 'https://docs.platform.sh/overview/cli.html'
-  version '3.26.0'
-  source_url 'https://github.com/platformsh/platformsh-cli/archive/v3.26.0.tar.gz'
-  source_sha256 '57c639c587c5a0254c022cf9954054aa3092b8350d891aaf399ff4f3a614c5c0'
+  version '3.52.2'
+  source_url 'https://github.com/platformsh/platformsh-cli/archive/v3.52.2.tar.gz'
+  source_sha256 '574e3b4b99224b39833409ce2972a6738844b22e3d4f035ce6f6e8cef527dfea'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/platformsh-3.26.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/platformsh-3.26.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/platformsh-3.26.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/platformsh-3.26.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '17cb068e71162c529129f21ace587cf83f0da33782726ca144416cabf95f44ae',
-     armv7l: '17cb068e71162c529129f21ace587cf83f0da33782726ca144416cabf95f44ae',
-       i686: 'd80488f79eef69722475c7bc1586510353f08918fb9aaf243045bd4e531913c0',
-     x86_64: '361d33cec0c787d0dd07bef361af4fd68ce23d0c90c4df494a984ad2ea223a57',
-  })
-
-  depends_on 'php7' unless File.exists? "#{CREW_PREFIX}/bin/php"
+  depends_on 'php' unless File.exists? "#{CREW_PREFIX}/bin/php"
 
   def self.install
-    system "wget https://github.com/platformsh/platformsh-cli/releases/download/v3.26.0/platform.phar"
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('platform.phar') ) == '8343ce8235535f2c388a5ed0f0a321debc9a1838fd53c006c75445b2e099cbe9'
+    system "wget https://github.com/platformsh/platformsh-cli/releases/download/v#{version}/platform.phar"
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('platform.phar') ) == 'aa420d0f2cf1efd90efb464dd0d7d544c1ba5be381e79eb22a86afb6f17bd181'
     system "install -Dm755 platform.phar #{CREW_DEST_PREFIX}/bin/platform"
   end
 end

--- a/packages/poppler.rb
+++ b/packages/poppler.rb
@@ -3,48 +3,52 @@ require 'package'
 class Poppler < Package
   description 'Poppler is a PDF rendering library based on the xpdf-3.0 code base.'
   homepage 'https://poppler.freedesktop.org/'
-  version '0.63.0'
-  source_url 'https://poppler.freedesktop.org/poppler-0.63.0.tar.xz'
-  source_sha256 '27cc8addafc791e1a26ce6acc2b490926ea73a4f89196dd8a7742cff7cf8a111'
+  version '0.86.1'
+  source_url 'https://poppler.freedesktop.org/poppler-0.86.1.tar.xz'
+  source_sha256 'af630a277c8e194c31339c5446241834aed6ed3d4b4dc7080311e51c66257f6c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.63.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.63.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.63.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.63.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.86.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.86.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.86.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.86.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '327284b83bcd2b5ab97ba2d471fd25bbc7da95704f1d766bb85c56232b2d84df',
-     armv7l: '327284b83bcd2b5ab97ba2d471fd25bbc7da95704f1d766bb85c56232b2d84df',
-       i686: '06c135358dcdef45c53460c0724b8a565348e4ccc5053ad29eb605b6bc1ff31d',
-     x86_64: 'e32bb8caf1dfea59b8c295d0e0c02c60e2917b18f1c667a1765d5cebb62a59be',
+    aarch64: 'd7a3f4fbf1f47c73958e64b3ec1009865fe291f651de0dd6c5c25283a3bcc77d',
+     armv7l: 'd7a3f4fbf1f47c73958e64b3ec1009865fe291f651de0dd6c5c25283a3bcc77d',
+       i686: '1a79d3f532ba1d3d26da035676516cd7c1a184a3f703438ea615fa6d498416d4',
+     x86_64: '214addecd68af303a0e158f5e0ccd4910aea8a0073340adc9098d1307a56bc36',
   })
 
-  depends_on 'automake' => :build
+  depends_on 'boost'
   depends_on 'cairo'
+  depends_on 'curl'
+  depends_on 'freeglut'
   depends_on 'harfbuzz'
+  depends_on 'lcms'
   depends_on 'libjpeg'
   depends_on 'libpng'
+  depends_on 'libtiff'
   depends_on 'openjpeg'
-  depends_on 'zlibpkg'
-  depends_on 'cmake' => :build
+  depends_on 'poppler_data'
+  depends_on 'qttools'
 
   def self.build
-    system "mkdir -p builddir"
-    Dir.chdir("builddir") do
-      system "cmake",
-             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system 'cmake',
+             "-DCMAKE_CXX_FLAGS='-I#{CREW_PREFIX}/include/GL -I#{CREW_PREFIX}/include/openjpeg-2.3 -I#{CREW_PREFIX}/include'",
              "-DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX}",
-             "-DCMAKE_BUILD_TYPE=Release",
-             "-DENABLE_XPDF_HEADERS=ON",
-             ".."
-      system "make"
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '-DCMAKE_BUILD_TYPE=Release',
+             '..'
+      system 'make'
     end
   end
 
   def self.install
-    Dir.chdir("builddir") do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    Dir.chdir 'builddir' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
   end
 end

--- a/packages/powerstat.rb
+++ b/packages/powerstat.rb
@@ -3,29 +3,29 @@ require 'package'
 class Powerstat < Package
   description 'Powerstat measures the power consumption of a laptop using the ACPI battery information.'
   homepage 'http://kernel.ubuntu.com/~cking/powerstat/'
-  version '0.02.20'
-  source_url 'https://kernel.ubuntu.com/~cking/tarballs/powerstat/powerstat-0.02.20.tar.gz'
-  source_sha256 '679305b3a6d2cc9820d19247e9acc1fb2fa48e96a65bc253b358ba5b0a985de3'
+  version '0.02.22'
+  source_url 'https://kernel.ubuntu.com/~cking/tarballs/powerstat/powerstat-0.02.22.tar.gz'
+  source_sha256 'ef74e023353a24a0a52068a0e474041b9556bcef5b4fe41db44261afd32a6564'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.20-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.20-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.20-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.20-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.22-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.22-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.22-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.22-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '40781457dd33d5bbf4372dec0b0f23544e04c8545b54a6734e135ca3502c0e65',
-     armv7l: '40781457dd33d5bbf4372dec0b0f23544e04c8545b54a6734e135ca3502c0e65',
-       i686: 'a64eb0f7eef06b749f0ca89905e731102763e6bd1f7373a708664da5978df748',
-     x86_64: 'b345616591b185396594420bb43f193b56c450a964c847302ef5e72538ec7d5e',
+    aarch64: 'a80779c88fd6ba1d192530ce6fa281aad82237b3067f251815a2f2f2ad5aa51d',
+     armv7l: 'a80779c88fd6ba1d192530ce6fa281aad82237b3067f251815a2f2f2ad5aa51d',
+       i686: '2cf7b359839f8feedb8c41d976a196dfc0194edbc51e281e1ac7aa233e7974ad',
+     x86_64: 'cf5f0e425a5b4a0bfbcf4e3747ccd4f5edcd6489ae0bbb9db873cec95ba30406',
   })
 
   def self.build
     system "sed -i 's,/usr,#{CREW_PREFIX},g' Makefile"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/pthread_stubs.rb
+++ b/packages/pthread_stubs.rb
@@ -3,21 +3,21 @@ require 'package'
 class Pthread_stubs < Package
   description 'pthread stubs to get libX11 working'
   homepage 'https://x.org'
-  version '0.3'
-  source_url 'https://xcb.freedesktop.org/dist/libpthread-stubs-0.3.tar.bz2'
-  source_sha256 '35b6d54e3cc6f3ba28061da81af64b9a92b7b757319098172488a660e3d87299'
+  version '0.4'
+  source_url 'https://xcb.freedesktop.org/dist/libpthread-stubs-0.4.tar.bz2'
+  source_sha256 'e4d05911a3165d3b18321cc067fdd2f023f06436e391c6a28dff618a78d2e733'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pthread_stubs-0.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pthread_stubs-0.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pthread_stubs-0.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pthread_stubs-0.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pthread_stubs-0.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pthread_stubs-0.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pthread_stubs-0.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pthread_stubs-0.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '12a930c63c5e155059b74c057b342ea4c94f5c1533dd27af55386cd72f920716',
-     armv7l: '12a930c63c5e155059b74c057b342ea4c94f5c1533dd27af55386cd72f920716',
-       i686: 'a832fa2df7eb69c355a13b2d910230c6dcfd1c49cb263cd787d225c6c751b5a6',
-     x86_64: '6d38609d0e19a07642e1e463f68101dffa20b505cb88a443497fbe985cc1e852',
+    aarch64: '85fd777e81a2dd5e3954e82465291c2c889567b7ae8bbb7a3e51b196c8ed35dd',
+     armv7l: '85fd777e81a2dd5e3954e82465291c2c889567b7ae8bbb7a3e51b196c8ed35dd',
+       i686: '3fa0eb953101a37c924a22fa28699d1cb7e4a85bd79b7c492f087df91e108e42',
+     x86_64: '74d475f18422369cea3e5ca5591c55aa2caaac2ad23abaf17e5678daec534cf9',
   })
 
   def self.build

--- a/packages/pugixml.rb
+++ b/packages/pugixml.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Pugixml < Package
+  description 'Light-weight, simple and fast XML parser for C++ with XPath support'
+  homepage 'https://pugixml.org/'
+  version '1.10'
+  source_url 'https://github.com/zeux/pugixml/releases/download/v1.10/pugixml-1.10.tar.gz'
+  source_sha256 '55f399fbb470942410d348584dc953bcaec926415d3462f471ef350f29b5870a'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pugixml-1.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pugixml-1.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pugixml-1.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pugixml-1.10-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'c948a90abf61186a25c71ed9434e9bea9ac7f6a88578c05fe40ba006ede7d561',
+     armv7l: 'c948a90abf61186a25c71ed9434e9bea9ac7f6a88578c05fe40ba006ede7d561',
+       i686: '98434a99ee0c01a9b571939e206d2a0c62205abacd3cbc06a9226147837762ef',
+     x86_64: 'a3c3a28cad9b0e278c5d3e863d73b5ad4ec9498bb5d2f21804946d786af18234',
+  })
+
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '-DCMAKE_BUILD_TYPE=Release',
+             '-DBUILD_SHARED_LIBS=ON',
+             '..'
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
+  end
+end

--- a/packages/pycharm.rb
+++ b/packages/pycharm.rb
@@ -3,9 +3,9 @@ require 'package'
 class Pycharm < Package
   description 'The Python IDE for Professional Developers'
   homepage 'https://www.jetbrains.com/pycharm/'
-  version '2019.3.2'
-  source_url 'https://download.jetbrains.com/python/pycharm-community-anaconda-2019.3.2.tar.gz'
-  source_sha256 'fc38a10642cc14c71cbd45da18d97e517a8b2d7605df160819145f73e3d79b9e'
+  version '2019.3.3'
+  source_url 'https://download.jetbrains.com/python/pycharm-community-anaconda-2019.3.3.tar.gz'
+  source_sha256 'e84d392bfaeaf8b382ce7948261be2ff6d8bade5351b392571eb4c243aa88a61'
 
   depends_on 'jdk8'
   depends_on 'xdg_base'

--- a/packages/qrencode.rb
+++ b/packages/qrencode.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Qrencode < Package
+  description 'Libqrencode is a fast and compact library for encoding data in a QR Code symbol'
+  homepage 'https://fukuchi.org/works/qrencode/'
+  version '4.0.2'
+  source_url 'https://fukuchi.org/works/qrencode/qrencode-4.0.2.tar.gz'
+  source_sha256 'dbabe79c07614625d1f74d8c0ae2ee5358c4e27eab8fd8fe31f9365f821a3b1d'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qrencode-4.0.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qrencode-4.0.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qrencode-4.0.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qrencode-4.0.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '1135a62562f8a523968b5affb3fbd32cf1068701de6024ab1d1b612b39065cd3',
+     armv7l: '1135a62562f8a523968b5affb3fbd32cf1068701de6024ab1d1b612b39065cd3',
+       i686: 'a71bbdf13f9a57930d3d0064becdaa57613d3e16fe446e40698bc377881c9175',
+     x86_64: '20d0f46764c934a1d32f114c0488fb9b79a1761dbb757d51a009a2547b3cd682',
+  })
+
+
+  depends_on 'libpng'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/qtsvg.rb
+++ b/packages/qtsvg.rb
@@ -3,21 +3,21 @@ require 'package'
 class Qtsvg < Package
   description 'Provides classes for displaying the contents of SVG files.'
   homepage 'https://www.qt.io/'
-  version '5.12.3'
+  version '5.12.3-1'
   source_url 'http://download.qt.io/official_releases/qt/5.12/5.12.3/submodules/qtsvg-everywhere-src-5.12.3.tar.xz'
   source_sha256 'f666438dbf6816b7534e539b95e3fa4405f11d7e2e2bbcde34f2db5ae0f27dc2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.12.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.12.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.12.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.12.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.12.3-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.12.3-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.12.3-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.12.3-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '8d7b4568bca5a401a53d177f4a32bf28cb8865028fe72569508015b02a356e6a',
-     armv7l: '8d7b4568bca5a401a53d177f4a32bf28cb8865028fe72569508015b02a356e6a',
-       i686: '980a79436c094a1e057d05e44d3e49ddea30af0917b29e9576bd340c4e699a04',
-     x86_64: 'a5ec7c11247ab0c42061049ef313994c4a4ece6ac2bb6bceb1298e12114d6a8b',
+    aarch64: 'c89fb9e2a3031c2375dfb0fe46ab0b25850cd7c54fbe8ac147fdbbe1c572930d',
+     armv7l: 'c89fb9e2a3031c2375dfb0fe46ab0b25850cd7c54fbe8ac147fdbbe1c572930d',
+       i686: '808c77d05d0ebdf489bb3c99dd6ac89c52349e05df101781ca7fd4d97aa02688',
+     x86_64: 'e775106f346d65f528a55fa473cd45c3862bbb903a54268f0d8a754ef6574f5a',
   })
 
   depends_on 'qtbase'
@@ -34,5 +34,6 @@ class Qtsvg < Package
     FileUtils.cp_r 'include', "#{CREW_DEST_PREFIX}/share/Qt-5"
     FileUtils.cp_r 'mkspecs', "#{CREW_DEST_PREFIX}/share/Qt-5"
     FileUtils.cp_r 'plugins', "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'src', "#{CREW_DEST_PREFIX}/share/Qt-5"
   end
 end

--- a/packages/qtx11extras.rb
+++ b/packages/qtx11extras.rb
@@ -3,21 +3,21 @@ require 'package'
 class Qtx11extras < Package
   description 'Provides classes for developing for the X11 platform.'
   homepage 'https://www.qt.io/'
-  version '5.12.3'
+  version '5.12.3-1'
   source_url 'http://download.qt.io/official_releases/qt/5.12/5.12.3/submodules/qtx11extras-everywhere-src-5.12.3.tar.xz'
   source_sha256 '85e3ae5177970c2d8656226d7535d0dff5764c100e55a79a59161d80754ba613'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.12.3-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f88300f9d8d06dd02a44570832881dcc79e40a41e41a3e418122512eacce6f99',
-     armv7l: 'f88300f9d8d06dd02a44570832881dcc79e40a41e41a3e418122512eacce6f99',
-       i686: 'a2151e5240dafae30e73e7b2998b7b4c216478d780e4534540f48f817f5ee3a4',
-     x86_64: 'd0f65e142afaad622feb7fc8f25c04f3aed698677634115106ad4be3a3f75671',
+    aarch64: '730db647ee53c29484da0ee0bfdf9ffd5f239c5155dbe1664b9d776c9bffd55b',
+     armv7l: '730db647ee53c29484da0ee0bfdf9ffd5f239c5155dbe1664b9d776c9bffd55b',
+       i686: 'ad8cd860ab1b1846973e490b76bb015a8dd5ad13f874a9c8ae45f634db244011',
+     x86_64: '0eafd80bc09b178f93b0553352098a281ad90f88323121becb0b98842bc980a2',
   })
 
   depends_on 'qtbase'
@@ -32,5 +32,6 @@ class Qtx11extras < Package
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/Qt-5"
     FileUtils.cp_r 'include', "#{CREW_DEST_PREFIX}/share/Qt-5"
     FileUtils.cp_r 'mkspecs', "#{CREW_DEST_PREFIX}/share/Qt-5"
+    FileUtils.cp_r 'src', "#{CREW_DEST_PREFIX}/share/Qt-5"
   end
 end

--- a/packages/rtaudio.rb
+++ b/packages/rtaudio.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Rtaudio < Package
+  description 'RtAudio is a set of C++ classes that provide a common API (Application Programming Interface) for realtime audio input/output'
+  homepage 'http://www.music.mcgill.ca/~gary/rtaudio/'
+  version '5.1.0'
+  source_url 'http://www.music.mcgill.ca/~gary/rtaudio/release/rtaudio-5.1.0.tar.gz'
+  source_sha256 'ff138b2b6ed2b700b04b406be718df213052d4c952190280cf4e2fab4b61fe09'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rtaudio-5.1.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rtaudio-5.1.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rtaudio-5.1.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rtaudio-5.1.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '41cb81dbff61759c229705a92299c6e53329c8958d4d6381ea9d450750896e5d',
+     armv7l: '41cb81dbff61759c229705a92299c6e53329c8958d4d6381ea9d450750896e5d',
+       i686: '2ac3063104abbe1c0bfe2e38a437dfddb506b2e2ef40f3707606a5a899492c06',
+     x86_64: '78bd93817203d87bfe03d8d203b8f0ac792339b5214b08bc1ccbcc842499793b',
+  })
+
+  depends_on 'alsa_lib'
+  depends_on 'jack'
+  depends_on 'pulseaudio'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-maintainer-mode',
+           '--with-alsa',
+           '--with-jack',
+           '--with-pulse'
+    system 'make'
+  end
+
+  #def self.check
+  #  system 'make', 'check'
+  #end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/rubberband.rb
+++ b/packages/rubberband.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Rubberband < Package
+  description 'Rubber Band Library is a high quality software library for audio time-stretching and pitch-shifting.'
+  homepage 'https://breakfastquay.com/rubberband/'
+  version '1.8.2'
+  source_url 'https://breakfastquay.com/files/releases/rubberband-1.8.2.tar.bz2'
+  source_sha256 '86bed06b7115b64441d32ae53634fcc0539a50b9b648ef87443f936782f6c3ca'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rubberband-1.8.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rubberband-1.8.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rubberband-1.8.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rubberband-1.8.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'b684aa86b3ef03b2be91f518c5b88d536d9d3152eeab5670fd7117186742be8b',
+     armv7l: 'b684aa86b3ef03b2be91f518c5b88d536d9d3152eeab5670fd7117186742be8b',
+       i686: 'deb5b36f7b7b2da1390baf2330b533ab82598a46eeb7073d9f334cb905d006f8',
+     x86_64: '909761fb62e174eaf6b788afc0c1390a38083d7ac7571260f1e294b560dffdbf',
+  })
+
+  depends_on 'ladspa'
+  depends_on 'libsamplerate'
+  depends_on 'vamp_sdk'
+
+  def self.build
+    ENV['JAVA_HOME'] = "#{CREW_PREFIX}/share/jdk8"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    # Remove missing librubberband-jni.so.
+    system "sed -i '186d' Makefile"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    if ARCH == 'x86_64'
+      Dir.chdir "#{CREW_DEST_PREFIX}" do
+        FileUtils.mv 'lib/', 'lib64/'
+      end
+    end
+  end
+end

--- a/packages/setuptools.rb
+++ b/packages/setuptools.rb
@@ -3,21 +3,21 @@ require 'package'
 class Setuptools < Package
   description 'Easily download, build, install, upgrade, and uninstall Python packages'
   homepage 'https://pypi.org/project/setuptools/'
-  version '41.6.0'
-  source_url 'https://github.com/pypa/setuptools/archive/v41.6.0.tar.gz'
-  source_sha256 '1b91aa309ffa43656774984557d62fae1fded0491a16ba8084b21c92cd5ad093'
+  version '46.1.3'
+  source_url 'https://github.com/pypa/setuptools/archive/v46.1.3.tar.gz'
+  source_sha256 '984eeb7909fa610a441711c00dc4fa5bbf3c49f9b4b5204b56b7362bdd04f397'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/setuptools-41.6.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/setuptools-41.6.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/setuptools-41.6.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/setuptools-41.6.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/setuptools-46.1.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/setuptools-46.1.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/setuptools-46.1.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/setuptools-46.1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '367299e31ea2f88d4f93d5f1cf2cf374d3bc971f67a5b9306376ff8fdb35589b',
-     armv7l: '367299e31ea2f88d4f93d5f1cf2cf374d3bc971f67a5b9306376ff8fdb35589b',
-       i686: '27b624776104aafcd5905616b23b7eaf09a144e617be164a36d410f0e2e99d03',
-     x86_64: '0d8ab47acdfc8a951166b34ff696a1b62f630dc93146f8f8b3f6a79a466e0281',
+    aarch64: '480fa13c1f2ef97d31e08ec9da385f71034a878ec6a19ccfa7ef4fc776a12142',
+     armv7l: '480fa13c1f2ef97d31e08ec9da385f71034a878ec6a19ccfa7ef4fc776a12142',
+       i686: '758a37bddd867c069f237a6d70e56377e088391f1a75e1d81a230838aa5cd242',
+     x86_64: '58f237baeb6e5de572d63a357d8b5c92288112db572f619bb40713319692a94c',
   })
 
   depends_on 'python27'

--- a/packages/siege.rb
+++ b/packages/siege.rb
@@ -3,38 +3,32 @@ require 'package'
 class Siege < Package
   description 'Siege is an http load testing and benchmarking utility.'
   homepage 'https://www.joedog.org/siege-home/'
-  version '4.0.4'
-  source_url 'http://download.joedog.org/siege/siege-4.0.4.tar.gz'
-  source_sha256 '8f7dcf18bd722bb9cc92bc3ea4b59836b4a2f8d8f01d4a94c8d181f56d91ea6f'
+  version '4.0.5'
+  source_url 'http://download.joedog.org/siege/siege-4.0.5.tar.gz'
+  source_sha256 '3b4b7001afa4d80f3f4939066a4932e198e9f949dcc0e3affecbedd922800231'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/siege-4.0.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/siege-4.0.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/siege-4.0.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/siege-4.0.4-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/siege-4.0.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/siege-4.0.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/siege-4.0.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/siege-4.0.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '626dab09c5fe3682c416e379c3f3e3115f46658a0b1094786a3932afcc3286df',
-     armv7l: '626dab09c5fe3682c416e379c3f3e3115f46658a0b1094786a3932afcc3286df',
-       i686: '35b04a8f7c6a5fa298f617c9f6a3a1f387a0b2580504e493b6001a5bce96a6ef',
-     x86_64: '3b56b8491da7d50beaa5b8cad9c481c99fabe8e7f04368a93025af8fd0619e8f',
+    aarch64: 'bdebecd0f52474101942d8f0d993389b1ed3f6aa32d9c3c5a9ffd8ed719814a3',
+     armv7l: 'bdebecd0f52474101942d8f0d993389b1ed3f6aa32d9c3c5a9ffd8ed719814a3',
+       i686: '152e9eaff55b5cf304aa34a3eb3f4a17a2918a84f1e224c34713cde9334c1f99',
+     x86_64: 'b2bb5b875c5e4e7acec1d7c3a3e5e111751ca3ba6a9098be18c0bce295e240b6',
   })
 
-  depends_on 'compressdoc' => :build
-  depends_on 'diffutils' => :build
-  depends_on 'openssl'
-  depends_on 'perl'
-  depends_on 'zlibpkg'
-
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "./configure \
+           --prefix=#{CREW_PREFIX} \
+           --libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man1"
   end
 end

--- a/packages/six.rb
+++ b/packages/six.rb
@@ -3,21 +3,21 @@ require 'package'
 class Six < Package
   description 'Six is a Python 2 and 3 compatibility library.'
   homepage 'https://github.com/benjaminp/six'
-  version '1.12.0'
-  source_url 'https://github.com/benjaminp/six/archive/1.12.0.tar.gz'
-  source_sha256 '0ce7aef70d066b8dda6425c670d00c25579c3daad8108b3e3d41bef26003c852'
+  version '1.14.0'
+  source_url 'https://github.com/benjaminp/six/archive/1.14.0.tar.gz'
+  source_sha256 '6efff7289d1d369f0a25180433aba83ec2584e489e90f115b52ba69e4816cfb4'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.12.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.12.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.12.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.12.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.14.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.14.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.14.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/six-1.14.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'ba69ece2f777f5c2d7446f8f40c075e03ec4cfde838bd88cb7a7af5ecc77102e',
-     armv7l: 'ba69ece2f777f5c2d7446f8f40c075e03ec4cfde838bd88cb7a7af5ecc77102e',
-       i686: '7bc2e16af9e81fe89fda678fd770808fcd022f62dc9719a515b6dfaa54d93f55',
-     x86_64: '206dea928935e759ef3f37193595b32e1e2eef16f4be877ec41fe50cb6c67d2a',
+    aarch64: '194646b4fb1a0ed11492d21a45bc09d91ab7da78cbc8a6ad2f0c3ebe723692ba',
+     armv7l: '194646b4fb1a0ed11492d21a45bc09d91ab7da78cbc8a6ad2f0c3ebe723692ba',
+       i686: '51c17725b9925874af0fa7bcd86afbc930b5023ab353efb3754c69d7e7d52d4c',
+     x86_64: '649ca8a551af2fd558bc889cfa0df05ff2e2b853ea76786b61d5d8a765adcd02',
   })
 
   depends_on 'python3'

--- a/packages/skype.rb
+++ b/packages/skype.rb
@@ -3,7 +3,7 @@ require 'package'
 class Skype < Package
   description 'Skype is a telecommunications application that specializes in providing video chat and voice calls between devices'
   homepage 'https://www.skype.com/en/'
-  version '8.55.0.141'
+  version '8.56.0.103'
   case ARCH
   when 'x86_64'
     source_url 'file:///dev/null'
@@ -11,10 +11,10 @@ class Skype < Package
   end
 
   binary_url ({
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/skype-8.55.0.141-chromeos-x86_64.tar.xz'
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/skype-8.56.0.103-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    x86_64: '2d86530386eee57efd8a83848171d84cfefe9d1f31ebed133c699d25f074eef9'
+    x86_64: '1670a0c74ac08b224034aefbd27f3d03b89529e7168dc84ac095944a1aa93736',
   })
 
   depends_on 'alien' => :build
@@ -23,9 +23,9 @@ class Skype < Package
 
   def self.build
     system 'wget https://go.skype.com/skypeforlinux-64.deb'
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('skypeforlinux-64.deb') ) == '3ae2915428c94fccd7b86ee9e347812e0fd8d70c2883bb75865156e16ceecb79'
-    system 'alien -t -c skypeforlinux-64.deb'
-    system 'tar xvf skypeforlinux-8.55.0.141.tgz'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('skypeforlinux-64.deb') ) == '20b1b1b85c76cac9d224dccf5748cf21f954fe1a36c98fd5a7aa13d8448a1e07'
+    system 'alien -tc skypeforlinux-64.deb'
+    system "tar xvf skypeforlinux-#{version}.tgz"
   end
 
   def self.install

--- a/packages/smemstat.rb
+++ b/packages/smemstat.rb
@@ -3,21 +3,21 @@ require 'package'
 class Smemstat < Package
   description 'Smemstat reports the physical memory usage taking into consideration shared memory.'
   homepage 'http://kernel.ubuntu.com/~cking/smemstat/'
-  version '0.02.04'
-  source_url 'https://kernel.ubuntu.com/~cking/tarballs/smemstat/smemstat-0.02.04.tar.xz'
-  source_sha256 '108c2d76da762c9d8c50d87b3a58f3b4e44858dd8961a1f2681faa37aca56dce'
+  version '0.02.07'
+  source_url 'https://kernel.ubuntu.com/~cking/tarballs/smemstat/smemstat-0.02.07.tar.xz'
+  source_sha256 'acc17fdd6da92571e73a58bf1512b398cb307b80f46dc196cbb8102e7fb02526'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.04-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.04-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.04-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.04-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.07-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.07-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.07-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.07-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'a180f274a3ca85169e81d1b41293459258ad82d2e1e23c562bb45afd56cb1c3c',
-     armv7l: 'a180f274a3ca85169e81d1b41293459258ad82d2e1e23c562bb45afd56cb1c3c',
-       i686: '9be911ef92621d73cfa3ed6f9794d2deb2a9fb38db9116fcc6eb7d2990922ede',
-     x86_64: '0190150afb6f00f1fafa599056673f00b8a4a838c220fd2ba7a50a488337d549',
+    aarch64: '80549cd181fd79bd9c58462ea5e9b87d5f0c0657093a892803ae3db77980b7cb',
+     armv7l: '80549cd181fd79bd9c58462ea5e9b87d5f0c0657093a892803ae3db77980b7cb',
+       i686: 'b015b51fa07cbaeb7f3f2ae2abcef9a8c425a3f52a3c87c9ad51a4477c5fcf92',
+     x86_64: '80884214345553902dd3bef26011b1381c6f16382df34bbd473ee506ddf81e83',
   })
 
   depends_on 'ncurses'
@@ -25,10 +25,10 @@ class Smemstat < Package
   def self.build
     system "sed -i 's,/usr,#{CREW_PREFIX},g' Makefile"
     system "sed -i '/^CFLAGS += -Wall/s/$/ -I\\/usr\\/local\\/include\\/ncurses/' Makefile"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/sngrep.rb
+++ b/packages/sngrep.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Sngrep < Package
+  description 'An Ncurses SIP Messages flow viewer'
+  homepage 'https://github.com/irontec/sngrep'
+  version '1.4.6-1'
+  source_url 'https://github.com/irontec/sngrep/archive/v1.4.6.tar.gz'
+  source_sha256 '638d6557dc68db401b07d73b2e7f8276800281f021fe0c942992566d6b59a48a'
+
+  depends_on 'libpcap'
+  depends_on 'pcre'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sngrep-1.4.6-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sngrep-1.4.6-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sngrep-1.4.6-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sngrep-1.4.6-1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '09a6ad001c63ce4ac435c148e5bb6df64908b3e06f95520e268510aa89f8c13f',
+     armv7l: '09a6ad001c63ce4ac435c148e5bb6df64908b3e06f95520e268510aa89f8c13f',
+       i686: '9791803d412c9b0f3b25da9fc5c80483aa18262c6411f2eb1b7e636c1ca4c585',
+     x86_64: 'd370d8913abea954dc6420e2dae3d83373917e26935f58c66c38c59809fa275f',
+  })
+
+  def self.build
+    system './bootstrap.sh'
+    system "./configure CPPFLAGS='-I#{CREW_PREFIX}/include/ncursesw -I#{CREW_PREFIX}/include/pcap' \
+          --prefix=#{CREW_PREFIX} \
+          --libdir=#{CREW_LIB_PREFIX} \
+          --with-openssl \
+          --with-pcre \
+          --disable-logo \
+          --enable-ipv6"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/sphinx.rb
+++ b/packages/sphinx.rb
@@ -3,21 +3,21 @@ require 'package'
 class Sphinx < Package
   description 'Sphinx is a tool that makes it easy to create intelligent and beautiful documentation'
   homepage 'http://www.sphinx-doc.org/en/master/'
-  version '1.8.1'
-  source_url 'https://github.com/sphinx-doc/sphinx/archive/v1.8.1.tar.gz'
-  source_sha256 '3ca0ff96399444078bef0185f45a8a587d0b306d1348a1b071c838d846a3c25d'
+  version '2.4.4'
+  source_url 'https://github.com/sphinx-doc/sphinx/archive/v2.4.4.tar.gz'
+  source_sha256 '1b011dd7e965a87e93766dc64aaee2f08f800cb32a412b5bd2582b7e5660000c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sphinx-1.8.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sphinx-1.8.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sphinx-1.8.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sphinx-1.8.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sphinx-2.4.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sphinx-2.4.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sphinx-2.4.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sphinx-2.4.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '05b209fd2f9d5d478cb83d3998ab439fb1a0fa653f7e94bdd2a533774a54d3ea',
-     armv7l: '05b209fd2f9d5d478cb83d3998ab439fb1a0fa653f7e94bdd2a533774a54d3ea',
-       i686: 'b29c110624a4ca74c13752b83a817094b3994c1bfeae57375b6a4f798b145cdf',
-     x86_64: 'c6021656491f639e064ed18c760f68fe094946a47e46d1a52b6bb0da98ae94f7',
+    aarch64: '26e8b7a5c27b2abe254db5f627fd3f303fdcd1513588c56dff945f9b8da228dc',
+     armv7l: '26e8b7a5c27b2abe254db5f627fd3f303fdcd1513588c56dff945f9b8da228dc',
+       i686: '62e2224234224e05655cfdd622fd5f08181143f765e11dde3cf437321bc05023',
+     x86_64: '316a1e63f356c4396083b005367e89f8f2e33275820518d3c5fe5ea03471cdec',
   })
 
   depends_on 'setuptools'
@@ -25,7 +25,7 @@ class Sphinx < Package
   def self.install
     system 'git clone https://github.com/sphinx-doc/sphinx.git build'
     Dir.chdir 'build' do
-      system 'git checkout v1.8.1'
+      system 'git checkout v2.4.4'
       system "pip install . --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
     end
   end

--- a/packages/sqlmap.rb
+++ b/packages/sqlmap.rb
@@ -3,24 +3,24 @@ require 'package'
 class Sqlmap < Package
   description 'sqlmap is an open source penetration testing tool that automates the process of detecting and exploiting SQL injection flaws and taking over of database servers.'
   homepage 'http://sqlmap.org/'
-  version '1.2'
-  source_url 'https://github.com/sqlmapproject/sqlmap/archive/1.2.tar.gz'
-  source_sha256 '39e0ef58365a5a0413d88dfcc0d1c210b465661cb97c8e5b42c1feba791d2453'
+  version '1.4.2'
+  source_url 'https://github.com/sqlmapproject/sqlmap/archive/1.4.2.tar.gz'
+  source_sha256 '77faf85164eb17dce769ec830cbd146768644315bc1024613ad13155e09c2d11'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlmap-1.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sqlmap-1.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sqlmap-1.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlmap-1.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlmap-1.4.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sqlmap-1.4.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sqlmap-1.4.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlmap-1.4.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '973af18d7883218b102c9f2d0c87b9a393951eb7a0935ce2de495221311b8c57',
-     armv7l: '973af18d7883218b102c9f2d0c87b9a393951eb7a0935ce2de495221311b8c57',
-       i686: 'b924ba5594a1b6c35a023446499c4b4775d17baacbbdab990a34f58da50817d1',
-     x86_64: 'a4bf8317eb465acdf4bc743d6fddc838b16de909144cfa5706f6fbc45d942e7e',
+    aarch64: '02a1b56739af28c5c2dbd920f69c630e7e1ffafc043387b06534c9586886f5f7',
+     armv7l: '02a1b56739af28c5c2dbd920f69c630e7e1ffafc043387b06534c9586886f5f7',
+       i686: '0fbff386670b5ef09f12d3b3e3478d203f4f1140d529b039be36d7123399497e',
+     x86_64: '886d073baae73b24d03dfdc8c7d09dff3de47eda9229794caed5a1915b25c588',
   })
 
-  depends_on 'python27' unless File.exists? "#{CREW_PREFIX}/bin/python"
+  depends_on 'python27' unless File.exist? "#{CREW_PREFIX}/bin/python"
 
   def self.build
     system "echo '#!/bin/bash' > sqlmap"

--- a/packages/swig.rb
+++ b/packages/swig.rb
@@ -3,21 +3,21 @@ require 'package'
 class Swig < Package
   description 'Simplified Wrapper and Interface Generator'
   homepage 'http://www.swig.org'
-  version '3.0.12'
-  source_url 'http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz'
-  source_sha256 '7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d'
+  version '4.0.1'
+  source_url 'http://prdownloads.sourceforge.net/swig/swig-4.0.1.tar.gz'
+  source_sha256 '7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/swig-3.0.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/swig-3.0.12-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/swig-3.0.12-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/swig-3.0.12-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/swig-4.0.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/swig-4.0.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/swig-4.0.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/swig-4.0.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'e01ff7b79ecee04da5ab1e36ddbffb016d570d78c91187f6a9b4c000c615a541',
-     armv7l: 'e01ff7b79ecee04da5ab1e36ddbffb016d570d78c91187f6a9b4c000c615a541',
-       i686: '88e6f649ef905cf852ab4a51594f1497c0b2be93f4a5c9ef737ee2a2376f489d',
-     x86_64: '1ada3fd45ea500a386c1ed491b0520ceb0a822f151d70fe0019446f0b05cc8e8',
+    aarch64: 'bfcc6357fed1a729192a5f94fcb0a42ce9a391c71e973a5c71663bcec5758409',
+     armv7l: 'bfcc6357fed1a729192a5f94fcb0a42ce9a391c71e973a5c71663bcec5758409',
+       i686: 'd6f872741b8f4c6fb572db6d4e62a4259c43d7de5c3b879db20db4f9799a5d19',
+     x86_64: '55ba83675fb3106cb101f487d5d758c845d8cea922abaec52307f5f261fea1b5',
   })
 
   depends_on 'pcre'

--- a/packages/symfony.rb
+++ b/packages/symfony.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Symfony < Package
+  description 'Symfony is a set of PHP Components, a Web Application framework'
+  homepage 'https://symfony.com/'
+  version '4.13.3'
+  source_url 'file:///dev/null'
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+  depends_on 'php74' unless File.exist? "#{CREW_PREFIX}/bin/php"
+
+  def self.install
+    case ARCH
+    when 'aarch64', 'armv7l'
+      arch = 'arm'
+      sha256 = '7fed4138ee75f6b68e034760acd3ad9e0b95a41ab052a8454148891d8389670d'
+    when 'i686'
+      arch = '386'
+      sha256 = 'acafc620d486b7aff8d21adff32655c6b4db7f74f46248d0830ce5b93d324dbc'
+    when 'x86_64'
+      arch = 'amd64'
+      sha256 = '63a86004121244dc2ae1cef86ffe16c80e272c2b2f99397b9222390eb85426a2'
+    end
+    system "wget https://github.com/symfony/cli/releases/download/v#{version}/symfony_linux_#{arch}"
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("symfony_linux_#{arch}") ) == sha256
+    system "install -Dm755 symfony_linux_#{arch} #{CREW_DEST_PREFIX}/bin/symfony"
+  end
+
+  def self.postinstall
+    puts
+    puts 'Installing shell auto-completion...'.lightblue
+    system 'symfony self:shell-setup --silent'
+    puts
+  end
+end

--- a/packages/tcl.rb
+++ b/packages/tcl.rb
@@ -3,29 +3,37 @@ require 'package'
 class Tcl < Package
   description 'Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language, suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more.'
   homepage 'http://www.tcl.tk/'
-  version '8.6.9'
-  source_url 'https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz'
-  source_sha256 'ad0cd2de2c87b9ba8086b43957a0de3eb2eb565c7159d5f53ccbba3feb915f4e'
+  version '8.6.10'
+  source_url 'https://downloads.sourceforge.net/project/tcl/Tcl/8.6.10/tcl8.6.10-src.tar.gz'
+  source_sha256 '5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.9-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f798b7dd415d295724f0000d16a585b059b38813f49407c8f50c4eb51b59f537',
-     armv7l: 'f798b7dd415d295724f0000d16a585b059b38813f49407c8f50c4eb51b59f537',
-       i686: '7b8bc63aa6500c5c3f0e8f9231122bf6634261b1c28fac2328503e44290f685f',
-     x86_64: 'd452c8fd5a7907bede90d2d5d32d9483fa6ef34b87b9d1544fa769c0ae7890f6',
+    aarch64: '5591a9de473cfbb6102772d0ea4751ea65bf4d069573fc17f35b5e797a7db93c',
+     armv7l: '5591a9de473cfbb6102772d0ea4751ea65bf4d069573fc17f35b5e797a7db93c',
+       i686: '7dce88880df2dc338d5e2af96537f3ae031aae42865590a896de75b1704fb3aa',
+     x86_64: 'b841d095d897d29c491b98660957748af3216942e5bae44ec59a43c24bb608bf',
   })
 
   def self.build
     FileUtils.chdir('unix') do
       if ARCH == 'x86_64'
-        system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --enable-64bit"
+        system './configure',
+               "--prefix=#{CREW_PREFIX}",
+               "--libdir=#{CREW_LIB_PREFIX}",
+               "--mandir=#{CREW_PREFIX}/share/man",
+               '--enable-64bit'
       else
-        system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --disable-64bit"
+        system './configure',
+               "--prefix=#{CREW_PREFIX}",
+               "--libdir=#{CREW_LIB_PREFIX}",
+               "--mandir=#{CREW_PREFIX}/share/man",
+               '--disable-64bit'
       end
       system 'make'
     end
@@ -33,8 +41,9 @@ class Tcl < Package
 
   def self.install
     FileUtils.chdir('unix') do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-private-headers"
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-private-headers'
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/tclsh8.6", "#{CREW_DEST_PREFIX}/bin/tclsh"
     end
   end
 end

--- a/packages/terminus.rb
+++ b/packages/terminus.rb
@@ -1,0 +1,17 @@
+require 'package'
+
+class Terminus < Package
+  description 'The Pantheon CLI — a standalone utility for performing operations on the Pantheon Platform'
+  homepage 'https://github.com/pantheon-systems/terminus'
+  version '2.3.0'
+  source_url 'https://raw.githubusercontent.com/pantheon-systems/terminus/2.3.0/README.md'
+  source_sha256 '52e99c6db48987b1533d7c820ce77e27f416950347964885210bca7d2ac83c19'
+
+  depends_on 'php' unless File.exists? "#{CREW_PREFIX}/bin/php"
+
+  def self.install
+    system "wget https://github.com/pantheon-systems/terminus/releases/download/#{version}/terminus.phar"
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('terminus.phar') ) == 'fda289eb438f1b2a899b17879497d531c5234011e183d09953c8e54a795c6bca'
+    system "install -Dm755 terminus.phar #{CREW_DEST_PREFIX}/bin/terminus"
+  end
+end

--- a/packages/testdisk.rb
+++ b/packages/testdisk.rb
@@ -3,36 +3,35 @@ require 'package'
 class Testdisk < Package
   description 'TestDisk is powerful free data recovery software!'
   homepage 'https://www.cgsecurity.org/wiki/TestDisk'
-  version '7.1'
-  source_url 'https://www.cgsecurity.org/testdisk-7.1-WIP.tar.bz2'
-  source_sha256 '910d597b07e1da96aa73189a6f3121e38cb5bef857036d481ceaae7900da7429'
+  version '7.2'
+  source_url 'https://www.cgsecurity.org/testdisk-7.2-WIP.tar.bz2'
+  source_sha256 'c95dd532dad353713e8ca895a3faac31acef284f9f0fad299f69181fec583313'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'bbad6e298493e44ecea59ed07081c284d9533006fb68f16869f28bdcc2bb4dea',
-     armv7l: 'bbad6e298493e44ecea59ed07081c284d9533006fb68f16869f28bdcc2bb4dea',
-       i686: 'a80c70f716b4d227c8d283abbc6b73e375c5818a04e9b1b79c18c9508bc17e0e',
-     x86_64: '852cf726e057917fc7056c7828db350ba4ee79df4ed2e0423885a1781e52e206',
+    aarch64: 'd1d42ff50e0792de2c5ddaec3abcb5de9e7057a3d7f63f883cdf283d336850ce',
+     armv7l: 'd1d42ff50e0792de2c5ddaec3abcb5de9e7057a3d7f63f883cdf283d336850ce',
+       i686: 'a3da5c747e406e52ed72d119ba4c308e6465c85b594cf21be9e9e63151551bc7',
+     x86_64: '8b5a399c8e43c821156eb632805fe94f0d6f81e99aaffbeb2e54f54e3a887c77',
   })
 
-  depends_on 'compressdoc' => :build
-  depends_on 'ncurses'
   depends_on 'apriconv'
-  depends_on 'libjpeg'
+  depends_on 'compressdoc' => :build
+  depends_on 'libjpeg_turbo'
+  depends_on 'ncurses'
   depends_on 'zlibpkg'
 
   def self.build
     system "./configure --prefix=#{CREW_PREFIX}"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man8"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/tk.rb
+++ b/packages/tk.rb
@@ -3,21 +3,21 @@ require 'package'
 class Tk < Package
   description 'Tk is a graphical user interface toolkit that takes developing desktop applications to a higher level than conventional approaches.'
   homepage 'http://www.tcl.tk/'
-  version '8.6.9'
-  source_url 'https://downloads.sourceforge.net/tcl/tk8.6.9-src.tar.gz'
-  source_sha256 'd3f9161e8ba0f107fe8d4df1f6d3a14c30cc3512dfc12a795daa367a27660dac'
+  version '8.6.10'
+  source_url 'https://downloads.sourceforge.net/project/tcl/Tcl/8.6.10/tk8.6.10-src.tar.gz'
+  source_sha256 '63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.9-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '79f0e0905a1809f177b9ab3048168acb45491b58e9460ec1254f307397239b67',
-     armv7l: '79f0e0905a1809f177b9ab3048168acb45491b58e9460ec1254f307397239b67',
-       i686: '18708ac8f18cde32ef3787ec7a3ce1721a1243dbfb73b231b3b71995afe4d0de',
-     x86_64: 'd6e901e0e1f86d87d4f97e88a73380e98fdf73bdec4c27832c4f3feb6af953a9',
+    aarch64: '6d785178ad707132d9afdec648b992717d48690497da95d3969629b208e38f96',
+     armv7l: '6d785178ad707132d9afdec648b992717d48690497da95d3969629b208e38f96',
+       i686: '3ec13ce5720f008c8075fa8a6965b4a764f0993d9dadda2aa9268af2a563c400',
+     x86_64: 'd75b2657048e3f258826eb8ff1d9d4924021fe7869c41a6ac618a2df7df281ca',
   })
 
   depends_on 'xorg_lib'
@@ -48,7 +48,7 @@ class Tk < Package
 
   def self.install
     FileUtils.chdir('unix') do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
       FileUtils.ln_s "#{CREW_PREFIX}/bin/wish8.6", "#{CREW_DEST_PREFIX}/bin/wish"
     end
   end

--- a/packages/usbutils.rb
+++ b/packages/usbutils.rb
@@ -3,33 +3,44 @@ require 'package'
 class Usbutils < Package
   description 'Tools for examining usb devices'
   homepage 'http://linux-usb.sourceforge.net/'
-  version '009'
-  source_url 'https://www.kernel.org/pub/linux/utils/usb/usbutils/usbutils-009.tar.xz'
-  source_sha256 '8bbff0e54cb5f65a52be4feb9162fc0b022a97eb841b44784f7a89a9ea567160'
+  version '012'
+  source_url 'https://www.kernel.org/pub/linux/utils/usb/usbutils/usbutils-012.tar.xz'
+  source_sha256 '88634625f91840bc1993d2731cc081ee8d3b13d56069a95bdd6ac6ef0e063e46'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/usbutils-009-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/usbutils-009-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/usbutils-009-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/usbutils-009-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/usbutils-012-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/usbutils-012-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/usbutils-012-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/usbutils-012-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'de1120c77d3eca02c747435242a8c32c77fb365443a26ca08564f6f34ba2f431',
-     armv7l: 'de1120c77d3eca02c747435242a8c32c77fb365443a26ca08564f6f34ba2f431',
-       i686: 'c4a9a950367e2d5dedb4b71526a4b8f15e534e7c573d85bc909ded3d1e490d0f',
-     x86_64: '8d39c72db131b97b256ef91fc5360479abef2f0be17e785625476d58b8a6aa89',
+    aarch64: '84309375b4d635563a2bdc47e55c5a95841d18a937fcb3af646b51f5e1af5b53',
+     armv7l: '84309375b4d635563a2bdc47e55c5a95841d18a937fcb3af646b51f5e1af5b53',
+       i686: 'a174fbc8d94512af2591505a790226ec4230ea2236afe06f1ed119a33982b7c9',
+     x86_64: '483f60e4d8dd5f44a2fabe7840e560c1d5eb67ae4eddca08f209dc8b30b9d4bc',
   })
 
   depends_on 'libusb'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system './autogen.sh'
+    system "./configure \
+      --prefix=#{CREW_PREFIX} \
+      --libdir=#{CREW_LIB_PREFIX}"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.postinstall
+    FileUtils.mkdir_p "#{CREW_PREFIX}/share/hwdata/" unless Dir.exist? "#{CREW_PREFIX}/share/hwdata/"
+    system "wget http://www.linux-usb.org/usb.ids -O #{CREW_PREFIX}/share/hwdata/usb.ids"
+    puts "It's recommended that you setup a cron job to update this file regularly.".lightblue
+    puts 'You can install a cron package by executing `crew install cronie`'.lightblue
+    puts
+    puts 'Add a cron job with something like the following:' .lightblue
+    puts '# Update usb.ids at 6pm daily.'.lightblue
+    puts '0 18 * * * /usr/local/bin/crew postinstall usbutils >/dev/null 2>&1'.lightblue
   end
 end

--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -3,21 +3,21 @@ require 'package'
 class Util_linux < Package
   description 'essential linux tools'
   homepage 'https://www.kernel.org/pub/linux/utils/util-linux/'
-  version '2.34'
-  source_url 'https://kernel.org/pub/linux/utils/util-linux/v2.34/util-linux-2.34.tar.xz'
-  source_sha256 '743f9d0c7252b6db246b659c1e1ce0bd45d8d4508b4dfa427bbb4a3e9b9f62b5'
+  version '2.35.1'
+  source_url 'https://kernel.org/pub/linux/utils/util-linux/v2.35/util-linux-2.35.1.tar.xz'
+  source_sha256 'd9de3edd287366cd908e77677514b9387b22bc7b88f45b83e1922c3597f1d7f9'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.34-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.34-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.34-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.34-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.35.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.35.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.35.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.35.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '806848160db052933921a25eebb0772ff258f5e87ac58b3d932fce0a5acada82',
-     armv7l: '806848160db052933921a25eebb0772ff258f5e87ac58b3d932fce0a5acada82',
-       i686: 'f900818913f0a3f0396db7713ad99093af6fea2fd5a4d3e3131ac2ed60e845cd',
-     x86_64: 'f3bbcda8e4c87a20fc3fb6f12766af439bd30f931bd6e2a3f450cbdbed3bc084',
+    aarch64: 'ff43f032e650b280007e5717cda2fee20dca97ff731b6e4168ceeea251f93281',
+     armv7l: 'ff43f032e650b280007e5717cda2fee20dca97ff731b6e4168ceeea251f93281',
+       i686: 'e39aa402ff8679b68b761c4f41554f2e9cdcd688bd6b23f40c5bc54a26c1e864',
+     x86_64: '7b4ab11425c7e70d4addf48a71048fcd89197899cae254ee4e6cdbdccc93eed1',
   })
 
   depends_on 'python27'

--- a/packages/v4l_utils.rb
+++ b/packages/v4l_utils.rb
@@ -3,21 +3,21 @@ require 'package'
 class V4l_utils < Package
   description 'The v4l-utils are a series of packages for handling media devices.'
   homepage 'https://www.linuxtv.org/wiki/index.php/V4l-utils'
-  version '1.16.3'
-  source_url 'https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.16.3.tar.bz2'
-  source_sha256 '7c5c0d49c130cf65d384f28e9f3a53c5f7d17bf18740c48c40810e0fbbed5b54'
+  version '1.18.0'
+  source_url 'https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.18.0.tar.bz2'
+  source_sha256 '6cb60d822eeed20486a03cc23e0fc65956fbc1e85e0c1a7477f68bbd9802880d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.16.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.16.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.16.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.16.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.18.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.18.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.18.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.18.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'c73a40d699272e3526c6e949953f2cd910b67ec4641c2ed17a97945e35c7c6ae',
-     armv7l: 'c73a40d699272e3526c6e949953f2cd910b67ec4641c2ed17a97945e35c7c6ae',
-       i686: '261ccca7ffd43a12b4085f68ce5f223574bf7300f5f01960bfeb76f12c4fc59b',
-     x86_64: 'dc893b16e6fd881d6199b0bf0e6febae1ac36a48b775e0e1e159f07274dd1d14',
+    aarch64: 'baf11b08999b753b4b874b5fd5eebecb85f78679f0912350bffc8a27c558dc08',
+     armv7l: 'baf11b08999b753b4b874b5fd5eebecb85f78679f0912350bffc8a27c558dc08',
+       i686: '8c12cad6c323d2448c6dcb9b8c68c6b1c5aea6889c1c99fdbeea616529e8d38a',
+     x86_64: '17414e347092d411b24c3caa5f306f881996b639435c82d1a7aac9d693aa64d2',
   })
 
   depends_on 'sdl2_image'
@@ -30,7 +30,7 @@ class V4l_utils < Package
   end
 
   def self.build
-    puts "Forcing GOLD linker to be used.".orange
+    puts 'Switch to the gold linker.'.orange
     original_default = `ld_default g`.chomp
     system "./configure",
            "--disable-bpf",

--- a/packages/vamp_sdk.rb
+++ b/packages/vamp_sdk.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Vamp_sdk < Package
+  description 'Vamp is an audio processing plugin system for plugins that extract descriptive information from audio data — typically referred to as audio analysis plugins or audio feature extraction plugins.'
+  homepage 'https://vamp-plugins.org/'
+  version '2.9.0'
+  source_url 'https://code.soundsoftware.ac.uk/attachments/download/2588/vamp-plugin-sdk-2.9.0.tar.gz'
+  source_sha256 'b72a78ef8ff8a927dc2ed7e66ecf4c62d23268a5d74d02da25be2b8d00341099'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vamp_sdk-2.9.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vamp_sdk-2.9.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vamp_sdk-2.9.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vamp_sdk-2.9.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fc53ab7e53a476611498b38139aaa3be69b39efe097ff97b5633b53d0883981c',
+     armv7l: 'fc53ab7e53a476611498b38139aaa3be69b39efe097ff97b5633b53d0883981c',
+       i686: 'd376a24518bb74e53f5c1556cd570b1e7e910e6679f8b87b1e3b0778e924d724',
+     x86_64: 'cf7ca4db41a96a12eeb89c658153e4641101d10740dd4c89a6d3a66f289d2b5b',
+  })
+
+  depends_on 'libsndfile'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    if ARCH == 'x86_64'
+      Dir.chdir "#{CREW_DEST_PREFIX}" do
+        FileUtils.mv 'lib/', 'lib64/'
+      end
+    end
+  end
+end

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -3,9 +3,9 @@ require 'package'
 class Vim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.'
   homepage 'http://www.vim.org/'
-  version '8.2.0014'
-  source_url 'https://github.com/vim/vim/archive/v8.2.0014.tar.gz'
-  source_sha256 '5e433abdebf36855bcec38b4e195a1281d04309b72523a265a21288717061845'
+  version '8.2.0346'
+  source_url 'https://github.com/vim/vim/archive/v8.2.0346.tar.gz'
+  source_sha256 '418d1cbc9f53f31cb19869b6df0294ca5c377ca2824c759e3f6796edc60e5628'
 
   if ARGV[0] == 'install'
     gvim = `which gvim 2> /dev/null`.chomp
@@ -13,16 +13,16 @@ class Vim < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.0014-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.0014-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.0014-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.0014-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.0346-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.0346-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.0346-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.0346-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '23e46b4456fcf8af514dd4b014db36812f041498531ab10b7cd7595b4987922b',
-     armv7l: '23e46b4456fcf8af514dd4b014db36812f041498531ab10b7cd7595b4987922b',
-       i686: '8771da6eb9bca4ed4440cd4a4318bf93ee426034e8ffe733ff56fcefb401e8f6',
-     x86_64: 'bbc47db5a8b8fb98c4e7430ab7d32598f827ddb12f6d378fbc7d745a8447ebc7',
+    aarch64: '0f362bab2d9dd493eb2acfdd8980e2baa6ad53af112452ea705f10e38bfa393a',
+     armv7l: '0f362bab2d9dd493eb2acfdd8980e2baa6ad53af112452ea705f10e38bfa393a',
+       i686: '417bc9e5aa1300bc877c4bc81d9fa6f75de7502874d0eeb9c6e6bf9948511f1d',
+     x86_64: '2673362a6b1fef2f31c7a87ca45ec8dd045201e8331c86ec32d5f86fcca6acfb',
   })
 
   depends_on 'python27' => :build
@@ -34,7 +34,7 @@ class Vim < Package
     FileUtils.cd('src') do
       system "sed", "-i", "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|", "feature.h"
       system "sed", "-i", "s|^.*#define SYS_GVIMRC_FILE.*$|#define SYS_GVIMRC_FILE \"#{CREW_PREFIX}/etc/gvimrc\"|", "feature.h"
-      system "autoconf"
+      system 'autoconf'
     end
   end
 
@@ -42,23 +42,23 @@ class Vim < Package
     system "./configure",
               "--prefix=#{CREW_PREFIX}",
               "--localstatedir=#{CREW_PREFIX}/var/lib/vim",
-              "--with-features=huge",
+              '--with-features=huge',
               "--with-compiledby='Chromebrew'",
-              "--with-x=no",
-              "--disable-gui",
-              "--enable-multibyte",
-              "--enable-cscope",
-              "--enable-fontset",
-              "--enable-perlinterp=dynamic",
-              "--enable-pythoninterp=dynamic",
-              "--enable-python3interp=dynamic",
-              "--enable-rubyinterp=dynamic",
-              "--disable-selinux"
-    system "make"
+              '--with-x=no',
+              '--disable-gui',
+              '--enable-multibyte',
+              '--enable-cscope',
+              '--enable-fontset',
+              '--enable-perlinterp=dynamic',
+              '--enable-pythoninterp=dynamic',
+              '--enable-python3interp=dynamic',
+              '--enable-rubyinterp=dynamic',
+              '--disable-selinux'
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "VIMRCLOC=#{CREW_PREFIX}/etc", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", "VIMRCLOC=#{CREW_PREFIX}/etc", 'install'
 
     # these are provided by 'vim_runtime'
     FileUtils.rm_r "#{CREW_DEST_PREFIX}/share/vim"

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -3,21 +3,21 @@ require 'package'
 class Vim_runtime < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (shared runtime)'
   homepage 'http://www.vim.org/'
-  version '8.2.0014'
-  source_url 'https://github.com/vim/vim/archive/v8.2.0014.tar.gz'
-  source_sha256 '5e433abdebf36855bcec38b4e195a1281d04309b72523a265a21288717061845'
+  version '8.2.0346'
+  source_url 'https://github.com/vim/vim/archive/v8.2.0346.tar.gz'
+  source_sha256 '418d1cbc9f53f31cb19869b6df0294ca5c377ca2824c759e3f6796edc60e5628'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.0014-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.0014-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.0014-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.0014-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.0346-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.0346-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.0346-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.0346-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3911f7fb1bcc8ba9d7d8afdb9d70b7b86865b5f232bec647470db45fe84d87e2',
-     armv7l: '3911f7fb1bcc8ba9d7d8afdb9d70b7b86865b5f232bec647470db45fe84d87e2',
-       i686: 'c2859e2221137ad5bcb0583cadac66318915671e42ca9bca6b2e29219b06bf43',
-     x86_64: '801a6f930cf20529c5339a280566865646dad3c94681cf85d6b5f25d95ac80fa',
+    aarch64: 'c8b5083a493b85eea835b164dbd69e5d9487f1c18f066e76c3ba180b8e4de469',
+     armv7l: 'c8b5083a493b85eea835b164dbd69e5d9487f1c18f066e76c3ba180b8e4de469',
+       i686: '0e39577626ae0a4204782ea561a68f44fe260a34928f39b92cb6922905cde594',
+     x86_64: 'f2f37414827f3ea16de09fbdfe39831a6c8a485ce5db8790858077da24ebe545',
   })
 
   depends_on 'python27' => :build
@@ -28,7 +28,7 @@ class Vim_runtime < Package
     FileUtils.cd('src') do
       system "sed", "-i", "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|", "feature.h"
       system "sed", "-i", "s|^.*#define SYS_GVIMRC_FILE.*$|#define SYS_GVIMRC_FILE \"#{CREW_PREFIX}/etc/gvimrc\"|", "feature.h"
-      system "autoconf"
+      system 'autoconf'
     end
   end
 
@@ -36,23 +36,23 @@ class Vim_runtime < Package
     system "./configure",
               "--prefix=#{CREW_PREFIX}",
               "--localstatedir=#{CREW_PREFIX}/var/lib/vim",
-              "--with-features=huge",
+              '--with-features=huge',
               "--with-compiledby='Chromebrew'",
-              "--with-x=no",
-              "--disable-gui",
-              "--enable-multibyte",
-              "--enable-cscope",
-              "--enable-fontset",
-              "--enable-perlinterp=dynamic",
-              "--enable-pythoninterp=dynamic",
-              "--enable-python3interp=dynamic",
-              "--enable-rubyinterp=dynamic",
-              "--disable-selinux"
-    system "make"
+              '--with-x=no',
+              '--disable-gui',
+              '--enable-multibyte',
+              '--enable-cscope',
+              '--enable-fontset',
+              '--enable-perlinterp=dynamic',
+              '--enable-pythoninterp=dynamic',
+              '--enable-python3interp=dynamic',
+              '--enable-rubyinterp=dynamic',
+              '--disable-selinux'
+    system 'make'
   end
 
   def self.install
-    system "make", "VIMRCLOC=#{CREW_PREFIX}/etc", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "VIMRCLOC=#{CREW_PREFIX}/etc", "DESTDIR=#{CREW_DEST_DIR}", 'install'
 
     # bin and man will be provided by the 'vim' packages
     FileUtils.rm_r "#{CREW_DEST_PREFIX}/bin"

--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -3,21 +3,21 @@ require 'package'
 class Wayland < Package
   description 'Wayland is intended as a simpler replacement for X, easier to develop and maintain.'
   homepage 'https://wayland.freedesktop.org'
-  version '1.16.0'
-  source_url 'https://wayland.freedesktop.org/releases/wayland-1.16.0.tar.xz'
-  source_sha256 '4e72c2b56109ccfb6610d776e465f4ca0af2280c9c2f7d5cc23f0ed2548752f5'
+  version '1.18.0'
+  source_url 'https://wayland.freedesktop.org/releases/wayland-1.18.0.tar.xz'
+  source_sha256 '4675a79f091020817a98fd0484e7208c8762242266967f55a67776936c2e294d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wayland-1.16.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wayland-1.16.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/wayland-1.16.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wayland-1.16.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wayland-1.18.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wayland-1.18.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/wayland-1.18.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wayland-1.18.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f1377f242b5971d95f79351bd46a7fe938c28292d0c1b270445b978fe828bb4e',
-     armv7l: 'f1377f242b5971d95f79351bd46a7fe938c28292d0c1b270445b978fe828bb4e',
-       i686: '7a601e7b17493ad3f72f7248ba031fda587e9223398205701be82e74be8c95a8',
-     x86_64: '6f4ac29bcad6eb9160b1da611e189b744a5ba5945b20318d72639962a9f2a917',
+    aarch64: '0df3da39ddbfc87a0d4986c3dce8bf94ffc44d8333b3a9f9eae9c8b92f276e69',
+     armv7l: '0df3da39ddbfc87a0d4986c3dce8bf94ffc44d8333b3a9f9eae9c8b92f276e69',
+       i686: '22cbbe4b83eb9a6fc5e5cbac4946c72d7d6cd9bd8f3db3f208c049d406374d5a',
+     x86_64: 'bf28cacca6c316fba02ddb76bcd029034bedfd0ca3537231efce89b1ab81aa09',
   })
 
   depends_on 'libpng'

--- a/packages/wayland_protocols.rb
+++ b/packages/wayland_protocols.rb
@@ -3,21 +3,21 @@ require 'package'
 class Wayland_protocols < Package
   description 'Wayland is a protocol for a compositor to talk to its clients.'
   homepage 'https://wayland.freedesktop.org/'
-  version '1.17'
-  source_url 'https://wayland.freedesktop.org/releases/wayland-protocols-1.17.tar.xz'
-  source_sha256 'df1319cf9705643aea9fd16f9056f4e5b2471bd10c0cc3713d4a4cdc23d6812f'
+  version '1.20'
+  source_url 'https://wayland.freedesktop.org/releases/wayland-protocols-1.20.tar.xz'
+  source_sha256 '9782b7a1a863d82d7c92478497d13c758f52e7da4f197aa16443f73de77e4de7'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wayland_protocols-1.17-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wayland_protocols-1.17-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/wayland_protocols-1.17-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wayland_protocols-1.17-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wayland_protocols-1.20-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wayland_protocols-1.20-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/wayland_protocols-1.20-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wayland_protocols-1.20-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '80803133d8eb93e1039801ca3db1bf33995cf0d3a00ddef4b94314af9be05783',
-     armv7l: '80803133d8eb93e1039801ca3db1bf33995cf0d3a00ddef4b94314af9be05783',
-       i686: '43beccb1c83723527f975f3c59b8aadc7f4f14a9f57a90deda4bd81a3cb568aa',
-     x86_64: '9de19df7a57cb6a179d716a0eab6b86842b79048399fdb714ba2ba6bc9be6e1f',
+    aarch64: '8a227186e165292076d56b1ffc8db3c49180359f7a19a464987e3d1c6d9343df',
+     armv7l: '8a227186e165292076d56b1ffc8db3c49180359f7a19a464987e3d1c6d9343df',
+       i686: '6d153b9a6856e0207c0ff0ca98bba121fde245ab79c8a17a77e65071350b85fd',
+     x86_64: '01f3d8f5383c1fd9e52b4f5b001c8d3cb605871dff52a3a20dbe38852bf23a3b',
   })
 
   depends_on 'wayland'

--- a/packages/wing.rb
+++ b/packages/wing.rb
@@ -3,18 +3,18 @@ require 'package'
 class Wing < Package
   description 'Wing Personal is a free Python IDE designed for students and hobbyists.'
   homepage 'https://wingware.com/'
-  version '7.2.0.1'
+  version '7.2.1.0'
   case ARCH
   when 'x86_64'
-    source_url 'https://wingware.com/pub/wing-personal/7.2.0.1/wing-personal-7.2.0.1-linux-x64.tar.bz2'
-    source_sha256 '75a74725c8f7b8f4b00f5f24a259bfdc7b2ebcd84fa0a68e6ad2664e028ed54b'
+    source_url 'https://wingware.com/pub/wing-personal/7.2.1.0/wing-personal-7.2.1.0-linux-x64.tar.bz2'
+    source_sha256 'e42a8269a08c8bff6a91d021dcc11de8ab0b007a5a267bdeb870e7369f155064'
   end
 
   binary_url ({
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wing-7.2.0.1-chromeos-x86_64.tar.xz',
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wing-7.2.1.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    x86_64: '144dab3ac72b4f020a74f36e87eca46299939547c63106667be97a748d62b771',
+    x86_64: '8be03ea9bcfa884c4f4a324190ecf6cbefd7b82389e264b6a35e318f30ec7ed3',
   })
 
   depends_on 'python27'

--- a/packages/xcb_proto.rb
+++ b/packages/xcb_proto.rb
@@ -3,21 +3,21 @@ require 'package'
 class Xcb_proto < Package
   description 'The protocols for the X window system provide extended functionality for communication between a X client and the server.'
   homepage 'https://x.org'
-  version '1.12-0'
-  source_url 'https://www.x.org/archive/individual/xcb/xcb-proto-1.12.tar.gz'
-  source_sha256 'cfa49e65dd390233d560ce4476575e4b76e505a0e0bacdfb5ba6f8d0af53fd59'
+  version '1.14'
+  source_url 'https://www.x.org/archive/individual/xcb/xcb-proto-1.14.tar.xz'
+  source_sha256 '186a3ceb26f9b4a015f5a44dcc814c93033a5fc39684f36f1ecc79834416a605'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xcb_proto-1.12-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xcb_proto-1.12-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xcb_proto-1.12-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xcb_proto-1.12-0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xcb_proto-1.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xcb_proto-1.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xcb_proto-1.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xcb_proto-1.14-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f47314d58e562f5589b493e8d706dec77e6ddb29e67bcc39d2e1e003d58a21e4',
-     armv7l: 'f47314d58e562f5589b493e8d706dec77e6ddb29e67bcc39d2e1e003d58a21e4',
-       i686: 'd88237e6a04039dd2e9840bf5aaa5922c085aff13f14673aca68a8307ad486b6',
-     x86_64: '70b5922c8c39cc68d0e59f868a7c32b68b0ff4ebf1818db486f8febd23412636',
+    aarch64: '5b8707e7904fcbc6cbbc2ca2c8fa87cad36c354eb1055e912ae127f5cfd4163c',
+     armv7l: '5b8707e7904fcbc6cbbc2ca2c8fa87cad36c354eb1055e912ae127f5cfd4163c',
+       i686: 'ecd7091cf0089fcb0b3b66c431a607e441cb9029d4e37f272ac548857b50b80a',
+     x86_64: 'a4de2e1bdf7aacee5904d9854d365e87f87eff754fc8201341595788bd5bb686',
   })
   
   depends_on 'python27' => :build 

--- a/packages/xkbcomp.rb
+++ b/packages/xkbcomp.rb
@@ -3,21 +3,21 @@ require 'package'
 class Xkbcomp < Package
   description 'Compile XKB keyboard'
   homepage 'https://www.x.org'
-  version '1.4.2'
-  source_url 'https://www.x.org/archive/individual/app/xkbcomp-1.4.2.tar.bz2'
-  source_sha256 '6dd8bcb9be7e85bd7294abe261b8c7b0539d2fc93e41b80fb8bd013767ce8424'
+  version '1.4.3'
+  source_url 'https://www.x.org/archive/individual/app/xkbcomp-1.4.3.tar.bz2'
+  source_sha256 '06242c169fc11caf601cac46d781d467748c6a330e15b36dce46520b8ac8d435'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xkbcomp-1.4.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xkbcomp-1.4.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xkbcomp-1.4.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xkbcomp-1.4.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xkbcomp-1.4.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xkbcomp-1.4.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xkbcomp-1.4.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xkbcomp-1.4.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b986448256860bea87fec75ffcb92011b3be9c05f1d64c92a64291b514395900',
-     armv7l: 'b986448256860bea87fec75ffcb92011b3be9c05f1d64c92a64291b514395900',
-       i686: '878d5307237f7b84f1cd2a50ff8bc154c3e3b0f2300cb666fbe609e81ec30ce3',
-     x86_64: '0742f2c242ca42e98a7a938a2bbc891220aea671ea1f60ea8f9390d33abcc479',
+    aarch64: '711ac4cd7c2b87345fc7ba1e7ba9b961c17985e636de5aa628ae6ed0c40eff80',
+     armv7l: '711ac4cd7c2b87345fc7ba1e7ba9b961c17985e636de5aa628ae6ed0c40eff80',
+       i686: '8c7651c05a5d690b06ce52e45b9742109ed9481ac482e27accded5c88bf651de',
+     x86_64: '17f0570519a3a9e8da6cb8443fe33491b70900fcd2a420b2af0ab37ea029f07e',
   })
 
   depends_on 'mesa'

--- a/packages/xkeyboard_config.rb
+++ b/packages/xkeyboard_config.rb
@@ -4,35 +4,33 @@ require 'package'
 class Xkeyboard_config < Package
   description 'The non-arch keyboard configuration database for X Window.'
   homepage 'http://www.freedesktop.org/wiki/Software/XKeyboardConfig'
-  version '2.21'
-  source_url 'https://www.x.org/releases/individual/data/xkeyboard-config/xkeyboard-config-2.21.tar.bz2'
-  source_sha256 '30c17049fae129fc14875656da9aa3099e3031d6ce0ee1d77aae190fd9edcec5'
+  version '2.29'
+  source_url 'https://www.x.org/releases/individual/data/xkeyboard-config/xkeyboard-config-2.29.tar.bz2'
+  source_sha256 '1d4175278bf06000683656763a8b1d3282c61a314b6db41260c8efe92d621802'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xkeyboard_config-2.21-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xkeyboard_config-2.21-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xkeyboard_config-2.21-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xkeyboard_config-2.21-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xkeyboard_config-2.29-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xkeyboard_config-2.29-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xkeyboard_config-2.29-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xkeyboard_config-2.29-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f60a526d9c26835976d5186115b2bd340772d3e9efd7beae47424703c48da974',
-     armv7l: 'f60a526d9c26835976d5186115b2bd340772d3e9efd7beae47424703c48da974',
-       i686: '75204643000e91af66ab288e1e7740193d7c1d7ced2a9d8a9f3164a428664242',
-     x86_64: '8bdf41c09086fb7209ebb87072b5ef8268176f5051e99f60aa0375046585f776',
+    aarch64: 'eae7e1d93e5ad45040b4f98f641d9710c5815bc753fabb0e51d781eeb45785bc',
+     armv7l: 'eae7e1d93e5ad45040b4f98f641d9710c5815bc753fabb0e51d781eeb45785bc',
+       i686: '545e4eecd93f68f3aa6626933e082db6bb65889f68f9b47bf0d343d9a6b53cb7',
+     x86_64: 'a3d3467cbc60baa18a8f41585103ad440cff1461c835b895c82e5f51f4f34382',
   })
 
-  depends_on "util_macros" => :build
-  depends_on "intltool" => :build
-  depends_on "libx11"
-  depends_on "gettext" => :build
+  depends_on 'libx11'
 
   def self.build
+    system "sed -i 's,/usr/bin/python3,#{CREW_PREFIX}/bin/python3,' ./rules/compat/map-variants.py"
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
 end

--- a/packages/xorg_intel_driver.rb
+++ b/packages/xorg_intel_driver.rb
@@ -3,17 +3,18 @@ require 'package'
 class Xorg_intel_driver < Package
   description 'The Xorg Intel Driver package contains the X.Org Video Driver for Intel integrated video chips including 8xx, 9xx, Gxx, Qxx, HD, Iris, and Iris Pro graphics processors.'
   homepage 'https://01.org/linuxgraphics/'
-  version '3.3.17'
-  source_url 'https://github.com/endlessm/xf86-video-intel/archive/Release_3.3.17.tar.gz'
-  source_sha256 'a2de40b68fd1edc9b30fe364d6e7f2f5765834a519c75b42eeac568b3fa2c900'
+  version '3.7.8'
+  case ARCH
+  when 'x86_64'
+    source_url 'https://github.com/endlessm/xf86-video-intel/archive/Release_3.7.8.tar.gz'
+    source_sha256 '411d644cba1a46e9fd8143a969edc70a67ae18f15bba333f24ed8b87716f93fe'
+  end
 
   binary_url ({
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_intel_driver-3.3.17-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_intel_driver-3.3.17-chromeos-x86_64.tar.xz',
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_intel_driver-3.7.8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-       i686: 'cde6829f4369ebcc687ce8d8ca4bf13c22c815edb086bf7cd0cdd20cb42be1b1',
-     x86_64: 'a9c50a31933fba36b7e3440b897b52cb18c2e264b8ac86aa2253e0cb899cb2a3',
+    x86_64: '5bd9bdf5b812ee93a39809cd3ba7e05cd71251280d8049ac07deee29249f3fde',
   })
 
   depends_on 'xorg_server' => :build

--- a/packages/xorg_proto.rb
+++ b/packages/xorg_proto.rb
@@ -3,21 +3,21 @@ require 'package'
 class Xorg_proto < Package
   description 'The xorgproto package provides the header files required to build the X Window system, and to allow other applications to build against the installed X Window system.'
   homepage 'https://www.x.org/'
-  version '2018.4'
-  source_url 'https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2018.4.tar.bz2'
-  source_sha256 'fee885e0512899ea5280c593fdb2735beb1693ad170c22ebcc844470eec415a0'
+  version '2019.2'
+  source_url 'https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2019.2.tar.bz2'
+  source_sha256 '46ecd0156c561d41e8aa87ce79340910cdf38373b759e737fcbba5df508e7b8e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2018.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2018.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2018.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2018.4-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2019.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2019.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2019.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2019.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '92f1d6ea6ef2c905f2ae1749c57e0d6b962145f9936ce726b64624af4e835549',
-     armv7l: '92f1d6ea6ef2c905f2ae1749c57e0d6b962145f9936ce726b64624af4e835549',
-       i686: 'f9b2d6bd821fbac154f818ebe43eb5c5b07b4bfacb8ab66a141c7e7fcd6feaef',
-     x86_64: '1285c5962d32f9ca776261cd0a7ccf78b8fda8878d11032673932892c98e5b88',
+    aarch64: 'd9e18300bfff03320a890f93f3596ef598c072384bc364bde913d5ff707dc6f2',
+     armv7l: 'd9e18300bfff03320a890f93f3596ef598c072384bc364bde913d5ff707dc6f2',
+       i686: '265aed098ec9396c8f8944412c1cf1c83d8268fe4c5a663567cb845ff64eb7be',
+     x86_64: '14fec9e0ec5ad52bbf1035a080f2c16be9533e2090b78f3d06336990ebd2b99f',
   })
 
   def self.build

--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -3,21 +3,21 @@ require 'package'
 class Xorg_server < Package
   description 'The Xorg Server is the core of the X Window system.'
   homepage 'https://www.x.org'
-  version '1.20.3'
-  source_url 'https://www.x.org/releases/individual/xserver/xorg-server-1.20.3.tar.bz2'
-  source_sha256 '1b3ce466c12cacbe2252b3ad5b0ed561972eef9d09e75900d65fb1e21f9201de'
+  version '1.20.7'
+  source_url 'https://www.x.org/releases/individual/xserver/xorg-server-1.20.7.tar.bz2'
+  source_sha256 'bd5986f010f34f5b3d6bc99fe395ecb1e0dead15a26807e0c832701809a06ea1'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.3-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5603c3ad8211c77b9af761cb9ca78493b7a9a4f877197e619235e2892ffba8cc',
-     armv7l: '5603c3ad8211c77b9af761cb9ca78493b7a9a4f877197e619235e2892ffba8cc',
-       i686: 'cbec00ee50d01ccb2cdae94c2e62a254c6687a8f282ca7af24b625825dfb2958',
-     x86_64: 'daeac28c7d97ef2eaff50439cbb83299cf9df6c27a3ec816ffe55b2680b0053b',
+    aarch64: '311a12cae0c1f03dd40c3605168c0c8928d40fdd2bb6cf42e5d20a6c8a97b6c1',
+     armv7l: '311a12cae0c1f03dd40c3605168c0c8928d40fdd2bb6cf42e5d20a6c8a97b6c1',
+       i686: '83adbeae700a2f36a5d238094579dd08efb33cc26e63e05d7f60d417d0448810',
+     x86_64: '9ef9acf6f82c2815880438a323c1acf5625f1111963fba714c5c3d11697f4959',
   })
 
   depends_on 'pixman'
@@ -35,22 +35,22 @@ class Xorg_server < Package
   depends_on 'glproto'
 
   def self.build
-    system "./configure",
-             "--prefix=#{CREW_PREFIX}",
-             "--libdir=#{CREW_LIB_PREFIX}",
-             "--enable-xfree86-utils",
-             "--enable-xf86vidmode",
-             "--enable-glamor",
-             "--enable-xorg",
-             "--enable-xwayland",
-             "--enable-xvfb",
-             "--enable-xnest",
-             "--disable-systemd-logind"
-    system "make"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--enable-xfree86-utils',
+           '--enable-xf86vidmode',
+           '--enable-glamor',
+           '--enable-xorg',
+           '--enable-xwayland',
+           '--enable-xvfb',
+           '--enable-xnest',
+           '--disable-systemd-logind'
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    system "ln", "-sf", "Xwayland", "#{CREW_DEST_PREFIX}/bin/X"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.ln_sf 'Xwayland', "#{CREW_DEST_PREFIX}/bin/X"
   end
 end

--- a/packages/xxhash.rb
+++ b/packages/xxhash.rb
@@ -3,21 +3,21 @@ require 'package'
 class Xxhash < Package
   description 'xxHash is an extremely fast non-cryptographic hash algorithm, working at speeds close to RAM limits.'
   homepage 'https://cyan4973.github.io/xxHash/'
-  version '0.7.2'
-  source_url 'https://github.com/Cyan4973/xxHash/archive/v0.7.2.tar.gz'
-  source_sha256 '7e93d28e81c3e95ff07674a400001d0cdf23b7842d49b211e5582d00d8e3ac3e'
+  version '0.7.3'
+  source_url 'https://github.com/Cyan4973/xxHash/archive/v0.7.3.tar.gz'
+  source_sha256 '952ebbf5b11fbf59ae5d760a562d1e9112278f244340ad7714e8556cbe54f7f7'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.7.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.7.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.7.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.7.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.7.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.7.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.7.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.7.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '13b8a0673cc01d5c84196dbe821e905acfa8057ad2a44804dbe9169eda8039ea',
-     armv7l: '13b8a0673cc01d5c84196dbe821e905acfa8057ad2a44804dbe9169eda8039ea',
-       i686: '27202803f014e22ab41ca0729adeb618c4bae2c6710773a0a77e81357743eb64',
-     x86_64: '12e1f37a20e71fb5b6e685136c547ee0eff33d13457b459a67636bdd21f609ec',
+    aarch64: 'ebc5da796fed9aa28b1d1dfea223be7b82cb2b10a089a3fe17da44a526ce6d7f',
+     armv7l: 'ebc5da796fed9aa28b1d1dfea223be7b82cb2b10a089a3fe17da44a526ce6d7f',
+       i686: '5c4d9bf621e94373d0453f06a0a1fbd8f10002ba24f53355580eb52316653875',
+     x86_64: 'af56f28e9ef99aefed260fb19f931f9ddbe2ec1bdd22a90138e66f76ccbbe203',
   })
 
   def self.build

--- a/packages/xzutils.rb
+++ b/packages/xzutils.rb
@@ -3,21 +3,21 @@ require 'package'
 class Xzutils < Package
   description 'XZ Utils is free general-purpose data compression software with a high compression ratio.'
   homepage 'http://tukaani.org/xz/'
-  version '5.2.3-2'
-  source_url 'http://tukaani.org/xz/xz-5.2.3.tar.gz'
-  source_sha256 '71928b357d0a09a12a4b4c5fafca8c31c19b0e7d3b8ebb19622e96f26dbf28cb'
+  version '5.2.5'
+  source_url 'https://tukaani.org/xz/xz-5.2.5.tar.gz'
+  source_sha256 'f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xzutils-5.2.3-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xzutils-5.2.3-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xzutils-5.2.3-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xzutils-5.2.3-2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xzutils-5.2.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xzutils-5.2.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xzutils-5.2.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xzutils-5.2.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '839ead7097adee016986a9992d8cf8f4c91554ade2b6e111f7d0379c595be366',
-     armv7l: '839ead7097adee016986a9992d8cf8f4c91554ade2b6e111f7d0379c595be366',
-       i686: 'f64e279259996234dc193e8dee3a55738e3b85a299ed952920691942112d4fec',
-     x86_64: '933c51b479c58e277b6354913c76be9a021f2436df86b37e8eb3d328b9cd5fc2',
+    aarch64: 'bbb38dfbc5f7845dde5d4e6c1aa46be40d4d94f5db26b0aa20f1603a14c6e61d',
+     armv7l: 'bbb38dfbc5f7845dde5d4e6c1aa46be40d4d94f5db26b0aa20f1603a14c6e61d',
+       i686: '34db46c8dc58db4c212ba83e36eba17c8852eab14964a6a1d7ab75aaf23be91c',
+     x86_64: '05f0e86514ed8fefa240e0fc2d40cb2b95414d628f670b19a230a3867e992a24',
   })
 
   def self.build

--- a/packages/yarn.rb
+++ b/packages/yarn.rb
@@ -3,9 +3,9 @@ require 'package'
 class Yarn < Package
   description 'Yarn is a new package manager for JavaScript and an alternative to npm.'
   homepage 'https://yarnpkg.com/en/'
-  version '1.21.1'
-  source_url 'https://github.com/yarnpkg/yarn/releases/download/v1.21.1/yarn-v1.21.1.tar.gz'
-  source_sha256 'd1d9f4a0f16f5ed484e814afeb98f39b82d4728c6c8beaafb5abc99c02db6674'
+  version '1.22.4'
+  source_url 'https://github.com/yarnpkg/yarn/releases/download/v1.22.4/yarn-v1.22.4.tar.gz'
+  source_sha256 'bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58'
 
   binary_url ({
   })

--- a/tools/needs_binaries.sh
+++ b/tools/needs_binaries.sh
@@ -6,20 +6,22 @@ fi
 cd ../packages
 arch=$(uname -m)
 exclusions='android_studio.rb antlr4.rb asciinema.rb autosetup.rb broadway.rb cabal.rb checkinstall.rb codium.rb composer.rb cowsay.rb'
-exclusions+=' crew_profile.rb cros_resize.rb dart.rb docx2txt.rb dr.rb elixir.rb far.rb fortune.rb fortunes.rb fpc.rb freedos.rb gcc_tools.rb'
-exclusions+=' ghc.rb gittools.rb google_cloud_sdk.rb gradle.rb hugo.rb hunspell.rb julia.rb komodo.rb kr.rb ld_default.rb leiningen.rb'
-exclusions+=' libtinfo.rb lsb_release.rb mysqltuner.rb nconvert.rb neofetch.rb ngrok.rb nodebrew.rb nvm.rb oc.rb packer.rb perl_gcstring_linebreak.rb'
-exclusions+=' perl_io_socket_ssl.rb perl_locale_gettext.rb perl_locale_messages.rb perl_module_build.rb perl_read_key.rb perl_sgmls.rb'
-exclusions+=' perl_term_ansicolor.rb perl_text_charwidth.rb perl_text_unidecode.rb perl_text_wrapi18n.rb perl_time_hires.rb'
-exclusions+=' perl_unicode_eastasianwidth.rb perl_xml_parser.rb perl_xml_sax_parserfactory.rb perl_xml_simple.rb pipes_sh.rb'
-exclusions+=' pipesx_sh.rb pngcheck.rb qtcreator.rb sl.rb spark.rb stack.rb sublime_merge.rb sublime_text.rb thefuck.rb tinycore.rb'
-exclusions+=' tkdiff.rb txt2regex.rb uwsgi.rb v2ray.rb wp_cli.rb xdg_base.rb yarn.rb'
+exclusions+=' crew_profile.rb cros_resize.rb dart.rb depot_tools.rb docx2txt.rb dr.rb elixir.rb far.rb firefox.rb fortune.rb fortunes.rb'
+exclusions+=' fpc.rb freedos.rb gcc_tools.rb ghc.rb gittools.rb google_cloud_sdk.rb gradle.rb hugo.rb hunspell.rb idea.rb julia.rb komodo.rb'
+exclusions+=' kr.rb ld_default.rb leiningen.rb libtinfo.rb lsb_release.rb mysqltuner.rb nconvert.rb neofetch.rb netbeans.rb ngrok.rb nodebrew.rb'
+exclusions+=' nvm.rb oc.rb packer.rb perl_gcstring_linebreak.rb perl_io_socket_ssl.rb perl_locale_gettext.rb perl_locale_messages.rb'
+exclusions+=' perl_module_build.rb perl_read_key.rb perl_sgmls.rb perl_term_ansicolor.rb perl_text_charwidth.rb perl_text_unidecode.rb'
+exclusions+=' perl_text_wrapi18n.rb perl_time_hires.rb perl_unicode_eastasianwidth.rb perl_xml_parser.rb perl_xml_sax_parserfactory.rb'
+exclusions+=' perl_xml_simple.rb pipes_sh.rb pipesx_sh.rb platformsh.rb pngcheck.rb pycharm.rb qtcreator.rb sl.rb spark.rb stack.rb'
+exclusions+=' sublime_merge.rb sublime_text.rb terminus.rb thefuck.rb tinycore.rb tkdiff.rb txt2regex.rb uwsgi.rb v2ray.rb wp_cli.rb'
+exclusions+=' xdg_base.rb yarn.rb'
 if [[ "${arch}" == 'aarch64' || "${arch}" == 'armv7l' ]]; then
-  exclusions+=' az.rb cf.rb clisp.rb dropbox.rb fakeroot_ng.rb freebasic.rb miniconda3.rb misctools.rb oci.rb weston.rb wkhtmltox.rb'
-  exclusions+=' xorg_intel_driver.rb xorg_vmmouse_driver.rb'
+  exclusions+=' atom.rb az.rb cf.rb clisp.rb dropbox.rb fakeroot_ng.rb freebasic.rb miniconda3.rb misctools.rb oci.rb opera.rb skype.rb'
+  exclusions+=' weston.rb wing.rb wkhtmltox.rb xorg_intel_driver.rb xorg_vmmouse_driver.rb'
 fi
 if [[ "${arch}" == 'i686' ]]; then
-  exclusions+=' fakeroot_ng.rb'
+  exclusions+=' aqemu.rb atom.rb codelite.rb cras.rb dia.rb exa.rb fakeroot_ng.rb gimp.rb gtk_engines_adwaita.rb imagemagick6.rb'
+  exclusions+=' imagemagick7.rb libvncserver.rb neovim.rb opera.rb skype.rb tcpflow.rb wing.rb'
 fi
 packages=$(grep -L "${arch}:" *.rb)
 for p in ${packages}; do

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -44,13 +44,33 @@ url: http://download.aircrack-ng.org
 activity: none
 ---
 kind: url
+name: alien
+url: https://sourceforge.net/projects/alien-pkg-convert/files/release/
+activity: none
+---
+kind: url
 name: alive
 url: https://ftpmirror.gnu.org/alive/
 activity: none
 ---
 kind: url
+name: alpine
+url: http://alpine.x10host.com/alpine/release
+activity: none
+---
+kind: url
 name: alsa_lib
-url: ftp://ftp.alsa-project.org/pub/lib
+url: https://github.com/alsa-project/alsa-lib/releases
+activity: medium
+---
+kind: url
+name: alsa_tools
+url: https://github.com/alsa-project/alsa-tools/releases
+activity: medium
+---
+kind: url
+name: alsa_utils
+url: https://github.com/alsa-project/alsa-utils/releases
 activity: medium
 ---
 kind: url
@@ -109,6 +129,11 @@ url: https://apache.claz.org/apr
 activity: low
 ---
 kind: url
+name: apulse
+url: https://github.com/i-rinat/apulse/releases
+activity: none
+---
+kind: url
 name: aqemu
 url: https://sourceforge.net/projects/aqemu/files/aqemu/
 activity: none
@@ -149,14 +174,19 @@ url: https://sourceforge.net/projects/asciidoc/files/asciidoc/
 activity: none
 ---
 kind: url
+name: asciidoctor
+url: https://github.com/asciidoctor/asciidoctor/releases
+activity: medium
+---
+kind: url
 name: asciinema
 url: https://github.com/asciinema/asciinema/releases
 activity: medium
 ---
 kind: url
 name: aspell
-url: http://alpha.gnu.org/gnu/aspell
-activity: low
+url: https://ftpmirror.gnu.org/aspell
+activity: medium
 ---
 kind: url
 name: aspell_en
@@ -191,6 +221,11 @@ activity: medium
 kind: url
 name: atkmm
 url: https://ftp.gnome.org/pub/gnome/sources/atkmm/
+activity: medium
+---
+kind: url
+name: atom
+url: https://github.com/atom/atom/releases/
 activity: medium
 ---
 kind: url
@@ -384,6 +419,11 @@ url: https://github.com/box-project/box2/releases
 activity: none
 ---
 kind: url
+name: brackets
+url: https://github.com/adobe/brackets/releases/
+activity: medium
+---
+kind: url
 name: broadway
 url: https://developer.gnome.org/gtk3/stable/gtk-broadway.html
 activity: none
@@ -501,6 +541,11 @@ activity: none
 kind: url
 name: chromebrew_scripts
 url: https://github.com/uberhacker/chromebrew-scripts/releases
+activity: none
+---
+kind: url
+name: chrpath
+url: http://ftp.debian.org/debian/pool/main/c/chrpath/
 activity: none
 ---
 kind: url
@@ -744,6 +789,11 @@ url: https://ftpmirror.gnu.org/dejagnu/
 activity: low
 ---
 kind: url
+name: depot_tools
+url: https://chromium.googlesource.com/chromium/tools/depot_tools.git
+activity: high
+---
+kind: url
 name: desktop_file_utilities
 url: https://www.freedesktop.org/software/desktop-file-utils/releases/
 activity: none
@@ -792,6 +842,11 @@ kind: url
 name: dmidecode
 url: http://download.savannah.gnu.org/releases/dmidecode
 activity: low
+---
+kind: url
+name: dnsmasq
+url: http://thekelleys.org.uk/dnsmasq/
+activity: none
 ---
 kind: url
 name: docbook
@@ -866,6 +921,11 @@ activity: high
 kind: url
 name: duplicity
 url: https://launchpad.net/duplicity/+download
+activity: medium
+---
+kind: url
+name: ecasound
+url: https://nosignal.fi/download/
 activity: medium
 ---
 kind: url
@@ -999,6 +1059,11 @@ url: https://github.com/dirkvdb/ffmpegthumbnailer/releases/
 activity: none
 ---
 kind: url
+name: fftw
+url: ftp://ftp.fftw.org/pub/fftw/
+activity: none
+---
+kind: url
 name: figlet
 url: ftp://ftp.figlet.org/pub/figlet/program/unix
 activity: none
@@ -1019,6 +1084,11 @@ url: https://sourceforge.net/projects/pidgin/files/Pidgin/
 activity: low
 ---
 kind: url
+name: firefox
+url: https://archive.mozilla.org/pub/firefox/releases/
+activity: medium
+---
+kind: url
 name: firejail
 url: https://sourceforge.net/projects/firejail/files/firejail/
 activity: medium
@@ -1037,6 +1107,16 @@ kind: url
 name: flex
 url: https://github.com/westes/flex/releases
 activity: low
+---
+kind: url
+name: flif
+url: https://github.com/FLIF-hub/FLIF/releases
+activity: none
+---
+kind: url
+name: fltk
+url: https://github.com/fltk/fltk/releases
+activity: medium
 ---
 kind: url
 name: fly
@@ -1111,6 +1191,11 @@ activity: none
 kind: url
 name: freeglut
 url: https://sourceforge.net/projects/freeglut/files/freeglut/
+activity: none
+---
+kind: url
+name: freeimage
+url: https://sourceforge.net/projects/freeimage/files/Source%20Distribution/
 activity: none
 ---
 kind: url
@@ -1214,6 +1299,11 @@ url: https://github.com/prasmussen/gdrive/releases
 activity: none
 ---
 kind: url
+name: geany
+url: https://download.geany.org/
+activity: medium
+---
+kind: url
 name: gegl
 url: https://download.gimp.org/pub/gegl/
 activity: medium
@@ -1269,6 +1359,11 @@ url: https://ftp.gnu.org/gnu/ghostscript/
 activity: none
 ---
 kind: url
+name: giblib
+url: https://deb.debian.org/debian/pool/main/g/giblib/
+activity: none
+---
+kind: url
 name: gifgen
 url: https://github.com/lukechilds/gifgen/releases
 activity: none
@@ -1306,6 +1401,11 @@ activity: low
 kind: url
 name: gittools
 url: https://github.com/internetwache/GitTools/
+activity: none
+---
+kind: url
+name: glew
+url: https://github.com/nigels-com/glew/releases/
 activity: none
 ---
 kind: url
@@ -1461,6 +1561,11 @@ activity: low
 kind: url
 name: gpgme
 url: https://www.gnupg.org/ftp/gcrypt/gpgme
+activity: low
+---
+kind: url
+name: gphoto
+url: https://github.com/gphoto/gphoto2/releases
 activity: low
 ---
 kind: url
@@ -1744,6 +1849,11 @@ url: http://download.icu-project.org/files/icu4c
 activity: medium
 ---
 kind: url
+name: idea
+url: https://www.jetbrains.com/idea/download/other.html
+activity: medium
+---
+kind: url
 name: iftop
 url: http://www.ex-parrot.com/pdw/iftop/download
 activity: none
@@ -1834,9 +1944,19 @@ url: https://github.com/itstool/itstool/releases
 activity: low
 ---
 kind: url
+name: jack
+url: https://github.com/jackaudio/jack2/releases/
+activity: low
+---
+kind: url
 name: jam
 url: https://swarm.workshop.perforce.com/downloads/guest/perforce_software/jam/
 activity: none
+---
+kind: url
+name: janet
+url: https://github.com/janet-lang/janet/releases
+activity: medium
 ---
 kind: url
 name: jansson
@@ -1847,6 +1967,11 @@ kind: url
 name: jasper
 url: https://github.com/mdadams/jasper/releases
 activity: low
+---
+kind: url
+name: jbigkit
+url: https://www.cl.cam.ac.uk/~mgk25/jbigkit/download/
+activity: none
 ---
 kind: url
 name: jdk8
@@ -2054,6 +2179,11 @@ url: https://github.com/ivmai/libatomic_ops/releases
 activity: low
 ---
 kind: url
+name: libaudiofile
+url: https://github.com/mpruett/audiofile/releases
+activity: none
+---
+kind: url
 name: libavc1394
 url: https://sourceforge.net/projects/libavc1394/files/libavc1394/
 activity: none
@@ -2214,6 +2344,11 @@ url: http://www.exiv2.org/builds/
 activity: none
 ---
 kind: url
+name: libfdk_aac
+url: https://sourceforge.net/projects/opencore-amr/files/fdk-aac/
+activity: none
+---
+kind: url
 name: libffi
 url: http://sourceware.org/pub/libffi
 activity: none
@@ -2277,6 +2412,11 @@ kind: url
 name: libgpgerror
 url: https://www.gnupg.org/ftp/gcrypt/libgpg-error/
 activity: high
+---
+kind: url
+name: libgphoto
+url: https://github.com/gphoto/libgphoto2/releases
+activity: medium
 ---
 kind: url
 name: libgsf
@@ -2507,6 +2647,16 @@ kind: url
 name: librsync
 url: https://github.com/librsync/librsync/releases
 activity: low
+---
+kind: url
+name: libsamplerate
+url: http://www.mega-nerd.com/libsamplerate/download.html
+activity: none
+---
+kind: url
+name: libsass
+url: https://github.com/sass/libsass/releases
+activity: medium
 ---
 kind: url
 name: libsdl
@@ -3119,6 +3269,11 @@ url: https://mesa.freedesktop.org/archive/
 activity: high
 ---
 kind: url
+name: mesa_utils
+url: https://gitlab.freedesktop.org/mesa/demos/-/tags
+activity: none
+---
+kind: url
 name: meson
 url: https://github.com/mesonbuild/meson/releases
 activity: high
@@ -3234,6 +3389,11 @@ url: https://sourceforge.net/projects/mpg123/files/mpg123/
 activity: none
 ---
 kind: url
+name: mpv
+url: https://github.com/mpv-player/mpv/releases
+activity: high
+---
+kind: url
 name: msttcorefonts
 url: http://http.debian.net/debian/pool/contrib/m/msttcorefonts
 activity: low
@@ -3247,6 +3407,11 @@ kind: url
 name: mtools
 url: https://ftp.gnu.org/gnu/mtools
 activity: none
+---
+kind: url
+name: mtr
+url: ftp://ftp.bitwizard.nl/mtr/
+activity: low
 ---
 kind: url
 name: multitail
@@ -3359,6 +3524,11 @@ url: https://github.com/neovim/neovim/releases
 activity: low
 ---
 kind: url
+name: netbeans
+url: https://mirror.reverse.net/pub/apache/netbeans/netbeans/
+activity: medium
+---
+kind: url
 name: netcat
 url: https://sourceforge.net/projects/netcat/files/netcat/
 activity: none
@@ -3402,6 +3572,11 @@ kind: url
 name: ngrok
 url: https://ngrok.com/download
 activity: none
+---
+kind: url
+name: nim
+url: https://nim-lang.org/install_unix.html
+activity: medium
 ---
 kind: url
 name: ninja
@@ -3449,6 +3624,11 @@ url: http://http.debian.net/debian/pool/main/n/nss-mdns/
 activity: none
 ---
 kind: url
+name: numactl
+url: https://github.com/numactl/numactl/releases/
+activity: medium
+---
+kind: url
 name: nvm
 url: https://github.com/creationix/nvm/releases
 activity: medium
@@ -3487,6 +3667,11 @@ kind: url
 name: oniguruma
 url: https://github.com/kkos/oniguruma/releases
 activity: medium
+---
+kind: url
+name: openal
+url: https://github.com/kcat/openal-soft/releases
+activity: high
 ---
 kind: url
 name: openblas
@@ -3537,6 +3722,11 @@ kind: url
 name: openssh
 url: https://github.com/openssh/openssh-portable/releases
 activity: none
+---
+kind: url
+name: opera
+url: https://get.geo.opera.com/pub/opera/desktop/
+activity: medium
 ---
 kind: url
 name: optipng
@@ -3909,6 +4099,11 @@ url: https://www.x.org/archive/individual/lib/
 activity: none
 ---
 kind: url
+name: pugixml
+url: https://github.com/zeux/pugixml/releases
+activity: low
+---
+kind: url
 name: pulseaudio
 url: https://freedesktop.org/software/pulseaudio/releases
 activity: high
@@ -3932,6 +4127,11 @@ kind: url
 name: pycairo
 url: https://cairographics.org/releases/
 activity: none
+---
+kind: url
+name: pycharm
+url: https://www.jetbrains.com/pycharm/download/other.html
+activity: medium
 ---
 kind: url
 name: pygobject
@@ -3977,6 +4177,11 @@ kind: url
 name: qpdf
 url: https://github.com/qpdf/qpdf/releases
 activity: medium
+---
+kind: url
+name: qrencode
+url: https://github.com/fukuchi/libqrencode/releases
+activity: none
 ---
 kind: url
 name: qtbase
@@ -4139,8 +4344,18 @@ url: http://rsync.samba.org/ftp/rsync/src
 activity: low
 ---
 kind: url
+name: rtaudio
+url: http://www.music.mcgill.ca/~gary/rtaudio/release/
+activity: low
+---
+kind: url
 name: rtmpdump
 url: https://git.ffmpeg.org/gitweb/rtmpdump.git
+activity: none
+---
+kind: url
+name: rubberband
+url: https://breakfastquay.com/files/releases/
 activity: none
 ---
 kind: url
@@ -4222,6 +4437,11 @@ kind: url
 name: scron
 url: https://git.2f30.org/scron/
 activity: none
+---
+kind: url
+name: scrot
+url: https://github.com/resurrecting-open-source-projects/scrot/releases
+activity: medium
 ---
 kind: url
 name: sdl2_image
@@ -4309,6 +4529,11 @@ url: https://github.com/benjaminp/six/releases
 activity: low
 ---
 kind: url
+name: skype
+url: https://www.skype.com/en/get-skype/
+activity: medium
+---
+kind: url
 name: sl
 url: https://github.com/mtoyoda/sl/releases
 activity: none
@@ -4337,6 +4562,16 @@ kind: url
 name: smemstat
 url: http://kernel.ubuntu.com/~cking/tarballs/smemstat
 activity: medium
+---
+kind: url
+name: snappy
+url: https://github.com/google/snappy/releases
+activity: high
+---
+kind: url
+name: sngrep
+url: https://github.com/irontec/sngrep/releases
+activity: none
 ---
 kind: url
 name: snooze
@@ -4534,9 +4769,19 @@ url: ftp://ftp.porcupine.org/pub/security/
 activity: none
 ---
 kind: url
+name: tdb
+url: https://www.samba.org/ftp/tdb/
+activity: medium
+---
+kind: url
 name: termcap
 url: https://ftp.gnu.org/gnu/termcap
 activity: none
+---
+kind: url
+name: terminus
+url: https://github.com/pantheon-systems/terminus/releases
+activity: medium
 ---
 kind: url
 name: terraform
@@ -4774,6 +5019,11 @@ url: http://sourceware.org/pub/valgrind
 activity: none
 ---
 kind: url
+name: vamp_sdk
+url: https://code.soundsoftware.ac.uk/projects/vamp-plugin-sdk/files
+activity: medium
+---
+kind: url
 name: vdev
 url: https://github.com/jcnelson/vdev/releases
 activity: none
@@ -4806,6 +5056,11 @@ activity: low
 kind: url
 name: vpnc
 url: https://www.unix-ag.uni-kl.de/~massar/vpnc
+activity: none
+---
+kind: url
+name: vtable_dumper
+url: https://github.com/lvc/vtable-dumper/releases
 activity: none
 ---
 kind: url
@@ -4876,6 +5131,11 @@ activity: medium
 kind: url
 name: wine
 url: https://dl.winehq.org/wine/source
+activity: high
+---
+kind: url
+name: wing
+url: https://wingware.com/pub/wing-personal/
 activity: high
 ---
 kind: url


### PR DESCRIPTION
Tested on aarch64.
Fixes #1324.
Fixes #1378.
Fixes #1406.
Fixes #3512.

@cstrouse:  The way this works is use `#{CREW_OPTIONS}` to replace `--prefix=#{CREW_PREFIX}` and `--libdir=#{CREW_LIB_PREFIX}` configure options.  See the output of `crew const CREW_OPTIONS`.  Example `self.build` section:
```
  def self.build
    system "./configure \
           #{CREW_OPTIONS} \
           --enable-shared \
           --enable-static \
           --enable-relocatable \
           --enable-extra-encodings"
    system 'make'
  end
```