### PR TITLE
install.sh: Use optional ARCH env variable in install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ CREW_BREW_DIR="${CREW_PREFIX}/tmp/crew/"
 CREW_DEST_DIR="${CREW_BREW_DIR}/dest"
 CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 
-ARCH="$(uname -m)"
+ARCH="${ARCH:-$(uname -m)}"
 
 if [ "${EUID}" == "0" ]; then
   echo 'Chromebrew should not be installed or run as root.'


### PR DESCRIPTION
This allows passing ```ARCH``` as an environment variable during virtualized installs. 

Nothing should change if such an environment variable is not passed.

This helps in testing ```i686``` & ```armv7l``` architectures by just passing ```ARCH=i686 install.sh``` during installs.

Works properly:
- [x] x86_64
