### PR TITLE
Add adwaita_icon_theme

### DIFF
--- a/packages/adwaita_icon_theme.rb
+++ b/packages/adwaita_icon_theme.rb
@@ -12,15 +12,17 @@ class Adwaita_icon_theme < Package
   depends_on 'librsvg'
   depends_on 'gdk_pixbuf' 
   depends_on 'vala' => :build
+  depends_on 'llvm' => :build
+  depends_on 'xdg_base'
   
   def self.build
     ENV['CFLAGS'] = "-fuse-ld=lld"
     ENV['CXXFLAGS'] = "-fuse-ld=lld"
     ENV['GDK_PIXBUF_MODULEDIR'] = "#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders"
     ENV['GDK_PIXBUF_MODULE_FILE'] = "#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
-    ENV['LIBRARY_PATH'] = "#{CREW_LIB_PREFIX}:/usr/$ARCH_LIB:/$ARCH_LIB:/usr/lib:/lib"
+    ENV['LIBRARY_PATH'] = "#{CREW_LIB_PREFIX}:/usr/#{ARCH_LIB}:/#{ARCH_LIB}"
     # Need to make sure svg support is properly loaded otherwise build fails.
-    system "LD_LIBRARY_PATH=#{CREW_LIB_PREFIX}:/usr/#{ARCH_LIB}:/#{ARCH_LIB}:/usr/lib:/lib #{CREW_PREFIX}/sbin/ldconfig"
+    system "LD_LIBRARY_PATH=#{CREW_LIB_PREFIX}:/usr/#{ARCH_LIB}:/#{ARCH_LIB} #{CREW_PREFIX}/sbin/ldconfig"
     system "gdk-pixbuf-query-loaders > #{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     system "./configure #{CREW_OPTIONS} "
     system 'make'
@@ -31,6 +33,8 @@ class Adwaita_icon_theme < Package
   
     def self.postinstall
     puts "To add basic settings, execute the following:".lightblue
+    puts "Note that this will overwrite any existing ~/.config/gtk-3.0/settings.ini file!".lightred
+    puts
     puts "mkdir #{HOME}/.config/gtk-3.0".lightblue
     puts "cat << 'EOF' > #{HOME}/.config/gtk-3.0/settings.ini
 [Settings]

--- a/packages/adwaita_icon_theme.rb
+++ b/packages/adwaita_icon_theme.rb
@@ -22,7 +22,6 @@ class Adwaita_icon_theme < Package
     ENV['GDK_PIXBUF_MODULE_FILE'] = "#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     ENV['LIBRARY_PATH'] = "#{CREW_LIB_PREFIX}:/usr/#{ARCH_LIB}:/#{ARCH_LIB}"
     # Need to make sure svg support is properly loaded otherwise build fails.
-    system "LD_LIBRARY_PATH=#{CREW_LIB_PREFIX}:/usr/#{ARCH_LIB}:/#{ARCH_LIB} #{CREW_PREFIX}/sbin/ldconfig"
     system "gdk-pixbuf-query-loaders > #{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
     system "./configure #{CREW_OPTIONS} "
     system 'make'

--- a/packages/adwaita_icon_theme.rb
+++ b/packages/adwaita_icon_theme.rb
@@ -1,0 +1,44 @@
+require 'package'
+
+class Adwaita_icon_theme < Package
+  description 'Theme consisting of a set of icons for GTK+'
+  homepage 'https://gitlab.gnome.org/GNOME/adwaita-icon-theme'
+  version '3.38.0'
+  compatibility 'all'
+  source_url 'https://ftp.gnome.org/pub/GNOME/sources/adwaita-icon-theme/3.38/adwaita-icon-theme-3.38.0.tar.xz'
+  source_sha256 '6683a1aaf2430ccd9ea638dd4bfe1002bc92b412050c3dba20e480f979faaf97'
+
+  depends_on 'gtk3'
+  depends_on 'librsvg'
+  depends_on 'gdk_pixbuf' 
+  depends_on 'vala' => :build
+  
+  def self.build
+    ENV['CFLAGS'] = "-fuse-ld=lld"
+    ENV['CXXFLAGS'] = "-fuse-ld=lld"
+    ENV['GDK_PIXBUF_MODULEDIR'] = "#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders"
+    ENV['GDK_PIXBUF_MODULE_FILE'] = "#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+    ENV['LIBRARY_PATH'] = "#{CREW_LIB_PREFIX}:/usr/$ARCH_LIB:/$ARCH_LIB:/usr/lib:/lib"
+    # Need to make sure svg support is properly loaded otherwise build fails.
+    system "LD_LIBRARY_PATH=#{CREW_LIB_PREFIX}:/usr/#{ARCH_LIB}:/#{ARCH_LIB}:/usr/lib:/lib #{CREW_PREFIX}/sbin/ldconfig"
+    system "gdk-pixbuf-query-loaders > #{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+    system "./configure #{CREW_OPTIONS} "
+    system 'make'
+  end
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+  
+    def self.postinstall
+    puts "To add basic settings, execute the following:".lightblue
+    puts "mkdir #{HOME}/.config/gtk-3.0".lightblue
+    puts "cat << 'EOF' > #{HOME}/.config/gtk-3.0/settings.ini
+[Settings]
+gtk-application-prefer-dark-theme = false
+gtk-icon-theme-name = adwaita
+gtk-fallback-icon-theme = gnome
+gtk-font-name = Arial 10
+EOF".lightblue
+    puts
+  end
+end


### PR DESCRIPTION
Compilation is tricky, in that it depends upon other packages being fully installed properly, including gdk_pixbuf & librsvg, but once those are installed with proper svg support everything works fine.

Works properly:
- [x] x86_64
- [x] armv7l 
