### PR TITLE
Update LibreSSL to 3.1.4 (OpenBSD 6.7 rel branch)

### DIFF
--- a/packages/libressl.rb
+++ b/packages/libressl.rb
@@ -3,23 +3,11 @@ require 'package'
 class Libressl < Package
   description 'LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014, with goals of modernizing the codebase, improving security, and applying best practice development processes.'
   homepage 'https://www.libressl.org/'
-  version '3.0.2-2'
+  version '3.1.4-1'
   compatibility 'all'
-  source_url 'https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.0.2.tar.gz'
-  source_sha256 'df7b172bf79b957dd27ef36dcaa1fb162562c0e8999e194aa8c1a3df2f15398e'
+  source_url 'https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.1.4.tar.gz'
+  source_sha256 '414c149c9963983f805a081db5bd3aec146b5f82d529bb63875ac941b25dcbb6'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.0.2-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.0.2-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.0.2-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.0.2-2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '3fa0ddc595f4973667126e09db28fe6bb2dd78e7a6a7952967adc88fc15bcbcb',
-     armv7l: '3fa0ddc595f4973667126e09db28fe6bb2dd78e7a6a7952967adc88fc15bcbcb',
-       i686: '71187f8e35218a94809de75caecb458c356e2800b0366a2833e04071b9fc5dec',
-     x86_64: 'ac5d4d2aea9c58a107a1f0e954c7ccbb5e6347292c655ed3f378d92a950499e1',
-  })
 
   def self.build
     system "./configure #{CREW_OPTIONS} --with-openssldir=/etc/ssl"
@@ -37,9 +25,9 @@ class Libressl < Package
     FileUtils.rm_rf "#{CREW_DEST_DIR}/etc/ssl"
 
     # add symlink to libcrypto.so.1.0.0
-    FileUtils.ln_s "#{CREW_LIB_PREFIX}/libcrypto.so.45.0.5", "#{CREW_DEST_LIB_PREFIX}/libcrypto.so.1.0.0"
+    FileUtils.ln_s "#{CREW_LIB_PREFIX}/libcrypto.so.46.0.1", "#{CREW_DEST_LIB_PREFIX}/libcrypto.so.1.0.0"
 
     # add symlink to libssl.so.1.0.0
-    FileUtils.ln_s "#{CREW_LIB_PREFIX}/libssl.so.47.0.6", "#{CREW_DEST_LIB_PREFIX}/libssl.so.1.0.0"
+    FileUtils.ln_s "#{CREW_LIB_PREFIX}/libssl.so.48.0.1", "#{CREW_DEST_LIB_PREFIX}/libssl.so.1.0.0"
   end
 end


### PR DESCRIPTION
Updates LibreSSL to the OpenBSD 6.7 release branch

## Before you submit a pull request

## Description

Updating LibreSSL to keep in line with OpenBSD's current release branch.
## Addtional information

Works properly:
- [x] x86_64

---

