### PR TITLE
Python2.7: fix pip

### DIFF
--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -3,34 +3,31 @@ require 'package'
 class Python27 < Package
   description 'Python is a programming language that lets you work quickly and integrate systems more effectively.'
   homepage 'https://www.python.org/'
-  version '2.7.17'
+  version '2.7.17-1'
   compatibility 'all'
   source_url 'https://www.python.org/ftp/python/2.7.17/Python-2.7.17.tar.xz'
   source_sha256 '4d43f033cdbd0aa7b7023c81b0e986fd11e653b5248dac9144d508f11812ba41'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.17-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.17-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.17-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/python27-2.7.17-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '753d3df25a3353384c6d938a907305825d5f6d8eda3189a18de877c3d5dc6075',
-     armv7l: '753d3df25a3353384c6d938a907305825d5f6d8eda3189a18de877c3d5dc6075',
-       i686: 'a3c9214188a6648ade671337591b93a4e8b53e733442a6db6bbd366559605928',
-     x86_64: '671417cd3cdc21f4196fb7515beeb8c3a1d4fbc302cf4a3094a504ab71291fd4',
-  })
 
   depends_on 'bz2' => :build
   depends_on 'sqlite' => :build
 
+    # Using /tmp breaks test_distutils, test_subprocess.
+    # Proxy setting breaks test_httpservers, test_ssl,
+    # test_urllib, test_urllib2, test_urllib2_localnet.
+    # So, modifying environment variable to make pass tests.
+    ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
   def self.build
     # IMPORTANT: Do not build with python27 already installed or pip will not be included.
     # python requires #{CREW_LIB_PREFIX}, so leave as is but specify -rpath
+    # SSL errors in test may require a 2021 version of libressl.
+    
     system "./configure", "CPPFLAGS=-I#{CREW_PREFIX}/include/ncurses -I#{CREW_PREFIX}/include/ncursesw",
         "LDFLAGS=-Wl,-rpath,-L#{CREW_LIB_PREFIX}",
-        "--with-ensurepip=install", "--enable-shared"
-    system 'make'
+        "--enable-shared",
+        "--enable-optimizations"
+    system "make -j#{CREW_NPROC}"
+    
   end
 
   def self.install
@@ -44,13 +41,14 @@ class Python27 < Package
       system "mkdir -p #{CREW_DEST_LIB_PREFIX}"
       system "cd #{CREW_DEST_LIB_PREFIX} && ln -s ../lib/libpython*.so* ."
     end
+    
+    # Install pip
+    system "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
+    # Set maximum version of setuptools compatible with python 2.7.
+    system "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:#{CREW_DEST_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/python ./get-pip.py setuptools==44.1.1 --prefix=#{CREW_PREFIX} --root=#{CREW_DEST_DIR}"
   end
 
   def self.check
-    # Using /tmp breaks test_distutils, test_subprocess.
-    # Proxy setting breaks test_httpservers, test_ssl,
-    # test_urllib, test_urllib2, test_urllib2_localnet.
-    # So, modifying environment variable to make pass tests.
-    #system "TMPDIR=#{CREW_PREFIX}/tmp http_proxy= https_proxy= ftp_proxy= make test"
+    #system "http_proxy= https_proxy= ftp_proxy= make test"
   end
 end

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -3,10 +3,10 @@ require 'package'
 class Python27 < Package
   description 'Python is a programming language that lets you work quickly and integrate systems more effectively.'
   homepage 'https://www.python.org/'
-  version '2.7.17-1'
+  version '2.7.18'
   compatibility 'all'
-  source_url 'https://www.python.org/ftp/python/2.7.17/Python-2.7.17.tar.xz'
-  source_sha256 '4d43f033cdbd0aa7b7023c81b0e986fd11e653b5248dac9144d508f11812ba41'
+  source_url 'https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tar.xz'
+  source_sha256 'b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43'
 
 
   depends_on 'bz2' => :build

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -46,6 +46,9 @@ class Python27 < Package
     system "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
     # Set maximum version of setuptools compatible with python 2.7.
     system "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:#{CREW_DEST_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/python ./get-pip.py setuptools==44.1.1 --prefix=#{CREW_PREFIX} --root=#{CREW_DEST_DIR}"
+    # pip is in python3. Remove python2 pip since deprecated and leave pip2
+    FileUtils.rm "#{CREW_DEST_PREFIX}/bin/pip"
+    system "sed -i \"s%#{CREW_DEST_PREFIX}/bin/python%#{CREW_PREFIX}/bin/python%g\" #{CREW_DEST_PREFIX}/bin/pip2"
   end
 
   def self.check


### PR DESCRIPTION
Fixes #4631 
 (NSS refuses to compile with broken python2.7, which doesn't install a working pip due to setuptools no longer supporting python 2.7)

Works properly:
- [x] x86_64