### PR TITLE
gtk add atk dep, Atk ->  2.36

### DIFF
--- a/packages/atk.rb
+++ b/packages/atk.rb
@@ -3,33 +3,23 @@ require 'package'
 class Atk < Package
   description 'ATK provides the set of accessibility interfaces that are implemented by other tookits and applications'
   homepage 'https://developer.gnome.org/atk'
-  version '2.26.1'
+  version '2.36'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/atk/2.26/atk-2.26.1.tar.xz'
-  source_sha256 'ef00ff6b83851dddc8db38b4d9faeffb99572ba150b0664ee02e46f015ea97cb'
+  source_url 'https://download.gnome.org/sources/atk/2.36/atk-2.36.0.tar.xz'
+  source_sha256 'fb76247e369402be23f1f5c65d38a9639c1164d934e40f6a9cf3c9e96b652788'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/atk-2.26.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/atk-2.26.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/atk-2.26.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/atk-2.26.1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '70c1f880c008c5f4282881ec3874db7b10967d2b5cdb6e6ad6ccdcad3ce474b7',
-     armv7l: '70c1f880c008c5f4282881ec3874db7b10967d2b5cdb6e6ad6ccdcad3ce474b7',
-       i686: 'f23be7cebc618b3c77e0a2f600cca826c76e31fba9ecf4161acfd464a7ee67a4',
-     x86_64: '9207587db8548706d1fd592aee5f2e501218d9c44367b0f9826869a44215989b',
-  })
 
   depends_on 'gobject_introspection'
   depends_on 'six' => :build
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "meson #{CREW_MESON_OPTIONS} build"
+    system "meson configure build"
+    system 'ninja -C build'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
   end
+
 end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -26,6 +26,7 @@ class Gtk3 < Package
   depends_on 'shared_mime_info'
   depends_on 'six' => :build
   depends_on 'xdg_base'
+  depends_on 'atk'
 
   def self.build
     # The lld linker allows linking against system ChromeOS libs.


### PR DESCRIPTION
gtk3 wants a newer atk than in the repos.
 - atk -> 2.36
 - gtk3 add dep for atk

Works properly:
- [x] x86_64
