### PR TITLE
Delete symlinks on Cloudready before install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,12 @@ case "${ARCH}" in
 esac
 
 # This will allow things to work without sudo
-sudo chown -R "$(id -u)":"$(id -g)" "${CREW_PREFIX}"
+sudo chown -R "$(id -u)":"$(id -g)" "${CREW_PREFIX}/*/*"
+# Delete 'var' symlink on Cloudready platform
+if [[ $(cat /etc/lsb-release | grep neverware) != "" ]]; then
+  sudo rm -rf /usr/local/var
+  sudo rm -rf /usr/local/local
+fi
 
 # prepare directories
 for dir in "${CREW_CONFIG_PATH}/meta" "${CREW_DEST_DIR}" "${CREW_PACKAGES_PATH}"; do

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ esac
 # This will allow things to work without sudo
 sudo chown -R "$(id -u)":"$(id -g)" "${CREW_PREFIX}"
 # Delete 'var' symlink on Cloudready platform
-if [[ $(cat /etc/lsb-release | grep neverware) != "" ]]; then
+if [[ $(grep neverware /etc/lsb-release) != "" ]]; then
   sudo rm -rf /usr/local/var
   sudo rm -rf /usr/local/local
 fi

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ case "${ARCH}" in
 esac
 
 # This will allow things to work without sudo
-sudo chown -R "$(id -u)":"$(id -g)" "${CREW_PREFIX}/*/*"
+sudo chown -R "$(id -u)":"$(id -g)" "${CREW_PREFIX}"
 # Delete 'var' symlink on Cloudready platform
 if [[ $(cat /etc/lsb-release | grep neverware) != "" ]]; then
   sudo rm -rf /usr/local/var


### PR DESCRIPTION
On Cloudready, `var` is a symlink which pointed to `/var` by default
```shell
lrwxrwxrwx  1 root    root        1 Nov 10 11:49 var -> /var
```