### PR TITLE
Add pre-built binaries for docbook packages and dependencies

### DIFF
--- a/packages/docbook_xml42.rb
+++ b/packages/docbook_xml42.rb
@@ -8,23 +8,36 @@ class Docbook_xml42 < Package
   source_url 'http://www.oasis-open.org/docbook/xml/4.2/docbook-xml-4.2.zip'
   source_sha256 'acc4601e4f97a196076b7e64b368d9248b07c7abf26b34a02cca40eeebe60fa2'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '3f0deabad453e1c61893206ec60921ec1a1fbb2ea76f22bd144a9bfa932a40a1',
+     armv7l: '3f0deabad453e1c61893206ec60921ec1a1fbb2ea76f22bd144a9bfa932a40a1',
+       i686: '6166d954c4ae7d0832213fa924e2c17b2b211c8b3a95caab6f708219a114bc7b',
+     x86_64: '6864f9733627d85e8088c87dc098a74ad3d1d6503c28e3b6c2ed78f3ac57dde6',
+  })
+
   depends_on 'docbook_xml51'
   depends_on 'docbook_xsl' # Requires the catalog.xml created within this package
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.2//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.1.2//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.2//EN' '#{CREW_PREFIX}/share/xml/docbook/4.2/catalog.xml'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.1.2//EN' '#{CREW_PREFIX}/share/xml/docbook/4.2/catalog.xml'
-
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.2//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.1.2//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.2//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.2/catalog.xml'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.1.2//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.2/catalog.xml'
 EOF"
-    system "bash ./remove_add.sh"
+    system 'bash ./remove_add.sh'
   end
+
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
-    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
   end
 end
 

--- a/packages/docbook_xml43.rb
+++ b/packages/docbook_xml43.rb
@@ -8,22 +8,36 @@ class Docbook_xml43 < Package
   source_url 'http://www.oasis-open.org/docbook/xml/4.3/docbook-xml-4.3.zip'
   source_sha256 '23068a94ea6fd484b004c5a73ec36a66aa47ea8f0d6b62cc1695931f5c143464'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '7c4339228b5d7840b588aa434e3bfaf22830a3479e1f8edb166384a1ec61d8c4',
+     armv7l: '7c4339228b5d7840b588aa434e3bfaf22830a3479e1f8edb166384a1ec61d8c4',
+       i686: '7dd4c1bc19666b1932f451e1ca90c7e13820149b0ff4b80c31bb850128bfdb9c',
+     x86_64: '56826d7a6b5abde5b17f1df6f32d6b97222f6e00c4f8fc0b50bfb1467489a208',
+  })
+
   depends_on 'docbook'
   depends_on 'xmlcatmgr'
   depends_on 'docbook_xml'
   depends_on 'docbook_xsl'
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
-xmlcatmgr -c #{CREW_PREFIX}/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.3//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.3//EN' '#{CREW_PREFIX}/share/xml/docbook/4.3/catalog.xml'
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.3//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.3//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.3/catalog.xml'
 EOF"
-    system "bash ./remove_add.sh"
+    system 'bash ./remove_add.sh'
   end
+
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/4.3/"
-    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/4.3/"
+    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/4.3/"
   end
 end
 

--- a/packages/docbook_xml44.rb
+++ b/packages/docbook_xml44.rb
@@ -8,19 +8,33 @@ class Docbook_xml44 < Package
   source_url 'http://www.oasis-open.org/docbook/xml/4.4/docbook-xml-4.4.zip'
   source_sha256 '02f159eb88c4254d95e831c51c144b1863b216d909b5ff45743a1ce6f5273090'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f56b6c50394ce4ba7cc71097954872461835a2f4502c133b6ca9d815821caa0c',
+     armv7l: 'f56b6c50394ce4ba7cc71097954872461835a2f4502c133b6ca9d815821caa0c',
+       i686: 'c285506ebd3e12e15c03907e6d289f5a8d60e98e76175119960c9b9c78c687b3',
+     x86_64: 'bce18b425d7180f3cf1d1f3b4a1b4aba30916ed0743bc38b126857d9e92ea45a',
+  })
+
   depends_on 'docbook_xml51'
   depends_on 'docbook_xsl'
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.4//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.4//EN' '#{CREW_PREFIX}/share/xml/docbook/4.4/catalog.xml'
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.4//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.4//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.4/catalog.xml'
 EOF"
-    system "bash ./remove_add.sh"
+    system 'bash ./remove_add.sh'
   end
+
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
-    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
   end
 end

--- a/packages/docbook_xml45.rb
+++ b/packages/docbook_xml45.rb
@@ -8,20 +8,34 @@ class Docbook_xml45 < Package
   source_url 'http://www.oasis-open.org/docbook/xml/4.5/docbook-xml-4.5.zip'
   source_sha256 '4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'b328c89d8af6d6230a1d6e336601fa85f78486e28e9e4afdc085c38b94196857',
+     armv7l: 'b328c89d8af6d6230a1d6e336601fa85f78486e28e9e4afdc085c38b94196857',
+       i686: 'a79e4186e7f8bbe0f9d09cf8f7ad2116c4f3a07f654c968b303b0f307c0bb439',
+     x86_64: 'a6330711188580cae005ed58e79b7c4eb39532f20cbd8e847d7ba4299b32533f',
+  })
+
   depends_on 'docbook_xml51'
   depends_on 'docbook_xsl'
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V4.5//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V4.5//EN' '#{CREW_PREFIX}/share/xml/docbook/4.5/catalog.xml'
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.5//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.5//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.5/catalog.xml'
 EOF"
-    system "bash ./remove_add.sh"
+    system 'bash ./remove_add.sh'
   end
+
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
-    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
   end
 end
 

--- a/packages/docbook_xml50.rb
+++ b/packages/docbook_xml50.rb
@@ -8,19 +8,33 @@ class Docbook_xml50 < Package
   source_url 'https://docbook.org/xml/5.0/docbook-5.0.zip'
   source_sha256 '3dcd65e1f5d9c0c891b3be204fa2bb418ce485d32310e1ca052e81d36623208e'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f8ffcb93e529832869efcaa84bbd38e449ec040d4a8592b2a0ec9a575ce12194',
+     armv7l: 'f8ffcb93e529832869efcaa84bbd38e449ec040d4a8592b2a0ec9a575ce12194',
+       i686: '68f0e60692f7af3303df137fe4dbad87d39146257c719e968ad8747d2c90f324',
+     x86_64: 'fcb2668caca391127e526c0a568ccc3ed0ec0f9903180ebb8483795ed12ea5e6',
+  })
+
   depends_on 'docbook_xml51'
   depends_on 'docbook_xsl'
   
   def self.prebuild
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook remove public '-//OASIS//DTD DocBook XML V5.0//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook add public '-//OASIS//DTD DocBook XML V5.0//EN' '#{CREW_PREFIX}/share/xml/docbook/5.0/catalog.xml'
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V5.0//EN'
+xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V5.0//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/5.0/catalog.xml'
 EOF"
-    system "bash ./remove_add.sh"
+    system 'bash ./remove_add.sh'
   end
+
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
-    FileUtils.cp_r Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
   end
 end

--- a/packages/docbook_xml51.rb
+++ b/packages/docbook_xml51.rb
@@ -11,16 +11,16 @@ class Docbook_xml51 < Package
   source_sha256 'b3f3413654003c1e773360d7fc60ebb8abd0e8c9af8e7d6c4b55f124f34d1e7f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml-5.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
-     armv7l: '9f3ef8937e0b9f16158d66fe97fea777065790f9999e24e4dc295f461efe9b4b',
-       i686: '118a652d4b192525f2400ec121747b1824292b874941b04da037b4a031107148',
-     x86_64: '19aefa5a44bdd6a0ff77072f2fe45e1b032a06d9a72faeb51ac3cae2d49e992c',
+    aarch64: '8bf41dbd91624c154972a4b0adf16ba0edbc77cdddf579baccd7877a8b9fddbf',
+     armv7l: '8bf41dbd91624c154972a4b0adf16ba0edbc77cdddf579baccd7877a8b9fddbf',
+       i686: '3512b6df3df4e420df0b265dd02dbfb76d6b7d4cbcdcdd18dfd54e0d03d869b3',
+     x86_64: '718587a22a3fa9e91d8b974e5e02d4f21223d7699b7f4cae91faba1f7ea25358',
   })
 
   depends_on 'docbook'
@@ -34,71 +34,70 @@ class Docbook_xml51 < Package
     system "install -v -d -m755 #{CREW_DEST_PREFIX}/share/xml/docbook/#{xml_dtd}"
     system "install -v -d -m755 #{CREW_DEST_PREFIX}/etc/xml"
     system "cp -rpa . #{CREW_DEST_PREFIX}/share/xml/docbook/#{xml_dtd}/"
-    system "rm -f #{CREW_PREFIX}/etc/xml/docbook && \
-                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/docbook && \
+    system "rm -f #{CREW_PREFIX}/etc/xml/docbook* && \
+                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/docbook.xml && \
             xmlcatalog --noout --add 'public' \
                 '-//OASIS//DTD DocBook XML V#{xml_version}//EN' \
                 'http://www.oasis-open.org/docbook/xml/#{xml_version}/docbookx.dtd' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'public' \
                 '-//OASIS//DTD DocBook XML CALS Table Model V#{xml_version}//EN' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/calstblx.dtd' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'public' \
                 '-//OASIS//DTD XML Exchange Table Model 19990315//EN' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/soextblx.dtd' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'public' \
                 '-//OASIS//ELEMENTS DocBook XML Information Pool V#{xml_version}//EN' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbpoolx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'public' \
                 '-//OASIS//ELEMENTS DocBook XML Document Hierarchy V#{xml_version}//EN' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbhierx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'public' \
                 '-//OASIS//ELEMENTS DocBook XML HTML Tables V#{xml_version}//EN' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/htmltblx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'public' \
                 '-//OASIS//ENTITIES DocBook XML Notations V#{xml_version}//EN' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbnotnx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'public' \
                 '-//OASIS//ENTITIES DocBook XML Character Entities V#{xml_version}//EN' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbcentx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'public' \
                 '-//OASIS//ENTITIES DocBook XML Additional General Entities V#{xml_version}//EN' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbgenent.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'rewriteSystem' \
                 'http://www.oasis-open.org/docbook/xml/#{xml_version}' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook &&
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
             xmlcatalog --noout --add 'rewriteURI' \
                 'http://www.oasis-open.org/docbook/xml/#{xml_version}' \
                 'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook"
+                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml"
     
-    system "rm -f #{CREW_PREFIX}/etc/xml/catalog && \
-                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/catalog && \
+    system "rm -f #{CREW_PREFIX}/etc/xml/catalog* && \
+                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/catalog.xml && \
             xmlcatalog --noout --add 'delegatePublic' \
                 '-//OASIS//ENTITIES DocBook XML' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog &&
+                'file://#{CREW_PREFIX}/etc/xml/docbook.xml' \
+                #{CREW_DEST_PREFIX}/etc/xml/catalog.xml &&
             xmlcatalog --noout --add 'delegatePublic' \
                 '-//OASIS//DTD DocBook XML' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog &&
+                'file://#{CREW_PREFIX}/etc/xml/docbook.xml' \
+                #{CREW_DEST_PREFIX}/etc/xml/catalog.xml &&
             xmlcatalog --noout --add 'delegateSystem' \
                 'http://www.oasis-open.org/docbook/' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog &&
+                'file://#{CREW_PREFIX}/etc/xml/docbook.xml' \
+                #{CREW_DEST_PREFIX}/etc/xml/catalog.xml &&
             xmlcatalog --noout --add 'delegateURI' \
                 'http://www.oasis-open.org/docbook/' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog"
-    system "install -v -Dm755 #{CREW_DEST_PREFIX}/etc/xml/catalog #{CREW_DEST_PREFIX}/etc/xml/catalog.xml"
+                'file://#{CREW_PREFIX}/etc/xml/docbook.xml' \
+                #{CREW_DEST_PREFIX}/etc/xml/catalog.xml"
   end
 end

--- a/packages/docbook_xsl.rb
+++ b/packages/docbook_xsl.rb
@@ -11,6 +11,19 @@ class Docbook_xsl < Package
   source_url 'https://downloads.sourceforge.net/sourceforge/docbook/docbook-xsl-1.79.1.tar.bz2'
   source_sha256 '725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.1-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.1-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.1-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.1-2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'd7a0dc1bcfb4a670ca50f70c34d479f887ef918317babaca146b412e2bbc4c44',
+     armv7l: 'd7a0dc1bcfb4a670ca50f70c34d479f887ef918317babaca146b412e2bbc4c44',
+       i686: '92b5c7a3b696123ec9c19b3686910176127fd4c23dcfe3f47ea305e17d393a17',
+     x86_64: 'ac55be955bd36b0d7f6481bbc2e4a58bdff336fdc536d29156963bc4f5e3b949',
+  })
+
   depends_on 'docbook_xml51'
   depends_on 'xmlcatmgr'
 
@@ -30,8 +43,8 @@ class Docbook_xsl < Package
             cp -v -R . #{CREW_DEST_PREFIX}/share/xml/#{xsl_stylesheets}/"
     system "install -v -m644 -D README #{CREW_DEST_PREFIX}/share/doc/#{docbook_xsl}/README.txt &&
             install -v -m644 RELEASE-NOTES* NEWS* #{CREW_DEST_PREFIX}/share/doc/#{docbook_xsl}"
-    system "sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml"
     system "cat << EOF > ./remove_add.sh
+sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml remove rewriteSystem 'http://docbook.sourceforge.net/release/xsl/snapshot_9899/'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml remove rewriteURI 'http://docbook.sourceforge.net/release/xsl/current/'
 xmlcatmgr -c #{CREW_PREFIX}/etc/xml/catalog.xml remove rewriteURI 'http://docbook.sourceforge.net/release/xsl/snapshot_9899/'

--- a/packages/gtk_doc.rb
+++ b/packages/gtk_doc.rb
@@ -10,11 +10,23 @@ class Gtk_doc < Package
   source_url 'https://ftp.gnome.org/pub/GNOME/sources/gtk-doc/1.32/gtk-doc-1.32.tar.xz'
   source_sha256 'de0ef034fb17cb21ab0c635ec730d19746bce52984a6706e7bbec6fb5e0b907c'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk_doc-1.32-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk_doc-1.32-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk_doc-1.32-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk_doc-1.32-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '49133e1cd655aab18ea109fde3d5496f76e5e4443f5a11e2241bfc4256d782f8',
+     armv7l: '49133e1cd655aab18ea109fde3d5496f76e5e4443f5a11e2241bfc4256d782f8',
+       i686: '4a925e816c2c222ea973525be6dab5ee90d1524f541b30166ca57b07b5e99eec',
+     x86_64: 'cabae34fc1c371a929052a3611be30164d2961eb0b203f5239c91d8cb5480a96',
+  })
+
   depends_on 'docbook_xml'
-  depends_on 'docbook_xsl'
+  depends_on 'fop'
   depends_on 'itstool'
   depends_on 'libxslt'
-  depends_on 'docbook_xml43'
 
   def self.patch
     puts
@@ -41,11 +53,13 @@ class Gtk_doc < Package
     system 'patch -Np1 -i output-reproducible.patch'
     puts
   end
+
   def self.build
-      system "./configure #{CREW_OPTIONS} --with-xml-catalog=#{CREW_PREFIX}/etc/xml/catalog.xml"
-      system 'make'
+    system "./configure #{CREW_OPTIONS} --with-xml-catalog=#{CREW_PREFIX}/etc/xml/catalog.xml"
+    system 'make'
   end
+
   def self.install
-      system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/xmlcatmgr.rb
+++ b/packages/xmlcatmgr.rb
@@ -8,12 +8,25 @@ class Xmlcatmgr < Package
   source_url 'https://downloads.sourceforge.net/sourceforge/xmlcatmgr/xmlcatmgr-2.2.tar.gz'
   source_sha256 'ea1142b6aef40fbd624fc3e2130cf10cf081b5fa88e5229c92b8f515779d6fdc'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xmlcatmgr-2.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xmlcatmgr-2.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xmlcatmgr-2.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xmlcatmgr-2.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '24f525796676d285347f300bb26b60c728d6384032e0dad2230bc0c4bbb41eea',
+     armv7l: '24f525796676d285347f300bb26b60c728d6384032e0dad2230bc0c4bbb41eea',
+       i686: '656fb01f7e1e1f7c78b4f389d7bd80404a26333d23eb257517972d167952e439',
+     x86_64: 'b7942cbf386adb0b43116c5f041ff97a3c2c7202687a0a03575e498e0b8d43b1',
+  })
 
   def self.build
-      system "./configure #{CREW_OPTIONS} "
-      system 'make'
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
   end
+
   def self.install
-      system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end


### PR DESCRIPTION
Fixes #4319.
Fixes #4320.
Tested on all architectures.