### PR TITLE
unzip: update ubuntu maintainer patchset

### DIFF
--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -3,33 +3,22 @@ require 'package'
 class Unzip < Package
   description 'UnZip is an extraction utility for archives compressed in .zip format (also called \'zipfiles\').'
   homepage 'http://www.info-zip.org/UnZip.html'
-  version '1.6_1-1'
+  version '6.0-2'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip60.tar.gz'
   source_sha256 '036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/unzip-1.6_1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/unzip-1.6_1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/unzip-1.6_1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/unzip-1.6_1-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'e72843178559c924341a969fe9560b56e00b4dd539085e853f0de9602240970a',
-     armv7l: 'e72843178559c924341a969fe9560b56e00b4dd539085e853f0de9602240970a',
-       i686: 'c166df14f26735426dbbbd9bfddcfbf1940057d4b3ef2713adc75f4225312af1',
-     x86_64: 'b3ef4ace8bc32020363d00183eaf19ec5f8358180292216558927f937da1daea',
-  })
+
 
   depends_on 'compressdoc' => :build
   depends_on 'patch' => :build
 
   # adapted from the homebrew recipe as seen at: https://github.com/Homebrew/homebrew-dupes/blob/master/unzip.rb
-  # Upstream is unmaintained so we use the Ubuntu unzip-6.0-20ubuntu1 patchset:
-  # http://changelogs.ubuntu.com/changelogs/pool/main/u/unzip/unzip_6.0-20ubuntu1/changelog
+  # Upstream is unmaintained so we use the Ubuntu unzip_6.0-25ubuntu1 patchset:
+  # https://changelogs.ubuntu.com/changelogs/pool/main/u/unzip/unzip_6.0-25ubuntu1/changelog
   def self.patch
-    patch_url = "https://launchpad.net/ubuntu/+archive/primary/+files/unzip_6.0-20ubuntu1.debian.tar.xz"
-    patch_sha256 = "0ddf122ef15b739e3ea06db4b9e80f40759dce23a2c886678881453a43bd0842"
+    patch_url = "http://archive.ubuntu.com/ubuntu/pool/main/u/unzip/unzip_6.0-25ubuntu1.debian.tar.xz"
+    patch_sha256 = '6a22b0d23cf8b9e1a74626d7d9af5efe1257e157f20006272dc68693a13f3b45'
 
     system('wget', '--continue', '--no-check-certificate', patch_url, '-O', 'unzippatches.tar.xz')
     abort 'Checksum mismatch :/ try again' unless Digest::SHA256.hexdigest( File.read("./unzippatches.tar.xz") ) == patch_sha256
@@ -39,11 +28,9 @@ class Unzip < Package
   end
 
   def self.build
-    if ARCH == "armv7l"
-      system "make -f unix/Makefile linux_noasm"
-    else
-      system "make -f unix/Makefile generic"
-    end
+    # LCHMOD is not supported in linux.
+    system 'echo "CFLAGS=-DNO_LCHMOD" >> flags'
+    system "make -f unix/Makefile generic"
   end
 
   def self.install

--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -8,7 +8,18 @@ class Unzip < Package
   source_url 'https://downloads.sourceforge.net/project/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip60.tar.gz'
   source_sha256 '036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37'
 
-
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/unzip-6.0-2-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/unzip-6.0-2-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/unzip-6.0-2-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/unzip-6.0-2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: '116ed2b03bcaeaa7ccd339e58b67519361933490d1469a72b3c9e12808fc4797',
+      armv7l: '116ed2b03bcaeaa7ccd339e58b67519361933490d1469a72b3c9e12808fc4797',
+        i686: '488891584f8cf53bcd3969140ab0baffeec4cffb4964c6b836d745afd17a86fe',
+      x86_64: 'a58e8a34a46721674ba16198fa943297c6fa80c5933b956bd1ebb6fe91ac6b89',
+  })
 
   depends_on 'compressdoc' => :build
   depends_on 'patch' => :build


### PR DESCRIPTION
- update "upstream" ubuntu maintainer patchset
- Remove armv7l logic, since this appears to compile just fine on armv7l with the generic target.
- Add ```-DNO_LCHMOD``` CFLAG via flags file since unzip complains occasionally about LCHMOD not being supported.

Works properly:
- [x] x86_64
- [x] armv7l
