### PR TITLE
Aria2 + lto

### DIFF
--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -3,22 +3,23 @@ require 'package'
 class Aria2 < Package
   description 'aria2 is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.'
   homepage 'https://aria2.github.io/'
-  version '1.35.0'
+  @_ver = '1.35.0'
+  version @_ver + '-1'
   compatibility 'all'
-  source_url 'https://github.com/aria2/aria2/releases/download/release-1.35.0/aria2-1.35.0.tar.xz'
+  source_url "https://github.com/aria2/aria2/releases/download/release-#{@_ver}/aria2-#{@_ver}.tar.xz"
   source_sha256 '1e2b7fd08d6af228856e51c07173cfcf987528f1ac97e04c5af4a47642617dfd'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-1-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-1-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-1-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '96165af26f6187b56c2c96f7b40b7ec9ad21a96bc5799f216b1d285ef4936991',
-     armv7l: '96165af26f6187b56c2c96f7b40b7ec9ad21a96bc5799f216b1d285ef4936991',
-       i686: '76e9f7fff4da28c97c2706445486fa7559b76654c129ba229b00379b75d4ae1a',
-     x86_64: '60bbe750f1d5442d1fe0bee0644d70d4855a7cdd55c9e960c970d4817de5ed1b',
+     aarch64: '29b2e520194d7ed596ea0bfa4f75d46d2e74462ea5dc8fd21d4638bdc8e7b932',
+      armv7l: '29b2e520194d7ed596ea0bfa4f75d46d2e74462ea5dc8fd21d4638bdc8e7b932',
+        i686: 'eb3ceec16c9bc7f07f0a5ebf51753545b3ff0c57fc1af7ab3e9e95bdc13ba164',
+      x86_64: 'f8a4926df1f68968bddd3cae7784842a94b39e200bfc6e0332a73389b775dd08',
   })
 
   depends_on 'c_ares'
@@ -27,23 +28,18 @@ class Aria2 < Package
   depends_on 'libxml2'
   depends_on 'sqlite'
   depends_on 'zlibpkg'
-  depends_on 'ld_default' => :build
 
   def self.build
-    # Use the gold linker.
-    old_ld = `ld_default g`.chomp
-    system './configure',
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}",
-      '--without-libnettle',
-      '--with-libgcrypt',
-      '--disable-dependency-tracking'
+    system "env CFLAGS='-fuse-ld=gold -flto' CXXFLAGS='-fuse-ld=gold -flto' \
+     ./configure #{CREW_OPTIONS} \
+      --without-libnettle \
+      --with-libgcrypt \
+      --disable-dependency-tracking"
     system 'make'
-    # Restore the original linker.
-    system 'ld_default', "#{old_ld}"
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/#{ARCH}-cros-linux-gnu-aria2c", "#{CREW_DEST_PREFIX}/bin/aria2c"
   end
 end

--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -16,10 +16,10 @@ class Aria2 < Package
       x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '29b2e520194d7ed596ea0bfa4f75d46d2e74462ea5dc8fd21d4638bdc8e7b932',
-      armv7l: '29b2e520194d7ed596ea0bfa4f75d46d2e74462ea5dc8fd21d4638bdc8e7b932',
-        i686: 'eb3ceec16c9bc7f07f0a5ebf51753545b3ff0c57fc1af7ab3e9e95bdc13ba164',
-      x86_64: 'f8a4926df1f68968bddd3cae7784842a94b39e200bfc6e0332a73389b775dd08',
+     aarch64: '423e0f0ce0893269aca65177a9eaee299eef8b1be2e728c77988ae3e9e741037',
+      armv7l: '423e0f0ce0893269aca65177a9eaee299eef8b1be2e728c77988ae3e9e741037',
+        i686: 'a083bbc6d31677f4eb795433bffbe75468783f0d2d3fe9d95db9140f09ab7ce2',
+      x86_64: '2a7c0fc6c91b8b4217d7b69b0fa607a963ecbf17c689008c989841c89a610160',
   })
 
   depends_on 'c_ares'
@@ -29,6 +29,13 @@ class Aria2 < Package
   depends_on 'sqlite'
   depends_on 'zlibpkg'
 
+  case ARCH
+  when 'aarch64', 'armv7l'
+  @gnuabi = 'gnueabihf'
+  when 'x86_64', 'i686'
+  @gnuabi = 'gnu'
+  end
+  
   def self.build
     system "env CFLAGS='-fuse-ld=gold -flto' CXXFLAGS='-fuse-ld=gold -flto' \
      ./configure #{CREW_OPTIONS} \
@@ -40,6 +47,6 @@ class Aria2 < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    FileUtils.ln_s "#{CREW_PREFIX}/bin/#{ARCH}-cros-linux-gnu-aria2c", "#{CREW_DEST_PREFIX}/bin/aria2c"
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/#{ARCH}-cros-linux-#{@gnuabi}-aria2c", "#{CREW_DEST_PREFIX}/bin/aria2c"
   end
 end


### PR DESCRIPTION
Fixes #4741
- removes ld_default dep too


Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686
