### PR TITLE
Python3 -> 3.9.0

### DIFF
--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -33,7 +33,7 @@ class Python3 < Package
       "LDFLAGS=-Wl,-rpath,-L#{CREW_LIB_PREFIX}",
       '--enable-shared',
       "--enable-optimizations"
-    system 'make'
+    system "make -j#{CREW_NPROC}"
   end
 
   def self.install

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -50,6 +50,8 @@ class Python3 < Package
     # Install pip
     system "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
     system "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:#{CREW_DEST_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/python3 ./get-pip.py --prefix=#{CREW_PREFIX} --root=#{CREW_DEST_DIR}"
+    system "sed -i \"s%#{CREW_DEST_PREFIX}/bin/python3%#{CREW_PREFIX}/bin/python3%g\" #{CREW_DEST_PREFIX}/bin/pip"
+    system "sed -i \"s%#{CREW_DEST_PREFIX}/bin/python3%#{CREW_PREFIX}/bin/python3%g\" #{CREW_DEST_PREFIX}/bin/pip3"
   end
 
   def self.postinstall

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -31,7 +31,7 @@ class Python3 < Package
     # python requires /usr/local/lib, so leave as is but specify -rpath
     system './configure', "CPPFLAGS=-I#{CREW_PREFIX}/include/ncurses -I#{CREW_PREFIX}/include/ncursesw",
       "LDFLAGS=-Wl,-rpath,-L#{CREW_LIB_PREFIX}",
-      '--enable-shared',
+      "--enable-shared",
       "--enable-optimizations"
     system "make -j#{CREW_NPROC}"
   end


### PR DESCRIPTION
Also align pip3 installation with that of today's change in 2.7.18, doing it in the regular install section and not in the post-install section.

Works properly:
- [x] x86_64
