### PR TITLE
Add obs package and libmbedtls dependency

### DIFF
--- a/packages/libmbedtls.rb
+++ b/packages/libmbedtls.rb
@@ -1,0 +1,42 @@
+require 'package'
+
+class Libmbedtls < Package
+  description 'An open source, portable, easy to use, readable and flexible SSL library'
+  homepage 'https://tls.mbed.org/'
+  version '2.16.5'
+  source_url 'https://tls.mbed.org/download/mbedtls-2.16.5-apache.tgz'
+  source_sha256 '65b4c6cec83e048fd1c675e9a29a394ea30ad0371d37b5742453f74084e7b04d'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libmbedtls-2.16.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libmbedtls-2.16.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libmbedtls-2.16.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libmbedtls-2.16.5-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e110f3d42b6228c10790996e834ff21f1fe99cbc93d7869fc3d9e5dc058a6f64',
+     armv7l: 'e110f3d42b6228c10790996e834ff21f1fe99cbc93d7869fc3d9e5dc058a6f64',
+       i686: 'fb8257eb9eaa4fbaf25ae518464013b0b6c0fc4ebd02c25ff657df64df517b6a',
+     x86_64: '28de88799e5aa56d9ae16c8df6e22b60607d58f1191a3a37ff14270fb3c88e6b',
+  })
+
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '-DUSE_SHARED_MBEDTLS_LIBRARY=ON',
+             '-DCMAKE_BUILD_TYPE=Release',
+             '-DENABLE_ZLIB_SUPPORT=ON',
+             '..'
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+      FileUtils.mv "#{CREW_DEST_PREFIX}/lib", "#{CREW_DEST_LIB_PREFIX}" if ARCH == 'x86_64'
+    end
+  end
+end

--- a/packages/obs.rb
+++ b/packages/obs.rb
@@ -1,0 +1,70 @@
+require 'package'
+
+class Obs < Package
+  description 'Free and open source software for video recording and live streaming.'
+  homepage 'https://obsproject.com/'
+  version '24.0.5'
+  case ARCH
+  when 'i686', 'x86_64'
+    source_url 'https://github.com/obsproject/obs-studio/archive/24.0.5.tar.gz'
+    source_sha256 'b3d65f36ad2bfcd6ffde1771be64662ce8e8771349fab82bb49f80dbb1f5f2e6'
+
+    depends_on 'curl'
+    depends_on 'ffmpeg'
+    depends_on 'jack'
+    depends_on 'jansson'
+    depends_on 'libmbedtls'
+    depends_on 'luajit'
+    depends_on 'qtsvg'
+    depends_on 'qtx11extras'
+    depends_on 'v4l_utils'
+    depends_on 'xdg_base'
+    depends_on 'sommelier'
+  end
+
+  binary_url ({
+      i686: 'https://dl.bintray.com/chromebrew/chromebrew/obs-24.0.5-chromeos-i686.tar.xz',
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/obs-24.0.5-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+      i686: 'b27299c233995f0c03a4dc2a8563bec7a2f00582a2554d62829d216769f42d5c',
+    x86_64: '854492244415cea4b4874cf3cd2302649d5b538d89366f2fd1ccceda7ff1f3ea',
+  })
+
+  def self.build
+    # Use the gold linker.
+    old_ld = `ld_default g`.chomp
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             '-DCMAKE_BUILD_TYPE=Release',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '..'
+      system 'make'
+    end
+    # Restore the original linker.
+    system 'ld_default', "#{old_ld}"
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
+    case ARCH
+    when 'x86_64'
+      Dir.chdir CREW_DEST_PREFIX do
+        FileUtils.mv Dir.glob('lib/*'), 'lib64/'
+      end
+    end
+  end
+
+  def self.postinstall
+    puts
+    puts "To get started, type 'obs'.".lightblue
+    puts
+    puts "To completely remove, execute the following:".lightblue
+    puts "crew remove obs".lightblue
+    puts "rm -rf ~/.config/obs-studio/".lightblue
+    puts
+  end
+end


### PR DESCRIPTION
obs: Free and open source software for video recording and live streaming.  See https://obsproject.com/.
libmbedtls: An open source, portable, easy to use, readable and flexible SSL library.  See https://tls.mbed.org/.
Tested on i686 and x86_64.  Unable to build on armv7l or aarch64.  I wasn't able to get this working on my low powered and incompatible Chromebooks but maybe someone with a beefier system can get it working.