### PR TITLE
Crewfix update

### DIFF
--- a/packages/gcc_tools.rb
+++ b/packages/gcc_tools.rb
@@ -18,6 +18,7 @@ set -e
 # define constants
 CREW_PREFIX="${CREW_PREFIX:-/usr/local}"
 ARCH_ACTUAL="$(uname -m)"
+[[ "$ARCH_ACTUAL" == "armv8l" ]] && ARCH_ACTUAL="armv7l"
 ARCH="${ARCH:-$ARCH_ACTUAL}"
 LIB_SUFFIX=""
 [ "${ARCH}" == "x86_64" ] && LIB_SUFFIX="64"

--- a/packages/gcc_tools.rb
+++ b/packages/gcc_tools.rb
@@ -17,12 +17,14 @@ set -e
 
 # define constants
 CREW_PREFIX="${CREW_PREFIX:-/usr/local}"
-ARCH_ACTUAL="$(uname -m)"
-[[ "$ARCH_ACTUAL" == "armv8l" ]] && ARCH_ACTUAL="armv7l"
-ARCH="${ARCH:-$ARCH_ACTUAL}"
+ARCH="$(uname -m)"
 LIB_SUFFIX=""
 [ "${ARCH}" == "x86_64" ] && LIB_SUFFIX="64"
-CURL="LD_LIBRARY_PATH=/usr/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} /usr/bin/curl"
+if curl --version &>/dev/null; then
+  CURL=curl
+else
+  CURL="LD_LIBRARY_PATH=/usr/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} /usr/bin/curl"
+fi
 
 function download_check () {
   cd /tmp
@@ -45,7 +47,7 @@ function download_check () {
 if [ ! -f "${CREW_PREFIX}/lib${LIB_SUFFIX}/libssp.so.0" ]; then
   # prepare gcc8 url and sha256
   case "${ARCH}" in
-  "aarch64"|"armv7l")
+  "aarch64"|"armv7l"|"armv8l")
     url="https://dl.bintray.com/chromebrew/chromebrew/gcc8-8.3.0-chromeos-armv7l.tar.xz"
     sha256="fbd8a589befb3d10400af6e4975d02a6940bab4907628f8fc0d6913ea89f70ae"
     ;;
@@ -68,7 +70,7 @@ fi
 if [ ! -f "${CREW_PREFIX}/bin/ruby" ]; then
   # prepare ruby url and sha256
   case "${ARCH}" in
-  "aarch64"|"armv7l")
+  "aarch64"|"armv7l"|"armv8l")
     url="https://dl.bintray.com/chromebrew/chromebrew/ruby-2.7.2-chromeos-armv7l.tar.xz"
     sha256="a435e6bf7965e1a82e8842e5ea66bdd670ec9b627d785bd720d3d2652fc89f6d"
     ;;

--- a/packages/gcc_tools.rb
+++ b/packages/gcc_tools.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gcc_tools < Package
   description 'Tools for working with gcc packages'
   homepage 'https://github.com/skycocker/chromebrew'
-  version '1.1'
+  version '1.2'
   compatibility 'all'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
@@ -17,16 +17,18 @@ set -e
 
 # define constants
 CREW_PREFIX="${CREW_PREFIX:-/usr/local}"
-ARCH="$(uname -m)"
+ARCH_ACTUAL="$(uname -m)"
+ARCH="${ARCH:-$ARCH_ACTUAL}"
 LIB_SUFFIX=""
 [ "${ARCH}" == "x86_64" ] && LIB_SUFFIX="64"
+CURL="LD_LIBRARY_PATH=/usr/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} /usr/bin/curl"
 
 function download_check () {
   cd /tmp
 
   #download
   echo "Downloading ${1}..."
-  curl --progress-bar -C - -L --ssl "${2}" -o "${3}"
+  "${CURL}" --progress-bar -C - -L --ssl "${2}" -o "${3}"
 
   #verify
   echo "Verifying ${1}..."


### PR DESCRIPTION
-for the situation where curl's underlying chromebrew libraries are broken.
-for the situation where on armv8l host.
-part of this will be part of the non-libssp gcc package I'm testing.

Works properly:
- [x] x86_64
- [x] armv7l/armv8l
