### PR TITLE
Update fpc from 3.0.4 to 3.2.0

### DIFF
--- a/packages/fpc.rb
+++ b/packages/fpc.rb
@@ -3,15 +3,18 @@ require 'package'
 class Fpc < Package
   description 'Free Pascal is a 32, 64 and 16 bit professional Pascal compiler.'
   homepage 'https://www.freepascal.org/'
-  version '3.0.4'
-  compatibility 'i686,x86_64'
+  version '3.2.0'
+  compatibility 'all'
   case ARCH
+  when 'aarch64', 'armv7l'
+    source_url 'https://downloads.sourceforge.net/project/freepascal/Linux/3.2.0/fpc-3.2.0.arm-linux.tar'
+    source_sha256 'b78c72859e1e147e33991e1bb1e937654859799ae2afc145257c834a8d52737e'
   when 'i686'
-    source_url 'http://downloads.sourceforge.net/project/freepascal/Linux/3.0.4/fpc-3.0.4.i386-linux.tar'
-    source_sha256 'aa6da9a58d155bbaa71aaa7f414d64b02b3e450dc23eed7c161eac6d547fae17'
+    source_url 'https://downloads.sourceforge.net/project/freepascal/Linux/3.2.0/fpc-3.2.0.i386-linux.tar'
+    source_sha256 '2110eb1d7a35311f587694f9b25dc2660e0116eafd9884c4c7ab2f2716080578'
   when 'x86_64'
-    source_url 'http://downloads.sourceforge.net/project/freepascal/Linux/3.0.4/fpc-3.0.4.x86_64-linux.tar'
-    source_sha256 '7e965baf13c9822a0ff39e7bbfa040bd5599e94d0f3338f1ac4efa989081fd77'
+    source_url 'https://downloads.sourceforge.net/project/freepascal/Linux/3.2.0/fpc-3.2.0-x86_64-linux.tar'
+    source_sha256 'd19252e6cfe52f1217f4822a548ee699eaa7e044807aaf8429a0532cb7e4cb3d'
   end
 
   def self.build


### PR DESCRIPTION
Tested on all architectures.  The arm test was a bit flaky but every other platform worked fine, although the fpc executable appeared to be expecting ppc architecture?