### PR TITLE
Freetype update to 2.10.4

### DIFF
--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -3,23 +3,10 @@ require 'package'
 class Freetype < Package
   description 'FreeType is a freely available software library to render fonts.'
   homepage 'https://www.freetype.org/'
-  version '2.10.1'
+  version '2.10.4'
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.10.1.tar.xz'
-  source_sha256 '16dbfa488a21fe827dc27eaf708f42f7aa3bb997d745d31a19781628c36ba26f'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.10.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.10.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.10.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype-2.10.1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '227d47ee4d7b5cb50cbe4be8cec8be7125ebd28d96e649972aa8ba2e947a5fa2',
-     armv7l: '227d47ee4d7b5cb50cbe4be8cec8be7125ebd28d96e649972aa8ba2e947a5fa2',
-       i686: 'de195bd3d95afa2ba8e0ef7bf137d957037d41b356ee482f6b270e6cf0780780',
-     x86_64: 'ccadfa7f9242639930dd5ae0fd9ac1609901ffefb33842c4dbd63f729f853a74',
-  })
+  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.xz'
+  source_sha256 '86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784'
 
   depends_on 'expat'
   depends_on 'libpng'   # freetype needs zlib optionally. zlib is also the dependency of libpng

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -3,23 +3,10 @@ require 'package'
 class Freetype_sub < Package
   description 'Freetype_sub is a version without harfbuzz. It is intended to handle circular dependency betwwen freetype and harfbuzz.'
   homepage 'https://www.freetype.org/'
-  version '2.10.1'
+  version '2.10.4'
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.10.1.tar.xz'
-  source_sha256 '16dbfa488a21fe827dc27eaf708f42f7aa3bb997d745d31a19781628c36ba26f'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.10.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.10.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.10.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freetype_sub-2.10.1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '61decfc0ca8f0e58eb496856b6ed89e124f5223ba95bcc1afdc21eca1a647b74',
-     armv7l: '61decfc0ca8f0e58eb496856b6ed89e124f5223ba95bcc1afdc21eca1a647b74',
-       i686: '78d772a1a74ae57272edf940bdbcf348a6e2abe7aa6f552c4176b9fd46311f72',
-     x86_64: '8726f91f8884fe8875098d6cf2e323dcc79d50adeaa927d1092f87c4af961f44',
-  })
+  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.xz'
+  source_sha256 '86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784'
 
   depends_on 'expat'
   depends_on 'libpng'   # freetype needs zlib optionally. zlib is also the dependency of libpng


### PR DESCRIPTION
CVE-2020-15999
"This is an emergency release, fixing a severe vulnerability in embedded PNG bitmap handling...All users should update immediately."

https://www.phoronix.com/scan.php?page=news_item&px=FreeType-2.10.4-Released

Works properly:
- [x] x86_64
