### PR TITLE
crew: Replace '-' with '_' in crew install <pkgName>

### DIFF
--- a/crew
+++ b/crew
@@ -949,7 +949,7 @@ end
 
 def build_command (args)
   args["<name>"].each do |name|
-    @pkgName = name
+    @pkgName = name.gsub('-', '_')
     search @pkgName
     print_current_package @opt_verbose
     resolve_dependencies_and_build
@@ -958,7 +958,7 @@ end
 
 def download_command (args)
   args["<name>"].each do |name|
-    @pkgName = name
+    @pkgName = name.gsub('-', '_')
     search @pkgName
     print_current_package @opt_verbose
     download
@@ -977,7 +977,7 @@ end
 
 def files_command (args)
   args["<name>"].each do |name|
-    @pkgName = name
+    @pkgName = name.gsub('-', '_')
     search @pkgName
     print_current_package
     files name
@@ -1017,18 +1017,19 @@ end
 
 def postinstall_command (args)
   args["<name>"].each do |name|
-    search name, true
-    if @device[:installed_packages].any? do |elem| elem[:name] == name end
+    @pkgName = name.gsub('-', '_')
+    search @pkgName, true
+    if @device[:installed_packages].any? do |elem| elem[:name] == @pkgName end
       @pkg.postinstall
     else
-      puts "Package #{name} is not installed. :(".lightred
+      puts "Package #{@pkgName} is not installed. :(".lightred
     end
   end
 end
 
 def reinstall_command (args)
   args["<name>"].each do |name|
-    @pkgName = name
+    @pkgName = name.gsub('-', '_')
     search @pkgName
     print_current_package
     @pkg.build_from_source = true if @opt_src or @opt_recursive
@@ -1042,13 +1043,13 @@ end
 
 def remove_command (args)
   args["<name>"].each do |name|
-    remove name
+    remove name.gsub('-', '_')
   end
 end
 
 def search_command (args)
   args["<name>"].each do |name|
-    regexp_search name
+    regexp_search name.gsub('-', '_')
   end.empty? and begin
     list_packages
   end
@@ -1060,7 +1061,7 @@ end
 
 def upgrade_command (args)
   args["<name>"].each do |name|
-    @pkgName = name
+    @pkgName = name.gsub('-', '_')
     search @pkgName
     print_current_package
     @pkg.build_from_source = true if @opt_src

--- a/crew
+++ b/crew
@@ -995,7 +995,7 @@ end
 
 def install_command (args)
   args["<name>"].each do |name|
-    @pkgName = name
+    @pkgName = name.gsub('-', '_')
     search @pkgName
     print_current_package true
     @pkg.build_from_source = true if @opt_src or @opt_recursive

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.2'
+CREW_VERSION = '1.7.3'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
This will definitely reduce confusion for users :)

Tested with commands:
```shell
crew download xfce4-terminal
crew install xfce4-terminal
crew reinstall xfce4-terminal
crew remove xfce4-terminal
crew files xfce4-terminal
crew search xfce4-terminal
```