### PR TITLE
curl: #5062: Update build options and remove dep on rtmpdump

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -4,24 +4,23 @@ class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
   @_ver = "7.74.0"
-  version @_ver + '-2'
+  version @_ver + '-3'
   compatibility 'all'
   source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
   source_sha256 '999d5f2c403cf6e25d58319fdd596611e455dd195208746bc6e6d197a77e878b'
 
   binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.74.0-2-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.74.0-2-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.74.0-2-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.74.0-2-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.74.0-3-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.74.0-3-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.74.0-3-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/curl-7.74.0-3-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '48caa978643acd326ffdf3e3f4bc502d48c8aafc73b1e39e47d710174fad2145',
-      armv7l: '48caa978643acd326ffdf3e3f4bc502d48c8aafc73b1e39e47d710174fad2145',
-        i686: 'fed721a267a16a27df602b6116d0be04423bb58194d567dbf42727e6d61afdf2',
-      x86_64: 'e8a8120132ce90acda8cc2b9f87c609dd4eca1851a8ef990b2d99eebf84372b1',
+     aarch64: '5012f55827b4a9214b1a769672c3218c5cd3cbb7915e91e563eae3aa13db73ce',
+      armv7l: '5012f55827b4a9214b1a769672c3218c5cd3cbb7915e91e563eae3aa13db73ce',
+        i686: '86b61da0ae5c15b4b96243943806669f75204b7aa5d8054650000a66648d0e67',
+      x86_64: '5a12aacb4f66ae223d25cf21d8bc5b73236bec93f7346158d0224840704ed9fb',
   })
-
 
   depends_on 'groff' => :build
   depends_on 'brotli'

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -33,7 +33,6 @@ class Curl < Package
   depends_on 'libtirpc'
   depends_on 'libunbound'
   depends_on 'openldap'
-  depends_on 'rtmpdump'
   depends_on 'zstd'
 
   def self.build
@@ -41,8 +40,10 @@ class Curl < Package
     ./configure #{CREW_OPTIONS} \
     --disable-maintainer-mode \
     --enable-ares \
-    --with-ldap-lib=#{CREW_LIB_PREFIX}/libldap.so \
-    --with-lber-lib=#{CREW_LIB_PREFIX}/liblber.so"
+    --with-ldap-lib=ldap \
+    --with-lber-lib=lber \
+    --with-libmetalink \
+    --without-librtmp"
     system 'make'
   end
 


### PR DESCRIPTION
## Description
    * Build with
        -  --with-ldap-lib=ldap
        -  --with-lber-lib=lber
        -  --with-libmetalink
        -  --without-librtmp
        -  --without-libssh2     # Since we don't declare libssh2 as a dependency of curl,
                                 # we should prevent curl from relying on it

Relates to #5602
## Addtional information
- [ ] x86_64: ***NO: Some tests failed*** with complaints from valgrind about out-of-bounds reads and relying on an uninitialized value for a jump. I wasn't able to figure out what as causing this.
- [ ] aarch64 (unable to test)
