### PR TITLE
libiconv: delete iconv.h (conflict with glibc)

### DIFF
--- a/packages/libiconv.rb
+++ b/packages/libiconv.rb
@@ -3,23 +3,11 @@ require 'package'
 class Libiconv < Package
   description 'GNU charset conversion library for libc which does not implement it.'
   homepage 'https://www.gnu.org/software/libiconv/'
-  version '1.16-2'
+  version '1.16-3'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/libiconv/libiconv-1.16.tar.gz'
   source_sha256 'e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libiconv-1.16-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libiconv-1.16-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libiconv-1.16-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libiconv-1.16-2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '83ebdeb7420ca8b5b52cb92b0367d708dc1bbcdf08acc6044004b474b2b7e606',
-     armv7l: '83ebdeb7420ca8b5b52cb92b0367d708dc1bbcdf08acc6044004b474b2b7e606',
-       i686: 'd239e42841b7bcea1669e0389cecbe01a23a5e1249623f90101cf9ff5861086f',
-     x86_64: '6a344f234625a49d73b0ed8d3e3633c41186c78390ea1342081ded649fcc8dea',
-  })
 
   def self.build
     system "./configure #{CREW_OPTIONS} --enable-static --enable-relocatable --enable-extra-encodings"
@@ -28,5 +16,7 @@ class Libiconv < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    # Remove iconv.h which conflicts with same file from glibc
+    FileUtils.rm "#{CREW_DEST_PREFIX}/include/iconv.h"
   end
 end


### PR DESCRIPTION
Fixes #4758 #4745

This is only an issue at compilation. People will need to do a ```crew reinstall glibc``` after this to compile packages which need ```iconv.h```. The only package which has a problem is ```r.rb``` which is still current.

libdin2, curl, & git can be updated to remove the libiconv dependency after this is installed and glic is reinstalled, leaving only ```r.rb``` with a libiconv dependency.

git should be updated to 2.29.2 thus: https://github.com/skycocker/chromebrew/issues/4758#issuecomment-745376437

libidn2 should be updated to 2.3.0 thus: https://github.com/skycocker/chromebrew/issues/4758#issuecomment-745377054

curl should be updated to 7.74.0 thus:
https://github.com/skycocker/chromebrew/issues/4758#issuecomment-745377280

(These latter packages can all be updated at leisure. But the libiconv package will fix other compiles, so it should probably be done sooner. Since we're not removing the libiconv library, packages needing it should continue to work.)

Works properly:
- [x] x86_64

