### PR TITLE
VSCodium 1.49.2 

### DIFF
--- a/packages/codium.rb
+++ b/packages/codium.rb
@@ -3,7 +3,7 @@ require 'package'
 class Codium < Package
   description 'VSCodium is Open Source Software Binaries of VSCode with a community-driven default configuration.'
   homepage 'https://vscodium.com/'
-  version '1.49.1'
+  version '1.49.2'
   compatibility 'aarch64,armv7l,x86_64'
   case ARCH
   when 'aarch64', 'armv7l'
@@ -11,8 +11,8 @@ class Codium < Package
     source_sha256 '6534d7b10b13a1effadf408899c90a23a8a499298d686a3e8e74535c186a6b65'
     @arch = 'arm'
   when 'x86_64'
-    source_url 'https://github.com/VSCodium/vscodium/releases/download/1.49.1/VSCodium-linux-x64-1.49.1.tar.gz'
-    source_sha256 'e47a97b8038424cbe1f586034be7b2fb46c65fd010ef94727d7785f7831c6183'
+    source_url 'https://github.com/VSCodium/vscodium/releases/download/1.49.2/VSCodium-linux-x64-1.49.2.tar.gz'
+    source_sha256 'ee19facd95a7be910cb62b95a7f551c6ad7e82502b37d03a05e14b4ad08d7aa7'
     @arch = 'x64'
   end
 


### PR DESCRIPTION
Interestingly enough the release page did not have an "arm" build this time around only "arm64" builds.