### PR TITLE
Update OpenSSH to 8.4p1, fix configure error

### DIFF
--- a/packages/openssh.rb
+++ b/packages/openssh.rb
@@ -8,18 +8,6 @@ class Openssh < Package
   source_url 'https://github.com/openssh/openssh-portable/archive/V_8_4_P1.tar.gz'
   source_sha256 'b924181983a77cb10e61530960e818ccae075e5c457ea6b9f67e4946009563db'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-8.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-8.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-8.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-8.4-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '929ce84481704dcb7ffc18d7b86b955753adc5ec8b6d3b73142d68fceb972aad',
-     armv7l: '929ce84481704dcb7ffc18d7b86b955753adc5ec8b6d3b73142d68fceb972aad',
-       i686: '752f4c864ffb5fbacd158d8f0c6fc32f457027434522efa4bdc2beaa37888e87',
-     x86_64: '22e4e13c61d74f4b49737031644ce1d5e22a131c5f3c9e32e4b769e27092d188',
-  })
 
   depends_on 'autoconf' => :build
   depends_on 'compressdoc' => :build

--- a/packages/openssh.rb
+++ b/packages/openssh.rb
@@ -6,7 +6,7 @@ class Openssh < Package
   version '8.4'
   compatibility 'all'
   source_url 'https://github.com/openssh/openssh-portable/archive/V_8_4_P1.tar.gz'
-  source_sha256 '5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24'
+  source_sha256 'b924181983a77cb10e61530960e818ccae075e5c457ea6b9f67e4946009563db'
 
   binary_url ({
     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-8.4-chromeos-armv7l.tar.xz',

--- a/packages/openssh.rb
+++ b/packages/openssh.rb
@@ -3,16 +3,16 @@ require 'package'
 class Openssh < Package
   description 'OpenSSH is the premier connectivity tool for remote login with the SSH protocol.'
   homepage 'https://www.openssh.com/'
-  version '7.6'
+  version '8.4'
   compatibility 'all'
-  source_url 'https://github.com/openssh/openssh-portable/archive/V_7_6_P1.tar.gz'
-  source_sha256 'b358ed7afa55bfed9ddc618e3c24ca6de5cd9d64b0e347b8262934038ec82a1a'
+  source_url 'https://github.com/openssh/openssh-portable/archive/V_8_4_P1.tar.gz'
+  source_sha256 '5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-7.6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-7.6-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-7.6-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-7.6-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-8.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-8.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-8.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssh-8.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
     aarch64: '929ce84481704dcb7ffc18d7b86b955753adc5ec8b6d3b73142d68fceb972aad',

--- a/packages/openssh.rb
+++ b/packages/openssh.rb
@@ -25,7 +25,7 @@ class Openssh < Package
   depends_on 'compressdoc' => :build
 
   def self.build
-    system "autoconf"
+    system "autoreconf -fiv"
     system "autoheader"
     system "./configure --prefix=#{CREW_PREFIX}"
     system "make"


### PR DESCRIPTION


## Description
configure was erroring out with this error:

```
checking if cc supports -Werror... yes
./configure: line 5480: syntax error near unexpected token `-pipe'
./configure: line 5480: `       OSSH_CHECK_CFLAG_COMPILE(-pipe)'
```

Modifying the autoconf line to ```autoreconf -fiv``` fixes the issue.

## Addtional information

Works properly:
- [x] x86_64


---
