### PR TITLE
[Fix Package] elogind

### DIFF
--- a/packages/elogind.rb
+++ b/packages/elogind.rb
@@ -21,6 +21,7 @@ class Elogind < Package
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
+            -Drootprefix=#{CREW_PREFIX} \
             --strip \
             -Dcgroup-controller=elogind \
             -Dman=false \
@@ -37,8 +38,5 @@ class Elogind < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-    FileUtils.mv Dir.glob('bin/*'), "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.mv etc, "#{CREW_DEST_PREFIX}/etc"
-    FileUtils.mv Dir.glob("#{ARCH_LIB}/*"), CREW_DEST_LIB_PREFIX
   end
 end

--- a/packages/elogind.rb
+++ b/packages/elogind.rb
@@ -1,13 +1,13 @@
 require 'package'
 
 class Elogind < Package
-  description 'Standalone logind fork'
+  description 'Standalone systemd-logind fork'
   homepage 'https://github.com/elogind/elogind'
   version '243.4'
   compatibility 'all'
   source_url 'https://github.com/elogind/elogind/archive/v243.4.tar.gz'
   source_sha256 'f1098745863138e6270ea22e78a39baef9a0356b48246c5a53b34211992dc7db'
-
+  
   depends_on 'eudev'
   depends_on 'libcap'
   depends_on 'libseccomp'
@@ -27,25 +27,18 @@ class Elogind < Package
             -Ddefault-hierarchy=legacy \
             -Ddefault-kill-user-processes=false \
             -Dhalt-path=/sbin/halt \
+            -Drootlibdir=#{CREW_PREFIX}/#{ARCH_LIB} \
             -Drootlibexecdir=#{CREW_PREFIX}/libexec/elogind \
+            -Drootbindir=#{CREW_PREFIX}/bin \
             -Dreboot-path=/sbin/reboot \
-            _build"
-    Dir.chdir '_build' do
-      system 'meson', 'compile'
-    end
+            builddir"
+    system "ninja -C builddir"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
-    system "mv #{CREW_DEST_DIR}/bin/* #{CREW_DEST_DIR}/usr/local/bin/"
-    system "mv #{CREW_DEST_DIR}/etc #{CREW_DEST_DIR}/usr/local/etc"
-    system "mv #{CREW_DEST_DIR}/lib/* #{CREW_DEST_DIR}/usr/local/lib/"
-    system "mv #{CREW_DEST_DIR}/lib64/* #{CREW_DEST_DIR}/usr/local/lib64" # Please help rubyize
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    FileUtils.mv Dir.glob('bin/*'), "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mv etc, "#{CREW_DEST_PREFIX}/etc"
+    FileUtils.mv Dir.glob("#{ARCH_LIB}/*"), CREW_DEST_LIB_PREFIX
   end
-  
-#  def self.check
-#    Dir.chdir '_build' do
-#      system 'meson', 'test'
-#    end
-#  end
 end

--- a/packages/elogind.rb
+++ b/packages/elogind.rb
@@ -29,7 +29,7 @@ class Elogind < Package
             -Dhalt-path=/sbin/halt \
             -Drootlibexecdir=#{CREW_PREFIX}/libexec/elogind \
             -Dreboot-path=/sbin/reboot \
-            _build" # Manpages fail to build, keeping them disabled
+            _build"
     Dir.chdir '_build' do
       system 'meson', 'compile'
     end
@@ -43,9 +43,9 @@ class Elogind < Package
     system "mv #{CREW_DEST_DIR}/lib64/* #{CREW_DEST_DIR}/usr/local/lib64" # Please help rubyize
   end
   
-  def self.check
-    Dir.chdir '_build' do
-      system 'meson', 'test'
-    end
-  end
+#  def self.check
+#    Dir.chdir '_build' do
+#      system 'meson', 'test'
+#    end
+#  end
 end


### PR DESCRIPTION
The elogind package had/has a strange problem where, even though it's told the prefix is at `/usr/local/` it still makes and puts files in `/bin` `/etc` `/lib` and `/lib64`. This file moves them to their appropriate places during `self.install`. `ldd` shows that the binaries will still work, but I haven't tested them. This fix is primarily to move the shared libraries from `/lib64` to `/usr/local/lib64` which is necessary for some packages I have in the works. I also enabled link-time optimization and it works well!