### PR TITLE
libRsvg Update to 2.50.1

### DIFF
--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -1,50 +1,43 @@
 require 'package'
 
 class Librsvg < Package
-  description 'Scalable Vector Graphics (SVG) rendering library.'
+  description 'SVG library for GNOME'
   homepage 'https://wiki.gnome.org/Projects/LibRsvg'
-  version '2.42.3'
+  version '2.50.1'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/librsvg/2.42/librsvg-2.42.3.tar.xz'
-  source_sha256 '704f2c44b9b170fc5498de36a161d01ca8f584ba9c42654b98565a7b7bcbe657'
+  source_url 'https://ftp.gnome.org/pub/GNOME/sources/librsvg/2.50/librsvg-2.50.1.tar.xz'
+  source_sha256 '9bd9799322e06cf5db19b9f7afb728edac6efcf0110baafc44f0f96f45df9a09'
 
-  binary_url ({
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.42.3-chromeos-x86_64.tar.xz',
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.42.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.42.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.42.3-chromeos-i686.tar.xz',
-  })
-  binary_sha256 ({
-     x86_64: '36d8876ec5ce51fd153cda5a64e52586e4a9853e3428cd1c24cf5be60f3a95ac',
-    aarch64: '692cdd07b2038a00220d1177a32692e56171188388282a4ca75a480ac26d78a2',
-     armv7l: '692cdd07b2038a00220d1177a32692e56171188388282a4ca75a480ac26d78a2',
-       i686: '2c590e62ab4bee72be2f8014c9b256d24fbdcf307c0f2ac44dcabee6c566cfdb',
-  })
-
-  depends_on 'gtk_doc'
-  depends_on 'vala'
   depends_on 'cairo'
-  depends_on 'pango'
-  depends_on 'libcroco'
-  depends_on 'gdk_pixbuf'
   depends_on 'gobject_introspection'
-  depends_on 'gtk3'
-  depends_on 'rust' => :build
-  depends_on 'six' => :build
-
+  depends_on 'freetype'
+  depends_on 'gdk_pixbuf'
+  depends_on 'libcroco'
+  depends_on 'pango'
+  depends_on 'rust' => ':build'
+  depends_on 'python3'
+  depends_on 'glib'
+  depends_on 'gdk_pixbuf'
+  depends_on 'vala' => ':build'
+  depends_on 'six' => ':build'
+  depends_on 'vala' => ':build'
+  
   def self.build
-    system "rustup install stable"
+  # Following rustup modification as per 
+  # https://github.com/rust-lang/rustup/issues/1167#issuecomment-367061388
+    system "rustup install stable || (rm -frv ~/.rustup/toolchains/* && rustup install stable)"
     system "rustup default stable"
     system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--enable-introspection",
-           "--enable-vala",
-           "--disable-static"
-    system "make"
+      "--prefix=#{CREW_PREFIX}",
+      "--libdir=#{CREW_LIB_PREFIX}",
+      "--enable-introspection=yes",
+      "--enable-vala=yes",
+      "--disable-static",
+      "--enable-pixbuf-loader",
+      "--disable-tools"
+      system 'make'
   end
-
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -14,21 +14,20 @@ class Librsvg < Package
   depends_on 'gdk_pixbuf'
   depends_on 'libcroco'
   depends_on 'pango'
-  depends_on 'rust' => ':build'
+  depends_on 'rust' => :build
   depends_on 'python3'
   depends_on 'glib'
   depends_on 'gdk_pixbuf'
-  depends_on 'vala' => ':build'
+  depends_on 'vala' => :build
   depends_on 'six' => ':build'
   
   def self.build
   # Following rustup modification as per 
   # https://github.com/rust-lang/rustup/issues/1167#issuecomment-367061388
-    system "rustup install stable || (rm -frv ~/.rustup/toolchains/* && rustup install stable)"
+    system "rustup install stable --profile minimal || (rm -frv ~/.rustup/toolchains/* && rustup install stable --profile minimal)"
     system "rustup default stable"
     system "./configure",
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}",
+      #{CREW_OPTIONS},
       "--enable-introspection=yes",
       "--enable-vala=yes",
       "--disable-static",

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -5,7 +5,7 @@ class Librsvg < Package
   homepage 'https://wiki.gnome.org/Projects/LibRsvg'
   version '2.50.1'
   compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/GNOME/sources/librsvg/2.50/librsvg-2.50.1.tar.xz'
+  source_url 'https://download.gnome.org/sources/librsvg/2.50/librsvg-2.50.1.tar.xz'
   source_sha256 '9bd9799322e06cf5db19b9f7afb728edac6efcf0110baafc44f0f96f45df9a09'
 
   depends_on 'cairo'

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -20,7 +20,6 @@ class Librsvg < Package
   depends_on 'gdk_pixbuf'
   depends_on 'vala' => ':build'
   depends_on 'six' => ':build'
-  depends_on 'vala' => ':build'
   
   def self.build
   # Following rustup modification as per 

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -15,11 +15,9 @@ class Librsvg < Package
   depends_on 'libcroco'
   depends_on 'pango'
   depends_on 'rust' => :build
-  depends_on 'python3'
   depends_on 'glib'
-  depends_on 'gdk_pixbuf'
   depends_on 'vala' => :build
-  depends_on 'six' => ':build'
+  depends_on 'six' => :build
   
   def self.build
   # Following rustup modification as per 


### PR DESCRIPTION
Update LibRsvg to 2.50.1 and fix logic in case Rust install is broken.

Works properly:
- [x] x86_64
