### PR TITLE
Remove sommelier dependency for gdk_pixbuf

### DIFF
--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -28,7 +28,6 @@ class Gdk_pixbuf < Package
   depends_on 'libtiff'
   depends_on 'libjpeg_turbo'
   depends_on 'six'
-  depends_on 'sommelier'
 
   def self.build
     Dir.mkdir 'build'


### PR DESCRIPTION
`gdk_pixbuf` also have a Wayland mode :)
```bash
export GDK_BACKEND=wayland

    --or--

export GDK_BACKEND=x11
```