### PR TITLE
Cras to stabilize-13654.B

### DIFF
--- a/packages/cras.rb
+++ b/packages/cras.rb
@@ -3,12 +3,25 @@ require 'package'
 class Cras < Package
   description 'ChromeOS Audio Server'
   homepage 'https://www.chromium.org/chromium-os/chromiumos-design-docs/cras-chromeos-audio-server'
-  version 'stabilize-13360.B'
-  compatibility 'aarch64,armv7l,x86_64'
-  case ARCH
-  when 'aarch64', 'armv7l', 'x86_64'
-    source_url 'https://chromium.googlesource.com/chromiumos/third_party/adhd/+/refs/heads/stabilize-13360.B/cras/README.md'
-    source_sha256 '27f138b73f3e6b46c6f1af509ed6887c76fc234c026ce08383712a87efdf97d6'
+  version 'stabilize-13654.B'
+  compatibility 'all'
+  source_url "https://chromium.googlesource.com/chromiumos/third_party/adhd/+/refs/heads/#{version}/cras/README.md"
+  source_sha256 '355514e78ba4d1736f53c427c329bdfad327afc052a1b78d543cb4840d199b4e'
+
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-13654.B-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-13654.B-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-13654.B-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-13654.B-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: '586a93c5359b39c91a576904a212dde5926581d603263874d71feef6ef6cf1e2',
+      armv7l: '586a93c5359b39c91a576904a212dde5926581d603263874d71feef6ef6cf1e2',
+        i686: '4f488c0a8ca5115995c2d9530442c7ad58da8bb19684d75815c6b60d9ae8ed18',
+      x86_64: '1f53ed96948e29f71d42f1b437e7e4637f6e08a4e573966ec139bb3437ed0d21',
+  })
+
+
     depends_on 'alsa_lib'
     depends_on 'ladspa'
     depends_on 'iniparser'
@@ -17,18 +30,8 @@ class Cras < Package
     depends_on 'dbus'
     depends_on 'rust' => ':build'
     depends_on 'llvm' => ':build'
-  end
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-13360.B-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-13360.B-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cras-stabilize-13360.B-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'b6f00eaca8ce6b3df30539bfd9b41f611fd8e215842b3b785cc4ba58452f7cf9',
-     armv7l: 'b6f00eaca8ce6b3df30539bfd9b41f611fd8e215842b3b785cc4ba58452f7cf9',
-     x86_64: '816885e44dec95ca74e887d8fe57e164ef3a3ce1e2e5d9499a199b5513367e6b',
-  })
+    depends_on 'gtest' => :build
+    depends_on 'eudev'
 
   def self.build
     system 'git', 'clone', 'https://chromium.googlesource.com/chromiumos/third_party/adhd', '-b', version, '.'
@@ -57,21 +60,24 @@ ctl.!default {
 }
 _EOF_'
       system './git_prepare.sh'
-      ENV['CC'] = 'clang'
-      ENV['CXX'] = 'clang++'
-      ENV['CXXFLAGS'] = "-g -O2 -std=gnu++11 -Wall"
-      ENV['CFLAGS'] = "-g -O2 -Wall"
-      system './configure',
-             "--prefix=#{CREW_PREFIX}",
-             "--libdir=#{CREW_LIB_PREFIX}",
-             '--disable-alsa-plugin',
-             '--disable-static',
-             '--disable-webrtc-apm',
-             '--enable-sse42',
-             '--enable-avx',
-             '--enable-avx2',
-             '--enable-fma'
-      system "make -j#{CREW_NPROC}"
+      if ARCH == 'i686'
+        system "CFLAGS='-fuse-ld=lld -msse2' ./configure #{CREW_OPTIONS} \
+          --disable-alsa-plugin \
+          --disable-webrtc-apm \
+          --enable-sse42 \
+          --enable-avx \
+          --enable-avx2 
+          --enable-fma"
+      else
+        system "CFLAGS='-fuse-ld=lld' ./configure #{CREW_OPTIONS} \
+          --disable-alsa-plugin \
+          --disable-webrtc-apm \
+          --enable-sse42 \
+          --enable-avx \
+          --enable-avx2 \
+          --enable-fma"
+      end
+      system "make"
     end
   end
 


### PR DESCRIPTION
Fix compile for i686.

Works properly:
- [x] x86_64

Builds properly:
- [x] armv7l
- [x] i686

(Tested by running ```LD_LIBRARY_PATH=/usr/lib64 alsamixer```)
