### PR TITLE
binutils -> 2.35.1

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,23 +3,11 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
-  version '2.34'
+  version '2.35.1'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/binutils/binutils-2.34.tar.lz'
-  source_sha256 '5cec79823ef596817aa57a3f470a1afa9827bf14e3583a4e445dc046cc38d29c'
+  source_url 'https://ftpmirror.gnu.org/binutils/binutils-2.35.1.tar.xz'
+  source_sha256 '3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.34-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.34-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.34-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.34-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'b8194c2d9448796a2c8c5a2e0be669ab32b2a2fb832b4acccff09cb417d0d91f',
-     armv7l: 'b8194c2d9448796a2c8c5a2e0be669ab32b2a2fb832b4acccff09cb417d0d91f',
-       i686: '30a101614d39a99caebd12b3037917a428c618fd4378a04c21469d201c2e9fff',
-     x86_64: 'cc790a554f99715bd5cccefd14f965d885ef2c694afd461007a7f3b37386b91b',
-  })
 
   depends_on 'filecmd'
   depends_on 'texinfo'
@@ -37,8 +25,10 @@ class Binutils < Package
               --enable-plugins \
               --disable-bootstrap \
               --enable-64-bit-bfd \
+              --enable-lto \
+              --enable-vtable-verify \
               --disable-werror"
-      system 'make'
+      system "make -j#{CREW_NPROC}"
     end
   end
 

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -28,7 +28,7 @@ class Binutils < Package
               --enable-lto \
               --enable-vtable-verify \
               --disable-werror"
-      system "make -j#{CREW_NPROC}"
+      system 'make'
     end
   end
 


### PR DESCRIPTION
- Added lto
- Added vtable-verify (llvm compile was complaining about this.)

Works properly:
- [x] x86_64
- [x] armv7l
