### PR TITLE
Util_linux: add dependencies and -> 2.36.1,  use linux_pam

### DIFF
--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -11,7 +11,7 @@ class Util_linux < Package
   depends_on 'libcap_ng'
   depends_on 'vdev'
   depends_on 'libtinfo'
-  depends_on 'openpam'
+  depends_on 'linux_pam'
   depends_on 'pcre2'
 
   def self.build

--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -3,31 +3,20 @@ require 'package'
 class Util_linux < Package
   description 'essential linux tools'
   homepage 'https://www.kernel.org/pub/linux/utils/util-linux/'
-  version '2.35.1'
+  version '2.36.1'
   compatibility 'all'
-  source_url 'https://kernel.org/pub/linux/utils/util-linux/v2.35/util-linux-2.35.1.tar.xz'
+  source_url 'https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.36/util-linux-2.36.1.tar.xz'
   source_sha256 'd9de3edd287366cd908e77677514b9387b22bc7b88f45b83e1922c3597f1d7f9'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.35.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.35.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.35.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/util_linux-2.35.1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'ff43f032e650b280007e5717cda2fee20dca97ff731b6e4168ceeea251f93281',
-     armv7l: 'ff43f032e650b280007e5717cda2fee20dca97ff731b6e4168ceeea251f93281',
-       i686: 'e39aa402ff8679b68b761c4f41554f2e9cdcd688bd6b23f40c5bc54a26c1e864',
-     x86_64: '7b4ab11425c7e70d4addf48a71048fcd89197899cae254ee4e6cdbdccc93eed1',
-  })
 
   depends_on 'libcap_ng'
   depends_on 'vdev'
+  depends_on 'libtinfo'
+  depends_on 'openpam'
+  depends_on 'pcre2'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system "./configure #{CREW_OPTIONS} --with-python=3 \
+    --enable-fs-paths-extra=#{CREW_PREFIX}/sbin"
     system "sed -i -e '/chgrp/d' -e '/chown/d' Makefile"
     system 'make'
   end


### PR DESCRIPTION
Fixes #4619 (in part)

Updates to 2.36.1, fixes missing dependency libraries and switches to using python3 & linux_pam from using openpam.

(openpam causes a crash in ```su```, and I don't know what else is broken similarly.)

This requires the libdb reversion in https://github.com/skycocker/chromebrew/pull/4623 and also the updated linux_pam in https://github.com/skycocker/chromebrew/pull/4624

Works properly:
- [x] x86_64
