### PR TITLE
Add all versions of docbook_xml

### DIFF
--- a/packages/docbook_xml.rb
+++ b/packages/docbook_xml.rb
@@ -1,103 +1,18 @@
 require 'package'
 
-# from LFS: http://www.linuxfromscratch.org/blfs/view/cvs/pst/docbook.html
-
 class Docbook_xml < Package
-  description 'document type definitions for verification of XML data files against the DocBook rule set'
+  description 'Meta package for all versions of docbook_xml'
   compatibility 'all'
   homepage 'http://www.docbook.org'
-  version '5.1'
-  source_url 'https://docbook.org/xml/5.1/docbook-v5.1-os.zip'
-  source_sha256 'b3f3413654003c1e773360d7fc60ebb8abd0e8c9af8e7d6c4b55f124f34d1e7f'
+  version '5.1-1'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
-     armv7l: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
-       i686: '118a652d4b192525f2400ec121747b1824292b874941b04da037b4a031107148',
-     x86_64: '19aefa5a44bdd6a0ff77072f2fe45e1b032a06d9a72faeb51ac3cae2d49e992c',
-  })
+  depends_on 'docbook_xml51'
+  depends_on 'docbook_xml50'
+  depends_on 'docbook_xml45'
+  depends_on 'docbook_xml44'
+  depends_on 'docbook_xml43'
+  depends_on 'docbook_xml42'
+  
+  is_fake
 
-  depends_on 'docbook'
-  depends_on 'sgml_common'
-
-  def self.install
-
-    xml_version = '5.1'
-    xml_dtd = "xml-dtd-#{xml_version}"
-
-    system "install -v -d -m755 #{CREW_DEST_PREFIX}/share/xml/docbook/#{xml_dtd}"
-    system "install -v -d -m755 #{CREW_DEST_PREFIX}/etc/xml"
-    system "cp -rpa . #{CREW_DEST_PREFIX}/share/xml/docbook/#{xml_dtd}/"
-    system "rm -f #{CREW_PREFIX}/etc/xml/docbook && \
-                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/docbook && \
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//DTD DocBook XML V#{xml_version}//EN' \
-                'http://www.oasis-open.org/docbook/xml/#{xml_version}/docbookx.dtd' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//DTD DocBook XML CALS Table Model V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/calstblx.dtd' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//DTD XML Exchange Table Model 19990315//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/soextblx.dtd' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ELEMENTS DocBook XML Information Pool V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbpoolx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ELEMENTS DocBook XML Document Hierarchy V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbhierx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ELEMENTS DocBook XML HTML Tables V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/htmltblx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ENTITIES DocBook XML Notations V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbnotnx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ENTITIES DocBook XML Character Entities V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbcentx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ENTITIES DocBook XML Additional General Entities V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbgenent.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'rewriteSystem' \
-                'http://www.oasis-open.org/docbook/xml/#{xml_version}' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
-            xmlcatalog --noout --add 'rewriteURI' \
-                'http://www.oasis-open.org/docbook/xml/#{xml_version}' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook"
-    
-    system "rm -f #{CREW_PREFIX}/etc/xml/catalog && \
-                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/catalog && \
-            xmlcatalog --noout --add 'delegatePublic' \
-                '-//OASIS//ENTITIES DocBook XML' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog &&
-            xmlcatalog --noout --add 'delegatePublic' \
-                '-//OASIS//DTD DocBook XML' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog &&
-            xmlcatalog --noout --add 'delegateSystem' \
-                'http://www.oasis-open.org/docbook/' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog &&
-            xmlcatalog --noout --add 'delegateURI' \
-                'http://www.oasis-open.org/docbook/' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog"
-  end
 end

--- a/packages/docbook_xml42.rb
+++ b/packages/docbook_xml42.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Docbook_xml42 < Package
+  description 'Version 4.2 - document type definitions for verification of XML data files against the DocBook rule set'
+  compatibility 'all'
+  homepage 'http://www.docbook.org'
+  version '4.2'
+  source_url 'http://www.oasis-open.org/docbook/xml/4.2/docbook-xml-4.2.zip'
+  source_sha256 'acc4601e4f97a196076b7e64b368d9248b07c7abf26b34a02cca40eeebe60fa2'
+
+  depends_on 'docbook_xml51'
+  depends_on 'docbook_xsl' # Requires the catalog.xml created within this package
+  
+  def self.prebuild
+    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
+    system "cat << EOF > ./remove_add.sh
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.2//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.1.2//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.2//EN' '#{CREW_PREFIX}/share/xml/docbook/4.2/catalog.xml'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.1.2//EN' '#{CREW_PREFIX}/share/xml/docbook/4.2/catalog.xml'
+
+EOF"
+    system "bash ./remove_add.sh"
+  end
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+  end
+end
+

--- a/packages/docbook_xml44.rb
+++ b/packages/docbook_xml44.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Docbook_xml44 < Package
+  description 'Version 4.4 - document type definitions for verification of XML data files against the DocBook rule set'
+  compatibility 'all'
+  homepage 'http://www.docbook.org'
+  version '4.4'
+  source_url 'http://www.oasis-open.org/docbook/xml/4.4/docbook-xml-4.4.zip'
+  source_sha256 '02f159eb88c4254d95e831c51c144b1863b216d909b5ff45743a1ce6f5273090'
+
+  depends_on 'docbook_xml51'
+  depends_on 'docbook_xsl'
+  
+  def self.prebuild
+    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
+    system "cat << EOF > ./remove_add.sh
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.4//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.4//EN' '#{CREW_PREFIX}/share/xml/docbook/4.4/catalog.xml'
+EOF"
+    system "bash ./remove_add.sh"
+  end
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+  end
+end

--- a/packages/docbook_xml45.rb
+++ b/packages/docbook_xml45.rb
@@ -1,0 +1,27 @@
+require 'package'
+
+class Docbook_xml45 < Package
+  description 'Version 4.5 -document type definitions for verification of XML data files against the DocBook rule set'
+  compatibility 'all'
+  homepage 'http://www.docbook.org'
+  version '4.5'
+  source_url 'http://www.oasis-open.org/docbook/xml/4.5/docbook-xml-4.5.zip'
+  source_sha256 '4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4'
+
+  depends_on 'docbook_xml51'
+  depends_on 'docbook_xsl'
+  
+  def self.prebuild
+    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
+    system "cat << EOF > ./remove_add.sh
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.5//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.5//EN' '#{CREW_PREFIX}/share/xml/docbook/4.5/catalog.xml'
+EOF"
+    system "bash ./remove_add.sh"
+  end
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+  end
+end
+

--- a/packages/docbook_xml50.rb
+++ b/packages/docbook_xml50.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Docbook_xml50 < Package
+  description 'Version 50 - document type definitions for verification of XML data files against the DocBook rule set'
+  compatibility 'all'
+  homepage 'http://www.docbook.org'
+  version '5.0'
+  source_url 'https://docbook.org/xml/5.0/docbook-5.0.zip'
+  source_sha256 '3dcd65e1f5d9c0c891b3be204fa2bb418ce485d32310e1ca052e81d36623208e'
+
+  depends_on 'docbook_xml51'
+  depends_on 'docbook_xsl'
+  
+  def self.prebuild
+    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
+    system "cat << EOF > ./remove_add.sh
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V5.0//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V5.0//EN' '#{CREW_PREFIX}/share/xml/docbook/5.0/catalog.xml'
+EOF"
+    system "bash ./remove_add.sh"
+  end
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+  end
+end

--- a/packages/docbook_xml51.rb
+++ b/packages/docbook_xml51.rb
@@ -1,0 +1,104 @@
+require 'package'
+
+# from LFS: http://www.linuxfromscratch.org/blfs/view/cvs/pst/docbook.html
+
+class Docbook_xml51 < Package
+  description 'Version 5.1 - document type definitions for verification of XML data files against the DocBook rule set'
+  compatibility 'all'
+  homepage 'http://www.docbook.org'
+  version '5.1'
+  source_url 'https://docbook.org/xml/5.1/docbook-v5.1-os.zip'
+  source_sha256 'b3f3413654003c1e773360d7fc60ebb8abd0e8c9af8e7d6c4b55f124f34d1e7f'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
+     armv7l: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
+       i686: '118a652d4b192525f2400ec121747b1824292b874941b04da037b4a031107148',
+     x86_64: '19aefa5a44bdd6a0ff77072f2fe45e1b032a06d9a72faeb51ac3cae2d49e992c',
+  })
+
+  depends_on 'docbook'
+  depends_on 'sgml_common'
+
+  def self.install
+
+    xml_version = '5.1'
+    xml_dtd = "xml-dtd-#{xml_version}"
+
+    system "install -v -d -m755 #{CREW_DEST_PREFIX}/share/xml/docbook/#{xml_dtd}"
+    system "install -v -d -m755 #{CREW_DEST_PREFIX}/etc/xml"
+    system "cp -rpa . #{CREW_DEST_PREFIX}/share/xml/docbook/#{xml_dtd}/"
+    system "rm -f #{CREW_PREFIX}/etc/xml/docbook && \
+                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/docbook && \
+            xmlcatalog --noout --add 'public' \
+                '-//OASIS//DTD DocBook XML V#{xml_version}//EN' \
+                'http://www.oasis-open.org/docbook/xml/#{xml_version}/docbookx.dtd' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'public' \
+                '-//OASIS//DTD DocBook XML CALS Table Model V#{xml_version}//EN' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/calstblx.dtd' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'public' \
+                '-//OASIS//DTD XML Exchange Table Model 19990315//EN' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/soextblx.dtd' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'public' \
+                '-//OASIS//ELEMENTS DocBook XML Information Pool V#{xml_version}//EN' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbpoolx.mod' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'public' \
+                '-//OASIS//ELEMENTS DocBook XML Document Hierarchy V#{xml_version}//EN' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbhierx.mod' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'public' \
+                '-//OASIS//ELEMENTS DocBook XML HTML Tables V#{xml_version}//EN' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/htmltblx.mod' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'public' \
+                '-//OASIS//ENTITIES DocBook XML Notations V#{xml_version}//EN' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbnotnx.mod' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'public' \
+                '-//OASIS//ENTITIES DocBook XML Character Entities V#{xml_version}//EN' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbcentx.mod' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'public' \
+                '-//OASIS//ENTITIES DocBook XML Additional General Entities V#{xml_version}//EN' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbgenent.mod' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'rewriteSystem' \
+                'http://www.oasis-open.org/docbook/xml/#{xml_version}' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+            xmlcatalog --noout --add 'rewriteURI' \
+                'http://www.oasis-open.org/docbook/xml/#{xml_version}' \
+                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}' \
+                #{CREW_DEST_PREFIX}/etc/xml/docbook"
+    
+    system "rm -f #{CREW_PREFIX}/etc/xml/catalog && \
+                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/catalog && \
+            xmlcatalog --noout --add 'delegatePublic' \
+                '-//OASIS//ENTITIES DocBook XML' \
+                'file://#{CREW_PREFIX}/etc/xml/docbook' \
+                #{CREW_DEST_PREFIX}/etc/xml/catalog &&
+            xmlcatalog --noout --add 'delegatePublic' \
+                '-//OASIS//DTD DocBook XML' \
+                'file://#{CREW_PREFIX}/etc/xml/docbook' \
+                #{CREW_DEST_PREFIX}/etc/xml/catalog &&
+            xmlcatalog --noout --add 'delegateSystem' \
+                'http://www.oasis-open.org/docbook/' \
+                'file://#{CREW_PREFIX}/etc/xml/docbook' \
+                #{CREW_DEST_PREFIX}/etc/xml/catalog &&
+            xmlcatalog --noout --add 'delegateURI' \
+                'http://www.oasis-open.org/docbook/' \
+                'file://#{CREW_PREFIX}/etc/xml/docbook' \
+                #{CREW_DEST_PREFIX}/etc/xml/catalog"
+    system "install -v -Dm755 #{CREW_DEST_PREFIX}/etc/xml/catalog #{CREW_DEST_PREFIX}/etc/xml/catalog.xml"
+  end
+end

--- a/packages/docbook_xsl.rb
+++ b/packages/docbook_xsl.rb
@@ -7,25 +7,12 @@ class Docbook_xsl < Package
   description 'The DocBook XSL Stylesheets package contains XSL stylesheets. These are useful for performing transformations on XML DocBook files.'
   compatibility 'all'
   homepage 'https://github.com/docbook/xslt10-stylesheets'
-  version '1.79.1-1'
+  version '1.79.1-2'
   source_url 'https://downloads.sourceforge.net/sourceforge/docbook/docbook-xsl-1.79.1.tar.bz2'
   source_sha256 '725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.1-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'c13af861d61b6fa028f9226b7bf162d16806dde5defb6de159c2783f07823dd5',
-     armv7l: 'c13af861d61b6fa028f9226b7bf162d16806dde5defb6de159c2783f07823dd5',
-       i686: '185c090525ab3928fd6403fd3704bb21e2ebfbec6bdb78d802a253a25df3b570',
-     x86_64: '49941481dcefe3b2c570ee916e478c33c25f36694d5d028356defcaa3401f882',
-  })
-
-
-  depends_on 'docbook_xml'
+  depends_on 'docbook_xml51'
+  depends_on 'xmlcatmgr'
 
   def self.patch
     system 'wget -O "non-recursive_string_subst.patch" "https://git.io/JUZ02"'
@@ -43,20 +30,17 @@ class Docbook_xsl < Package
             cp -v -R . #{CREW_DEST_PREFIX}/share/xml/#{xsl_stylesheets}/"
     system "install -v -m644 -D README #{CREW_DEST_PREFIX}/share/doc/#{docbook_xsl}/README.txt &&
             install -v -m644 RELEASE-NOTES* NEWS* #{CREW_DEST_PREFIX}/share/doc/#{docbook_xsl}"
-    system 'cat << \'EOF\' > ./catalog.xml
-<?xml version="1.0" encoding="utf-8"?>
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-  <!-- XML Catalog file for DocBook XSL Stylesheets vsnapshot_9899 -->
-  <rewriteURI uriStartString="http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
-  <rewriteSystem systemIdStartString="http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
-  <rewriteURI uriStartString="http://docbook.sourceforge.net/release/xsl/snapshot_9899/" rewritePrefix="./"/>
-  <rewriteSystem systemIdStartString="http://docbook.sourceforge.net/release/xsl/snapshot_9899/" rewritePrefix="./"/>
-  <delegatePublic publicIdStartString="-//OASIS//ENTITIES DocBook XML" catalog="file:///usr/local/etc/xml/docbook"/>
-  <delegatePublic publicIdStartString="-//OASIS//DTD DocBook XML" catalog="file:///usr/local/etc/xml/docbook"/>
-  <delegateSystem systemIdStartString="http://www.oasis-open.org/docbook/" catalog="file:///usr/local/etc/xml/docbook"/>
-  <delegateURI uriStartString="http://www.oasis-open.org/docbook/" catalog="file:///usr/local/etc/xml/docbook"/>
-</catalog>
-EOF'
-    system "install -v -Dm644 catalog.xml #{CREW_DEST_PREFIX}/etc/xml/catalog.xml"
+    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
+    system "cat << EOF > ./remove_add.sh
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml remove rewriteSystem 'http://docbook.sourceforge.net/release/xsl/snapshot_9899/'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml remove rewriteURI 'http://docbook.sourceforge.net/release/xsl/current/'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml remove rewriteURI 'http://docbook.sourceforge.net/release/xsl/snapshot_9899/'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml add rewriteSystem 'http://docbook.sourceforge.net/release/xsl/snapshot_9899/' './'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml add rewriteURI 'http://docbook.sourceforge.net/release/xsl/current/' './'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml add rewriteURI 'http://docbook.sourceforge.net/release/xsl/snapshot_9899/' './'
+EOF"
+    system "bash ./remove_add.sh"
   end
 end
+
+# NOTE: 


### PR DESCRIPTION
Depends on `docbook_xml43` and `xmlcatmgr` from #4305 
Installs all versions of `docbook_xml`, `docbook_xsl` has been edited to use `xmlcatmgr` instead of a `echo` command, both `/usr/local/etc/catalog` & `/usr/local/etc/catalog.xml` are used now. 
***
> I was planning on turning `docbook_xml` into a `is_fake` package that installs 4.2, 4.2, 4.3, 4.5, 5.0, and 5.1, since that's what most distros seem to do. ~ After the PR gets merged that is, having `xmlcatmgr` makes things super easy!
> ***
> > For reference, here is xpbs-src's template for docbook-xml which installs 4.5, 4.4, 4.3, and 4.2
> > > https://github.com/void-linux/void-packages/blob/master/srcpkgs/docbook-xml/template
> ***
> It's easy to support multiple versions as the source is simply a `.zip` with files that need to be copied to `/usr/share/xml/docbook/v*/`, and an XML entry to link them.
> ***
> > ```ruby
> > def self.install
> >    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/4.3/"
> >    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/4.3/"
> >  end
> > ```
***
Instances of `/usr/local` are required as they are being redirected into a bash script please see #4315 for more info