### PR TITLE
Update parted to 3.4

### DIFF
--- a/packages/parted.rb
+++ b/packages/parted.rb
@@ -18,8 +18,8 @@ class Parted < Package
   binary_sha256 ({
      aarch64: 'ede8edf189c6a15f7f73c5473230e183e658515392727cf263bcec6f6e7a3145',
       armv7l: 'ede8edf189c6a15f7f73c5473230e183e658515392727cf263bcec6f6e7a3145',
-        i686: '0105eb1b9b74e671c2a8e2798ecbf45aa52cddc2a7a9c92de57716f6652a5229',
-      x86_64: '516dcdcb2ff040ed538a79f74d5f409b6059641620f6b8b239b584637513ec3e',
+        i686: '4df150824d0b15cbbd57e3d053dfdb7ae636165e61082ec294981abf96dacf58',
+      x86_64: 'c5dbafb2ff514b1eec1f9cdb5cffae0659120151ecb6d3552230a2a5054c95dc',
   })
 
   depends_on 'lvm2'

--- a/packages/parted.rb
+++ b/packages/parted.rb
@@ -3,23 +3,23 @@ require 'package'
 class Parted < Package
   description 'Create, destroy, resize, check, copy partitions and file systems.'
   homepage 'https://www.gnu.org/software/parted'
-  @_ver = '3.3'
+  @_ver = '3.4'
   version @_ver
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/parted/parted-#{@_ver}.tar.xz"
-  source_sha256 '57e2b4bd87018625c515421d4524f6e3b55175b472302056391c5f7eccb83d44'
+  source_sha256 'e1298022472da5589b7f2be1d5ee3c1b66ec3d96dfbad03dc642afd009da5342'
 
   binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/parted-3.3-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/parted-3.3-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/parted-3.3-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/parted-3.3-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/parted-3.4-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/parted-3.4-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/parted-3.4-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/parted-3.4-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '98ed6e820c9c05fc359d47ff2eea255cb1b336f86db4b212c9382ca4c12ae580',
-      armv7l: '98ed6e820c9c05fc359d47ff2eea255cb1b336f86db4b212c9382ca4c12ae580',
-        i686: 'ce9523de48e30a28c75f0c5651eb17030f02c78e47d2fd700456f44e2566557f',
-      x86_64: '7c80e009bb00704ddd43e79f18f1e1c9ade975590c1fa0d28fdedd8ebc679ef4',
+     aarch64: 'ede8edf189c6a15f7f73c5473230e183e658515392727cf263bcec6f6e7a3145',
+      armv7l: 'ede8edf189c6a15f7f73c5473230e183e658515392727cf263bcec6f6e7a3145',
+        i686: '0105eb1b9b74e671c2a8e2798ecbf45aa52cddc2a7a9c92de57716f6652a5229',
+      x86_64: '516dcdcb2ff040ed538a79f74d5f409b6059641620f6b8b239b584637513ec3e',
   })
 
   depends_on 'lvm2'
@@ -27,7 +27,7 @@ class Parted < Package
   depends_on 'readline'
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
       ./configure #{CREW_OPTIONS}"
     system "make"
   end


### PR DESCRIPTION
- This is probably useful for us: libparted: Add ChromeOS Kernel partition flag

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686
