### PR TITLE
Glib -> 2.67.1

### DIFF
--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,23 +3,11 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  version '2.67.0'
+  version '2.67.1'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/glib/2.67/glib-2.67.0.tar.xz'
-  source_sha256 '0b15e57ab6c2bb90ced4e24a1b0d8d6e9a13af8a70266751aa3a45baffeed7c1'
+  source_url 'https://download.gnome.org/sources/glib/2.67/glib-2.67.1.tar.xz'
+  source_sha256 '3b3409fe3a93f9e9f6f5dc9cd8405edfd7513b289589987e568369e627d3350c'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '0d66968376ed154064cda24cc3df68bf8e54f1f6f5cdbd05fc7389b4847ec119',
-     armv7l: '0d66968376ed154064cda24cc3df68bf8e54f1f6f5cdbd05fc7389b4847ec119',
-       i686: 'f5c028746bb4e0cc54e1cda5c0b1226f7ac663d21924fc2cd259c0047b2395e1',
-     x86_64: '5a825a37542e1a8ebeb53eaefb321345a164dd822156b92602befc399ce9cce0',
-  })
 
   depends_on 'pcre2'
   depends_on 'libffi'


### PR DESCRIPTION
Fixes: #4700 (in part)
- With this I am able to get glade to install properly on x86_64 & armv7l.

Compiles & packages:
- [x] x86_64
- [x] i686
- [x] armv7l

(Also I have packages for these.)
```
  binary_url ({
     aarch64: 'file:///usr/local/tmp/packages/glib-2.67.1-chromeos-armv7l.tar.xz',
      armv7l: 'file:///usr/local/tmp/packages/glib-2.67.1-chromeos-armv7l.tar.xz',
        i686: 'file:///usr/local/tmp/packages/glib-2.67.1-chromeos-i686.tar.xz',
      x86_64: 'file:///usr/local/tmp/packages/glib-2.67.1-chromeos-x86_64.tar.xz',
  })
  binary_sha256 ({
     aarch64: '94ce4d658fb1a13ab29244bc113bcb1ea78413c3abde24cbc909bb67d4920058',
      armv7l: '94ce4d658fb1a13ab29244bc113bcb1ea78413c3abde24cbc909bb67d4920058',
        i686: '4c66ab7980b9152d0010e997b39d012cf911d8fae1acbac0605bef6e0fc3d3e8',
      x86_64: '7bd6720c47773e22ff45b07337ca820bb77af0b076ffe83bc8ae6f570f7a8895',
  })
```

