### PR TITLE
Add pre-built binaries for bacon, cpustat, powerstat and smemstat

### DIFF
--- a/packages/bacon.rb
+++ b/packages/bacon.rb
@@ -8,8 +8,16 @@ class Bacon < Package
   source_sha256 '7f907f4ede68704eefd076733f617438c4baba98e9a1e8676ea1a00c4f8476ae'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bacon-3.9.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'e3688910dbee42cea250706e85b73dc6970aceabb25b855f0d7729ee07421f66',
+     armv7l: 'e3688910dbee42cea250706e85b73dc6970aceabb25b855f0d7729ee07421f66',
+       i686: 'ed8ac51c3a7f75e27cca79c1fe050f65aa6a188a2b58898961df43a7855d60db',
+     x86_64: '4a5ac4797556651820de1081d7be92726d1c01be68f4945f4bc2e78790a1f599',
   })
 
   def self.build

--- a/packages/cpustat.rb
+++ b/packages/cpustat.rb
@@ -8,8 +8,16 @@ class Cpustat < Package
   source_sha256 'ea9ab5a970ec657496c0127e3e5d58d49ce0fe07e750b4aafcfeb4896ccd74e9'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cpustat-0.02.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd8a55c174fee28fc12a5a153836696fdfc7320f5fbc106095e0d18faccc7c58e',
+     armv7l: 'd8a55c174fee28fc12a5a153836696fdfc7320f5fbc106095e0d18faccc7c58e',
+       i686: '8e215c1064acc4bc8329f801d79aa96b7d8537596e6b91c12037c5782f5b3454',
+     x86_64: '8e96b86281a64fe06adc42c18a8507f0e52ffba4368cd3acb96b4f428ad0bb0d',
   })
 
   def self.build

--- a/packages/powerstat.rb
+++ b/packages/powerstat.rb
@@ -8,8 +8,16 @@ class Powerstat < Package
   source_sha256 'ef74e023353a24a0a52068a0e474041b9556bcef5b4fe41db44261afd32a6564'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.22-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.22-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.22-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.22-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'a80779c88fd6ba1d192530ce6fa281aad82237b3067f251815a2f2f2ad5aa51d',
+     armv7l: 'a80779c88fd6ba1d192530ce6fa281aad82237b3067f251815a2f2f2ad5aa51d',
+       i686: '2cf7b359839f8feedb8c41d976a196dfc0194edbc51e281e1ac7aa233e7974ad',
+     x86_64: 'cf5f0e425a5b4a0bfbcf4e3747ccd4f5edcd6489ae0bbb9db873cec95ba30406',
   })
 
   def self.build

--- a/packages/smemstat.rb
+++ b/packages/smemstat.rb
@@ -8,8 +8,16 @@ class Smemstat < Package
   source_sha256 'acc17fdd6da92571e73a58bf1512b398cb307b80f46dc196cbb8102e7fb02526'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.07-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.07-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.07-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/smemstat-0.02.07-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '80549cd181fd79bd9c58462ea5e9b87d5f0c0657093a892803ae3db77980b7cb',
+     armv7l: '80549cd181fd79bd9c58462ea5e9b87d5f0c0657093a892803ae3db77980b7cb',
+       i686: 'b015b51fa07cbaeb7f3f2ae2abcef9a8c425a3f52a3c87c9ad51a4477c5fcf92',
+     x86_64: '80884214345553902dd3bef26011b1381c6f16382df34bbd473ee506ddf81e83',
   })
 
   depends_on 'ncurses'


### PR DESCRIPTION
Tested on all architectures.