### PR TITLE
Add pre-built binaries for packages e-x

### DIFF
--- a/packages/exo.rb
+++ b/packages/exo.rb
@@ -8,6 +8,19 @@ class Exo < Package
   source_url "https://archive.xfce.org/src/xfce/exo/4.16/exo-#{version}.tar.bz2"
   source_sha256 '1975b00eed9a8aa1f899eab2efaea593731c19138b83fdff2f13bdca5275bacc'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/exo-4.16.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/exo-4.16.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/exo-4.16.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/exo-4.16.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f0320072faf16879bbd5dac3ccb130995a7a7240b18fea972ea4689c2355caf0',
+     armv7l: 'f0320072faf16879bbd5dac3ccb130995a7a7240b18fea972ea4689c2355caf0',
+       i686: 'ed48c7732a1b6ee48f1b8e3edf5c6eefc6799c53b13770eb0570ee2ce4c92e0a',
+     x86_64: '8500a41e6e353f7a68e384d221085395c0cad4dcd2c9cc537b7b2dc01fd5bacc',
+  })
+
   depends_on 'libxfce4ui'
   depends_on 'xfce4_dev_tools'
 

--- a/packages/libxfce4ui.rb
+++ b/packages/libxfce4ui.rb
@@ -8,6 +8,19 @@ class Libxfce4ui < Package
   source_url "https://archive.xfce.org/src/xfce/libxfce4ui/4.16/libxfce4ui-4.16.0.tar.bz2"
   source_sha256 '8b06c9e94f4be88a9d87c47592411b6cbc32073e7af9cbd64c7b2924ec90ceaa'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4ui-4.16.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4ui-4.16.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4ui-4.16.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4ui-4.16.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '2c97cfdf36b164b7c798dc42d16b0e4abd6777b4ab4dd6c115f4b43359afa4ad',
+     armv7l: '2c97cfdf36b164b7c798dc42d16b0e4abd6777b4ab4dd6c115f4b43359afa4ad',
+       i686: 'aec6b72ae1c3405524e8f823746e18139f4c5a8e3855322c4a128f5d29a29186',
+     x86_64: '109195c13796a024b26c3d58773555cc62bb9b373fbcb8a511816dbe63bdd043',
+  })
+
   depends_on 'gtk3'
   depends_on 'gtk2'
   depends_on 'pygtk' # For gtk+

--- a/packages/libxfce4util.rb
+++ b/packages/libxfce4util.rb
@@ -8,6 +8,19 @@ class Libxfce4util < Package
   source_url 'https://archive.xfce.org/src/xfce/libxfce4util/4.16/libxfce4util-4.16.0.tar.bz2'
   source_sha256 '60598d745d1fc81ff5ad3cecc3a8d1b85990dd22023e7743f55abd87d8b55b83'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4util-4.16.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4util-4.16.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4util-4.16.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxfce4util-4.16.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'ceca4f8f984045af5c7d945c679884e034ccbe005b778ad51bb957cf59c00cc8',
+     armv7l: 'ceca4f8f984045af5c7d945c679884e034ccbe005b778ad51bb957cf59c00cc8',
+       i686: '6bd36fee5ba039cfd4eeba7d35dd8518d077c8ff7ab3655592a47c2d3b1f6f4a',
+     x86_64: '077a6ddd98402bced4c6269ce7374452ef3709a4c821565c643108ccb8c3cd8e',
+  })
+
   depends_on 'gobject_introspection'
 
   def self.build

--- a/packages/startup_notification.rb
+++ b/packages/startup_notification.rb
@@ -3,27 +3,29 @@ require 'package'
 class Startup_notification < Package
   description 'Library for tracking application startup'
   homepage 'http://www.freedesktop.org'
-  version '0.12'
+  version '0.12-1'
   compatibility 'all'
   source_url 'https://freedesktop.org/software/startup-notification/releases/startup-notification-0.12.tar.gz'
   source_sha256 '3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-chromeos-x86_64.tar.xz',
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '731097a23182eb11aa6858425948fc29f616721189f6bfb1203ebffefba98965',
-     armv7l: '731097a23182eb11aa6858425948fc29f616721189f6bfb1203ebffefba98965',
-       i686: '4fb01aac0d158c6cbf866ecca912f592de05a43191ef87679f47bc1eede1d4e8',
-     x86_64: '722f0cb744f3b4b947782fd22dec23e6c9459d4786196cb5798c6faa74219939',
+    aarch64: 'c6a0bf1e9af0ac20da92a9c4e2bde6fa48cfbdc7a5b6e436aaf2814472ec9914',
+     armv7l: 'c6a0bf1e9af0ac20da92a9c4e2bde6fa48cfbdc7a5b6e436aaf2814472ec9914',
+       i686: '23ed0fa58d54e3d04c068e4cf591c292a5ae1ee56093349e35adb7eab47e5f7e',
+     x86_64: 'b8fa364b3a6cd8c9f9c1cf18782086de55cea6354200448aa5c6d96f4f840b38',
   })
-  
+
+  depends_on 'xcb_util'
+
   def self.build
     system "./configure #{CREW_OPTIONS}"
-    system "make -j#{CREW_NPROC}"
+    system 'make'
   end
 
   def self.install

--- a/packages/thunar.rb
+++ b/packages/thunar.rb
@@ -8,6 +8,19 @@ class Thunar < Package
   source_url "https://archive.xfce.org/src/xfce/thunar/4.16/thunar-#{version}.tar.bz2"
   source_sha256 'da2d17d2cb69eb33768690b714cc232ed367cbd71eb9543aaa2a805d05dc3ce1'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/thunar-4.16.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/thunar-4.16.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/thunar-4.16.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/thunar-4.16.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f72859ef9d34c9f53b027e3ff4f939d53dfd02e2e14fa1ccba7272857dff6846',
+     armv7l: 'f72859ef9d34c9f53b027e3ff4f939d53dfd02e2e14fa1ccba7272857dff6846',
+       i686: 'a9968a493f18165318d3c1580e7aef64af66872290eb9f80d3164b3a1d4f06bd',
+     x86_64: 'a07083925abfeb69f6e960869a61da8039b8afa0a79c9601f312cdb750ccfb86',
+  })
+
   depends_on 'exo'
   depends_on 'libexif'
   depends_on 'libgudev'

--- a/packages/xfce4_panel.rb
+++ b/packages/xfce4_panel.rb
@@ -8,6 +8,19 @@ class Xfce4_panel < Package
   source_url "https://archive.xfce.org/src/xfce/xfce4-panel/4.16/xfce4-panel-#{version}.tar.bz2"
   source_sha256 '5e979aeeb37d306d72858b1bc67448222ea7a68de01409055b846cd31f3cc53d'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_panel-4.16.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_panel-4.16.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_panel-4.16.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_panel-4.16.0-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '338ec0279e7da70d8748e5a434b82a52230f2f0359903e1a93488e144c8b9c1b',
+     armv7l: '338ec0279e7da70d8748e5a434b82a52230f2f0359903e1a93488e144c8b9c1b',
+       i686: 'ddcb71b0ab71cb33e90c1d0eee09aafbe3aa70d5b76c6e35a6174ecfed8489c5',
+     x86_64: 'a756559d9682ea4857c576af6b305c8ee29e1c8d59b9776cdf9b85de07bc7130',
+  })
+
   depends_on 'libwnck'
   depends_on 'libxfce4ui'
   depends_on 'xfconf'

--- a/packages/xfce4_terminal.rb
+++ b/packages/xfce4_terminal.rb
@@ -8,6 +8,19 @@ class Xfce4_terminal < Package
   source_url "https://archive.xfce.org/src/apps/xfce4-terminal/0.8/xfce4-terminal-#{version}.tar.bz2"
   source_sha256 '7a3337c198e01262a0412384823185753ac8a0345be1d6776a7e9bbbcbf33dc7'
 
+  binary_url ({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_terminal-0.8.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_terminal-0.8.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_terminal-0.8.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xfce4_terminal-0.8.10-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'b11aa2b481bf89d83e2d1e8086f8a38947c6f1b1e5ec7b3db2e4a9a71b192aa1',
+     armv7l: 'b11aa2b481bf89d83e2d1e8086f8a38947c6f1b1e5ec7b3db2e4a9a71b192aa1',
+       i686: 'bc19f058e7e0fd3b50b8838668f151db825172a3e5ef64736d40f916ea02a817',
+     x86_64: 'dfa50e1a41870d5e63316a95fccd57a51e420045c8fd583a9bcc18ead9ddaa71',
+  })
+
   depends_on 'desktop_file_utilities'
   depends_on 'gtkvte'
   depends_on 'exo' => :build


### PR DESCRIPTION
Fixes #4860.
Fixes #4861.
Tested on all architectures.