### PR TITLE
Fix docbook_x*l*

### DIFF
--- a/packages/docbook_xml42.rb
+++ b/packages/docbook_xml42.rb
@@ -12,8 +12,8 @@ class Docbook_xml42 < Package
   depends_on 'docbook_xsl' # Requires the catalog.xml created within this package
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.2//EN'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.1.2//EN'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.2//EN' '#{CREW_PREFIX}/share/xml/docbook/4.2/catalog.xml'

--- a/packages/docbook_xml43.rb
+++ b/packages/docbook_xml43.rb
@@ -14,8 +14,8 @@ class Docbook_xml43 < Package
   depends_on 'docbook_xsl'
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
 xmlcatmgr -c #{CREW_PREFIX}/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.3//EN'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.3//EN' '#{CREW_PREFIX}/share/xml/docbook/4.3/catalog.xml'
 EOF"

--- a/packages/docbook_xml44.rb
+++ b/packages/docbook_xml44.rb
@@ -12,8 +12,8 @@ class Docbook_xml44 < Package
   depends_on 'docbook_xsl'
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.4//EN'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.4//EN' '#{CREW_PREFIX}/share/xml/docbook/4.4/catalog.xml'
 EOF"

--- a/packages/docbook_xml45.rb
+++ b/packages/docbook_xml45.rb
@@ -12,8 +12,8 @@ class Docbook_xml45 < Package
   depends_on 'docbook_xsl'
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.5//EN'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.5//EN' '#{CREW_PREFIX}/share/xml/docbook/4.5/catalog.xml'
 EOF"

--- a/packages/docbook_xml50.rb
+++ b/packages/docbook_xml50.rb
@@ -12,8 +12,8 @@ class Docbook_xml50 < Package
   depends_on 'docbook_xsl'
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V5.0//EN'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V5.0//EN' '#{CREW_PREFIX}/share/xml/docbook/5.0/catalog.xml'
 EOF"

--- a/packages/docbook_xml51.rb
+++ b/packages/docbook_xml51.rb
@@ -9,20 +9,7 @@ class Docbook_xml51 < Package
   version '5.1'
   source_url 'https://docbook.org/xml/5.1/docbook-v5.1-os.zip'
   source_sha256 'b3f3413654003c1e773360d7fc60ebb8abd0e8c9af8e7d6c4b55f124f34d1e7f'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
-     armv7l: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
-       i686: '118a652d4b192525f2400ec121747b1824292b874941b04da037b4a031107148',
-     x86_64: '19aefa5a44bdd6a0ff77072f2fe45e1b032a06d9a72faeb51ac3cae2d49e992c',
-  })
-
+  
   depends_on 'docbook'
   depends_on 'sgml_common'
 

--- a/packages/docbook_xml51.rb
+++ b/packages/docbook_xml51.rb
@@ -87,5 +87,6 @@ class Docbook_xml51 < Package
                 'file://#{CREW_PREFIX}/etc/xml/docbook' \
                 #{CREW_DEST_PREFIX}/etc/xml/catalog"
     system "install -v -Dm755 #{CREW_DEST_PREFIX}/etc/xml/catalog #{CREW_DEST_PREFIX}/etc/xml/catalog.xml"
+    system "install -v -Dm755 #{CREW_DEST_PREFIX}/etc/xml/catalog.xml #{CREW_DEST_PREFIX}/etc/xml/catalog"
   end
 end

--- a/packages/docbook_xsl.rb
+++ b/packages/docbook_xsl.rb
@@ -30,8 +30,8 @@ class Docbook_xsl < Package
             cp -v -R . #{CREW_DEST_PREFIX}/share/xml/#{xsl_stylesheets}/"
     system "install -v -m644 -D README #{CREW_DEST_PREFIX}/share/doc/#{docbook_xsl}/README.txt &&
             install -v -m644 RELEASE-NOTES* NEWS* #{CREW_DEST_PREFIX}/share/doc/#{docbook_xsl}"
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml remove rewriteSystem 'http://docbook.sourceforge.net/release/xsl/snapshot_9899/'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml remove rewriteURI 'http://docbook.sourceforge.net/release/xsl/current/'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml remove rewriteURI 'http://docbook.sourceforge.net/release/xsl/snapshot_9899/'


### PR DESCRIPTION
A issue has been brought to my attention by a friend.
```
    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
```
Will fail on new installs. And has been moved to the bash script as it is required for existing installs.
Fixes #4319