### PR TITLE
Update ngrok from 2.3.15 to 2.3.35

### DIFF
--- a/packages/ngrok.rb
+++ b/packages/ngrok.rb
@@ -3,20 +3,17 @@ require 'package'
 class Ngrok < Package
   description 'ngrok exposes local servers behind NATs and firewalls to the public internet over secure tunnels.'
   homepage 'https://ngrok.com/'
-  version '2.3.15'
+  version '2.3.35'
   case ARCH
-  when 'aarch64'
-    source_url 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm.zip'
-    source_sha256 'd7c1beab61690cf83be3fc4e26880806e3c2ebbe6357182457f4cad22ae033de'
-  when 'armv7l'
-    source_url 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-arm.zip'
-    source_sha256 'd7c1beab61690cf83be3fc4e26880806e3c2ebbe6357182457f4cad22ae033de'
+  when 'aarch64', 'armv7l'
+    source_url 'https://bin.equinox.io/a/dFJfzZziYxC/ngrok-2.3.35-linux-arm.tar.gz'
+    source_sha256 '2721e6d74f7d26f061c96df3b5676f32cf4b94a5b43d44d9a535f777dc0b863e'
   when 'i686'
-    source_url 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-386.zip'
-    source_sha256 'e8b8b033b4aec785e0ba1e5ce5893982fc9740aeb2006b1f9c2d2a906f5884f9'
+    source_url 'https://bin.equinox.io/a/3BwMsheYHot/ngrok-2.3.35-linux-386.tar.gz'
+    source_sha256 '12c79750c1d5d78c9924d56e448ae5ceb78fe06bfc3d724ed9028b02b0cda56b'
   when 'x86_64'
-    source_url 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip'
-    source_sha256 '45d8a9e10abff1c77210acc0c123cdea3b7fbce7cfc1a06138c6392379775b17'
+    source_url 'https://bin.equinox.io/a/jAq5uX8wfS8/ngrok-2.3.35-linux-amd64.tar.gz'
+    source_sha256 '55df9c479b41a3b9b488458b5fb758df63001d14196a4126e3f669542c8727e9'
   end
 
   binary_url ({


### PR DESCRIPTION
Update package and change source_url to specific version instead of
latest stable archive to reduce maintenance workload.

Tested on ARM.

Closes #4075 