### PR TITLE
Add pre-built binaries for hplip, hunspell_base, qrencode and testdisk

### DIFF
--- a/packages/hplip.rb
+++ b/packages/hplip.rb
@@ -4,12 +4,19 @@ class Hplip < Package
   description 'Print, Scan and Fax Drivers for Linux'
   homepage 'https://developers.hp.com/hp-linux-imaging-and-printing/'
   version '3.20.2'
-  source_url 'https://sourceforge.net/projects/hplip/files/hplip/3.20.2/hplip-3.20.2.tar.gz'
-  source_sha256 '90c49d74688b4d745a739a6db9bf8dbdfa134c24e921e31909bffe9d84f471c2'
+  case ARCH
+  when 'i686', 'x86_64'
+    source_url 'https://sourceforge.net/projects/hplip/files/hplip/3.20.2/hplip-3.20.2.tar.gz'
+    source_sha256 '90c49d74688b4d745a739a6db9bf8dbdfa134c24e921e31909bffe9d84f471c2'
+  end
 
   binary_url ({
+      i686: 'https://dl.bintray.com/chromebrew/chromebrew/hplip-3.20.2-chromeos-i686.tar.xz',
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/hplip-3.20.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+      i686: '3665d159fe1684d280689e09546a9f6cb0ab7be68d4e670f40c4111ae015d8b7',
+    x86_64: '05b80f04ea8ac68ffad990ed86140932f6353d25f7fd116df5190e8484385f09',
   })
 
   depends_on 'cups'

--- a/packages/hunspell_base.rb
+++ b/packages/hunspell_base.rb
@@ -8,8 +8,16 @@ class Hunspell_base < Package
   source_sha256 'bb27b86eb910a8285407cf3ca33b62643a02798cf2eef468c0a74f6c3ee6bc8a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/hunspell_base-1.7.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'e3e77aa133961b491fee9c7b139d3ae40f04a407faff775cf76a204a947a7b62',
+     armv7l: 'e3e77aa133961b491fee9c7b139d3ae40f04a407faff775cf76a204a947a7b62',
+       i686: 'd4cdc61aac3ab02d3234146364cb1c747e0c070a219197f6990f1d61877b3b13',
+     x86_64: '9f7a88d1e448094147b004a80b62ec5e9cf25b5e93ccbb363a2dddb3461ed8a2',
   })
 
   depends_on 'readline'

--- a/packages/qrencode.rb
+++ b/packages/qrencode.rb
@@ -8,8 +8,16 @@ class Qrencode < Package
   source_sha256 'dbabe79c07614625d1f74d8c0ae2ee5358c4e27eab8fd8fe31f9365f821a3b1d'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qrencode-4.0.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qrencode-4.0.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qrencode-4.0.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qrencode-4.0.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '1135a62562f8a523968b5affb3fbd32cf1068701de6024ab1d1b612b39065cd3',
+     armv7l: '1135a62562f8a523968b5affb3fbd32cf1068701de6024ab1d1b612b39065cd3',
+       i686: 'a71bbdf13f9a57930d3d0064becdaa57613d3e16fe446e40698bc377881c9175',
+     x86_64: '20d0f46764c934a1d32f114c0488fb9b79a1761dbb757d51a009a2547b3cd682',
   })
 
 

--- a/packages/testdisk.rb
+++ b/packages/testdisk.rb
@@ -8,8 +8,16 @@ class Testdisk < Package
   source_sha256 'c95dd532dad353713e8ca895a3faac31acef284f9f0fad299f69181fec583313'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/testdisk-7.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd1d42ff50e0792de2c5ddaec3abcb5de9e7057a3d7f63f883cdf283d336850ce',
+     armv7l: 'd1d42ff50e0792de2c5ddaec3abcb5de9e7057a3d7f63f883cdf283d336850ce',
+       i686: 'a3da5c747e406e52ed72d119ba4c308e6465c85b594cf21be9e9e63151551bc7',
+     x86_64: '8b5a399c8e43c821156eb632805fe94f0d6f81e99aaffbeb2e54f54e3a887c77',
   })
 
   depends_on 'apriconv'


### PR DESCRIPTION
Closes #3159.  Tested on all architectures.