### PR TITLE
WIP: BREAKING CHANGE: isl -> 0.23

### DIFF
--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -18,8 +18,8 @@ class Isl < Package
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     system "mkdir -p #{CREW_DEST_LIB_PREFIX}"
     # For backwards compatibility:
-    system "ln -sfr #{CREW_DEST_LIB_PREFIX}/libisl.so.23.0.0 #{CREW_DEST_LIB_PREFIX}/libisl.so.15"
-    system "ln -sfr #{CREW_DEST_LIB_PREFIX}/libisl.so.23.0.0 #{CREW_DEST_LIB_PREFIX}/libisl.so.19"
+    FileUtils.ln_sf "#{CREW_PREFIX}/libisl.so.23.0.0", "#{CREW_DEST_LIB_PREFIX}/libisl.so.15"
+    FileUtils.ln_sf "#{CREW_PREFIX}/libisl.so.23.0.0", "#{CREW_DEST_LIB_PREFIX}/libisl.so.19"
   end
 
   def self.check

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -3,33 +3,23 @@ require 'package'
 class Isl < Package
   description 'Integer Set Library for manipulating sets and relations of integer points bounded by linear constraints'
   homepage 'http://isl.gforge.inria.fr/'
-  version '0.20-1'
+  version '0.23'
   compatibility 'all'
-  source_url 'http://isl.gforge.inria.fr/isl-0.20.tar.xz'
-  source_sha256 'a5596a9fb8a5b365cb612e4b9628735d6e67e9178fae134a816ae195017e77aa'
+  source_url 'http://isl.gforge.inria.fr/isl-0.23.tar.xz'
+  source_sha256 '5efc53efaef151301f4e7dde3856b66812d8153dede24fab17673f801c8698f2'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/isl-0.20-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/isl-0.20-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/isl-0.20-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/isl-0.20-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '9a8a172724c6d1721c9435946834e3072a2a8b92a7288845f13a37e6378028f1',
-     armv7l: '9a8a172724c6d1721c9435946834e3072a2a8b92a7288845f13a37e6378028f1',
-       i686: '964be2d6db0292809b58316e644e6d800c0a5caa7c441ab6fed1e1fa225d97e1',
-     x86_64: '0cfc7be2bf9ab7ea4229c5f7a2da40c2365bc824b45df3dfa337dcfcb16df40b',
-  })
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     system "mkdir -p #{CREW_DEST_LIB_PREFIX}"
-    system "ln -s #{CREW_LIB_PREFIX}/libisl.so.19.1.0 #{CREW_DEST_LIB_PREFIX}/libisl.so.15"
+    # For backwards compatibility:
+    system "ln -sfr #{CREW_DEST_LIB_PREFIX}/libisl.so.23.0.0 #{CREW_DEST_LIB_PREFIX}/libisl.so.15"
+    system "ln -sfr #{CREW_DEST_LIB_PREFIX}/libisl.so.23.0.0 #{CREW_DEST_LIB_PREFIX}/libisl.so.19"
   end
 
   def self.check

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -18,8 +18,8 @@ class Isl < Package
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
     system "mkdir -p #{CREW_DEST_LIB_PREFIX}"
     # For backwards compatibility:
-    FileUtils.ln_sf "#{CREW_PREFIX}/libisl.so.23.0.0", "#{CREW_DEST_LIB_PREFIX}/libisl.so.15"
-    FileUtils.ln_sf "#{CREW_PREFIX}/libisl.so.23.0.0", "#{CREW_DEST_LIB_PREFIX}/libisl.so.19"
+    FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libisl.so.23.0.0", "#{CREW_DEST_LIB_PREFIX}/libisl.so.15"
+    FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libisl.so.23.0.0", "#{CREW_DEST_LIB_PREFIX}/libisl.so.19"
   end
 
   def self.check


### PR DESCRIPTION
Not sure how to best do this.

gcc occasionally complains about a missing ``` libisl.so.19``` after this is installed.

Recompiling gcc10 might be an option?

But gcc also complains about libiconv issues during compilation. (Is there a special dance with uninstalling libiconv, then reinstalling glibc, and then recompiling gcc10?)

Works properly:
- [ ] x86_64 (gcc whines about missing libisl.so.19)
