### PR TITLE
Add arping package and libnet dependency

### DIFF
--- a/packages/arping.rb
+++ b/packages/arping.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Arping < Package
+  description 'ARP Ping'
+  homepage 'https://github.com/ThomasHabets/arping'
+  version '2.21'
+  source_url 'https://github.com/ThomasHabets/arping/archive/arping-2.21.tar.gz'
+  source_sha256 '7bf550571aa1d4a2b00878bb2f6fb857a09d30bf65411c90d62afcd86755bd81'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/arping-2.21-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/arping-2.21-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/arping-2.21-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/arping-2.21-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e85f871e84dce5360c1b50eccaa3ae5a1beaea9f89120cf0da19ffcabcf19fa1',
+     armv7l: 'e85f871e84dce5360c1b50eccaa3ae5a1beaea9f89120cf0da19ffcabcf19fa1',
+       i686: 'b808583d44c865ac023986b02e4c1ad8d9fbdbd12540775f620953b01a810e50',
+     x86_64: '46c5c7e174bb800bb317e09df6f77448040c7aeda137a23e2b8ed85ecb852fcb',
+  })
+
+  depends_on 'libpcap'
+  depends_on 'libnet'
+
+  def self.build
+    system './bootstrap.sh'
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libnet.rb
+++ b/packages/libnet.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Libnet < Package
+  description 'A portable framework for low-level network packet construction'
+  homepage 'https://github.com/libnet/libnet'
+  version '1.2'
+  source_url 'https://github.com/libnet/libnet/releases/download/v1.2/libnet-1.2.tar.gz'
+  source_sha256 'caa4868157d9e5f32e9c7eac9461efeff30cb28357f7f6bf07e73933fb4edaa7'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libnet-1.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libnet-1.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libnet-1.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libnet-1.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f5470d38812054ec3e6debbcaa9f40bf8af6d466586ac5b468934308510ad60b',
+     armv7l: 'f5470d38812054ec3e6debbcaa9f40bf8af6d466586ac5b468934308510ad60b',
+       i686: '7816e92e1ade988289088c4a7732716b22747b3e4b1e8017a65e37d65c01a116',
+     x86_64: '41332bb8b21536bc8fcb14b9efb87d7caa4dff2c0942a4ef5d43a38a48e969c6',
+  })
+
+  def self.build
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end


### PR DESCRIPTION
ARP Ping broadcasts a who-has ARP packet on the network and prints answers. VERY useful when you are trying to pick an unused IP for a net that you don't yet have routing to.  See https://github.com/ThomasHabets/arping.  libnet is a portable framework for low-level network packet construction.  See https://github.com/libnet/libnet.