### PR TITLE
Add GNU MACchanger to package list

### DIFF
--- a/packages/macchanger.rb
+++ b/packages/macchanger.rb
@@ -5,8 +5,8 @@ class Macchanger < Package
   homepage 'http://www.gnu.org/software/macchanger/'
   version '1.7.0'
   compatibility 'all'
-  source_url 'https://ftp.gnu.org/gnu/macchanger/macchanger-1.6.0.tar.gz'
-  source_sha256 '31534f138f1d21fa247be74ba6bef3fbfa47bbcd5033e99bd10c432fe58e51f7'
+  source_url 'https://github.com/alobbs/macchanger/releases/download/1.7.0/macchanger-1.7.0.tar.gz'
+  source_sha256 'dae2717c270fd5f62d790dbf80c19793c651b1b26b62c101b82d5fdf25a845bf'
 
   def self.build
     system "./configure", "--prefix=#{CREW_PREFIX}"

--- a/packages/macchanger.rb
+++ b/packages/macchanger.rb
@@ -9,7 +9,7 @@ class Macchanger < Package
   source_sha256 'dae2717c270fd5f62d790dbf80c19793c651b1b26b62c101b82d5fdf25a845bf'
 
   def self.build
-    system "./configure", "--prefix=#{CREW_PREFIX}"
+    system "./configure #{CREW_OPTIONS}"
     system "make"
   end
 

--- a/packages/macchanger.rb
+++ b/packages/macchanger.rb
@@ -1,0 +1,22 @@
+require 'package'
+
+class Macchanger < Package
+  description 'GNU MAC Changer is an utility that makes the maniputation of MAC addresses of network interfaces easier.'
+  homepage 'http://www.gnu.org/software/macchanger/'
+  version '1.7.0'
+  compatibility 'all'
+  source_url 'https://ftp.gnu.org/gnu/macchanger/macchanger-1.6.0.tar.gz'
+  source_sha256 '31534f138f1d21fa247be74ba6bef3fbfa47bbcd5033e99bd10c432fe58e51f7'
+
+  def self.build
+    system "./configure", "--prefix=#{CREW_PREFIX}"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+  def self.check
+    system "make", "check"
+  end
+end


### PR DESCRIPTION
Allow for mac address "spoofing" along with other things

Tested on x86_64. Not tested on any other architecture, however I don't see why it wouldn't work. It compiles in less than a minute so it may not need a binary package.