### PR TITLE
gobject_introspection: rebuild to remove /usr/lib64 deps being pulled in

### DIFF
--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -3,31 +3,32 @@ require 'package'
 class Gobject_introspection < Package
   description 'GObject introspection is a middleware layer between C libraries (using GObject) and language bindings.'
   homepage 'https://wiki.gnome.org/action/show/Projects/GObjectIntrospection'
-  version '1.66.1-1'
+  version '1.66.1-2'
   compatibility 'all'
   source_url 'https://download.gnome.org/sources/gobject-introspection/1.66/gobject-introspection-1.66.1.tar.xz'
   source_sha256 'dd44a55ee5f426ea22b6b89624708f9e8d53f5cc94e5485c15c87cb30e06161d'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.66.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.66.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.66.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.66.1-1-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.66.1-2-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.66.1-2-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.66.1-2-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gobject_introspection-1.66.1-2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '1aad738ef27dad976f69f79682b27ed57fb1a8005c495cf743badfcf86ee2c52',
-     armv7l: '1aad738ef27dad976f69f79682b27ed57fb1a8005c495cf743badfcf86ee2c52',
-       i686: '92437ff31a46c7a54bf86c17a98d9accd43f3096d3276cc4bd7fe0def389c93a',
-     x86_64: '9ae418f953bc4985940c065c5c6264b106e87af0841b43c716d91566869784b2',
+     aarch64: '3628085f0787c7b525307f6da6aa27d2422315b53e0e201f7f8d1567a09dce4b',
+      armv7l: '3628085f0787c7b525307f6da6aa27d2422315b53e0e201f7f8d1567a09dce4b',
+        i686: '5e2b0ab9f9df8a749b83a0801e329579f29ad3c76c34086a47019499b38412fd',
+      x86_64: '45cf5b99b8a7b5d9c60e4e5310ce3ee447cbebb331b6a54f9ef43ec7c59f4826',
   })
 
   depends_on 'glib'
 
-  ENV['CFLAGS'] = '-fuse-ld=lld'
-  ENV['CXXFLAGS'] = '-fuse-ld=lld'
-
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} \
+    meson #{CREW_MESON_OPTIONS} \
+    -Dc_args='-fuse-ld=lld' \
+    -Dcpp_args='-fuse-ld=lld' \
+    builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end


### PR DESCRIPTION
- no longer complaining of libffi from /usr/lib64 being pulled in on dependent packages.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686
