### PR TITLE
Add pre-built binaries for poppler, qt packages and sass

### DIFF
--- a/packages/poppler.rb
+++ b/packages/poppler.rb
@@ -4,13 +4,19 @@ class Poppler < Package
   description 'Poppler is a PDF rendering library based on the xpdf-3.0 code base.'
   homepage 'https://poppler.freedesktop.org/'
   version '20.08.0'
-  compatibility 'all'
+  compatibility 'aarch64,armv7l,x86_64'
   source_url 'https://poppler.freedesktop.org/poppler-20.08.0.tar.xz'
   source_sha256 'ae65fef04bbf63259a6352e7b620719115d4fb97f5079b0b8b00a8eb0c86eca5'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-20.08.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-20.08.0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-20.08.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'defc7c9fc0961e514c9c78c838e2acbf627b613ec3d0b1c0b16e7ffb9f55c04d',
+     armv7l: 'defc7c9fc0961e514c9c78c838e2acbf627b613ec3d0b1c0b16e7ffb9f55c04d',
+     x86_64: '69e2e8d06d22a11684aeb2a43980e75a4e9fccee29fc53961ca7a990ca218ce9',
   })
 
   depends_on 'boost'

--- a/packages/qtbase.rb
+++ b/packages/qtbase.rb
@@ -9,8 +9,16 @@ class Qtbase < Package
   source_sha256 '33960404d579675b7210de103ed06a72613bfc4305443e278e2d32a3eb1f3d8c'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtbase-5.15.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtbase-5.15.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtbase-5.15.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtbase-5.15.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '435c4acd25637c6d7f547ca12ff327f5019abe2fda9ba2e27babbe5d7da41abc',
+     armv7l: '435c4acd25637c6d7f547ca12ff327f5019abe2fda9ba2e27babbe5d7da41abc',
+       i686: 'b0c8d00a7330421b3ee08bd25d4db907119a50a70006f145b61f34fadc850169',
+     x86_64: 'bacd7fe55f8eb855ad3c09769f588c69185971269c3ec845e15f7163a2300c35',
   })
 
   depends_on 'alsa_plugins'

--- a/packages/qtdeclarative.rb
+++ b/packages/qtdeclarative.rb
@@ -4,13 +4,19 @@ class Qtdeclarative < Package
   description 'Provides QML and Quick declaratives.'
   homepage 'https://www.qt.io/'
   version '5.15.1'
-  compatibility 'all'
+  compatibility 'aarch64,armv7l,x86_64'
   source_url 'http://download.qt.io/official_releases/qt/5.15/5.15.1/submodules/qtdeclarative-everywhere-src-5.15.1.tar.xz'
   source_sha256 '7e30f0ccba61f9d71720b91d7f7523c23677f23cd96065cb71df1b0df329d768'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtdeclarative-5.15.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtdeclarative-5.15.1-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtdeclarative-5.15.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'e95739560c1a124ddc52362945327cb60a1fc0bda568ca15011848750b8554d9',
+     armv7l: 'e95739560c1a124ddc52362945327cb60a1fc0bda568ca15011848750b8554d9',
+     x86_64: '44824e25081beff3552b35a09de7ae0948d8040199e6acadcfeb765e2451a68a',
   })
 
   depends_on 'python27'

--- a/packages/qtfm.rb
+++ b/packages/qtfm.rb
@@ -4,13 +4,19 @@ class Qtfm < Package
   description 'Lightweight desktop independent Qt file manager'
   homepage 'https://qtfm.eu/'
   version '6.2.0'
-  compatibility 'all'
+  compatibility 'aarch64,armv7l,x86_64'
   source_url 'https://github.com/rodlie/qtfm/archive/6.2.0.tar.gz'
   source_sha256 '58c6af502b606e63f96e8aec96b65ca9125be18ecdd5e4680ccaf50e9c40b064'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtfm-6.2.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtfm-6.2.0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtfm-6.2.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'bb5fb4098d06a1fe0e8c6ba11335da83f23b5057d40e3f451c8db1074b1008af',
+     armv7l: 'bb5fb4098d06a1fe0e8c6ba11335da83f23b5057d40e3f451c8db1074b1008af',
+     x86_64: 'ff50100f60fed4086578db1514178b897e834bcbe81c331b50711aa8d341010b',
   })
 
   depends_on 'qtbase'

--- a/packages/qtsvg.rb
+++ b/packages/qtsvg.rb
@@ -9,8 +9,16 @@ class Qtsvg < Package
   source_sha256 '308160223c0bd7492d56fb5d7b7f705bfb130947ac065bf39280ec6d7cbe4f6a'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.15.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.15.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.15.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtsvg-5.15.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '45a4e115d43f59daa636a53050ef477da6e790cda70872cb9c1c07c4963e2337',
+     armv7l: '45a4e115d43f59daa636a53050ef477da6e790cda70872cb9c1c07c4963e2337',
+       i686: 'c2fef5e314f284a1a731b7274890056331dd812605c1614fd62024d7fd0648dc',
+     x86_64: '4b833b5a94e5b5daa251a57b5f94c46b806b8b605a8e1cd77fb4a9ae3ffacbf7',
   })
 
   depends_on 'qtbase'

--- a/packages/qttools.rb
+++ b/packages/qttools.rb
@@ -4,16 +4,25 @@ class Qttools < Package
   description 'Qt Tools'
   homepage 'https://github.com/qt/qttools'
   version '5.15.1'
-  compatibility 'all'
+  compatibility 'aarch64,armv7l,x86_64'
   source_url 'http://download.qt.io/official_releases/qt/5.15/5.15.1/submodules/qttools-everywhere-src-5.15.1.tar.xz'
   source_sha256 'c98ee5f0f980bf68cbf0c94d62434816a92441733de50bd9adbe9b9055f03498'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.1-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'b800130b6db80652fc3c9bde2008b8fa64b1e5bab5dfe717c10b8fb04d686b94',
+     armv7l: 'b800130b6db80652fc3c9bde2008b8fa64b1e5bab5dfe717c10b8fb04d686b94',
+     x86_64: 'ca2818363c965077ae2eaf6430369f5a37f5288dd229bbf352072c2a8adffa03',
   })
 
   depends_on 'qtbase'
+  depends_on 'libtinfo'
+  depends_on 'llvm'
+  depends_on 'zstd'
   depends_on 'sommelier'
 
   def self.build

--- a/packages/qtx11extras.rb
+++ b/packages/qtx11extras.rb
@@ -9,8 +9,16 @@ class Qtx11extras < Package
   source_sha256 'f7cd7c475a41840209808bf8b1de1c6587c3c74e5ae3b0969760b9ed35159e59'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.15.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.15.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.15.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qtx11extras-5.15.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'ea7ce2aabb51547b5bc0856c5e1ed456dc088cff9fbdf1963b4fcdb7f7b626bd',
+     armv7l: 'ea7ce2aabb51547b5bc0856c5e1ed456dc088cff9fbdf1963b4fcdb7f7b626bd',
+       i686: '44b9aa475e5e07e1ae93109ba7611fb881787e45a894a468d704a784dba39f36',
+     x86_64: '08bd84632909341214c35adaa3857f44c111d7c182c33aee3654c34f43dad055',
   })
 
   depends_on 'qtbase'

--- a/packages/sass.rb
+++ b/packages/sass.rb
@@ -4,13 +4,19 @@ class Sass < Package
   description 'A Dart implementation of Sass. Sass makes CSS fun again.'
   homepage 'https://sass-lang.com/'
   version '1.26.10'
-  compatibility 'all'
+  compatibility 'aarch64,armv7l,x86_64'
   source_url 'https://github.com/sass/dart-sass/archive/1.26.10.tar.gz'
   source_sha256 '9131be72e3eb6d32265e354d6da9f9162d9b28ed5b4910f03744c31509be894f'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sass-1.26.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sass-1.26.10-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sass-1.26.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '8383f0b0ceb0cd6193bd029bba483bc427fa150ecf2753180a5d75b2f16f4c72',
+     armv7l: '8383f0b0ceb0cd6193bd029bba483bc427fa150ecf2753180a5d75b2f16f4c72',
+     x86_64: 'c7bfe1b6caf87fd1f78d7ce0cc9e4ec68633d80f150470e751885df2fe0a0781',
   })
 
   depends_on 'dart'


### PR DESCRIPTION
Tested on all architectures.  Fixes #4309.