### PR TITLE
Update yajl from 2.1.0-1 to 2.1.0-2

### DIFF
--- a/packages/yajl.rb
+++ b/packages/yajl.rb
@@ -3,28 +3,28 @@ require 'package'
 class Yajl < Package
   description 'A fast streaming JSON parsing library in C.'
   homepage 'http://lloyd.github.io/yajl/'
-  version '2.1.0-1'
+  version '2.1.0-2'
   compatibility 'all'
   source_url 'https://github.com/lloyd/yajl/archive/2.1.0.tar.gz'
   source_sha256 '3fb73364a5a30efe615046d07e6db9d09fd2b41c763c5f7d3bfb121cd5c5ac5a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yajl-2.1.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yajl-2.1.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yajl-2.1.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yajl-2.1.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yajl-2.1.0-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yajl-2.1.0-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yajl-2.1.0-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yajl-2.1.0-2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'efdb7b820b6c7cc02e5d443db956eefd74c537e38b0cba19adf81ded4f10ff9a',
-     armv7l: 'efdb7b820b6c7cc02e5d443db956eefd74c537e38b0cba19adf81ded4f10ff9a',
-       i686: 'd5f49f959e0de265a0f1ffda1e0000850753b4247cdc3b9b5a7256c6560ab166',
-     x86_64: 'c16902c4da5b807783a9002566328c1e6545c0f5eb4d673b5fbb0d028bdb0513',
+    aarch64: '4afb152584a025239161684888378662bc1305adccd63b5b5246581a914b74c8',
+     armv7l: '4afb152584a025239161684888378662bc1305adccd63b5b5246581a914b74c8',
+       i686: 'fab84163e9ddd02ec0286ccbad845005d376352f392e68bd57955b003c788d89',
+     x86_64: 'f702d50a8e81b5fcfed7229a782aae5f03e45d85b0a386a24d152e3fac5ed595',
   })
 
   def self.build
     Dir.mkdir 'build'
     Dir.chdir 'build' do
-      system "cmake .. -DCMAKE_C_FLAGS=' -fPIC' -DPREFIX=#{CREW_PREFIX} -DCMAKE_INSTALL_LIBDIR=#{CREW_DEST_LIB_PREFIX}"
+      system "cmake .. -DCMAKE_C_FLAGS=' -fPIC' -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DCMAKE_BUILD_TYPE=Release"
       system 'make'
     end
   end
@@ -32,6 +32,13 @@ class Yajl < Package
   def self.install
     Dir.chdir 'build' do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+      case ARCH
+      when 'x86_64'
+        Dir.chdir "#{CREW_DEST_PREFIX}" do
+          FileUtils.mkdir 'lib64'
+          FileUtils.mv Dir.glob('lib/*'), 'lib64/'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Fix library path for x86_64
- Tested on all architectures