### PR TITLE
Add pre-built binaries for rsync and xxhash

### DIFF
--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -9,16 +9,24 @@ class Rsync < Package
   source_sha256 'becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e'
 
   binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rsync-3.2.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rsync-3.2.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rsync-3.2.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rsync-3.2.3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: 'cc3dafbe2332746b08f3c3c88ae5ec72ad33e0889055264cceae90905e368f14',
+     armv7l: 'cc3dafbe2332746b08f3c3c88ae5ec72ad33e0889055264cceae90905e368f14',
+       i686: 'f107cf84d70674007a950b9cfef59e5e7683713f8b02ed8d4aaedb4225a032d9',
+     x86_64: 'b6c07acfcfc6b71b508ca1068d3374af6ed4858a7aed638628fa5ca6c1ddb071',
   })
 
-  depends_on "zstd"
-  depends_on "lz4"
-  depends_on "xxhash"
+  depends_on 'zstd'
+  depends_on 'lz4'
+  depends_on 'xxhash'
 
   def self.build
-    system './configure'
+    system "./configure #{CREW_OPTIONS} --disable-maintainer-mode"
     system 'make'
   end
 

--- a/packages/xxhash.rb
+++ b/packages/xxhash.rb
@@ -3,29 +3,29 @@ require 'package'
 class Xxhash < Package
   description 'xxHash is an extremely fast non-cryptographic hash algorithm, working at speeds close to RAM limits.'
   homepage 'https://cyan4973.github.io/xxHash/'
-  version '0.8.0'
+  version '0.8.0-1'
   compatibility 'all'
   source_url 'https://github.com/Cyan4973/xxHash/archive/v0.8.0.tar.gz'
   source_sha256 '7054c3ebd169c97b64a92d7b994ab63c70dd53a06974f1f630ab782c28db0f4f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.8.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.8.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.8.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.8.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.8.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.8.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.8.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xxhash-0.8.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '3ce8bfe1e4f45e1f5ddd9b540bef8c5d17575a2e7f12ec11813c6e457b8f3100',
-     armv7l: '3ce8bfe1e4f45e1f5ddd9b540bef8c5d17575a2e7f12ec11813c6e457b8f3100',
-       i686: 'e13d6c726026d7926161eda09ddee6241f947e1d4854c8be3a4c4768443b890e',
-     x86_64: '12a168084bccb1ab631ebdc6f785c485268bee73060cf2900c84fbe3b8e0b3d3',
+    aarch64: '3b84bfc646e491a012434a68aebd38c10a7c667096b7ba9aba0fd1d8899a34f6',
+     armv7l: '3b84bfc646e491a012434a68aebd38c10a7c667096b7ba9aba0fd1d8899a34f6',
+       i686: '341858534ccf356d1b6a7313b07f36c42da188a2055ac610bb8dd715ada0227d',
+     x86_64: 'a6d0d300a1e11a255d545f759598c35b280083055954765c4f68e5c733e74ecc',
   })
 
   def self.build
-    system 'make', "PREFIX=#{CREW_PREFIX}"
+    system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}"
   end
 
   def self.install
-    system 'make', "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
- Add CREW_OPTIONS to configure rsync
- Add LIBDIR path to xxhash
- Tested on all architectures

Fixes #4443.