### PR TITLE
Add pre-built binaries for graphene, gtk4, nss and pygments

### DIFF
--- a/packages/graphene.rb
+++ b/packages/graphene.rb
@@ -8,6 +8,18 @@ class Graphene < Package
   source_url 'https://github.com/ebassi/graphene/archive/1.10.2.tar.gz'
   source_sha256 '87c682291fa38a131aaf9aaee17d053d7bd4ea5309d305a356619c95784b9b4d'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/graphene-1.10.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/graphene-1.10.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/graphene-1.10.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/graphene-1.10.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'dbcb1dcb4f783438cf7b3f1cdc59e336be93a79bd69ce82d124bb57f022ac85e',
+     armv7l: 'dbcb1dcb4f783438cf7b3f1cdc59e336be93a79bd69ce82d124bb57f022ac85e',
+       i686: '467726c35c5cda9fc7faf720d349188070b904bfc0c4217c78db39949f37361b',
+     x86_64: '0594d3faa99f8ce2520f87af671be452b1d401cbf4e400f8da52390772c389dc',
+  })
 
   depends_on 'gobject_introspection' => :build
 

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -4,32 +4,43 @@ class Gtk4 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk4/'
   version '4.0'
-  compatibility 'all'
-  source_url 'https://download.gnome.org/sources/gtk/4.0/gtk-4.0.0.tar.xz'
-  source_sha256 'd46cf5b127ea27dd9e5d2ff6ed500cb4067eeb2cb1cd2c313ccde8013b0b9bf9'
+  compatibility 'aarch64,armv7l,x86_64'
+  case ARCH
+  when 'aarch64', 'armv7l', 'x86_64'
+    source_url 'https://download.gnome.org/sources/gtk/4.0/gtk-4.0.0.tar.xz'
+    source_sha256 'd46cf5b127ea27dd9e5d2ff6ed500cb4067eeb2cb1cd2c313ccde8013b0b9bf9'
+    depends_on 'cups'
+    depends_on 'at_spi2_atk'
+    depends_on 'gnome_icon_theme'
+    depends_on 'gobject_introspection'
+    depends_on 'gdk_pixbuf'
+    depends_on 'graphene'
+    depends_on 'hicolor_icon_theme'
+    depends_on 'iso_codes'
+    depends_on 'json_glib'
+    depends_on 'libepoxy'
+    depends_on 'libxkbcommon'
+    depends_on 'llvm' => :build
+    depends_on 'shared_mime_info'
+    depends_on 'six' => :build
+    depends_on 'xdg_base'
+    depends_on 'pygments' => :build
+  end
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f7201d1c2146a2183f6235b22697d54c87d2afc271c08a22d4e4d4511d9d173c',
+     armv7l: 'f7201d1c2146a2183f6235b22697d54c87d2afc271c08a22d4e4d4511d9d173c',
+     x86_64: '64ae34d9c3db55c399b26ae37824d5a3c6023e96cf3552d0d3924c1899af1143',
+  })
 
-
-  depends_on 'cups'
-  depends_on 'at_spi2_atk'
-  depends_on 'gnome_icon_theme'
-  depends_on 'gobject_introspection'
-  depends_on 'gdk_pixbuf'
-  depends_on 'graphene'
-  depends_on 'hicolor_icon_theme'
-  depends_on 'iso_codes'
-  depends_on 'json_glib'
-  depends_on 'libepoxy'
-  depends_on 'libxkbcommon'
-  depends_on 'llvm' => :build
-  depends_on 'shared_mime_info'
-  depends_on 'six' => :build
-  depends_on 'xdg_base'
-  depends_on 'pygments' => :build
-  
   def self.build
-    ENV['CFLAGS'] = "-fuse-ld=lld"
-    ENV['CXXFLAGS'] = "-fuse-ld=lld"
+    ENV['CFLAGS'] = '-fuse-ld=lld'
+    ENV['CXXFLAGS'] = '-fuse-ld=lld'
     system "meson #{CREW_MESON_OPTIONS} \
     -Dbroadway-backend=true \
     -Ddemos=false\
@@ -40,7 +51,7 @@ class Gtk4 < Package
     -Dmutest:default_library=both \
     -Dsassc:default_library=both \
     build"
-    system "meson configure build"
+    system 'meson configure build'
     system 'ninja -C build'
   end
 

--- a/packages/nss.rb
+++ b/packages/nss.rb
@@ -8,6 +8,19 @@ class Nss < Package
   source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_59_RTM/src/nss-3.59-with-nspr-4.29.tar.gz'
   source_sha256 '2e2c09c17b1c9f43a2f0a5d83a30a712bff3016d2b7cf5a3dd904847292607ae'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.59-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.59-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.59-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nss-3.59-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '9f1ab2d6fbaa5d94e51fa485c9325ae7ddd4d8df13ddfd87cb51aa89133c5feb',
+     armv7l: '9f1ab2d6fbaa5d94e51fa485c9325ae7ddd4d8df13ddfd87cb51aa89133c5feb',
+       i686: 'c54d6fbf8d44db101797e5d5b610baef75de5c92a37dec48cc6cb810e1d14f1c',
+     x86_64: '41ff455950be5e96a72c494c4a1993f5efbbe9d8a1c747682bc279fd7bd156eb',
+  })
+
   depends_on 'gyp' => :build
   depends_on 'nspr'
   depends_on 'sqlite'

--- a/packages/pygments.rb
+++ b/packages/pygments.rb
@@ -8,6 +8,18 @@ class Pygments < Package
   source_url 'https://files.pythonhosted.org/packages/29/60/8ff9dcb5eac7f4da327ba9ecb74e1ad783b2d32423c06ef599e48c79b1e1/Pygments-2.7.3.tar.gz'
   source_sha256 'ccf3acacf3782cbed4a989426012f1c535c9a90d3a7fc3f16d231b9372d2b716'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pygments-2.7.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pygments-2.7.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pygments-2.7.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pygments-2.7.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'a0c567de5b740fa9156211359821ff1fa737c9a789f7d609e5d03a0a4d3d3eef',
+     armv7l: 'a0c567de5b740fa9156211359821ff1fa737c9a789f7d609e5d03a0a4d3d3eef',
+       i686: 'c80eefe6b9224f9bf83725b67fb435ff9f2c11f3a76d39b08f23ee4be2bfc082',
+     x86_64: '726b9bf55accde82012775ec6aa1117a022d9f03cd8e6d12bb8bceaa8f4d9694',
+  })
 
   def self.install
     system "pip3 install pygments --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"


### PR DESCRIPTION
Fixes #4769.  Tested on all architectures.