### PR TITLE
Update: gtk_doc

### DIFF
--- a/packages/docbook_xml43.rb
+++ b/packages/docbook_xml43.rb
@@ -1,0 +1,29 @@
+require 'package'
+
+class Docbook_xml43 < Package
+  description 'document type definitions for verification of XML data files against the DocBook rule set'
+  compatibility 'all'
+  homepage 'http://www.docbook.org'
+  version '4.3'
+  source_url 'http://www.oasis-open.org/docbook/xml/4.3/docbook-xml-4.3.zip'
+  source_sha256 '23068a94ea6fd484b004c5a73ec36a66aa47ea8f0d6b62cc1695931f5c143464'
+
+  depends_on 'docbook'
+  depends_on 'xmlcatmgr'
+  depends_on 'docbook_xml'
+  depends_on 'docbook_xsl'
+  
+  def self.prebuild
+    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
+    system "cat << EOF > ./remove_add.sh
+xmlcatmgr -c #{CREW_PREFIX}/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.3//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.3//EN' '#{CREW_PREFIX}/share/xml/docbook/4.3/catalog.xml'
+EOF"
+    system "bash ./remove_add.sh"
+  end
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/4.3/"
+    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/4.3/"
+  end
+end
+

--- a/packages/gtk_doc.rb
+++ b/packages/gtk_doc.rb
@@ -1,38 +1,51 @@
 require 'package'
 
+# There are alot of patches to grab here ~ They've all come from Void-Packages (xbps-src)
+
 class Gtk_doc < Package
-  description 'GTK-Doc is a project which was started to generate API documentation from comments added to C code.'
-  homepage 'https://www.gtk.org/gtk-doc'
-  version '1.29'
+  description 'Documentation tool for public library API'
+  homepage 'https://www.gtk.org/gtk-doc/'
+  version '1.32'
   compatibility 'all'
-  source_url 'https://github.com/GNOME/gtk-doc/archive/GTK_DOC_1_29.tar.gz'
-  source_sha256 'fdf5051e1f164fc1454a4530d217ee2c09dcc2c8e42b93cd5d68645493319ce5'
+  source_url 'https://ftp.gnome.org/pub/GNOME/sources/gtk-doc/1.32/gtk-doc-1.32.tar.xz'
+  source_sha256 'de0ef034fb17cb21ab0c635ec730d19746bce52984a6706e7bbec6fb5e0b907c'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk_doc-1.29-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk_doc-1.29-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk_doc-1.29-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk_doc-1.29-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '8641b7d74ba0de51e40347751c5022164f490703fcab9902d85843a3c6a8df41',
-     armv7l: '8641b7d74ba0de51e40347751c5022164f490703fcab9902d85843a3c6a8df41',
-       i686: '6c14eadd88bb454b2bdd1212935095d6fe478e932bc6bab301d519e767217c2f',
-     x86_64: '53adc04a62779005099e257fc2ba6df76c0b8a9dce8cc31bd6eac6f4181b69c4',
-  })
-
-  depends_on 'six'
+  depends_on 'docbook_xml'
+  depends_on 'docbook_xsl'
+  depends_on 'itstool'
   depends_on 'libxslt'
+  depends_on 'docbook_xml43'
 
-  def self.build
-    system './autogen.sh',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--with-xml-catalog=#{CREW_PREFIX}/etc/xml/catalog"
-    system 'make'
+  def self.patch
+    puts
+    puts 'Grabbing patches'.lightblue
+    system 'curl --ssl -L -o "output-reproducible.patch" "https://git.io/JUlWD" --progress-bar'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('output-reproducible.patch') ) == '701fe4124a94b124e943e9220f4ea42de7fe191379f41c349cc2f69ece37af24'
+    system 'curl --ssl -L -o "tree-structure-without-using-anytree.patch" "https://git.io/JUlOD" --progress-bar'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('tree-structure-without-using-anytree.patch') ) == '8423045330d66f119d1a1caab6d08b1121230d3103de405840be1743af71c8b3'
+    system 'curl --ssl -L -o "support-deprecated-struct-members.patch" "https://git.io/JUl3O" --progress-bar'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('support-deprecated-struct-members.patch') ) == '3f9c3c68640c76c10d9262e0678828374d8dbbb9cd9d30b64f2aed7a78277d1f'
+    system 'curl --ssl -L -o "typedef-can-be-followed-by-decorator.patch" "https://git.io/JUl3C" --progress-bar'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('typedef-can-be-followed-by-decorator.patch') ) == '16c4d633ddf0e72a7146cf6427b15c9a3780d5b6e36185baaead2e529741da2c'
+    system 'curl --ssl -L -o "IGNORE_DEPRECATIONS-lines.patch" "https://git.io/JUl3o" --progress-bar'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('IGNORE_DEPRECATIONS-lines.patch') ) == '7b4703006fa03a58faa72287e043f31893f8bbb2ea69ee15a2c5b29e5ff56534'
+    system 'curl --ssl -L -o  "revert_fix_build.patch" "https://git.io/JUl3H" --progress-bar'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('revert_fix_build.patch') ) == 'e1520094c3cc110767f840f7a710ce56cdaae4650316a5407337425dd37969c4'
+    puts
+    puts 'Applying patches'.lightblue
+    system 'patch -Np1 -i revert_fix_build.patch'
+    system 'patch -Np1 -i IGNORE_DEPRECATIONS-lines.patch'
+    system 'patch -Np1 -i typedef-can-be-followed-by-decorator.patch'
+    system 'patch -Np1 -i support-deprecated-struct-members.patch'
+    system 'patch -Np1 -i tree-structure-without-using-anytree.patch'
+    system 'patch -Np1 -i output-reproducible.patch'
+    puts
   end
-
+  def self.build
+      system "./configure #{CREW_OPTIONS} --with-xml-catalog=#{CREW_PREFIX}/etc/xml/catalog.xml"
+      system 'make'
+  end
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/xmlcatmgr.rb
+++ b/packages/xmlcatmgr.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Xmlcatmgr < Package
+  description 'XML and SGML catalog manager'
+  homepage 'https://xmlcatmgr.sourceforge.net'
+  version '2.2'
+  compatibility 'all'
+  source_url 'https://downloads.sourceforge.net/sourceforge/xmlcatmgr/xmlcatmgr-2.2.tar.gz'
+  source_sha256 'ea1142b6aef40fbd624fc3e2130cf10cf081b5fa88e5229c92b8f515779d6fdc'
+
+
+  def self.build
+      system "./configure #{CREW_OPTIONS} "
+      system 'make'
+  end
+  def self.install
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end


### PR DESCRIPTION
I hate to open a WIP PR, but I am having a *very* hard time getting things to work, so, I'd love some help!
***
What's being done:
`gtk_doc` is going from `1.29` to `1.32`
Which requires `DocBook XML DTD V4.3`
> Our version of `docbook_xml` is too new

So a new package for `docbook_xml`(`43`) version 4.3 needs to be made, I did that, but, compiling for `gtk_doc` still fails-
~
Additionally: 
`xmlcatmgr` has been added and will ease the editing of `catalog.xml`\
And there are **alot** of patches that need to be applied to `gtk_doc`, and the way I have it set up to grab and apply these patches isn't ideal.
***
For reference, here is `xpbs-src`'s template for `docbook-xml` which installs `4.5`, `4.4`, `4.3`, and `4.2`
> https://github.com/void-linux/void-packages/blob/master/srcpkgs/docbook-xml/template