### PR TITLE
graphite: freetype isn't needed after building

### DIFF
--- a/packages/graphite.rb
+++ b/packages/graphite.rb
@@ -3,7 +3,7 @@ require 'package'
 class Graphite < Package
   description 'Reimplementation of the SIL Graphite text processing engine'
   homepage 'https://github.com/silnrsi/graphite'
-  version '1.3.14'
+  version '1.3.14-1'
   compatibility 'all'
   source_url 'https://github.com/silnrsi/graphite/releases/download/1.3.14/graphite2-1.3.14.tgz'
   source_sha256 'f99d1c13aa5fa296898a181dff9b82fb25f6cc0933dbaa7a475d8109bd54209d'

--- a/packages/graphite.rb
+++ b/packages/graphite.rb
@@ -21,7 +21,7 @@ class Graphite < Package
      x86_64: '4fa9b76604330c23c0cf84650698c21e2715a42238841f963bbd6dcf4785ba77',
   })
 
-  depends_on 'freetype'
+  depends_on 'freetype_sub' => :build
   
   def self.build
     Dir.mkdir 'build'


### PR DESCRIPTION
Trying to eliminate a circular dependency in building harfbuzz.

This shouldn't require a rebuild.

Works properly:
- [x] x86_64

