### PR TITLE
[qtx11extras] missing libs

### DIFF
--- a/packages/qtx11extras.rb
+++ b/packages/qtx11extras.rb
@@ -3,7 +3,7 @@ require 'package'
 class Qtx11extras < Package
   description 'Provides classes for developing for the X11 platform.'
   homepage 'https://www.qt.io/'
-  version '5.15.1'
+  version '5.15.1-1'
   compatibility 'all'
   source_url 'http://download.qt.io/official_releases/qt/5.15/5.15.1/submodules/qtx11extras-everywhere-src-5.15.1.tar.xz'
   source_sha256 'f7cd7c475a41840209808bf8b1de1c6587c3c74e5ae3b0969760b9ed35159e59'
@@ -20,6 +20,8 @@ class Qtx11extras < Package
   end
 
   def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}"	
+    system "cp -a lib/* #{CREW_DEST_LIB_PREFIX}"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/Qt-5"
     FileUtils.cp_r 'include', "#{CREW_DEST_PREFIX}/share/Qt-5"
     FileUtils.cp_r 'mkspecs', "#{CREW_DEST_PREFIX}/share/Qt-5"


### PR DESCRIPTION
I added the previous lib copy lines. Indeed this folder disappeared with 5.15.0 which was my working version when updating qt packages. Meanwhile they updated qt versions and I just tested what I had done. @uberhacker due to your remarks, I checked the removal of lib folder in qtx11extras and plugin in qttools. plugin doesn't exist anymore, but lib re-appeared.