### PR TITLE
xdpyinfo: fix package name detritus

### DIFF
--- a/packages/xdpyinfo.rb
+++ b/packages/xdpyinfo.rb
@@ -3,7 +3,7 @@
 
 require 'package'
 
-class Xorg_xdpyinfo < Package
+class Xdpyinfo < Package
   description 'Display information utility for X'
   version '1.3.2'
   compatibility 'all'


### PR DESCRIPTION
That was sloppy. :/

Works properly:
- [x] x86_64
