### PR TITLE
harfbuzz, cairo: Fix dependencies

### DIFF
--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -22,7 +22,6 @@ class Gobject_introspection < Package
   })
 
   depends_on 'glib'
-  depends_on 'cairo'
 
   def self.build
     system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -11,7 +11,7 @@ class Harfbuzz < Package
 
 #  depends_on 'cairo' => ':build'
   depends_on 'glib' => :build
-  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gobject_introspection'
   depends_on 'ragel' => :build
   depends_on 'freetype_sub'
   depends_on 'six' => :build

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -11,7 +11,7 @@ class Harfbuzz < Package
 
 #  depends_on 'cairo' => ':build'
   depends_on 'glib' => :build
-#  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gobject_introspection' => ':build'
   depends_on 'ragel' => :build
   depends_on 'freetype_sub'
   depends_on 'six' => :build


### PR DESCRIPTION
Harfbuzz needs gobjects_introspection, which has an unnecessary cairo dependency.

This fix to both avoids pulling in full freetype as a circular dependency.

Works properly:
- [x] x86_64

