### PR TITLE
[hugo] Move to Hugo-Extended when available to enable SASS/SCSS

### DIFF
--- a/packages/hugo.rb
+++ b/packages/hugo.rb
@@ -3,7 +3,7 @@ require 'package'
 class Hugo < Package
   description 'Hugo is one of the most popular open-source static site generators.'
   homepage 'https://gohugo.io'
-  version '0.72.0'
+  version '0.72.0-1'
   compatibility 'all'
 
   case ARCH
@@ -14,8 +14,8 @@ class Hugo < Package
     source_url 'https://github.com/gohugoio/hugo/releases/download/v0.72.0/hugo_0.72.0_Linux-32bit.tar.gz'
     source_sha256 '573e41bf48b678ed909d4cf5b053fb4f259d672c0df7118ec980dcba000349fd'
   when 'x86_64'
-    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.72.0/hugo_0.72.0_Linux-64bit.tar.gz'
-    source_sha256 '28353611210d48c681f1f83a64ce36972d010e751f2794122db80f5060fe933d'
+    source_url 'https://github.com/gohugoio/hugo/releases/download/v0.72.0/hugo_extended_0.72.0_Linux-64bit.tar.gz'
+    source_sha256 '11c46ecc3ad6d96f94515358e5528d01dfe88f4956b56027c85e9a516348ef12'
   end
 
   binary_url ({


### PR DESCRIPTION
Default Hugo version lacks functional support for sass/scss. Extended version provides it but is only available to x86_64 platforms. So I chose to point to extended version for x86_64 architecture and keep the classical one for other architectures. I definitely think extended version should be the norm and don't think we should maintain 2 packages such as `hugo` and `hugo_extended`