### PR TITLE
Add pre-built binaries for brotli and libmbedtls

### DIFF
--- a/packages/brotli.rb
+++ b/packages/brotli.rb
@@ -9,8 +9,16 @@ class Brotli < Package
   source_sha256 'a0bfaf49d8d35262ef1d1e617486b061f47c634721c345051bf8d9fb806f3bb9'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/brotli-1.0.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/brotli-1.0.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/brotli-1.0.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/brotli-1.0.8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '636a5bb46059311e280f1828aa032e2d2bad83905b124549159b73e279856688',
+     armv7l: '636a5bb46059311e280f1828aa032e2d2bad83905b124549159b73e279856688',
+       i686: 'c16396d2d9a4a000b360fd6f096e4f0053abafb7bf1f8c84766527ea7a4b074f',
+     x86_64: '921fc1be57c195176d500f82bf96a52566824e62036c329ced629a0177c7c9d1',
   })
 
   def self.build

--- a/packages/libmbedtls.rb
+++ b/packages/libmbedtls.rb
@@ -8,6 +8,19 @@ class Libmbedtls < Package
   source_url 'https://github.com/ARMmbed/mbedtls/archive/v2.16.8.tar.gz'
   source_sha256 'fe9e3b15c3375943bdfebbbb20dd6b4f1147b3b5d926248bd835d73247407430'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libmbedtls-2.16.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libmbedtls-2.16.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libmbedtls-2.16.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libmbedtls-2.16.8-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fa1207538c87a278987bd49aa789d9a064745eb17af6e0bca986cab290f7c8e4',
+     armv7l: 'fa1207538c87a278987bd49aa789d9a064745eb17af6e0bca986cab290f7c8e4',
+       i686: '82f4fe07be9599125bbce078e3ff8a5c3f2c96691270abc60cf97fed79879e45',
+     x86_64: '58e98d4edf8ff733228ff2499e7faf33bfc1d90bc6c834e8b1b78b7c369b85f1',
+  })
+
   def self.build
     Dir.mkdir 'build'
     Dir.chdir 'build' do


### PR DESCRIPTION
Tested on all architectures.