### PR TITLE
mandb:  Minor fix for issue with post-install on docker images.

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -56,6 +56,6 @@ class Mandb < Package
   end
 
   def self.postinstall
-    system 'mandb -c'
+    system "LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} mandb -c"
   end
 end


### PR DESCRIPTION
Docker installs complain about the post-install section being unable to find libraries while running mandb -c.

``` "mandb: error while loading shared libraries: libgdbm.so.6:"```

This fixes that issue. **No rebuild is required for this change.**

Works properly:
- [x] x86_64
