### PR TITLE
libxinerama: Update depends

### DIFF
--- a/packages/libxinerama.rb
+++ b/packages/libxinerama.rb
@@ -1,26 +1,12 @@
-
 require 'package'
 
 class Libxinerama < Package
   description 'Xorg library, Xinerama is an X11 extension which provides support for extending a desktop across multiple displays.'
   homepage 'https://www.x.org/'
   compatibility 'all'
-  version '1.1.3-1'
-  source_url 'https://www.x.org/archive//individual/lib/libXinerama-1.1.3.tar.gz'
-  source_sha256 '0ba243222ae5aba4c6a3d7a394c32c8b69220a6872dbb00b7abae8753aca9a44'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxinerama-1.1.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxinerama-1.1.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxinerama-1.1.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxinerama-1.1.3-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '0ad8a511d0955f8cfcb767174c4ee55f4203a47a95f4281d9f2717a1b3147322',
-     armv7l: '0ad8a511d0955f8cfcb767174c4ee55f4203a47a95f4281d9f2717a1b3147322',
-       i686: '5e909ef4db126d972af64310b8ce806deb60f95b21406393f01a1f8e99b21a59',
-     x86_64: '73f25bf7cf51787d00e2fbe46cf6589e321c465333e8d2c9dc3d97bfa93a70da',
-  })
+  version '1.1.4'
+  source_url 'https://www.x.org/archive/individual/lib/libXinerama-1.1.4.tar.bz2'
+  source_sha256 '0008dbd7ecf717e1e507eed1856ab0d9cf946d03201b85d5dcf61489bb02d720'
 
   depends_on 'libx11'
   depends_on 'libxcb'

--- a/packages/libxinerama.rb
+++ b/packages/libxinerama.rb
@@ -5,7 +5,7 @@ class Libxinerama < Package
   description 'Xorg library, Xinerama is an X11 extension which provides support for extending a desktop across multiple displays.'
   homepage 'https://www.x.org/'
   compatibility 'all'
-  version '1.1.3'
+  version '1.1.3-1'
   source_url 'https://www.x.org/archive//individual/lib/libXinerama-1.1.3.tar.gz'
   source_sha256 '0ba243222ae5aba4c6a3d7a394c32c8b69220a6872dbb00b7abae8753aca9a44'
 
@@ -22,8 +22,9 @@ class Libxinerama < Package
      x86_64: '73f25bf7cf51787d00e2fbe46cf6589e321c465333e8d2c9dc3d97bfa93a70da',
   })
 
-  depends_on 'fontconfig'
+  depends_on 'libx11'
   depends_on 'libxcb'
+  depends_on 'libxext'
 
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/libxinerama.rb
+++ b/packages/libxinerama.rb
@@ -27,7 +27,7 @@ class Libxinerama < Package
   depends_on 'libxext'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "./configure #{CREW_OPTIONS}"
     system "make"
   end
 


### PR DESCRIPTION
Does not need fontconfig to compile, but does need libx11 & libxext.


Works properly:
- [x] x86_64

