### PR TITLE
Update gtk3 to 3.24.23 & use clang

### DIFF
--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -22,7 +22,7 @@ class Gtk3 < Package
   depends_on 'shared_mime_info'
   depends_on 'six' => :build
   depends_on 'xdg_base'
-  depends_on 'llvm'
+  depends_on 'llvm' => :build
 
   def self.build
     # Using clang enables the lld linker, hopefully allowing ChromeOS libs like libgles to be used.

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -3,23 +3,10 @@ require 'package'
 class Gtk3 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk3/3.0/'
-  version '3.24.9'
+  version '3.24.23'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.9.tar.xz'
-  source_sha256 '577eb0270d9adf2eb2aa4b03f9c7873fadb20cf265194d0139570f738493e635'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.9-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '45f35424d4861f51e2f5a0db47326917dd79dd0bdf2985416150c972b8e73afb',
-     armv7l: '45f35424d4861f51e2f5a0db47326917dd79dd0bdf2985416150c972b8e73afb',
-       i686: 'c1aea89a1dd4e99399fb14c876694930818826b40d004b51f6fdf5017a772d0e',
-     x86_64: '733220ec0f0d4eb5d51c03b76d9c06564440a77ddc2ff3c63dca8ba2ed72380c',
-  })
+  source_url 'https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.23.tar.xz'
+  source_sha256 '5d864d248357a2251545b3387b35942de5f66e4c66013f0962eb5cb6f8dae2b1'
 
   depends_on 'gdk_pixbuf'
   depends_on 'iso_codes'
@@ -35,8 +22,11 @@ class Gtk3 < Package
   depends_on 'shared_mime_info'
   depends_on 'six' => :build
   depends_on 'xdg_base'
+  depends_on 'llvm'
 
   def self.build
+    # Using clang enables the lld linker, hopefully allowing ChromeOS libs like libgles to be used.
+    ENV['CC'] = "clang"
     system './configure',
            '--with-x',
            '--enable-cups',


### PR DESCRIPTION
I'm using clang here to compile instead of gcc since that uses old and thus one may be able to use some of the libraries which ChromeOS ships with.

For some reason I was unable to get it to use lld with gcc easily in the install.
(The end goal is to get graphics acceleration working.)

Works properly:
- [x] x86_64
