### PR TITLE
Add tar to core package list

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -64,5 +64,8 @@ class Buildessential < Package
 
   # perl module build ?
   # depends_on 'perl_module_build'
+  
+  # archive utilities
+  depends_on 'tar'
 
 end


### PR DESCRIPTION
Although chromeos comes with tar, this will come with an updated binary for older chromebooks, especially chromebooks that are/are reaching EOL