### PR TITLE
Add nedit package and motif dependency

### DIFF
--- a/packages/motif.rb
+++ b/packages/motif.rb
@@ -1,0 +1,42 @@
+require 'package'
+
+class Motif < Package
+  description 'Motif is a freely available source code distribution for the Motif user interface component toolkit.'
+  homepage 'https://motif.ics.com/'
+  version '2.3.8'
+  source_url 'https://downloads.sourceforge.net/project/motif/Motif%202.3.8%20Source%20Code/motif-2.3.8.tar.gz'
+  source_sha256 '859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/motif-2.3.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/motif-2.3.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/motif-2.3.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/motif-2.3.8-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '1c54520d4eaf0c6f9731aa486d63df65b6f0b32edef3eff2184dc6b699851b42',
+     armv7l: '1c54520d4eaf0c6f9731aa486d63df65b6f0b32edef3eff2184dc6b699851b42',
+       i686: '6ff165d03c99b80835f8e115712bcd54538c6a3024481e88cc8419043e3d070c',
+     x86_64: '2eb3c2761fdae830ecf8ab30b406de48a566112e635d63456d802da5ff012081',
+  })
+
+  depends_on 'fontconfig'
+  depends_on 'freetype'
+  depends_on 'libjpeg'
+  depends_on 'libpng'
+  depends_on 'sommelier'
+
+  def self.build
+    system "./configure #{CREW_OPTIONS} --with-x --enable-xft --enable-png --enable-jpeg"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end
+

--- a/packages/nedit.rb
+++ b/packages/nedit.rb
@@ -1,0 +1,47 @@
+require 'package'
+
+class Nedit < Package
+  description 'A fast, compact Motif/X11 plain text editor, for most popular Unix systems.'
+  homepage 'https://sourceforge.net/projects/nedit/'
+  version '5.7'
+  source_url 'https://downloads.sourceforge.net/project/nedit/nedit-source/nedit-5.7-src.tar.gz'
+  source_sha256 'add9ac79ff973528ad36c86858238bac4f59896c27dbf285cbe6a4d425fca17a'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nedit-5.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nedit-5.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nedit-5.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nedit-5.7-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '4fba5943ef167821c201b21a09dece98b6d81cbcb79527c64e95000f4479c3d8',
+     armv7l: '4fba5943ef167821c201b21a09dece98b6d81cbcb79527c64e95000f4479c3d8',
+       i686: 'a51c662322d42a5a9a040f0c5eda0535c1f03fbc3bb15cb4652a5c7fb5ede8b2',
+     x86_64: 'c2db0f40ee914ab92f65814953542ec9e5634415ea155076cf9e67f50e9428ed',
+  })
+
+  depends_on 'motif'
+
+  def self.patch
+    system "sed -i 's/\$@/linux/g' Makefile"
+  end
+
+  def self.build
+    system 'make', 'linux'
+    Dir.chdir 'doc' do
+      system 'make', 'man'
+    end
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system "install -Dm755 ./source/nc #{CREW_DEST_PREFIX}/bin/nc"
+    system "install -Dm755 ./source/nedit #{CREW_DEST_PREFIX}/bin/nedit"
+    system "install -Dm644 ./doc/nc.man #{CREW_DEST_MAN_PREFIX}/man1/nc.1"
+    system "install -Dm644 ./doc/nedit.man #{CREW_DEST_MAN_PREFIX}/man1/nedit.1"
+  end
+end
+


### PR DESCRIPTION
A fast, compact Motif/X11 plain text editor, for most popular Unix systems. Features significant support for programmers including syntax highlighting, macro language, and streamlined keyboard navigation. Mature and stable.

Motif is a freely available source code distribution for the Motif user interface component toolkit. Motif 2.3.8 is an updated version of Open Motif 2.3 and is a major bug fix release.

Fixes #4082.  Thanks to @dji-transpire for the initial packages.
