### PR TITLE
Update libusbmuxd to 2.0.1

### DIFF
--- a/packages/libplist.rb
+++ b/packages/libplist.rb
@@ -3,26 +3,19 @@ require 'package'
 class Libplist < Package
   description 'A library to handle Apple Property List format'
   homepage 'http://www.libimobiledevice.org/'
-  version '2.0.0'
-  source_url 'http://www.libimobiledevice.org/downloads/libplist-2.0.0.tar.bz2'
-  source_sha256 '3a7e9694c2d9a85174ba1fa92417cfabaea7f6d19631e544948dc7e17e82f602'
+  version '2.1.0'
+  source_url 'https://github.com/libimobiledevice/libplist/archive/2.1.0.tar.gz'
+  source_sha256 '4b33f9af3f9208d54a3c3e1a8c149932513f451c98d1dd696fe42c06e30b7f03'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libplist-2.0.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libplist-2.0.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libplist-2.0.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libplist-2.0.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '361fcbe8e9ddd1ea0827c1fad4788b3f5dbf7c344eb0b44ad9c11e20fb0af72c',
-     armv7l: '361fcbe8e9ddd1ea0827c1fad4788b3f5dbf7c344eb0b44ad9c11e20fb0af72c',
-       i686: '1f2db0a7e401c870a8bd8a2c5b59669524e35fffbdd5f58ac8c7fa297004cb9c',
-     x86_64: '67d760c5c49508d8d89b6b81cd3480183b0fee278c59d5c20d6ccf6d483afeea',
   })
 
   depends_on 'glib'
 
   def self.build
+    system './autogen.sh CC=gcc CXX=g++'
     system './configure',
       "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}",

--- a/packages/libusbmuxd.rb
+++ b/packages/libusbmuxd.rb
@@ -3,27 +3,20 @@ require 'package'
 class Libusbmuxd < Package
   description 'USB Multiplex Daemon'
   homepage 'http://www.libimobiledevice.org/'
-  version '1.0.9'
-  source_url 'http://www.libimobiledevice.org/downloads/libusbmuxd-1.0.9.tar.bz2'
-  source_sha256 '2e3f708a3df30ad7832d2d2389eeb29f68f4e4488a42a20149cc99f4f9223dfc'
+  version '2.0.1'
+  source_url 'https://github.com/libimobiledevice/libusbmuxd/archive/2.0.1.tar.gz'
+  source_sha256 'f93faf3b3a73e283646f4d62b3421aeccf58142266b0eb22b2b13dd4b2362eb8'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libusbmuxd-1.0.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libusbmuxd-1.0.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libusbmuxd-1.0.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libusbmuxd-1.0.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'd47e325523f0167e598638cc889058c4dbaae0d2277d867b1ee86cc5b2285b1b',
-     armv7l: 'd47e325523f0167e598638cc889058c4dbaae0d2277d867b1ee86cc5b2285b1b',
-       i686: '85cc5ad75e883f17e1ea5b6de634c7db4cbd390b62b0f8d75950ee494cf28eb6',
-     x86_64: 'b9b4ba031ce059483b3e72abf300534f121f37b2759352c87c87fe3595ac83b2',
   })
 
   depends_on 'glib'
   depends_on 'libplist'
 
   def self.build
+    system './autogen.sh'
     system './configure',
       "--prefix=#{CREW_PREFIX}",
       "--libdir=#{CREW_LIB_PREFIX}",


### PR DESCRIPTION
Updating libusbmuxd required an updated libplist package which it
depends on (included). This release also doesn't build properly with out
clang/llvm package (switched to GCC). We need to get clang working as
the gcc-built version doesn't support some features for fuzzing.

Tested on ARM.