### PR TITLE
Add -fcommon to trousers build to support gcc10 (fixes #4994)

### DIFF
--- a/packages/trousers.rb
+++ b/packages/trousers.rb
@@ -27,11 +27,15 @@ class Trousers < Package
 
   def self.build
     system './configure', '--disable-static', '--with-gui=none',
-      "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
+      "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}", 'CFLAGS=-fcommon'
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/trousers.rb
+++ b/packages/trousers.rb
@@ -3,22 +3,23 @@ require 'package'
 class Trousers < Package
   description 'The open-source TCG Software Stack.'
   homepage 'http://trousers.sourceforge.net/'
-  version '0.3.14-1'
+  @_ver = '0.3.14'
+  version @_ver
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/project/trousers/trousers/0.3.14/trousers-0.3.14.tar.gz'
+  source_url "https://downloads.sourceforge.net/project/trousers/trousers/#{@_ver}/trousers-#{@_ver}.tar.gz"
   source_sha256 'ce50713a261d14b735ec9ccd97609f0ad5ce69540af560e8c3ce9eb5f2d28f47'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '4118ffa8a3a479f2b3f64bf500a5bc7e243b7833ac7e31cb982682b3ac3da323',
-     armv7l: '4118ffa8a3a479f2b3f64bf500a5bc7e243b7833ac7e31cb982682b3ac3da323',
-       i686: '5c3121a5b5e52b16d63d00da0ceb281734f2cd262d5f686692260a9841abd62b',
-     x86_64: '9ffc0da97adbc542a44285882a8ace99e21986e11a7676da3314c9ab59a94700',
+     aarch64: '24985a1b1725983d79858df465e2b25a2c5f60dee41ff70d7f4987602ef13864',
+      armv7l: '24985a1b1725983d79858df465e2b25a2c5f60dee41ff70d7f4987602ef13864',
+        i686: '80fa9d0426440f6fb1f8cdfbc1a7120ba25a8d3387bb68db4347d0b052b5de4c',
+      x86_64: '0650dd02ec6c5219fa959e495e8022032ea4e0a55605dcaec169c6cbd40cae9f',
   })
 
   depends_on 'openssl'
@@ -26,8 +27,9 @@ class Trousers < Package
   depends_on 'pkgconfig'
 
   def self.build
-    system './configure', '--disable-static', '--with-gui=none',
-      "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}", 'CFLAGS=-fcommon'
+    system "CFLAGS='-fcommon -flto -pipe' ./configure \
+      #{CREW_OPTIONS} \
+      --with-gui=none"
     system 'make'
   end
 

--- a/packages/trousers.rb
+++ b/packages/trousers.rb
@@ -3,23 +3,23 @@ require 'package'
 class Trousers < Package
   description 'The open-source TCG Software Stack.'
   homepage 'http://trousers.sourceforge.net/'
-  @_ver = '0.3.14'
+  @_ver = '0.3.15'
   version @_ver
   compatibility 'all'
   source_url "https://downloads.sourceforge.net/project/trousers/trousers/#{@_ver}/trousers-#{@_ver}.tar.gz"
-  source_sha256 'ce50713a261d14b735ec9ccd97609f0ad5ce69540af560e8c3ce9eb5f2d28f47'
+  source_sha256 '1e5be93e518372acf1d92d2f567d01a46fdb0b730487e544e6fb896c59cac77f'
 
   binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.14-1-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '24985a1b1725983d79858df465e2b25a2c5f60dee41ff70d7f4987602ef13864',
-      armv7l: '24985a1b1725983d79858df465e2b25a2c5f60dee41ff70d7f4987602ef13864',
-        i686: '80fa9d0426440f6fb1f8cdfbc1a7120ba25a8d3387bb68db4347d0b052b5de4c',
-      x86_64: '0650dd02ec6c5219fa959e495e8022032ea4e0a55605dcaec169c6cbd40cae9f',
+     aarch64: 'd9f1c2a10973b25b26576c8c7c913b4ff898417a6f425732a81b22b4c8daa566',
+      armv7l: 'd9f1c2a10973b25b26576c8c7c913b4ff898417a6f425732a81b22b4c8daa566',
+        i686: 'bc2f18fada6ff3dc0203aa87d7a2e3b001d18db59aae3d094f2341bffa530c24',
+      x86_64: '40601f6366e0d308ece858293e0cc61fcc31ce568b796ea37beb3c3e34ab370f',
   })
 
   depends_on 'openssl'
@@ -27,6 +27,7 @@ class Trousers < Package
   depends_on 'pkgconfig'
 
   def self.build
+    system "./bootstrap.sh"
     system "CFLAGS='-fcommon -flto -pipe' ./configure \
       #{CREW_OPTIONS} \
       --with-gui=none"


### PR DESCRIPTION
Fixes #4994

## Description
Adds `CFLAGS=-fcommon` to args passed to `./configure` when building trousers.

## Addtional information
 * Package needs to be rebuilt for openssl

Works properly:
- [x] x86_64
- [ ] aarch64 (not able to test, no aarch64 hardware)