### PR TITLE
gobject _introspection: doesn't need cairo, use meson options

### DIFF
--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -22,10 +22,9 @@ class Gobject_introspection < Package
   })
 
   depends_on 'glib'
-  depends_on 'cairo'
 
   def self.build
-    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
+    system "meson #{CREW_MESON_OPTIONS} builddir"
     system "ninja -C builddir"
   end
 


### PR DESCRIPTION
doesn't need cairo.
added crew_meson_options

Works properly:
- [x] x86_64
- [x] i686
