### PR TITLE
Packages rebuilt not to use libiconv

### DIFF
--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -3,22 +3,23 @@ require 'package'
 class Gettext < Package
   description 'GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages.'
   homepage 'https://www.gnu.org/software/gettext/'
-  version '0.21'
+  @_ver = '0.21'
+  version "#{@ver}-1"
   compatibility 'all'
-  source_url 'https://gnu.freemirror.org/gnu/gettext/gettext-0.21.tar.lz'
+  source_url "https://gnu.freemirror.org/gnu/gettext/gettext-#{@_ver}.tar.lz"
   source_sha256 '435b546e3880ab767c967c0731b20629a0cb0ba620e6bac2f590f401c10ebb45'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gettext-0.21-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gettext-0.21-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gettext-0.21-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gettext-0.21-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gettext-0.21-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gettext-0.21-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gettext-0.21-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gettext-0.21-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '6489c458f5f3ad46d60415fd5097bac4ed5d1c739500b2ca90262a75cb05b17e',
-     armv7l: '6489c458f5f3ad46d60415fd5097bac4ed5d1c739500b2ca90262a75cb05b17e',
-       i686: '178c97cca996dbb982deb8ab6ce7faea9c1ae4795e8f716a1a92565b5c7b52c6',
-     x86_64: 'c51bf8877623c0c797b6a3eaf36a60693a45a044371601d065f8e904f8eadd8c',
+  binary_sha256({
+    aarch64: '57ae562920cf6caefb4e6e764a171a8a78f18e5767668e42e4722cc63612cfa7',
+     armv7l: '57ae562920cf6caefb4e6e764a171a8a78f18e5767668e42e4722cc63612cfa7',
+       i686: '520172814ee0312877b6a0fb0d5d9f4e22473cf5bb9272facf93bf4d5597d1c0',
+     x86_64: 'de490d13276f5b9a48e007b57c08c64aac21730b1091be453c1373a0e1c26c52'
   })
 
   depends_on 'ncurses'
@@ -27,12 +28,18 @@ class Gettext < Package
   depends_on 'jdk8' => :build
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-static --enable-shared --with-pic"
+    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+
+    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto'  LDFLAGS='-flto=auto'\
+    ./configure #{CREW_OPTIONS} \
+    --disable-static \
+    --enable-shared \
+    --with-pic"
     system 'make'
   end
 
   def self.check
-    #system 'make', 'check'
+    # system 'make', 'check'
   end
 
   def self.install

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -4,33 +4,37 @@ class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
   @_ver = '2.30.0'
-  version @_ver + '-1'
+  version "#{@_ver}-2"
   compatibility 'all'
   source_url "https://github.com/git/git/archive/v#{@_ver}.tar.gz"
   source_sha256 '8db4edd1a0a74ebf4b78aed3f9e25c8f2a7db3c00b1aaee94d1e9834fae24e61'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.30.0-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.30.0-1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.30.0-1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.30.0-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.30.0-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.30.0-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.30.0-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/git-2.30.0-2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '4386bc951eaa7311b8c828fb76b030410f63686c9c86f6288b2a1025594166f1',
-      armv7l: '4386bc951eaa7311b8c828fb76b030410f63686c9c86f6288b2a1025594166f1',
-        i686: '6dd0fc056dd3cdca76596603c1a161724e8f81d68c50bf18f25877e4df8dc9e4',
-      x86_64: 'ae2a5001e272fdf4a1f212ed31f38b62e2fd20205f8ab0c77ab7226b8a94b6ac',
+  binary_sha256({
+    aarch64: 'a11bad34ddd17924b226026eccabf449381cf6b069715b914ab7bd66b3190a36',
+     armv7l: 'a11bad34ddd17924b226026eccabf449381cf6b069715b914ab7bd66b3190a36',
+       i686: 'd09ad3f842c1fefba128e28252d383b69bc890627e7759abeb1d75b624bf4d84',
+     x86_64: '3a63be93d3bbc46811a7f8b81a8e4b08c03ff82facf36419030ac214b60e4e6b'
   })
 
   depends_on 'curl' => :build
   depends_on 'python3' => :build
 
   def self.build
+    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+
     system 'autoreconf -i'
     system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
+    LDFLAGS='-flto=auto' \
     ./configure \
+    #{CREW_OPTIONS} \
     --with-openssl=#{CREW_PREFIX}/etc/ssl \
-    --without-tcltk #{CREW_OPTIONS} \
+    --without-tcltk \
     --with-perl=#{CREW_PREFIX}/bin/perl \
     --with-python=#{CREW_PREFIX}/bin/python3 \
     --with-gitconfig=#{CREW_PREFIX}/etc/gitconfig \
@@ -46,15 +50,15 @@ class Git < Package
 
   def self.postinstall
     puts
-    puts "Git completion support is available for the following shells:".lightblue
+    puts 'Git completion support is available for the following shells:'.lightblue
     system "ls #{CREW_PREFIX}/share/git-completion"
     puts
-    puts "To add git completion for bash, execute the following:".lightblue
+    puts 'To add git completion for bash, execute the following:'.lightblue
     puts "echo '# git completion' >> ~/.bashrc".lightblue
     puts "echo 'if [ -f #{CREW_PREFIX}/share/git-completion/git-completion.bash ]; then' >> ~/.bashrc".lightblue
     puts "echo '  source #{CREW_PREFIX}/share/git-completion/git-completion.bash' >> ~/.bashrc".lightblue
     puts "echo 'fi' >> ~/.bashrc".lightblue
-    puts "source ~/.bashrc".lightblue
+    puts 'source ~/.bashrc'.lightblue
     puts
   end
 end

--- a/packages/libarchive.rb
+++ b/packages/libarchive.rb
@@ -4,29 +4,32 @@ class Libarchive < Package
   description 'Multi-format archive and compression library.'
   homepage 'https://www.libarchive.org/'
   @_ver = '3.5.1'
-  version @_ver
+  version "#{@_ver}-1"
   compatibility 'all'
   source_url "https://www.libarchive.org/downloads/libarchive-#{@_ver}.tar.xz"
   source_sha256 '0e17d3a8d0b206018693b27f08029b598f6ef03600c2b5d10c94ce58692e299b'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.5.1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.5.1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.5.1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.5.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.5.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.5.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.5.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libarchive-3.5.1-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '1f88febf96c404466b7e86849b291ecd8e3086021b6fd3fb6b4887f3935e24d8',
-      armv7l: '1f88febf96c404466b7e86849b291ecd8e3086021b6fd3fb6b4887f3935e24d8',
-        i686: '457630efbf3cb6af9a88cd3229407e416ec478b78c176bd3735c40f1edbfd192',
-      x86_64: 'f70e487934dfd505812e01ae2d4cf2c7fc7077cab847240b9f0d840f7d360f55',
+  binary_sha256({
+    aarch64: 'd58404d09d291373169e80b4012ffb5c51f30760503769808b7a9e98111cfb68',
+     armv7l: 'd58404d09d291373169e80b4012ffb5c51f30760503769808b7a9e98111cfb68',
+       i686: 'b7634129d40fe7beed9185ce73ed78730c8255485d59d4316d67267a0b56c206',
+     x86_64: '53a2d351d07063157a3ed33a8cf711af401b7adee4c72f4fa5772637e4823fa3'
   })
 
   depends_on 'lz4'
   depends_on 'xzutils' => :build
 
   def self.build
+    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
       ./configure #{CREW_OPTIONS}"
     system 'make'
   end

--- a/packages/libical.rb
+++ b/packages/libical.rb
@@ -2,22 +2,22 @@ require 'package'
 
 class Libical < Package
   description 'An open source reference implementation of the icalendar data type and serialization format'
-  version '3.0.8.99' # 3.0.8 doesn't compile.
+  version '3.0.9'
   compatibility 'all'
-  source_url 'https://github.com/libical/libical/archive/07dc84fb0d5e50fb493005e10fa41930111da48f.zip'
-  source_sha256 '5fdf39b0ea654589bf2e9aa88ef1b0206c18aa6987f5a4299db3748e8b1eefd6'
+  source_url 'https://github.com/libical/libical/releases/download/v3.0.9/libical-3.0.9.tar.gz'
+  source_sha256 'bd26d98b7fcb2eb0cd5461747bbb02024ebe38e293ca53a7dfdcb2505265a728'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libical-3.0.8.99-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libical-3.0.8.99-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libical-3.0.8.99-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libical-3.0.8.99-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libical-3.0.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libical-3.0.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libical-3.0.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libical-3.0.9-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'ff814e2b53f6c707a029f74895c90cde0b4bf6b8156dfbc03ecb9f49d34dc919',
-     armv7l: 'ff814e2b53f6c707a029f74895c90cde0b4bf6b8156dfbc03ecb9f49d34dc919',
-       i686: '1a9abe4217cf37eefd0e09ced2203651dd283157072efb850b7bdcb69ebdee39',
-     x86_64: 'f21f8c0273497d6906a087cfad00d0ab51f588121d0f0564a391364caabc9781',
+  binary_sha256({
+    aarch64: '7db2461fee6be357f39abd270cfad5f20aa2e0d40f65a3310f1d2cc755c50e5e',
+     armv7l: '7db2461fee6be357f39abd270cfad5f20aa2e0d40f65a3310f1d2cc755c50e5e',
+       i686: '15749b91f620d4f108c6c73ce3a23075621a13728348d401ae499b1db047b747',
+     x86_64: 'd3ebd14fbd5b34f1c0347dfb21e6b278a6a7131fb9367a1be0e53d23cac755ac'
   })
 
   depends_on 'glib'
@@ -27,18 +27,20 @@ class Libical < Package
   depends_on 'gobject_introspection' => ':build'
 
   def self.build
-    Dir.mkdir 'build'
-    Dir.chdir 'build' do
-      system "cmake #{CREW_CMAKE_OPTIONS} .. -G Ninja \
-        -DGOBJECT_INTROSPECTION=true \
-        -DICAL_GLIB_VAPI=true \
-        -DICAL_BUILD_DOCS=false \
-        -DLIBICAL_BUILD_TESTING=false"
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      cmake #{CREW_CMAKE_OPTIONS} .. -G Ninja \
+      -DGOBJECT_INTROSPECTION=true \
+      -DICAL_GLIB_VAPI=true \
+      -DICAL_BUILD_DOCS=false \
+      -DLIBICAL_BUILD_TESTING=false"
     end
-    system "ninja -C build"
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/libpsl.rb
+++ b/packages/libpsl.rb
@@ -3,30 +3,34 @@ require 'package'
 class Libpsl < Package
   description 'C library for the Public Suffix List'
   homepage 'https://github.com/rockdaboot/libpsl'
-  version '0.20.2'
+  @_ver = '0.21.1'
+  version @_ver
   compatibility 'all'
-  source_url 'https://github.com/rockdaboot/libpsl/releases/download/libpsl-0.20.2/libpsl-0.20.2.tar.gz'
-  source_sha256 'f8fd0aeb66252dfcc638f14d9be1e2362fdaf2ca86bde0444ff4d5cc961b560f'
+  source_url "https://github.com/rockdaboot/libpsl/releases/download/#{@_ver}/libpsl-#{@_ver}.tar.lz"
+  source_sha256 '644375d557bb3b84c485df2dae98ee388fe1e11fb75230004e4b8623b3b833a9'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpsl-0.20.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpsl-0.20.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpsl-0.20.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpsl-0.20.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpsl-0.21.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpsl-0.21.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpsl-0.21.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpsl-0.21.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'f6dab3749e5e195e417775c03870738aef36454f5124e59708c70a006b417b9c',
-     armv7l: 'f6dab3749e5e195e417775c03870738aef36454f5124e59708c70a006b417b9c',
-       i686: '51e81940423ac5bf3de3a931f697d1b0962a74be326f7cf0685f0328d97b7dab',
-     x86_64: 'f7f422c26f3d5b3cf690a6f9db6245f32ec7700d1db8e2b33eac212ca00c422e',
+  binary_sha256({
+    aarch64: '9b8376e9c1b5e65363e0c4a7ad61721930e07dbaa032c76455723186d6268d47',
+     armv7l: '9b8376e9c1b5e65363e0c4a7ad61721930e07dbaa032c76455723186d6268d47',
+       i686: 'c5d298373d73a26ecd8559254f00286f14e129a09dbe13f94252356a332fc172',
+     x86_64: 'e8c7a5c5f46be4ff1158d5d643a3efa14fcf008f4f6af906703612b907c9e725'
   })
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Ddocs=disabled \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/pkgconfig.rb
+++ b/packages/pkgconfig.rb
@@ -2,51 +2,57 @@ require 'package'
 
 class Pkgconfig < Package
   description 'pkg-config is a helper tool used when compiling applications and libraries.'
-  homepage 'https://www.freedesktop.org/wiki/Software/pkg-config/'
-  version '0.29.2-1'
+  homepage 'https://gitlab.freedesktop.org/pkg-config/pkg-config'
+  version '0.29.2-d97d'
   compatibility 'all'
-  source_url 'http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz'
-  source_sha256 '6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591'
+  source_url 'https://gitlab.freedesktop.org/pkg-config/pkg-config/-/archive/d97db4fae4c1cd099b506970b285dc2afd818ea2/pkg-config-d97db4fae4c1cd099b506970b285dc2afd818ea2.tar.bz2'
+  source_sha256 'beeeb23b4581241517e45e57d901459022376c3143f415fac1a1216d583b1796'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pkgconfig-0.29.2-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pkgconfig-0.29.2-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pkgconfig-0.29.2-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pkgconfig-0.29.2-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pkgconfig-0.29.2-d97d-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pkgconfig-0.29.2-d97d-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pkgconfig-0.29.2-d97d-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pkgconfig-0.29.2-d97d-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '88909e28a93e6b1baf864d8ba5b2d3eb28edb9bbc8455211c0d26993562e5895',
-     armv7l: '88909e28a93e6b1baf864d8ba5b2d3eb28edb9bbc8455211c0d26993562e5895',
-       i686: 'a225901ea0c0236f77f308814acfdfd262a649efd1bee95f21fc5b16fa198f69',
-     x86_64: 'e86ed00a42e902ce4364c04d01f8bb94da0e31d740025f978ddb024a06f52ec8',
+  binary_sha256({
+    aarch64: '5f3ad29987b8e93d88dce19fbd5b968809857d0267baab4f68d4a7129b06cd8b',
+     armv7l: '5f3ad29987b8e93d88dce19fbd5b968809857d0267baab4f68d4a7129b06cd8b',
+       i686: 'f9773b42423eaf021eb2104d568455661e879e3de80ffe54f78a74c3631186dc',
+     x86_64: 'f17babbbfcf112c2bff4844545e401fe0c705062c1f354ac446da5e8021b7f1b'
   })
 
   def self.build
+    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+
+    # As per https://gitlab.gnome.org/GNOME/glib/-/issues/1159
+    # To fix broken check-print-options test
+    system "sed -i '/glib-gettext.m4/d' glib/acinclude.m4"
+    system 'env NOCONFIGURE=1 ./autogen.sh'
     case ARCH
     when 'x86_64'
-      system './configure',
-             "--prefix=#{CREW_PREFIX}",
-             "--libdir=#{CREW_LIB_PREFIX}",
-             '--with-internal-glib',
-             "--with-pc-path=#{CREW_PREFIX}/lib/pkgconfig:#{CREW_PREFIX}/lib64/pkgconfig:#{CREW_PREFIX}/share/pkgconfig",
-             "--with-system-include-path=/usr/include:#{CREW_PREFIX}/include",
-             "--with-system-library-path=#{CREW_PREFIX}/lib:#{CREW_PREFIX}/lib64",
-             '--disable-static',
-             '--enable-shared',
-             '--disable-host-tool',
-             '--with-libiconv=gnu'
-    when 'i686','armv7l','aarch64'
-      system './configure',
-             "--prefix=#{CREW_PREFIX}",
-             "--libdir=#{CREW_LIB_PREFIX}",
-             '--with-internal-glib',
-             "--with-pc-path=#{CREW_PREFIX}/lib/pkgconfig:#{CREW_PREFIX}/share/pkgconfig",
-             "--with-system-include-path=/usr/include:#{CREW_PREFIX}/include",
-             "--with-system-library-path=#{CREW_PREFIX}/lib",
-             '--disable-static',
-             '--enable-shared',
-             '--disable-host-tool',
-             '--with-libiconv=gnu'
+      system "env CFLAGS='-pipe -flto=auto' \
+        CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+        GLIB_CFLAGS='-I#{CREW_PREFIX}/include/glib-2.0 -I#{CREW_LIB_PREFIX}/glib-2.0/include' \
+        GLIB_LIBS=-lglib-2.0 \
+        ./configure #{CREW_OPTIONS} \
+        --with-pc-path=#{CREW_PREFIX}/lib/pkgconfig:#{CREW_PREFIX}/lib64/pkgconfig:#{CREW_PREFIX}/share/pkgconfig \
+        --with-system-include-path=/usr/include:#{CREW_PREFIX}/include \
+        --with-system-library-path=#{CREW_LIB_PREFIX} \
+        --enable-shared \
+        --disable-host-tool \
+        --with-libiconv=gnu"
+    when 'i686', 'armv7l', 'aarch64'
+      system "env CFLAGS='-pipe -flto=auto' \
+        CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+        GLIB_CFLAGS='-I#{CREW_PREFIX}/include/glib-2.0 -I#{CREW_LIB_PREFIX}/glib-2.0/include' \
+        GLIB_LIBS=-lglib-2.0 \
+        ./configure #{CREW_OPTIONS} \
+        --with-pc-path=#{CREW_PREFIX}/lib/pkgconfig:#{CREW_PREFIX}/share/pkgconfig \
+        --with-system-include-path=/usr/include:#{CREW_PREFIX}/include \
+        --with-system-library-path=#{CREW_LIB_PREFIX} \
+        --enable-shared \
+        --disable-host-tool \
+        --with-libiconv=gnu"
     end
     system 'make'
   end


### PR DESCRIPTION
iconv.h is now being drawn from glibc. Rebuilds of these programs and others which depend upon libiconv thus don't work properly. This is a rebuild of packages such that they do not have a libiconv dependency.

git and curl had to be rebuilt for crew to work w/o libiconv installed.

install.sh has not been updated...

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686
