### PR TITLE
Update youtubedl to 2021.01.08

### DIFF
--- a/packages/youtubedl.rb
+++ b/packages/youtubedl.rb
@@ -2,24 +2,11 @@ require 'package'
 
 class Youtubedl < Package
   description 'Command-line program to download videos from YouTube.com and other video sites'
-  homepage 'http://rg3.github.io/youtube-dl/'
-  version '2020.12.14'
+  homepage 'https://youtube-dl.org/'
+  version '2021.01.08'
   compatibility 'all'
-  source_url 'https://github.com/ytdl-org/youtube-dl/archive/2020.12.14.tar.gz'
-  source_sha256 '34f5f817bf82bb2f768bb3cf2460e7341e3df3cf8901ed00aebb9b97a308c980'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/youtubedl-2020.12.14-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/youtubedl-2020.12.14-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/youtubedl-2020.12.14-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/youtubedl-2020.12.14-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'dcb6599df3d676da65a142510428e4f05eda6c1d713d02eefe9024f26f51b78d',
-     armv7l: 'dcb6599df3d676da65a142510428e4f05eda6c1d713d02eefe9024f26f51b78d',
-       i686: '0b80c2458c82cf40365ec8c1080e44accd065feb1a7c212db2603fc3af3a8e76',
-     x86_64: 'c1a343feeb52cb380eea8b134799d69d690fcea4103272c0c5c5a79f93e872e7',
-  })
+  source_url 'https://github.com/ytdl-org/youtube-dl/releases/download/2021.01.08/youtube-dl-2021.01.08.tar.gz'
+  source_sha256 '7340448a90ac82dfb2b1b6569f08bd87552b9b1647a81eb735e11dd6d30607cd'
 
   def self.install
     system "pip install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR} -I youtube-dl==#{version}"


### PR DESCRIPTION
I also changed the homepage to the website listed on youtubedl's github

I'm not sure how you as a chromebrew community handle binary packages so I just removed them but you're welcome to add the older ones back or make new ones and add them before the file merges
