### PR TITLE
Use arm64 codium on arm64, not armhf

### DIFF
--- a/packages/codium.rb
+++ b/packages/codium.rb
@@ -5,7 +5,11 @@ class Codium < Package
   homepage 'https://vscodium.com/'
   version '1.42.1'
   case ARCH
-  when 'aarch64', 'armv7l'
+  when 'aarch64'
+    source_url 'https://github.com/VSCodium/vscodium/releases/download/1.42.1/VSCodium-linux-arm64-1.42.1.tar.gz'
+    source_sha256 'e40af11260dfe851510272c5ecb22cdbb65bbee6545eba841bdcc81165aada27'
+    @arch = 'arm64'
+  when 'armv7l'
     source_url 'https://github.com/VSCodium/vscodium/releases/download/1.42.1/VSCodium-linux-arm-1.42.1.tar.gz'
     source_sha256 '4406e67781b543b2d1b8a25b038a675d94bd778c1d95356ca4abbcfe2758ea21'
     @arch = 'arm'


### PR DESCRIPTION
Instead of using 32-bit ARM builds of Codium, this PR makes the package use 64-bit builds, which might perform better.

I haven't tested installing Codium with Chromebrew, but I know that arm64 builds work well.