### PR TITLE
Pygments: uninstall before install solves upgrade

### DIFF
--- a/packages/pygments.rb
+++ b/packages/pygments.rb
@@ -3,12 +3,13 @@ require 'package'
 class Pygments < Package
   description 'Python Syntax Highlighter'
   homepage 'https://pygments.org/'
-  version '2.7.3-1'
+  version '2.7.3-2'
   compatibility 'all'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
   def self.install
-    system "pip3 install pygments --no-warn-script-location --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"
+    system "pip3 uninstall -y pygments"
+    system "pip3 install --upgrade --no-warn-script-location pygments --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"
   end
 end


### PR DESCRIPTION
Fixes #4781

```
  def self.install
    system "pip3 uninstall -y pygments"
    system "pip3 install --upgrade --no-warn-script-location pygments --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"
  end
```


Works properly:
- [x] x86_64
