### PR TITLE
RFC/WIP ruby wrapper for crew

### DIFF
--- a/crew
+++ b/crew
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env ruby_safe
 require_relative 'lib/color'
 
 # Disallow sudo

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.5.1'
+CREW_VERSION = '1.5.2'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/packages/gcc_tools.rb
+++ b/packages/gcc_tools.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gcc_tools < Package
   description 'Tools for working with gcc packages'
   homepage 'https://github.com/skycocker/chromebrew'
-  version '1.1'
+  version '1.2'
   compatibility 'all'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'

--- a/packages/gcc_tools.rb
+++ b/packages/gcc_tools.rb
@@ -86,6 +86,12 @@ if [ ! -f "${CREW_PREFIX}/bin/ruby" ]; then
 fi
 EOF'
 
+    system 'cat << "EOF" > ruby_safe
+#!/bin/bash
+ruby --version &>/dev/null || crewfix
+exec ruby "$@"
+EOF'
+    
     system 'cat << "EOF" > gcc_switcher
 #!/bin/bash
 gccver=$(gcc -v 2>&1 | tail -1 | cut -d" " -f3)
@@ -143,13 +149,15 @@ EOF'
 
   def self.install
     system "install -Dm755 crewfix #{CREW_DEST_PREFIX}/bin/crewfix"
+    system "install -Dm755 ruby_safe #{CREW_DEST_PREFIX}/bin/ruby_safe"
     system "install -Dm755 gcc_switcher #{CREW_DEST_PREFIX}/bin/gcc_switcher"
   end
 
   def self.postinstall
-    puts "This package contains two scripts:".lightblue
+    puts "This package contains three scripts:".lightblue
     puts
     puts "crewfix - Repairs the crew command if gcc is removed".lightblue
+    puts "ruby_safe - Runs crewfix if gcc is removed & ruby is invoked".lightblue
     puts "gcc_switcher - Allows switching between gcc versions".lightblue
     puts
     puts "In most cases, you will only need to use the gcc_switcher command.".lightblue


### PR DESCRIPTION
```crew``` doesn't work if gcc is broken (uninstalled, etc.)

```crewfix``` can fix this, but why not make that automatic, so that one doesn't have to know to invoke crewfix?

By invoking ruby with a wrapper which runs ```crewfix``` if ruby is broken, we can deal with that automatically.

But there's a chicken/egg problem where ```ruby_safe``` needs to be installed before dropping it into ```crew```.

I put ```ruby_safe``` into gcc_tools, but that would have to be installed/updated before ```crew``` is changed.

Also, is there unnecessary overhead from invoking crew through a bash or shell wrapper?

Works properly:
- [ ] x86_64 (needs ruby_safe installed first!)