### PR TITLE
glib: Don't use dev version, and use option for external iconv

### DIFF
--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,19 +3,17 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  version '2.67.0'
+  version '2.66.3'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/glib/2.67/glib-2.67.0.tar.xz'
-  source_sha256 '0b15e57ab6c2bb90ced4e24a1b0d8d6e9a13af8a70266751aa3a45baffeed7c1'
+  source_url 'https://download.gnome.org/sources/glib/2.66/glib-2.66.3.tar.xz'
+  source_sha256 '79f31365a99cb1cc9db028625635d1438890702acde9e2802eae0acebcf7b5b1'
 
 
   depends_on 'util_linux'
   depends_on 'six'
-  
-  ENV['LDFLAGS'] = "-liconv"
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} -Dinternal_pcre=true builddir"
+    system "meson #{CREW_MESON_OPTIONS} -Dinternal_pcre=true -Diconv=external builddir"
     system "ninja -C builddir"
   end
 


### PR DESCRIPTION
This takes out the LDFLAGS fix, which pollutes other compiles.

This is a cleaner fix for glib not finding iconv.

(This also downgrades to 2.66.3, which is the current non-dev version.)

Works properly:
- [x] x86_64
