### PR TITLE
Update php packages

### DIFF
--- a/packages/php.rb
+++ b/packages/php.rb
@@ -3,7 +3,7 @@ require 'package'
 class Php < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '5.6.40-7.4.2'
+  version '5.6.40-7.4.3'
 
   is_fake
 
@@ -15,9 +15,9 @@ class Php < Package
     puts "  5.6 = PHP 5.6.40"
     puts "  7.0 = PHP 7.0.33"
     puts "  7.1 = PHP 7.1.33"
-    puts "  7.2 = PHP 7.2.27"
-    puts "  7.3 = PHP 7.3.14"
-    puts "  7.4 = PHP 7.4.2"
+    puts "  7.2 = PHP 7.2.28"
+    puts "  7.3 = PHP 7.3.15"
+    puts "  7.4 = PHP 7.4.3"
     puts "    0 = Cancel"
 
     while version = STDIN.gets.chomp

--- a/packages/php72.rb
+++ b/packages/php72.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php72 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.2.27'
-  source_url 'https://php.net/distributions/php-7.2.27.tar.xz'
-  source_sha256 '7bd0fb9e3b63cfe53176d1f3565cd686f90b3926217158de5ba57091f49e4c32'
+  version '7.2.28'
+  source_url 'https://php.net/distributions/php-7.2.28.tar.xz'
+  source_sha256 'afe1863301da572dee2e0bad8014813bcced162f980ddc8ec8e41fd72263eb2d'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -13,20 +13,20 @@ class Php72 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.27-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.28-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.28-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.28-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php72-7.2.28-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '200c2376c4dcd3435a8813d13ff14dcd9dd28b849822841c40a2ef1d27516d0f',
-     armv7l: '200c2376c4dcd3435a8813d13ff14dcd9dd28b849822841c40a2ef1d27516d0f',
-       i686: 'aa8177e8f6e9f58d07b35a68c83103552d585aaa4ec2abbcbe34b7b067a6b493',
-     x86_64: '18c012beea8876a2d4820698ba0ab533cbea191c32a048f9d93457cfda4fbcf5',
+    aarch64: '22228720dcbcd3d18db17090dc5132ee17c66616be3341a76276f9c57f17e6af',
+     armv7l: '22228720dcbcd3d18db17090dc5132ee17c66616be3341a76276f9c57f17e6af',
+       i686: 'fddca73852fea1bea599cd8faae6eb948407380f0cbb652e91b04a489deb1bc5',
+     x86_64: '0a2de5b5d4087a12e8bfb602dd998ff7e9069fd265b2563515be96b9b515d604',
   })
 
   depends_on 'libgcrypt'
-  depends_on 'libwebp'
+  depends_on 'libjpeg_turbo'
   depends_on 'libxslt'
   depends_on 'libzip'
   depends_on 'curl'
@@ -69,13 +69,7 @@ class Php72 < Package
            "--sbindir=#{CREW_PREFIX}/bin",
            "--with-config-file-path=#{CREW_PREFIX}/etc",
            "--with-libdir=#{ARCH_LIB}",
-           "--with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype",
-           "--with-pcre-regex=#{CREW_LIB_PREFIX}",
-           "--with-jpeg-dir=#{CREW_LIB_PREFIX}",
            "--with-kerberos=#{CREW_LIB_PREFIX}",
-           "--with-png-dir=#{CREW_LIB_PREFIX}",
-           "--with-webp-dir=#{CREW_LIB_PREFIX}",
-           "--with-xpm-dir=#{CREW_LIB_PREFIX}",
            '--enable-exif',
            '--enable-fpm',
            '--enable-ftp',

--- a/packages/php73.rb
+++ b/packages/php73.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php73 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.3.14'
-  source_url 'https://php.net/distributions/php-7.3.14.tar.xz'
-  source_sha256 'cc05dd373ca5d36652800762f65c10e828a17de35aaf246262e3efa99d00cdb0'
+  version '7.3.15'
+  source_url 'https://php.net/distributions/php-7.3.15.tar.xz'
+  source_sha256 'de7ae7cf3d1dbb2824975b26b32991dac2b732886ec22075b8c53b261b018166'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -13,20 +13,20 @@ class Php73 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.14-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.15-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.15-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.15-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php73-7.3.15-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '0155c17c10baa03c36e9e43ab9249b994eda6477a210d8bce7a40ac23c623a4d',
-     armv7l: '0155c17c10baa03c36e9e43ab9249b994eda6477a210d8bce7a40ac23c623a4d',
-       i686: '03efd2ecd997bf5e0d8e4a3ed7a16bcbf29d4cee7c43d4277775c22902ba9f31',
-     x86_64: '9247dc95950d33454a41a4477513b2e0ec48b20dcb59a510472714925a1be0d2',
+    aarch64: '00a0dcd74ada06ab58d1f648c029523f53992db3d39ffd2f86260a3fcb6c7421',
+     armv7l: '00a0dcd74ada06ab58d1f648c029523f53992db3d39ffd2f86260a3fcb6c7421',
+       i686: 'ef4a22a0be11cd0d87eb6f183c4c4c532ae54d4a7693c3fdd46f942153997254',
+     x86_64: '9bdeb1365963887b254ef15b3d11c918acc7741e0eba624dda8ef7ef3ae0180e',
   })
 
   depends_on 'libgcrypt'
-  depends_on 'libwebp'
+  depends_on 'libjpeg_turbo'
   depends_on 'libxslt'
   depends_on 'libzip'
   depends_on 'curl'
@@ -69,13 +69,7 @@ class Php73 < Package
            "--sbindir=#{CREW_PREFIX}/bin",
            "--with-config-file-path=#{CREW_PREFIX}/etc",
            "--with-libdir=#{ARCH_LIB}",
-           "--with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype",
-           "--with-pcre-regex=#{CREW_LIB_PREFIX}",
-           "--with-jpeg-dir=#{CREW_LIB_PREFIX}",
            "--with-kerberos=#{CREW_LIB_PREFIX}",
-           "--with-png-dir=#{CREW_LIB_PREFIX}",
-           "--with-webp-dir=#{CREW_LIB_PREFIX}",
-           "--with-xpm-dir=#{CREW_LIB_PREFIX}",
            '--enable-exif',
            '--enable-fpm',
            '--enable-ftp',

--- a/packages/php74.rb
+++ b/packages/php74.rb
@@ -3,9 +3,9 @@ require 'package'
 class Php74 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  version '7.4.2'
-  source_url 'https://www.php.net/distributions/php-7.4.2.tar.xz'
-  source_sha256 '98284deac017da0d426117ecae7599a1f1bf62ae3911e8bc16c4403a8f4bdf13'
+  version '7.4.3'
+  source_url 'https://www.php.net/distributions/php-7.4.3.tar.xz'
+  source_sha256 'cf1f856d877c268124ded1ede40c9fb6142b125fdaafdc54f855120b8bc6982a'
 
   if ARGV[0] == 'install'
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
@@ -13,23 +13,23 @@ class Php74 < Package
   end
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.2-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/php74-7.4.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1772f9875a24d504c367a3aaef3574906c746babccf0e951da5e0f016e72175c',
-     armv7l: '1772f9875a24d504c367a3aaef3574906c746babccf0e951da5e0f016e72175c',
-       i686: 'f5c0e82ece2a9d9c2fa259f644eca699e6eacedf6566fdd7f7b8fce9416d2510',
-     x86_64: '9ce8fb964eca402de3072e061e8bc48e4cf6438abd72031299f5db2f30156304',
+    aarch64: '9e350ad837fd7817904e367ca0e6369c8a449ce0333b9fd58b0d0230d42afbc3',
+     armv7l: '9e350ad837fd7817904e367ca0e6369c8a449ce0333b9fd58b0d0230d42afbc3',
+       i686: 'e2129fedb5909c8c1312a3f5e807a9898c0d1fb9395818595ab85ca8c052d58e',
+     x86_64: 'f75435a6d55c616243ed84ace3623a9b7ec22e118f593b2826e1fee69271d46f',
   })
 
   depends_on 'aspell_en'
   depends_on 'libedit'
   depends_on 'libgcrypt'
+  depends_on 'libjpeg_turbo'
   depends_on 'libsodium'
-  depends_on 'libwebp'
   depends_on 'libxslt'
   depends_on 'libzip'
   depends_on 'curl'
@@ -74,13 +74,7 @@ class Php74 < Package
            "--sbindir=#{CREW_PREFIX}/bin",
            "--with-config-file-path=#{CREW_PREFIX}/etc",
            "--with-libdir=#{ARCH_LIB}",
-           "--with-freetype-dir=#{CREW_PREFIX}/include/freetype2/freetype",
-           "--with-pcre-regex=#{CREW_LIB_PREFIX}",
-           "--with-jpeg-dir=#{CREW_LIB_PREFIX}",
            "--with-kerberos=#{CREW_LIB_PREFIX}",
-           "--with-png-dir=#{CREW_LIB_PREFIX}",
-           "--with-webp-dir=#{CREW_LIB_PREFIX}",
-           "--with-xpm-dir=#{CREW_LIB_PREFIX}",
            '--enable-bcmath',
            '--enable-calendar',
            '--enable-dba=shared',
@@ -120,9 +114,7 @@ class Php74 < Package
            '--with-sodium',
            '--with-tidy',
            '--with-unixODBC',
-           '--with-webp',
            '--with-xmlrpc',
-           '--with-xpm',
            '--with-xsl',
            '--with-zip',
            '--with-zlib'


### PR DESCRIPTION
This update removes extensions that require X libraries to reduce to a sane number of package dependencies.  Resolves #3791.

- Update php72 from 7.2.27 to 7.2.28
- Update php73 from 7.3.14 to 7.3.15
- Update php74 from 7.4.2 to 7.4.3

Tested on all architectures.
