### PR TITLE
enchant: needs gnupg installed to compile

### DIFF
--- a/packages/enchant.rb
+++ b/packages/enchant.rb
@@ -11,6 +11,7 @@ class Enchant < Package
 
   depends_on 'aspell_en'
   depends_on 'hunspell'
+  depends_on 'gnupg'
 
   def self.build
     system "./bootstrap" 


### PR DESCRIPTION
enchant needs gnupg installed for bootstrap to work.

Works properly:
- [x] x86_64
