### PR TITLE
Add alsa_utils package

### DIFF
--- a/packages/alsa_utils.rb
+++ b/packages/alsa_utils.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Alsa_utils < Package
+  description 'The Advanced Linux Sound Architecture (ALSA) - utilities'
+  homepage 'https://github.com/alsa-project/alsa-utils'
+  version '1.2.2'
+  source_url 'https://github.com/alsa-project/alsa-utils/archive/v1.2.2.tar.gz'
+  source_sha256 '9da1ce4f12a4dd56d55cd5a8f6ae7d56ac91397c3d37fdfcd737adeeb34fce1c'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_utils-1.2.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_utils-1.2.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_utils-1.2.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/alsa_utils-1.2.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'cff8b1579f0d7b918ac5f9bfb7dd3e6bfb4f4beff4eb28eae425add13b1c0ee2',
+     armv7l: 'cff8b1579f0d7b918ac5f9bfb7dd3e6bfb4f4beff4eb28eae425add13b1c0ee2',
+       i686: '27c3a3394bcadf2751fbeb755b269cedbd078349638b64e3febdf1ef7c468ad9',
+     x86_64: '31deca395175c3c5fde640609bb635a1a35a329fe840c63fd2c280462e82d7d7',
+  })
+
+  depends_on 'alsa_lib'
+
+  def self.build
+    system "./gitcompile --prefix=#{CREW_PREFIX}"
+  end
+
+  def self.check
+    # This takes several hours to run!
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end


### PR DESCRIPTION
This package contains the command line utilities for the ALSA project.
The package can be compiled only with the installed ALSA driver and
the ALSA C library (alsa-lib).
```
Utility         | Description
----------------|----------------------------------------------------
alsaconf        | the ALSA driver configurator script
alsa-info       | a script to gather information about ALSA subsystem
alsactl         | an utility for soundcard settings management
aplay/arecord   | an utility for the playback / capture of .wav,.voc,.au files
axfer           | an utility to transfer audio data frame (enhancement of aplay)
amixer          | a command line mixer
alsamixer       | a ncurses mixer
amidi           | a utility to send/receive sysex dumps or other MIDI data
iecset          | a utility to show/set the IEC958 status bits
speaker-test    | a speaker test utility
alsaloop        | a software loopback for PCM devices
alsaucm         | Use Case Manager utility
alsabat         | a sound tester for ALSA sound card driver
alsatplg        | ALSA topology compiler
```
You may give a look for more information about the ALSA project to URL http://www.alsa-project.org.
Tested on all architectures.  All `make check` tests pass.