### PR TITLE
OpenSSL 1.1.1i

### DIFF
--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -4,7 +4,7 @@ class Openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
   @_ver = '1.1.1i'
-  version _ver
+  version @_ver
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
   source_sha256 'e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242'

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -27,26 +27,26 @@ class Openssl < Package
 
   case ARCH
   when 'aarch64','armv7l'
-    ARCH_C_FLAGS = '-march=armv7-a -mfloat-abi=hard'
-    ARCH_CXX_FLAGS = '-march=armv7-a -mfloat-abi=hard'
+    @ARCH_C_FLAGS = '-march=armv7-a -mfloat-abi=hard'
+    @ARCH_CXX_FLAGS = '-march=armv7-a -mfloat-abi=hard'
     OPENSSL_CONFIGURE_TARGET = 'linux-generic32'
   when 'i686'
-    ARCH_C_FLAGS = ''
-    ARCH_CXX_FLAGS = ''
+    @ARCH_C_FLAGS = ''
+    @ARCH_CXX_FLAGS = ''
     OPENSSL_CONFIGURE_TARGET = 'linux-x86'
   when 'x86_64'
-    ARCH_C_FLAGS = ''
-    ARCH_CXX_FLAGS = ''
+    @ARCH_C_FLAGS = ''
+    @ARCH_CXX_FLAGS = ''
     OPENSSL_CONFIGURE_TARGET = 'linux-x86_64'
   end
-  ARCH_C_LTO_FLAGS = "#{ARCH_C_FLAGS} -flto=auto"
-  ARCH_CXX_LTO_FLAGS = "#{ARCH_CXX_FLAGS} -flto=auto"
+  @ARCH_C_LTO_FLAGS = "#{@ARCH_C_FLAGS} -flto=auto"
+  @ARCH_CXX_LTO_FLAGS = "#{@ARCH_CXX_FLAGS} -flto=auto"
 
   def self.build
     # This gives you the list of OpenSSL configure targets
     system "./Configure LIST"
     system "env  PATH=#{CREW_LIB_PREFIX}/ccache/bin:#{CREW_PREFIX}/bin:/usr/bin:/bin \
-    CFLAGS=\"#{ARCH_C_LTO_FLAGS}\" CXXFLAGS=\"#{ARCH_CXX_LTO_FLAGS}\" \
+    CFLAGS=\"#{@ARCH_C_LTO_FLAGS}\" CXXFLAGS=\"#{@ARCH_CXX_LTO_FLAGS}\" \
     ./Configure --prefix=#{CREW_PREFIX} \
     --libdir=#{CREW_LIB_PREFIX} \
     --openssldir=#{CREW_PREFIX}/etc/ssl \

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -4,7 +4,7 @@ class Openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
   _ver = '1.1.1i'
-  version "#{_ver}"
+  version _ver
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{_ver}.tar.gz"
   source_sha256 'e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242'

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -6,7 +6,7 @@ class Openssl < Package
   @_ver = '1.1.1i'
   version _ver
   compatibility 'all'
-  source_url "https://www.openssl.org/source/openssl-#{_ver}.tar.gz"
+  source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
   source_sha256 'e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242'
 
   binary_url ({

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -1,12 +1,64 @@
 require 'package'
 
 class Openssl < Package
-  description 'OpenSSL is a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.'
-  homepage 'https://www.openssl.org/'
-  version '3.0.2'
+  description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
+  homepage 'https://www.openssl.org'
+  _ver = '1.1.1i'
+  version "#{_ver}"
   compatibility 'all'
+  source_url "https://www.openssl.org/source/openssl-#{_ver}.tar.gz"
+  source_sha256 'e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242'
 
-  is_fake
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.1.1i-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.1.1i-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.1.1i-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/openssl-1.1.1i-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: 'c3033ec7b37b5d451f528df4361a348a3dde750d71a131551039bed8880b5bb0',
+      armv7l: 'c3033ec7b37b5d451f528df4361a348a3dde750d71a131551039bed8880b5bb0',
+        i686: 'a1435f3a49db9dd3f07f3558cfffdbb0f724b15b1dba430ce3ad028b5d861366',
+      x86_64: '52a43bc84d243218a2bf98c8895b1e366887a7e5308e711a3145ffe7879fe9e0',
+  })
 
-  depends_on 'libressl'
+
+  depends_on 'ccache' => :build
+
+  case ARCH
+  when 'aarch64','armv7l'
+    ARCH_C_FLAGS = '-march=armv7-a -mfloat-abi=hard'
+    ARCH_CXX_FLAGS = '-march=armv7-a -mfloat-abi=hard'
+    OPENSSL_CONFIGURE_TARGET = 'linux-generic32'
+  when 'i686'
+    ARCH_C_FLAGS = ''
+    ARCH_CXX_FLAGS = ''
+    OPENSSL_CONFIGURE_TARGET = 'linux-x86'
+  when 'x86_64'
+    ARCH_C_FLAGS = ''
+    ARCH_CXX_FLAGS = ''
+    OPENSSL_CONFIGURE_TARGET = 'linux-x86_64'
+  end
+  ARCH_C_LTO_FLAGS = "#{ARCH_C_FLAGS} -flto=auto"
+  ARCH_CXX_LTO_FLAGS = "#{ARCH_CXX_FLAGS} -flto=auto"
+
+  def self.build
+    # This gives you the list of OpenSSL configure targets
+    system "./Configure LIST"
+    system "env  PATH=#{CREW_LIB_PREFIX}/ccache/bin:#{CREW_PREFIX}/bin:/usr/bin:/bin \
+    CFLAGS=\"#{ARCH_C_LTO_FLAGS}\" CXXFLAGS=\"#{ARCH_CXX_LTO_FLAGS}\" \
+    ./Configure --prefix=#{CREW_PREFIX} \
+    --libdir=#{CREW_LIB_PREFIX} \
+    --openssldir=#{CREW_PREFIX}/etc/ssl \
+    #{OPENSSL_CONFIGURE_TARGET}"
+    system "make"
+  end
+  
+  def self.check
+    system "make test"
+  end
+  
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install_sw install_ssldirs"
+  end
 end

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,7 +3,7 @@ require 'package'
 class Openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
-  _ver = '1.1.1i'
+  @_ver = '1.1.1i'
   version _ver
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{_ver}.tar.gz"


### PR DESCRIPTION
Fixes #4888

- Does NOT appear to conflict with libraries from libressl
- As long as this is installed after libressl, all new compiles should use the openssl headers and build with openssl
- Tested to work with curl.
- This can be added to ```install.sh``` after the libressl lines.
- Once packages using libressl have been recompiled with openssl, we can remove libressl. 

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686
