### PR TITLE
Add zig package

### DIFF
--- a/packages/zig.rb
+++ b/packages/zig.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Zig < Package
+  description 'Programming language designed for robustness, optimality, and clarity'
+  homepage 'https://ziglang.org/'
+  version '0.7.1'
+  compatibility 'x86_64 aarch64'
+  source_url 'https://ziglang.org/download/0.7.1/zig-0.7.1.tar.xz'
+  source_sha256 '2db3b944ab368d955b48743d9f7c963b8f96de1a441ba5a35e197237cc6dae44'
+
+ def self.build
+   Dir.mkdir 'build'
+   FileUtils.cd('build') do
+     system "cmake #{CREW_CMAKE_OPTIONS} .."
+     system 'make'
+   end
+ end
+ def self.install
+   FileUtils.cd('build') do
+     system "DESTDIR=#{CREW_DEST_DIR} make install"
+   end
+  end
+end


### PR DESCRIPTION
[Zig](https://ziglang.org) is a relatively new programming lang, that competes with C rather than being built on it.  
Zig (`zig cc`/`c++`) can be used as a drop-in replacement for `gcc` for `g++` (C/C++) and produces smaller binaries at the cost of double the compilation of that of `gcc`.  

---

I'll be using this in an upcoming project as it produces smaller binaries than `gcc`, but my Chromebooks recently bit the dust, and this requires testing, though is should build fine as this package script was generated based on the template from xbps-src, where there are also 0 patches.