### PR TITLE
[New Package] dosfstools

### DIFF
--- a/packages/dosfstools.rb
+++ b/packages/dosfstools.rb
@@ -8,8 +8,6 @@ class Dosfstools < Package
   source_url 'https://github.com/dosfstools/dosfstools/releases/download/v4.1/dosfstools-4.1.tar.xz'
   source_sha256 'e6b2aca70ccc3fe3687365009dd94a2e18e82b688ed4e260e04b7412471cc173'
 
-  depends_on 'vim' => :check #Requires `xxd` to check, otherwise all checks are skipped and test exits 0.
-
   def self.build
     system "./configure #{CREW_OPTIONS}"
     system "make"
@@ -17,9 +15,5 @@ class Dosfstools < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-  end
-
-  def self.check
-    system "make", "check"
   end
 end

--- a/packages/dosfstools.rb
+++ b/packages/dosfstools.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Dosfstools < Package
+  description 'dosfstools consists of the programs mkfs.fat, fsck.fat and fatlabel to create, check and label file systems of the FAT family.'
+  homepage 'https://github.com/dosfstools/dosfstools'
+  compatibility 'all'
+  version '4.1'
+  source_url 'https://github.com/dosfstools/dosfstools/releases/download/v4.1/dosfstools-4.1.tar.xz'
+  source_sha256 'e6b2aca70ccc3fe3687365009dd94a2e18e82b688ed4e260e04b7412471cc173'
+
+  depends_on 'vim' => :check #Requires `xxd` to check, otherwise all checks are skipped and test exits 0.
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
+  end
+end

--- a/packages/dosfstools.rb
+++ b/packages/dosfstools.rb
@@ -9,7 +9,7 @@ class Dosfstools < Package
   source_sha256 'e6b2aca70ccc3fe3687365009dd94a2e18e82b688ed4e260e04b7412471cc173'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS} --enable-compat-symlinks"
     system "make"
   end
 


### PR DESCRIPTION
compiles on x86_64 just fine. It compiles in less than a minute so it may not need a binary package. Strange note: the make check script in the makefile requires `xxd` which seems to be part of the vim package. This is only required to check and not to build or install, so I did something I hadn't seen before and added the line;
```
depends_on 'vim' => :check
```
It doesn't seem to cause a problem however I'm not sure it actually does anything.