### PR TITLE
Libressl Security Update

### DIFF
--- a/packages/libressl.rb
+++ b/packages/libressl.rb
@@ -8,9 +8,20 @@ class Libressl < Package
   source_url 'https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.2.3.tar.gz'
   source_sha256 '412dc2baa739228c7779e93eb07cd645d5c964d2f2d837a9fd56db7498463d73'
 
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.2.3-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.2.3-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.2.3-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.2.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: '59a8e3c3cf6bd97210f04882c2b0ce94566311f360536d1174d7e04e8f9884ab',
+      armv7l: '59a8e3c3cf6bd97210f04882c2b0ce94566311f360536d1174d7e04e8f9884ab',
+        i686: 'd6962728e73894df3382ad17035b838f213f246edb6dc4aa54522c3bc5c59dd8',
+      x86_64: 'be499bd46626d26ed6c333dc1a74df423537053e6afbf2a14e542c5ceec796ef',
+  })
 
   def self.build
-    system "./configure --help"
     system "./configure #{CREW_OPTIONS} --with-openssldir=#{CREW_PREFIX}/etc/ssl"
     system 'make'
   end

--- a/packages/libressl.rb
+++ b/packages/libressl.rb
@@ -3,25 +3,14 @@ require 'package'
 class Libressl < Package
   description 'LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014, with goals of modernizing the codebase, improving security, and applying best practice development processes.'
   homepage 'https://www.libressl.org/'
-  version '3.2.2'
+  version '3.2.3'
   compatibility 'all'
-  source_url 'https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.2.2.tar.gz'
-  source_sha256 'a9d1e1d030b8bcc67bf6428b8c0fff14a5602e2236257b9e3d77acaf12e2a7a1'
+  source_url 'https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.2.3.tar.gz'
+  source_sha256 '412dc2baa739228c7779e93eb07cd645d5c964d2f2d837a9fd56db7498463d73'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.2.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.2.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.2.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libressl-3.2.2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '36a493288d8d24cdb4c52866d37fcc47530417158717819443b4a087fd035d08',
-     armv7l: '36a493288d8d24cdb4c52866d37fcc47530417158717819443b4a087fd035d08',
-       i686: 'f900f8674e63a71e2206f8458d94c039e375af3be7027047818fd680fb78aa78',
-     x86_64: '2995523debedf84f763b79fb73b7958656c6d8e1a20628220e4b3d45b3dfa25a',
-  })
 
   def self.build
+    system "./configure --help"
     system "./configure #{CREW_OPTIONS} --with-openssldir=#{CREW_PREFIX}/etc/ssl"
     system 'make'
   end


### PR DESCRIPTION
"We have released LibreSSL 3.2.3, which will be arriving in the
LibreSSL directory of your local OpenBSD mirror soon.

It includes the following security fix:

    * Malformed ASN.1 in a certificate revocation list or a timestamp
      response token can lead to a NULL pointer dereference.

The LibreSSL project continues improvement of the codebase to reflect modern,
safe programming practices. We welcome feedback and improvements from the
broader community. Thanks to all of the contributors who helped make this
release possible."


Works properly:
- [x] x86_64

Will need binaries...