### PR TITLE
Update libxml2 and libxml2_python from 2.9.9 to 2.9.10

### DIFF
--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,51 +3,42 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.9'
-  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.9/libxml2-v2.9.9.tar.bz2'
-  source_sha256 'd598e907b5f3efa992b65094f7113d9d8cc87238f32e4e1ddf8beff01b60a653'
+  version '2.9.10'
+  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.10/libxml2-v2.9.10.tar.bz2'
+  source_sha256 '5f1cc19c849cccabb983881cf1ebf833f42db5d7b8afba7a7763a2ac3101715c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.9-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2-2.9.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '8f7a474b5d0f8f800faa8e585662561dc4a0db3a494b2a949e96e63becf84262',
-     armv7l: '8f7a474b5d0f8f800faa8e585662561dc4a0db3a494b2a949e96e63becf84262',
-       i686: 'b248be959d940cb499e4692973865770a74fe1e10dfd7706cca36cc3ef3a0067',
-     x86_64: 'd2a31a3c95de67b23488340deea7025cdf953700e141a629de11711d17d3794a',
+    aarch64: '6c7da2f6074adc4022ade9e72a070037657a1c708150404c5b9c7d07634c5390',
+     armv7l: '6c7da2f6074adc4022ade9e72a070037657a1c708150404c5b9c7d07634c5390',
+       i686: '9baf9a41ad01e2b6d09f09c9a65a74b37ac839e53ce00c0ebf048bc1d1d7b01f',
+     x86_64: '4c1305434bbac822e6d08234d3058e94bca0ab95591ca25a0ccc8675cd16c48e',
   })
  
   depends_on 'zlibpkg'
 
   def self.build
     system './autogen.sh'
-    system "./configure",
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}",
-      "--enable-shared",
-      "--disable-static",
-      "--with-pic",
-      "--without-python",   # libxml2-python built in another package (libxml2_python)
-      "--without-lzma",
-      "--with-zlib",
-      "--with-icu",
-      "--with-threads",
-      "--with-history"
-    system "make"
-  end
-
-  def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    # libxml2-python built in another package (libxml2_python)
+    system "./configure #{CREW_OPTIONS} --enable-shared --disable-static --with-pic \
+--without-python --without-lzma --with-zlib --with-icu --with-threads --with-history"
+    system 'make'
   end
 
   def self.check
     # Remove EBCDIC test since it fails.
     # Check https://mail.gnome.org/archives/xml/2010-April/msg00010.html for details.
-    system "rm", "test/ebcdic_566012.xml"
+    system 'rm', 'test/ebcdic_566012.xml'
 
-    system "make", "check"
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libxml2_python.rb
+++ b/packages/libxml2_python.rb
@@ -3,25 +3,22 @@ require 'package'
 class Libxml2_python < Package
   description 'Libxml2 (python module) is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.9'
-  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.9.tar.gz'
-  source_sha256 '94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871'
+  version '2.9.10'
+  source_url 'ftp://xmlsoft.org/libxml2/libxml2-2.9.10.tar.gz'
+  source_sha256 'aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.9-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxml2_python-2.9.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '05b9616edf2809cea4bfaa2a0f9b21e8455871e04f9a76f08c5472e25ab655c6',
-     armv7l: '05b9616edf2809cea4bfaa2a0f9b21e8455871e04f9a76f08c5472e25ab655c6',
-       i686: '9676158d3071ecd96bd3fc3cb0619dd137efc39b23a8c1d0c4d38990d58223ad',
-     x86_64: '54261947d04449bdeb3af3fd9c60b450fc8237defdee0076d23122786eb05934',
+    aarch64: 'e4e0785991911d9a84fc6023345fb5bf1195b14ecff7ab32e2f5fc7e03301569',
+     armv7l: 'e4e0785991911d9a84fc6023345fb5bf1195b14ecff7ab32e2f5fc7e03301569',
+       i686: 'cd4f6ebe11023d88de1e9809fbfd4f1e85d4513cb34450dd9d67fa2f55d96f45',
+     x86_64: 'a4e7d5428a898c545a2f97d41454d711224341b93782cc7e1a435c442b952ade',
   })
-
-  depends_on 'python27'
-  depends_on 'libxml2'
 
   def self.build
     Dir.chdir("python") do
@@ -31,8 +28,7 @@ class Libxml2_python < Package
 
   def self.install
     Dir.chdir("python") do
-      system "python2 setup.py install --root=#{CREW_DEST_DIR}"
+      system "python2 setup.py install --prefix=#{CREW_PREFIX} --root=#{CREW_DEST_DIR}"
     end
   end
-
 end


### PR DESCRIPTION
Tested on all architectures.  Needed for #4103.