### PR TITLE
Add LTO meson option

### DIFF
--- a/crew
+++ b/crew
@@ -325,6 +325,7 @@ def const (var)
       'CREW_LIB_PREFIX',
       'CREW_LIB_SUFFIX',
       'CREW_MAN_PREFIX',
+      'CREW_MESON_LTO_OPTIONS',
       'CREW_MESON_OPTIONS',
       'CREW_NOT_COMPRESS',
       'CREW_NOT_STRIP',

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -68,7 +68,7 @@ when 'x86_64'
 end
 
 CREW_OPTIONS = "--prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --mandir=#{CREW_MAN_PREFIX} --build=#{CREW_BUILD} --host=#{CREW_BUILD} --target=#{CREW_BUILD}"
-CREW_MESON_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=release -Dc_args='-fuse-ld=lld'"
+CREW_MESON_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=release -Dc_args='-fuse-ld=lld' -Dcpp_args='-fuse-ld=lld'"
 CREW_MESON_LTO_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=release   -Dcpp_args='-flto -fuse-ld=gold' -Dcpp_link_args='-flto' -Dc_args='-flto -fuse-ld=gold' -Dc_link_args='-flto'"
 
 # Cmake sometimes wants to use LIB_SUFFIX to install libs in LIB64, so specify such for x86_64

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.5.4'
+CREW_VERSION = '1.5.5'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines
@@ -69,6 +69,7 @@ end
 
 CREW_OPTIONS = "--prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --mandir=#{CREW_MAN_PREFIX} --build=#{CREW_BUILD} --host=#{CREW_BUILD} --target=#{CREW_BUILD}"
 CREW_MESON_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=release -Dc_args='-fuse-ld=lld'"
+CREW_MESON_LTO_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=release   -Dcpp_args='-flto -fuse-ld=gold' -Dcpp_link_args='-flto' -Dc_args='-flto -fuse-ld=gold' -Dc_link_args='-flto'"
 
 # Cmake sometimes wants to use LIB_SUFFIX to install libs in LIB64, so specify such for x86_64
 # This is often considered deprecated. See discussio at https://gitlab.kitware.com/cmake/cmake/-/issues/18640 


### PR DESCRIPTION
LTO isn't currently being used on any packages.

Let's start doing that?

This creates a ```CREW_MESON_LTO_OPTIONS``` option to enable LTO with GCC and NOT using the lld linker.
(LLD doesn't support the LTO from GCC... I'm working on getting LLVM's LTO working... which should work with lld.)

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686


- Also this fixes cpp_args not having the fuse lld option for CREW_MESON_OPTIONS