### PR TITLE
[New Package] libgdiplus

### DIFF
--- a/packages/libgdiplus.rb
+++ b/packages/libgdiplus.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Libgdiplus < Package
+  description 'libgdiplus is the mono library that provides a GDI+-compatible API on non-windows operating systems.'
+  homepage 'https://www.mono-project.com/docs/gui/libgdiplus/'
+  version '6.0.5'
+  compatibility 'all'
+  source_url 'https://github.com/mono/libgdiplus/archive/6.0.5.tar.gz'
+  source_sha256 '1fd034f4b636214cc24e94c563cd10b3f3444d9f0660927b60e63fd4131d97fa'
+
+  depends_on 'glib'
+  depends_on 'cairo'
+  depends_on 'graphite'
+  depends_on 'libexif'
+  depends_on 'libjpeg'
+  depends_on 'libtiff'
+  
+  def self.build
+    system "env NOCONFIGURE=1 ./autogen.sh"
+    system "./configure #{CREW_OPTIONS} \
+            --disable-static"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+end


### PR DESCRIPTION
compiles fine on x86_64
For some reason, the `make` stage fails unless `libffi` and `wayland` are compiled from the source first and `./configure` doesn't detect `libtiff` unless it's compiled from the source first. That may indicate something is wrong with those binaries, and this package probably shouldn't be merged until those are rebuilt.