### PR TITLE
Add libgphoto, gphoto and pugixml packages

### DIFF
--- a/packages/gphoto.rb
+++ b/packages/gphoto.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Gphoto < Package
+  description 'The gphoto2 commandline tool for accessing and controlling digital cameras.'
+  homepage 'http://www.gphoto.org/'
+  version '2.5.23'
+  source_url 'https://github.com/gphoto/gphoto2/archive/gphoto2-2_5_23-release.tar.gz'
+  source_sha256 'dc78b7f8a88803937301d157b5b32cd45f6defcc771564438a477a7fb05f4489'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gphoto-2.5.23-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gphoto-2.5.23-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gphoto-2.5.23-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gphoto-2.5.23-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '055e881c56a7e40a0208176d08555a8992f15844aedc204f53d99db8e86e1f31',
+     armv7l: '055e881c56a7e40a0208176d08555a8992f15844aedc204f53d99db8e86e1f31',
+       i686: '72969ad37c17319ce08ca6a80d26d8cfd1bbeac71cbfbcf4ae89f582d6db0f52',
+     x86_64: '92fcfd96e8a3a8d40d5a2661d5a9b37dad019ef086b925c97a738c9879c82663',
+  })
+
+  depends_on 'libgphoto'
+  depends_on 'popt'
+
+  def self.build
+    system 'autoreconf -is'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libgphoto.rb
+++ b/packages/libgphoto.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Libgphoto < Package
+  description 'The libgphoto2 camera access and control library.'
+  homepage 'http://www.gphoto.org/'
+  version '2.5.23'
+  source_url 'https://github.com/gphoto/libgphoto2/archive/libgphoto2-2_5_23-release.tar.gz'
+  source_sha256 '8de52fd997aceda895abad5d8d95a888bce24a1c739079cff64dae1da7039dde'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgphoto-2.5.23-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgphoto-2.5.23-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgphoto-2.5.23-chromeos-i686.tar.xz',
+    x86_64: 'file:///home/chronos/user/chromebrew/release/x86_64/libgphoto-2.5.23-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256 ({
+    aarch64: 'dfb2080fbbd42cfffdc05a6bb6d52775b807825d1b3b7ca18934c70d88beb1be',
+     armv7l: 'dfb2080fbbd42cfffdc05a6bb6d52775b807825d1b3b7ca18934c70d88beb1be',
+       i686: '9f33a1541717bf823171eef395dd8fe32aacf3804c120591e771c08034ea374a',
+     x86_64: 'f427fa32d155986cd13cdf9eebf9efc8d3adb6e1d5f478a9d6658be0bf0052e1',
+  })
+
+  depends_on 'gtk_doc'
+  depends_on 'libexif'
+  depends_on 'libusb'
+
+  def self.build
+    system 'autoreconf --install --symlink'
+    system './configure',
+           '--with-camlibs=all,outdated',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/pugixml.rb
+++ b/packages/pugixml.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Pugixml < Package
+  description 'Light-weight, simple and fast XML parser for C++ with XPath support'
+  homepage 'https://pugixml.org/'
+  version '1.10'
+  source_url 'https://github.com/zeux/pugixml/releases/download/v1.10/pugixml-1.10.tar.gz'
+  source_sha256 '55f399fbb470942410d348584dc953bcaec926415d3462f471ef350f29b5870a'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pugixml-1.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pugixml-1.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pugixml-1.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pugixml-1.10-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'c948a90abf61186a25c71ed9434e9bea9ac7f6a88578c05fe40ba006ede7d561',
+     armv7l: 'c948a90abf61186a25c71ed9434e9bea9ac7f6a88578c05fe40ba006ede7d561',
+       i686: '98434a99ee0c01a9b571939e206d2a0c62205abacd3cbc06a9226147837762ef',
+     x86_64: 'a3c3a28cad9b0e278c5d3e863d73b5ad4ec9498bb5d2f21804946d786af18234',
+  })
+
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '-DCMAKE_BUILD_TYPE=Release',
+             '-DBUILD_SHARED_LIBS=ON',
+             '..'
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
+  end
+end


### PR DESCRIPTION
gPhoto2 is a free, redistributable, ready to use set of digital camera software applications for Unix-like systems, written by a whole team of dedicated volunteers around the world. It supports more than 2500 cameras  See http://www.gphoto.org/.

Pugixml is a light-weight, simple and fast XML parser for C++ with XPath support.  See https://pugixml.org/.

Tested on all architectures.