### PR TITLE
pygobject: update to git to avoid gtk4 breakage

### DIFF
--- a/packages/pygobject.rb
+++ b/packages/pygobject.rb
@@ -3,37 +3,38 @@ require 'package'
 class Pygobject < Package
   description 'PyGObject is a Python package which provides bindings for GObject based libraries such as GTK+, GStreamer, WebKitGTK+, GLib, GIO and many more.'
   homepage 'https://pygobject.readthedocs.io/en/latest/'
-  version '3.38'
+  version '3.38-0a16'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/pygobject/-/archive/pygobject-3-38/pygobject-pygobject-3-38.tar.bz2'
-  source_sha256 '460b525c3763b78fc535f16f7ef24e51339ff112bc457e5a252a8afd7ecfcf9d'
+  source_url 'https://gitlab.gnome.org/GNOME/pygobject/-/archive/0a16082c3e092fdccf5499172a4b9dec07aa383d/pygobject-0a16082c3e092fdccf5499172a4b9dec07aa383d.tar.bz2'
+  source_sha256 'f83531eeb2d4980afde618a83d16749b14e47d92673a6b1ec63ae7a0a01c4bfc'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.38-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.38-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.38-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.38-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.38-0a16-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.38-0a16-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.38-0a16-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.38-0a16-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '85c923964fcc0cfe03930ba133087e6eb2e1a1409f35d2641e57d8e63237c973',
-     armv7l: '85c923964fcc0cfe03930ba133087e6eb2e1a1409f35d2641e57d8e63237c973',
-       i686: '95563888d6b078754ab1057510c05d88fc554b616b7082cec5a12fdd14df1582',
-     x86_64: '24f6390e2b45414e33558fadbf82d12e409ee4341f44e121e15463d87943e6b2',
+     aarch64: '5124d5109eb258b51096120bbe3a3c56cb0e7d8cc2a5489ff88f24ac09cc790c',
+      armv7l: '5124d5109eb258b51096120bbe3a3c56cb0e7d8cc2a5489ff88f24ac09cc790c',
+        i686: '2fe8b9a1e55979e386c4e828eac1bb291c5fdce811c6c4ef506bd6aa112d6b5f',
+      x86_64: 'f0ce44968f0f7bf36dfe99484a97965ab66530f120b47a789a7c58cdfe43c1cf',
   })
-
 
   depends_on 'glib'
   depends_on 'gobject_introspection'
   depends_on 'pycairo'
 
   def self.build
-    system 'pip install pycairo'
-    system "python3 setup.py build"
+    system 'pip3 install --upgrade pycairo'
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "python3 setup.py install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"
-    system 'pip uninstall --yes pycairo'
-    system "pip install pycairo --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system 'pip3 uninstall --yes pycairo'
   end
 end

--- a/packages/pygobject.rb
+++ b/packages/pygobject.rb
@@ -15,10 +15,10 @@ class Pygobject < Package
       x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pygobject-3.38-0a16-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '5124d5109eb258b51096120bbe3a3c56cb0e7d8cc2a5489ff88f24ac09cc790c',
-      armv7l: '5124d5109eb258b51096120bbe3a3c56cb0e7d8cc2a5489ff88f24ac09cc790c',
-        i686: '2fe8b9a1e55979e386c4e828eac1bb291c5fdce811c6c4ef506bd6aa112d6b5f',
-      x86_64: 'f0ce44968f0f7bf36dfe99484a97965ab66530f120b47a789a7c58cdfe43c1cf',
+     aarch64: '25288827bdc2116b0afabca5b4016a3d53feb884dbb4514281e1ac2eb50212bb',
+      armv7l: '25288827bdc2116b0afabca5b4016a3d53feb884dbb4514281e1ac2eb50212bb',
+        i686: 'e85370c34c4beb590b8bf9695dfcbc8107b958d37fec6a49d39c445b30e7cfc2',
+      x86_64: '65a8a2138b1ddae9cf90782515295577219bee5e26c41f3285077d92ddffd10f',
   })
 
   depends_on 'glib'
@@ -36,5 +36,6 @@ class Pygobject < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
     system 'pip3 uninstall --yes pycairo'
+    system "pip3 install pycairo --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
   end
 end


### PR DESCRIPTION
- Apps still need to be updated, but they don't break due to pygobject failure any more.
- updated to use meson as well

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686
