### PR TITLE
Edit: docbook_xsl - Revert to 1.79.1 - See #4275

### DIFF
--- a/packages/docbook_xsl.rb
+++ b/packages/docbook_xsl.rb
@@ -1,39 +1,28 @@
 require 'package'
 
-# from LFS: http://www.linuxfromscratch.org/blfs/view/cvs/pst/docbook-xsl.html
+# Note: due to issues with catalog.xml caused by 1.79.2 not existing on the sourceforge server we have reverted to 1.79.1
+# from Void Linux https://git.io/JUZ02
 
 class Docbook_xsl < Package
   description 'The DocBook XSL Stylesheets package contains XSL stylesheets. These are useful for performing transformations on XML DocBook files.'
   compatibility 'all'
   homepage 'https://github.com/docbook/xslt10-stylesheets'
-  version '1.79.2'
-  source_url 'https://github.com/docbook/xslt10-stylesheets/releases/download/release/1.79.2/docbook-xsl-1.79.2.tar.bz2'
-  source_sha256 '316524ea444e53208a2fb90eeb676af755da96e1417835ba5f5eb719c81fa371'
+  version '1.79.1-1'
+  source_url 'https://downloads.sourceforge.net/sourceforge/docbook/docbook-xsl-1.79.1.tar.bz2'
+  source_sha256 '725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '261d6d7afe8e41a399381b5052b7bc3760627d1c66cae9375fc46abc7918c172',
-     armv7l: '261d6d7afe8e41a399381b5052b7bc3760627d1c66cae9375fc46abc7918c172',
-       i686: 'b6a64fd1351743c240d9e3531b270af4a94538aa6282e5bedc616b2f3d3d8455',
-     x86_64: '614d4499046ae97483544777e0ac75d915c51ac734b28361843d82493e2b45ee',
-  })
 
   depends_on 'docbook_xml'
 
   def self.patch
-    system 'wget http://www.linuxfromscratch.org/patches/blfs/svn/docbook-xsl-1.79.2-stack_fix-1.patch'
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('docbook-xsl-1.79.2-stack_fix-1.patch') ) == 'a92c39715c54949ba9369add1809527b8f155b7e2a2b2e30cb4b39ee715f2e30'
-    system 'patch -Np1 -i docbook-xsl-1.79.2-stack_fix-1.patch'
+    system 'wget -O "non-recursive_string_subst.patch" "https://git.io/JUZ02"'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('non-recursive_string_subst.patch') ) == '1efc7c0a67d3c655f9e6df78aa6cec2583b4c94792bf5112925cd9b2086914fd'
+    system 'patch -Np1 -i non-recursive_string_subst.patch ./lib/lib.xsl'
   end
 
   def self.install
 
-    xsl_version = '1.79.2'
+    xsl_version = '1.79.1'
     xsl_stylesheets = "xsl-stylesheets-#{xsl_version}"
     docbook_xsl = "docbook-xsl-#{xsl_version}"
 
@@ -41,23 +30,20 @@ class Docbook_xsl < Package
             cp -v -R . #{CREW_DEST_PREFIX}/share/xml/#{xsl_stylesheets}/"
     system "install -v -m644 -D README #{CREW_DEST_PREFIX}/share/doc/#{docbook_xsl}/README.txt &&
             install -v -m644 RELEASE-NOTES* NEWS* #{CREW_DEST_PREFIX}/share/doc/#{docbook_xsl}"
-    system "xmlcatalog --noout --add 'rewriteSystem' \
-                       'http://docbook.sourceforge.net/release/xsl/#{xsl_version}' \
-                       '#{CREW_PREFIX}/share/xml/docbook/#{xsl_stylesheets}' \
-                #{CREW_PREFIX}/etc/xml/catalog &&
-            xmlcatalog --noout --add 'rewriteURI' \
-                       'http://docbook.sourceforge.net/release/xsl/#{xsl_version}' \
-                       '#{CREW_PREFIX}/share/xml/docbook/#{xsl_stylesheets}' \
-                #{CREW_PREFIX}/etc/xml/catalog &&
-            xmlcatalog --noout --add 'rewriteSystem' \
-                       'http://docbook.sourceforge.net/release/xsl/current' \
-                       '#{CREW_PREFIX}/share/xml/docbook/#{xsl_stylesheets}' \
-                #{CREW_PREFIX}/etc/xml/catalog &&
-            xmlcatalog --noout --add 'rewriteURI' \
-                       'http://docbook.sourceforge.net/release/xsl/current' \
-                       '#{CREW_PREFIX}/share/xml/docbook/#{xsl_stylesheets}' \
-                #{CREW_PREFIX}/etc/xml/catalog"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/xml"
-    system "mv #{CREW_PREFIX}/etc/xml/catalog #{CREW_DEST_PREFIX}/etc/xml/"
+    system 'cat << \'EOF\' > ./catalog.xml
+<?xml version="1.0" encoding="utf-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <!-- XML Catalog file for DocBook XSL Stylesheets vsnapshot_9899 -->
+  <rewriteURI uriStartString="http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
+  <rewriteSystem systemIdStartString="http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
+  <rewriteURI uriStartString="http://docbook.sourceforge.net/release/xsl/snapshot_9899/" rewritePrefix="./"/>
+  <rewriteSystem systemIdStartString="http://docbook.sourceforge.net/release/xsl/snapshot_9899/" rewritePrefix="./"/>
+  <delegatePublic publicIdStartString="-//OASIS//ENTITIES DocBook XML" catalog="file:///usr/local/etc/xml/docbook"/>
+  <delegatePublic publicIdStartString="-//OASIS//DTD DocBook XML" catalog="file:///usr/local/etc/xml/docbook"/>
+  <delegateSystem systemIdStartString="http://www.oasis-open.org/docbook/" catalog="file:///usr/local/etc/xml/docbook"/>
+  <delegateURI uriStartString="http://www.oasis-open.org/docbook/" catalog="file:///usr/local/etc/xml/docbook"/>
+</catalog>
+EOF'
+    system "install -v -Dm644 catalog.xml \"#{CREW_DEST_PREFIX}/etc/xml/catalog.xml\""
   end
 end


### PR DESCRIPTION
Fixes #4275 
***
> After checking "https://github.com/docbook/xslt10-stylesheets/releases/tag/release%2F1.79.2" I found 1.79.2 was a minor release to reflect the move from sourceforge to github, and no other changes were made...

~
> "http://www.linuxfromscratch.org/patches/blfs/svn/docbook-xsl-1.79.2-stack_fix-1.patch" is no-longer available

~
> `xsl_version = '1.79.2'` Cannot be used as "`http://docbook.sourceforge.net/release/xsl/1.79.2`" does not exist
***
Additionally, the `xmlcatalog` command that was being used fails during the compilation, thus I have replaced it with a heredoc command.