### PR TITLE
[composer] Switch to upstream installer sha384 checksum

### DIFF
--- a/packages/composer.rb
+++ b/packages/composer.rb
@@ -22,7 +22,8 @@ class Composer < Package
 
   def self.install
     system "php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\""
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA384.hexdigest( File.read('composer-setup.php') ) == 'c5b9b6d368201a9db6f74e2611495f369991b72d9c8cbd3ffbc63edff210eb73d46ffbfce88669ad33695ef77dc76976'
+    system 'curl -Ls -o installer.sig https://composer.github.io/installer.sig'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA384.hexdigest( File.read('composer-setup.php') ) == File.read('installer.sig')
     system "mkdir -p #{CREW_DEST_PREFIX}/bin"
     system "php composer-setup.php --install-dir=#{CREW_DEST_PREFIX}/bin --filename=composer --version=#{version}"
     system "mkdir -p #{CREW_DEST_PREFIX}/.config"


### PR DESCRIPTION
This replaces the hardcoded sha384 checksum for the installer to use the
sha384 checksum provided by the upstream project. Their packaging
guidelines recommend this as the preferred way of validating the
integrity of the installer. This removes the need to constantly update
our package when they make changes to the installer.

Fixes #3833