### PR TITLE
Update freerdp from 2.0.0-rc4-1 to 2.2.0

### DIFF
--- a/packages/freerdp.rb
+++ b/packages/freerdp.rb
@@ -3,22 +3,22 @@ require 'package'
 class Freerdp < Package
   description 'FreeRDP is a free implementation of the Remote Desktop Protocol.'
   homepage 'https://www.freerdp.com/'
-  version '2.0.0-rc4-1'
+  version '2.2.0'
   compatibility 'all'
-  source_url 'https://github.com/FreeRDP/FreeRDP/archive/2.0.0-rc4.tar.gz'
-  source_sha256 '3406f3bfab63f81c1533029a5bf73949ff60f22f6e155c5a08005b8b8afe6d49'
+  source_url 'https://github.com/FreeRDP/FreeRDP/archive/2.2.0.tar.gz'
+  source_sha256 '883bc0396c6be9aba6bc07ebc8ff08457125868ada0f06554e62ef072f90cf59'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freerdp-2.0.0-rc4-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freerdp-2.0.0-rc4-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freerdp-2.0.0-rc4-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freerdp-2.0.0-rc4-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freerdp-2.2.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freerdp-2.2.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freerdp-2.2.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freerdp-2.2.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '47473dda58b59aa8e278b695c12d0639638e6071a856e1acc27f1abcda8ef3ca',
-     armv7l: '47473dda58b59aa8e278b695c12d0639638e6071a856e1acc27f1abcda8ef3ca',
-       i686: '93612031e2fbddcc09ce7338a631783b39c7518946b9d8ee09b148c7774ed93c',
-     x86_64: 'a029e77ed6c8d47ebcd7c74a8b1430b158f6ebdb04384697abe7c8da613526cf',
+    aarch64: 'de7c23e9ddeed50896daed5081a2aaf8fb849799faee83155d2a32939abbf6a7',
+     armv7l: 'de7c23e9ddeed50896daed5081a2aaf8fb849799faee83155d2a32939abbf6a7',
+       i686: '860fe130e143159c859d7adfe872c305de6a3a17a5d06becbeb86c191ae9320b',
+     x86_64: 'c10b462dee10090118d9bfd676d591512f90e6e1cbf9a678c7d5869a6bb3adfc',
   })
 
   depends_on 'cups'


### PR DESCRIPTION
Tested on all architectures.