### PR TITLE
libunwind rebuild without leaking ENV variables

### DIFF
--- a/packages/libunwind.rb
+++ b/packages/libunwind.rb
@@ -21,8 +21,6 @@ class Libunwind < Package
       x86_64: 'a759499690b70258e91d8ac7cd32047a3cf3308364b04f062e8fc60a33782ec6',
   })
 
-  depends_on 'xzutils' => :build
-
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
     ./configure #{CREW_OPTIONS} --enable-ptrace"

--- a/packages/libunwind.rb
+++ b/packages/libunwind.rb
@@ -3,33 +3,29 @@ require 'package'
 class Libunwind < Package
   description 'libunwind is a portable and efficient C programming interface (API) to determine the call-chain of a program.'
   homepage 'https://www.nongnu.org/libunwind/'
-  version '1.5.0'
+  version '1.5.0-1'
   compatibility 'all'
   source_url 'https://download.savannah.gnu.org/releases/libunwind/libunwind-1.5.0.tar.gz'
   source_sha256 '90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libunwind-1.5.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libunwind-1.5.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libunwind-1.5.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libunwind-1.5.0-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libunwind-1.5.0-1-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libunwind-1.5.0-1-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/libunwind-1.5.0-1-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libunwind-1.5.0-1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '96274d710810abd35f6a38f1c2d8c39f85959cc26de07f98a78dd27ff03dce9c',
-     armv7l: '96274d710810abd35f6a38f1c2d8c39f85959cc26de07f98a78dd27ff03dce9c',
-       i686: '508923a9dbdbacb0eeab2244db0c7caca2e8bcd3acd4d1c154c63eb600483937',
-     x86_64: '3453e7f9438a665df84f39fcbd1c996009988480f05ec3489712efdf3c1499e0',
+     aarch64: 'c1b315c17464f67a1e719a615da0154c661eaf1e6e1584f8a68870a2de8721e8',
+      armv7l: 'c1b315c17464f67a1e719a615da0154c661eaf1e6e1584f8a68870a2de8721e8',
+        i686: 'd697d0a6c015dc8c01593669679c367ca0c9f412e140adb2d4ced0af9fb42fb2',
+      x86_64: 'a759499690b70258e91d8ac7cd32047a3cf3308364b04f062e8fc60a33782ec6',
   })
 
   depends_on 'xzutils' => :build
 
-  # Fixes GCC 10 compilation.
-  # As per https://github.com/libunwind/libunwind/pull/166
-  # Fixes llvm11 compilation as per
-  # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=230399#c9
-  ENV['CFLAGS'] = '-fcommon -fexceptions -funwind-tables'
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-ptrace"
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+    ./configure #{CREW_OPTIONS} --enable-ptrace"
     system 'make'
   end
 


### PR DESCRIPTION

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686