### PR TITLE
force gcc use, update to 3.51

### DIFF
--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -1,25 +1,26 @@
 require 'package'
-
+  
 class Filezilla < Package
   description 'FileZilla Client is a free FTP solution.'
   homepage 'https://filezilla-project.org/'
-  version '3.50.0'
+  version '3.51.0'
   compatibility 'all'
-  source_url 'https://download.filezilla-project.org/client/FileZilla_3.50.0_src.tar.bz2'
-  source_sha256 'e0db87269ca5208aad14a02415337b4f9efe3c49c2d4d14e66e921c78a135c10'
+  source_url 'https://download.filezilla-project.org/client/FileZilla_3.51.0_src.tar.bz2'
+  source_sha256 '82be1c4a4f51bb32a599d0b4cc3a24127ba948c0af0f957233cc6a13ea3b6c4c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.50.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.50.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.50.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.50.0-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.51.0-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.51.0-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.51.0-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.51.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '65db514c90a9b9255985c3175d2a19b66c7f9c5924c8651aea788e12abafcdf6',
-     armv7l: '65db514c90a9b9255985c3175d2a19b66c7f9c5924c8651aea788e12abafcdf6',
-       i686: '82cb9f2f8ca314d7e558017794d3e38df39103cb4d24ed0623b01d7ff3a3472c',
-     x86_64: '42a7b7c6fe4c7f2e07cd029d720663e5e78b891427d4b1440f355ba6aa5d3604',
+     aarch64: '16f8dcf227c393a4f408656cb10e1d5c14144dc1bdd89a6fc5e5ba50fef8e7c8',
+      armv7l: '16f8dcf227c393a4f408656cb10e1d5c14144dc1bdd89a6fc5e5ba50fef8e7c8',
+        i686: '20a8a674b2aa6f1d9358848de435a715bd8c5ff37558107d4f87d11c865be10d',
+      x86_64: '95c2ca352901e85f2450b65b92c0868ece5120e5a02f20194d768d5f915cf731',
   })
+
 
   depends_on 'dbus'
   depends_on 'gnome_icon_theme'
@@ -31,7 +32,13 @@ class Filezilla < Package
   depends_on 'xdg_utils'
   depends_on 'sommelier'
 
+  def self.patch
+    system 'filefix'
+  end
+
   def self.build
+    ENV['CC'] = 'gcc'
+    ENV['CXX'] = 'g++'
     system "./configure #{CREW_OPTIONS} --disable-maintainer-mode --with-pugixml=builtin"
     system 'make'
   end


### PR DESCRIPTION
Fixes #4821

- force gcc in package. Still doesn't address underlying issue with environment variables being screwed up during package compiles.

Works properly:
- [ ] x86_64 (gives same error.)
- [ ] aarch64 ?
- [ ] armv7l ?

Error on x86_64 is:
```
Reading locale option from /home/chronos/user/.config/filezilla/filezilla.xml
Fatal Error: Mismatch between the program and library build versions detected.
The library used 3.0 (wchar_t,compiler with C++ ABI 1013,wx containers,compatible with 2.8),
and your program used 3.0 (wchar_t,compiler with C++ ABI 1014,wx containers,compatible with 2.8).
Aborted (core dumped)
```

(This is a non-working package... but it compiles fine. )

The underlying problem appears to be wxwidgets.rb needing an update?

This is as far as I got this evening. Environment variables are still wonky, making this a difficult slog.
(The following does NOT compile on x86_64 for me)
```
require 'package'

class Wxwidgets < Package
  description 'wxWidgets is a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base.'
  homepage 'https://www.wxwidgets.org/'
  version '3.1.4'
  compatibility 'all'
  source_url 'https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxWidgets-3.1.4.tar.bz2'
  source_sha256 '3ca3a19a14b407d0cdda507a7930c2e84ae1c8e74f946e0144d2fa7d881f1a94'



  depends_on 'gst_plugins_base'
  depends_on 'libnotify'
  depends_on 'libsdl'
  depends_on 'libsecret'
  depends_on 'libsoup'
  depends_on 'mesa'
  depends_on 'gtk3'

  def self.build
# This is from the arch install pkgfile
system "cat <<'EOF'> make-abicheck-non-fatal.patch
diff -up wxGTK-2.8.12/src/common/appbase.cpp.abicheck wxGTK-2.8.12/src/common/appbase.cpp
--- wxGTK-2.8.12/src/common/appbase.cpp.abicheck        2015-03-12 17:15:18.000000000 +0100
+++ wxGTK-2.8.12/src/common/appbase.cpp 2015-03-12 17:15:57.000000000 +0100
@@ -424,10 +424,7 @@ bool wxAppConsole::CheckBuildOptions(con
         msg.Printf(_T(\"Mismatch between the program and library build versions detected.\nThe library used %s,\nand %s used %s.\"),
                    lib.c_str(), progName.c_str(), prog.c_str());

-        wxLogFatalError(msg.c_str());
-
-        // normally wxLogFatalError doesn't return
-        return false;
+        wxLogWarning(msg.c_str());
     }
 #undef wxCMP
EOF"
    system "patch -Np1 -i make-abicheck-non-fatal.patch || true"
    system "env && \
     unset CC CXX CXXFLAGS CFLAGS && \
      export LIBRARY_PATH=#{CREW_LIB_PREFIX} && \
      export LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} && \
      export CC=gcc && \
     export CXX=g++ && \
     export CFLAGS= && \
     env && \
     ./configure #{CREW_OPTIONS} \
    --with-gtk=3 --with-opengl --enable-unicode \
    --enable-graphics_ctx --enable-mediactrl --enable-webview --with-regex=builtin \
    --with-libpng=sys \
    --with-libjpeg=sys \
    --with-libtiff=sys \
    --without-gnomevfs \
    --disable-precomp-headers"
   system 'make'
  end

  def self.install
    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
  end
end
```
This however does compile on i686:

```
require 'package'

class Wxwidgets < Package
  description 'wxWidgets is a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base.'
  homepage 'https://www.wxwidgets.org/'
  version '3.1.4'
  compatibility 'all'
  source_url 'https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxWidgets-3.1.4.tar.bz2'
  source_sha256 '3ca3a19a14b407d0cdda507a7930c2e84ae1c8e74f946e0144d2fa7d881f1a94'



  depends_on 'gst_plugins_base'
  depends_on 'libnotify'
  depends_on 'libsdl'
  depends_on 'libsecret'
  depends_on 'libsoup'
  depends_on 'mesa'
  depends_on 'gtk3'

  def self.build
system "cat <<'EOF'> make-abicheck-non-fatal.patch
diff -up wxGTK-2.8.12/src/common/appbase.cpp.abicheck wxGTK-2.8.12/src/common/appbase.cpp
--- wxGTK-2.8.12/src/common/appbase.cpp.abicheck        2015-03-12 17:15:18.000000000 +0100
+++ wxGTK-2.8.12/src/common/appbase.cpp 2015-03-12 17:15:57.000000000 +0100
@@ -424,10 +424,7 @@ bool wxAppConsole::CheckBuildOptions(con
         msg.Printf(_T(\"Mismatch between the program and library build versions detected.\nThe library used %s,\nand %s used %s.\"),
                    lib.c_str(), progName.c_str(), prog.c_str());

-        wxLogFatalError(msg.c_str());
-
-        // normally wxLogFatalError doesn't return
-        return false;
+        wxLogWarning(msg.c_str());
     }
 #undef wxCMP
EOF"
    system "patch -Np1 -i make-abicheck-non-fatal.patch || true"
    system "./configure #{CREW_OPTIONS} \
    --with-gtk=3 --with-opengl --enable-unicode \
    --enable-graphics_ctx --enable-mediactrl --enable-webview --with-regex=builtin \
    --with-libpng=sys \
    --with-libjpeg=sys \
    --with-libtiff=sys \
    --without-gnomevfs \
    --disable-precomp-headers"
   system 'make'
  end

  def self.install
    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
  end
end
```

