### PR TITLE
Fix 'Package php7 not found' in composer

### DIFF
--- a/packages/composer.rb
+++ b/packages/composer.rb
@@ -3,11 +3,11 @@ require 'package'
 class Composer < Package
   description 'Dependency Manager for PHP'
   homepage 'https://getcomposer.org/'
-  version '1.9.2-1'
+  version '1.9.2'
   source_url 'https://github.com/composer/composer/archive/1.9.2.tar.gz'
   source_sha256 'bb855149a0c691c11aeb563bbe185bc0de3988c4e678c803762ee4d76dcb3436'
 
-  depends_on 'php7' unless File.exists? "#{CREW_PREFIX}/bin/php"
+  depends_on 'php' unless File.exists? "#{CREW_PREFIX}/bin/php"
   depends_on 'xdg_base'
 
   def self.preinstall


### PR DESCRIPTION
Fix `The defined install version (1.9.2-1) does not match release pattern.
composer failed to install: `php composer-setup.php --install-dir=/usr/local/tmp/crew/dest/usr/local/bin --filename=composer --version=1.9.2-1` exited with 1`