### PR TITLE
Add rubberband package and dependencies

### DIFF
--- a/packages/fftw.rb
+++ b/packages/fftw.rb
@@ -1,0 +1,39 @@
+require 'package'
+
+class Fftw < Package
+  description 'FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data'
+  homepage 'http://www.fftw.org/'
+  version '3.3.8'
+  source_url 'http://www.fftw.org/fftw-3.3.8.tar.gz'
+  source_sha256 '6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f3e94c3a07e8966eafe02daa3673de462bab1fbbb0f1aefcc844ffbc53c84307',
+     armv7l: 'f3e94c3a07e8966eafe02daa3673de462bab1fbbb0f1aefcc844ffbc53c84307',
+       i686: '03800193d0be4a716331a27a948022d0a6ac94183a6b2fe0a988f5d94e3e8ff9',
+     x86_64: '47c9b73133cf16339ab6c229ba74ec73155f0fc1bf01bfd0e4e2c6ac7c46f78e',
+  })
+
+  def self.build
+    system './configure',
+           '--enable-shared=yes',
+           '--disable-maintainer-mode',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libsamplerate.rb
+++ b/packages/libsamplerate.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Libsamplerate < Package
+  description 'Secret Rabbit Code (aka libsamplerate) is a Sample Rate Converter for audio.'
+  homepage 'http://www.mega-nerd.com/libsamplerate/'
+  version '0.1.9'
+  source_url 'http://www.mega-nerd.com/libsamplerate/libsamplerate-0.1.9.tar.gz'
+  source_sha256 '0a7eb168e2f21353fb6d84da152e4512126f7dc48ccb0be80578c565413444c1'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsamplerate-0.1.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsamplerate-0.1.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsamplerate-0.1.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsamplerate-0.1.9-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'cae5af051ec2d36af1e8c1acfc8fc8fd3b7d81d22492a6f2226561c78733775f',
+     armv7l: 'cae5af051ec2d36af1e8c1acfc8fc8fd3b7d81d22492a6f2226561c78733775f',
+       i686: '4f848d40fd487d9241008719b31df0dbf5257db5b9741977b5811fa691e9304e',
+     x86_64: '57c63e7f734cd31d645ec93582488f1c6fb1a14de3c8ad6b1d0cf9c9464e48bc',
+  })
+
+  depends_on 'alsa_lib'
+  depends_on 'fftw'
+  depends_on 'libsndfile'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/rubberband.rb
+++ b/packages/rubberband.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Rubberband < Package
+  description 'Rubber Band Library is a high quality software library for audio time-stretching and pitch-shifting.'
+  homepage 'https://breakfastquay.com/rubberband/'
+  version '1.8.2'
+  source_url 'https://breakfastquay.com/files/releases/rubberband-1.8.2.tar.bz2'
+  source_sha256 '86bed06b7115b64441d32ae53634fcc0539a50b9b648ef87443f936782f6c3ca'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rubberband-1.8.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rubberband-1.8.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rubberband-1.8.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rubberband-1.8.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'b684aa86b3ef03b2be91f518c5b88d536d9d3152eeab5670fd7117186742be8b',
+     armv7l: 'b684aa86b3ef03b2be91f518c5b88d536d9d3152eeab5670fd7117186742be8b',
+       i686: 'deb5b36f7b7b2da1390baf2330b533ab82598a46eeb7073d9f334cb905d006f8',
+     x86_64: '909761fb62e174eaf6b788afc0c1390a38083d7ac7571260f1e294b560dffdbf',
+  })
+
+  depends_on 'ladspa'
+  depends_on 'libsamplerate'
+  depends_on 'vamp_sdk'
+
+  def self.build
+    ENV['JAVA_HOME'] = "#{CREW_PREFIX}/share/jdk8"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    # Remove missing librubberband-jni.so.
+    system "sed -i '186d' Makefile"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    if ARCH == 'x86_64'
+      Dir.chdir "#{CREW_DEST_PREFIX}" do
+        FileUtils.mv 'lib/', 'lib64/'
+      end
+    end
+  end
+end

--- a/packages/vamp_sdk.rb
+++ b/packages/vamp_sdk.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Vamp_sdk < Package
+  description 'Vamp is an audio processing plugin system for plugins that extract descriptive information from audio data — typically referred to as audio analysis plugins or audio feature extraction plugins.'
+  homepage 'https://vamp-plugins.org/'
+  version '2.9.0'
+  source_url 'https://code.soundsoftware.ac.uk/attachments/download/2588/vamp-plugin-sdk-2.9.0.tar.gz'
+  source_sha256 'b72a78ef8ff8a927dc2ed7e66ecf4c62d23268a5d74d02da25be2b8d00341099'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vamp_sdk-2.9.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vamp_sdk-2.9.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vamp_sdk-2.9.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vamp_sdk-2.9.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fc53ab7e53a476611498b38139aaa3be69b39efe097ff97b5633b53d0883981c',
+     armv7l: 'fc53ab7e53a476611498b38139aaa3be69b39efe097ff97b5633b53d0883981c',
+       i686: 'd376a24518bb74e53f5c1556cd570b1e7e910e6679f8b87b1e3b0778e924d724',
+     x86_64: 'cf7ca4db41a96a12eeb89c658153e4641101d10740dd4c89a6d3a66f289d2b5b',
+  })
+
+  depends_on 'libsndfile'
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    if ARCH == 'x86_64'
+      Dir.chdir "#{CREW_DEST_PREFIX}" do
+        FileUtils.mv 'lib/', 'lib64/'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rubber Band Library is a high quality software library for audio time-stretching and pitch-shifting.  See https://breakfastquay.com/rubberband/.

Dependencies include fftw, libsamplerate and vamp_sdk:
- FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data.  See http://www.fftw.org/.
- Secret Rabbit Code (aka libsamplerate) is a Sample Rate Converter for audio. 
 See http://www.mega-nerd.com/libsamplerate/.
- Vamp is an audio processing plugin system for plugins that extract descriptive information from audio data — typically referred to as audio analysis plugins or audio feature extraction plugins. 
 See https://vamp-plugins.org/.

Tested on all architectures.