### PR TITLE
Harfbuzz update to 2.7.2, use meson

### DIFF
--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -10,20 +10,19 @@ class Harfbuzz < Package
 
 
 #  depends_on 'cairo' => ':build'
-  depends_on 'glib' => ':build'
+  depends_on 'glib' => :build
 #  depends_on 'gobject_introspection' => ':build'
-  depends_on 'ragel' => ':build'
+  depends_on 'ragel' => :build
   depends_on 'freetype_sub'
-  depends_on 'six' => ':build'
-  depends_on 'meson' => ':build'
-#  depends_on 'graphite' => ':build'
+  depends_on 'six' => :build
+  depends_on 'meson' => :build
+  depends_on 'graphite' => :build
 
   def self.build
     ENV['CFLAGS'] = "-fuse-ld=lld"
     ENV['CXXFLAGS'] = "-fuse-ld=lld"
     system "meson",
-      "-Dprefix=#{CREW_PREFIX}",
-      "-Dlibdir=#{CREW_LIB_PREFIX}",
+      #{CREW_MESON_OPTIONS},
       "-Dintrospection=enabled",
       "-Dbenchmark=disabled",
       "-Dtests=disabled",

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -15,7 +15,6 @@ class Harfbuzz < Package
   depends_on 'ragel' => :build
   depends_on 'freetype_sub'
   depends_on 'six' => :build
-  depends_on 'meson' => :build
   depends_on 'graphite' => :build
 
   def self.build

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -9,16 +9,18 @@ class Harfbuzz < Package
   source_sha256 'b8c048d7c2964a12f2c80deb6634dfc836b603dd12bf0d0a3df1627698e220ce'
 
 
-  depends_on 'cairo' => ':build'
+#  depends_on 'cairo' => ':build'
   depends_on 'glib' => ':build'
-  depends_on 'gobject_introspection' => ':build'
+#  depends_on 'gobject_introspection' => ':build'
   depends_on 'ragel' => ':build'
   depends_on 'freetype_sub'
   depends_on 'six' => ':build'
   depends_on 'meson' => ':build'
-  depends_on 'graphite' => ':build'
+#  depends_on 'graphite' => ':build'
 
   def self.build
+    ENV['CFLAGS'] = "-fuse-ld=lld"
+    ENV['CXXFLAGS'] = "-fuse-ld=lld"
     system "meson",
       "-Dprefix=#{CREW_PREFIX}",
       "-Dlibdir=#{CREW_LIB_PREFIX}",

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -3,34 +3,35 @@ require 'package'
 class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
-  version '2.6.4'
+  version '2.7.2'
   compatibility 'all'
-  source_url 'https://github.com/harfbuzz/harfbuzz/releases/download/2.6.4/harfbuzz-2.6.4.tar.xz'
-  source_sha256 '9413b8d96132d699687ef914ebb8c50440efc87b3f775d25856d7ec347c03c12'
+  source_url 'https://github.com/harfbuzz/harfbuzz/releases/download/2.7.2/harfbuzz-2.7.2.tar.xz'
+  source_sha256 'b8c048d7c2964a12f2c80deb6634dfc836b603dd12bf0d0a3df1627698e220ce'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-2.6.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-2.6.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-2.6.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/harfbuzz-2.6.4-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'a8e4b59ff79cf7d445693aaf4cb3b942551d927be47436a70114e286947c5ee6',
-     armv7l: 'a8e4b59ff79cf7d445693aaf4cb3b942551d927be47436a70114e286947c5ee6',
-       i686: '10aa0c94e9a04d86ae06d9508aac0a1224942dffd2d3982aa7a7e27c14499ccf',
-     x86_64: '76d5d648508cb2a85c128d8a0a529ea0f57ff86982ddf5c1aa3fb277d76825dc',
-  })
 
-  depends_on 'glib'
+  depends_on 'cairo' => ':build'
+  depends_on 'glib' => ':build'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'ragel' => ':build'
   depends_on 'freetype_sub'
-  depends_on 'six' => :build
+  depends_on 'six' => ':build'
+  depends_on 'meson' => ':build'
+  depends_on 'graphite' => ':build'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "meson",
+      "-Dprefix=#{CREW_PREFIX}",
+      "-Dlibdir=#{CREW_LIB_PREFIX}",
+      "-Dintrospection=enabled",
+      "-Dbenchmark=disabled",
+      "-Dtests=disabled",
+      "-Dgraphite=enabled",
+      "-Ddocs=disabled",
+      "builddir"
+    system "meson compile -C builddir"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} meson install -C builddir"
   end
 end


### PR DESCRIPTION
Part of https://github.com/skycocker/chromebrew/pull/4450 and upcoming adwaita_icon_theme PR

There MAY be circular dependencies here...   Do we need a harfbuzz_sub package?

Works properly:
- [x] x86_64
