### PR TITLE
Add logic for virtualized building of armv7l

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.4.4'
+CREW_VERSION = '1.4.5'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,11 @@
 
 CREW_VERSION = '1.4.4'
 
-ARCH = `uname -m`.strip
+ARCH_ACTUAL = `uname -m`.strip
+# This helps with virtualized builds on aarch64 machines
+# which report armv8l when linux32 is run.
+ARCH = if ARCH_ACTUAL == 'armv8l' then 'armv7l' else ARCH_ACTUAL end
+
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
 LIBC_VERSION = if File.exist? "/#{ARCH_LIB}/libc-2.27.so" then '2.27' else '2.23' end
 


### PR DESCRIPTION
#{CREW_OPTIONS} logic is predicated upon selecting the correct option from x86_64, arm7l, and aarch64 taken from ```uname -m```. However, when running in linux32 on aarch64, one is likely to get ```armv8l```. This changes the logic slightly such that when running in armv8l one is identified in crew as armv7l, which lets the #{CREW_OPTIONS} macro work correctly for testing armv7l builds.

Works properly:
- [x] x86_64 (libressl 3.2.2 builds just fine.)
- [x] armv7l (libressl builds just fine in my docker container)
