### PR TITLE
Add pre-built binaries for babl, gegl, gimp and sqlitebrowser

### DIFF
--- a/packages/babl.rb
+++ b/packages/babl.rb
@@ -8,8 +8,16 @@ class Babl < Package
   source_sha256 '9a710b6950da37ada94cd9e2046cbce26de12473da32a7b79b7d1432fc66ce0e'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.74-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.74-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.74-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.74-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '319993fa7f4b0894f58234c3d840c2659ca3f682184a2475f2103043be99152b',
+     armv7l: '319993fa7f4b0894f58234c3d840c2659ca3f682184a2475f2103043be99152b',
+       i686: '74452a7d6df248030c52677af9dded5d015719a8df074e32c957671126798141',
+     x86_64: '5ca99064abc0954b593f43b820a572b138b0828949e4169dcb69ce7c91b016e3',
   })
 
   depends_on 'meson' => :build

--- a/packages/gegl.rb
+++ b/packages/gegl.rb
@@ -8,8 +8,16 @@ class Gegl < Package
   source_sha256 '1888ec41dfd19fe28273795c2209efc1a542be742691561816683990dc642c61'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.22-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.22-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.22-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.22-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'b96e1964c8b842c855ad08a8fa12c1ca1df48745b75c8a7210e4e91e55f1bbd6',
+     armv7l: 'b96e1964c8b842c855ad08a8fa12c1ca1df48745b75c8a7210e4e91e55f1bbd6',
+       i686: 'f47a712d92c1cd4b3293eac5a9cf6d5597162b73f4f7879dea18273b679da4b0',
+     x86_64: '04bb398c76229e19c6936d1d3e5fea733345db9055b517257f6f39b73201e0a6',
   })
 
   depends_on 'asciidoc'

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -8,8 +8,14 @@ class Gimp < Package
   source_sha256 '65bfe111e8eebffd3dde3016ccb507f9948d2663d9497cb438d9bb609e11d716'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.18-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.18-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.18-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '079527b6bb35dbbb7a5b70a8aaae03bb9e90341d1f638e82114c254a35074c9e',
+     armv7l: '079527b6bb35dbbb7a5b70a8aaae03bb9e90341d1f638e82114c254a35074c9e',
+     x86_64: '976807fa73b0f6f3c69750aab669e4ab095f237cdc3970b63e1df50b98f2d619',
   })
 
   depends_on 'aalib'
@@ -34,7 +40,8 @@ class Gimp < Package
   depends_on 'sommelier'
 
   def self.build
-    system "LIBS='-lm' ./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --disable-maintainer-mode"
+    ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
+    system "LIBS='-lm' ./configure #{CREW_OPTIONS} --disable-maintainer-mode"
     system 'make'
   end
 

--- a/packages/sqlitebrowser.rb
+++ b/packages/sqlitebrowser.rb
@@ -8,12 +8,21 @@ class Sqlitebrowser < Package
   source_sha256 '298acb28878aa712277a1c35c185b07a5a1671cc3e2c6a21b323477b91d486fc'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlitebrowser-3.11.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sqlitebrowser-3.11.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sqlitebrowser-3.11.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sqlitebrowser-3.11.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'a2ef3c40eb1eed02125a24b2b4d9ffaa81d9dfa4be9042ddf410c53cdcf6eab7',
+     armv7l: 'a2ef3c40eb1eed02125a24b2b4d9ffaa81d9dfa4be9042ddf410c53cdcf6eab7',
+       i686: '116f831ced1a81c4d2bd7dfc6fc29f31b6cbd2ca6101605cdcbab789bf155e31',
+     x86_64: 'b4213ade6b79ad9a03f2062c08dfde249009f0de6115b94e15b37edfc087949e',
   })
 
   depends_on 'sqlite'
   depends_on 'qtbase'
+  depends_on 'sommelier'
 
   def self.build
     system 'cmake',


### PR DESCRIPTION
Tested on all architectures.  Unable to compile gimp on i686 but it wouldn't work anyway even if it did.