### PR TITLE
Add gcalculator package and dependencies

### DIFF
--- a/packages/gcalculator.rb
+++ b/packages/gcalculator.rb
@@ -1,0 +1,47 @@
+require 'package'
+
+class Gcalculator < Package
+  description 'Calculator for solving mathematical equations'
+  homepage 'https://gitlab.gnome.org/GNOME/gnome-calculator'
+  version '3.36.0'
+  source_url 'https://gitlab.gnome.org/GNOME/gnome-calculator/-/archive/3.36.0/gnome-calculator-3.36.0.tar.bz2'
+  source_sha256 '9d82e8b32cd3c41517d9bfc234b88359b1bef8f1bfa02994b622788272846b3a'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcalculator-3.36.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcalculator-3.36.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcalculator-3.36.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcalculator-3.36.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '6ef512061c2826d965bbc6be61d1070b96f815daedfb047f4ea958059825e1bc',
+     armv7l: '6ef512061c2826d965bbc6be61d1070b96f815daedfb047f4ea958059825e1bc',
+       i686: '7152af3ed58253c04bb23edfed46213107d1584f9fb6bb92a349139840ce099b',
+     x86_64: 'b75a8c4fd588b2546389a1817a808420b68a73db71af95b2c3bb5d49e473ccbf',
+  })
+
+  depends_on 'setuptools' => :build
+  depends_on 'gtksourceview'
+  depends_on 'itstool'
+  depends_on 'libgee'
+  depends_on 'libsoup'
+  depends_on 'sommelier'
+
+  def self.build
+    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+
+  def self.postinstall
+    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
+    puts
+    puts "To use the gui calculator, execute 'gnome-calculator'".lightblue
+    puts
+    puts "To use the cli calculator, execute 'gcalccmd'".lightblue
+    puts
+  end
+end

--- a/packages/gtksourceview.rb
+++ b/packages/gtksourceview.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Gtksourceview < Package
+  description 'Source code editing widget'
+  homepage 'https://wiki.gnome.org/Projects/GtkSourceView'
+  version '4.6.0'
+  source_url 'https://github.com/GNOME/gtksourceview/archive/4.6.0.tar.gz'
+  source_sha256 '34008d2e2fa07355e58f6bb6e9ae970b1370fe95e17ba4b0650b473b4d41860c'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview-4.6.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview-4.6.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview-4.6.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview-4.6.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '1cf5dee7a1e574ddfb02364a1fd05bc71a64644b44070b5704e3df0712ce9dea',
+     armv7l: '1cf5dee7a1e574ddfb02364a1fd05bc71a64644b44070b5704e3df0712ce9dea',
+       i686: '7e9b0644c2385801f413803dd5aace6fd8d28a374374797430cfabe371d7703d',
+     x86_64: 'e292727fd829b94c40072d118ddd2a861528da4d272294d2dae4fde6081ffe80',
+  })
+
+  depends_on 'setuptools' => :build
+  depends_on 'vala'
+  depends_on 'gtk3'
+
+  def self.build
+    system "meson --buildtype=plain --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/libgee.rb
+++ b/packages/libgee.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Libgee < Package
+  description 'Libgee is an utility library providing GObject-based interfaces and classes for commonly used data structures.'
+  homepage 'https://wiki.gnome.org/Projects/Libgee'
+  version '0.20.3'
+  source_url 'https://download.gnome.org/sources/libgee/0.20/libgee-0.20.3.tar.xz'
+  source_sha256 'd0b5edefc88cbca5f1709d19fa62aef490922c6577a14ac4e7b085507911a5de'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgee-0.20.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgee-0.20.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgee-0.20.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgee-0.20.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '5b56ee3c98f061b93b725b1b9ca2d1e5ce8b5e1bf17c30c361a20de0874079fd',
+     armv7l: '5b56ee3c98f061b93b725b1b9ca2d1e5ce8b5e1bf17c30c361a20de0874079fd',
+       i686: '6987e6ff636e7d964a2427ea298597985c0f5c0ec218615559560e5c0954d452',
+     x86_64: '227764127203eff1a10ec93f248a047c13744f51a41b4cce2aea71da274e8266',
+  })
+
+  def self.build
+    ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end


### PR DESCRIPTION
Calculator for solving mathematical equations.  See https://gitlab.gnome.org/GNOME/gnome-calculator.
Dependencies include:
gtksourceview - Source code editing widget.  See https://wiki.gnome.org/Projects/GtkSourceView.
libgee - Libgee is an utility library providing GObject-based interfaces and classes for commonly used data structures.  See https://wiki.gnome.org/Projects/Libgee.
Tested on all architectures.