### PR TITLE
Update go from 1.12 to 1.14 and fix aarch64 builds

### DIFF
--- a/packages/go.rb
+++ b/packages/go.rb
@@ -3,21 +3,13 @@ require 'package'
 class Go < Package
   description 'Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.'
   homepage 'https://golang.org/'
-  version '1.12'
-  source_url 'https://dl.google.com/go/go1.12.src.tar.gz'
-  source_sha256 '09c43d3336743866f2985f566db0520b36f4992aea2b4b2fd9f52f17049e88f2'
+  version '1.14'
+  source_url 'https://dl.google.com/go/go1.14.src.tar.gz'
+  source_sha256 '6d643e46ad565058c7a39dac01144172ef9bd476521f42148be59249e4b74389'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.12-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.12-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.12-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'ba79eb1b8d48ce92d1a31d9f173941cc55fa55ff847cc5fab36a66c1ce77938b',
-     armv7l: 'ba79eb1b8d48ce92d1a31d9f173941cc55fa55ff847cc5fab36a66c1ce77938b',
-       i686: 'a96ebc21fbe093d956e06c3f977ecadc8a0840830585eec08aecbd629250beb6',
-     x86_64: '2620b266c38b8a9dce103886346a40d66b9a8eaccf98e1cff7f0e958f2a53cb2',
   })
 
   # Tests requires perl
@@ -34,12 +26,14 @@ class Go < Package
         system "GOROOT_BOOTSTRAP=#{CREW_PREFIX}/share/go_bootstrap/go \
                 TMPDIR=#{CREW_PREFIX}/tmp \
                 GOROOT_FINAL=#{CREW_PREFIX}/share/go \
-                ./make.bash"
+                %s \
+                ./make.bash" % 'GOHOSTARCH=arm' if ARCH == 'aarch64'
       else
         system "GOROOT_BOOTSTRAP=#{CREW_PREFIX}/share/go \
                 TMPDIR=#{CREW_PREFIX}/tmp \
                 GOROOT_FINAL=#{CREW_PREFIX}/share/go \
-                ./make.bash"
+                %s \
+                ./make.bash" % 'GOHOSTARCH=arm' if ARCH == 'aarch64'
       end
     end
   end


### PR DESCRIPTION
In addition to updating the package, building from source now works on
aarch64-based Chromebooks.

Tested on Samsung Chromebook Plus v1.

Fixes #1324 