### PR TITLE
Build libplist with gcc rather than clang

### DIFF
--- a/packages/libplist.rb
+++ b/packages/libplist.rb
@@ -15,7 +15,8 @@ class Libplist < Package
   depends_on 'glib'
 
   def self.build
-    system "./configure CC=gcc CXX=g++ \
+    system './autogen.sh CC=gcc CXX=g++'
+    system "./configure \
       --prefix=#{CREW_PREFIX} \
       --libdir=#{CREW_LIB_PREFIX}"
     system 'make'

--- a/packages/libplist.rb
+++ b/packages/libplist.rb
@@ -23,10 +23,9 @@ class Libplist < Package
   depends_on 'glib'
 
   def self.build
-    system './configure',
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}",
-      '--disable-dependency-tracking'
+    system "./configure CC=gcc CXX=g++ \
+      --prefix=#{CREW_PREFIX} \
+      --libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 


### PR DESCRIPTION
Clang is the preferred way for building the libimobiledevice packages
since several features cannot be built using gcc (fuzzing, etc). Until
we have a more stable, mature clang package the tools for working with
Apple devices will be built with gcc.

Tested on ARM. Closes #3873 