### PR TITLE
Add appres, bitmap, editres and rendercheck X app packages

### DIFF
--- a/packages/appres.rb
+++ b/packages/appres.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Appres < Package
+  description 'The appres program prints the resources seen by an application (or subhierarchy of an application) with the specified class and instance names.'
+  homepage 'https://www.x.org'
+  version '1.0.5'
+  compatibility 'all'
+  source_url 'https://x.org/archive/individual/app/appres-1.0.5.tar.bz2'
+  source_sha256 'ffad893712c81943b919e3cbfe46fc65259cc0d9eb96d5e658670e3fbb265928'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/appres-1.0.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/appres-1.0.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/appres-1.0.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/appres-1.0.5-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e470f6c5a1c9d2ef2f89efe68b1243952d6697f8cd265b1baca52353933b9908',
+     armv7l: 'e470f6c5a1c9d2ef2f89efe68b1243952d6697f8cd265b1baca52353933b9908',
+       i686: 'ecfbf924a5003f2de92a65c559f0422547fe336d704d2e1d99b16bc8cbcda424',
+     x86_64: 'be67999ef4b05b90136fd8c0551473c3605046154127e62292bdfa0bd5c194af',
+  })
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/bitmap.rb
+++ b/packages/bitmap.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Bitmap < Package
+  description 'bitmap, bmtoa, atobm - X bitmap (XBM) editor and converter utilities'
+  homepage 'https://www.x.org'
+  version '1.0.9'
+  compatibility 'all'
+  source_url 'https://x.org/archive/individual/app/bitmap-1.0.9.tar.bz2'
+  source_sha256 'e0f3afad5272d796f54c33fa1b5bd1fb3f62843a54b28c87196d06a35123e5f5'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bitmap-1.0.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bitmap-1.0.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bitmap-1.0.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bitmap-1.0.9-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '45218cfba754b357f8e0dac9f73b70200a8e10835317e69d20da17ec5d9ca8d0',
+     armv7l: '45218cfba754b357f8e0dac9f73b70200a8e10835317e69d20da17ec5d9ca8d0',
+       i686: '4d534650ef7d4fa093fba30398684611328586f059bb2f6ae422c09205a087ac',
+     x86_64: 'b83e9bd27893924cbde524bf8fb0da3d7055b7ca94b60f51d6f1af2b0002f59c',
+  })
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/editres.rb
+++ b/packages/editres.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Editres < Package
+  description 'Editres is a tool that allows users and application developers to view the full widget hierarchy of any Xt Toolkit application that speaks the Editres protocol.'
+  homepage 'https://www.x.org'
+  version '1.0.7'
+  compatibility 'all'
+  source_url 'https://x.org/archive/individual/app/editres-1.0.7.tar.bz2'
+  source_sha256 '089ad34628e55a779b97e369f55fb12caefc96d684b508d9022eb9e12b775c11'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/editres-1.0.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/editres-1.0.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/editres-1.0.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/editres-1.0.7-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'a0d58ce9b3c97f216a4f44b41b0597d434609db993f623ad2679f83eda9647e5',
+     armv7l: 'a0d58ce9b3c97f216a4f44b41b0597d434609db993f623ad2679f83eda9647e5',
+       i686: 'e631c24169d134eb2a467c0a435223512120c3c9aa9ebf770e3a33cfd4cb2232',
+     x86_64: '33bc1a315e539c110dcaf04b0b89eb1da83dc14b3c568d2fac25982e248f1869',
+  })
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/rendercheck.rb
+++ b/packages/rendercheck.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Rendercheck < Package
+  description 'rendercheck is a program to test a Render extension implementation against separate calculations of expected output.'
+  homepage 'https://www.x.org'
+  version '1.5'
+  compatibility 'all'
+  source_url 'https://x.org/archive/individual/app/rendercheck-1.5.tar.bz2'
+  source_sha256 '00605679436d65ccf9a6f1f1cb206df7a2e8b28a7821e867922d2b14b009f1cc'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rendercheck-1.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rendercheck-1.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/rendercheck-1.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rendercheck-1.5-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '90b0f792889946717870f1497e523c3229cb5840feaf1152da6a125710310697',
+     armv7l: '90b0f792889946717870f1497e523c3229cb5840feaf1152da6a125710310697',
+       i686: 'b0ca933742e0d17470c8f1d3e66dac65c5a03ac4d490a477e6e59c700b08b1b7',
+     x86_64: '7c29b512ecdf2472ade1bce7f7b7491cd8f828a1146061fa8e2e512de6dd1dc9',
+  })
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end


### PR DESCRIPTION
- The appres program prints the resources seen by an application (or subhierarchy of an application) with the specified class and instance names.
- bitmap, bmtoa, atobm - X bitmap (XBM) editor and converter utilities
- Editres is a tool that allows users and application developers to view the full widget hierarchy of any Xt Toolkit application that speaks the Editres protocol.
- rendercheck is a program to test a Render extension implementation against separate calculations of expected output.

Tested on all architectures.