### PR TITLE
libdrm & mesa: xorg_libs not needed for compile

### DIFF
--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -22,7 +22,6 @@ class Libdrm < Package
   })
 
   depends_on 'libpciaccess'
-  depends_on 'xorg_lib'
   depends_on 'eudev'
   depends_on 'libxslt'
 

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -20,6 +20,10 @@ class Mesa < Package
   depends_on 'libxvmc'
   depends_on 'llvm' => :build
   depends_on 'meson' => :build
+  depends_on 'libxrender'
+  depends_on 'libxdamage'
+  depends_on 'libxshmfence'
+  depends_on 'libxxf86vm'
   depends_on 'valgrind'
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader'


### PR DESCRIPTION
libdrm uses xorg_libs, which is a hack creating circular dependencies, especially since libdrm doesn't need any of those to compile.

This moves dependencies back out to individual app dependencies.

Mesa also has dependencies added which it needs to compile which are otherwise in xorg_libs.


Works properly (both libdrm & mesa are compiling):
- [x] x86_64

There is likely breakage in downstream (of libdrm) apps, but those should be noticed when there is a version bump and/or someone decides to compile from source.
