### PR TITLE
Add pre-built binaries for neovim

### DIFF
--- a/packages/neovim.rb
+++ b/packages/neovim.rb
@@ -9,6 +9,7 @@ class Neovim < Package
   when 'aarch64', 'armv7l', 'x86_64'
     source_url 'https://github.com/neovim/neovim/archive/v0.4.4.tar.gz'
     source_sha256 '2f76aac59363677f37592e853ab2c06151cca8830d4b3fe4675b4a52d41fc42c'
+    depends_on 'xdg_base'
   end
 
   binary_url ({

--- a/packages/neovim.rb
+++ b/packages/neovim.rb
@@ -12,8 +12,14 @@ class Neovim < Package
   end
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/neovim-0.4.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/neovim-0.4.4-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/neovim-0.4.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '4f070268cb5386ad3cff2c3a5e7f332a79ce28335ec13f17763d2cb0c5a6083b',
+     armv7l: '4f070268cb5386ad3cff2c3a5e7f332a79ce28335ec13f17763d2cb0c5a6083b',
+     x86_64: '013241fb25fa27c2247ade5cffdc3694dcd58e4783c7b7a4bf339b92332804d5',
   })
 
   def self.patch


### PR DESCRIPTION
Tested on:
- [x] aarch64
- [x] armv7l
- [x] x86_64