### PR TITLE
Put `startsommelier` to a script command instead of a variable

### DIFF
--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -70,7 +70,8 @@ class Sommelier < Package
       system "echo '  echo \"sommelier process \$SOMM is running\"' >> stopsommelier"
       system "echo '  exit 1' >> stopsommelier"
       system "echo 'fi' >> stopsommelier"
-      system "echo 'set -a && source ~/.sommelier.env && set +a && initsommelier' > startsommelier"
+      system "echo '#!/bin/bash' > startsommelier"
+      system "echo 'set -a && source ~/.sommelier.env && set +a && initsommelier' >> startsommelier"
     end
   end
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -70,6 +70,7 @@ class Sommelier < Package
       system "echo '  echo \"sommelier process \$SOMM is running\"' >> stopsommelier"
       system "echo '  exit 1' >> stopsommelier"
       system "echo 'fi' >> stopsommelier"
+      system "echo 'set -a && source ~/.sommelier.env && set +a && initsommelier' > startsommelier"
     end
   end
 
@@ -79,6 +80,7 @@ class Sommelier < Package
       system "install -Dm755 sommelierd #{CREW_DEST_PREFIX}/sbin/sommelierd"
       system "install -Dm755 initsommelier #{CREW_DEST_PREFIX}/bin/initsommelier"
       system "install -Dm755 stopsommelier #{CREW_DEST_PREFIX}/bin/stopsommelier"
+      system "install -Dm755 startsommelier #{CREW_DEST_PREFIX}/bin/startsommelier"
       system "install -Dm644 .sommelier.env #{CREW_DEST_HOME}/.sommelier.env"
     end
   end
@@ -93,7 +95,6 @@ class Sommelier < Package
     puts "echo 'fi' >> ~/.bashrc".lightblue
     puts "echo 'sudo chmod -R 1777 /tmp/.X11-unix' >> ~/.bashrc".lightblue
     puts "echo 'sudo chown root:root /tmp/.X11-unix' >> ~/.bashrc".lightblue
-    puts "echo 'alias startsommelier=\"set -a && source ~/.sommelier.env && set +a && initsommelier\"' >> ~/.bashrc".lightblue
     puts "echo 'startsommelier' >> ~/.bashrc".lightblue
     puts "source ~/.bashrc".lightblue
     puts


### PR DESCRIPTION
Make `startsommelier` usable in a sh script

Fixes #4482 
Fixes #4495 