### PR TITLE
Python 3.9.1

### DIFF
--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -3,23 +3,11 @@ require 'package'
 class Python3 < Package
   description 'Python is a programming language that lets you work quickly and integrate systems more effectively.'
   homepage 'https://www.python.org/'
-  version '3.9.0'
+  version '3.9.1'
   compatibility 'all'
-  source_url 'https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz'
-  source_sha256 '9c73e63c99855709b9be0b3cc9e5b072cb60f37311e8c4e50f15576a0bf82854'
+  source_url 'https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz'
+  source_sha256 '991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'afd80fd6f5f187c946ed112eeac7a881686d1efdc4ac1287e833ab1069ca800b',
-     armv7l: 'afd80fd6f5f187c946ed112eeac7a881686d1efdc4ac1287e833ab1069ca800b',
-       i686: '1f332e7b195d5e62a1dd9f7d648f7c4af058c1eaba9ac497772f05f7dbf622c1',
-     x86_64: '78dbbe2f8735a165e052da3fb7cdf14f80e0a88c9d4adcb2a47b930f1ded9ac5',
-  })
 
   depends_on 'bz2'
   depends_on 'xzutils'

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -79,7 +79,7 @@ class Python3 < Package
   def self.postinstall
     puts
     puts "Upgrading pip...".lightblue
-    system 'pip3 install --upgrade pip'
+    system "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} python3 get-pip.py -U"
     puts
   end
 end


### PR DESCRIPTION
- Also using get-pip to upgrade pip, as this was the only way I was able to do this without the install throwing an error.

Works properly:
- [x] x86_64
