### PR TITLE
Add pre-built binaries for gobject_introspection, pango and poppler packages

### DIFF
--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -8,8 +8,16 @@ class Gobject_introspection < Package
   source_sha256 'eac05a63091c81adfdc8ef34820bcc7e7778c5b9e34734d344fc9e69ddf4fc82'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.64.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.64.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.64.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.64.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '38781ac9905d88ebfcd5f776cdec1d7ff79b45b0f03dbf7e72e729a232175389',
+     armv7l: '38781ac9905d88ebfcd5f776cdec1d7ff79b45b0f03dbf7e72e729a232175389',
+       i686: '0244b19fa91d0524eceb40b1694ee3473d212d5cd9d3147fcb3e59406d98dbd6',
+     x86_64: '10e3f341d3bbe14d741062463bc6eb0631051db075cef3782b3273191aea098b',
   })
 
   depends_on 'glib'

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -8,8 +8,16 @@ class Pango < Package
   source_sha256 '66a5b6cc13db73efed67b8e933584509f8ddb7b10a8a40c3850ca4a985ea1b1f'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.44.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.44.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.44.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.44.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'ec4d228e60636eaeae2f60a9d15d30685dfaba9b9664b633956bd2cf910f4aa1',
+     armv7l: 'ec4d228e60636eaeae2f60a9d15d30685dfaba9b9664b633956bd2cf910f4aa1',
+       i686: '6393f959ff12bafce05ba84eb60a1143bdd78cd2afdc56477d663f8ddd914db4',
+     x86_64: '535b15a6d6f7f0433b697565f1490901606803dc9af598655cb69aaf4da616b1',
   })
 
   depends_on 'harfbuzz'

--- a/packages/poppler.rb
+++ b/packages/poppler.rb
@@ -8,36 +8,47 @@ class Poppler < Package
   source_sha256 'af630a277c8e194c31339c5446241834aed6ed3d4b4dc7080311e51c66257f6c'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.86.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.86.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.86.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-0.86.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'd7a3f4fbf1f47c73958e64b3ec1009865fe291f651de0dd6c5c25283a3bcc77d',
+     armv7l: 'd7a3f4fbf1f47c73958e64b3ec1009865fe291f651de0dd6c5c25283a3bcc77d',
+       i686: '1a79d3f532ba1d3d26da035676516cd7c1a184a3f703438ea615fa6d498416d4',
+     x86_64: '214addecd68af303a0e158f5e0ccd4910aea8a0073340adc9098d1307a56bc36',
   })
 
-  depends_on 'automake' => :build
+  depends_on 'boost'
   depends_on 'cairo'
+  depends_on 'curl'
+  depends_on 'freeglut'
   depends_on 'harfbuzz'
+  depends_on 'lcms'
   depends_on 'libjpeg'
   depends_on 'libpng'
+  depends_on 'libtiff'
   depends_on 'openjpeg'
-  depends_on 'zlibpkg'
-  depends_on 'cmake' => :build
+  depends_on 'poppler_data'
+  depends_on 'qttools'
 
   def self.build
-    system "mkdir -p builddir"
-    Dir.chdir("builddir") do
-      system "cmake",
-        "-DCMAKE_CXX_FLAGS='-I#{CREW_PREFIX}/include/openjpeg-2.3 -I#{CREW_PREFIX}/include'",
-             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system 'cmake',
+             "-DCMAKE_CXX_FLAGS='-I#{CREW_PREFIX}/include/GL -I#{CREW_PREFIX}/include/openjpeg-2.3 -I#{CREW_PREFIX}/include'",
              "-DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX}",
-             "-DCMAKE_BUILD_TYPE=Release",
-             "-DENABLE_XPDF_HEADERS=ON",
-             ".."
-      system "make"
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '-DCMAKE_BUILD_TYPE=Release',
+             '..'
+      system 'make'
     end
   end
 
   def self.install
-    Dir.chdir("builddir") do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    Dir.chdir 'builddir' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
   end
 end


### PR DESCRIPTION
Fixes #3942 
Fixes #3943 
Fixes #3945
Tested on all architectures.