### PR TITLE
Add pre-built binaries for exo, glibmm, gtkmm3, libcanberra, libxfce4ui, libxfce4util, pavucontrol, pulseaudio, sxhkd, xfce4_dev_tools, xfce4_terminal and xfconf

### DIFF
--- a/packages/exo.rb
+++ b/packages/exo.rb
@@ -2,23 +2,39 @@ require 'package'
 
 class Exo < Package
   description 'Extension library for the Xfce desktop environment'
-  homepage "https://xfce.org/"
+  homepage 'https://xfce.org/'
   version '0.12.11'
   compatibility 'all'
-  source_url "https://archive.xfce.org/src/xfce/exo/0.12/exo-0.12.11.tar.bz2"
+  source_url 'https://archive.xfce.org/src/xfce/exo/0.12/exo-0.12.11.tar.bz2'
   source_sha256 'ec892519c08a67f3e0a1f0f8d43446e26871183e5aa6be7f82e214f388d1e5b6'
-    
-  depends_on 'libxfce4util'
-    
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/exo-0.12.11-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/exo-0.12.11-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/exo-0.12.11-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/exo-0.12.11-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '07177dc02a65d560e209dbe516aa38cd359b176689866e43e460d9269925b336',
+     armv7l: '07177dc02a65d560e209dbe516aa38cd359b176689866e43e460d9269925b336',
+       i686: 'ca69b4854fd2b219b04519b5f118b88afb0ba66362dbc2c0b4dcad39b051820b',
+     x86_64: '9dba0db6d8e8253fc739b803aa604b2cc385d58af660e5b9c74332a9dae43075',
+  })
+
+  depends_on 'libxfce4ui'
+  depends_on 'xfce4_dev_tools'
+
   def self.patch
-       system "mkdir m4"
-       system "NOCONFIGURE=1 xdt-autogen"
+    system "mkdir m4"
+    system "NOCONFIGURE=1 xdt-autogen"
   end
+
   def self.build
-     system "./configure #{CREW_OPTIONS}"
-      system "make -j#{CREW_NPROC}"
+    system "./configure #{CREW_OPTIONS}"
+    system "make -j#{CREW_NPROC}"
   end
+
   def self.install
-     system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/glibmm.rb
+++ b/packages/glibmm.rb
@@ -1,21 +1,35 @@
 require 'package'
 
 class Glibmm < Package
-  description "C++ bindings for GLib"
-  homepage "https://www.gtkmm.org"
-  version "2.64.2"
-  compatibility "all"
-  source_url "https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.64/glibmm-2.64.2.tar.xz"
-  source_sha256 "a75282e58d556d9b2bb44262b6f5fb76c824ac46a25a06f527108bec86b8d4ec"
+  description 'C++ bindings for GLib'
+  homepage 'https://www.gtkmm.org'
+  version '2.64.2'
+  compatibility 'all'
+  source_url 'https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.64/glibmm-2.64.2.tar.xz'
+  source_sha256 'a75282e58d556d9b2bb44262b6f5fb76c824ac46a25a06f527108bec86b8d4ec'
 
-  depends_on "libsigcplusplus"
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.64.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.64.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.64.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.64.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '72bb27894e3eb810f9cb188a4b80c286213900f01b310ab39b6a68370e9dda3a',
+     armv7l: '72bb27894e3eb810f9cb188a4b80c286213900f01b310ab39b6a68370e9dda3a',
+       i686: '96cfa5d2030370e2dd75ac11dd6389eef53751dab7a66f20abd5f53eaa7ffa48',
+     x86_64: '97c66ad7fb93bf2715de8cfda6ce6afeb0f83d5235602cd7ba3d4cc42f02c6eb',
+  })
+
+  depends_on 'libsigcplusplus'
   depends_on 'mm_common' => :build
 
   def self.build
-      system "./configure #{CREW_OPTIONS} "
-      system "make -j#{CREW_NPROC}"
+    system "./configure #{CREW_OPTIONS} "
+    system "make -j#{CREW_NPROC}"
   end
+
   def self.install
-      system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/gtkmm3.rb
+++ b/packages/gtkmm3.rb
@@ -8,6 +8,19 @@ class Gtkmm3 < Package
   source_url 'https://ftp.gnome.org/pub/gnome/sources/gtkmm/3.24/gtkmm-3.24.1.tar.xz'
   source_sha256 'ddfe42ed2458a20a34de252854bcf4b52d3f0c671c045f56b42aa27c7542d2fd'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '86060a13fc77c19a96824ec0dfa5d2aca1efbf5f49f1c413dac08689709c7756',
+     armv7l: '86060a13fc77c19a96824ec0dfa5d2aca1efbf5f49f1c413dac08689709c7756',
+       i686: '9f3e44da54fc92ca271d659c089da52d7dadb30fbd8449f7cf9efacd847dafee',
+     x86_64: 'a725c0b8d92256ba6a598de8f3bf7be4494b81be248013206d78e353dcba2c14',
+  })
+
   depends_on 'atkmm'
   depends_on 'gtk3'
   depends_on 'pangomm'
@@ -18,6 +31,6 @@ class Gtkmm3 < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libcanberra.rb
+++ b/packages/libcanberra.rb
@@ -1,28 +1,42 @@
 require 'package'
 
 class Libcanberra < Package
-    description "XDG Sound Theme and Name Specification library implementation"
-    homepage "http://0pointer.de/lennart/projects/libcanberra/"
-    version "0.30"
-    compatibility "all"
-    source_url "http://pkgs.fedoraproject.org/repo/pkgs/libcanberra/libcanberra-0.30.tar.xz/34cb7e4430afaf6f447c4ebdb9b42072/libcanberra-0.30.tar.xz"
-    source_sha256 "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+  description 'XDG Sound Theme and Name Specification library implementation'
+  homepage 'http://0pointer.de/lennart/projects/libcanberra/'
+  version '0.30'
+  compatibility 'all'
+  source_url 'http://pkgs.fedoraproject.org/repo/pkgs/libcanberra/libcanberra-0.30.tar.xz/34cb7e4430afaf6f447c4ebdb9b42072/libcanberra-0.30.tar.xz'
+  source_sha256 'c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72'
 
-    depends_on "pygtk"
-    depends_on "libvorbis"
-    depends_on "libtool"
-    depends_on "gstreamer"
-    depends_on "alsa_lib"
-    depends_on "tdb"
-    depends_on "pulseaudio"
-    depends_on "eudev"
-    depends_on "vala"
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcanberra-0.30-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcanberra-0.30-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcanberra-0.30-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcanberra-0.30-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '64475dc749ad8fe0a31ba8d72feaab22b938ddb148a571bf9372ff8f269b52f9',
+     armv7l: '64475dc749ad8fe0a31ba8d72feaab22b938ddb148a571bf9372ff8f269b52f9',
+       i686: '29ee2f4ead00d48eab9b03762d4fcedcd7e509bb465ccbc3d78e7e883ad0b7ce',
+     x86_64: 'ccdff75c92bef914c837df98cb914a86f7580543a378e00eca9223da525332d5',
+  })
 
-    def self.build
-        system "./configure #{CREW_OPTIONS} --enable-alsa --enable-null --disable-lynx --enable-gstreamer --disable-oss --with-builtin=dso"
-        system "make -j#{CREW_NPROC}"
-    end
-    def self.install
-        system "make install DESTDIR=#{CREW_DEST_DIR}"
-    end
+  depends_on 'pygtk'
+  depends_on 'libvorbis'
+  depends_on 'libtool'
+  depends_on 'gstreamer'
+  depends_on 'alsa_lib'
+  depends_on 'tdb'
+  depends_on 'pulseaudio'
+  depends_on 'eudev'
+  depends_on 'vala'
+
+  def self.build
+    system "./configure #{CREW_OPTIONS} --enable-alsa --enable-null --disable-lynx --enable-gstreamer --disable-oss --with-builtin=dso"
+    system "make -j#{CREW_NPROC}"
+  end
+
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
 end

--- a/packages/libxfce4ui.rb
+++ b/packages/libxfce4ui.rb
@@ -2,22 +2,36 @@ require 'package'
 
 class Libxfce4ui < Package
   description 'Replacement of the old libxfcegui4 library'
-  homepage "https://xfce.org/"
+  homepage 'https://xfce.org/'
   version '4.15.3'
   compatibility 'all'
-  source_url "https://archive.xfce.org/src/xfce/libxfce4ui/4.15/libxfce4ui-4.15.3.tar.bz2"
+  source_url 'https://archive.xfce.org/src/xfce/libxfce4ui/4.15/libxfce4ui-4.15.3.tar.bz2'
   source_sha256 'ce89419720da0fa84a3bb46bc447564c5800057c026c272ae0b016918c0a9307'
-    
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4ui-4.15.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4ui-4.15.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4ui-4.15.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4ui-4.15.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '54ae66c12fc66405c48554cc4d9e439e84a65da3cf438f907febbc15f76eadb7',
+     armv7l: '54ae66c12fc66405c48554cc4d9e439e84a65da3cf438f907febbc15f76eadb7',
+       i686: '91273a8ee09968a855c910684b7b5d4c388f6c53f19c7965b5265fc456a22d92',
+     x86_64: 'c41174c81ff48917e9e89f99d970ff716261247ab0a8cfd0ae17ebfe85e69cde',
+  })
+
   depends_on 'gtk3'
   depends_on 'gtk2'
   depends_on 'pygtk' # For gtk+
   depends_on 'xfconf'
-    
+
   def self.build
-      system "./configure #{CREW_OPTIONS}"
-      system "make -j#{CREW_NPROC}"
- end
- def self.install
-      system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "./configure #{CREW_OPTIONS}"
+    system "make -j#{CREW_NPROC}"
+  end
+
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/libxfce4util.rb
+++ b/packages/libxfce4util.rb
@@ -1,20 +1,34 @@
 require 'package'
 
 class Libxfce4util < Package
-    description 'Utility library for the Xfce4 desktop environment'
-    homepage "https://xfce.org/"
-    version '4.14.0'
-    compatibility 'all'
-    source_url "https://archive.xfce.org/src/xfce/libxfce4util/4.14/libxfce4util-4.14.0.tar.bz2"
-    source_sha256 '32ad79b7992ec3fd863e8ff2f03eebda8740363ef9d7d910a35963ac1c1a6324'
-    
-    depends_on 'libxfce4ui'
-    
-    def self.build
-        system "./configure #{CREW_OPTIONS}"
-        system "make -j#{CREW_NPROC}"
-    end
-    def self.install
-        system "make install DESTDIR=#{CREW_DEST_DIR}"
-    end
+  description 'Utility library for the Xfce4 desktop environment'
+  homepage 'https://xfce.org/'
+  version '4.14.0'
+  compatibility 'all'
+  source_url 'https://archive.xfce.org/src/xfce/libxfce4util/4.14/libxfce4util-4.14.0.tar.bz2'
+  source_sha256 '32ad79b7992ec3fd863e8ff2f03eebda8740363ef9d7d910a35963ac1c1a6324'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4util-4.14.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4util-4.14.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4util-4.14.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4util-4.14.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '06023cc89141955768a6c19ec1c9fa6c3c6944d6d0aee7d09007cb9eafdf0354',
+     armv7l: '06023cc89141955768a6c19ec1c9fa6c3c6944d6d0aee7d09007cb9eafdf0354',
+       i686: 'd53ff9b81ee9b2be8992ab2471af839f2ec7d7ab22f384bc6e356b9cc6e6a501',
+     x86_64: 'f95cdc9a803db597e3996e4a21e430db51558c8b9b1a9b771e2baebedbc2bb8a',
+  })
+
+  depends_on 'gobject_introspection'
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system "make -j#{CREW_NPROC}"
+  end
+
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
 end

--- a/packages/pavucontrol.rb
+++ b/packages/pavucontrol.rb
@@ -1,25 +1,39 @@
 require 'package'
 
 class Pavucontrol < Package
-    description "PulseAudio Volume Control"
-    homepage "https://freedesktop.org/software/pulseaudio/pavucontrol/"
-    version "4.0"
-    compatibility "all"
-    source_url "https://freedesktop.org/software/pulseaudio/pavucontrol//pavucontrol-4.0.tar.xz"
-    source_sha256 "8fc45bac9722aefa6f022999cbb76242d143c31b314e2dbb38f034f4069d14e2"
+  description 'PulseAudio Volume Control'
+  homepage 'https://freedesktop.org/software/pulseaudio/pavucontrol/'
+  version '4.0'
+  compatibility 'all'
+  source_url 'https://freedesktop.org/software/pulseaudio/pavucontrol//pavucontrol-4.0.tar.xz'
+  source_sha256 '8fc45bac9722aefa6f022999cbb76242d143c31b314e2dbb38f034f4069d14e2'
 
-    depends_on "gtkmm2"
-    depends_on "gtkmm3"
-    depends_on "libcanberra"
-    depends_on "pygtk"
-    depends_on "pulseaudio"
-    depends_on "glibmm"
-    
-    def self.build
-        system "./configure #{CREW_OPTIONS}"
-        system "make -j#{CREW_NPROC} -lgtkmm-3.24" # Issue with gtkmm - gtk::builder
-    end
-    def self.install
-        system "make install DESTDIR=#{CREW_DEST_DIR}"
-    end
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '97f4ff801cdca8a12c665e5d1467e1749f06803fb7f2ac4423be95c057fc8e13',
+     armv7l: '97f4ff801cdca8a12c665e5d1467e1749f06803fb7f2ac4423be95c057fc8e13',
+       i686: '1b536d2c99e5466a4939b82b25cd94f105ce2ca24cece37f868df3bc30078496',
+     x86_64: '91919320ed61fdc26730f8a7d1d19dbc712b158b16ddd2de4d77ad029b461b52',
+  })
+
+  depends_on 'gtkmm2'
+  depends_on 'gtkmm3'
+  depends_on 'libcanberra'
+  depends_on 'pygtk'
+  depends_on 'pulseaudio'
+  depends_on 'glibmm'
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system "make -j#{CREW_NPROC} -lgtkmm-3.24" # Issue with gtkmm - gtk::builder
+  end
+
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
 end

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -8,6 +8,19 @@ class Pulseaudio < Package
   source_url 'https://freedesktop.org/software/pulseaudio/releases/pulseaudio-13.99.1.tar.gz'
   source_sha256 '80d3a217567e6eb52234e638765f0e0e7fe8feee89c2e532a15250ed6a8bfd30'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-13.99.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-13.99.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-13.99.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-13.99.1-1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fa9ead7cf978e3d598f2795427638d10a7895ede724bd82256dd64c7f5e91544',
+     armv7l: 'fa9ead7cf978e3d598f2795427638d10a7895ede724bd82256dd64c7f5e91544',
+       i686: 'd05e537614795f8e03592b9a2b4a23c3980fc70888323ac08a4cae1b992bb856',
+     x86_64: '58ed8261edea0ea1e276c548591f44476f36758edef831870f8d1e8820e13e9e',
+  })
+
   depends_on 'gsettings_desktop_schemas'
   depends_on 'alsa_plugins' => :build
   depends_on 'tcpwrappers'

--- a/packages/sxhkd.rb
+++ b/packages/sxhkd.rb
@@ -8,6 +8,19 @@ class Sxhkd < Package
   source_url 'https://github.com/baskerville/sxhkd/archive/0.6.2.tar.gz'
   source_sha256 '1edc8b1a8b3631c10ba9cb9df1181830dacbbdf77adb558e31d5dd2029637386'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sxhkd-0.6.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sxhkd-0.6.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sxhkd-0.6.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sxhkd-0.6.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'ddc4774617d8238d80e4319771f1a9d6ef76f91337f76fa68aa49c543042bed9',
+     armv7l: 'ddc4774617d8238d80e4319771f1a9d6ef76f91337f76fa68aa49c543042bed9',
+       i686: '0363cb29cef86ce890375b5b6f471b8f07bab7b4762d230a9e550e7cdb8ab29b',
+     x86_64: '8781a6790da9fa13c94e6b751f99fa448a9380d4be599aec7c56bad4a9b7e3b5',
+  })
+
   depends_on 'xcb_util_keysyms'
   depends_on 'xcb_util'
   depends_on 'libxcb'

--- a/packages/xfce4_dev_tools.rb
+++ b/packages/xfce4_dev_tools.rb
@@ -2,19 +2,33 @@ require 'package'
 
 class Xfce4_dev_tools < Package
   description 'Xfce4 development tools'
-  homepage "https://xfce.org/"
+  homepage 'https://xfce.org/'
   version '4.14.0'
   compatibility 'all'
-  source_url "https://archive.xfce.org/src/xfce/xfce4-dev-tools/4.14/xfce4-dev-tools-4.14.0.tar.bz2"
+  source_url 'https://archive.xfce.org/src/xfce/xfce4-dev-tools/4.14/xfce4-dev-tools-4.14.0.tar.bz2'
   source_sha256 '2c9eb8e0fe23e47dc31411a93b683fd1b7a49140e9163f0aab9e94a3d8a0b5fd'
-    
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_dev_tools-4.14.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_dev_tools-4.14.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_dev_tools-4.14.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_dev_tools-4.14.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '8b1ceccfed1a4bdb34dbf9ed35c246cca5035754ae01185db88261cd5ed62dd4',
+     armv7l: '8b1ceccfed1a4bdb34dbf9ed35c246cca5035754ae01185db88261cd5ed62dd4',
+       i686: 'fe79c7ae95dc08eb4a32168d8b0ff5fcd203cd91d7b12d894a94f826d84dd425',
+     x86_64: '24341f2465119626d4625ba9926f7d63f7e6a95bba6f18e01706025855399c9e',
+  })
+
   depends_on 'gtk_doc'
 
   def self.build
-      system "./configure #{CREW_OPTIONS}"
-      system "make -j#{CREW_NPROC}"
+    system "./configure #{CREW_OPTIONS}"
+    system "make -j#{CREW_NPROC}"
   end
+
   def self.install
-      system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/xfce4_terminal.rb
+++ b/packages/xfce4_terminal.rb
@@ -1,23 +1,39 @@
 require 'package'
-    
+
 class Xfce4_terminal < Package
- description 'Modern terminal emulator primarly for the Xfce desktop environment'
- homepage "https://xfce.org/"
- version '0.8.9'
- compatibility 'all'
- source_url "https://archive.xfce.org/src/apps/xfce4-terminal/0.8/xfce4-terminal-0.8.9.tar.bz2"
- source_sha256 '247683a51a964cfaa6b1e92030afe9f782efebfcb550a464170b53eb94216795'
-    
- depends_on 'desktop_file_utilities'
- depends_on 'gtkvte' => :build
- depends_on 'exo' => :build
- depends_on 'hicolor_icon_theme'
-    
+  description 'Modern terminal emulator primarly for the Xfce desktop environment'
+  homepage 'https://xfce.org/'
+  version '0.8.9'
+  compatibility 'all'
+  source_url 'https://archive.xfce.org/src/apps/xfce4-terminal/0.8/xfce4-terminal-0.8.9.tar.bz2'
+  source_sha256 '247683a51a964cfaa6b1e92030afe9f782efebfcb550a464170b53eb94216795'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_terminal-0.8.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_terminal-0.8.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_terminal-0.8.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_terminal-0.8.9-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'd37498733609e4d3f3f15850338c4784a4eb78a004e7e25acf77931926e10bfc',
+     armv7l: 'd37498733609e4d3f3f15850338c4784a4eb78a004e7e25acf77931926e10bfc',
+       i686: '9840a888716501c16051c3d5bd1e2589041842e5ce04752e5ad4ccca1040d220',
+     x86_64: '8de24a4111db8171a242bf6a0365c9cb491fdcd472909fef82dce15a11f51d20',
+  })
+
+  depends_on 'desktop_file_utilities'
+  depends_on 'gtkvte'
+  depends_on 'exo' => :build
+  depends_on 'hicolor_icon_theme'
+  depends_on 'startup_notification'
+  depends_on 'sommelier'
+
   def self.build
-      system "./configure #{CREW_OPTIONS}"
-      system "make -j#{CREW_NPROC}"
+    system "./configure #{CREW_OPTIONS}"
+    system "make -j#{CREW_NPROC}"
   end
+
   def self.install
-      system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/xfconf.rb
+++ b/packages/xfconf.rb
@@ -1,20 +1,36 @@
 require 'package'
 
 class Xfconf < Package
-    description 'Xfce hierarchical (tree-like) configuration system'
-    homepage "https://xfce.org/"
+  description 'Xfce hierarchical (tree-like) configuration system'
+  homepage 'https://xfce.org/'
   version '4.14.3'
   compatibility 'all'
-  source_url "https://archive.xfce.org/src/xfce/xfconf/4.14/xfconf-4.14.3.tar.bz2"
+  source_url 'https://archive.xfce.org/src/xfce/xfconf/4.14/xfconf-4.14.3.tar.bz2'
   source_sha256 '589052a0efc6151c5fb5f438da463502a4fd91848cae7b9376d417be4c5a0c02'
-    
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xfconf-4.14.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xfconf-4.14.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xfconf-4.14.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xfconf-4.14.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '14c0ea331495d775cefe7d47d0ad3b916ca1b32cee886dcd526f6577d9e8e846',
+     armv7l: '14c0ea331495d775cefe7d47d0ad3b916ca1b32cee886dcd526f6577d9e8e846',
+       i686: '477b34ac827fc9765cfd099ff63904eb05d1f028eee93e40aa67540812306516',
+     x86_64: '9550ca9cf26bfd14b99997fd5cee8ef9b3b4045f3c7a88c9cb27e2f4a32d58c9',
+  })
+
   depends_on 'gobject_introspection' # For --enable-gsettings-backend
-    
+  depends_on 'libxfce4util'
+  depends_on 'vala' => :build
+
   def self.build
-     system "./configure #{CREW_OPTIONS} --enable-gsettings-backend"
-     system "make -j#{CREW_NPROC}"
+    system "./configure #{CREW_OPTIONS} --enable-gsettings-backend"
+    system "make -j#{CREW_NPROC}"
   end
+
   def self.install
-     system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end


### PR DESCRIPTION
Tested on all architectures.

Fixes #4233
Fixes #4234