### PR TITLE
gcc10 => 10.2.1, with fixed compilation

### DIFF
--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -3,23 +3,12 @@ require 'package'
 class Gcc10 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '10.2.1-07fe'
+  version '10.2.1-65fc'
   compatibility 'all'
-  source_url 'https://github.com/gcc-mirror/gcc/archive/07fed10b19e1d88ad111fd27b4181e53d1aa6778.zip'
-  source_sha256 '455b11e3e82118d8b026cb1a8cb0e7b8331f1f9d76551c60e6792d488b4f1f12'
+  source_url 'https://github.com/gcc-mirror/gcc/archive/65fcf1c2d7f192dc7fda621e27d6c17d08e89352.zip'
+  source_sha256 'fc3cd8d70beb7e0d910f4e0006d95a60e9dee60de7dd3544e92229591372b8ea'
 
-  binary_url ({
-     aarch64: 'file:///usr/local/tmp/packages/gcc10-10.2.1-07fe-chromeos-armv7l.tar.xz',
-      armv7l: 'file:///usr/local/tmp/packages/gcc10-10.2.1-07fe-chromeos-armv7l.tar.xz',
-        i686: 'file:///usr/local/tmp/packages/gcc10-10.2.1-07fe-chromeos-i686.tar.xz',
-      x86_64: 'file:///usr/local/tmp/packages/gcc10-10.2.1-07fe-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-     aarch64: 'e5405c03363f2e1feff695da2c29320665698b41877bfc32bdb670b330d7099b',
-      armv7l: 'e5405c03363f2e1feff695da2c29320665698b41877bfc32bdb670b330d7099b',
-        i686: '8562773de8265d440a6b4de987676959dfd5c46a7153bb0c1cb24776ba500c03',
-      x86_64: '40fe0391e7cb070e1f3fe7d140dcefdcb64cd6f3063784ae93aa309cce479bc4',
-  })
+
 
 
 
@@ -65,63 +54,51 @@ class Gcc10 < Package
     sed -i '77a #ifndef PATH_MAX' libsanitizer/asan/asan_linux.cpp)"
     Dir.chdir("objdir") do
       case ARCH
-      when 'armv7l', 'armv8l', 'aarch64'
-        system "../configure",
-        "--prefix=#{CREW_PREFIX}",
-        "--libdir=#{CREW_LIB_PREFIX}",
-        "--build=armv7l-cros-linux-gnueabihf",
-        "--host=armv7l-cros-linux-gnueabihf",
-        "--target=armv7l-cros-linux-gnueabihf",
-        "--enable-checking=release",
-        "--disable-multilib",
-        "--enable-lto",
-        "--enable-threads=posix",
-        "--disable-bootstrap",
-        "--disable-werror",
-        "--disable-libmpx",
-        "--enable-static",
-        "--enable-shared",
-        "--program-suffix=-#{gcc_version}",
-        "--with-arch=armv7-a",
-        "--with-tune=cortex-a15",
-        "--with-fpu=neon",
-        "--with-float=hard"
-      when 'x86_64'
-        system "../configure",
-        "--prefix=#{CREW_PREFIX}",
-        "--libdir=#{CREW_LIB_PREFIX}",
-        "--build=#{ARCH}-cros-linux-gnu",
-        "--host=#{ARCH}-cros-linux-gnu",
-        "--target=#{ARCH}-cros-linux-gnu",
-        "--enable-checking=release",
-        "--enable-lto",
-        "--disable-multilib",
-        "--enable-threads=posix",
-        "--disable-bootstrap",
-        "--disable-werror",
-        "--disable-libmpx",
-        "--enable-static",
-        "--enable-shared",
-        "--program-suffix=-#{gcc_version}",
-        "--with-arch-64=x86-64"
+      when 'armv7l', 'aarch64'
+        system "../configure #{CREW_OPTIONS} \
+        --enable-checking=release \
+        --disable-multilib \
+        --enable-lto \
+        --enable-threads=posix \
+        --disable-bootstrap \
+        --disable-werror \
+        --disable-libmpx \
+        --enable-static \
+        --enable-shared \
+        --with-pic \
+        --program-suffix=-#{gcc_version} \
+        --with-arch=armv7-a \
+        --with-tune=cortex-a15 \
+        --with-fpu=neon \
+        --with-float=hard"
+      when 'x86_64', 'i686'
+        system "../configure  #{CREW_OPTIONS} \
+        --enable-checking=release \
+        --enable-lto \
+        --disable-multilib \
+        --enable-threads=posix \
+        --disable-bootstrap \
+        --disable-werror \
+        --disable-libmpx \
+        --enable-static \
+        --enable-shared \
+        --with-pic \
+        --program-suffix=-#{gcc_version} \
+        --with-arch-64=x86-64"
       when 'i686'
-        system "../configure",
-        "--prefix=#{CREW_PREFIX}",
-        "--libdir=#{CREW_LIB_PREFIX}",
-        "--build=#{ARCH}-cros-linux-gnu",
-        "--host=#{ARCH}-cros-linux-gnu",
-        "--target=#{ARCH}-cros-linux-gnu",
-        "--enable-checking=release",
-        "--enable-lto",
-        "--disable-multilib",
-        "--enable-threads=posix",
-        "--disable-bootstrap",
-        "--disable-werror",
-        "--disable-libmpx",
-        "--enable-static",
-        "--enable-shared",
-        "--program-suffix=-#{gcc_version}",
-        "--with-arch-32=i686"
+        system "../configure  #{CREW_OPTIONS} \
+        --enable-checking=release \
+        --enable-lto \
+        --disable-multilib \
+        --enable-threads=posix \
+        --disable-bootstrap \
+        --disable-werror \
+        --disable-libmpx \
+        --enable-static \
+        --enable-shared \
+        --with-pic \
+        --program-suffix=-#{gcc_version} \
+        --with-arch-32=#{ARCH}"
       end
       system 'make'
     end

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -3,10 +3,10 @@ require 'package'
 class Gcc10 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '10.2.1-e73c'
+  version '10.2.1-e731'
   compatibility 'all'
-  source_url 'https://github.com/gcc-mirror/gcc/archive/e73caa0fc12e4b33563d68ee58b8af882b2341e6.zip'
-  source_sha256 '61b3e87c52e232c0e6c07b054c215d6c5bda09b910655b00080fa7cc634a436f'
+  source_url 'https://github.com/gcc-mirror/gcc/archive/e731714eb2b4844771fa6f2a7a80d863490b8e6d.zip'
+  source_sha256 '20d5e2d12bd237151ba5be0d2f192de12fe0ea0db71b3f3dfd52b4828ea4267f'
 
   depends_on 'unzip' => :build
   depends_on 'gawk' => :build
@@ -14,6 +14,7 @@ class Gcc10 < Package
   depends_on 'icu4c' => :build
   depends_on 'python27' => :build
   depends_on 'python3' => :build
+  depends_on 'ccache' => :build
 
   depends_on 'binutils'
   depends_on 'gmp'
@@ -30,6 +31,12 @@ class Gcc10 < Package
   end
 
   def self.build
+    # Set ccache sloppiness as per
+    # https://wiki.archlinux.org/index.php/Ccache#Sloppiness
+    system "ccache --set-config=sloppiness=file_macro,locale,time_macros"
+    # Prefix ccache to path.
+    ENV['PATH'] = "#{CREW_LIB_PREFIX}/ccache/bin:#{CREW_PREFIX}/bin:/usr/bin:/bin"
+    
     gcc_version = version.split("-")[0]
     
     # previous compile issue

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -3,23 +3,26 @@ require 'package'
 class Gcc10 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '10.2.0'
+  version '10.2.1-07fe'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz'
-  source_sha256 'b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c'
+  source_url 'https://github.com/gcc-mirror/gcc/archive/07fed10b19e1d88ad111fd27b4181e53d1aa6778.zip'
+  source_sha256 '455b11e3e82118d8b026cb1a8cb0e7b8331f1f9d76551c60e6792d488b4f1f12'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.0-chromeos-x86_64.tar.xz',
+     aarch64: 'file:///usr/local/tmp/packages/gcc10-10.2.1-07fe-chromeos-armv7l.tar.xz',
+      armv7l: 'file:///usr/local/tmp/packages/gcc10-10.2.1-07fe-chromeos-armv7l.tar.xz',
+        i686: 'file:///usr/local/tmp/packages/gcc10-10.2.1-07fe-chromeos-i686.tar.xz',
+      x86_64: 'file:///usr/local/tmp/packages/gcc10-10.2.1-07fe-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '832a12c3db18537775d174c4188cf4bc14aeed72b243a1099e8f1715f6575dbc',
-     armv7l: '832a12c3db18537775d174c4188cf4bc14aeed72b243a1099e8f1715f6575dbc',
-       i686: 'c319f3a643f23b409fef6baffa91eea8afc43936d95ca467f0f26945cde6e5cf',
-     x86_64: 'fc3b15e4b499548131389f38b67cc4ab35e32a4fe9d21f96b108c7a3d20598de',
+     aarch64: 'e5405c03363f2e1feff695da2c29320665698b41877bfc32bdb670b330d7099b',
+      armv7l: 'e5405c03363f2e1feff695da2c29320665698b41877bfc32bdb670b330d7099b',
+        i686: '8562773de8265d440a6b4de987676959dfd5c46a7153bb0c1cb24776ba500c03',
+      x86_64: '40fe0391e7cb070e1f3fe7d140dcefdcb64cd6f3063784ae93aa309cce479bc4',
   })
+
+
+
 
   depends_on 'unzip' => :build
   depends_on 'gawk' => :build
@@ -36,12 +39,17 @@ class Gcc10 < Package
   depends_on 'glibc'
   depends_on 'zstd'
 
+  
+  
   def self.preinstall
-    gccver = `gcc -v 2>&1 | tail -1 | cut -d' ' -f3`.chomp
-    abort "GCC version #{gccver} already installed.".lightgreen unless "#{gccver}" == "No" || "#{gccver}" == "not" || "#{gccver}" == "gcc:" || "#{gccver}" == "#{version}"
+    installed_gccver = `gcc -v 2>&1 | tail -1 | cut -d' ' -f3`.chomp
+    gcc_version = version.split("-")[0]
+    abort "GCC version #{installed_gccver} already installed.".lightgreen unless "#{installed_gccver}" == "No" || "#{installed_gccver}" == "not" || "#{installed_gccver}" == "gcc:" || "#{installed_gccver}" == "#{gcc_version}"
   end
 
   def self.build
+    gcc_version = version.split("-")[0]
+    
     # previous compile issue
     # /usr/local/bin/ld: cannot find crti.o: No such file or directory
     # /usr/local/bin/ld: cannot find /usr/lib64/libc_nonshared.a
@@ -58,7 +66,7 @@ class Gcc10 < Package
     sed -i '77a #ifndef PATH_MAX' libsanitizer/asan/asan_linux.cpp)"
     Dir.chdir("objdir") do
       case ARCH
-      when 'armv7l', 'aarch64'
+      when 'armv7l', 'armv8l', 'aarch64'
         system "../configure",
         "--prefix=#{CREW_PREFIX}",
         "--libdir=#{CREW_LIB_PREFIX}",
@@ -74,7 +82,7 @@ class Gcc10 < Package
         "--disable-libmpx",
         "--enable-static",
         "--enable-shared",
-        "--program-suffix=-#{version}",
+        "--program-suffix=-#{gcc_version}",
         "--with-arch=armv7-a",
         "--with-tune=cortex-a15",
         "--with-fpu=neon",
@@ -95,7 +103,7 @@ class Gcc10 < Package
         "--disable-libmpx",
         "--enable-static",
         "--enable-shared",
-        "--program-suffix=-#{version}",
+        "--program-suffix=-#{gcc_version}",
         "--with-arch-64=x86-64"
       when 'i686'
         system "../configure",
@@ -113,7 +121,7 @@ class Gcc10 < Package
         "--disable-libmpx",
         "--enable-static",
         "--enable-shared",
-        "--program-suffix=-#{version}",
+        "--program-suffix=-#{gcc_version}",
         "--with-arch-32=i686"
       end
       system 'make'
@@ -132,8 +140,11 @@ class Gcc10 < Package
     Dir.chdir("objdir") do
       system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
 
-      gcc_arch = `gcc -dumpmachine`.chomp
-      gcc_dir = "gcc/#{gcc_arch}/#{version}"
+      gcc_arch = `gcc/xgcc -dumpmachine`.chomp
+      gcc_version = version.split("-")[0]
+      #gcc_version = `cat ../gcc/BASE-VER`
+      #gcc_version = `gcc/xgcc -dumpversion`.chomp
+      gcc_dir = "gcc/#{gcc_arch}/#{gcc_version}"
       gcc_libdir = "#{CREW_LIB_PREFIX}/#{gcc_dir}"
 
       # http://www.linuxfromscratch.org/lfs/view/development/chapter06/gcc.html#contents-gcc
@@ -146,41 +157,41 @@ class Gcc10 < Package
       system "install -v -dm755 #{CREW_DEST_LIB_PREFIX}/bfd-plugins"
 
       # Add a compatibility symlink to enable building programs with Link Time Optimization (LTO)
-      system "ln -sfv #{CREW_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so #{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
+      system "ln -rsfv #{CREW_DEST_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so #{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
 
       # Make symbolic links
       Dir.chdir "#{CREW_DEST_LIB_PREFIX}/#{gcc_dir}" do
         system "find . -type f -maxdepth 1 -exec ln -sv #{gcc_libdir}/{} #{CREW_DEST_LIB_PREFIX}/{} \\;"
       end
 
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-#{version} #{CREW_DEST_PREFIX}/bin/cc"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-#{version} #{CREW_DEST_PREFIX}/bin/gcc"
-      system "ln -sv #{CREW_PREFIX}/bin/c++-#{version} #{CREW_DEST_PREFIX}/bin/c++"
-      system "ln -sv #{CREW_PREFIX}/bin/g++-#{version} #{CREW_DEST_PREFIX}/bin/g++"
-      system "ln -sv #{CREW_PREFIX}/bin/cpp-#{version} #{CREW_DEST_PREFIX}/bin/cpp"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-ar-#{version} #{CREW_DEST_PREFIX}/bin/gcc-ar"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-nm-#{version} #{CREW_DEST_PREFIX}/bin/gcc-nm"
-      system "ln -sv #{CREW_PREFIX}/bin/gcc-ranlib-#{version} #{CREW_DEST_PREFIX}/bin/gcc-ranlib"
-      system "ln -sv #{CREW_PREFIX}/bin/gcov-#{version} #{CREW_DEST_PREFIX}/bin/gcov"
-      system "ln -sv #{CREW_PREFIX}/bin/gcov-dump-#{version} #{CREW_DEST_PREFIX}/bin/gcov-dump"
-      system "ln -sv #{CREW_PREFIX}/bin/gcov-tool-#{version} #{CREW_DEST_PREFIX}/bin/gcov-tool"
-      system "ln -sv #{CREW_PREFIX}/bin/gfortran-#{version} #{CREW_DEST_PREFIX}/bin/gfortran"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-#{gcc_version} #{CREW_DEST_PREFIX}/bin/cc"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcc"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/c++-#{gcc_version} #{CREW_DEST_PREFIX}/bin/c++"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/g++-#{gcc_version} #{CREW_DEST_PREFIX}/bin/g++"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/cpp-#{gcc_version} #{CREW_DEST_PREFIX}/bin/cpp"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-ar-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcc-ar"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-nm-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcc-nm"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-ranlib-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcc-ranlib"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcov-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcov"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcov-dump-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcov-dump"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcov-tool-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcov-tool"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gfortran-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gfortran"
 
-      system "ln -sv #{CREW_PREFIX}/bin/#{gcc_arch}-c++-#{version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-c++"
-      system "ln -sv #{CREW_PREFIX}/bin/#{gcc_arch}-g++-#{version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-g++"
-      system "ln -sv #{CREW_PREFIX}/bin/#{gcc_arch}-gcc-#{version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc"
-      system "ln -sv #{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ar-#{version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ar"
-      system "ln -sv #{CREW_PREFIX}/bin/#{gcc_arch}-gcc-nm-#{version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-nm"
-      system "ln -sv #{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ranlib-#{version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ranlib"
-      system "ln -sv #{CREW_PREFIX}/bin/#{gcc_arch}-gfortran-#{version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gfortran"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-c++-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-c++"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-g++-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-g++"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ar-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ar"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-nm-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-nm"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ranlib-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ranlib"
+      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gfortran-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gfortran"
 
-      system "ln -sv #{CREW_PREFIX}/share/man/man1/cpp-#{version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/cpp.1.gz"
-      system "ln -sv #{CREW_PREFIX}/share/man/man1/g++-#{version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/g++.1.gz"
-      system "ln -sv #{CREW_PREFIX}/share/man/man1/gcc-#{version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcc.1.gz"
-      system "ln -sv #{CREW_PREFIX}/share/man/man1/gcov-#{version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcov.1.gz"
-      system "ln -sv #{CREW_PREFIX}/share/man/man1/gcov-dump-#{version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcov-dump.1.gz"
-      system "ln -sv #{CREW_PREFIX}/share/man/man1/gcov-tool-#{version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcov-tool.1.gz"
-      system "ln -sv #{CREW_PREFIX}/share/man/man1/gfortran-#{version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gfortran.1.gz"
+      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/cpp-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/cpp.1.gz"
+      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/g++-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/g++.1.gz"
+      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gcc-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcc.1.gz"
+      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gcov-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcov.1.gz"
+      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gcov-dump-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcov-dump.1.gz"
+      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gcov-tool-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcov-tool.1.gz"
+      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gfortran-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gfortran.1.gz"
     end
   end
 end

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -54,8 +54,7 @@ class Gcc10 < Package
     # /usr/local/bin/ld: cannot find crti.o: No such file or directory
     # /usr/local/bin/ld: cannot find /usr/lib64/libc_nonshared.a
     ENV["LIBRARY_PATH"] = "#{CREW_LIB_PREFIX}"   # fix x86_64 issues
-    system "mkdir -p objdir"
-    system "mkdir -p objdir/gcc/.deps"
+    FileUtils.mkdir_p "objdir/gcc/.deps"
     # This fixes a PATH_MAX undefined error which breaks libsanitizer
     # "libsanitizer/asan/asan_linux.cpp:217:21: error: ‘PATH_MAX’ was not declared in this scope"
     # This is defined in https://chromium.googlesource.com/chromiumos/third_party/kernel/+/refs/heads/chromeos-5.4/include/uapi/linux/limits.h
@@ -150,48 +149,48 @@ class Gcc10 < Package
       # http://www.linuxfromscratch.org/lfs/view/development/chapter06/gcc.html#contents-gcc
       # move a misplaced file
       # The installation stage puts some files used by gdb under the /usr/local/lib(64) directory. This generates spurious error messages when performing ldconfig. This command moves the files to another location.
-      system "mkdir -pv #{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib"
-      system "mv -v #{CREW_DEST_LIB_PREFIX}/*gdb.py #{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib"
+      FileUtils.mkdir_p  "#{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib"
+      FileUtils.mv Dir.glob("#{CREW_DEST_LIB_PREFIX}/*gdb.py"), "#{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib/"
 
       # Install Binary File Descriptor library (BFD)
       system "install -v -dm755 #{CREW_DEST_LIB_PREFIX}/bfd-plugins"
 
       # Add a compatibility symlink to enable building programs with Link Time Optimization (LTO)
-      system "ln -rsfv #{CREW_DEST_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so #{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
+      FileUtils.ln_sf "#{CREW_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so", "#{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
 
       # Make symbolic links
       Dir.chdir "#{CREW_DEST_LIB_PREFIX}/#{gcc_dir}" do
         system "find . -type f -maxdepth 1 -exec ln -sv #{gcc_libdir}/{} #{CREW_DEST_LIB_PREFIX}/{} \\;"
       end
 
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-#{gcc_version} #{CREW_DEST_PREFIX}/bin/cc"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcc"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/c++-#{gcc_version} #{CREW_DEST_PREFIX}/bin/c++"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/g++-#{gcc_version} #{CREW_DEST_PREFIX}/bin/g++"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/cpp-#{gcc_version} #{CREW_DEST_PREFIX}/bin/cpp"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-ar-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcc-ar"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-nm-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcc-nm"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcc-ranlib-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcc-ranlib"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcov-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcov"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcov-dump-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcov-dump"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gcov-tool-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gcov-tool"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/gfortran-#{gcc_version} #{CREW_DEST_PREFIX}/bin/gfortran"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/cc"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/c++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/c++"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/g++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/g++"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/cpp-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/cpp"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-ar-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc-ar"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-nm-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc-nm"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc-ranlib"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcov-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcov"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcov-dump-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcov-dump"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcov-tool-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcov-tool"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gfortran-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gfortran"
 
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-c++-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-c++"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-g++-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-g++"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ar-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ar"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-nm-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-nm"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ranlib-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ranlib"
-      system "ln -rsv #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gfortran-#{gcc_version} #{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gfortran"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-c++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-c++"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-g++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-g++"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ar-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ar"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-nm-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-nm"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ranlib"
+      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gfortran-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gfortran"
 
-      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/cpp-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/cpp.1.gz"
-      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/g++-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/g++.1.gz"
-      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gcc-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcc.1.gz"
-      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gcov-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcov.1.gz"
-      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gcov-dump-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcov-dump.1.gz"
-      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gcov-tool-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gcov-tool.1.gz"
-      system "ln -rsv #{CREW_DEST_PREFIX}/share/man/man1/gfortran-#{gcc_version}.1.gz #{CREW_DEST_PREFIX}/share/man/man1/gfortran.1.gz"
+      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/cpp-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/cpp.1.gz"
+      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/g++-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/g++.1.gz"
+      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gcc-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcc.1.gz"
+      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gcov-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov.1.gz"
+      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gcov-dump-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov-dump.1.gz"
+      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gcov-tool-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov-tool.1.gz"
+      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gfortran-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gfortran.1.gz"
     end
   end
 end

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -183,13 +183,13 @@ class Gcc10 < Package
       FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-ranlib"
 
 
-      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/cpp-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/cpp.1.gz"
-      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/g++-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/g++.1.gz"
-      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gcc-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcc.1.gz"
-      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gcov-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov.1.gz"
-      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gcov-dump-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov-dump.1.gz"
-      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gcov-tool-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov-tool.1.gz"
-      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gfortran-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gfortran.1.gz"
+      FileUtils.ln_s "#{CREW_MAN_PREFIX}/man1/cpp-#{gcc_version}.1.gz", "#{CREW_DEST_MAN_PREFIX}/man1/cpp.1.gz"
+      FileUtils.ln_s "#{CREW_MAN_PREFIX}/man1/g++-#{gcc_version}.1.gz", "#{CREW_DEST_MAN_PREFIX}/man1/g++.1.gz"
+      FileUtils.ln_s "#{CREW_MAN_PREFIX}/man1/gcc-#{gcc_version}.1.gz", "#{CREW_DEST_MAN_PREFIX}/man1/gcc.1.gz"
+      FileUtils.ln_s "#{CREW_MAN_PREFIX}/man1/gcov-#{gcc_version}.1.gz", "#{CREW_DEST_MAN_PREFIX}/man1/gcov.1.gz"
+      FileUtils.ln_s "#{CREW_MAN_PREFIX}/man1/gcov-dump-#{gcc_version}.1.gz", "#{CREW_DEST_MAN_PREFIX}/man1/gcov-dump.1.gz"
+      FileUtils.ln_s "#{CREW_MAN_PREFIX}/man1/gcov-tool-#{gcc_version}.1.gz", "#{CREW_DEST_MAN_PREFIX}/man1/gcov-tool.1.gz"
+      FileUtils.ln_s "#{CREW_MAN_PREFIX}/man1/gfortran-#{gcc_version}.1.gz", "#{CREW_DEST_MAN_PREFIX}/man1/gfortran.1.gz"
     end
   end
 end

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -15,11 +15,14 @@ class Gcc10 < Package
       x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-67cb-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: 'fb98eccd98a78ff5b61bc56ac5a039f18c59e8aa232b90973e6d38b023a32bd8',
-      armv7l: 'fb98eccd98a78ff5b61bc56ac5a039f18c59e8aa232b90973e6d38b023a32bd8',
-        i686: '24e9130977ab9b9879c3be71b058cd168ed43271aaa0ac363c578074914ad12b',
-      x86_64: '9a349f9766c82746d44a8a1bffd3295295ff2ef955da23ee1f67915ec20d3ccd',
+     aarch64: 'e8f28370ad3a9b762602b9b3d70ae4ddad013a2dc8609a4a9dddb0ed929de35d',
+      armv7l: 'e8f28370ad3a9b762602b9b3d70ae4ddad013a2dc8609a4a9dddb0ed929de35d',
+        i686: 'a2eb1e7cd7acbff4e55417d6b8381bde8e203d70bcbf849a729f80d2bcfca2b2',
+      x86_64: '878be29dd3a2409c28b1d2c1e71774ceb23d9849b9242387148c0ca19f60c6a2',
   })
+
+
+
 
   depends_on 'unzip' => :build
   depends_on 'gawk' => :build
@@ -78,7 +81,6 @@ class Gcc10 < Package
         --disable-multilib \
         --enable-lto \
         --enable-threads=posix \
-        --disable-bootstrap \
         --disable-werror \
         --disable-libmpx \
         --enable-static \
@@ -88,35 +90,36 @@ class Gcc10 < Package
         --with-arch=armv7-a \
         --with-tune=cortex-a15 \
         --with-fpu=neon \
-        --with-float=hard"
+        --with-float=hard \
+        --with-build-config=bootstrap-lto-lean"
       when 'x86_64'
         system "../configure  #{CREW_OPTIONS} \
         --enable-checking=release \
         --enable-lto \
         --disable-multilib \
         --enable-threads=posix \
-        --disable-bootstrap \
         --disable-werror \
         --disable-libmpx \
         --enable-static \
         --enable-shared \
         --with-pic \
         --program-suffix=-#{gcc_version} \
-        --with-arch-64=x86-64"
+        --with-arch-64=x86-64 \
+        --with-build-config=bootstrap-lto-lean"
       when 'i686'
         system "../configure  #{CREW_OPTIONS} \
         --enable-checking=release \
         --enable-lto \
         --disable-multilib \
         --enable-threads=posix \
-        --disable-bootstrap \
         --disable-werror \
         --disable-libmpx \
         --enable-static \
         --enable-shared \
         --with-pic \
         --program-suffix=-#{gcc_version} \
-        --with-arch-32=#{ARCH}"
+        --with-arch-32=#{ARCH} \
+        --with-build-config=bootstrap-lto-lean"
       end
       system 'make'
     end

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -3,10 +3,12 @@ require 'package'
 class Gcc10 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '10.2.1-65fc'
+  version '10.2.1-a5bc'
   compatibility 'all'
-  source_url 'https://github.com/gcc-mirror/gcc/archive/65fcf1c2d7f192dc7fda621e27d6c17d08e89352.zip'
-  source_sha256 'fc3cd8d70beb7e0d910f4e0006d95a60e9dee60de7dd3544e92229591372b8ea'
+  source_url 'https://github.com/gcc-mirror/gcc/archive/a5bcb9487dd62b853a6813387309e5f83a47ce0d.zip'
+  source_sha256 '86b301b834dc38cac8160ea2a18c17b8075dfb2a3ba257578ced30df522136db'
+
+
 
 
 
@@ -52,7 +54,12 @@ class Gcc10 < Package
     system "grep  -q 4096 libsanitizer/asan/asan_linux.cpp || (sed -i '77a #endif' libsanitizer/asan/asan_linux.cpp &&
     sed -i '77a #define PATH_MAX 4096' libsanitizer/asan/asan_linux.cpp &&
     sed -i '77a #ifndef PATH_MAX' libsanitizer/asan/asan_linux.cpp)"
+    # Fix "crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object"
+    # when building static llvm
+    system "sed -i 's/-fbuilding-libgcc -fno-stack-protector/-fbuilding-libgcc -fPIC -fno-stack-protector/g' libgcc/Makefile.in"
     Dir.chdir("objdir") do
+      ENV['CFLAGS'] = '-fPIC'
+      ENV['CXXFLAGS'] = '-fPIC'
       case ARCH
       when 'armv7l', 'aarch64'
         system "../configure #{CREW_OPTIONS} \
@@ -157,9 +164,14 @@ class Gcc10 < Package
       FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-g++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-g++"
       FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc"
       FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ar-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ar"
+
       FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-nm-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-nm"
       FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ranlib"
       FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gfortran-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gfortran"
+      
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-ar-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-ar"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-nm-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-nm"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-ranlib"
 
       FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/cpp-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/cpp.1.gz"
       FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/g++-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/g++.1.gz"

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -3,10 +3,23 @@ require 'package'
 class Gcc10 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '10.2.1-e731'
+  version '10.2.1-67cb'
   compatibility 'all'
-  source_url 'https://github.com/gcc-mirror/gcc/archive/e731714eb2b4844771fa6f2a7a80d863490b8e6d.zip'
-  source_sha256 '20d5e2d12bd237151ba5be0d2f192de12fe0ea0db71b3f3dfd52b4828ea4267f'
+  source_url 'https://github.com/gcc-mirror/gcc/archive/67cbe5c8e68299442552f18139e0689646f9729d.zip'
+  source_sha256 '59793cd37021aefeb1152a85dee3e97c443d66a6798907346b2e63678ce0eff6'
+
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-67cb-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-67cb-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-67cb-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-67cb-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: 'fb98eccd98a78ff5b61bc56ac5a039f18c59e8aa232b90973e6d38b023a32bd8',
+      armv7l: 'fb98eccd98a78ff5b61bc56ac5a039f18c59e8aa232b90973e6d38b023a32bd8',
+        i686: '24e9130977ab9b9879c3be71b058cd168ed43271aaa0ac363c578074914ad12b',
+      x86_64: '9a349f9766c82746d44a8a1bffd3295295ff2ef955da23ee1f67915ec20d3ccd',
+  })
 
   depends_on 'unzip' => :build
   depends_on 'gawk' => :build

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -3,26 +3,23 @@ require 'package'
 class Gcc10 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '10.2.1-67cb'
+  version '10.2.1-0f64'
   compatibility 'all'
-  source_url 'https://github.com/gcc-mirror/gcc/archive/67cbe5c8e68299442552f18139e0689646f9729d.zip'
-  source_sha256 '59793cd37021aefeb1152a85dee3e97c443d66a6798907346b2e63678ce0eff6'
+  source_url 'https://github.com/gcc-mirror/gcc/archive/0f64123bde80a37c8d9aced69405e71848a23b95.zip'
+  source_sha256 '87f1b3344db6cdcb7295e63c031e00f2c7755c2656cf9603aeb32cf5a5539ec7'
 
   binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-67cb-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-67cb-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-67cb-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-67cb-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-0f64-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-0f64-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-0f64-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcc10-10.2.1-0f64-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: 'e8f28370ad3a9b762602b9b3d70ae4ddad013a2dc8609a4a9dddb0ed929de35d',
-      armv7l: 'e8f28370ad3a9b762602b9b3d70ae4ddad013a2dc8609a4a9dddb0ed929de35d',
-        i686: 'a2eb1e7cd7acbff4e55417d6b8381bde8e203d70bcbf849a729f80d2bcfca2b2',
-      x86_64: '878be29dd3a2409c28b1d2c1e71774ceb23d9849b9242387148c0ca19f60c6a2',
+     aarch64: 'dc0760c6fc123a48a72a6f5492f56d2be4273c29be3dfce6e7b202521c659365',
+      armv7l: 'dc0760c6fc123a48a72a6f5492f56d2be4273c29be3dfce6e7b202521c659365',
+        i686: '52850f19acb5c7def3b7116a5873a5c68c4f9a7fa254b5198deacff36f1e15aa',
+      x86_64: '438ae78481cbbfcc38c6d917498f6b6f0681627a798b263bb9b8ef222ee38b35',
   })
-
-
-
 
   depends_on 'unzip' => :build
   depends_on 'gawk' => :build
@@ -139,8 +136,6 @@ class Gcc10 < Package
 
       gcc_arch = `gcc/xgcc -dumpmachine`.chomp
       gcc_version = version.split("-")[0]
-      #gcc_version = `cat ../gcc/BASE-VER`
-      #gcc_version = `gcc/xgcc -dumpversion`.chomp
       gcc_dir = "gcc/#{gcc_arch}/#{gcc_version}"
       gcc_libdir = "#{CREW_LIB_PREFIX}/#{gcc_dir}"
 

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -3,17 +3,10 @@ require 'package'
 class Gcc10 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '10.2.1-a5bc'
+  version '10.2.1-e73c'
   compatibility 'all'
-  source_url 'https://github.com/gcc-mirror/gcc/archive/a5bcb9487dd62b853a6813387309e5f83a47ce0d.zip'
-  source_sha256 '86b301b834dc38cac8160ea2a18c17b8075dfb2a3ba257578ced30df522136db'
-
-
-
-
-
-
-
+  source_url 'https://github.com/gcc-mirror/gcc/archive/e73caa0fc12e4b33563d68ee58b8af882b2341e6.zip'
+  source_sha256 '61b3e87c52e232c0e6c07b054c215d6c5bda09b910655b00080fa7cc634a436f'
 
   depends_on 'unzip' => :build
   depends_on 'gawk' => :build
@@ -29,8 +22,6 @@ class Gcc10 < Package
   depends_on 'isl'
   depends_on 'glibc'
   depends_on 'zstd'
-
-  
   
   def self.preinstall
     installed_gccver = `gcc -v 2>&1 | tail -1 | cut -d' ' -f3`.chomp
@@ -78,7 +69,7 @@ class Gcc10 < Package
         --with-tune=cortex-a15 \
         --with-fpu=neon \
         --with-float=hard"
-      when 'x86_64', 'i686'
+      when 'x86_64'
         system "../configure  #{CREW_OPTIONS} \
         --enable-checking=release \
         --enable-lto \
@@ -172,6 +163,7 @@ class Gcc10 < Package
       FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-ar-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-ar"
       FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-nm-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-nm"
       FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-ranlib"
+
 
       FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/cpp-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/cpp.1.gz"
       FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/g++-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/g++.1.gz"

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -156,41 +156,41 @@ class Gcc10 < Package
       system "install -v -dm755 #{CREW_DEST_LIB_PREFIX}/bfd-plugins"
 
       # Add a compatibility symlink to enable building programs with Link Time Optimization (LTO)
-      FileUtils.ln_sf "#{CREW_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so", "#{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
+      FileUtils.ln_s "#{CREW_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so", "#{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
 
       # Make symbolic links
       Dir.chdir "#{CREW_DEST_LIB_PREFIX}/#{gcc_dir}" do
         system "find . -type f -maxdepth 1 -exec ln -sv #{gcc_libdir}/{} #{CREW_DEST_LIB_PREFIX}/{} \\;"
       end
 
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/cc"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/c++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/c++"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/g++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/g++"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/cpp-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/cpp"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-ar-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc-ar"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-nm-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc-nm"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc-ranlib"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcov-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcov"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcov-dump-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcov-dump"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gcov-tool-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcov-tool"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/gfortran-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gfortran"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/cc"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/c++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/c++"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/g++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/g++"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/cpp-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/cpp"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-ar-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc-ar"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-nm-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc-nm"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcc-ranlib"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcov-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcov"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcov-dump-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcov-dump"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gcov-tool-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gcov-tool"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/gfortran-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/gfortran"
 
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-c++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-c++"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-g++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-g++"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ar-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ar"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-nm-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-nm"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ranlib"
-      FileUtils.ln_sf "#{CREW_PREFIX}/bin/#{gcc_arch}-gfortran-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gfortran"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-c++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-c++"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-g++-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-g++"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ar-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ar"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-nm-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-nm"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gcc-ranlib-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gcc-ranlib"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/#{gcc_arch}-gfortran-#{gcc_version}", "#{CREW_DEST_PREFIX}/bin/#{gcc_arch}-gfortran"
 
-      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/cpp-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/cpp.1.gz"
-      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/g++-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/g++.1.gz"
-      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gcc-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcc.1.gz"
-      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gcov-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov.1.gz"
-      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gcov-dump-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov-dump.1.gz"
-      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gcov-tool-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov-tool.1.gz"
-      FileUtils.ln_sf "#{CREW_PREFIX}/share/man/man1/gfortran-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gfortran.1.gz"
+      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/cpp-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/cpp.1.gz"
+      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/g++-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/g++.1.gz"
+      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gcc-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcc.1.gz"
+      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gcov-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov.1.gz"
+      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gcov-dump-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov-dump.1.gz"
+      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gcov-tool-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gcov-tool.1.gz"
+      FileUtils.ln_s "#{CREW_PREFIX}/share/man/man1/gfortran-#{gcc_version}.1.gz", "#{CREW_DEST_PREFIX}/share/man/man1/gfortran.1.gz"
     end
   end
 end


### PR DESCRIPTION
Fixes #4684 

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

(There have been no more tags on the 10.2 branch, but the 10.x tree is currently marked as 10.2.1.)

Obviously, this is not fully rubified, but this doesn't appear to break anything, which is good.

(I have binaries for these too.)