### PR TITLE
Update gcc_tools from 1.0 to 1.1 and add gcc10 option

### DIFF
--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -8,6 +8,18 @@ class Gcc10 < Package
   source_url 'https://ftpmirror.gnu.org/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz'
   source_sha256 'b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '832a12c3db18537775d174c4188cf4bc14aeed72b243a1099e8f1715f6575dbc',
+     armv7l: '832a12c3db18537775d174c4188cf4bc14aeed72b243a1099e8f1715f6575dbc',
+       i686: 'c319f3a643f23b409fef6baffa91eea8afc43936d95ca467f0f26945cde6e5cf',
+     x86_64: 'fc3b15e4b499548131389f38b67cc4ab35e32a4fe9d21f96b108c7a3d20598de',
+  })
 
   depends_on 'unzip' => :build
   depends_on 'gawk' => :build
@@ -28,7 +40,6 @@ class Gcc10 < Package
     gccver = `gcc -v 2>&1 | tail -1 | cut -d' ' -f3`.chomp
     abort "GCC version #{gccver} already installed.".lightgreen unless "#{gccver}" == "No" || "#{gccver}" == "not" || "#{gccver}" == "gcc:" || "#{gccver}" == "#{version}"
   end
-
 
   def self.build
     # previous compile issue

--- a/packages/gcc_tools.rb
+++ b/packages/gcc_tools.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gcc_tools < Package
   description 'Tools for working with gcc packages'
   homepage 'https://github.com/skycocker/chromebrew'
-  version '1.0'
+  version '1.1'
   compatibility 'all'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
@@ -66,16 +66,16 @@ if [ ! -f "${CREW_PREFIX}/bin/ruby" ]; then
   # prepare ruby url and sha256
   case "${ARCH}" in
   "aarch64"|"armv7l")
-    url="https://dl.bintray.com/chromebrew/chromebrew/ruby-2.5.3-chromeos-armv7l.tar.xz"
-    sha256="5e485a0320b298e1f5c4ff50d98c6fe6d06ad9a38d9119d580a8b469418e1e6a"
+    url="https://dl.bintray.com/chromebrew/chromebrew/ruby-2.7.2-chromeos-armv7l.tar.xz"
+    sha256="a435e6bf7965e1a82e8842e5ea66bdd670ec9b627d785bd720d3d2652fc89f6d"
     ;;
   "i686")
-    url="https://dl.bintray.com/chromebrew/chromebrew/ruby-2.5.3-chromeos-i686.tar.xz"
-    sha256="6f4a5b96c31ef5ee4f09ac15da4c7a4a9d838ed5233038136ead1e155d17f342"
+    url="https://dl.bintray.com/chromebrew/chromebrew/ruby-2.7.2-chromeos-i686.tar.xz"
+    sha256="81865864d3ba93b6cbd5dc8e1b6cb51bd2ebe854f6c01e282c1b73f379fb7caf"
     ;;
   "x86_64")
-    url="https://dl.bintray.com/chromebrew/chromebrew/ruby-2.5.3-chromeos-x86_64.tar.xz"
-    sha256="352b78fc883cf8936136991fda9ca5d49e90b2951626158d6af8ef4b58d67f97"
+    url="https://dl.bintray.com/chromebrew/chromebrew/ruby-2.7.2-chromeos-x86_64.tar.xz"
+    sha256="658808516b7a2e58f8102fd131e765aaa79f2a7c906d0330b7e883fbdc12d1a9"
     ;;
   esac
   tarfile="$(basename ${url})"
@@ -89,32 +89,55 @@ EOF'
     system 'cat << "EOF" > gcc_switcher
 #!/bin/bash
 gccver=$(gcc -v 2>&1 | tail -1 | cut -d" " -f3)
-if [[ "$gccver" == "No" || "$gccver" == "gcc:" ]]; then
-  echo "Enter the GCC version to install:"
-  echo "7 = GCC 7.4.0"
-  echo "8 = GCC 8.3.0"
+v=$(echo $gccver | cut -d"." -f1)
+if test $1; then
+  valid=
+  gv="7 8 10"
+  for g in $gv; do
+    [ $1 == $g ] && valid=1
+  done
+  [ ! $valid ] && echo "Usage: $(basename $0) [version] where [version] is one of $gv" && exit 1
+  [ $1 == $v ] && echo "GCC version $gccver currently installed." && exit 1
+  version=$1
 else
-  echo "GCC version $gccver currently installed."
-  echo "Enter the GCC version to install:"
-  if [ "$gccver" == "8.3.0" ]; then
-    echo "7 = GCC 7.4.0"
-  fi
-  if [ "$gccver" == "7.4.0" ]; then
-    echo "8 = GCC 8.3.0"
+  version=
+  versions=(0 7 8 10)
+  if [[ "$gccver" == "No" || "$gccver" == "gcc:" ]]; then
+    until [[ " ${versions[@]} " =~ " ${version} " ]]; do
+      echo "Enter the GCC version to install:"
+      echo " 7 = GCC 7.4.0"
+      echo " 8 = GCC 8.3.0"
+      echo "10 = GCC 10.2.0"
+      echo " 0 = Cancel"
+      read version
+    done
+  else
+    echo "GCC version $gccver currently installed."
+    until [[ " ${versions[@]} " =~ " ${version} " ]]; do
+      echo "Enter the GCC version to install:"
+      case $v in
+        7)
+          echo " 8 = GCC 8.3.0"
+          echo "10 = GCC 10.2.0"
+          ;;
+        8)
+          echo " 7 = GCC 7.4.0"
+          echo "10 = GCC 10.2.0"
+          ;;
+        10)
+          echo " 7 = GCC 7.4.0"
+          echo " 8 = GCC 8.3.0"
+          ;;
+        0)
+          ;;
+      esac
+      echo " 0 = Cancel"
+      read version
+    done
   fi
 fi
-echo "0 = Cancel"
-read version
-case $version in
-  7)
-    crew remove gcc8 && crewfix && crew install gcc7
-    ;;
-  8)
-    crew remove gcc7 && crewfix && crew install gcc8
-    ;;
-  *)
-    ;;
-esac
+[ $v == $version ] && echo "GCC version $gccver currently installed." && exit 1
+[ $version != 0 ] && crew remove curl gcc$v && crewfix && crew install curl gcc$version
 EOF'
   end
 


### PR DESCRIPTION
Fixes #4429.
- Add parameter handling to gcc_switcher script
- Add pre-built binaries for gcc10
- Tested on all architectures.
