### PR TITLE
Update all perl module packages

### DIFF
--- a/packages/perl_carp_clan.rb
+++ b/packages/perl_carp_clan.rb
@@ -15,11 +15,13 @@ class Perl_carp_clan < Package
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_carp_clan-6.08-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '34f5a19b0f6d50b9c808b706aacac94c851608545f253ee812f1c34baea93b92',
-     armv7l: '34f5a19b0f6d50b9c808b706aacac94c851608545f253ee812f1c34baea93b92',
-       i686: '38300c01e5721e453e498a09037d5e6ca5e221544eeca93dbbdd5fefcbfff6dc',
-     x86_64: '777456ea1e8bde75969472f97838926b3ed40a5c02c1bad27d5416f87488e86d',
+    aarch64: 'dc90c4812e8dc89fbdc37173fc5e28bdbbf2d4b7ef4e5a1848cafa3b93c92a0e',
+     armv7l: 'dc90c4812e8dc89fbdc37173fc5e28bdbbf2d4b7ef4e5a1848cafa3b93c92a0e',
+       i686: '937964b41cd2e593626e588c850f402eeea22c0cd0c26621590026599dca70db',
+     x86_64: '64a770bb270702be5eaab0092f20d2fdf3176cd73d73710e112f568f9df449eb',
   })
+
+  depends_on 'perl'
 
   def self.build
     system 'perl', 'Makefile.PL'

--- a/packages/perl_date_calc.rb
+++ b/packages/perl_date_calc.rb
@@ -15,11 +15,13 @@ class Perl_date_calc < Package
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_date_calc-6.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '90ad46018f2e5c87be03c6af856c5dcb0b7a48374be980be47c6e1a79c5c36d8',
-     armv7l: '90ad46018f2e5c87be03c6af856c5dcb0b7a48374be980be47c6e1a79c5c36d8',
-       i686: '0d4b3245024b920cc13334882bdd005c40acc291d4c7cd9791497aed63b404df',
-     x86_64: '9ef0460ae307268e3855b9060bb424a158afc59f15ed6c88c2b6d9fdaa908e99',
+    aarch64: '3814f76c7a5a978752feaeda8e8b69b2cd6464e862749c28c9db9984a573f9c9',
+     armv7l: '3814f76c7a5a978752feaeda8e8b69b2cd6464e862749c28c9db9984a573f9c9',
+       i686: 'e32643c29b7a584b795d798b04f43fa1dce5709e0b5aa640ea0d1377115b3e29',
+     x86_64: '41473868421126d03723e7abb31183e1bd7dfa4178cbd6c6065f4cbe2712dee4',
   })
+
+  depends_on 'perl'
 
   def self.build
     system 'perl', 'Makefile.PL'

--- a/packages/perl_date_format.rb
+++ b/packages/perl_date_format.rb
@@ -15,11 +15,13 @@ class Perl_date_format < Package
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_date_format-2.33-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '74d7cd93d8ab1f1f143be489f57d4379be75524cbf0423a486986d363e64d4ac',
-     armv7l: '74d7cd93d8ab1f1f143be489f57d4379be75524cbf0423a486986d363e64d4ac',
-       i686: '4833d86c673142afde1cf51e83f852d626c7e0adca756ac4ba0cb565b05984ed',
-     x86_64: '4098fabdb8fc6d0ba4011c984a1f1d1b1e7247526e19ee57da9933625d3ccee4',
+    aarch64: 'e12636b27086aab2d0726826041b3b2765b6b5e6f83de7b65e8da61164faeff7',
+     armv7l: 'e12636b27086aab2d0726826041b3b2765b6b5e6f83de7b65e8da61164faeff7',
+       i686: 'ea76e2d8a143358d2813861b9cd89a5e80078d172310b321bd3a05f6af36094e',
+     x86_64: '3af38627d41d1e3536fa9d7c3db4e0d4a6573a579ee1eac9af10384ac19a1d95',
   })
+
+  depends_on 'perl'
 
   def self.build
     system 'perl', 'Makefile.PL'

--- a/packages/perl_date_manip.rb
+++ b/packages/perl_date_manip.rb
@@ -15,11 +15,13 @@ class Perl_date_manip < Package
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_date_manip-6.82-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '8bb3990ae8ae820b943beb44e4b180176177b3af132cfae85218b24b3cbb1629',
-     armv7l: '8bb3990ae8ae820b943beb44e4b180176177b3af132cfae85218b24b3cbb1629',
-       i686: '42ffbe1fe5a9f32d769e546ead28e079a0e4fad8adb2390c3fd0c1bf495bda3c',
-     x86_64: '8b8d2e4baef4aad3238cdd476a851a6e3c6eb33fd585dbc59788247f89d8b130',
+    aarch64: '114afa63adb7758a46d04deba5917617872662dd440ab6dc3f5e89dfb547fced',
+     armv7l: '114afa63adb7758a46d04deba5917617872662dd440ab6dc3f5e89dfb547fced',
+       i686: '1d1d2202e2cca01e13660c8b9c3f430749d5c3619916de0e04a0c2072209da29',
+     x86_64: 'ab630a996ee8119a67846d16f51a0749e38a0ab6b46f9c6495304e09a03c4c03',
   })
+
+  depends_on 'perl'
 
   def self.build
     system 'perl', 'Makefile.PL'

--- a/packages/perl_file_tail.rb
+++ b/packages/perl_file_tail.rb
@@ -15,11 +15,13 @@ class Perl_file_tail < Package
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_file_tail-1.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b229def8b897d284dbb4358272c80d66efcf5a07a5a754af6845667b57296fb3',
-     armv7l: 'b229def8b897d284dbb4358272c80d66efcf5a07a5a754af6845667b57296fb3',
-       i686: 'e3a076ec4e1fa188338a6830cb88f13dd99b7dcc1863010a79a441ee32525d65',
-     x86_64: '3ddfb4ca1947794e63e375a7b68bab4e676f565ac2b7b1ceca3bcb6c4f45d9aa',
+    aarch64: 'f01dfbccd682bd74baea061f0143963cfd7271219eedfbd4ee659e7561096923',
+     armv7l: 'f01dfbccd682bd74baea061f0143963cfd7271219eedfbd4ee659e7561096923',
+       i686: '9cb02093a16544f73b266b6f6ca112a336ad2b0453e2a1e3f20f7e1087b973aa',
+     x86_64: '16fef92f4059a8a047a8fc859f0297fbe2f7a056e7ab3f20a8d9a73c91334eda',
   })
+
+  depends_on 'perl'
 
   def self.build
     system 'perl', 'Makefile.PL'

--- a/packages/perl_gcstring_linebreak.rb
+++ b/packages/perl_gcstring_linebreak.rb
@@ -3,35 +3,37 @@ require 'package'
 class Perl_gcstring_linebreak < Package
   description 'UAX 14 Unicode Line Breaking Algorithm - Perl binding Unicode::LineBreak Unicode::GCString'
   homepage 'http://search.cpan.org/~nezumi/Unicode-LineBreak-2018.003/lib/Unicode/LineBreak.pod'
-  version '2018.003'
+  version '2019.001'
   compatibility 'all'
-  source_url 'https://github.com/hatukanezumi/Unicode-LineBreak/archive/Unicode-LineBreak-2018.003.tar.gz'
-  source_sha256 '6f8cb4de140f8b63924786df8b0c2389c342bccdee05fbb1b9af8d8b6a8a3fad'
+  source_url 'https://github.com/hatukanezumi/Unicode-LineBreak/archive/Unicode-LineBreak-2019.001.tar.gz'
+  source_sha256 'bc9f96cf8bea60665e8ad67e90b0db3cc0bcdb97101e15c8c44ea671ba256577'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_gcstring_linebreak-2018.003-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_gcstring_linebreak-2018.003-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_gcstring_linebreak-2018.003-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_gcstring_linebreak-2018.003-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_gcstring_linebreak-2019.001-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_gcstring_linebreak-2019.001-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_gcstring_linebreak-2019.001-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_gcstring_linebreak-2019.001-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '6b4d8c4737b77a5b36be8dacf5cd6671252479ff4f3dd55a9d5c95478923b321',
-     armv7l: '6b4d8c4737b77a5b36be8dacf5cd6671252479ff4f3dd55a9d5c95478923b321',
-       i686: 'ae3dfe0e317fec4d8c3a0d88fa1dc1733da800fcf23c0053886ee477b94f1057',
-     x86_64: 'bb0a1cd5fd243b0c07cd40fdbf77e9c7150807beb418a68f894f58e226f1c24a',
+    aarch64: 'f3305554fcb79da45098b3b13aa792f74ba773447d2ca7c0b1c114e1fcfd6511',
+     armv7l: 'f3305554fcb79da45098b3b13aa792f74ba773447d2ca7c0b1c114e1fcfd6511',
+       i686: 'e98342303364ca0faaa8cb272147c4b12aa172ff2d923fb2ee3f3ad160f6c7b2',
+     x86_64: '155551083e64b975e1019808f89ca3d42a8ff318367124ad5eedaff610e3f3f0',
   })
 
+  depends_on 'perl'
+
   def self.build
-      system "git", "clone", "--recurse-submodules", "https://github.com/hatukanezumi/Unicode-LineBreak", "-b", "Unicode-LineBreak-2018.003"
-    Dir.chdir ("Unicode-LineBreak") do
-      system "perl", "Makefile.PL"
-      system "make"
+    system 'git', 'clone', '--recurse-submodules', 'https://github.com/hatukanezumi/Unicode-LineBreak', '-b', "Unicode-LineBreak-#{version}"
+    Dir.chdir 'Unicode-LineBreak' do
+      system 'perl', 'Makefile.PL'
+      system 'make'
     end
   end
 
   def self.install
-    Dir.chdir ("Unicode-LineBreak") do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    Dir.chdir 'Unicode-LineBreak' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
   end
 end

--- a/packages/perl_io_socket_ssl.rb
+++ b/packages/perl_io_socket_ssl.rb
@@ -3,22 +3,22 @@ require 'package'
 class Perl_io_socket_ssl < Package
   description 'IO::Socket::SSL - SSL sockets with IO::Socket interface'
   homepage 'https://metacpan.org/pod/IO::Socket::SSL'
-  version '2.060'
+  version '2.068'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.060.tar.gz'
-  source_sha256 'fb5b2877ac5b686a5d7b8dd71cf5464ffe75d10c32047b5570674870e46b1b8c'
+  source_url 'https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.068.tar.gz'
+  source_sha256 '4420fc0056f1827b4dd1245eacca0da56e2182b4ef6fc078f107dc43c3fb8ff9'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_io_socket_ssl-2.060-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_io_socket_ssl-2.060-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_io_socket_ssl-2.060-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_io_socket_ssl-2.060-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_io_socket_ssl-2.068-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_io_socket_ssl-2.068-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_io_socket_ssl-2.068-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_io_socket_ssl-2.068-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3a53e101598580430bacbb43d7aa785132e5caa9e01f904931cf9b78655bc98e',
-     armv7l: '3a53e101598580430bacbb43d7aa785132e5caa9e01f904931cf9b78655bc98e',
-       i686: '8c375d51e437ddf009c08f4fe94f343e637e5ec908c620bda70d14a3a0f3d461',
-     x86_64: '821a9cb6261699a5d81069540971f42c4a4a2e7dfc46b92bea7b093e47653d17',
+    aarch64: '290136e4383f9f88e8d9ca18d73c41ed6eb96f7d81f1c3baa3c6ef3087283560',
+     armv7l: '290136e4383f9f88e8d9ca18d73c41ed6eb96f7d81f1c3baa3c6ef3087283560',
+       i686: '7cb1cfb6c47f5cc3f817867af6a883e403316258d68361028615b8b0373ad772',
+     x86_64: 'ffc3268461e4c52068243e8a1480bc829d420c284d842c02975d1175493f8558',
   })
 
   depends_on 'perl'

--- a/packages/perl_locale_gettext.rb
+++ b/packages/perl_locale_gettext.rb
@@ -5,21 +5,21 @@ class Perl_locale_gettext < Package
   description 'Locale::gettext - message handling functions'
   homepage 'https://metacpan.org/pod/Locale::gettext'
   compatibility 'all'
-  version '1.07'
+  version '1.07-1'
   source_url 'https://cpan.metacpan.org/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz'
   source_sha256 '909d47954697e7c04218f972915b787bd1244d75e3bd01620bc167d5bbc49c15'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_gettext-1.07-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_gettext-1.07-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_gettext-1.07-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_gettext-1.07-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_gettext-1.07-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_gettext-1.07-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_gettext-1.07-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_gettext-1.07-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '39aad2115541343c8dd71cfaae94b3d000101b5674b8deff6a0b5be74c3d8382',
-     armv7l: '39aad2115541343c8dd71cfaae94b3d000101b5674b8deff6a0b5be74c3d8382',
-       i686: '577de273943d0f5f4991989c3d677bae5bfbe0af87b4ddaa3d969ce11fc683dc',
-     x86_64: '034808aee7e907baa2cd7d46c9892cd12e1f6be4932444ee272575e527d6176e',
+    aarch64: '2ca25cdafbe78b4d6b5e01c8985c20a2341c06c3b6969c50fa57f5dda2980e07',
+     armv7l: '2ca25cdafbe78b4d6b5e01c8985c20a2341c06c3b6969c50fa57f5dda2980e07',
+       i686: 'cf09ba00b54abf698b8c90e08c0de4f99856179551033f81e7984b4f1ae99e8f',
+     x86_64: '1183aaa19a065dcc5578276614e4e42f178b76e629d52285f68a12dae87f9232',
   })
 
   depends_on 'perl'
@@ -29,17 +29,16 @@ class Perl_locale_gettext < Package
 
   def self.install
     # install files to build directory
-    system 'cpanm', '-l', "build", '--self-contained', '.'
+    system 'cpanm', '-l', 'build', '--self-contained', '.'
 
     # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    FileUtils.mkdir_p libdir
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
 
     # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
   end
 
   def self.check

--- a/packages/perl_locale_messages.rb
+++ b/packages/perl_locale_messages.rb
@@ -3,22 +3,22 @@ require 'package'
 class Perl_locale_messages < Package
   description 'Perl Locale::Messages - Gettext Like Message Retrieval.'
   homepage 'https://metacpan.org/pod/Locale::Messages'
-  version '1.29'
+  version '1.31'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/G/GU/GUIDO/libintl-perl-1.29.tar.gz'
-  source_sha256 '78935f10db6d6a080c3160b4ae02c3f6ed07ef6bf624623295a87545e0cbfbb1'
+  source_url 'https://cpan.metacpan.org/authors/id/G/GU/GUIDO/libintl-perl-1.31.tar.gz'
+  source_sha256 'cad0b1fd0abfa1340dea089ec45ee3dacd9710c9fd942c064bb8124273b3caa9'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_messages-1.29-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_messages-1.29-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_messages-1.29-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_messages-1.29-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_messages-1.31-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_messages-1.31-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_messages-1.31-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_locale_messages-1.31-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f882f4e99637315fa64b43b5e801714f32cc451efbdde2adbe4544cba9599b72',
-     armv7l: 'f882f4e99637315fa64b43b5e801714f32cc451efbdde2adbe4544cba9599b72',
-       i686: 'd09491828102b107c0b3e944414a54b3bc22d643de39f5e7d5bd572c806a8785',
-     x86_64: 'd4e294eaee1da9208dbe5d7fd844a455e106d20eff826e7e6339e2e11c6ed5c3',
+    aarch64: 'aac0aa6fe8609a8f51f755f738613842dad332d641e3ddbebb30565a82d87be9',
+     armv7l: 'aac0aa6fe8609a8f51f755f738613842dad332d641e3ddbebb30565a82d87be9',
+       i686: '3f100a08dfb9ef440f75bc5891c6642dbb569c8e404524c497df9f1778dad440',
+     x86_64: '11676c56fb5897372398f0ebb4ce8a870757e680ec63dcf7baee6695df53dc52',
   })
 
   depends_on 'perl'
@@ -28,17 +28,16 @@ class Perl_locale_messages < Package
 
   def self.install
     # install files to build directory
-    system 'cpanm', '-l', "build", '--self-contained', '.'
+    system 'cpanm', '-l', 'build', '--self-contained', '.'
 
     # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    FileUtils.mkdir_p libdir
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
 
     # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
   end
 
   def self.check

--- a/packages/perl_module_build.rb
+++ b/packages/perl_module_build.rb
@@ -3,22 +3,22 @@ require 'package'
 class Perl_module_build < Package
   description 'Module::Build - Build and install Perl modules'
   homepage 'https://metacpan.org/pod/Module::Build'
-  version '0.4224'
+  version '0.4231'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-0.4224.tar.gz'
-  source_sha256 'a6ca15d78244a7b50fdbf27f85c85f4035aa799ce7dd018a0d98b358ef7bc782'
+  source_url 'https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-0.4231.tar.gz'
+  source_sha256 '7e0f4c692c1740c1ac84ea14d7ea3d8bc798b2fb26c09877229e04f430b2b717'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_module_build-0.4224-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_module_build-0.4224-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_module_build-0.4224-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_module_build-0.4224-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_module_build-0.4231-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_module_build-0.4231-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_module_build-0.4231-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_module_build-0.4231-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '33263a4ab0f415024332bb60252fc51c9d6c3682003072cbb4456836acb19ac4',
-     armv7l: '33263a4ab0f415024332bb60252fc51c9d6c3682003072cbb4456836acb19ac4',
-       i686: '316393abe23f888aaef40be326a37481b63594000d0557d7f19ddf50b555ba89',
-     x86_64: '4e32b1519375b8b3b2b7262e864f2ba1d4d777dda64e96bdfb2c79d82cd9914b',
+    aarch64: 'b8407fa11a374de2c9a07ecae133cee6872b433872b6b3bef2a51218bf0d3c4c',
+     armv7l: 'b8407fa11a374de2c9a07ecae133cee6872b433872b6b3bef2a51218bf0d3c4c',
+       i686: '5c0b7f602df7ff123b58d4e6cdea0fcc019a482f06de809219f9d4fbb23e9992',
+     x86_64: '71b31393762a1eaa299d3e519aa1b72f152eb405378e2d37001d62a809791a92',
   })
 
   depends_on 'perl'
@@ -28,17 +28,16 @@ class Perl_module_build < Package
 
   def self.install
     # install files to build directory
-    system 'cpanm', '-l', "build", '--self-contained', '.'
+    system 'cpanm', '-l', 'build', '--self-contained', '.'
 
     # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    FileUtils.mkdir_p libdir
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
 
     # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
   end
 
   def self.check

--- a/packages/perl_read_key.rb
+++ b/packages/perl_read_key.rb
@@ -3,30 +3,32 @@ require 'package'
 class Perl_read_key < Package
   description 'Character mode terminal access for Perl Term::ReadKey'
   homepage 'https://metacpan.org/source/JSTOWE/TermReadKey-2.37/'
-  version '2.37'
+  version '2.38'
   compatibility 'all'
-  source_url 'https://github.com/jonathanstowe/TermReadKey/archive/v2.37.tar.gz'
-  source_sha256 '0fa4fb2f8145e3fb2c2129ad28d55be175abcc258f239ba8ddc2cd83790aa8fb'
+  source_url 'https://github.com/jonathanstowe/TermReadKey/archive/2.38.tar.gz'
+  source_sha256 'bb669c422d7094e19fa85d43676b67933b86d4a1f6b39fed5dbfaaaa97716c1d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_read_key-2.37-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_read_key-2.37-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_read_key-2.37-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_read_key-2.37-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_read_key-2.38-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_read_key-2.38-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_read_key-2.38-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_read_key-2.38-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '4e9628ee71561b0b6b63a5aeffd31d0b128b0cefa989ce5b16a956122aa1f387',
-     armv7l: '4e9628ee71561b0b6b63a5aeffd31d0b128b0cefa989ce5b16a956122aa1f387',
-       i686: '476c3fb90d238d61040f0a5cdd5c8ffc0ad676327f635fbc851a6b4788b4c149',
-     x86_64: '966e8c16894a81003dd29af9c5ceb69d5e2a509c56a8701ff680fe4a2f21868d',
+    aarch64: '2c32777a39c44accb5bf5ee9b9155cc186faf148a4cc89218c50fe9ca38a7fdf',
+     armv7l: '2c32777a39c44accb5bf5ee9b9155cc186faf148a4cc89218c50fe9ca38a7fdf',
+       i686: '8cf68da938a505a90e84d442e196f0eaa58802568cb42b1ffb087265ec79f251',
+     x86_64: 'e06db1036175a0277adc945b09d213dd3f18f4978399e6aa27c9d79b3aa18360',
   })
 
+  depends_on 'perl'
+
   def self.build
-    system "perl", "Makefile.PL"
-    system "make"
+    system 'perl', 'Makefile.PL'
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/perl_sgmls.rb
+++ b/packages/perl_sgmls.rb
@@ -5,24 +5,23 @@ class Perl_sgmls < Package
   description 'a set of Perl5 routines for processing the output from the onsgmls SGML parsers.'
   homepage 'http://search.cpan.org/dist/SGMLSpm/'
   compatibility 'all'
-  version '1.1'
-  source_url 'http://search.cpan.org/CPAN/authors/id/R/RA/RAAB/SGMLSpm-1.1.tar.gz'   # can not install it if using https://
+  version '1.1-1'
+  source_url 'https://cpan.metacpan.org/authors/id/R/RA/RAAB/SGMLSpm-1.1.tar.gz'
   source_sha256 '550c9245291c8df2242f7e88f7921a0f636c7eec92c644418e7d89cfea70b2bd'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_sgmls-1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_sgmls-1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_sgmls-1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_sgmls-1.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_sgmls-1.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_sgmls-1.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_sgmls-1.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_sgmls-1.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5ca57ff49308f61c1c48a8ea4592dc1a3283522cc86ac638eadfc05948e4c96f',
-     armv7l: '5ca57ff49308f61c1c48a8ea4592dc1a3283522cc86ac638eadfc05948e4c96f',
-       i686: '3788e14aada718fca83522f402afd2c8ac49524cc797dbd7ab155ca84d9bb3e7',
-     x86_64: '3d2b15ddb42f1ae17d1adc7062859355a7e5de56af48dacabe7fead5ee2159de',
+    aarch64: '6ab37b70516fc82b41caf4f2fb4d41840cdb25d05ff370f3ac6f61b70352d0d9',
+     armv7l: '6ab37b70516fc82b41caf4f2fb4d41840cdb25d05ff370f3ac6f61b70352d0d9',
+       i686: 'e2affa6d9cb0e2b5ce47e782c04d18fd1cbd0cb7236ed081c0e2bc75ac5238dc',
+     x86_64: 'c04a99f872685d663b89e99ea435e1e62971b234889cc78880d1cb811202e5bd',
   })
 
-  depends_on 'perl'
   depends_on 'perl_module_build'
 
   def self.build
@@ -30,17 +29,16 @@ class Perl_sgmls < Package
 
   def self.install
     # install files to build directory
-     system 'cpanm', '-l', "build", '.'      # remove '--self-contained' here, since it will build module_build again.
+     system 'cpanm', '-l', 'build', '.' # remove '--self-contained' here, since it will build module_build again.
 
     # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    FileUtils.mkdir_p libdir
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
 
     # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
   end
 
   def self.check

--- a/packages/perl_term_ansicolor.rb
+++ b/packages/perl_term_ansicolor.rb
@@ -3,30 +3,32 @@ require 'package'
 class Perl_term_ansicolor < Package
   description 'Character mode terminal access for Perl Term::ANSIColor'
   homepage 'https://www.eyrie.org/~eagle/software/ansicolor/'
-  version '4.06'
+  version '5.01'
   compatibility 'all'
-  source_url 'https://github.com/rra/ansicolor/archive/release/4.06.tar.gz'
-  source_sha256 '0cf6f25ac82ccc0aff2bcfdec23879469626db80f0f50105ec5100236a6830cf'
+  source_url 'https://github.com/rra/ansicolor/archive/release/5.01.tar.gz'
+  source_sha256 'c4865a9fe2ce3a46fd4f11215dcba05a9d5603e797a2623abc19cc14b4a0609a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_term_ansicolor-4.06-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_term_ansicolor-4.06-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_term_ansicolor-4.06-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_term_ansicolor-4.06-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_term_ansicolor-5.01-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_term_ansicolor-5.01-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_term_ansicolor-5.01-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_term_ansicolor-5.01-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'c737c0b923940f726cbbfe7621a80fc3210f4f6b54829d74f992729bbd4551bb',
-     armv7l: 'c737c0b923940f726cbbfe7621a80fc3210f4f6b54829d74f992729bbd4551bb',
-       i686: '54381d835ba791f21964f94e3bd06772b18a6a2b467b909d752971ac54246eb1',
-     x86_64: '87c9ab464473d6d6b155bb28a40ed5738b7485452e85fe9bf2c8e86e17a27635',
+    aarch64: 'c96e95727d025667223e7a03bc89fdc061c3d83e4660815a4bf33aa72aafcd09',
+     armv7l: 'c96e95727d025667223e7a03bc89fdc061c3d83e4660815a4bf33aa72aafcd09',
+       i686: 'bd6ea6dff3b5ceed3f29f495c66473cc943a30d2e6c6a0337f8d0efb16e0b7e4',
+     x86_64: '057c9ccc3a3bb84354c4e81383961e9a0d886b3a1e7d3c8a960336da6383b3ba',
   })
 
+  depends_on 'perl'
+
   def self.build
-    system "perl", "Makefile.PL"
-    system "make"
+    system 'perl', 'Makefile.PL'
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/perl_text_charwidth.rb
+++ b/packages/perl_text_charwidth.rb
@@ -3,22 +3,22 @@ require 'package'
 class Perl_text_charwidth < Package
   description 'Text::CharWidth - Get number of occupied columns of a string on terminals'
   homepage 'https://metacpan.org/pod/Text::CharWidth'
-  version '0.04'
+  version '0.04-1'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/K/KU/KUBOTA/Text-CharWidth-0.04.tar.gz'
   source_sha256 'abded5f4fdd9338e89fd2f1d8271c44989dae5bf50aece41b6179d8e230704f8'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_charwidth-0.04-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_charwidth-0.04-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_charwidth-0.04-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_charwidth-0.04-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_charwidth-0.04-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_charwidth-0.04-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_charwidth-0.04-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_charwidth-0.04-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '34c7986c7a9f0cbcf4540589008993463b26dc7a35dd640530eb63d5eda686d3',
-     armv7l: '34c7986c7a9f0cbcf4540589008993463b26dc7a35dd640530eb63d5eda686d3',
-       i686: 'e08cd144f70759d29e21d244fa8bdd42b57e44944cf6e20bfd49273a493f2281',
-     x86_64: '0f36d56af9de52d9b4f65f8d5f231b2fe0e4faf4b534906cf2e949fcc8b4c1a5',
+    aarch64: 'f3d97714e0b0a6004c74c2c0e3ce3b716bbd15faebf67f11b8c3b44744417e22',
+     armv7l: 'f3d97714e0b0a6004c74c2c0e3ce3b716bbd15faebf67f11b8c3b44744417e22',
+       i686: '876b30f1223dd35171bee51adcc898c2a5a0b2e77837fbcb08aa2d2570790c62',
+     x86_64: 'a8b8882ce818811dc8eeb67c42cea8ef9ef3ca53e7c791e031bcf127b69db277',
   })
 
   depends_on 'perl'
@@ -28,17 +28,16 @@ class Perl_text_charwidth < Package
 
   def self.install
     # install files to build directory
-    system 'cpanm', '-l', "build", '--self-contained', '.'
+    system 'cpanm', '-l', 'build', '--self-contained', '.'
 
     # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    FileUtils.mkdir_p libdir
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
 
     # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
   end
 
   def self.check

--- a/packages/perl_text_unidecode.rb
+++ b/packages/perl_text_unidecode.rb
@@ -3,22 +3,22 @@ require 'package'
 class Perl_text_unidecode < Package
   description 'Perl Text::Unidecode -- plain ASCII transliterations of Unicode text.'
   homepage 'https://metacpan.org/pod/Text::Unidecode'
-  version '1.30'
+  version '1.30-1'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/S/SB/SBURKE/Text-Unidecode-1.30.tar.gz'
   source_sha256 '6c24f14ddc1d20e26161c207b73ca184eed2ef57f08b5fb2ee196e6e2e88b1c6'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_unidecode-1.30-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_unidecode-1.30-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_unidecode-1.30-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_unidecode-1.30-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_unidecode-1.30-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_unidecode-1.30-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_unidecode-1.30-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_unidecode-1.30-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'e9fff94d0d53791b6bb6715667bd64969f92391eec6f39bd3117a358de01843c',
-     armv7l: 'e9fff94d0d53791b6bb6715667bd64969f92391eec6f39bd3117a358de01843c',
-       i686: 'b1bef306347759d19448beb7cfaddafe5d5222f6ba3b8305796a6f01bd5c31fa',
-     x86_64: 'bfcee9cb5a3315a021cea9f6bfb5a225d0b20690c66af7ffa6bfedefc7883749',
+    aarch64: '43b5783ca695cc44a5129fab5e176b24f94a300ab4e28f65ae9155c36dad93c8',
+     armv7l: '43b5783ca695cc44a5129fab5e176b24f94a300ab4e28f65ae9155c36dad93c8',
+       i686: 'd29c8c82aff2664ef8184bf225fe581c30cddcf632300c781eca4fcab9dd3732',
+     x86_64: '0a862d29622f5516bee8b00706d7c59f2e2ed091c484c9366fa515dcab213581',
   })
 
   depends_on 'perl'
@@ -28,17 +28,16 @@ class Perl_text_unidecode < Package
 
   def self.install
     # install files to build directory
-    system 'cpanm', '-l', "build", '--self-contained', '.'
+    system 'cpanm', '-l', 'build', '--self-contained', '.'
 
     # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    FileUtils.mkdir_p libdir
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
 
     # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
   end
 
   def self.check

--- a/packages/perl_text_wrapi18n.rb
+++ b/packages/perl_text_wrapi18n.rb
@@ -3,43 +3,41 @@ require 'package'
 class Perl_text_wrapi18n < Package
   description 'Text::WrapI18N - Line wrapping module with support for multibyte, fullwidth, and combining characters and languages without whitespaces between words.'
   homepage 'https://metacpan.org/pod/Text::WrapI18N'
-  version '0.06'
+  version '0.06-1'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/K/KU/KUBOTA/Text-WrapI18N-0.06.tar.gz'
   source_sha256 '4bd29a17f0c2c792d12c1005b3c276f2ab0fae39c00859ae1741d7941846a488'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_wrapi18n-0.06-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_wrapi18n-0.06-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_wrapi18n-0.06-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_wrapi18n-0.06-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_wrapi18n-0.06-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_wrapi18n-0.06-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_wrapi18n-0.06-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_text_wrapi18n-0.06-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3978d40b0eb71c01e5a26d5e4f9069f41a7a8a477db3f1e20060274f503a814a',
-     armv7l: '3978d40b0eb71c01e5a26d5e4f9069f41a7a8a477db3f1e20060274f503a814a',
-       i686: 'c258b217a57569491a4200c92e07688fc7333b57207025ec760199218ac6a242',
-     x86_64: '5725c4a81381834d1c3701e05413d766d6882f98e7a0daf793cadb93e9a20962',
+    aarch64: '87bebe91adc2d9b6b288691dace869f93e51a828086174d8c9380665dc7267a5',
+     armv7l: '87bebe91adc2d9b6b288691dace869f93e51a828086174d8c9380665dc7267a5',
+       i686: '3e5e0d3bdea86b958a2fdfe990f51055e9e35ea761ab525c6063dbeed4a1b7bb',
+     x86_64: 'bef63d98fe23d6963d97c60051874e586ef7765b1284b62e8847832a73f5ff5d',
   })
 
-  depends_on 'perl'
-  depends_on 'perl_text_charwidth'  # add dependency
+  depends_on 'perl_text_charwidth'
 
   def self.build
   end
 
   def self.install
     # install files to build directory
-    system 'cpanm', '-l', "build", '.'            #  remove --self-contained
+    system 'cpanm', '-l', 'build', '.' #  remove --self-contained
 
     # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    FileUtils.mkdir_p libdir
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
 
     # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
   end
 
   def self.check

--- a/packages/perl_time_hires.rb
+++ b/packages/perl_time_hires.rb
@@ -3,30 +3,32 @@ require 'package'
 class Perl_time_hires < Package
   description 'High resolution alarm, sleep, gettimeofday, interval timers Time::HiRes'
   homepage 'https://metacpan.org/release/Time-HiRes'
-  version '1.9758'
+  version '1.9758-1'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/J/JH/JHI/Time-HiRes-1.9758.tar.gz'
   source_sha256 '5bfa145bc11e70a8e337543b1084a293743a690691b568493455dedf58f34b1e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_time_hires-1.9758-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_time_hires-1.9758-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_time_hires-1.9758-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_time_hires-1.9758-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_time_hires-1.9758-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_time_hires-1.9758-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_time_hires-1.9758-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_time_hires-1.9758-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '40c061bbf460cd2f617e94802ed91d3c7a97fc142e4c649ef72160d868e68a94',
-     armv7l: '40c061bbf460cd2f617e94802ed91d3c7a97fc142e4c649ef72160d868e68a94',
-       i686: 'dd6a1fcab145b5e92ccdec417e61c66beb0f303e0cbc98a5b4ff45cdb0261d09',
-     x86_64: '79dfe890436e0e110ae7af0e3905f1aea79b684c63cc751140638eb71e62170a',
+    aarch64: '71dfe08892dc8c59a158448050d5d7bd5ea2a4c93adae3304c8645aa612a41e8',
+     armv7l: '71dfe08892dc8c59a158448050d5d7bd5ea2a4c93adae3304c8645aa612a41e8',
+       i686: '22b74828e23eb8c2a4e3394dbccbe05cd90423f99d3baeaa718dbad011100eef',
+     x86_64: 'dd240247cb8051dea6df3af7ea09c45cf16a26790f807139c5a02e9663433ae7',
   })
 
+  depends_on 'perl'
+
   def self.build
-    system "perl", "Makefile.PL"
-    system "make"
+    system 'perl', 'Makefile.PL'
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/perl_unicode_eastasianwidth.rb
+++ b/packages/perl_unicode_eastasianwidth.rb
@@ -3,44 +3,36 @@ require 'package'
 class Perl_unicode_eastasianwidth < Package
   description 'Perl Unicode::EastAsianWidth - East Asian Width properties.'
   homepage 'https://metacpan.org/pod/Unicode::EastAsianWidth'
-  version '1.33'
+  version '12.0'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/A/AU/AUDREYT/Unicode-EastAsianWidth-1.33.tar.gz'
-  source_sha256 '41c9f0b50c45dd806a97de73f9fe93516b6c63255e2a5174e5fb2d89635c7797'
+  source_url 'https://cpan.metacpan.org/authors/id/A/AU/AUDREYT/Unicode-EastAsianWidth-12.0.tar.gz'
+  source_sha256 '2a5bfd926c4fe5f77e6137da2c31ac2545282ae5fec6e9af0fdd403555a90ff4'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_unicode_eastasianwidth-1.33-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_unicode_eastasianwidth-1.33-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_unicode_eastasianwidth-1.33-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_unicode_eastasianwidth-1.33-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_unicode_eastasianwidth-12.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_unicode_eastasianwidth-12.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_unicode_eastasianwidth-12.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_unicode_eastasianwidth-12.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'a307d2bfb7805a345ed47069aa51db0f509f7887f034e972c2125f1ce7781617',
-     armv7l: 'a307d2bfb7805a345ed47069aa51db0f509f7887f034e972c2125f1ce7781617',
-       i686: '738bd0a51ae004d7d1fc03cb9d73d1a3fd7674f40f4b0fc049749a313e1b3cac',
-     x86_64: 'ca7516e05ea52ad7c988209ee0fdce1aebf32434eb2ba7f6fc03015588088a6f',
+    aarch64: '5593ee971d525518b3ceb87f09ac1e72f9588f07560af63eb11ab82da3f69e49',
+     armv7l: '5593ee971d525518b3ceb87f09ac1e72f9588f07560af63eb11ab82da3f69e49',
+       i686: '6cd20f8a7cfb18799864003c76475c4e8280c7367f7285460facbf44d9279a5d',
+     x86_64: 'd200c9e1cc6c1e02a690006914c0f7e7845e7af92d2ec858df58b5f9cd0e3c4c',
   })
 
   depends_on 'perl'
 
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
+
   def self.build
+    system 'make'
   end
 
   def self.install
-    # install files to build directory
-    system 'cpanm', '-l', "build", '--self-contained', '.'
-
-    # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
-
-    # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
-  end
-
-  def self.check
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/perl_xml_parser.rb
+++ b/packages/perl_xml_parser.rb
@@ -3,25 +3,23 @@ require 'package'
 class Perl_xml_parser < Package
   description 'Perl XML::Parser - A perl module for parsing XML documents'
   homepage 'https://metacpan.org/pod/XML::Parser'
-  version '2.44-1'
+  version '2.46'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz'
-  source_sha256 '1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216'
+  source_url 'https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz'
+  source_sha256 'd331332491c51cccfb4cb94ffc44f9cd73378e618498d4a37df9e043661c515d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.44-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.44-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.44-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.44-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.46-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.46-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.46-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_parser-2.46-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5e423eb9425b1431bf189aa14ae6bb84bb7d919c41d5d9ef4abe10de4cd25fd9',
-     armv7l: '5e423eb9425b1431bf189aa14ae6bb84bb7d919c41d5d9ef4abe10de4cd25fd9',
-       i686: 'eb4bf3f2606e99f7226bf1672f53ed70803cd086ba6e7db034f7965cc57ad320',
-     x86_64: '3ad7284bc32559076decee33bbb633e0bc3465f37f4af9c55ebff66bf662a288',
+    aarch64: '19c9f04e36592ba130c178c0b19a0418959f7dbc5ff69d926cc7d7953ebf5ce8',
+     armv7l: '19c9f04e36592ba130c178c0b19a0418959f7dbc5ff69d926cc7d7953ebf5ce8',
+       i686: 'a8be7da651c6064359978d81c536511c225f62d17a2c8d498b8290a48c6104ff',
+     x86_64: 'ba095c1e93328e0117c3ad5097dc4de88969f7ef70829e1d4d355afdb508f37d',
   })
-
-
 
   depends_on 'expat'
   depends_on 'perl'
@@ -34,14 +32,13 @@ class Perl_xml_parser < Package
     system 'cpanm', '-l', 'build', '--self-contained', '--force', '.'
 
     # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    FileUtils.mkdir_p libdir
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
 
     # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
   end
 
   def self.check

--- a/packages/perl_xml_sax_parserfactory.rb
+++ b/packages/perl_xml_sax_parserfactory.rb
@@ -3,22 +3,22 @@ require 'package'
 class Perl_xml_sax_parserfactory < Package
   description 'XML::SAX::ParserFactory is a factory class for providing an application with a Perl SAX2 XML parser.'
   homepage 'https://metacpan.org/source/GRANTM/XML-SAX-0.99/SAX/'
-  version '0.99'
+  version '1.02'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-0.99.tar.gz'
-  source_sha256 '32b04b8e36b6cc4cfc486de2d859d87af5386dd930f2383c49347050d6f5ad84'
+  source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-1.02.tar.gz'
+  source_sha256 '4506c387043aa6a77b455f00f57409f3720aa7e553495ab2535263b4ed1ea12a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-0.99-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-0.99-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-0.99-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-0.99-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-1.02-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-1.02-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-1.02-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_sax_parserfactory-1.02-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '2e6a336ca325eb357f004fa6098be754a0ad12a5a75c2d47d9e8db9029ca45e7',
-     armv7l: '2e6a336ca325eb357f004fa6098be754a0ad12a5a75c2d47d9e8db9029ca45e7',
-       i686: '422881325203864e4207eb056efcfa5e6424e8338344eb806b192975c28b2d99',
-     x86_64: 'a40967f018b01f5463597cc39b0abf07a1053aa551e5b04be2aaec6119894b94',
+    aarch64: '9a65d90e104f6345618c68a626188de073498c5a836f02478ee0388af74197d2',
+     armv7l: '9a65d90e104f6345618c68a626188de073498c5a836f02478ee0388af74197d2',
+       i686: 'beaa39f268e11c8b66b12599defed197de773bcc2f9938bdbfcf9696fa198fb4',
+     x86_64: '99d8022173ad714e70c9f235264bce34a3a2f1af65269cc929e4d23a0347e66a',
   })
 
   depends_on 'perl'
@@ -28,17 +28,16 @@ class Perl_xml_sax_parserfactory < Package
 
   def self.install
     # install files to build directory
-    system 'cpanm', '-l', "build", '--self-contained', '.'
+    system 'cpanm', '-l', 'build', '--self-contained', '.'
 
     # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
+    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
+    FileUtils.mkdir_p libdir
+    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
 
     # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
+    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
   end
 
   def self.check

--- a/packages/perl_xml_simple.rb
+++ b/packages/perl_xml_simple.rb
@@ -3,44 +3,36 @@ require 'package'
 class Perl_xml_simple < Package
   description 'XML::Simple - An API for simple XML files'
   homepage 'https://metacpan.org/pod/XML::Simple'
-  version '2.25'
+  version '2.25-1'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-Simple-2.25.tar.gz'
   source_sha256 '531fddaebea2416743eb5c4fdfab028f502123d9a220405a4100e68fc480dbf8'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_simple-2.25-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_simple-2.25-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_simple-2.25-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_simple-2.25-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_simple-2.25-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_simple-2.25-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_simple-2.25-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/perl_xml_simple-2.25-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '2efbab66fa6fb4366cf7858730a1735cca8b8908e9177efab82681e3cc225ada',
-     armv7l: '2efbab66fa6fb4366cf7858730a1735cca8b8908e9177efab82681e3cc225ada',
-       i686: '4f9ac7dcea9016a27d1c9d7652c78e995dbaa6d01d4ffdd4f6891e979310768a',
-     x86_64: 'c7add802bb163ef97c3e5e3746c0af744cb811477f0d915c2b3b46d01fa03908',
+    aarch64: '1e59e0c43b8bfecf21365d9ee0b58db3faa544f07da1aa349734ba34b75541a0',
+     armv7l: '1e59e0c43b8bfecf21365d9ee0b58db3faa544f07da1aa349734ba34b75541a0',
+       i686: 'e035d818f9ef397fbc8f4f9e0aa95dc360c797931808f03e46a7cf7a7393a158',
+     x86_64: '13dd6b54550fc74148e635ea6ef7afecbe49ae691b85e745f4ed5e0667da79e6',
   })
 
   depends_on 'perl_xml_parser'
 
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
+
   def self.build
+    system 'make'
   end
 
   def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '--force', '.'
-
-    # install lib
-    libdir = `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    system "mkdir -p #{CREW_DEST_DIR}#{libdir}"
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{CREW_DEST_DIR}#{libdir}; tar xfp -)"
-
-    # install man
-    mandir = "#{CREW_PREFIX}/share/man"
-    system "mkdir -p #{CREW_DEST_DIR}#{mandir}"
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_DIR}#{mandir}; tar xfp -)"
-  end
-
-  def self.check
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
All perl module packages needed rebuilt since the perl version is hardcoded in the directory names.  Tested on all architectures.