### PR TITLE
xwayland: Fix X symlink

### DIFF
--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -151,6 +151,6 @@ EOF"
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
     FileUtils.mv "#{CREW_DEST_PREFIX}/bin/Xwayland", "#{CREW_DEST_PREFIX}/bin/Xwayland.elf"
     system "install -Dm755 Xwayland_sh #{CREW_DEST_PREFIX}/bin/Xwayland"
-    FileUtils.ln_sf "#{CREW_DEST_PREFIX}/bin/Xwayland", "#{CREW_DEST_PREFIX}/bin/X"
+    system "ln -sfr #{CREW_DEST_PREFIX}/bin/Xwayland #{CREW_DEST_PREFIX}/bin/X"
   end
 end

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -151,6 +151,6 @@ EOF"
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
     FileUtils.mv "#{CREW_DEST_PREFIX}/bin/Xwayland", "#{CREW_DEST_PREFIX}/bin/Xwayland.elf"
     system "install -Dm755 Xwayland_sh #{CREW_DEST_PREFIX}/bin/Xwayland"
-    system "ln -sfr #{CREW_DEST_PREFIX}/bin/Xwayland #{CREW_DEST_PREFIX}/bin/X"
+    FileUtils.ln_sf "#{CREW_PREFIX}/bin/Xwayland", "#{CREW_DEST_PREFIX}/bin/X"
   end
 end

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -3,24 +3,11 @@ require 'package'
 class Xwayland < Package
   description 'X server configured to work with weston or sommelier'
   homepage 'https://x.org'
-  version '1.20.9-1'
+  version '1.20.9-2'
   compatibility 'all'
   # Using xorg ToT due to large number of recent xwayland commits.
   source_url 'https://github.com/freedesktop/xorg-xserver/archive/d18dcecbe08a9ff22e43f12b6b7679a6ef1a6eb0.zip'
   source_sha256 '091edf47059adfa09242906db97e1d9d44dc6557efde4af861a7055975fa55ce'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.9-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.9-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.9-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.9-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '09a2f25dadcdf4d04bd7939daccef4286540dc17da05f96dd27001d5e29e64bd',
-     armv7l: '09a2f25dadcdf4d04bd7939daccef4286540dc17da05f96dd27001d5e29e64bd',
-       i686: '3ad7dc7bc50cb4dbb9951b730fb1b12b1974a1942716110ceb66ed3a4607342a',
-     x86_64: '5d88e6eead59c165464489aee67fa8a28005ec2e407d5d3e042bde27beeb1c9a',
-  })
 
   depends_on 'libepoxy'
   depends_on 'xorg_proto'


### PR DESCRIPTION
Fixes #4652

This might be a packaging issue, but I noticed this:
```
ls -aFl /usr/local/bin/X
lrwxrwxrwx. 1 chronos chronos 47 Nov 24 17:11 /usr/local/bin/X -> /usr/local/tmp/crew/dest/usr/local/bin/Xwayland
```


Works properly:
- [x] x86_64
