### PR TITLE
Add pre-built binaries for powerstat and stressng

### DIFF
--- a/packages/powerstat.rb
+++ b/packages/powerstat.rb
@@ -9,8 +9,16 @@ class Powerstat < Package
   source_sha256 '12781cb108be1fc3be5ec893e6d025bfb40ada060bdc5f7715b65397620f2c7b'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.24-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.24-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.24-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/powerstat-0.02.24-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '76653569b562862ac42fd13a04a0f89b450da94450b6a25eccb7e1e399267dcb',
+     armv7l: '76653569b562862ac42fd13a04a0f89b450da94450b6a25eccb7e1e399267dcb',
+       i686: '69f76808c40ed957f30738fbb0e76d50a592ec610f8d58ca117e6daceee8e51f',
+     x86_64: '1be1187a936d8e2c0bbe20ad45a350c8b63ce75ef77ee63fd7bbe0b33690c541',
   })
 
   def self.build

--- a/packages/stressng.rb
+++ b/packages/stressng.rb
@@ -9,8 +9,16 @@ class Stressng < Package
   source_sha256 '07090ed5aef4e8d406f9c1927fc816db1068ab02d3aa53120481b14872a9c5f7'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/stressng-0.11.08-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/stressng-0.11.08-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/stressng-0.11.08-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/stressng-0.11.08-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '4c3489fafb782bb165e2b2c776c44d1f31a8971293f0db661d2968b157f99326',
+     armv7l: '4c3489fafb782bb165e2b2c776c44d1f31a8971293f0db661d2968b157f99326',
+       i686: '4878e3a8ba6f1a73f1d65d9d297d01d52bd8bbe3d561619bc79144c2959591b4',
+     x86_64: '83717195b9dd2795ffbda928870e333b609fc16eab63a3980fefb5b69a186584',
   })
 
   def self.build


### PR DESCRIPTION
Tested on all architectures.