### PR TITLE
Remove  + @fileutils_verbose.to_s from crew

### DIFF
--- a/crew
+++ b/crew
@@ -590,7 +590,7 @@ def build_and_preconfigure (target_dir)
     @pkg.build
     @pkg.in_build = false
     # wipe crew destdir
-    FileUtils.rm_rf Dir.glob("#{CREW_DEST_DIR}/*") + @fileutils_verbose.to_s
+    FileUtils.rm_rf Dir.glob("#{CREW_DEST_DIR}/*")
     puts 'Preconfiguring package...'
     @pkg.install
 
@@ -843,7 +843,7 @@ def resolve_dependencies_and_build
   ensure
     #cleanup
     unless @opt_keep
-      FileUtils.rm_rf Dir.glob("#{CREW_BREW_DIR}/*") + @fileutils_verbose.to_s
+      FileUtils.rm_rf Dir.glob("#{CREW_BREW_DIR}/*")
       FileUtils.mkdir_p "#{CREW_BREW_DIR}/dest" #this is a little ugly, feel free to find a better way
     end
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.5.8'
+CREW_VERSION = '1.5.9'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
building packages is broken. This fixes that.

```
/usr/local/bin/crew:593:in `+': no implicit conversion of String into Array (TypeError)
        from /usr/local/bin/crew:593:in `block in build_and_preconfigure'
        from /usr/local/bin/crew:577:in `chdir'
        from /usr/local/bin/crew:577:in `build_and_preconfigure'
        from /usr/local/bin/crew:862:in `build_package'
        from /usr/local/bin/crew:840:in `resolve_dependencies_and_build'
        from /usr/local/bin/crew:947:in `block in build_command'
        from /usr/local/bin/crew:943:in `each'
        from /usr/local/bin/crew:943:in `build_command'
        from /usr/local/bin/crew:1078:in `<main>'
```

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l