### PR TITLE
Revert ghostscript package to restore availability on arm

### DIFF
--- a/packages/ghostscript.rb
+++ b/packages/ghostscript.rb
@@ -2,21 +2,22 @@ require 'package'
 
 class Ghostscript < Package
   description 'Ghostscript is the name of a set of software that provides an interpreter for the PostScript language and the PDF file format.'
-  homepage 'https://www.ghostscript.com/'
-  version '9.52'
-  case ARCH
-  when 'i686', 'x86_64'
-    source_url 'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs952/ghostscript-9.52.tar.xz'
-    source_sha256 '57442acf8b46453a9b5fc6fec738fbbb7e13a3d3e00f1aaaa0975529bc203c7c'
-  end
+  homepage 'https://www.gnu.org/software/ghostscript/'
+  version '9.14.1-1'
+  source_url 'https://ftpmirror.gnu.org/ghostscript/gnu-ghostscript-9.14.1.tar.xz'
+  source_sha256 '424a4ff333a594fdd397cd8adc4249bad7d74a6ae653f840dee72b27f1bf1da0'
 
   binary_url ({
-      i686: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.52-chromeos-i686.tar.xz',
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.52-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.14.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.14.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.14.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.14.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-      i686: 'e03c125fcc7a4a0bbc9e73cc96b2c9f32f7e20e5791e68f8a81cae6d667da789',
-    x86_64: 'df1b614750f332fb8d759fe5b9c5c231193d745abc0c47db493470fa7d40e459',
+    aarch64: 'eb8e98fe8b0eb70ce20c56878e962d690f25703326cdca60865ed05e5444cd3f',
+     armv7l: 'eb8e98fe8b0eb70ce20c56878e962d690f25703326cdca60865ed05e5444cd3f',
+       i686: '31827f5362971f99ba3aa5aa6f4fdc3a4ca4368bf72a499538fdf7f98fff3d41',
+     x86_64: '23325d5f8c5cbb538a366313d68da5a35677ddf963ecfdfe8a40d0617c55b2bc',
   })
 
   depends_on 'cups'
@@ -26,12 +27,12 @@ class Ghostscript < Package
   depends_on 'libtiff'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --with-drivers=ALL"
+    system './configure',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '--disable-dependency-tracking',
+           '--disable-static'
     system 'make'
-  end
-
-  def self.check
-    system 'make', 'check'
   end
 
   def self.install


### PR DESCRIPTION
Gimp depends on ghostscript which was working on arm with the earlier version.