### PR TITLE
New Package: libefl

### DIFF
--- a/packages/bdftopcf.rb
+++ b/packages/bdftopcf.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Bdftopcf < Package
+  description 'BDF to PCF font converter for X11'
+  homepage 'https://xorg.freedesktop.org/'
+  version '1.1'
+  compatibility 'all'
+  source_url 'https://www.x.org/releases/individual/app/bdftopcf-1.1.tar.bz2'
+  source_sha256 '4b4df05fc53f1e98993638d6f7e178d95b31745c4568cee407e167491fd311a2'
+
+  depends_on 'libxfont'
+
+  def self.build
+      system "./configure #{CREW_OPTIONS} "
+      system "make -j#{CREW_NPROC}"
+  end
+  def self.install
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/bullet.rb
+++ b/packages/bullet.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Bullet < Package
+  description '3D Collision Detection and Rigid Body Dynamics Library'
+  homepage 'https://pybullet.org/Bullet/phpBB3/'
+  version '2.89'
+  compatibility 'all'
+  source_url 'https://github.com/bulletphysics/bullet3/archive/2.89.tar.gz'
+  source_sha256 '621b36e91c0371933f3c2156db22c083383164881d2a6b84636759dc4cbb0bb8'
+
+  depends_on 'libglu'
+
+  def self.build
+    FileUtils.mkdir_p "build"
+    Dir.chdir 'build' do
+    	system "cmake .. -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DINSTALL_LIBDIR=#{CREW_LIB_PREFIX} -DCMAKE_BUILD_TYPE=Release"
+    	system "make -j#{CREW_NPROC}"
+    end
+  end
+  def self.install
+    Dir.chdir 'build' do
+    	system "DESTDIR=#{CREW_DEST_DIR} make install"
+    end
+  end
+end

--- a/packages/font_misc_misc.rb
+++ b/packages/font_misc_misc.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Font_misc_misc < Package
+  description 'Standard X11 fixed PCF fonts'
+  homepage 'https://xorg.freedesktop.org/'
+  version '1.1.2'
+  compatibility 'all'
+  source_url 'https://www.x.org/releases/individual/font/font-misc-misc-1.1.2.tar.bz2'
+  source_sha256 'b8e77940e4e1769dc47ef1805918d8c9be37c708735832a07204258bacc11794'
+
+  depends_on 'font_util'
+  depends_on 'mkfontscale'
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system "make -j#{CREW_NPROC}"
+  end
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/font_util.rb
+++ b/packages/font_util.rb
@@ -1,34 +1,20 @@
 require 'package'
 
 class Font_util < Package
-  description 'X.Org font utilities'
-  homepage 'https://www.freedesktop.org'
-  version '1.3.1'
+  description 'Tools for truncating and subseting of ISO10646-1 BDF fonts'
+  homepage 'https://xorg.freedesktop.org'
+  version '1.3.2'
   compatibility 'all'
-  source_url 'https://www.x.org/archive/individual/font/font-util-1.3.1.tar.bz2'
-  source_sha256 'aa7ebdb0715106dd255082f2310dbaa2cd7e225957c2a77d719720c7cc92b921'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/font_util-1.3.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/font_util-1.3.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/font_util-1.3.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/font_util-1.3.1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'a5617374b5f1354f427fbbc25e7d5bf8b300a53b5c48d0d347096ed45c2f1cf3',
-     armv7l: 'a5617374b5f1354f427fbbc25e7d5bf8b300a53b5c48d0d347096ed45c2f1cf3',
-       i686: 'ad05ed87b4da0069c731bcd3a17f077b9d317c3784c2a954c4284bc1197e5434',
-     x86_64: '3d87ede9af652619cfc28f1cf16779a841228233978605c9a234501b789fd86c',
-  })
+  source_url 'https://www.x.org/releases/individual/font/font-util-1.3.2.tar.bz2'
+  source_sha256 '3ad880444123ac06a7238546fa38a2a6ad7f7e0cc3614de7e103863616522282'
 
   depends_on 'util_macros'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+      system "./configure #{CREW_OPTIONS} "
+      system "make -j#{CREW_NPROC}"
   end
-
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/ghostscript.rb
+++ b/packages/ghostscript.rb
@@ -1,42 +1,34 @@
 require 'package'
 
 class Ghostscript < Package
-  description 'Ghostscript is the name of a set of software that provides an interpreter for the PostScript language and the PDF file format.'
-  homepage 'https://www.gnu.org/software/ghostscript/'
-  version '9.14.1-1'
+  description 'Interpreter for the PostScript language'
+  homepage 'https://www.ghostscript.com/'
+  version '9.52'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/ghostscript/gnu-ghostscript-9.14.1.tar.xz'
-  source_sha256 '424a4ff333a594fdd397cd8adc4249bad7d74a6ae653f840dee72b27f1bf1da0'
+  source_url 'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs952/ghostscript-9.52.tar.xz'
+  source_sha256 '57442acf8b46453a9b5fc6fec738fbbb7e13a3d3e00f1aaaa0975529bc203c7c'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.14.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.14.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.14.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ghostscript-9.14.1-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'eb8e98fe8b0eb70ce20c56878e962d690f25703326cdca60865ed05e5444cd3f',
-     armv7l: 'eb8e98fe8b0eb70ce20c56878e962d690f25703326cdca60865ed05e5444cd3f',
-       i686: '31827f5362971f99ba3aa5aa6f4fdc3a4ca4368bf72a499538fdf7f98fff3d41',
-     x86_64: '23325d5f8c5cbb538a366313d68da5a35677ddf963ecfdfe8a40d0617c55b2bc',
-  })
-
-  depends_on 'cups'
-  depends_on 'gtk3'
+  depends_on 'dbus'
+  depends_on 'fontconfig'
+  depends_on 'jasper'
+  depends_on 'gsfonts'
   depends_on 'lcms'
-  depends_on 'libpng'
-  depends_on 'libtiff'
-
-  def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-dependency-tracking',
-           '--disable-static'
+  depends_on 'libxext'
+  depends_on 'libxt'
+  depends_on 'openjpeg'
+  depends_on 'libpaper'
+  depends_on 'cups'
+  
+def self.build
+    system "CPPFLAGS='-DPNG_ARM_NEON_OPT=0' ./configure #{CREW_OPTIONS} --disable-dependency-tracking -disable-static"
     system 'make'
+    system "make so" # Make libgs
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "make soinstall DESTDIR=#{CREW_DEST_DIR}" # Install libgs
+    FileUtils.cp_r Dir.glob('./base/*.h'), "#{CREW_DEST_PREFIX}/include/ghostscript"
+    FileUtils.ln_sf 'ghostscript', "#{CREW_DEST_PREFIX}/include/ps"
   end
 end

--- a/packages/gsfonts.rb
+++ b/packages/gsfonts.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Gsfonts < Package
+  description 'Ghostscript standard Type1 fonts'
+  homepage 'https://sourceforge.net/projects/gs-fonts/'
+  version '8.11'
+  compatibility 'all'
+  source_url 'https://managedway.dl.sourceforge.net/project/ghostscript/AFPL%20Ghostscript/8.14/ghostscript-fonts-std-8.11.tar.gz'
+  source_sha256 '0eb6f356119f2e49b2563210852e17f57f9dcc5755f350a69a46a0d641a0c401'
+
+  depends_on 'font_util'
+  depends_on 'font_misc_misc'
+  depends_on 'bdftopcf'
+  
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/fonts/Type1"
+    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/fonts/Type1"
+  end
+end

--- a/packages/libefl.rb
+++ b/packages/libefl.rb
@@ -1,0 +1,68 @@
+require 'package'
+
+class Libefl < Package
+  description 'Enlightenment Foundation Libraries'
+  homepage 'https://enlightenment.org'
+  version '1.24.3'
+  compatibility 'all'
+  source_url 'https://download.enlightenment.org/rel/libs/efl/efl-1.24.3.tar.xz'
+  source_sha256 'de95c6e673c170c1e21382918b122417c091c643e7dcaced89aa785529625c2a'
+
+  depends_on 'lz4'
+  depends_on 'libusb'
+  depends_on 'fontconfig'
+  depends_on 'fribidi'
+  depends_on 'libjpeg_turbo'
+  depends_on 'libpng'
+  depends_on 'giflib'
+  depends_on 'libtiff'
+  depends_on 'libwebp'
+  depends_on 'avahi'
+  depends_on 'eudev'
+  depends_on 'bullet'
+  depends_on 'libsndfile'
+  depends_on 'luajit'
+  depends_on 'poppler'
+  depends_on 'librsvg'
+  depends_on 'libspectre'
+  depends_on 'libraw'
+  depends_on 'openjpeg'
+  depends_on 'gstreamer'
+  depends_on 'mesa'
+  depends_on 'libxcomposite'
+  depends_on 'libxcursor'
+  depends_on 'libxp'
+  depends_on 'libxrandr'
+  depends_on 'libxscrnsaver'
+  depends_on 'libxdamage'
+  depends_on 'libxrender'
+  depends_on 'libxi'
+  depends_on 'libxinerama'
+  depends_on 'libxpresent'
+  depends_on 'xcb_util'
+  depends_on 'xcb_util_keysyms'
+  depends_on 'xcb_util_image'
+  depends_on 'xcb_util_renderutil'
+  depends_on 'xcb_util_wm'
+  depends_on 'xorg_proto'
+  depends_on 'gnutls'
+
+  def self.build
+    system 'meson',
+           "--prefix=#{CREW_PREFIX}",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '-Dcrypto=gnutls',
+           '-Dsystemd=false',
+           '-Dglib=false',
+           '-Dgstreamer=false',
+           '-Decore-imf-loaders-disabler=ibus,scim',
+           '-Demotion-loaders-disabler=gstreamer1,gstreamer,xine',
+           '-Demotion-generic-loaders-disabler=vlc',
+           '_build'
+    system 'ninja -v -C _build'
+  end
+  
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
+  end
+end

--- a/packages/libfontenc.rb
+++ b/packages/libfontenc.rb
@@ -1,35 +1,21 @@
 require 'package'
 
 class Libfontenc < Package
-  description 'library for the X window system'
-  homepage 'https://x.org'
-  version '1.1.3'
+  description 'Fontenc Library from X.org'
+  homepage 'https://xorg.freedesktop.org/'
+  version '1.1.4'
   compatibility 'all'
-  source_url 'https://www.x.org/archive/individual/lib/libfontenc-1.1.3.tar.gz'
-  source_sha256 '6fba26760ca8d5045f2b52ddf641c12cedc19ee30939c6478162b7db8b6220fb'
+  source_url 'https://www.x.org/releases/individual/lib/libfontenc-1.1.4.tar.bz2'
+  source_sha256 '2cfcce810ddd48f2e5dc658d28c1808e86dcf303eaff16728b9aa3dbc0092079'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libfontenc-1.1.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libfontenc-1.1.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libfontenc-1.1.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libfontenc-1.1.3-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '80f8be4b0ed9e282172ca04b5945dfeca2f64c676afb45d727fce8dc0c1100ca',
-     armv7l: '80f8be4b0ed9e282172ca04b5945dfeca2f64c676afb45d727fce8dc0c1100ca',
-       i686: '18570f0cbbd7083ff01de80bf13a565f34319f27a93427fcf9dd2f47577c8342',
-     x86_64: 'e908f737e72de556d70a7013efeaf6a23bdeb570b159df3907cdc387584b0de2',
-  })
-  
   depends_on 'xorg_proto'
   depends_on 'zlibpkg'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "./configure #{CREW_OPTIONS} --with-fontrootdir=#{CREW_PREFIX}/share/fonts/X11"
+    system "make -j#{CREW_NPROC}"
   end
-
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/libpaper.rb
+++ b/packages/libpaper.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Libpaper < Package
+  description 'Library for handling paper characteristics'
+  homepage 'http://packages.debian.org/unstable/source/libpaper'
+  version '1.1.28'
+  compatibility 'all'
+  source_url 'http://ftp.debian.org/debian/pool/main/libp/libpaper/libpaper_1.1.28.tar.gz'
+  source_sha256 'c8bb946ec93d3c2c72bbb1d7257e90172a22a44a07a07fb6b802a5bb2c95fddc'
+
+  def self.build
+      system "autoreconf -fi"
+      system "./configure #{CREW_OPTIONS}"
+      system "make -j#{CREW_NPROC}"
+  end
+  def self.install
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/libraw.rb
+++ b/packages/libraw.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Libraw < Package
+  description 'Raw image decoder library'
+  homepage 'https://www.libraw.org'
+  version '0.19.5'
+  compatibility 'all'
+  source_url 'https://www.libraw.org/data/LibRaw-0.19.5.tar.gz'
+  source_sha256 '40a262d7cc71702711a0faec106118ee004f86c86cc228281d12d16da03e02f5'
+
+  depends_on 'jasper'
+  depends_on 'lcms'
+
+  def self.build
+      system "./configure #{CREW_OPTIONS} "
+      system "make -j#{CREW_NPROC}"
+  end
+  def self.install
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/libspectre.rb
+++ b/packages/libspectre.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Libspectre < Package
+  description 'Small library for rendering Postscript documents'
+  homepage 'https://www.freedesktop.org/wiki/Software/libspectre/'
+  version '0.2.9'
+  compatibility 'all'
+  source_url 'https://libspectre.freedesktop.org/releases/libspectre-0.2.9.tar.gz'
+  source_sha256 '49ae9c52b5af81b405455c19fe24089d701761da2c45d22164a99576ceedfbed'
+
+  depends_on 'ghostscript' # = libgs
+
+  def self.build
+      system "./configure #{CREW_OPTIONS} --disable-static"
+      system "make -j#{CREW_NPROC}"
+  end
+  def self.install
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/libxp.rb
+++ b/packages/libxp.rb
@@ -1,0 +1,22 @@
+require 'package'
+
+class Libxp < Package
+  description 'x print service extension library'
+  homepage 'https://xorg.freedesktop.org'
+  version '1.0.3'
+  compatibility 'all'
+  source_url 'https://www.x.org/releases/individual/lib/libXp-1.0.3.tar.bz2'
+  source_sha256 '7f360c9905849c3587d48efc0f0ecbc852c19f61a52b18530d6b005cb9148c57'
+
+  depends_on 'xorg_proto'
+  depends_on 'libxext'
+  depends_on 'printproto'
+
+  def self.build
+      system "./configure #{CREW_OPTIONS} --enable-malloc0returnsnull"
+      system "make -j#{CREW_NPROC}"
+  end
+  def self.install
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/libxpresent.rb
+++ b/packages/libxpresent.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Libxpresent < Package
+  description 'XPresent extension C library'
+  homepage 'https://cgit.freedesktop.org/xorg/lib/libXpresent/'
+  version '1.0.0'
+  compatibility 'all'
+  source_url 'https://www.x.org/releases/individual/lib/libXpresent-1.0.0.tar.gz'
+  source_sha256 '92f1bdfb67ae2ffcdb25ad72c02cac5e4912dc9bc792858240df1d7f105946fa'
+
+  depends_on 'libxfixes'
+  depends_on 'libxrandr'
+
+  def self.build
+      system "./configure #{CREW_OPTIONS} "
+      system "make -j#{CREW_NPROC}"
+  end
+  def self.install
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/mkfontscale.rb
+++ b/packages/mkfontscale.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Mkfontscale < Package
+  description 'X11 Scalable Font Index Generator'
+  homepage 'https://www.x.org/wiki'
+  version '1.2.1'
+  compatibility 'all'
+  source_url 'https://www.x.org/releases/individual/app/mkfontscale-1.2.1.tar.bz2'
+  source_sha256 'ca0495eb974a179dd742bfa6199d561bda1c8da4a0c5a667f21fd82aaab6bac7'
+
+  depends_on 'xorg_proto'
+  depends_on 'zlibpkg'
+  depends_on 'freetype'
+  depends_on 'libfontenc'
+
+  def self.build
+      system "./configure #{CREW_OPTIONS}"
+      system "make -j#{CREW_NPROC}"
+  end
+  def self.install
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/printproto.rb
+++ b/packages/printproto.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Printproto < Package
+  description 'Xprint build headers'
+  homepage 'https://xorg.freedesktop.org'
+  version '1.0.5'
+  compatibility 'all'
+  source_url 'https://xorg.freedesktop.org/releases/individual/proto/printproto-1.0.5.tar.bz2'
+  source_sha256 '1298316cf43b987365ab7764d61b022a3d7f180b67b423eed3456862d155911a'
+
+  def self.build
+      system "./configure #{CREW_OPTIONS}"
+      system "make -j#{CREW_NPROC}"
+  end
+  def self.install
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end


### PR DESCRIPTION
## Changes
`font_util` - Updated to `1.3.2`
`ghostscript` - Updated to `9.52` - Add `libgs` shared library - `libspectre` dependency
`libfontenc` - Updated to `1.1.4`

## Additions 
`libefl`
~
`bdftopcf` - `gsfonts` dependency
`bullet` - `libefl` dependency
`font_misc_misc` - `gsfonts` dependency
`gsfonts` - `ghostscript` dependency
`libpaper` - `ghostscript` dependency
`libraw` - `libefl` dependency
`printproto` - `libxp` dependency
`libxp` - `libefl` dependency
`libspectre` - `libefl` dependency
`libxpresent` - `libefl` dependency
`mkfontscale` - `gsfonts` dependency