### PR TITLE
Add pre-built binaries for girara, zathura and zathura_poppler_pdf

### DIFF
--- a/packages/girara.rb
+++ b/packages/girara.rb
@@ -8,8 +8,16 @@ class Girara < Package
   source_sha256 'e78257e4218a0f7f59cc1bea472c7c6794fa51cd9261d87affbe731c1e22c6a5'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/girara-0.3.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/girara-0.3.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/girara-0.3.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/girara-0.3.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '80227f425ebf691df7460693665197e0b1a2fdfbf147a2c94b49e2b446123cad',
+     armv7l: '80227f425ebf691df7460693665197e0b1a2fdfbf147a2c94b49e2b446123cad',
+       i686: '57c818963505dd97b50c3776f9b1a3e78ec9b6ef51b22940a5f477bfbcbb0542',
+     x86_64: '3b3f8d2c75abbe4a2f00b42a94239a988b293857450ca63afa827d4fbd9c436f',
   })
 
   depends_on 'gtk3'

--- a/packages/zathura.rb
+++ b/packages/zathura.rb
@@ -8,11 +8,20 @@ class Zathura < Package
   source_sha256 '0c3997aafbcdaaae60a4522f208adadfdd2758b432ce94ea16fbcee937cb762c'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/zathura-0.4.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/zathura-0.4.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/zathura-0.4.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/zathura-0.4.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'ec4a508b374e3169f04fe2018ae95d3fe9b7a88a2604bfcfe1a7a1ecd1f0aa6e',
+     armv7l: 'ec4a508b374e3169f04fe2018ae95d3fe9b7a88a2604bfcfe1a7a1ecd1f0aa6e',
+       i686: 'a1e6e108ff1747f6297faa3497bca3d4ad88fb4969955f5aacbfba5116168eed',
+     x86_64: '05b3d7cd6b2ee0548041bb6a8a3743560962ad84350f547642a3a30b1fa89dda',
   })
 
   depends_on 'girara'
+  depends_on 'zathura_poppler_pdf'
 
   def self.build
     system "meson  --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
@@ -21,12 +30,5 @@ class Zathura < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
-
-  def self.postinstall
-    puts
-    puts "Please add plugins such as : zathura_poppler_pdf".lightblue
-    puts "Use command like : 'crew install zathura_poppler_pdf'".lightblue
-    puts
   end
 end

--- a/packages/zathura_poppler_pdf.rb
+++ b/packages/zathura_poppler_pdf.rb
@@ -8,11 +8,18 @@ class Zathura_poppler_pdf < Package
   source_sha256 'd5cc3a7dae49471b85b503bbb9049c6f8d10903f4a611d721a2e0fefe726d4ed'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/zathura_poppler_pdf-0.3.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/zathura_poppler_pdf-0.3.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/zathura_poppler_pdf-0.3.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/zathura_poppler_pdf-0.3.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '8f0a5457aa3ed3f5eed6f602b4439967ab6957b3d1e04e7f9a9468d77713f1ea',
+     armv7l: '8f0a5457aa3ed3f5eed6f602b4439967ab6957b3d1e04e7f9a9468d77713f1ea',
+       i686: 'cc192c10e8188c90ca55162e60aba590e0cebe4235ee93e58a9c868115224f3f',
+     x86_64: '2a45979d58fa1ca321cd4432a2591f6e6737212ebef0abb30d9e25f5b8f1b3d0',
   })
 
-  depends_on 'zathura'
   depends_on 'poppler'
 
   def self.build


### PR DESCRIPTION
Tested on all architectures.  @vincowl: During my testing, I found that zathura is unusable without zathura_poppler_pdf, so I made that a dependency of zathura.  You can also build zathura_poppler_pdf without zathura installed because it is only a run-time dependency.  Hopefully, that makes sense.