### PR TITLE
Vala: Fix build error due to configure failure

### DIFF
--- a/packages/vala.rb
+++ b/packages/vala.rb
@@ -14,6 +14,13 @@ class Vala < Package
   depends_on 'glib'
   depends_on 'dbus'
 
+  # Configure failure causes build issues on arm7l with 0.50.1
+  # See https://web.archive.org/web/20141023144118/http://www.graphviz.org/bugs/b1966.html
+  # for discussion of why this might be happening.
+  if ARCH =~ /^(arm7l|aarch64)$/
+    ENV['LDFLAGS'] = '-lm'
+  end
+  
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system "make"


### PR DESCRIPTION
See https://web.archive.org/web/20141023144118/http://www.graphviz.org/bugs/b1966.html

In short, the sincos, etc errors are due to configure assuming that mlib functions are available without ```-lm``` but that's not actually the case with arm7l gcc?


Fixes #4474 

Works properly:
- [x] x86_64
- [x] armv7l (compiled on a M85 fievel recovery image based system with ```CFLAGS="-march=armv7-a"``` & gcc10 & a graphviz update, but the latter probably isn't necessary. If so, one could always update that too.)
