### PR TITLE
partial revert of archive_package to restore package building functionality

### DIFF
--- a/crew
+++ b/crew
@@ -880,8 +880,12 @@ end
 
 def archive_package (pwd)
   pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
-  system "tar -cJf #{@verbose} #{CREW_DEST_DIR}/#{pwd}/#{pkg_name} *"
-  system "sha256sum #{pwd}/#{pkg_name} > #{pwd}/#{pkg_name}.sha256"
+  Dir.chdir CREW_DEST_DIR do
+    system "tar cJf #{pwd}/#{pkg_name} *"
+  end
+  Dir.chdir pwd do
+    system "sha256sum #{pkg_name} > #{pkg_name}.sha256"
+  end
 end
 
 def remove (pkgName)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.5.9'
+CREW_VERSION = '1.5.10'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Fixes #4977 

This is a partial revert, removing the verbose option, which appears to be broken.

Packages being built can now be archived again.

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l

(Also, maybe we need a unit testing script for the crew script to test all options?)