### PR TITLE
Fix TypeError in `crew const` when a value is nil

### DIFF
--- a/crew
+++ b/crew
@@ -315,7 +315,7 @@ end
 def const (var)
   if var
     value = eval(var)
-    puts var + '=' + value
+    puts "#{var}=#{value}"
   else
     vars = [
       'ARCH',
@@ -349,7 +349,7 @@ def const (var)
     ]
     vars.each { |var|
       value = eval(var)
-      puts var + '=' + value
+      puts "#{var}=#{value}"
     }
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.5.10'
+CREW_VERSION = '1.5.11'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
## Description
Does what it says on the tin

## Addtional information
Works properly:
- [x] x86_64
- [ ] aarch64 (no env to test with)