### PR TITLE
Vulkan 1.2.165

### DIFF
--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -1,28 +1,28 @@
-# Adapted from Arch Linux vulkan-headers PKGBUILD at:
-# https://github.com/archlinux/svntogit-packages/raw/packages/vulkan-headers/trunk/PKGBUILD
-
 require 'package'
 
 class Vulkan_headers < Package
   description 'Vulkan header files'
   homepage 'https://github.com/KhronosGroup/Vulkan-Headers'
-  version '1.2.157'
+  version '1.2.165'
   compatibility 'all'
-  source_url 'https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.157.tar.gz'
-  source_sha256 'dbc121f58641acd45c386ee96ecd5e10a124c489087443d7367fff4b53b49283'
+  source_url 'https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.165.tar.gz'
+  source_sha256 '3f9435a93ba13d94d0c3265a47e0436579e46bb9ca085e9b16a753458e4d79d2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.157-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.157-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.157-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.157-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.165-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.165-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.165-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_headers-1.2.165-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b130e7ad0d764c3e829d0da62260ebdbe192deb699a1540eb9a347b2c1948429',
-     armv7l: 'b130e7ad0d764c3e829d0da62260ebdbe192deb699a1540eb9a347b2c1948429',
-       i686: '75afde70082d150fbf190381da67e6d179968c8d0ecd59151b57a2fade44e8dc',
-     x86_64: '6bc64672860d7c8dc181d730b892ade24003e28b86102be78df28a6025d390b6',
+     aarch64: '03d07ab7485d23e1c0018f2ec02c877997382db4abf3ae80a43cda6a494c5383',
+      armv7l: '03d07ab7485d23e1c0018f2ec02c877997382db4abf3ae80a43cda6a494c5383',
+        i686: '66ec66419c0725af304b422462364449785c92c2599f392044b31d39d4d4ce4b',
+      x86_64: 'f4a32c518e378b6ec9c6d7535df7b7269a04ee0bdff98c50435219fbf6610788',
   })
+
+
+
 
   def self.build
     Dir.mkdir 'build'

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -21,9 +21,6 @@ class Vulkan_headers < Package
       x86_64: 'f4a32c518e378b6ec9c6d7535df7b7269a04ee0bdff98c50435219fbf6610788',
   })
 
-
-
-
   def self.build
     Dir.mkdir 'build'
     Dir.chdir 'build' do

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -1,28 +1,26 @@
-# Adapted from Arch Linux vulkan-icd-loader PKGBUILD at:
-# https://github.com/archlinux/svntogit-packages/raw/packages/vulkan-icd-loader/trunk/PKGBUILD
-
 require 'package'
 
 class Vulkan_icd_loader < Package
   description 'Vulkan Installable Client Driver ICD Loader'
   homepage 'https://github.com/KhronosGroup/Vulkan-Loader'
-  version '1.2.153-2'
+  version '1.2.165'
   compatibility 'all'
-  source_url 'https://github.com/KhronosGroup/Vulkan-Loader/archive/v1.2.153.tar.gz'
-  source_sha256 '5fb906b2dc968f2256f2d09b093ec8cc7f19812d656c649de8ed709a6da63d4a'
+  source_url 'https://github.com/KhronosGroup/Vulkan-Loader/archive/v1.2.165.tar.gz'
+  source_sha256 'cee0bca20c1665d944bdb310795e92401062228012f503e0b89d1ca5ac9a85d2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.153-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.153-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.153-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.153-2-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.165-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.165-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.165-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vulkan_icd_loader-1.2.165-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '5756b62ea74988eef3cbf9e189ded23fb826848f086b5f809309276c7556d5eb',
-     armv7l: '5756b62ea74988eef3cbf9e189ded23fb826848f086b5f809309276c7556d5eb',
-       i686: '0505cb5556abb969fca4378f7d16979fa38739a6804c4dce7f2e3965cea0eeb6',
-     x86_64: 'f234c7327d2044847bd39d354aa0769997da8797162f2ae7b818de6b53de9a1a',
+     aarch64: '111892eecd85e7df76077ba8dd3856da3da6f33b733fa29fb01aa468e954d84e',
+      armv7l: '111892eecd85e7df76077ba8dd3856da3da6f33b733fa29fb01aa468e954d84e',
+        i686: 'ecdd392d03a787e2196201247cd46412accea070a13d79f2eb00ffa452d64ff1',
+      x86_64: '067011ff594dff5c3fff6b4bc32d0275656d685011fcf498c93b5b78a55b8198',
   })
+
 
   depends_on 'llvm' => ':build'
   depends_on 'libx11'
@@ -34,13 +32,11 @@ class Vulkan_icd_loader < Package
   depends_on 'vulkan_headers' => ':build'
 
   def self.build
-    ENV['CC'] = 'clang'
-    ENV['CXX'] = 'clang'
+    ENV['CXXFLAGS'] = "-fuse-ld=lld"
     Dir.mkdir 'build'
     Dir.chdir 'build' do
-      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
+      system "cmake #{CREW_CMAKE_OPTIONS} \
         -DVULKAN_HEADERS_INSTALL_DIR=#{CREW_PREFIX} \
-        -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX} \
         -DCMAKE_INSTALL_SYSCONFDIR=#{CREW_PREFIX}/etc \
         -DCMAKE_INSTALL_DATADIR=#{CREW_PREFIX}/share \
         -DCMAKE_SKIP_RPATH=True \
@@ -48,7 +44,6 @@ class Vulkan_icd_loader < Package
         -DBUILD_WSI_XCB_SUPPORT=On \
         -DBUILD_WSI_XLIB_SUPPORT=On \
         -DBUILD_WSI_WAYLAND_SUPPORT=On \
-        -DCMAKE_BUILD_TYPE=Release \
         .. && make"
     end
   end

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -21,7 +21,6 @@ class Vulkan_icd_loader < Package
       x86_64: '067011ff594dff5c3fff6b4bc32d0275656d685011fcf498c93b5b78a55b8198',
   })
 
-
   depends_on 'llvm' => ':build'
   depends_on 'libx11'
   depends_on 'libxrandr'


### PR DESCRIPTION
- Update to 1.2.165
- also let gcc compile these.
- more CREW_OPTIONS usage

Works properly:
- [x] x86_64
