### PR TITLE
Libxrandr has a libxext dependency.

### DIFF
--- a/packages/libxrandr.rb
+++ b/packages/libxrandr.rb
@@ -11,6 +11,7 @@ class Libxrandr < Package
 
   depends_on 'libxrender'
   depends_on 'libx11'
+  depends_on 'libxext'
   depends_on 'llvm' => ':build'
 
   def self.build


### PR DESCRIPTION
Fixes #4489 

Works properly:
- [x] x86_64
- [x] i686

(Using a fresh [docker container](https://gist.github.com/satmandu/791dd6e982d365dda6bbba5c332f0f73) to test individual package installs, missing dependencies become obvious!)