### PR TITLE
Add pre-built binaries for gnome_keyring and dependencies

### DIFF
--- a/packages/gcr.rb
+++ b/packages/gcr.rb
@@ -4,9 +4,20 @@ class Gcr < Package
   description 'GNOME crypto package'
   homepage 'https://www.gnome.org'
   version '3.36.0'
-  compatibility 'all'
+  compatibility 'aarch64,armv7l,x86_64'
   source_url 'https://ftp.gnome.org/pub/GNOME/sources/gcr/3.36/gcr-3.36.0.tar.xz'
   source_sha256 'aaf9bed017a2263c6145c89a1a84178f9f40f238426463e4ae486694ef5f6601'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.36.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.36.0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.36.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e0830fd1ebb83ec32587d1c299565262c0af0b1d8ea893f3d92572b3b44d85df',
+     armv7l: 'e0830fd1ebb83ec32587d1c299565262c0af0b1d8ea893f3d92572b3b44d85df',
+     x86_64: '9417383cdb622492605252348a7b966041fbfea37d52d8467f9c8328e6d2050c',
+  })
 
   depends_on 'pygtk'
   depends_on 'libgcrypt'
@@ -17,12 +28,13 @@ class Gcr < Package
   depends_on 'glib'
   depends_on 'gnupg'
   depends_on 'libxslt'
+  depends_on 'vala' => :build
 
   def self.build
     system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} _build -Dgtk_doc=false" # Due to issues with gtk_doc it has been disabled; I will revist this when gtk_doc is fixed
     system 'ninja -v -C _build'
   end
-  
+
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
   end

--- a/packages/gnome_keyring.rb
+++ b/packages/gnome_keyring.rb
@@ -4,9 +4,20 @@ class Gnome_keyring < Package
   description 'GNOME password and secret manager'
   homepage 'https://www.gnome.org'
   version '3.36.0'
-  compatibility 'all'
+  compatibility 'aarch64,armv7l,x86_64'
   source_url 'https://ftp.gnome.org/pub/GNOME/sources/gnome-keyring/3.36/gnome-keyring-3.36.0.tar.xz'
   source_sha256 'a264b57a8d1a71fdf0d66e8cd6033d013fb828be279c35766545eb9bb3734f87'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_keyring-3.36.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_keyring-3.36.0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_keyring-3.36.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'a274265a95ebb7f2519476673da11d438b8996bcdd38ac64064aa1cbda594f92',
+     armv7l: 'a274265a95ebb7f2519476673da11d438b8996bcdd38ac64064aa1cbda594f92',
+     x86_64: 'ce2df2cef40f9b97903e2695c519f9b5e3c0f25fdc3f0cb399515d3463e92d6b',
+  })
 
   depends_on 'gcr'
   depends_on 'libcap'
@@ -19,11 +30,12 @@ class Gnome_keyring < Package
   depends_on 'libxslt'
   depends_on 'openssh'
 
-  def self.builds
-      system "./configure #{CREW_OPTIONS} --with-pam-dir=#{CREW_PREFIX}/lib/security --disable-schemas-compile --disable-doc" # Docs cannot be used due to #4275
-      system "make -j#{CREW_NPROC}"
+  def self.build
+    system "./configure #{CREW_OPTIONS} --with-pam-dir=#{CREW_PREFIX}/lib/security --disable-schemas-compile --disable-doc" # Docs cannot be used due to #4275
+    system 'make'
   end
+
   def self.install
-      system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/libgnome_keyring.rb
+++ b/packages/libgnome_keyring.rb
@@ -4,18 +4,31 @@ class Libgnome_keyring < Package
   description 'GNOME keyring client library'
   homepage 'https://www.gnome.org'
   version '3.12.0'
-  compatibility 'all'
+  compatibility 'aarch64,armv7l,x86_64'
   source_url 'https://ftp.gnome.org/pub/GNOME/sources/libgnome-keyring/3.12/libgnome-keyring-3.12.0.tar.xz'
   source_sha256 'c4c178fbb05f72acc484d22ddb0568f7532c409b0a13e06513ff54b91e947783'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgnome_keyring-3.12.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgnome_keyring-3.12.0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgnome_keyring-3.12.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'db8b7355277ec22342f1cebe983de9a70dc0638c0fe5f42e7c4ef24ea6b42c81',
+     armv7l: 'db8b7355277ec22342f1cebe983de9a70dc0638c0fe5f42e7c4ef24ea6b42c81',
+     x86_64: '7cd854b285d63aab304bd06aa13f63e4264e3643a7a3917fdc3e944445986f5a',
+  })
+
   depends_on 'dbus'
   depends_on 'libgcrypt'
+  depends_on 'llvm' => :build
 
   def self.build
-      system "./configure #{CREW_OPTIONS} --enable-introspection=no --enable-vala=no"
-      system "make -j#{CREW_NPROC}"
+    system "./configure #{CREW_OPTIONS} --enable-introspection=no --enable-vala=no"
+    system 'make'
   end
+
   def self.install
-      system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end


### PR DESCRIPTION
Fixes #4279.  Tested on:
- [x] aarch64
- [x] armv7l
- [x] x86_64