### PR TITLE
Add Gentoo pax_utils

### DIFF
--- a/packages/pax_utils.rb
+++ b/packages/pax_utils.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Pax_utils < Package
+  description 'ELF utils that can check files for security relevant properties'
+  homepage 'https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities'
+  version '1.2.5'
+  compatibility 'all'
+  source_url 'https://dev.gentoo.org/~slyfox/distfiles/pax-utils-1.2.5.tar.xz'
+  source_sha256 '7ce7170ceed255bb47cac03b88bcbc636b0e412cac974e213e8017a1dae292ec'
+
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pax_utils-1.2.5-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pax_utils-1.2.5-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/pax_utils-1.2.5-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pax_utils-1.2.5-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: 'e7140bfffd7af0f75c3d95bf40626f2f83a855b7cdbe3d9e019424a6d356f293',
+      armv7l: 'e7140bfffd7af0f75c3d95bf40626f2f83a855b7cdbe3d9e019424a6d356f293',
+        i686: 'a818331f5f3f431fbdcfadf9418ad4e99cdf3bfa2271a1d921c4e30ad5dc0e63',
+      x86_64: '712f217975226bbb33e2ddb16d049f389618bf48bea5410aeb389043c1ab06a3',
+  })
+
+  depends_on 'libcap' => ':build'
+  depends_on 'libseccomp' => ':build'
+
+  def self.build
+    #system "sed -E 's|(  paths =) \[\]|\1 [#{CREW_LIB_PREFIX}]|g' -i lddtree.py"
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+    ./configure \
+    #{CREW_OPTIONS} \
+    --with-caps \
+    --with-seccomp \
+    --with-python"
+    system "make"
+  end
+  
+  def self.install
+  system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/pax_utils.rb
+++ b/packages/pax_utils.rb
@@ -37,7 +37,6 @@ class Pax_utils < Package
   end
   
   def self.install
-  
-  system "make DESTDIR=#{CREW_DEST_DIR} install"
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/pax_utils.rb
+++ b/packages/pax_utils.rb
@@ -15,17 +15,18 @@ class Pax_utils < Package
       x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pax_utils-1.2.5-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: 'e7140bfffd7af0f75c3d95bf40626f2f83a855b7cdbe3d9e019424a6d356f293',
-      armv7l: 'e7140bfffd7af0f75c3d95bf40626f2f83a855b7cdbe3d9e019424a6d356f293',
-        i686: 'a818331f5f3f431fbdcfadf9418ad4e99cdf3bfa2271a1d921c4e30ad5dc0e63',
-      x86_64: '712f217975226bbb33e2ddb16d049f389618bf48bea5410aeb389043c1ab06a3',
+     aarch64: 'edc856ff6cc451358da1fb46a2a1023594f3d243cb1c30e5aa67c9ee9ed4dac6',
+      armv7l: 'edc856ff6cc451358da1fb46a2a1023594f3d243cb1c30e5aa67c9ee9ed4dac6',
+        i686: '9254843237e4bba47da7c4ec63ca7109e32ad7fee5822a1862fdddc789c280bb',
+      x86_64: '836d8627d96ed61608cb7bee423db753fc00c67600c62386e1df98d4529c35c9',
   })
 
+  depends_on 'pyelftools'
   depends_on 'libcap' => ':build'
   depends_on 'libseccomp' => ':build'
 
   def self.build
-    #system "sed -E 's|(  paths =) \[\]|\1 [#{CREW_LIB_PREFIX}]|g' -i lddtree.py"
+    system "sed -i 's|/usr/bin/env python|/usr/bin/env python3|g' lddtree.py"
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
     ./configure \
     #{CREW_OPTIONS} \
@@ -36,6 +37,7 @@ class Pax_utils < Package
   end
   
   def self.install
+  
   system "make DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/pyelftools.rb
+++ b/packages/pyelftools.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Pyelftools < Package
+  description 'Pure-Python library for parsing and analyzing ELF files and DWARF debugging information.'
+  homepage 'https://github.com/eliben/pyelftools'
+  version '0.27'
+  compatibility 'all'
+  source_url 'file:///dev/null'
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+  binary_url ({
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pyelftools-0.27-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pyelftools-0.27-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/pyelftools-0.27-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pyelftools-0.27-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+     aarch64: '6948872decb8cbd4b9da384e6684fcf55736bd1fd998b94878f0d7896a0c32bb',
+      armv7l: '6948872decb8cbd4b9da384e6684fcf55736bd1fd998b94878f0d7896a0c32bb',
+        i686: '2781fb4f954695bdb05a0e5c6b2c36a3b88bc89ae5c001fca16c9daa2c839363',
+      x86_64: 'cd61b483e2268bfa2f09390710f44d183c8151b1e05d64dcb705ca297cda6b6d',
+  })
+
+  def self.install
+    system "pip3 uninstall -y pyelftools"
+    system "pip3 install --upgrade --no-warn-script-location pyelftools --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"
+  end
+end


### PR DESCRIPTION
This package has ```lddtools``` which can be used to find binaries with broken library dependencies.
It requires pyelftools.

e.g.
```
chronos@localhost /usr/local/lib64 $ /usr/local/bin/lddtree -a --skip-non-elfs /usr/local/lib64/libunbound.so
/usr/local/lib64/libunbound.so (interpreter => None)
    libssl.so.1.0.0 => None
    libcrypto.so.1.0.0 => None
    libpthread.so.0 => /usr/local/lib64/libpthread.so.0
        libc.so.6 => /usr/local/lib64/libc.so.6
            ld-linux-x86-64.so.2 => /usr/local/lib64/ld-linux-x86-64.so.2
        ld-linux-x86-64.so.2 => /usr/local/lib64/ld-linux-x86-64.so.2
    libc.so.6 => /usr/local/lib64/libc.so.6
        ld-linux-x86-64.so.2 => /usr/local/lib64/ld-linux-x86-64.so.2
chronos@localhost /usr/local/lib64 $ 
```

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686