### PR TITLE
[rtmpdump]: Pass variables to make instead of patching the Makefile

### DIFF
--- a/packages/rtmpdump.rb
+++ b/packages/rtmpdump.rb
@@ -7,7 +7,7 @@ class Rtmpdump < Package
   compatibility 'all'
   source_url 'https://git.ffmpeg.org/gitweb/rtmpdump.git/snapshot/c5f04a58fc2aeea6296ca7c44ee4734c18401aa3.tar.gz'
   source_sha256 'fd8c21263d93fbde8bee8aa6c5f6a657789674bb0f9e74f050651504d5f43b46'
-  @make_common_opts = ["prefix=#{CREW_PREFIX}", "libdir=#{CREW_LIB_PREFIX}", 'CRYPTO=GNUTLS']
+  @make_common_opts = ['SYS=posix', "prefix=#{CREW_PREFIX}", "libdir=#{CREW_LIB_PREFIX}", 'CRYPTO=GNUTLS']
 
   binary_url ({
      aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rtmpdump-c5f04a58f-1-chromeos-armv7l.tar.xz',
@@ -23,7 +23,7 @@ class Rtmpdump < Package
   })
 
   def self.build
-    system 'make', *@make_common_opts
+    system "make", *@make_common_opts
   end
 
   def self.install

--- a/packages/rtmpdump.rb
+++ b/packages/rtmpdump.rb
@@ -7,6 +7,7 @@ class Rtmpdump < Package
   compatibility 'all'
   source_url 'https://git.ffmpeg.org/gitweb/rtmpdump.git/snapshot/c5f04a58fc2aeea6296ca7c44ee4734c18401aa3.tar.gz'
   source_sha256 'fd8c21263d93fbde8bee8aa6c5f6a657789674bb0f9e74f050651504d5f43b46'
+  @make_common_opts = ["prefix=#{CREW_PREFIX}", "libdir=#{CREW_LIB_PREFIX}", 'CRYPTO=GNUTLS']
 
   binary_url ({
      aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rtmpdump-c5f04a58f-1-chromeos-armv7l.tar.xz',
@@ -20,20 +21,12 @@ class Rtmpdump < Package
         i686: '109fb6fa70409f8ba274fa452c2e04dc1ff3ba740f618525c188139c1ddce363',
       x86_64: '0212408c6faad92b5909d77188d8c27e68ce955f61dcb5597603303e31e601ce',
   })
-  
-  def self.patch
-    system "sed -i 's,prefix=/usr/local,prefix=#{CREW_PREFIX},' Makefile"
-    system "sed -i 's,prefix=/usr/local,prefix=#{CREW_PREFIX},' librtmp/Makefile"
-    system "sed -i 's,libdir=\$(prefix)/lib,libdir=#{CREW_LIB_PREFIX},' librtmp/Makefile"
-    # OpenSSL builds are broken.
-    system "sed -e 's/^CRYPTO=OPENSSL/#CRYPTO=OPENSSL/' -e 's/#CRYPTO=GNUTLS/CRYPTO=GNUTLS/' -i Makefile -i librtmp/Makefile"
-  end
- 
+
   def self.build
-    system 'make'
+    system 'make', *@make_common_opts
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system 'make', *@make_common_opts, "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
## Description
Patching the Makefile for rtmpdump should not be necessary. GNU make allows us to override the variables on the command line. See [this link](https://www.gnu.org/software/make/manual/html_node/Overriding.html#Overriding)

## Addtional information
Works properly:
- [x] x86_64
- [ ] aarch64 (cannot test, no hw)

Tested by running crew build and verifying that files are packaged into the correct tree structure (i.e. under /usr/local) and that binaries are linked against GnuTLS