### PR TITLE
mesa update to 20.2.1, use gcc10 for building

### DIFF
--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -34,9 +34,7 @@ class Mesa < Package
 
     # Just use mostly defaults.
     system "meson",
-      "-Dprefix=#{CREW_PREFIX}",
-      "-Dlibdir=#{CREW_LIB_PREFIX}",
-      "-Dbuildtype=release",
+      #{CREW_MESON_OPTIONS},
       "builddir"
     system "ninja -C builddir"
   end

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -9,6 +9,7 @@ class Mesa < Package
   source_sha256 'd1a46d9a3f291bc0e0374600bdcb59844fa3eafaa50398e472a36fc65fd0244a'
   
 
+  depends_on 'gcc10' => :build
   depends_on 'setuptools' => :build
   depends_on 'libva'
   depends_on 'libvdpau'
@@ -27,11 +28,10 @@ class Mesa < Package
     system "pip3 uninstall -y Mako MarkupSafe || :"
     system "pip3 install --prefix \"#{CREW_PREFIX}\" --root \"#{CREW_DEST_DIR}\" Mako"
     system "pip3 install --prefix \"#{CREW_PREFIX}\" Mako"
-    # Workaround for lld having issues with gcc(8?) on arm7l.
-    if ARCH =~ /^(x86_64|i686|aarch64)$/
-      ENV['CFLAGS'] = "-fuse-ld=lld"
-      ENV['CXXFLAGS'] = "-fuse-ld=lld"
-    end
+    
+    ENV['CFLAGS'] = "-fuse-ld=lld"
+    ENV['CXXFLAGS'] = "-fuse-ld=lld"
+
     # Just use mostly defaults.
     system "meson",
       "-Dprefix=#{CREW_PREFIX}",

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -9,19 +9,19 @@ class Mesa < Package
   source_sha256 'd1a46d9a3f291bc0e0374600bdcb59844fa3eafaa50398e472a36fc65fd0244a'
   
 
-  depends_on 'setuptools' => ':build'
+  depends_on 'setuptools' => :build
   depends_on 'libva'
   depends_on 'libvdpau'
   depends_on 'wayland_protocols'
   depends_on 'elfutils'
-  depends_on 'llvm' => ':build'
-  depends_on 'meson' => ':build'
+  depends_on 'llvm' => :build
+  depends_on 'meson' => :build
   depends_on 'libdrm'
-  depends_on 'libunwind' => ':build'
-  depends_on 'vulkan_headers' => ':build'
-  depends_on 'vulkan_icd_loader' => ':build'
-  depends_on 'glslang' => ':build'
-  depends_on 'zstd' => ':build'
+  depends_on 'libunwind' => :build
+  depends_on 'vulkan_headers' => :build
+  depends_on 'vulkan_icd_loader' => :build
+  depends_on 'glslang' => :build
+  depends_on 'zstd' => :build
 
   def self.build
     system "pip3 uninstall -y Mako MarkupSafe || :"

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -3,54 +3,40 @@ require 'package'
 class Mesa < Package
   description 'Open-source implementation of the OpenGL specification'
   homepage 'https://www.mesa3d.org'
-  version '20.2.0'
+  version '20.2.1'
   compatibility 'all'
-  source_url 'https://mesa.freedesktop.org/archive/mesa-20.2.0.tar.xz'
-  source_sha256 '63f0359575d558ef98dd78adffc0df4c66b76964ebf603b778b7004964191d30'
+  source_url 'https://mesa.freedesktop.org/archive/mesa-20.2.1.tar.xz'
+  source_sha256 'd1a46d9a3f291bc0e0374600bdcb59844fa3eafaa50398e472a36fc65fd0244a'
+  
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-20.2.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-20.2.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-20.2.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mesa-20.2.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '48ea7803900737f3cb039916a194803df7c74350856baf1e32867f4c7dbaffc4',
-     armv7l: '48ea7803900737f3cb039916a194803df7c74350856baf1e32867f4c7dbaffc4',
-       i686: '09e41a089c50399f2b5667d19214df84e7542c1e35a9f2a48e3b1d1c844df69e',
-     x86_64: '8dc082dc17b1ba23d3e6590b7696dbdfcb63ed5a03fb22c7682ecd6fce529642',
-  })
-
-  depends_on 'setuptools' => :build
+  depends_on 'setuptools' => ':build'
   depends_on 'libva'
   depends_on 'libvdpau'
   depends_on 'wayland_protocols'
   depends_on 'elfutils'
-  depends_on 'llvm'
+  depends_on 'llvm' => ':build'
+  depends_on 'meson' => ':build'
   depends_on 'libdrm'
+  depends_on 'libunwind' => ':build'
+  depends_on 'vulkan_headers' => ':build'
+  depends_on 'vulkan_icd_loader' => ':build'
+  depends_on 'glslang' => ':build'
+  depends_on 'zstd' => ':build'
 
   def self.build
     system "pip3 uninstall -y Mako MarkupSafe || :"
     system "pip3 install --prefix \"#{CREW_PREFIX}\" --root \"#{CREW_DEST_DIR}\" Mako"
     system "pip3 install --prefix \"#{CREW_PREFIX}\" Mako"
+    # Workaround for lld having issues with gcc(8?) on arm7l.
+    if ARCH =~ /^(x86_64|i686|aarch64)$/
+      ENV['CFLAGS'] = "-fuse-ld=lld"
+      ENV['CXXFLAGS'] = "-fuse-ld=lld"
+    end
+    # Just use mostly defaults.
     system "meson",
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}",
-      "-Dshared-glapi=true",
-      "-Dgallium-drivers=auto",
-      "-Ddri-drivers=auto",
-      "-Dosmesa=classic",
-      "-Dopengl=true",
-      "-Degl=auto",
-      "-Dgallium-xvmc=auto",
-      "-Dgallium-nine=true",
-      "-Dgles1=auto",
-      "-Dgles2=auto",
-      "-Dplatforms=x11,drm,wayland",
-      "-Dgbm=auto",
-      "-Dgallium-xa=auto",
-      "-Dglx=auto",
-      "-Dllvm=true",
+      "-Dprefix=#{CREW_PREFIX}",
+      "-Dlibdir=#{CREW_LIB_PREFIX}",
+      "-Dbuildtype=release",
       "builddir"
     system "ninja -C builddir"
   end


### PR DESCRIPTION
Use as many defaults as possible since meson can figure them out.

Also enable clang lld for non-arm7l since at least on x86_64 this seems to be important to enabling graphics acceleration via sommelier. I believe this is the final part of https://github.com/skycocker/chromebrew/pull/4450 for enabling graphics acceleration.

(If llvm's linker works with a newer GCC on arm7l the conditional switch should be removed and lld should be enabled for al architectures.)

Works properly:
- [x] x86_64
