### PR TITLE
[New Package] gettext-tiny

### DIFF
--- a/packages/gettext_tiny.rb
+++ b/packages/gettext_tiny.rb
@@ -9,7 +9,7 @@ class Gettext_tiny < Package
   source_sha256 'a9a72cfa21853f7d249592a3c6f6d36f5117028e24573d092f9184ab72bbe187'
 
   def self.preinstall
-    abort "gettext already installed. gettext_tiny conflics with gettext.".lightred if File.exist? "#{CREW_PREFIX}/bin/msgcomm"
+    abort "gettext already installed. gettext_tiny conflicts with gettext.".lightred if File.exist? "#{CREW_PREFIX}/bin/msgcomm"
   end
 
   def self.build

--- a/packages/gettext_tiny.rb
+++ b/packages/gettext_tiny.rb
@@ -8,11 +8,15 @@ class Gettext_tiny < Package
   source_url 'http://ftp.barfooze.de/pub/sabotage/tarballs/gettext-tiny-0.3.2.tar.xz'
   source_sha256 'a9a72cfa21853f7d249592a3c6f6d36f5117028e24573d092f9184ab72bbe187'
 
+  def self.preinstall
+    abort "gettext already installed. gettext_tiny conflics with gettext.".lightred if File.exist? "#{CREW_PREFIX}/bin/msgcomm"
+  end
+
   def self.build
     system "make", "LIBINTL=NONE"
   end
 
   def self.install
-    system "make", "LIBINTL=NONE", "DESTDIR=#{CREW_DEST_DIR}", "prefix=/usr/local", "install"
+    system "make", "LIBINTL=NONE", "DESTDIR=#{CREW_DEST_DIR}", "prefix=#{CREW_PREFIX}", "libdir=#{CREW_LIB_PREFIX}", "install"
   end
 end

--- a/packages/gettext_tiny.rb
+++ b/packages/gettext_tiny.rb
@@ -5,7 +5,7 @@ class Gettext_tiny < Package
   homepage 'https://github.com/sabotage-linux/gettext-tiny'
   version '0.3.2'
   compatibility 'all'
-  source_url 'http://ftp.barfooze.de/pub/sabotage/tarballs/gettext-tiny-0.3.2.tar.xz'
+  source_url 'https://ftp.barfooze.de/pub/sabotage/tarballs/gettext-tiny-0.3.2.tar.xz'
   source_sha256 'a9a72cfa21853f7d249592a3c6f6d36f5117028e24573d092f9184ab72bbe187'
 
   def self.preinstall

--- a/packages/gettext_tiny.rb
+++ b/packages/gettext_tiny.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Gettext_tiny < Package
+  description 'gettext-tiny provides lightweight replacements for tools typically used from the GNU gettext suite.'
+  homepage 'https://github.com/sabotage-linux/gettext-tiny'
+  version '0.3.2'
+  compatibility 'all'
+  source_url 'http://ftp.barfooze.de/pub/sabotage/tarballs/gettext-tiny-0.3.2.tar.xz'
+  source_sha256 'a9a72cfa21853f7d249592a3c6f6d36f5117028e24573d092f9184ab72bbe187'
+
+  def self.build
+    system "make", "LIBINTL=NONE"
+  end
+
+  def self.install
+    system "make", "LIBINTL=NONE", "DESTDIR=#{CREW_DEST_DIR}", "prefix=/usr/local", "install"
+  end
+end


### PR DESCRIPTION
builds and works on x86_64. Incompatible with gettext (i wish there was a field for like `conflicts 'gettext'` don't try to have both installed it might overwrite some files.
it's designed for smaller/embedded systems and is designed for musl although it works fine with glibc