### PR TITLE
Upgrade emacs and gemacs to 27.1

### DIFF
--- a/packages/emacs.rb
+++ b/packages/emacs.rb
@@ -3,22 +3,14 @@ require 'package'
 class Emacs < Package
   description 'An extensible, customizable, free/libre text editor - and more.'
   homepage 'http://www.gnu.org/software/emacs/'
-  version '26.3'
+  version '27.1'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/emacs/emacs-26.3.tar.xz'
-  source_sha256 '4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485'
+  source_url 'https://ftpmirror.gnu.org/emacs/emacs-27.1.tar.xz'
+  source_sha256 '4a4c128f915fc937d61edfc273c98106711b540c9be3cd5d2e2b9b5b2f172e41'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-26.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-26.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-26.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/emacs-26.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'cb3fbd500feee768ab1925d9a62c587563a5dbb362dea8fec72017e17990454b',
-     armv7l: 'cb3fbd500feee768ab1925d9a62c587563a5dbb362dea8fec72017e17990454b',
-       i686: 'ef10c17c31286f47a0ae03204a406421501f452184b37fc6411d4c6cfa88381b',
-     x86_64: 'd32ea23bb1c6ecc1588f2665da8c5f47367cf78b4dc9cefabed36a9386c748a2',
   })
 
   depends_on 'lcms'

--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -3,25 +3,16 @@ require 'package'
 class Gemacs < Package
   description 'An extensible, customizable, free/libre text editor - and more.'
   homepage 'https://www.gnu.org/software/emacs/'
-  version '26.3'
+  version '27.1'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/emacs/emacs-26.3.tar.xz'
-  source_sha256 '4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485'
+  source_url 'https://ftpmirror.gnu.org/emacs/emacs-27.1.tar.xz'
+  source_sha256 '4a4c128f915fc937d61edfc273c98106711b540c9be3cd5d2e2b9b5b2f172e41'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-26.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '45bae4cffee76691bf89478032d4ac68faf331b263696b6236b3cdcaa9ae8eee',
-     armv7l: '45bae4cffee76691bf89478032d4ac68faf331b263696b6236b3cdcaa9ae8eee',
-       i686: '2980639d04f3d911773b3a97f0a99e604eb38f5155beabafb3d02cb033ce3a93',
-     x86_64: '3e3becfa06271d8b9a13aacdbc0a9f3aeade8ddfa7991f1a24c4f6b8bdc30a89',
   })
 
-  depends_on 'emacs'
   depends_on 'giflib'
   depends_on 'libjpeg'
   depends_on 'libpng'
@@ -34,17 +25,20 @@ class Gemacs < Package
             --prefix=#{CREW_PREFIX} \
             --localstatedir=#{CREW_PREFIX}/share \
             --without-selinux \
+            --with-modules \
+            --with-imagemagick \
             --with-x=yes \
             --with-x-toolkit=gtk3 \
             --with-gif=yes \
-	    --with-jpeg=yes \
-	    --with-png=yes \
-	    --with-rsvg=yes" 
+            --with-jpeg=yes \
+            --with-png=yes \
+            --with-rsvg=yes" 
     system 'make'
   end
 
   def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     system "install -Dm755 src/emacs #{CREW_DEST_PREFIX}/bin/gemacs"
-    system "install -Dm755 src/emacs-26.3.1 #{CREW_DEST_PREFIX}/bin/gemacs-26.3.1"
+    system "install -Dm755 src/emacs-27.1.1 #{CREW_DEST_PREFIX}/bin/gemacs-27.1.1"
   end
 end


### PR DESCRIPTION
@uberhacker Please note that I had to remove the `emacs` dependency to the `gemacs` package. Indeed I couldn't make it work as before due to fingerprints errors (installations split). 
I think it is OK since emacs and gemacs aims two different needs : emacs is lightest as possible without X layer, whereas gemacs is "classic". One who wish to install emacs may not want gemacs and one who wants gemacs won't need emacs since he can launch gemacs without X if needed.