### PR TITLE
Correct dependencies declaration

### DIFF
--- a/packages/font_misc_misc.rb
+++ b/packages/font_misc_misc.rb
@@ -3,13 +3,14 @@ require 'package'
 class Font_misc_misc < Package
   description 'Standard X11 fixed PCF fonts'
   homepage 'https://xorg.freedesktop.org/'
-  version '1.1.2'
+  version '1.1.2-1'
   compatibility 'all'
   source_url 'https://www.x.org/releases/individual/font/font-misc-misc-1.1.2.tar.bz2'
   source_sha256 'b8e77940e4e1769dc47ef1805918d8c9be37c708735832a07204258bacc11794'
 
   depends_on 'font_util'
   depends_on 'mkfontscale'
+  depends_on 'bdftopcf'
 
   def self.build
     system "./configure #{CREW_OPTIONS}"

--- a/packages/gsfonts.rb
+++ b/packages/gsfonts.rb
@@ -3,14 +3,13 @@ require 'package'
 class Gsfonts < Package
   description 'Ghostscript standard Type1 fonts'
   homepage 'https://sourceforge.net/projects/gs-fonts/'
-  version '8.11'
+  version '8.11-1'
   compatibility 'all'
   source_url 'https://managedway.dl.sourceforge.net/project/ghostscript/AFPL%20Ghostscript/8.14/ghostscript-fonts-std-8.11.tar.gz'
   source_sha256 '0eb6f356119f2e49b2563210852e17f57f9dcc5755f350a69a46a0d641a0c401'
 
   depends_on 'font_util'
   depends_on 'font_misc_misc'
-  depends_on 'bdftopcf'
   
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/fonts/Type1"


### PR DESCRIPTION
Since #4267, `ghostscript` update fails due to dependencies errors. These are not applied to the correct packages.