### PR TITLE
PCRE cleanups

### DIFF
--- a/packages/pcre.rb
+++ b/packages/pcre.rb
@@ -3,26 +3,21 @@ require 'package'
 class Pcre < Package
   description 'The PCRE library is a set of functions that implement regular expression pattern matching using the same syntax and semantics as Perl 5.'
   homepage 'http://pcre.org/'
-  version '8.44'
+  version '8.44-1'
   compatibility 'all'
   source_url 'https://ftp.pcre.org/pub/pcre/pcre-8.44.tar.bz2'
   source_sha256 '19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.44-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.44-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.44-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pcre-8.44-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'b4c172b57311480be50e1f683d1df5319bd92aac6c154d0c940d35d95fc23688',
-     armv7l: 'b4c172b57311480be50e1f683d1df5319bd92aac6c154d0c940d35d95fc23688',
-       i686: '16d71a0624f07bb7cc341cbcec798a0838bbac822df307c6d4ff20a2061a8f5e',
-     x86_64: '99901d63534b07b3cfde714bfbc10b1eb19eef49fb68a8d9e498cac58a523f01',
-  })
-
   def self.build
-    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic", "--enable-utf"
+    system "./configure #{CREW_OPTIONS} \
+  --enable-shared \
+  --disable-static \
+  --with-pic \
+  --enable-utf \
+  --enable-pcre16 \
+  --enable-pcre32 \
+  --enable-jit \
+  --enable-pcretest-libreadline"
     system 'make'
   end
 

--- a/packages/pcre2.rb
+++ b/packages/pcre2.rb
@@ -3,7 +3,7 @@ require 'package'
 class Pcre2 < Package
   description 'The PCRE2 package contains a new generation of the Perl Compatible Regular Expression libraries.'
   homepage 'http://pcre.org/'
-  version '10.35'
+  version '10.35-2'
   compatibility 'all'
   source_url 'https://ftp.pcre.org/pub/pcre/pcre2-10.35.tar.gz'
   source_sha256 '8fdcef8c8f4cd735169dd0225fd010487970c1bcadd49e9b90e26c7250a33dc9'
@@ -25,14 +25,10 @@ class Pcre2 < Package
   depends_on 'libtool' => :build
 
   def self.build
-    system "./configure \
-           --prefix=#{CREW_PREFIX} \
-           --libdir=#{CREW_LIB_PREFIX} \
+    system "./configure  #{CREW_OPTIONS} \
            --enable-pcre2-16 \
            --enable-pcre2-32 \
            --enable-unicode \
-           --enable-pcre2-16 \
-           --enable-pcre2-32 \
            --enable-pcre2test-libreadline \
            --enable-jit \
            --disable-static"


### PR DESCRIPTION
GLIB was telling me that PCRE wasn't compiled with UTF8, so this appears to fix this.

Works properly:
- [x] x86_64
