### PR TITLE
Eliminate nested searching to speed up `crew search`

### DIFF
--- a/crew
+++ b/crew
@@ -91,8 +91,14 @@ end
   @device[key] = @device[key].to_sym rescue @device[key]
 end
 
-def print_package(pkgName, extra = false)
-  search pkgName, true
+def print_package(pkgPath, extra = false)
+  pkgName = File.basename pkgPath, '.rb'
+  set_package pkgName, pkgPath
+  print_current_package extra
+end
+
+def print_current_package (extra = false)
+  pkgName = @pkg.name
   status = ''
   status = 'installed' if @device[:installed_packages].any? do |elem| elem[:name] == pkgName end
   status = 'incompatible' unless @device[:compatible_packages].any? do |elem| elem[:name] == pkgName end
@@ -113,18 +119,17 @@ def print_package(pkgName, extra = false)
   puts ""
 end
 
-def set_package (pkgName, silent = false)
-  require CREW_LIB_PATH + 'packages/' + pkgName
+def set_package (pkgName, pkgPath)
+  require pkgPath
   @pkg = Object.const_get(pkgName.capitalize)
   @pkg.build_from_source = true if @opt_recursive
   @pkg.name = pkgName
-  print_package(pkgName, true) unless silent
 end
 
 def list_packages
   Find.find (CREW_LIB_PATH + 'packages') do |filename|
     if File.extname(filename) == '.rb'
-      print_package File.basename filename, '.rb'
+      print_package filename
     end
   end
 end
@@ -138,7 +143,7 @@ def list_available
     end
     if @notInstalled and File.extname(filename) == '.rb'
       pkgName = File.basename filename, '.rb'
-      set_package pkgName, true
+      set_package pkgName, filename
       if @pkg.compatibility.include? 'all' or @pkg.compatibility.include? ARCH
         puts pkgName
       else
@@ -158,7 +163,7 @@ def list_compatible(compat = true)
   Find.find (CREW_LIB_PATH + 'packages') do |filename|
     if File.extname(filename) == '.rb'
       pkgName = File.basename filename, '.rb'
-      set_package pkgName, true
+      set_package pkgName, filename
       if compat
         if @pkg.compatibility.include? 'all' or @pkg.compatibility.include? ARCH
           if File.exist? CREW_CONFIG_PATH + 'meta/' + pkgName + '.filelist'
@@ -181,7 +186,7 @@ def generate_compatible
   Find.find (CREW_LIB_PATH + 'packages') do |filename|
     if File.extname(filename) == '.rb'
       pkgName = File.basename filename, '.rb'
-      set_package pkgName, true
+      set_package pkgName, filename
       if @pkg.compatibility.include? 'all' or @pkg.compatibility.include? ARCH
         #add to compatible packages
         @device[:compatible_packages].push(name: @pkg.name)
@@ -196,29 +201,29 @@ end
 
 def search (pkgName, silent = false)
   Find.find (CREW_LIB_PATH + 'packages') do |filename|
-    return set_package(pkgName, silent) if filename == CREW_LIB_PATH + 'packages/' + pkgName + '.rb'
+    return set_package(pkgName, filename) if filename == CREW_LIB_PATH + 'packages/' + pkgName + '.rb'
   end
   abort "Package #{pkgName} not found. :(".lightred unless silent
 end
 
-def regexp_search(pkgName)
+def regexp_search(pkgPat)
+  re = Regexp.new(pkgPat, true)
   results = Dir["#{CREW_LIB_PATH}packages/*.rb"].sort \
-    .select  { |f| File.basename(f, '.rb') =~ Regexp.new(pkgName, true) } \
-    .collect { |f| File.basename(f, '.rb') } \
+    .select  { |f| File.basename(f, '.rb') =~ re } \
     .each    { |f| print_package(f, @opt_verbose) }
   if results.empty?
-    Find.find ("#{CREW_LIB_PATH}packages/") do |packageName|
-      if File.file? packageName
-        package = File.basename packageName, '.rb'
-        search package, true
-        if ( @pkg.description =~ /#{pkgName}/i )
-          print_package(package, @opt_verbose)
-          results.push(package)
+    Find.find ("#{CREW_LIB_PATH}packages/") do |packagePath|
+      if File.file? packagePath and File.extname(packagePath) == '.rb'
+        packageName = File.basename packagePath, '.rb'
+        set_package packageName, packagePath
+        if ( @pkg.description =~ /#{pkgPat}/i )
+          print_current_package @opt_verbose
+          results.push(packageName)
         end
       end
     end
   end
-  abort "Package #{pkgName} not found. :(".lightred unless results.length > 0
+  abort "Package #{pkgPat} not found. :(".lightred unless results.length > 0
 end
 
 def help (pkgName)
@@ -464,6 +469,7 @@ def upgrade
       puts "Updating packages..."
       toBeUpdated.each do |package|
         search package
+        print_current_package
         puts "Updating " + @pkg.name + "..." if @opt_verbose
         @pkg.in_upgrade = true
         resolve_dependencies_and_install
@@ -796,6 +802,7 @@ def resolve_dependencies
   if proceed
     @dependencies.each do |dep|
       search dep
+      print_current_package
       install
     end
   end
@@ -974,7 +981,7 @@ def remove (pkgName)
     file.write JSON.pretty_generate(out)
   end
 
-  set_package pkgName, true
+  search pkgName, true
   @pkg.remove
 
   puts "#{pkgName.capitalize} removed!".lightgreen
@@ -984,6 +991,7 @@ def build_command (args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
+    print_current_package
     resolve_dependencies_and_build
   end
 end
@@ -992,6 +1000,7 @@ def download_command (args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
+    print_current_package
     download
   end
 end
@@ -1010,6 +1019,7 @@ def files_command (args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
+    print_current_package
     files name
   end
 end
@@ -1027,6 +1037,7 @@ def install_command (args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
+    print_current_package
     @pkg.build_from_source = true if @opt_src or @opt_recursive
     resolve_dependencies_and_install
   end
@@ -1046,7 +1057,7 @@ end
 
 def postinstall_command (args)
   args["<name>"].each do |name|
-    set_package name, true
+    search name, true
     if @device[:installed_packages].any? do |elem| elem[:name] == name end
       @pkg.postinstall
     else
@@ -1059,6 +1070,7 @@ def reinstall_command (args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
+    print_current_package
     @pkg.build_from_source = true if @opt_src or @opt_recursive
     if @pkgName
       @pkg.in_upgrade = true
@@ -1090,6 +1102,7 @@ def upgrade_command (args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
+    print_current_package
     @pkg.build_from_source = true if @opt_src
     upgrade
   end.empty? and begin

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.5.5'
+CREW_VERSION = '1.5.6'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Fixes #4943

## Note
I am not at all familiar with ruby and not at all confident in my choice of variable names. Any feedback is most welcome.

## Description
In most or all of the places where `set_package` and `print_package` are called, the full path to the package file and the package name are known or trivially computed. However, `print_package` calls `search`,  `set_package` may call `print_package`, and `search` calls `set_package`. This leads to a lot of redundant calls and traversals of the package directory.

My solution to this was to modify these functions so that print_package takes the path to the package file and computes the package name, passing both to set_package before calling a function to print the current package (`@pkg`). Callers of search that expected it to print package information now have to call print_current_package after calling search.

## Addtional information
Works properly:
- [x] x86_64
- [ ] aarch64 - Unknown, but I can't imagine why it wouldn't. I don't have an aarch64 device with which to test.

Tested by running
* `crew build cowsay`
* `crew const`
* `crew download cowsay`
* `crew download -v cowsay`
* `crew files gcc10`
* `crew install hexedit`
* `for i in available installed compatible incompatible; do crew list $i; done;`
* `crew reinstall -v hexedit`
* `crew remove -v hexedit`
* `crew search latex`
* `crew search -v latex`
* `crew search`
* `crew search ^a`
* `crew update`
* `crew upgrade`
* `crew whatprovides gcc10`
* a few other commands