### PR TITLE
New Package: pavucontrol - Packaged with templator

### DIFF
--- a/packages/glibmm.rb
+++ b/packages/glibmm.rb
@@ -1,42 +1,21 @@
 require 'package'
 
 class Glibmm < Package
-  description 'Glibmm package is a set of C++ bindings for GLib'
-  homepage 'https://www.gtkmm.org/en/'
-  version '2.56.0-0'
-  compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/glibmm/2.56/glibmm-2.56.0.tar.xz'
-  source_sha256 '6e74fcba0d245451c58fc8a196e9d103789bc510e1eee1a9b1e816c5209e79a9'
+  description "C++ bindings for GLib"
+  homepage "https://www.gtkmm.org"
+  version "2.64.2"
+  compatibility "all"
+  source_url "https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.64/glibmm-2.64.2.tar.xz"
+  source_sha256 "a75282e58d556d9b2bb44262b6f5fb76c824ac46a25a06f527108bec86b8d4ec"
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.56.0-0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '734ea5bce78ffef9ad52a2d7503b55b2bb47cbe743142c371ac68cb543df4343',
-     armv7l: '734ea5bce78ffef9ad52a2d7503b55b2bb47cbe743142c371ac68cb543df4343',
-       i686: 'c88a048055070b1c14c296f49eb20333a6ffe4a8e4c37fdab06990fd798b6b87',
-     x86_64: '3c30713258dd4972d7118024d44e09f87e1eeea466dfc4b72cb5bb8ea19347bc',
-  })
-
-  depends_on 'glib'
-  depends_on 'libsigcplusplus' # sigc++-2.0
+  depends_on "libsigcplusplus"
   depends_on 'mm_common' => :build
 
   def self.build
-    # fix the documents directory name
-    system "sed -e '/^libdocdir =/ s/$(book_name)/glibmm-2.56.0/' \
-    -i docs/Makefile.in"
-    system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+      system "./configure #{CREW_OPTIONS} "
+      system "make -j#{CREW_NPROC}"
   end
-
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
- end
-
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
 end

--- a/packages/gtkmm3.rb
+++ b/packages/gtkmm3.rb
@@ -3,38 +3,21 @@ require 'package'
 class Gtkmm3 < Package
   description 'The Gtkmm3 package provides a C++ interface to GTK+ 3.'
   homepage 'https://www.gtkmm.org/'
-  version '3.22.2'
+  version '3.24.1'
   compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/gtkmm/3.22/gtkmm-3.22.2.tar.xz'
-  source_sha256 '91afd98a31519536f5f397c2d79696e3d53143b80b75778521ca7b48cb280090'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.22.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.22.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.22.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.22.2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '01538cda99b9b67168aa6d723a06b80d8ebd4bf0bc3b218f793f70868ee2a8da',
-     armv7l: '01538cda99b9b67168aa6d723a06b80d8ebd4bf0bc3b218f793f70868ee2a8da',
-       i686: '3a89b7fd9f1b2c7bd863070144d3d84d0e99797eac3f8dfd06f7e88441ea0541',
-     x86_64: '53bab1cbca694187e64084186991068557f6126064a0ca21f96508d55c9fba88',
-  })
+  source_url 'https://ftp.gnome.org/pub/gnome/sources/gtkmm/3.24/gtkmm-3.24.1.tar.xz'
+  source_sha256 'ddfe42ed2458a20a34de252854bcf4b52d3f0c671c045f56b42aa27c7542d2fd'
 
   depends_on 'atkmm'
   depends_on 'gtk3'
   depends_on 'pangomm'
 
   def self.build
-    # fix the documents directory name
-    system "sed -e '/^libdocdir =/ s/$(book_name)/gtkmm-3.22.2/' \
-    -i docs/Makefile.in"
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "./configure #{CREW_OPTIONS}"
+    system "make -j#{CREW_NPROC}"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
- end
-
+  end
 end

--- a/packages/libcanberra.rb
+++ b/packages/libcanberra.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Libcanberra < Package
+    description "XDG Sound Theme and Name Specification library implementation"
+    homepage "http://0pointer.de/lennart/projects/libcanberra/"
+    version "0.30"
+    compatibility "all"
+    source_url "http://pkgs.fedoraproject.org/repo/pkgs/libcanberra/libcanberra-0.30.tar.xz/34cb7e4430afaf6f447c4ebdb9b42072/libcanberra-0.30.tar.xz"
+    source_sha256 "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+
+    depends_on "pygtk"
+    depends_on "libvorbis"
+    depends_on "libtool"
+    depends_on "gstreamer"
+    depends_on "alsa_lib"
+    depends_on "tdb"
+    depends_on "pulseaudio"
+    depends_on "eudev"
+    depends_on "vala"
+
+    def self.build
+        system "./configure #{CREW_OPTIONS} --enable-alsa --enable-null --disable-lynx --enable-gstreamer --disable-oss --with-builtin=dso"
+        system "make -j#{CREW_NPROC}"
+    end
+    def self.install
+        system "make install DESTDIR=#{CREW_DEST_DIR}"
+    end
+end

--- a/packages/pavucontrol.rb
+++ b/packages/pavucontrol.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Pavucontrol < Package
+    description "PulseAudio Volume Control"
+    homepage "https://freedesktop.org/software/pulseaudio/pavucontrol/"
+    version "4.0"
+    compatibility "all"
+    source_url "https://freedesktop.org/software/pulseaudio/pavucontrol//pavucontrol-4.0.tar.xz"
+    source_sha256 "8fc45bac9722aefa6f022999cbb76242d143c31b314e2dbb38f034f4069d14e2"
+
+    depends_on "gtkmm2"
+    depends_on "gtkmm3"
+    depends_on "libcanberra"
+    depends_on "pygtk"
+    depends_on "pulseaudio"
+    depends_on "glibmm"
+    
+    def self.build
+        system "./configure #{CREW_OPTIONS}"
+        system "make -j#{CREW_NPROC} -lgtkmm-3.24" # Issue with gtkmm - gtk::builder
+    end
+    def self.install
+        system "make install DESTDIR=#{CREW_DEST_DIR}"
+    end
+end


### PR DESCRIPTION
I'm working on packaging `pavucontrol` it's been relativity easy due to [Templator](https://github.com/ThatGeekyWeeb/templator), It takes `template`'s from the void-linux repo and converts them into 70% usable package scripts. My main issues are `gtkmm3` & `glibmm` both of which are outdated to the point where the linkers fail 100% of the time, I've repackaged them both and I'm still working on tests, I'm opening this PR to ask for help where it is needed, as there are many issues, and compiling `gtkmm3` and `glibmm` is not practical as it takes a very long time. Hopefully after the updates to `gtkmm3` and `glibmm` I provided, there will be no issues, otherwise I hope I can ask for help here! :)
~
All of the package scripts here were generated using [Templator](https://github.com/ThatGeekyWeeb/templator)
~
`.gitignore` should be ignored, I've used to it prevent pushing `templator.sh` and the templates I've sourced from void linux.