### PR TITLE
xorg_proto update to 2020.1, and build with meson & llvm.

### DIFF
--- a/packages/xorg_proto.rb
+++ b/packages/xorg_proto.rb
@@ -3,35 +3,35 @@ require 'package'
 class Xorg_proto < Package
   description 'The xorgproto package provides the header files required to build the X Window system, and to allow other applications to build against the installed X Window system.'
   homepage 'https://www.x.org/'
-  version '2019.2'
+  version '2020.1'
   compatibility 'all'
-  source_url 'https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2019.2.tar.bz2'
-  source_sha256 '46ecd0156c561d41e8aa87ce79340910cdf38373b759e737fcbba5df508e7b8e'
+  source_url 'https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2020.1.tar.bz2'
+  source_sha256 '54a153f139035a376c075845dd058049177212da94d7a9707cf9468367b699d2'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2019.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2019.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2019.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2019.2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'd9e18300bfff03320a890f93f3596ef598c072384bc364bde913d5ff707dc6f2',
-     armv7l: 'd9e18300bfff03320a890f93f3596ef598c072384bc364bde913d5ff707dc6f2',
-       i686: '265aed098ec9396c8f8944412c1cf1c83d8268fe4c5a663567cb845ff64eb7be',
-     x86_64: '14fec9e0ec5ad52bbf1035a080f2c16be9533e2090b78f3d06336990ebd2b99f',
-  })
 
+  depends_on 'meson' => ':build'
+  depends_on 'llvm' => ':build'
+  
+   def self.patch
+	  # XKB: Mark key name arrays as not NUL-terminated strings
+	  patch_url = 'https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/commit/21e05da99c855481b638a7789ad5600b5b283680.patch'
+	  patch_sha256 = 'd3c39abc92c098107b21081ff5f2971a6e43b616e2e268057f1f89e49d65856f'
+  end
+  
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--datadir=#{CREW_LIB_PREFIX}",   # install *.pc in #{CREW_LIB_PREFIX}/pkgconfig
-           '--enable-strict-compilation',
-           '--enable-specs'
-    system 'make'
+    ENV['CC'] = 'clang'
+    ENV['CXX'] = 'clang'
+    system "meson",
+	    "-Dprefix=#{CREW_PREFIX}",
+	    "-Dlibdir=#{CREW_LIB_PREFIX}",
+	    "-Ddatadir=#{CREW_LIB_PREFIX}",
+	    '-Dbuildtype=release',
+	    "build"
+    system "meson configure build"
+    system "ninja -C build"
   end
   
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+   system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
   end
 end


### PR DESCRIPTION
Update to 2020.1, and use meson, clang.

(Using clang when possible as part of https://github.com/skycocker/chromebrew/pull/4450 )

Works properly:
- [x] x86_64
