### PR TITLE
Add gspell

### DIFF
--- a/packages/gspell.rb
+++ b/packages/gspell.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Gspell < Package
+  description 'a flexible API to implement the spell checking in a GTK+ application'
+  version '1.9.1'
+  compatibility 'all'
+  source_url 'https://download.gnome.org/sources/gspell/1.9/gspell-1.9.1.tar.xz'
+  source_sha256 'dcbb769dfdde8e3c0a8ed3102ce7e661abbf7ddf85df08b29915e92cd723abdd'
+
+  depends_on 'gtk3'
+  depends_on 'enchant'
+  depends_on 'libxml2'
+  depends_on 'iso_codes'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'vala' => ':build'
+  depends_on 'gtk_doc' => ':build'
+
+  ENV['CC'] = "clang"
+  ENV['CXX'] = "clang"
+  ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+  def self.build
+    system "./configure --help"
+    system "./configure  #{CREW_OPTIONS} --enable-gtk-doc-html=no"
+    system "make"
+  end
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end


### PR DESCRIPTION
This uses clang because otherwise there are lld issues.

gtk-doc is disabled for creating documentation because docbook appears to be broken. See https://github.com/skycocker/chromebrew/issues/4361#issuecomment-738084505 & https://github.com/skycocker/chromebrew/issues/4361#issuecomment-738085899
e.g.
```
I/O error : Attempt to load network entity http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl
warning: failed to load external entity "http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl"
compilation error: file /usr/local/share/gtk-doc/data/gtk-doc.xsl line 11 element import
xsl:import : unable to load http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl
make[3]: *** [Makefile:845: html-build.stamp] Error 5
make[3]: Leaving directory '/usr/local/tmp/crew/gspell-1.9.1.tar.xz.dir/gspell-1.9.1/docs/reference'
make[2]: *** [Makefile:456: all-recursive] Error 1
make[2]: Leaving directory '/usr/local/tmp/crew/gspell-1.9.1.tar.xz.dir/gspell-1.9.1/docs'
make[1]: *** [Makefile:594: all-recursive] Error 1
make[1]: Leaving directory '/usr/local/tmp/crew/gspell-1.9.1.tar.xz.dir/gspell-1.9.1'
make: *** [Makefile:502: all] Error 2
```

Also enabled a ```./configure --help``` line because just like with ```meson configure build``` if you're building from the source it is useful to know what configure options are available.

Works properly:
- [x] x86_64
