### PR TITLE
Use builtin curl & have curl retry downloads

### DIFF
--- a/crew
+++ b/crew
@@ -494,9 +494,9 @@ def download
   end
   Dir.chdir CREW_BREW_DIR do
     if @opt_verbose then
-      system('curl', '-v', '--progress-bar', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
+      system('/usr/bin/curl', '-v', '--retry', '3', '--progress-bar', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
     else
-      system('curl', '--progress-bar', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
+      system('/usr/bin/curl', '--retry', '3', '--progress-bar', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
     end
     abort 'Checksum mismatch. :/ Try again.'.lightred unless
       Digest::SHA256.hexdigest( File.read("./#{filename}") ) == sha256sum


### PR DESCRIPTION
I'm getting tons of download failures on a sketchy connection. It would be nice if curl retried connections from crew commands.

Crew also crashes if I try to update libiconv. Can we just use the system ```/usr/bin/curl``` from crew? Are there any systems without a working built-in curl?

Works properly:
- [x] x86_64
- [x] arm7l (only tested in build container)
