### PR TITLE
Update xscreensaver and glfw dependency

### DIFF
--- a/packages/glfw.rb
+++ b/packages/glfw.rb
@@ -1,40 +1,39 @@
 require 'package'
 
-class Glfw < Package                 # The first character of the class name must be upper case
+class Glfw < Package
   description 'GLFW is an Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan development on the desktop. It provides a simple API for creating windows, contexts and surfaces, receiving input and events.'
   homepage 'http://www.glfw.org/'
-  version '3.2.1-1'
+  version '3.3.2'
   compatibility 'all'
-  source_url 'https://github.com/glfw/glfw/archive/3.2.1.zip'
-  source_sha256 '0c623f65a129c424d0fa45591694fde3719ad4a0955d4835182fda71b255446f'   # Use the command "sha256sum"
+  source_url 'https://github.com/glfw/glfw/releases/download/3.3.2/glfw-3.3.2.zip'
+  source_sha256 '08a33a512f29d7dbf78eab39bd7858576adcc95228c9efe8e4bc5f0f3261efc7'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glfw-3.2.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glfw-3.2.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glfw-3.2.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glfw-3.2.1-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glfw-3.3.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glfw-3.3.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glfw-3.3.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glfw-3.3.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '2a549383779eeab73503f189cc35249bf05e92fe4fdc69284501d1ab04b3b296',
-     armv7l: '2a549383779eeab73503f189cc35249bf05e92fe4fdc69284501d1ab04b3b296',
-       i686: '0792cf89605743251dcc304cefd2596ad1ed61fb3f72967c14119bfba0e22fcb',
-     x86_64: '41f70d1903f01a11ca658ef4460d6c2af09be0a3596e12bf75b663164107a84b',
+    aarch64: '375586eebe407a72dd6e819c236c75d45cdb6af2fb284452d92767ec0586a031',
+     armv7l: '375586eebe407a72dd6e819c236c75d45cdb6af2fb284452d92767ec0586a031',
+       i686: 'c52b95bd167f4b24d5b7ba78648cef228d8b35d16e95ff46db305721de5f23bd',
+     x86_64: '270e70447b7d59eb1db3ed2224f2542e45b864d6d56152236dcc22ea6a85cd1d',
   })
 
-  depends_on 'cmake' => :build      # packages with "=> :build" are only required if you're building from source 
   depends_on 'sommelier' => :build
 
-  def self.build                   # the steps required to build the package
-    case ARCH
-    when 'x86_64'
-      system "cmake", "-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}", "-DLIB_SUFFIX=64"
-    else
-      system "cmake", "-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}"
+  def self.build
+    Dir.mkdir 'build'
+    Dir.chdir 'build' do
+      system "cmake #{CREW_CMAKE_OPTIONS} -DBUILD_SHARED_LIBS=ON .."
+      system 'make'
     end
-    system 'make'
   end
 
-  def self.install                 # the steps required to install the package
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  def self.install
+    Dir.chdir 'build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
   end
 end

--- a/packages/xscreensaver.rb
+++ b/packages/xscreensaver.rb
@@ -3,10 +3,23 @@ require 'package'
 class Xscreensaver < Package
   description 'XScreenSaver is the standard screen saver collection shipped on most Linux and Unix systems running the X11 Window System.'
   homepage 'https://www.jwz.org/xscreensaver/download.html'
-  version '5.40'
+  version '5.44'
   compatibility 'all'
-  source_url 'https://www.jwz.org/xscreensaver/xscreensaver-5.40.tar.gz'
-  source_sha256 '30a0908d4164cf780ef034f87ba884316296b308af2484261ccde86be0c95ae0'
+  source_url 'https://www.jwz.org/xscreensaver/xscreensaver-5.44.tar.gz'
+  source_sha256 '73d8089cfc7d7363b5dac99b5b01dffb3429d0a855e6af16ce9a4b7777017b95'
+
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xscreensaver-5.44-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xscreensaver-5.44-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xscreensaver-5.44-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xscreensaver-5.44-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '6e6fe321404454f174492ed9b116ed339b7b3053c86d6af7b463d266b4558feb',
+     armv7l: '6e6fe321404454f174492ed9b116ed339b7b3053c86d6af7b463d266b4558feb',
+       i686: '601c1c6c14e128d6ec5bd69949cd7f25e50c7cd29b57cc2faf075ae0c36e0f60',
+     x86_64: '9f318d5f089884acfcef0ccfd0147535a44b38957f94338ff2f97e1cec27f3c0',
+  })
 
   depends_on 'glfw'
   depends_on 'freeglut'


### PR DESCRIPTION
- Update xscreensaver from 5.40 to 5.44
- Update glfw from 3.2.1-1 to 3.3.2

Tested on all architectures.