### PR TITLE
Add plplot and supporting packages

### DIFF
--- a/packages/libharu.rb
+++ b/packages/libharu.rb
@@ -1,0 +1,47 @@
+require 'package'
+
+class Libharu < Package
+  description 'libHaru is a free, cross platform, open source library for generating PDF files.'
+  homepage 'http://libharu.org/'
+  version '2.3.0'
+  source_url 'https://github.com/libharu/libharu/archive/RELEASE_2_3_0.tar.gz'
+  source_sha256 '8f9e68cc5d5f7d53d1bc61a1ed876add1faf4f91070dbc360d8b259f46d9a4d2'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libharu-2.3.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libharu-2.3.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libharu-2.3.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libharu-2.3.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '565b8d263ffbb640aa3c928a1cd563b809f0ed91557ff8b509713387926e5921',
+     armv7l: '565b8d263ffbb640aa3c928a1cd563b809f0ed91557ff8b509713387926e5921',
+       i686: 'bf59630d01e74a2e57bf0f68ad6d27c988081a1b428c9b657aba192a49bf5ee1',
+     x86_64: 'c14377ac7ffb373b6f7e911333fed79fb879993c512e1875224defba894b7e31',
+  })
+
+  depends_on 'libpng'
+
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             '-DCMAKE_BUILD_TYPE=Release',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '..'
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+      if ARCH == 'x86_64'
+        FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}"
+        FileUtils.mv Dir.glob("#{CREW_DEST_PREFIX}/lib/*"), "#{CREW_DEST_LIB_PREFIX}"
+      end
+      FileUtils.rm_f "#{CREW_DEST_PREFIX}/INSTALL"
+      FileUtils.rm_f "#{CREW_DEST_PREFIX}/README"
+    end
+  end
+end

--- a/packages/plplot.rb
+++ b/packages/plplot.rb
@@ -1,0 +1,59 @@
+require 'package'
+
+class Plplot < Package
+  description 'PLplot is a cross-platform software package for creating scientific plots'
+  homepage 'http://plplot.sourceforge.net/'
+  version '5.15.0'
+  source_url 'https://downloads.sourceforge.net/project/plplot/plplot/5.15.0%20Source/plplot-5.15.0.tar.gz'
+  source_sha256 'b92de4d8f626a9b20c84fc94f4f6a9976edd76e33fb1eae44f6804bdcc628c7b'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/plplot-5.15.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/plplot-5.15.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/plplot-5.15.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/plplot-5.15.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '13f6b739b87349e98ec82b542d0bce70b982f76b7e72ede1ff22d8f020bc05d3',
+     armv7l: '13f6b739b87349e98ec82b542d0bce70b982f76b7e72ede1ff22d8f020bc05d3',
+       i686: 'c3026a75081479d1722ef82f9e9c917eba87eea2c574ef2ea098479525ce5b1f',
+     x86_64: '6aa2d9509f13283391d604ae0e3d9ff501f0ccf3a527ac0fe6e584d20d2f30a0',
+  })
+
+  depends_on 'jdk8'
+  depends_on 'libharu'
+  depends_on 'lua'
+  depends_on 'ocaml'
+  depends_on 'pango'
+  depends_on 'qhull'
+  depends_on 'qtsvg'
+  depends_on 'swig'
+  depends_on 'tk'
+  depends_on 'wxwidgets'
+
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             '-DBUILD_TEST=ON',
+             '-DENABLE_DYNDRIVERS=OFF',
+             '-DUSE_INCRTCL_VERSION_4=ON',
+             "-DLIB_DIR=#{CREW_LIB_PREFIX}",
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '..'
+      system 'make'
+    end
+  end
+
+  def self.check
+    Dir.chdir 'build' do
+      #system 'ctest'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
+  end
+end

--- a/packages/qhull.rb
+++ b/packages/qhull.rb
@@ -1,0 +1,48 @@
+require 'package'
+
+class Qhull < Package
+  description 'Qhull computes the convex hull, Delaunay triangulation, Voronoi diagram, halfspace intersection about a point, furthest-site Delaunay triangulation, and furthest-site Voronoi diagram.'
+  homepage 'http://www.qhull.org/'
+  version '7.3.2'
+  source_url 'http://www.qhull.org/download/qhull-2019-src-7.3.2.tgz'
+  source_sha256 '2b7990558c363076261564f61b74db4d0d73b71869755108a469038c07dc43fb'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qhull-7.3.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qhull-7.3.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qhull-7.3.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qhull-7.3.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '7bc54fddbe41b66894fa2c713145af000e85e761f4dbd3198ceea3d2fe2760d3',
+     armv7l: '7bc54fddbe41b66894fa2c713145af000e85e761f4dbd3198ceea3d2fe2760d3',
+       i686: '50e78beea512b3784524e7c3d844c14fb4ec5c08a0b76e61561336249c07ae22',
+     x86_64: '725d91947d86ef4b70977b56770d78284fadd6b1de54042da95e885aa5b6f215',
+  })
+
+  def self.build
+    Dir.chdir 'build' do
+      system 'cmake',
+             '-DCMAKE_BUILD_TYPE=Release',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '..'
+      system 'make'
+    end
+  end
+
+  def self.check
+    Dir.chdir 'build' do
+      system 'ctest'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+      if ARCH == 'x86_64'
+        FileUtils.mkdir CREW_DEST_LIB_PREFIX
+        FileUtils.mv Dir.glob("#{CREW_DEST_PREFIX}/lib/*"), CREW_DEST_LIB_PREFIX
+      end
+    end
+  end
+end


### PR DESCRIPTION
PLplot is a cross-platform software package for creating scientific plots.  See http://plplot.sourceforge.net/.

Dependencies include:
- libHaru is a free, cross platform, open source library for generating PDF files.  See http://libharu.org/.
- Qhull computes the convex hull, Delaunay triangulation, Voronoi diagram, halfspace intersection about a point, furthest-site Delaunay triangulation, and furthest-site Voronoi diagram.  See http://www.qhull.org/.

Tested on all architectures.