### PR TITLE
[codium] Open File button crashes codium

### DIFF
--- a/packages/codium.rb
+++ b/packages/codium.rb
@@ -3,7 +3,7 @@ require 'package'
 class Codium < Package
   description 'VSCodium is Open Source Software Binaries of VSCode with a community-driven default configuration.'
   homepage 'https://vscodium.com/'
-  version '1.43.1'
+  version '1.43.1-1'
   case ARCH
   when 'aarch64', 'armv7l'
     source_url 'https://github.com/VSCodium/vscodium/releases/download/1.43.1/VSCodium-linux-arm-1.43.1.tar.gz'
@@ -22,10 +22,10 @@ class Codium < Package
   depends_on 'sommelier'
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/VSCodium-linux-#{@arch}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/VSCodium-linux-#{@arch}"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/VSCodium-linux-#{@arch}"
-    FileUtils.ln_s "../share/VSCodium-linux-#{@arch}/bin/codium", "#{CREW_DEST_PREFIX}/bin/codium"
+    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/VSCodium-linux-#{@arch}"
+    FileUtils.ln_s "../VSCodium-linux-#{@arch}/bin/codium", "#{CREW_DEST_PREFIX}/bin/codium"
   end
 
   def self.postinstall


### PR DESCRIPTION
With 1.43.1 version, when trying to open a folder or a file, codium crashes with following message 
```
Failed to load /usr/local/share/icons/gnome/16x16/status/image-missing.png: Unable to load image-loading module: /usr/local/share/VSCodium-linux-x64/../lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-png.so: /usr/local/share/VSCodium-linux-x64/../lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-png.so: cannot open shared object file: No such file or directory (gdk-pixbuf-error-quark, 5)
```
While I could not find out how this path can be set up, I changed the installation path. Any better idea welcomed !