### PR TITLE
libsoup -> 2.72

### DIFF
--- a/packages/libsoup.rb
+++ b/packages/libsoup.rb
@@ -3,35 +3,30 @@ require 'package'
 class Libsoup < Package
   description 'libsoup is an HTTP client/server library for GNOME.'
   homepage 'https://wiki.gnome.org/Projects/libsoup'
-  version '2.63.90'
+  version '2.72'
   compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/GNOME/sources/libsoup/2.63/libsoup-2.63.90.tar.xz'
-  source_sha256 '77b91be36717fb57144aa4222753fa7b7d81312439d59ac47486d675a3deae1a'
+  source_url 'https://download.gnome.org/sources/libsoup/2.72/libsoup-2.72.0.tar.xz'
+  source_sha256 '170c3f8446b0f65f8e4b93603349172b1085fb8917c181d10962f02bb85f5387'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.63.90-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.63.90-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.63.90-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.63.90-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'b7cd95e9443e96306cd0e6d5f35f99b826261b6b8e74181db37b52aa9c70a876',
-     armv7l: 'b7cd95e9443e96306cd0e6d5f35f99b826261b6b8e74181db37b52aa9c70a876',
-       i686: '06ed2cb292334a1c49d43677901407b49bf7888eaf9534f3455d69c9d6bee231',
-     x86_64: 'ff90e07fce6397d3ba711a615379f487266af5aa77359fa60fb193dff8da2dcb',
-  })
 
   depends_on 'glib_networking'
   depends_on 'libpsl'
   depends_on 'sqlite'
   depends_on 'vala'
+  depends_on 'llvm'
 
+  ENV['CC'] = 'clang'
+  ENV['CXX'] = 'clang'
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "meson #{CREW_MESON_OPTIONS} -Dtests=false \
+    -Dsysprof=disabled \
+    -Dintrospection=disabled \
+    builddir"
+    system "meson configure builddir"
+    system "ninja -C builddir"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end


### PR DESCRIPTION
Switched to meson, but can't seem to compile w/o clang.

Works properly:
- [x] x86_64
