### PR TITLE
Bind update to 9.17.8

### DIFF
--- a/packages/bind.rb
+++ b/packages/bind.rb
@@ -25,7 +25,6 @@ class Bind < Package
   depends_on 'libseccomp'
   depends_on 'libuv'
   depends_on 'libidn2'
-  depends_on 'libidn2'
 
   def self.build
     system "git config --global advice.detachedHead false"

--- a/packages/bind.rb
+++ b/packages/bind.rb
@@ -3,38 +3,43 @@ require 'package'
 class Bind < Package
   description 'BIND is open source software that enables you to publish your Domain Name System (DNS) information on the Internet, and to resolve DNS queries for your users.'
   homepage 'https://www.isc.org/downloads/bind/'
-  version '9.17.3'
+  version '9.17.8'
   compatibility 'all'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.3-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.8-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.8-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.8-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.8-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'b7dd57b241a5ef20ff4ecc36b90e442c3ae35b5f60aa890791226f54bfe188c8',
-     armv7l: 'b7dd57b241a5ef20ff4ecc36b90e442c3ae35b5f60aa890791226f54bfe188c8',
-       i686: 'a548e1980be640b0f541df3a1a4ad6f61483e39ba323b17159dccc68cd47286c',
-     x86_64: '60b6dabf560447184b9022188c74965ec22fd40becbf49d526b5ea36f0cc2c39',
+     aarch64: 'c757c886c9760396405166ee258b1953935ea3a61e40e6490c44aecbf64a5041',
+      armv7l: 'c757c886c9760396405166ee258b1953935ea3a61e40e6490c44aecbf64a5041',
+        i686: '54a28fd25b2602ac2fec3781e148c6ce9222537978b6ab79bc9457a0ab5ce534',
+      x86_64: '0d5568f9e16d5b76fd8da2815efce5dbbecb435ee99e8757141c10e8edd9539c',
   })
 
   depends_on 'libcap'
   depends_on 'libseccomp'
   depends_on 'libuv'
+  depends_on 'libidn2'
+  depends_on 'libidn2'
 
   def self.build
-    system 'git clone https://gitlab.isc.org/isc-projects/bind9.git'
+    system "git config --global advice.detachedHead false"
+    system 'git clone --depth=1 -b v9_17_8 https://gitlab.isc.org/isc-projects/bind9.git'
     Dir.chdir 'bind9' do
-      system 'git checkout v9_17_3'
       system 'pip3 install ply==3.11'
       system 'autoreconf -fi'
-      system './configure',
-             "--prefix=#{CREW_PREFIX}",
-             '--disable-maintainer-mode',
-             "--libdir=#{CREW_LIB_PREFIX}"
+      system "env CFLAGS='-DDIG_SIGCHASE -flto=auto' ./configure \
+              #{CREW_OPTIONS} \
+               --enable-fixed-rrset \
+               --enable-full-report \
+               --with-openssl \
+               --with-libidn2 \
+               --disable-maintainer-mode"
       system 'make'
     end
   end

--- a/packages/libtirpc.rb
+++ b/packages/libtirpc.rb
@@ -3,28 +3,29 @@ require 'package'
 class Libtirpc < Package
   description 'Libtirpc is a port of Suns Transport-Independent RPC library to Linux.'
   homepage 'https://sourceforge.net/projects/libtirpc'
-  version '1.0.2-0'
+  @_ver = '1.3.1'
+  version @_ver
   compatibility 'all'
-  source_url 'http://downloads.sourceforge.net/project/libtirpc/libtirpc/1.0.2/libtirpc-1.0.2.tar.bz2'
-  source_sha256 '723c5ce92706cbb601a8db09110df1b4b69391643158f20ff587e20e7c5f90f5'
+  source_url "http://downloads.sourceforge.net/project/libtirpc/libtirpc/#{@_ver}/libtirpc-#{@_ver}.tar.bz2"
+  source_sha256 '245895caf066bec5e3d4375942c8cb4366adad184c29c618d97f724ea309ee17'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libtirpc-1.0.2-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libtirpc-1.0.2-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libtirpc-1.0.2-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libtirpc-1.0.2-0-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libtirpc-1.3.1-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libtirpc-1.3.1-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/libtirpc-1.3.1-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libtirpc-1.3.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f2af84d80968a7b7271d7ed00e9fa771157530a237282c9c0cea0eea39fea167',
-     armv7l: 'f2af84d80968a7b7271d7ed00e9fa771157530a237282c9c0cea0eea39fea167',
-       i686: '3f484468cba8c5e69bff19eaa5c326dbb7e2e44d7e41c1c7ce3f570d0a7eb526',
-     x86_64: '6d4a7b558189ac4b78c24f6d5aa5904ed2dfe960ff3a6b1a4019294e2c051fc7',
+     aarch64: '489870e43cd86ca9aa252f3639f54e8af9bc6b33e16ef96aa66f0114bef8ee90',
+      armv7l: '489870e43cd86ca9aa252f3639f54e8af9bc6b33e16ef96aa66f0114bef8ee90',
+        i686: '987de099b04760d251425554071d505ec001818a152a782cd51b92ae6edf9dc5',
+      x86_64: '982db8c305a1c2859ab9954a18e03e5500a277fa00717e7646bf69b95a744213',
   })
 
   depends_on 'krb5'
-  
+
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "./configure #{CREW_OPTIONS}"
     system "make"
   end
 


### PR DESCRIPTION
 - Also adds libtirpc update needed for current bind compile
 - Add CFLAGs for DNSSEC signature chains, flto

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l