### PR TITLE
Add appstream_glib package and dependencies

### DIFF
--- a/packages/appstream_glib.rb
+++ b/packages/appstream_glib.rb
@@ -1,0 +1,47 @@
+require 'package'
+
+class Appstream_glib < Package
+  description 'This library provides objects and helper methods to help reading and writing AppStream metadata.'
+  homepage 'https://github.com/hughsie/appstream-glib'
+  version '0.7.18'
+  compatibility 'all'
+  source_url 'https://people.freedesktop.org/~hughsient/appstream-glib/releases/appstream-glib-0.7.18.tar.xz'
+  source_sha256 'ca1ed22e3bde3912cb903aaa7de085d55771da454f1c0573fd9608e1de9c4002'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fb88bafd2af9c6ee4c41a66b9f1004e57894dfe29d26a7fa04f38618e19a10f8',
+     armv7l: 'fb88bafd2af9c6ee4c41a66b9f1004e57894dfe29d26a7fa04f38618e19a10f8',
+       i686: '060c3a65ddaecbb8db18d84f58676ec56c390ec3d30dcba1580acf94981d0f40',
+     x86_64: 'e3d8b538cd64ef79b4efd8c77142f1b6de1b861072ca5d9d5441effe66aac846',
+  })
+
+  depends_on 'docbook' => :build
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'gobject_introspection'
+  depends_on 'gperf'
+  depends_on 'gtk_doc' => :build
+  depends_on 'gtk3'
+  depends_on 'json_glib'
+  depends_on 'libarchive'
+  depends_on 'libsoup'
+  depends_on 'libarchive'
+  depends_on 'libuuid'
+  depends_on 'libstemmer'
+  depends_on 'libyaml'
+
+  def self.build
+    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} -Dbuilder=false -Dman=false -Drpm=false _build"
+    system 'ninja -v -C _build'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
+  end
+end

--- a/packages/libstemmer.rb
+++ b/packages/libstemmer.rb
@@ -1,0 +1,44 @@
+require 'package'
+
+class Libstemmer < Package
+  description 'Snowball Stemming Algorithms'
+  homepage 'https://snowballstem.org/'
+  version '78c149'
+  compatibility 'all'
+  source_url 'https://github.com/zvelo/libstemmer/archive/78c149a3a6f262a35c7f7351d3f77b725fc646cf.tar.gz'
+  source_sha256 '9bbd1bd2b7829f6bdafba97667fc795b3a80785c2285a5b73c3006b0bf3db688'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libstemmer-78c149-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libstemmer-78c149-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libstemmer-78c149-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libstemmer-78c149-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '854bc6cb2855c76b052d49fc8ac0c2dbc3766fede27ba6eac71846eef85f9351',
+     armv7l: '854bc6cb2855c76b052d49fc8ac0c2dbc3766fede27ba6eac71846eef85f9351',
+       i686: 'aa04ec939e77fcce2cbbad9498f6d13c4ccd351bfef9540fa9ef9c13c467ba94',
+     x86_64: '687765fc1f522249eef1d40b85f5a5cab1483be44710af5ba37ae9f324d16c0a',
+  })
+
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system 'cmake',
+             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
+             '-DCMAKE_BUILD_TYPE=Release',
+             '-DBUILD_SHARED_LIBS=ON',
+             '..'
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
+    Dir.chdir CREW_DEST_PREFIX do
+      FileUtils.mv 'lib', 'lib64' if ARCH == 'x86_64'
+    end
+  end
+end

--- a/packages/libyaml.rb
+++ b/packages/libyaml.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Libyaml < Package
+  description 'LibYAML is a YAML parser and emitter library.'
+  homepage 'https://pyyaml.org/wiki/LibYAML'
+  version '0.2.5'
+  compatibility 'all'
+  source_url 'https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz'
+  source_sha256 'c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libyaml-0.2.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libyaml-0.2.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libyaml-0.2.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libyaml-0.2.5-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'c05fef7ea3a1d11e1cf5a95eb537f705b5999b07a2c892cc0145808a70d07200',
+     armv7l: 'c05fef7ea3a1d11e1cf5a95eb537f705b5999b07a2c892cc0145808a70d07200',
+       i686: '5a65d7491f853b9efebb6cc2c119daf28259bbb2e92ee38ce9d802b305d61fda',
+     x86_64: '157e3e7c7dad0cea905a78944270b7b1fdd58bd363eeb167784a6d90a8c362b8',
+  })
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -124,6 +124,11 @@ url: https://www.antlr.org/download
 activity: low
 ---
 kind: url
+name: appstream_glib
+url: https://people.freedesktop.org/~hughsient/appstream-glib/releases/
+activity: medium
+---
+kind: url
 name: apr
 url: https://apache.claz.org/apr
 activity: low
@@ -1396,6 +1401,11 @@ activity: low
 kind: url
 name: gc
 url: http://www.hboehm.info/gc/gc_source
+activity: low
+---
+kind: url
+name: gcab
+url: https://gitlab.gnome.org/GNOME/gcab/-/tags
 activity: low
 ---
 kind: url
@@ -3084,6 +3094,11 @@ url: https://www.libssh2.org/download
 activity: none
 ---
 kind: url
+name: libstemmer
+url: https://github.com/zvelo/libstemmer/
+activity: none
+---
+kind: url
 name: libstrophe
 url: https://github.com/strophe/libstrophe/releases
 activity: medium
@@ -3452,6 +3467,11 @@ kind: url
 name: libxxf86vm
 url: https://www.x.org/archive/individual/lib
 activity: none
+---
+kind: url
+name: libyaml
+url: https://github.com/yaml/libyaml/releases/
+activity: medium
 ---
 kind: url
 name: libzip


### PR DESCRIPTION
This library provides objects and helper methods to help reading and writing AppStream metadata. See https://github.com/hughsie/appstream-glib.  Tested on all architectures.