### PR TITLE
REVERT libdb to last unencumbered version

### DIFF
--- a/packages/libdb.rb
+++ b/packages/libdb.rb
@@ -2,10 +2,10 @@ require 'package'
 
 class Libdb < Package
   description 'Berkeley DB is a family of embedded key-value database libraries providing scalable high-performance data management services to applications.'
-  homepage 'http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html'
+  homepage 'https://github.com/berkeleydb/libdb'
   version '5.3.28'
   compatibility 'all'
-  source_url 'http://deb.debian.org/debian/pool/main/d/db5.3/db5.3_5.3.28+dfsg1.orig.tar.xz'
+  source_url 'https://github.com/berkeleydb/libdb/releases/download/v5.3.28/db-5.3.28.tar.gz'
   source_sha256 'b19bf3dd8ce74b95a7b215be9a7c8489e8e8f18da60d64d6340a06e75f497749'
 
 

--- a/packages/libdb.rb
+++ b/packages/libdb.rb
@@ -3,34 +3,22 @@ require 'package'
 class Libdb < Package
   description 'Berkeley DB is a family of embedded key-value database libraries providing scalable high-performance data management services to applications.'
   homepage 'http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html'
-  version '6.2.32'
+  version '5.3.28'
   compatibility 'all'
-  source_url 'https://download.oracle.com/berkeley-db/db-6.2.32.tar.gz'
-  source_sha256 'a9c5e2b004a5777aa03510cfe5cd766a4a3b777713406b02809c17c8e0e7a8fb'
+  source_url 'http://deb.debian.org/debian/pool/main/d/db5.3/db5.3_5.3.28+dfsg1.orig.tar.xz'
+  source_sha256 'b19bf3dd8ce74b95a7b215be9a7c8489e8e8f18da60d64d6340a06e75f497749'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libdb-6.2.32-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libdb-6.2.32-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libdb-6.2.32-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libdb-6.2.32-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'af75254a46b10c045b118c915e3b4021bd7a0158cb8069061ae82a715a732e10',
-     armv7l: 'af75254a46b10c045b118c915e3b4021bd7a0158cb8069061ae82a715a732e10',
-       i686: '0229c9ae467fd512120034336b24af89e7f8a58d8f7eaca09c9cccee8916844b',
-     x86_64: '507cc3f213d01122b5214302b7433c9a9926b0f9f57551aeee1f9fcca8c90d2e',
-  })
 
   def self.build
     Dir.chdir 'build_unix' do
-      system "../dist/configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+      system "../dist/configure #{CREW_OPTIONS} --enable-dbm"
       system 'make'
     end
   end
 
   def self.install
     Dir.chdir 'build_unix' do
-      system "make", "docdir=#{CREW_PREFIX}/share/doc/db-6.2.32", "DESTDIR=#{CREW_DEST_DIR}", "install"
+      system "make", "docdir=#{CREW_PREFIX}/share/doc/db-5.3.28", "DESTDIR=#{CREW_DEST_DIR}", "install"
     end
   end
 end


### PR DESCRIPTION
The 5.3 series is the last unencumbered version of libdb. Everything after that is under a different license, and distributions like debian won't even include newer versions.

Also added the ```--enable-dbm``` option which is needed for packages like linux_pam to compile properly.

Works properly:
- [x] x86_64

Yes this may cause regressions in packages, but I haven't seen any packages on my system I haven't built myself using libdb.
