### PR TITLE
xterm: non-ticlib version 362 compiles

### DIFF
--- a/packages/xterm.rb
+++ b/packages/xterm.rb
@@ -3,35 +3,35 @@ require 'package'
 class Xterm < Package
   description 'The xterm program is a terminal emulator for the X Window System.'
   homepage 'https://invisible-island.net/xterm/'
-  version '361'
+  version '362'
   compatibility 'all'
-  source_url "https://invisible-mirror.net/archives/xterm/xterm-361.tgz"
-  source_sha256 '85610f20d5e47205cc1b6876f7a4da28d6ae051bd8eac0b932e92c37a73a623f'
+  source_url "https://invisible-mirror.net/archives/xterm/xterm-362.tgz"
+  source_sha256 '1d4ffe226fa8f021859bbc3007788ff63a46a31242d9bd9a7bd7ebe24e81aca2'
+
+
+
   depends_on 'pcre'
   depends_on 'sommelier'
 
   def self.build
-    ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
-    ENV['PATH'] = '/bin:/sbin:/usr/local/bin' # The /usr/bin need to remove from PATH as bash will point 'tic' to /usr/bin/tic 
-    system "./configure",
-           "--with-x",
-           "--with-pcre",
-           "--with-xinerama",
-           "--enable-dabbrev",
-           "--enable-toolbar",
-           "--with-pkg-config",
-           "--enable-exec-xterm",
-           "--enable-16bit-chars",
-           "--enable-dec-locator",
-           "--enable-double-buffer",
-           "--enable-readline-mouse",
-           "--enable-regis-graphics",
-           "--enable-sixel-graphics",
+    system './configure',
+           '--with-x',
+           '--with-pcre',
+           '--with-xinerama',
+           '--enable-dabbrev',
+           '--enable-toolbar',
+           '--with-pkg-config',
+           '--enable-exec-xterm',
+           '--enable-16bit-chars',
+           '--enable-dec-locator',
+           '--enable-double-buffer',
+           '--enable-readline-mouse',
+           '--enable-regis-graphics',
+           '--enable-sixel-graphics',
            "--prefix=#{CREW_PREFIX}",
            "--with-xpm=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--with-ticlib"
-    system "make"
+           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'make'
   end
 
   def self.install


### PR DESCRIPTION
FIxes #4707 
Compiles for me, whereas the ticlib version did not.

Works properly:
- [x] x86_64
