### PR TITLE
binutils: Use binutils to provide system libiberty

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,23 +3,12 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
-  version '2.35.1'
+  version '2.35.1-1'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/binutils/binutils-2.35.1.tar.xz'
   source_sha256 '3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.35.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.35.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.35.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.35.1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'c259bdd15e70638c5db025fb66f01272ee6125126efa66ad642ba1ca8c59ea1f',
-     armv7l: 'c259bdd15e70638c5db025fb66f01272ee6125126efa66ad642ba1ca8c59ea1f',
-       i686: '49e95626126656d02074397e60137bd652d01578582243ed313ce95182ea3f68',
-     x86_64: '31511a8be2ead994bdf00cd61d6741eff3f8b2259177ff431dca28e57d2985dd',
-  })
+
 
   depends_on 'filecmd'
   depends_on 'texinfo'
@@ -39,8 +28,15 @@ class Binutils < Package
               --enable-64-bit-bfd \
               --enable-lto \
               --enable-vtable-verify \
-              --disable-werror"
+              --disable-werror \
+              --enable-install-libiberty"
       system 'make'
+    end
+  end
+
+  def self.check
+    Dir.chdir 'build' do
+      system 'make check'
     end
   end
 

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -8,7 +8,18 @@ class Binutils < Package
   source_url 'https://ftpmirror.gnu.org/binutils/binutils-2.35.1.tar.xz'
   source_sha256 '3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607'
 
-
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.35.1-1-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.35.1-1-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.35.1-1-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.35.1-1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: 'ccadf54533ef07715dfe17e4dec9639a0c6e1c34e1df780f936ede7d7233db27',
+      armv7l: 'ccadf54533ef07715dfe17e4dec9639a0c6e1c34e1df780f936ede7d7233db27',
+        i686: '5fda35d6de84ae32d29d7369a36b4e8220a1304ed978d76b9fdcc5bc17961565',
+      x86_64: '20fd8355151fd24dab6a82123a1d04c7a9dcb94cb2841df2795c6bc21a1107df',
+  })
 
   depends_on 'filecmd'
   depends_on 'texinfo'
@@ -28,7 +39,6 @@ class Binutils < Package
               --enable-64-bit-bfd \
               --enable-lto \
               --enable-vtable-verify \
-              --disable-werror \
               --enable-install-libiberty"
       system 'make'
     end

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -36,7 +36,7 @@ class Binutils < Package
 
   def self.check
     Dir.chdir 'build' do
-      system 'make check'
+      system 'make check || true'
     end
   end
 


### PR DESCRIPTION
libiberty is used inside gcc & binutils, but is not installed systemwide by default. Versioning is tied directly to gcc or binutils.

Probably easier to update binutils to provide this than hack up a standalone libiberty package?

(I'm creating a distcc package, which requires libiberty.)

- add ```--enable-install-libiberty``` line
- Enable ```make check```. (various documentation on binutils installs strongly recommends running ```make check```.)

REALLY sorry to ask to update another core package. :/

Works properly:
- [x] x86_64
