### PR TITLE
Xorg updates 

### DIFF
--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -3,55 +3,103 @@ require 'package'
 class Xorg_server < Package
   description 'The Xorg Server is the core of the X Window system.'
   homepage 'https://www.x.org'
-  version '1.20.7'
+  @_ver = '1.20.10'
+  version @_ver
   compatibility 'all'
-  source_url 'https://www.x.org/releases/individual/xserver/xorg-server-1.20.7.tar.bz2'
-  source_sha256 'bd5986f010f34f5b3d6bc99fe395ecb1e0dead15a26807e0c832701809a06ea1'
+  source_url "https://github.com/freedesktop/xorg-xserver/archive/xorg-server-#{@_ver}.tar.gz"
+  source_sha256 '499d2b79fdf78e2e06b0c17a4d735fe25ba9d44f689e06a7e82612c35083c4ad'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.7-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.7-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.7-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.10-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.10-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.10-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_server-1.20.10-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '311a12cae0c1f03dd40c3605168c0c8928d40fdd2bb6cf42e5d20a6c8a97b6c1',
-     armv7l: '311a12cae0c1f03dd40c3605168c0c8928d40fdd2bb6cf42e5d20a6c8a97b6c1',
-       i686: '83adbeae700a2f36a5d238094579dd08efb33cc26e63e05d7f60d417d0448810',
-     x86_64: '9ef9acf6f82c2815880438a323c1acf5625f1111963fba714c5c3d11697f4959',
+     aarch64: '8edf7fc935a34813a0fe13b648f4d1a34b3cd81a36d6f4d9ce3da1d5a31491bb',
+      armv7l: '8edf7fc935a34813a0fe13b648f4d1a34b3cd81a36d6f4d9ce3da1d5a31491bb',
+        i686: 'bbdda323bac7ddf8ab2431cdbf4f17e625589fad6faf82427f10aa94ece011e1',
+      x86_64: '58d115ea4b80448055099284a27c4c794ecdaa7aa24ade44c456b180532e0fee',
   })
 
-  depends_on 'pixman'
-  depends_on 'xorg_lib'
-  depends_on 'xorg_proto'
   depends_on 'libepoxy'
+  depends_on 'xorg_proto'
+  depends_on 'libxtrans'
+  depends_on 'libxkbfile'
+  depends_on 'wayland'
+  depends_on 'eudev'
+  depends_on 'libxfont'
+  depends_on 'libbsd'
+  depends_on 'nettle'
+  depends_on 'libtirpc'
+  depends_on 'pixman'
+  depends_on 'graphite'
+  depends_on 'libxkbcommon'
+  depends_on 'libunwind'
+  depends_on 'font_util'
+  depends_on 'xorg_lib'
   depends_on 'libtirpc'
   depends_on 'font_util'
-  depends_on 'libunwind'
   depends_on 'libbsd'
   depends_on 'dbus'
   depends_on 'lzma' => :build
-  depends_on 'libxkbcommon'
   depends_on 'xkbcomp'
   depends_on 'glproto'
+  depends_on 'mesa'
+
+  case ARCH
+    when 'armv7l', 'aarch64'
+      PEER_CMD_PREFIX='/lib/ld-linux-armhf.so.3'
+    when 'i686'
+      PEER_CMD_PREFIX='/lib/ld-linux-i686.so.2'
+    when 'x86_64'
+      PEER_CMD_PREFIX='/lib64/ld-linux-x86-64.so.2'
+  end
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--enable-xfree86-utils',
-           '--enable-xf86vidmode',
-           '--enable-glamor',
-           '--enable-xorg',
-           '--enable-xwayland',
-           '--enable-xvfb',
-           '--enable-xnest',
-           '--disable-systemd-logind'
-    system 'make'
+    system 'meson setup build'
+    system "meson configure #{CREW_MESON_LTO_OPTIONS} \
+              -Db_asneeded=false \
+              -Dipv6=true \
+              -Dxvfb=true \
+              -Dxnest=true \
+              -Dxcsecurity=true \
+              -Dxorg=true \
+              -Dxephyr=false \
+              -Dxwayland=true \
+              -Dglamor=true \
+              -Dudev=true \
+              -Dxwin=false \
+              -Dsystemd_logind=false \
+              -Dint10=false \
+              -Dlog_dir=#{CREW_PREFIX}/var/log \
+              build"
+    system 'meson configure build'
+    system 'ninja -C build'
+    system "cat <<'EOF'> Xwayland_sh
+#!/bin/bash
+if base=$(readlink \"$0\" 2>/dev/null); then
+  case $base in
+  /*) base=$(readlink -f \"$0\" 2>/dev/null);; # if $0 is abspath symlink, make symlink fully resolved.
+  *)  base=$(dirname \"$0\")/\"${base}\";;
+  esac
+else
+  case $0 in
+  /*) base=$0;;
+  *)  base=${PWD:-`pwd`}/$0;;
+  esac
+fi
+basedir=${base%/*}
+# TODO(crbug/1003841): Remove LD_ARGV0 once
+# ld.so supports forwarding the binary name.
+LD_ARGV0=\"$0\" LD_ARGV0_REL=\"../bin/Xwayland.sh\" exec   \"${basedir}/..#{PEER_CMD_PREFIX}\"   --library-path \"${basedir}/../#{ARCH_LIB}\"   --inhibit-rpath ''   \"${base}.elf\"   \"$@\"
+EOF"
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    FileUtils.ln_sf 'Xwayland', "#{CREW_DEST_PREFIX}/bin/X"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
+    FileUtils.mv "#{CREW_DEST_PREFIX}/bin/Xwayland", "#{CREW_DEST_PREFIX}/bin/Xwayland.elf"
+    system "install -Dm755 Xwayland_sh #{CREW_DEST_PREFIX}/bin/Xwayland"
+    FileUtils.ln_sf "#{CREW_PREFIX}/bin/Xwayland", "#{CREW_DEST_PREFIX}/bin/X"
   end
 end

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -4,24 +4,23 @@ class Xwayland < Package
   description 'X server configured to work with weston or sommelier'
   homepage 'https://x.org'
   @_ver = '1.20.10'
-  version @_ver + '-2'
+  version @_ver + '-3'
   compatibility 'all'
   source_url "https://github.com/freedesktop/xorg-xserver/archive/xorg-server-#{@_ver}.tar.gz"
   source_sha256 '499d2b79fdf78e2e06b0c17a4d735fe25ba9d44f689e06a7e82612c35083c4ad'
 
   binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.10-2-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.10-2-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.10-2-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.10-2-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.10-3-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.10-3-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.10-3-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xwayland-1.20.10-3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '56870da84a58bd14ac55464f7f0363de30c924fb4853d29d1c5c987ee5164914',
-      armv7l: '56870da84a58bd14ac55464f7f0363de30c924fb4853d29d1c5c987ee5164914',
-        i686: '5832302f0eed9f41e3eca584b9c3df401c3c5b551db087d9cc8e6d43d19056cf',
-      x86_64: 'acaa00da4c1c6200fa3c6ffa3f833e5d13bcd240bc0d6cb5277ee0c01299ba47',
+     aarch64: 'ac87ced50d92c75f578bd5738b81012b46bbcf4721c8b3c8074cb2963ca64d5c',
+      armv7l: 'ac87ced50d92c75f578bd5738b81012b46bbcf4721c8b3c8074cb2963ca64d5c',
+        i686: 'bdc936c7d24301256867aeb17200c669a424adeb9f009aeb602f205c228d5cf9',
+      x86_64: 'd20e78d4a44203eeeb7d6c3d33e7d50d777eb9a8016370f064f29a5b6be64e91',
   })
-
 
   depends_on 'libepoxy'
   depends_on 'xorg_proto'
@@ -96,15 +95,8 @@ class Xwayland < Package
   end
 
   def self.build
-    #case ARCH
-    #when 'aarch64', 'armv7l', 'x86_64'
-    #  ENV['CFLAGS'] = '-fuse-ld=lld'
-    #  ENV['CXXFLAGS'] = '-fuse-ld=lld'
-    #end
     system 'meson setup build'
-    system "meson configure #{CREW_MESON_OPTIONS} \
-              -Dc_link_args='-fuse-ld=lld' \
-              -Dcpp_link_args='-fuse-ld=lld' \
+    system "meson configure #{CREW_MESON_LTO_OPTIONS} \
               -Db_asneeded=false \
               -Dipv6=true \
               -Dxvfb=true \


### PR DESCRIPTION
- This is a sync of the Xwayland and Xorg_server packages. 
- Both packages are based on xorg 1.20.10
- Both are using the Xwayland script now. 
- The Xwayland package is using the google patches, while the xorg_server package is not. 
- Both packages appear to work fine with sommelier for me.
- Both packages report hardware acceleration with sommelier using ```glxinfo -B``` (despite having used gcc, LTO, & the gold linker to compile these.)

### **_I need help testing this on i686 and armv7l hardware, as I don't have either of those. We don't want anybody's X install to stop working._**

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l

Works properly:
- [x] x86_64
- [ ] i686 **_???_**
- [ ] armv7l  **_???_**
- [ ] Cloudready devices?  **_???_**

**Here's what would be useful to test:**
- [ ] sommelier w/ acceleration: ```restartsommelier ; glxinfo -B ```
 (```glxinfo``` is in the ```mesa_utils``` package.)
- [ ] making sure your X11 app of choice opens. (Make sure this isn't a Wayland app. ```xterm``` is a fine choice for testing.)