### PR TITLE
Patchelf to .12+

### DIFF
--- a/packages/patchelf.rb
+++ b/packages/patchelf.rb
@@ -3,26 +3,15 @@ require 'package'
 class Patchelf < Package
   description 'PatchELF is a small utility to modify the dynamic linker and RPATH of ELF executables.'
   homepage 'http://nixos.org/patchelf.html'
-  version '0.9'
+  version '0.12-f347'
   compatibility 'all'
-  source_url 'http://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2'
-  source_sha256 'a0f65c1ba148890e9f2f7823f4bedf7ecad5417772f64f994004f59a39014f83'
+  source_url 'https://github.com/NixOS/patchelf/archive/f34751b88bd07d7f44f5cd3200fb4122bf916c7e.zip'
+  source_sha256 '5ed94d15c44c13c1fa6a78b2f5ca499e465fd9171e4a1daf194e8523c04a9339'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.9-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '21d3cba32a4f062b3bcca3d707e010255d4d72271de51a30e516100b603f584f',
-     armv7l: '21d3cba32a4f062b3bcca3d707e010255d4d72271de51a30e516100b603f584f',
-       i686: '955d83ae8b1a20e3862a038a3d1c726337ff2398ced29183c6daa18d52cfde88',
-     x86_64: '361e72c9da52a344671c2e7826de40c04688ba99c075a83ed62aaf3ba89bc082',
-  })
 
   def self.build
-    system "./configure", "prefix=#{CREW_PREFIX}"
+    system "./bootstrap.sh"
+    system "./configure #{CREW_OPTIONS}"
     system "make"
   end
 

--- a/packages/patchelf.rb
+++ b/packages/patchelf.rb
@@ -8,17 +8,17 @@ class Patchelf < Package
   source_url 'https://github.com/NixOS/patchelf/archive/f34751b88bd07d7f44f5cd3200fb4122bf916c7e.zip'
   source_sha256 '5ed94d15c44c13c1fa6a78b2f5ca499e465fd9171e4a1daf194e8523c04a9339'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: 'e2b7945b1a842076b60347516561d29af99bc450ef66732d41086bb15bc8374d',
-      armv7l: 'e2b7945b1a842076b60347516561d29af99bc450ef66732d41086bb15bc8374d',
-        i686: '9496ae8276c538a798adcbf86816dab573c7ded0e96cd9e678991d7bd5ae54fe',
-      x86_64: 'c234ee6df670e7d1405ff57c607d529a0c9bed6815fd900a51059796620e1fdc',
+  binary_sha256({
+    aarch64: 'e2b7945b1a842076b60347516561d29af99bc450ef66732d41086bb15bc8374d',
+     armv7l: 'e2b7945b1a842076b60347516561d29af99bc450ef66732d41086bb15bc8374d',
+       i686: '9496ae8276c538a798adcbf86816dab573c7ded0e96cd9e678991d7bd5ae54fe',
+     x86_64: 'c234ee6df670e7d1405ff57c607d529a0c9bed6815fd900a51059796620e1fdc'
   })
 
   def self.build

--- a/packages/patchelf.rb
+++ b/packages/patchelf.rb
@@ -15,19 +15,20 @@ class Patchelf < Package
       x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '034a54878ec827f1ccc3544da727351aad90a609850429e6005942722d68752a',
-      armv7l: '034a54878ec827f1ccc3544da727351aad90a609850429e6005942722d68752a',
-        i686: 'ff9e45a2bdd883de56a4098f10f2e0ea8d8006dcdbf0c1f928252be5d1b921ab',
-      x86_64: '085b74a502d3e4cd4ab7977ecbc885c4b08e2dea395d6543f89def8f25e60541',
+     aarch64: 'e2b7945b1a842076b60347516561d29af99bc450ef66732d41086bb15bc8374d',
+      armv7l: 'e2b7945b1a842076b60347516561d29af99bc450ef66732d41086bb15bc8374d',
+        i686: '9496ae8276c538a798adcbf86816dab573c7ded0e96cd9e678991d7bd5ae54fe',
+      x86_64: 'c234ee6df670e7d1405ff57c607d529a0c9bed6815fd900a51059796620e1fdc',
   })
 
   def self.build
-    system "./bootstrap.sh"
-    system "./configure #{CREW_OPTIONS}"
-    system "make"
+    system './bootstrap.sh'
+    system "env CFLAGS='-flto=auto -ltinfo' CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
+             ./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/patchelf.rb
+++ b/packages/patchelf.rb
@@ -8,6 +8,18 @@ class Patchelf < Package
   source_url 'https://github.com/NixOS/patchelf/archive/f34751b88bd07d7f44f5cd3200fb4122bf916c7e.zip'
   source_sha256 '5ed94d15c44c13c1fa6a78b2f5ca499e465fd9171e4a1daf194e8523c04a9339'
 
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/patchelf-0.12-f347-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: '034a54878ec827f1ccc3544da727351aad90a609850429e6005942722d68752a',
+      armv7l: '034a54878ec827f1ccc3544da727351aad90a609850429e6005942722d68752a',
+        i686: 'ff9e45a2bdd883de56a4098f10f2e0ea8d8006dcdbf0c1f928252be5d1b921ab',
+      x86_64: '085b74a502d3e4cd4ab7977ecbc885c4b08e2dea395d6543f89def8f25e60541',
+  })
 
   def self.build
     system "./bootstrap.sh"


### PR DESCRIPTION
This version was able to work on the fbc freebasic binary, whereas the older version just borked it.

Works properly:
- [x] x86_64
