### PR TITLE
filezilla 3.5.1 Working with binaries

### DIFF
--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -3,22 +3,22 @@ require 'package'
 class Filezilla < Package
   description 'FileZilla Client is a free FTP solution.'
   homepage 'https://filezilla-project.org/'
-  version '3.50.0'
+  version '3.51.0'
   compatibility 'all'
-  source_url 'https://download.filezilla-project.org/client/FileZilla_3.50.0_src.tar.bz2'
-  source_sha256 'e0db87269ca5208aad14a02415337b4f9efe3c49c2d4d14e66e921c78a135c10'
+  source_url 'https://download.filezilla-project.org/client/FileZilla_3.51.0_src.tar.bz2'
+  source_sha256 '82be1c4a4f51bb32a599d0b4cc3a24127ba948c0af0f957233cc6a13ea3b6c4c'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.50.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.50.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.50.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.50.0-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.51.0-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.51.0-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.51.0-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.51.0-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '65db514c90a9b9255985c3175d2a19b66c7f9c5924c8651aea788e12abafcdf6',
-     armv7l: '65db514c90a9b9255985c3175d2a19b66c7f9c5924c8651aea788e12abafcdf6',
-       i686: '82cb9f2f8ca314d7e558017794d3e38df39103cb4d24ed0623b01d7ff3a3472c',
-     x86_64: '42a7b7c6fe4c7f2e07cd029d720663e5e78b891427d4b1440f355ba6aa5d3604',
+     aarch64: '09d27595590ea5d0e3a31b943a34962c8ec9314e8c3628472cb69f0c98bb3a25',
+      armv7l: '09d27595590ea5d0e3a31b943a34962c8ec9314e8c3628472cb69f0c98bb3a25',
+        i686: '731e2488ce0d5024b3f2ae8874dce80e2826d5aa6aefbb92b808e1ac08fafab9',
+      x86_64: 'a2bcd8daeca485ef2695b1eac1490cebb9cfa1d740d20e20ecacffb869451403',
   })
 
   depends_on 'dbus'
@@ -31,7 +31,13 @@ class Filezilla < Package
   depends_on 'xdg_utils'
   depends_on 'sommelier'
 
+  def self.patch
+    system 'filefix'
+  end
+
   def self.build
+    ENV['CC'] = 'gcc'
+    ENV['CXX'] = 'g++'
     system "./configure #{CREW_OPTIONS} --disable-maintainer-mode --with-pugixml=builtin"
     system 'make'
   end


### PR DESCRIPTION
Fixes #4821 4807

Works properly:
- [x] x86_64

(This has gcc & g++ hardcoded, but that's because I was having trouble with clang automatically getting selected. Once that issue is resolved we can probably get rid of those two lines.)

![image](https://user-images.githubusercontent.com/1096701/103245340-db81b980-492d-11eb-9179-6b92e09a78ef.png)

(As you can see I am still having leaking CFLAGS... but maybe in this case it might have helped.)