### PR TITLE
Let stopsommelier also pkill Xwayland

### DIFF
--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -60,6 +60,7 @@ class Sommelier < Package
       system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> stopsommelier"
       system "echo 'if [ ! -z \"\$SOMM\" ]; then' >> stopsommelier"
       system "echo '  killall -g sommelier' >> stopsommelier"
+      system "echo '  pkill Xwayland' >> stopsommelier"
       system "echo '  sleep 3' >> stopsommelier"
       system "echo 'fi' >> stopsommelier"
       system "echo 'SOMM=\$(pidof sommelier 2> /dev/null)' >> stopsommelier"


### PR DESCRIPTION
stopsommelier can leave Xwayland hanging. Kill it too.
startsommelier will then happily start Xwayland.

(killing Xwayland using the built-in ```pkill```.)

Works properly:
- [x] x86_64
- [ ] aarch64 (reasons why it doesn't)
