### PR TITLE
Add crew cache option

### DIFF
--- a/crew
+++ b/crew
@@ -524,7 +524,7 @@ def download
 
     unless ENV["CREW_CACHE_OPT"].to_s == ''
       puts "Caching downloaded archive".lightgreen
-      FileUtils.cp "#{filename}", "#{CREW_CACHE_DIR}" 
+      FileUtils.cp filename, CREW_CACHE_DIR
     end
   end
   return {source: source, filename: filename}

--- a/crew
+++ b/crew
@@ -497,15 +497,36 @@ def download
     sha256sum = @pkg.binary_sha256[@device[:architecture]]
   end
   Dir.chdir CREW_BREW_DIR do
+    unless ENV["CREW_CACHE_OPT"].to_s == ''
+      unless File.directory?(CREW_CACHE_DIR)
+        FileUtils.mkdir_p(CREW_CACHE_DIR) 
+      end
+      if File.file?("#{CREW_CACHE_DIR}#{filename}")
+        if Digest::SHA256.hexdigest( File.read("#{CREW_CACHE_DIR}#{filename}") ) == sha256sum then
+          FileUtils.cp "#{CREW_CACHE_DIR}#{filename}", "#{CREW_BREW_DIR}"
+          puts "Archive found in cache".lightgreen
+          return {source: source, filename: filename}
+          else
+          puts 'Cached archive checksum mismatch. :/ Will download.'.lightred
+        end
+      end
+    end
+
     if @opt_verbose then
       system('curl', '-v', '--retry', '3', '--progress-bar', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
     else
       system('curl', '--retry', '3', '--progress-bar', '-C', '-', '--insecure', '-L', '-#', url, '-o', filename)
     end
+
     abort 'Checksum mismatch. :/ Try again.'.lightred unless
       Digest::SHA256.hexdigest( File.read("./#{filename}") ) == sha256sum
+    puts "Archive downloaded".lightgreen
+
+    unless ENV["CREW_CACHE_OPT"].to_s == ''
+      puts "Caching downloaded archive".lightgreen
+      FileUtils.cp "#{filename}", "#{CREW_CACHE_DIR}" 
+    end
   end
-  puts "Archive downloaded".lightgreen
   return {source: source, filename: filename}
 end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.5.1'
+CREW_VERSION = '1.5.2'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines
@@ -22,6 +22,7 @@ CREW_MAN_PREFIX = CREW_PREFIX + '/share/man'
 CREW_LIB_PATH = CREW_PREFIX + '/lib/crew/'
 CREW_CONFIG_PATH = CREW_PREFIX + '/etc/crew/'
 CREW_BREW_DIR = CREW_PREFIX + '/tmp/crew/'
+CREW_CACHE_DIR = CREW_PREFIX + '/tmp/cache/'
 CREW_DEST_DIR = CREW_BREW_DIR + 'dest'
 CREW_DEST_PREFIX = CREW_DEST_DIR + CREW_PREFIX
 CREW_DEST_LIB_PREFIX = CREW_DEST_DIR + CREW_LIB_PREFIX

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -16,13 +16,13 @@ else
   CREW_PREFIX = ENV['CREW_PREFIX']
   @pkg.build_from_source = true
 end
+
 CREW_LIB_PREFIX = CREW_PREFIX + '/' + ARCH_LIB
 CREW_MAN_PREFIX = CREW_PREFIX + '/share/man'
 
 CREW_LIB_PATH = CREW_PREFIX + '/lib/crew/'
 CREW_CONFIG_PATH = CREW_PREFIX + '/etc/crew/'
 CREW_BREW_DIR = CREW_PREFIX + '/tmp/crew/'
-CREW_CACHE_DIR = CREW_PREFIX + '/tmp/cache/'
 CREW_DEST_DIR = CREW_BREW_DIR + 'dest'
 CREW_DEST_PREFIX = CREW_DEST_DIR + CREW_PREFIX
 CREW_DEST_LIB_PREFIX = CREW_DEST_DIR + CREW_LIB_PREFIX
@@ -33,6 +33,14 @@ if ENV['CREW_PREFIX'].to_s == ''
 else
   HOME = CREW_PREFIX + ENV['HOME']
 end
+
+if ENV['CREW_CACHE_DIR'].to_s == ''
+  CREW_CACHE_DIR = HOME + '.cache/crewcache'
+else
+  CREW_CACHE_DIR = ENV['CREW_CACHE_DIR']
+  @pkg.build_from_source = true
+end
+
 
 CREW_DEST_HOME = CREW_DEST_DIR + HOME
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -19,7 +19,6 @@ end
 
 CREW_LIB_PREFIX = CREW_PREFIX + '/' + ARCH_LIB
 CREW_MAN_PREFIX = CREW_PREFIX + '/share/man'
-
 CREW_LIB_PATH = CREW_PREFIX + '/lib/crew/'
 CREW_CONFIG_PATH = CREW_PREFIX + '/etc/crew/'
 CREW_BREW_DIR = CREW_PREFIX + '/tmp/crew/'
@@ -40,7 +39,6 @@ else
   CREW_CACHE_DIR = ENV['CREW_CACHE_DIR']
   @pkg.build_from_source = true
 end
-
 
 CREW_DEST_HOME = CREW_DEST_DIR + HOME
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -34,7 +34,7 @@ else
 end
 
 if ENV['CREW_CACHE_DIR'].to_s == ''
-  CREW_CACHE_DIR = HOME + '.cache/crewcache'
+  CREW_CACHE_DIR = HOME + '/.cache/crewcache/'
 else
   CREW_CACHE_DIR = ENV['CREW_CACHE_DIR']
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -37,7 +37,6 @@ if ENV['CREW_CACHE_DIR'].to_s == ''
   CREW_CACHE_DIR = HOME + '.cache/crewcache'
 else
   CREW_CACHE_DIR = ENV['CREW_CACHE_DIR']
-  @pkg.build_from_source = true
 end
 
 CREW_DEST_HOME = CREW_DEST_DIR + HOME


### PR DESCRIPTION
When developing packages with chromebrew, archive and source packages get downloaded over and over again, wasting bandwidth.

This modification lets you set a ```CREW_CACHE_OPT``` environment variable, which activates logic to both look for and save archives (package and source) during installs.

Not setting the variable leads to current behavior.

Works properly:
- [x] x86_64
