### PR TITLE
Add pre-built binaries for packages a-z

### DIFF
--- a/packages/apulse.rb
+++ b/packages/apulse.rb
@@ -9,8 +9,16 @@ class Apulse < Package
   source_sha256 '9234ec4e10e408b9c01d5f4ea768ad1fc15494217c932db2c435202a9c7b5efd'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/apulse-0.1.13-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/apulse-0.1.13-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/apulse-0.1.13-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/apulse-0.1.13-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'f5c79d86e9b448988428783b19faaf6f1d1ed3547d2ecd3667557530bb35ceda',
+     armv7l: 'f5c79d86e9b448988428783b19faaf6f1d1ed3547d2ecd3667557530bb35ceda',
+       i686: 'd471be802d11b38a24b55de9f6d095611e91f467c8b6850db043dab9c9ce89a6',
+     x86_64: '30b5533b7da5d2aeb8be93caf3e9a02db3a2f8479634d89c3dd38a290b2b6c90',
   })
 
 

--- a/packages/glmark2.rb
+++ b/packages/glmark2.rb
@@ -10,6 +10,19 @@ class Glmark2 < Package
   source_url 'https://github.com/glmark2/glmark2/archive/2020.04.tar.gz'
   source_sha256 '0fa7723111c928a73c04d4fa4adfc15a9dea6d335fe189f59c74ae5af26f99a2'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glmark2-2020.04-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glmark2-2020.04-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glmark2-2020.04-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glmark2-2020.04-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e4a59d48fdb44be2e3a8cbec3c0b9cd5c10a1dae8d07121010fd73b6986015d2',
+     armv7l: 'e4a59d48fdb44be2e3a8cbec3c0b9cd5c10a1dae8d07121010fd73b6986015d2',
+       i686: '49227b2fdedf881b927ca755404164587daf56ed1968854f2bb03071724d52a5',
+     x86_64: '32ed34762096df02768643f7781c7e1a587ce95e6cfd0a5ddbf6c4720b87d923',
+  })
+
   depends_on 'libjpeg_turbo'
   depends_on 'libpng'
   depends_on 'libx11'

--- a/packages/glslang.rb
+++ b/packages/glslang.rb
@@ -10,6 +10,19 @@ class Glslang < Package
   source_url 'https://github.com/KhronosGroup/glslang/archive/8.13.3743.tar.gz'
   source_sha256 '639ebec56f1a7402f2fa094469a5ddea1eceecfaf2e9efe361376a0f73a7ee2f'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glslang-8.13.3743-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glslang-8.13.3743-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glslang-8.13.3743-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glslang-8.13.3743-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '927f23fc3390cc2b66da76f8ebab2ed55e04c2544d8ed5ce3ce84f734d6631d6',
+     armv7l: '927f23fc3390cc2b66da76f8ebab2ed55e04c2544d8ed5ce3ce84f734d6631d6',
+       i686: '73a6dd675301d314921c69f016659cfe1c520176ece194eac6e47b934706b213',
+     x86_64: '51de97dab57fb0e21f4b0746b1117cca66481d8dfe63065edda8f122feaceb6f',
+  })
+
   def self.build
     system "./update_glslang_sources.py"
     

--- a/packages/graphite.rb
+++ b/packages/graphite.rb
@@ -8,6 +8,19 @@ class Graphite < Package
   source_url 'https://github.com/silnrsi/graphite/releases/download/1.3.14/graphite2-1.3.14.tgz'
   source_sha256 'f99d1c13aa5fa296898a181dff9b82fb25f6cc0933dbaa7a475d8109bd54209d'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/graphite-1.3.14-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/graphite-1.3.14-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/graphite-1.3.14-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/graphite-1.3.14-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '9820ae85855aa87264a16ee685ccafb83ef0a47ae3d90870d29f975aa2826bb1',
+     armv7l: '9820ae85855aa87264a16ee685ccafb83ef0a47ae3d90870d29f975aa2826bb1',
+       i686: '2a4fa173fd103be07f1d3b571136ce88bfc30915b8cbf3c5286028b022505067',
+     x86_64: '4fa9b76604330c23c0cf84650698c21e2715a42238841f963bbd6dcf4785ba77',
+  })
+
   depends_on 'freetype'
   
   def self.build

--- a/packages/libxdmcp.rb
+++ b/packages/libxdmcp.rb
@@ -8,6 +8,19 @@ class Libxdmcp < Package
   source_url 'https://www.x.org/pub/individual/lib/libXdmcp-1.1.3.tar.bz2'
   source_sha256 '20523b44aaa513e17c009e873ad7bbc301507a3224c232610ce2e099011c6529'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.3-0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.3-0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.3-0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxdmcp-1.1.3-0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'ef0521827a14d8b96ebebc7b427862a034d9aaf3bcb8a91d87a5210b64e1935f',
+     armv7l: 'ef0521827a14d8b96ebebc7b427862a034d9aaf3bcb8a91d87a5210b64e1935f',
+       i686: '2bde707c2fa208e763c691f7bd7c3ad79613d15f9a3068a528af5ba9809e26c3',
+     x86_64: 'c36427179ecf0ff60f51907008834c588fd533869b05d5487f309ad7235eccfa',
+  })
+
   depends_on "xorg_proto"
   depends_on "llvm" => ':build'
 

--- a/packages/mpv.rb
+++ b/packages/mpv.rb
@@ -9,9 +9,17 @@ class Mpv < Package
   source_sha256 '9163f64832226d22e24bbc4874ebd6ac02372cd717bef15c28a0aa858c5fe592'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.32.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.32.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.32.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.32.0-chromeos-x86_64.tar.xz',
     
   })
   binary_sha256 ({
+    aarch64: 'ae9f812ccb3239ca85d25a6e919e1ded6e459867ba00d2027ea832782a38f9f1',
+     armv7l: 'ae9f812ccb3239ca85d25a6e919e1ded6e459867ba00d2027ea832782a38f9f1',
+       i686: '41f96ce28132e2d60978c3e7450594b58b03fda67edbb8fa2e56ce6442d3d1ee',
+     x86_64: 'e9623b3fdd06ab5bb762a15a3d7ef9b7875a10d4f0a5baaed5f83b9250b9fbe4',
     
   })
 

--- a/packages/pcre2.rb
+++ b/packages/pcre2.rb
@@ -8,6 +8,19 @@ class Pcre2 < Package
   source_url 'https://ftp.pcre.org/pub/pcre/pcre2-10.35.tar.gz'
   source_sha256 '8fdcef8c8f4cd735169dd0225fd010487970c1bcadd49e9b90e26c7250a33dc9'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.35-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.35-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.35-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre2-10.35-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '73b9d315438b67b8478fe64a13755f2e1f1fb817bd3462a08d28c4d2b8d8f478',
+     armv7l: '73b9d315438b67b8478fe64a13755f2e1f1fb817bd3462a08d28c4d2b8d8f478',
+       i686: '6322b0b2c26d8db0b4538eb2427b14733e30b2dc660ae151d6f97bcb1d3b0a70',
+     x86_64: 'e792c0702d2c05ba5f19b6f4a7a89ba59b38a0bcf17144dcde3850a06009a727',
+  })
+
 
   depends_on 'libtool' => :build
 

--- a/packages/r.rb
+++ b/packages/r.rb
@@ -8,6 +8,19 @@ class R < Package
   source_url 'https://cran.r-project.org/src/base/R-4/R-4.0.3.tar.gz'
   source_sha256 '09983a8a78d5fb6bc45d27b1c55f9ba5265f78fa54a55c13ae691f87c5bb9e0d'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/r-4.0.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/r-4.0.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/r-4.0.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/r-4.0.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'a02c0c2dbc2550b88ca84a733340f1059dc3b419c79628181a51855209340063',
+     armv7l: 'a02c0c2dbc2550b88ca84a733340f1059dc3b419c79628181a51855209340063',
+       i686: 'c6ed99b4cafa87e7cf02b39f8433ce556a88c99dc6065cc46e9f3273f15f07d7',
+     x86_64: '925dfcc3add3c3039ff56135d483417581a7ba04449c1aff7d10149e2f5fad36',
+  })
+
 
 
   # depends_on 'gfortran'       # require gfortran enabled gcc

--- a/packages/vala.rb
+++ b/packages/vala.rb
@@ -8,6 +8,19 @@ class Vala < Package
   source_url 'https://download.gnome.org/sources/vala/0.50/vala-0.50.1.tar.xz'
   source_sha256 '958d9f06c9c3d7d1b2145512a9bc2a7c6aefbbf0416a04c7a0ecf463f7138f6c'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.50.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.50.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.50.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.50.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '38cb06cd9804c2ce375e637a1ab7e3f65d54fc0bb6d8e12e9af795d2ed99c58b',
+     armv7l: '38cb06cd9804c2ce375e637a1ab7e3f65d54fc0bb6d8e12e9af795d2ed99c58b',
+       i686: 'a999cbaa519fa66d072c30e6c147ebe94110eef9651732dfe09db6d6318e5c16',
+     x86_64: '5bdbef5e4f78303c0ab24333b552e797c7c7db3c1626af8c64b19e433a1cd764',
+  })
+
   depends_on 'flex'
   depends_on 'graphviz'
   depends_on 'libxslt'
@@ -15,11 +28,11 @@ class Vala < Package
   depends_on 'dbus'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "./configure #{CREW_OPTIONS} --disable-maintainer-mode --disable-valadoc"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -10,6 +10,19 @@ class Vulkan_headers < Package
   source_url 'https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.157.tar.gz'
   source_sha256 'dbc121f58641acd45c386ee96ecd5e10a124c489087443d7367fff4b53b49283'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.157-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.157-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.157-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.157-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'b130e7ad0d764c3e829d0da62260ebdbe192deb699a1540eb9a347b2c1948429',
+     armv7l: 'b130e7ad0d764c3e829d0da62260ebdbe192deb699a1540eb9a347b2c1948429',
+       i686: '75afde70082d150fbf190381da67e6d179968c8d0ecd59151b57a2fade44e8dc',
+     x86_64: '6bc64672860d7c8dc181d730b892ade24003e28b86102be78df28a6025d390b6',
+  })
+
   depends_on 'cmake'
   depends_on 'git'
   depends_on 'cmake' => ':build'

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -10,6 +10,19 @@ class Vulkan_icd_loader < Package
   source_url 'https://github.com/KhronosGroup/Vulkan-Loader/archive/v1.2.153.tar.gz'
   source_sha256 '5fb906b2dc968f2256f2d09b093ec8cc7f19812d656c649de8ed709a6da63d4a'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.153-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.153-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.153-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.153-2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '5756b62ea74988eef3cbf9e189ded23fb826848f086b5f809309276c7556d5eb',
+     armv7l: '5756b62ea74988eef3cbf9e189ded23fb826848f086b5f809309276c7556d5eb',
+       i686: '0505cb5556abb969fca4378f7d16979fa38739a6804c4dce7f2e3965cea0eeb6',
+     x86_64: 'f234c7327d2044847bd39d354aa0769997da8797162f2ae7b818de6b53de9a1a',
+  })
+
   depends_on 'libx11'
   depends_on 'libxrandr'
   depends_on 'vulkan_headers'

--- a/packages/xorg_proto.rb
+++ b/packages/xorg_proto.rb
@@ -8,6 +8,19 @@ class Xorg_proto < Package
   source_url 'https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2020.1.tar.bz2'
   source_sha256 '54a153f139035a376c075845dd058049177212da94d7a9707cf9468367b699d2'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2020.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2020.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2020.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_proto-2020.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '08d973f150fb2c4b421f50d2f9e960be4f23b8a096437a2e6b6c88ad15ea6138',
+     armv7l: '08d973f150fb2c4b421f50d2f9e960be4f23b8a096437a2e6b6c88ad15ea6138',
+       i686: '6c3b8c73f47cde6f77eaaec3bd25c5b9d9fdceb6c8a0e117ef35a32c3e7bc973',
+     x86_64: '57daeddeec66badd0a0090624cbd86ac16c6599a5cbeb2977546881ae45a0edb',
+  })
+
 
   depends_on 'meson' => ':build'
   depends_on 'llvm' => ':build'

--- a/packages/zathura.rb
+++ b/packages/zathura.rb
@@ -4,20 +4,33 @@ class Zathura < Package
   description 'zathura is a highly customizable and functional PDF document viewer'
   homepage 'https://pwmt.org/projects/zathura/'
   version '0.4.7'
-  compatibility 'all'
-  source_url 'https://pwmt.org/projects/zathura/download/zathura-0.4.7.tar.xz'
-  source_sha256 'e012dbfe2b981b826553a9af8420d42a9c5d3387fbe14a5399ce94a2d374a1e7'
+  compatibility 'aarch64,armv7l,x86_64'
+  case ARCH
+  when 'aarch64', 'armv7l', 'x86_64'
+    source_url 'https://pwmt.org/projects/zathura/download/zathura-0.4.7.tar.xz'
+    source_sha256 'e012dbfe2b981b826553a9af8420d42a9c5d3387fbe14a5399ce94a2d374a1e7'
+    depends_on 'appstream_glib'
+    depends_on 'bash_completion'
+    depends_on 'desktop_file_utilities'
+    depends_on 'fish'
+    depends_on 'girara'
+    depends_on 'libseccomp'
+    depends_on 'zathura_poppler_pdf'
+  end
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/zathura-0.4.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/zathura-0.4.7-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/zathura-0.4.7-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '401655bbb1a8f83cbcd158e67370abc105a292027f8b35ccbe6af04755b33d61',
+     armv7l: '401655bbb1a8f83cbcd158e67370abc105a292027f8b35ccbe6af04755b33d61',
+     x86_64: '7b56a87ff85d05ebcd9c8ea7cad130f861d9f3f6deaad0e8934ccc24ab4f87f1',
   })
 
-  depends_on 'girara'
-  depends_on 'zathura_poppler_pdf'
-
   def self.build
-    system "meson  --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
+    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} -Dmanpages=disabled -Dsynctex=disabled builddir"
     system "ninja -C builddir"
   end
 

--- a/tools/needs_binaries.sh
+++ b/tools/needs_binaries.sh
@@ -23,7 +23,7 @@ fi
 if [[ "${arch}" == 'i686' ]]; then
   exclusions+=' aqemu.rb atom.rb codelite.rb cras.rb dia.rb exa.rb fakeroot_ng.rb fzf.rb gcr.rb geany.rb gemacs.rb gimp.rb gitkraken.rb gnome_keyring.rb gtk_engines_adwaita.rb'
   exclusions+=' handbrake.rb imagemagick6.rb imagemagick7.rb libgnome_keyring.rb librespot.rb libvncserver.rb neovim.rb opera.rb poppler.rb ripgrep.rb rust.rb skype.rb tcpflow.rb'
-  exclusions+=' wing.rb xorg_intel_driver.rb'
+  exclusions+=' wing.rb xorg_intel_driver.rb zathura.rb'
 fi
 packages=$(grep -L "${arch}:" *.rb)
 for p in ${packages}; do

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1619,6 +1619,11 @@ url: https://github.com/g-truc/glm/releases/
 activity: medium
 ---
 kind: url
+name: glmark2
+url: https://github.com/glmark2/glmark2/releases/
+activity: medium
+---
+kind: url
 name: glog
 url: https://github.com/google/glog/releases
 activity: low
@@ -1627,6 +1632,11 @@ kind: url
 name: glproto
 url: https://github.com/freedesktop/glproto/releases
 activity: none
+---
+kind: url
+name: glslang
+url: https://github.com/KhronosGroup/glslang/releases/
+activity: medium
 ---
 kind: url
 name: glyr
@@ -1771,6 +1781,11 @@ activity: medium
 kind: url
 name: graphicsmagick
 url: https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/
+activity: medium
+---
+kind: url
+name: graphite
+url: https://github.com/silnrsi/graphite/releases
 activity: medium
 ---
 kind: url
@@ -4514,6 +4529,11 @@ url: https://github.com/pipeseroni/pipesX.sh/releases
 activity: none
 ---
 kind: url
+name: pipewire
+url: https://gitlab.freedesktop.org/pipewire/pipewire/-/tags
+activity: high
+---
+kind: url
 name: pixman
 url: https://www.cairographics.org/releases/
 activity: none
@@ -5674,6 +5694,11 @@ url: https://github.com/pypa/virtualenv/releases
 activity: low
 ---
 kind: url
+name: vivaldi
+url: https://vivaldi.com/download/
+activity: medium
+---
+kind: url
 name: vpnc
 url: https://www.unix-ag.uni-kl.de/~massar/vpnc
 activity: none
@@ -5682,6 +5707,16 @@ kind: url
 name: vtable_dumper
 url: https://github.com/lvc/vtable-dumper/releases
 activity: none
+---
+kind: url
+name: vulkan_headers
+url: https://github.com/KhronosGroup/Vulkan-Headers/releases
+activity: high
+---
+kind: url
+name: vulkan_icd_loader
+url: https://github.com/KhronosGroup/Vulkan-Loader/releases
+activity: high
 ---
 kind: url
 name: waf


### PR DESCRIPTION
- Add new packages to packages.yaml
- Exclude zathura for i686 in needs_binaries.sh
- Tested on all architectures