### PR TITLE
Weston update to 9.0.0

### DIFF
--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -45,5 +45,9 @@ class Weston < Package
     puts "echo '[terminal]' >> ~/.config/weston.ini".lightblue
     # Cousine is the defaut ChromeOS monospace font.
     puts "echo 'font=Cousine' >> ~/.config/weston.ini".lightblue
+    puts
+    puts "To run weston with xwayland try something like this:".lightred
+    puts "export WAYLAND_DISPLAY=wayland-1".lightred
+    puts "WAYLAND_DISPLAY=wayland-0 weston -Swayland-1 --xwayland".lightred
   end
 end

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -3,12 +3,13 @@ require 'package'
 class Weston < Package
   description 'Weston is the reference implementation of a Wayland compositor, and a useful compositor in its own right.'
   homepage 'http://wayland.freedesktop.org'
-  version '4.0.0'
+  version '9.0.0'
   compatibility 'i686,x86_64'
   case ARCH
   when 'i686', 'x86_64'
-    source_url 'https://github.com/wayland-project/weston/archive/4.0.0.tar.gz'
-    source_sha256 '46b0178cd37b0bf7471c9af12c847c7b8728699ecd5c04ce79be77ea12c98512'
+    source_url 'https://github.com/wayland-project/weston/archive/9.0.0.tar.gz'
+    source_sha256 '82b17ab1766f13557fc620c21e3c89165342d3a3ead79ba01181b4f7d2144487'
+
     depends_on 'harfbuzz'
     depends_on 'libxcursor'
     depends_on 'libinput'
@@ -19,29 +20,30 @@ class Weston < Package
     depends_on 'pango'
     depends_on 'dbus'
     depends_on 'libxxf86vm'
+    depends_on 'llvm' => :build
   end
 
-  binary_url ({
-      i686: 'https://dl.bintray.com/chromebrew/chromebrew/weston-4.0.0-chromeos-i686.tar.xz',
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/weston-4.0.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-      i686: '477a86049694ee6021a2cf98aa8d85acec4684fdee07c6f2508babd470d594f2',
-    x86_64: '758ecfd17e47436b7c219676f5959379ed6a1ea7838abeeb82c54be456a47aa7',
-  })
 
   def self.build
-    system './autogen.sh'
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-weston-launch',
-           '--enable-demo-clients-install'
-    system 'make'
+    ENV['CFLAGS'] = "-fuse-ld=lld"
+    ENV['CXXFLAGS'] = "-fuse-ld=lld"
+    system "meson #{CREW_MESON_OPTIONS} -Dshell-ivi=false -Dremoting=false -Dbackend-default=wayland -Dbackend-drm=false -Dpipewire=false -Dcolor-management-colord=false -Dcolor-management-lcms=false -Dbackend-rdp=false -Dlauncher-logind=false -Dweston-launch=false -Dsystemd=false -Dxwayland-path=#{CREW_PREFIX}/bin/Xwayland build"
+    system "meson configure build"
+    system 'ninja -C build'
   end
 
   def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja install -C build"
+  end
+  
+  def self.postinstall
+    puts
+    puts "To complete the installation, execute the following:".lightblue
+    puts "mkdir -p ~/.config".lightblue
+    puts "echo '[core]' >> ~/.config/weston.ini".lightblue
+    puts "echo 'xwayland=true' >> ~/.config/weston.ini".lightblue
+    puts "echo '[terminal]' >> ~/.config/weston.ini".lightblue
+    # Cousine is the defaut ChromeOS monospace font.
+    puts "echo 'font=Cousine' >> ~/.config/weston.ini".lightblue
   end
 end
-

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -21,6 +21,7 @@ class Weston < Package
     depends_on 'dbus'
     depends_on 'libxxf86vm'
     depends_on 'llvm' => :build
+    depends_on 'xdg_base'
   end
 
 
@@ -30,22 +31,21 @@ class Weston < Package
     system "meson #{CREW_MESON_OPTIONS} -Dshell-ivi=false -Dremoting=false -Dbackend-default=wayland -Dbackend-drm=false -Dpipewire=false -Dcolor-management-colord=false -Dcolor-management-lcms=false -Dbackend-rdp=false -Dlauncher-logind=false -Dweston-launch=false -Dsystemd=false -Dxwayland-path=#{CREW_PREFIX}/bin/Xwayland build"
     system "meson configure build"
     system 'ninja -C build'
+    system "cat <<'EOF'> weston.ini
+[core]
+'xwayland=true
+
+[terminal]
+font=Cousine
+EOF"
   end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja install -C build"
+    system "install -Dm644 weston.ini #{CREW_DEST_HOME}/.config/weston.ini"
   end
   
   def self.postinstall
-    puts
-    puts "To complete the installation, execute the following:".lightblue
-    puts "mkdir -p ~/.config".lightblue
-    puts "echo '[core]' >> ~/.config/weston.ini".lightblue
-    puts "echo 'xwayland=true' >> ~/.config/weston.ini".lightblue
-    puts "echo '[terminal]' >> ~/.config/weston.ini".lightblue
-    # Cousine is the defaut ChromeOS monospace font.
-    puts "echo 'font=Cousine' >> ~/.config/weston.ini".lightblue
-    puts
     puts "To run weston with xwayland try something like this:".lightred
     puts "export WAYLAND_DISPLAY=wayland-1".lightred
     puts "WAYLAND_DISPLAY=wayland-0 weston -Swayland-1 --xwayland".lightred

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -33,7 +33,7 @@ class Weston < Package
     system 'ninja -C build'
     system "cat <<'EOF'> weston.ini
 [core]
-'xwayland=true
+xwayland=true
 
 [terminal]
 font=Cousine


### PR DESCRIPTION
Weston 9.0 is MUCH faster.

Works properly:
- [x] x86_64


(also does what non-accelerated sommelier does, in a window.)

