### PR TITLE
Add pre-built binaries for glib, mkfontscale and sassc

### DIFF
--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -8,6 +8,19 @@ class Glib < Package
   source_url 'https://download.gnome.org/sources/glib/2.67/glib-2.67.0.tar.xz'
   source_sha256 '0b15e57ab6c2bb90ced4e24a1b0d8d6e9a13af8a70266751aa3a45baffeed7c1'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '0d66968376ed154064cda24cc3df68bf8e54f1f6f5cdbd05fc7389b4847ec119',
+     armv7l: '0d66968376ed154064cda24cc3df68bf8e54f1f6f5cdbd05fc7389b4847ec119',
+       i686: 'f5c028746bb4e0cc54e1cda5c0b1226f7ac663d21924fc2cd259c0047b2395e1',
+     x86_64: '5a825a37542e1a8ebeb53eaefb321345a164dd822156b92602befc399ce9cce0',
+  })
+
   depends_on 'pcre2'
   depends_on 'libffi'
   depends_on 'gettext'
@@ -15,11 +28,11 @@ class Glib < Package
   depends_on 'util_linux'
   depends_on 'six'
   
-  ENV['CFLAGS'] = "-fstack-protector"
+  ENV['CFLAGS'] = "-fno-stack-protector"
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
     -Dselinux=disabled \
-    -Dsysprof=enabled \
+    -Dsysprof=disabled \
     -Dman=false \
     -Dgtk_doc=false \
     -Diconv=external \

--- a/packages/mkfontscale.rb
+++ b/packages/mkfontscale.rb
@@ -3,26 +3,25 @@ require 'package'
 class Mkfontscale < Package
   description 'X11 Scalable Font Index Generator'
   homepage 'https://www.x.org/wiki'
-  version '1.2.1'
+  version '1.2.1-1'
   compatibility 'all'
   source_url 'https://www.x.org/releases/individual/app/mkfontscale-1.2.1.tar.bz2'
   source_sha256 'ca0495eb974a179dd742bfa6199d561bda1c8da4a0c5a667f21fd82aaab6bac7'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mkfontscale-1.2.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mkfontscale-1.2.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mkfontscale-1.2.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mkfontscale-1.2.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mkfontscale-1.2.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mkfontscale-1.2.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mkfontscale-1.2.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mkfontscale-1.2.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f2f749976b0fa50fc49d135c7a245ba37f9756b4280b52c756fa07e9a63f03cb',
-     armv7l: 'f2f749976b0fa50fc49d135c7a245ba37f9756b4280b52c756fa07e9a63f03cb',
-       i686: '3fc8fd6cf76dd72c13cff42c44bafe20c005e6865501128050b6243f1ea26499',
-     x86_64: 'e09eb5e4af8b9bd31cd3cbddfa806f5a1e11fd80d297527aec804047b1cef1ec',
+    aarch64: '6dc86c623685bdc66affcdf10ddf98f0c3d0a1426e68556eb5b3eb88a238c868',
+     armv7l: '6dc86c623685bdc66affcdf10ddf98f0c3d0a1426e68556eb5b3eb88a238c868',
+       i686: 'e8c657ed8473ecb36340e2c70429a27f864e29f408602e62bbdb35e7c7831ab0',
+     x86_64: '3c30b109c94cba6d833ad87644e01daba2a78a6954cea5d9b7749f569cd5bcac',
   })
 
   depends_on 'xorg_proto'
-  depends_on 'zlibpkg'
   depends_on 'freetype'
   depends_on 'libfontenc'
 

--- a/packages/sassc.rb
+++ b/packages/sassc.rb
@@ -7,6 +7,19 @@ class Sassc < Package
   source_url 'https://github.com/sass/sassc/archive/3.6.1.tar.gz'
   source_sha256 '8cee391c49a102b4464f86fc40c4ceac3a2ada52a89c4c933d8348e3e4542a60'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sassc-3.6.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sassc-3.6.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sassc-3.6.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sassc-3.6.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'fa342b7f0f008adf721fce11d5576148478d7e8008ec37be8a031e92f416b345',
+     armv7l: 'fa342b7f0f008adf721fce11d5576148478d7e8008ec37be8a031e92f416b345',
+       i686: '7f3d0319266009c1b7ee8949de91914116fc31b87949ba6fd57a0df3dd95633b',
+     x86_64: '156f5f33817ce351f7c890eee9a37a61dcd4abc96939ba9bfa49e31264c412da',
+  })
+
   depends_on 'libsass'
 
   def self.build


### PR DESCRIPTION
Fixes #4633
Fixes #4642
Tested on all architectures.