### PR TITLE
Filezilla 3.52.2 + deps rebuilds

### DIFF
--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -3,10 +3,24 @@ require 'package'
 class Filezilla < Package
   description 'FileZilla Client is a free FTP solution.'
   homepage 'https://filezilla-project.org/'
-  version '3.51.0-1'
+  @_ver = '3.52.2'
+  version @_ver
   compatibility 'all'
-  source_url 'https://download.filezilla-project.org/client/FileZilla_3.51.0_src.tar.bz2'
-  source_sha256 '82be1c4a4f51bb32a599d0b4cc3a24127ba948c0af0f957233cc6a13ea3b6c4c'
+  source_url "https://download.filezilla-project.org/client/FileZilla_#{@_ver}_src.tar.bz2"
+  source_sha256 'c0788816928a26e8863c7dc26b158644e71bef29406df7d2eda37dc4810d6cdf'
+
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.52.2-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.52.2-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.52.2-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/filezilla-3.52.2-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: '3585d8326e1784c9d690539a76854fe50c5aa81a7996bc4f97bf11a00dcb959e',
+      armv7l: '3585d8326e1784c9d690539a76854fe50c5aa81a7996bc4f97bf11a00dcb959e',
+        i686: 'a6bf0b25146e61c126f52d8a9b5efdea4fc25d03261b80a347fadff4af95f657',
+      x86_64: '336b624e5ae3e75a4b6bd2d008c3220347bc5bfba2cf8a1187090bc9ac450e4f',
+  })
 
   depends_on 'dbus'
   depends_on 'gnome_icon_theme'
@@ -20,22 +34,22 @@ class Filezilla < Package
   depends_on 'wayland_protocols'
   depends_on 'mesa'
   depends_on 'xcb_util'
-
+  depends_on 'wxwidgets'
 
   def self.patch
     system 'filefix'
   end
 
   def self.build
-    ENV['CC'] = 'gcc'
-    ENV['CXX'] = 'g++'
-    system "./configure #{CREW_OPTIONS} --disable-maintainer-mode --with-pugixml=builtin"
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      ./configure #{CREW_OPTIONS} --disable-maintainer-mode --with-pugixml=builtin"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
+  
   def self.postinstall
     puts
     puts "To complete the installation, execute the following:".lightblue

--- a/packages/libfilezilla.rb
+++ b/packages/libfilezilla.rb
@@ -3,24 +3,23 @@ require 'package'
 class Libfilezilla < Package
   description 'libfilezilla is a small and modern C++ library, offering some basic functionality to build high-performing, platform-independent programs.'
   homepage 'https://lib.filezilla-project.org/'
-  version '0.26'
+  version '0.26-1'
   compatibility 'all'
   source_url 'https://download.filezilla-project.org/libfilezilla/libfilezilla-0.26.0.tar.bz2'
   source_sha256 '17ed226593e8e466ce3c3f8ce583b36c79f163189ead54d631613cc3da5c80bd'
 
   binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.26-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.26-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.26-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.26-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.26-1-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.26-1-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.26-1-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libfilezilla-0.26-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '7f2ff4e1a1f55bac7e9450fc0d85f84ec21ec2a62f2c45c02c6342c7670dbfd3',
-      armv7l: '7f2ff4e1a1f55bac7e9450fc0d85f84ec21ec2a62f2c45c02c6342c7670dbfd3',
-        i686: 'd07c70bf760ed003bf5d2365ae23bb5adc4da0091aa07b69eaa14b5e9d27ee97',
-      x86_64: '982dbdceeeb0889dc516156785218bf520d25e1e1602cada0523f6cc7f14774e',
+     aarch64: 'feed1d31cf4d1939190e38d6649610250b76dd8242adfd644672d6e2530c5d66',
+      armv7l: 'feed1d31cf4d1939190e38d6649610250b76dd8242adfd644672d6e2530c5d66',
+        i686: '29cc4771df9bf63a0723ec43f1d5fa18ba1e17c93543888ba3fc6a2811d9910b',
+      x86_64: 'c442aadbe2e23252a3abcdcef79b0e771c29f4d940541d263f32dcddcabc030f',
   })
-
 
   depends_on 'p11kit'
 
@@ -29,7 +28,8 @@ class Libfilezilla < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/wxwidgets.rb
+++ b/packages/wxwidgets.rb
@@ -49,7 +49,6 @@ diff -up wxGTK-2.8.12/src/common/appbase.cpp.abicheck wxGTK-2.8.12/src/common/ap
  #undef wxCMP
 EOF"
     system "patch -Np1 -i make-abicheck-non-fatal.patch || true"
-    system "./configure --help"
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
       ./configure #{CREW_OPTIONS} \
       --with-gtk=3 \

--- a/packages/wxwidgets.rb
+++ b/packages/wxwidgets.rb
@@ -3,25 +3,23 @@ require 'package'
 class Wxwidgets < Package
   description 'wxWidgets is a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base.'
   homepage 'https://www.wxwidgets.org/'
-  version '3.0.5.1'
+  version '3.0.5.1-1'
   compatibility 'all'
   source_url 'https://github.com/wxWidgets/wxWidgets/archive/v3.0.5.1.tar.gz'
   source_sha256 'bae4d9f289e33a05fb8553fcc580564d30efe6a882ff08e3d4e09ef01f5f6578'
 
   binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.5.1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.5.1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.5.1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.5.1-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.5.1-1-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.5.1-1-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.5.1-1-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/wxwidgets-3.0.5.1-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '440d312b479a90ffd73e84c396b9d54a76a01f8049adb820535236845b8b2acb',
-      armv7l: '440d312b479a90ffd73e84c396b9d54a76a01f8049adb820535236845b8b2acb',
-        i686: 'aed2e2b7577f820dcb2f6eddaa39b6b602d47249b5dc8f5d0b2b18c6093b9c30',
-      x86_64: '3e3df3560a084dfe8e100728ae77ebcb68548186e05d7c787d162e015d71245c',
+     aarch64: '6831092ab33fdc4c10df52bdc779652f26f8d7c8a1e48097768a3892eea164f7',
+      armv7l: '6831092ab33fdc4c10df52bdc779652f26f8d7c8a1e48097768a3892eea164f7',
+        i686: '71f57c87fb5f1256a811e241ecc8db54a6042d4a9941128b09fff1e3192a8fa7',
+      x86_64: '04c515d5f4280c78e50ac0e79577f862ef3d526473e096e6ee8f731f43055135',
   })
-
-
 
   depends_on 'gst_plugins_base'
   depends_on 'libnotify'
@@ -51,15 +49,16 @@ diff -up wxGTK-2.8.12/src/common/appbase.cpp.abicheck wxGTK-2.8.12/src/common/ap
  #undef wxCMP
 EOF"
     system "patch -Np1 -i make-abicheck-non-fatal.patch || true"
-    system "unset CC CXX CXXFLAGS CFLAGS && \
-      export LIBRARY_PATH=#{CREW_LIB_PREFIX} && \
-      export LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} && \
-      export CC=gcc && \
-      export CXX=g++ && \
-      export CFLAGS= && \
+    system "./configure --help"
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
       ./configure #{CREW_OPTIONS} \
-      --with-gtk=3 --with-opengl --enable-unicode \
-      --enable-graphics_ctx --enable-mediactrl --enable-webview --with-regex=builtin \
+      --with-gtk=3 \
+      --with-opengl \
+      --enable-unicode \
+      --enable-graphics_ctx \
+      --enable-mediactrl \
+      --enable-webview \
+      --with-regex=builtin \
       --with-libpng=sys \
       --with-libjpeg=sys \
       --with-libtiff=sys \


### PR DESCRIPTION
- Fixes nettle dep failure in libfilezilla.
- Cleanups of package files
- Adds binaries

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686