### PR TITLE
Waypipe and deps

### DIFF
--- a/packages/libevdev.rb
+++ b/packages/libevdev.rb
@@ -3,33 +3,35 @@ require 'package'
 class Libevdev < Package
   description 'libevdev is a wrapper library for evdev devices.'
   homepage 'https://www.freedesktop.org/wiki/Software/libevdev'
-  version '1.5.9-0'
+  version '1.11.0'
   compatibility 'all'
-  source_url 'https://www.freedesktop.org/software/libevdev/libevdev-1.5.9.tar.xz'
-  source_sha256 'e1663751443bed9d3e76a4fe2caf6fa866a79705d91cacad815c04e706198a75'
+  source_url 'https://www.freedesktop.org/software/libevdev/libevdev-1.11.0.tar.xz'
+  source_sha256 '63f4ea1489858a109080e0b40bd43e4e0903a1e12ea888d581db8c495747c2d0'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libevdev-1.5.9-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libevdev-1.5.9-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libevdev-1.5.9-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libevdev-1.5.9-0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libevdev-1.11.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libevdev-1.11.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libevdev-1.11.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libevdev-1.11.0-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'ee50da24a54da6574d50571871052104ed46256280f4bc7c5698e76d7ecf4fd3',
-     armv7l: 'ee50da24a54da6574d50571871052104ed46256280f4bc7c5698e76d7ecf4fd3',
-       i686: 'af2583a717277459bd65c27b994a36ef2fc1e018278773c831153abc871e567d',
-     x86_64: '6f113678d99a5f4fc52db49702bb209e845de505c1bb456b4f2d1c862e9ff7ed',
+  binary_sha256({
+    aarch64: '3b4008a79759fdb098e2e93a5455aed90965d670d5a4328b67b49f4936584eb6',
+     armv7l: '3b4008a79759fdb098e2e93a5455aed90965d670d5a4328b67b49f4936584eb6',
+       i686: 'c4d8bad0f712c1cfacc725e7d317be45aa15bb67d281f8d73ca92a9e803dd116',
+     x86_64: '6afbae9d141ced6da39edb73127c4e247afd9abeae8a681b3dc8b62b7edc818d'
   })
 
   depends_on 'doxygen' => :build
-  depends_on 'python27' => :build
+  depends_on 'python3' => :build
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/libgudev.rb
+++ b/packages/libgudev.rb
@@ -3,33 +3,34 @@ require 'package'
 class Libgudev < Package
   description 'libgudev is a library with GObject bindings to libudev'
   homepage 'https://wiki.gnome.org/Projects/libgudev'
-  version '0.232'
+  version '234-1c7e'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/libgudev/232/libgudev-232.tar.xz'
-  source_sha256 'ee4cb2b9c573cdf354f6ed744f01b111d4b5bed3503ffa956cefff50489c7860'
+  source_url 'https://github.com/GNOME/libgudev/archive/1c7e05b40b92b67dac7a6cd27b70ba08956e4815.zip'
+  source_sha256 '5ecb0c8ca76b6da7c7ad01f947c407f3670362bf5d3244075928dd86e040fcc4'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgudev-0.232-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgudev-0.232-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgudev-0.232-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgudev-0.232-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgudev-234-1c7e-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgudev-234-1c7e-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgudev-234-1c7e-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgudev-234-1c7e-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'd45d9087a7128ca0b5c39dac0858728cd01f711dd57c3e8b1e716a85945cc7b8',
-     armv7l: 'd45d9087a7128ca0b5c39dac0858728cd01f711dd57c3e8b1e716a85945cc7b8',
-       i686: '8c9b9115d790ff7ba9d7ab4cc48aa9312c07c273141174acc02a546d20db25eb',
-     x86_64: '3c41340787b2f362448cf8c32b2a00814e190bd2028605a6b925589d1fb177a1',
+  binary_sha256({
+    aarch64: 'e636f1df415de3dddf08c3326d633b8bdf0223130e50cb2f62c5916b641c152a',
+     armv7l: 'e636f1df415de3dddf08c3326d633b8bdf0223130e50cb2f62c5916b641c152a',
+       i686: 'f4fb01f5d16cd38b890a85c501bfb9c22a29b8ad7a759430275b6a490d798795',
+     x86_64: '0980fde25a7a552e3f672d63c50e350a369667b9dbc69191635341ca64937f76'
   })
 
   depends_on 'gobject_introspection'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --disable-umockdev"   # umockdev is only for tests
-    system "make"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
-
 end

--- a/packages/libwacom.rb
+++ b/packages/libwacom.rb
@@ -2,34 +2,45 @@ require 'package'
 
 class Libwacom < Package
   description 'libwacom is a wrapper library for evdev devices.'
-  homepage 'http://linuxwacom.sourceforge.net/wiki/index.php/Libwacom'
-  version '0.28-0'
+  homepage 'https://github.com/linuxwacom/libwacom'
+  @_ver = 1.8
+  version @_ver
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/linuxwacom/libwacom-0.28.tar.bz2'
-  source_sha256 'e7d632301288b221cb5af69b4c5e57fd062bafd9a9acd6f9ce271570103267ef'
+  source_url "https://github.com/linuxwacom/libwacom/releases/download/libwacom-#{@_ver}/libwacom-#{@_ver}.tar.bz2"
+  source_sha256 '2e8075e60bbef74fe9c3539b0a0080efab28912b2552784d8b54dbbf1aaa63e5'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libwacom-0.28-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libwacom-0.28-0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libwacom-0.28-0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libwacom-0.28-0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libwacom-1.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libwacom-1.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libwacom-1.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libwacom-1.8-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '90853f518d643be9a53e4d8edd6f826156cc64189807a3565bffda8411fe9636',
-     armv7l: '90853f518d643be9a53e4d8edd6f826156cc64189807a3565bffda8411fe9636',
-       i686: 'cdd52b3f2c8a40be5907213be1861308ed53194a25b7b3afa9ca7e365025e741',
-     x86_64: '2ffb5dbd3620667a758b6e66f42a339474cdc9363bb942a8a696bc952b486b0b',
+  binary_sha256({
+    aarch64: '7029db156ea3a27a9024f12071cb1fb99a54f233b1df0b3c5eb6174d5e5a54fd',
+     armv7l: '7029db156ea3a27a9024f12071cb1fb99a54f233b1df0b3c5eb6174d5e5a54fd',
+       i686: '9c1f8a3548b8d374e7da99311b9ecd88781989f605ef7fa4f3b703f5bd8e6cf7',
+     x86_64: 'bd25043dcd7c6affa57e04ac2c9b6abebefa03ca7c6f83cb5c64827562ccf770'
   })
 
   depends_on 'libgudev'
   depends_on 'eudev'
+  depends_on 'libevdev'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "pip3 install --upgrade --no-warn-script-location pyudev --prefix #{CREW_PREFIX}"
+    system "pip3 install --upgrade --no-warn-script-location pytest --prefix #{CREW_PREFIX}"
+    system "pip3 install --upgrade --no-warn-script-location libevdev --prefix #{CREW_PREFIX}"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Dtests=disabled \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system 'pip3 uninstall -y pyudev'
+    system 'pip3 uninstall -y pytest'
+    system 'pip3 uninstall -y libevdev'
   end
 end

--- a/packages/waypipe.rb
+++ b/packages/waypipe.rb
@@ -1,0 +1,44 @@
+require 'package'
+
+class Waypipe < Package
+  description 'A proxy for Wayland protocol applications. WARNING: different versions are incompatible'
+  homepage 'https://gitlab.freedesktop.org/mstoeckl/waypipe'
+  version '0.7.2'
+  compatibility 'all'
+  source_url 'https://gitlab.freedesktop.org/mstoeckl/waypipe/-/archive/v0.7.2/waypipe-v0.7.2.tar.gz'
+  source_sha256 'b280079b05aef9b243be3644fc803e3feaa2fc2952d11a6c02ab33257fb52479'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/waypipe-0.7.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/waypipe-0.7.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/waypipe-0.7.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/waypipe-0.7.2-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '115949938eaf98fd38af6b1b8ffdb90e7976e87910fb5e0288d17c69d3cdb47c',
+     armv7l: '115949938eaf98fd38af6b1b8ffdb90e7976e87910fb5e0288d17c69d3cdb47c',
+       i686: '462f32367698388dd6333d14be082a20d1293102bfbb3ab5dfa9c8f55e42b3ea',
+     x86_64: '3e2bfc20d665b49b6023b2f6d1e703e9bfce519a802ea8c8d8dde33e5a179640'
+  })
+
+  depends_on 'mesa'
+  depends_on 'ffmpeg'
+  depends_on 'libva'
+  depends_on 'libdrm' => ':build'
+
+  def self.patch
+    system "sed -i '/#include \"util.h\"/a #include  <linux/version.h>' src/dmabuf.c"
+    system "sed -i 's#defined(__FreeBSD__)#defined(__FreeBSD__) || LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)#g' src/dmabuf.c"
+  end
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -3,42 +3,62 @@ require 'package'
 class Weston < Package
   description 'Weston is the reference implementation of a Wayland compositor, and a useful compositor in its own right.'
   homepage 'http://wayland.freedesktop.org'
-  version '9.0.0'
-  compatibility 'i686,x86_64'
-  case ARCH
-  when 'i686', 'x86_64'
-    source_url 'https://github.com/wayland-project/weston/archive/9.0.0.tar.gz'
-    source_sha256 '82b17ab1766f13557fc620c21e3c89165342d3a3ead79ba01181b4f7d2144487'
+  @_ver = '9.0.0'
+  version "#{@_ver}-1"
+  compatibility 'all'
+  source_url "https://github.com/wayland-project/weston/archive/#{@_ver}.tar.gz"
+  source_sha256 '82b17ab1766f13557fc620c21e3c89165342d3a3ead79ba01181b4f7d2144487'
 
-    depends_on 'harfbuzz'
-    depends_on 'libxcursor'
-    depends_on 'libinput'
-    depends_on 'libxkbcommon'
-    depends_on 'wayland_protocols'
-    depends_on 'libjpeg'
-    depends_on 'libunwind'
-    depends_on 'pango'
-    depends_on 'dbus'
-    depends_on 'libxxf86vm'
-    depends_on 'llvm' => :build
-    depends_on 'xdg_base'
-  end
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/weston-9.0.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/weston-9.0.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/weston-9.0.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/weston-9.0.0-1-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '9f5f48dfa122850c5a1041ae59c8358d76eb08adb84be474dba2cfdf430074ea',
+     armv7l: '9f5f48dfa122850c5a1041ae59c8358d76eb08adb84be474dba2cfdf430074ea',
+       i686: '1a3cfca6a5b69500859b5af32fb22b3c9539804df6d0995564a21bb6a4f89f37',
+     x86_64: '4c729aa9b4c39a9016bc3a69bd9e41c0ab3dd12466128a1f04c3e735b2206d12'
+  })
 
-  binary_url ({
-      i686: 'https://dl.bintray.com/chromebrew/chromebrew/weston-9.0.0-chromeos-i686.tar.xz',
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/weston-9.0.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-      i686: '8c685a9d0ae049ed457b32a5513aeb170496fe6c534542d4742092cc62673da4',
-    x86_64: '3f391f699eb4e4da0cbb54865d21cf828850889403ad0e99f1065d382ab97f71',
-  })
+  depends_on 'harfbuzz'
+  depends_on 'graphite'
+  depends_on 'libxcursor'
+  depends_on 'libinput'
+  depends_on 'libxkbcommon'
+  depends_on 'wayland_protocols'
+  depends_on 'libjpeg'
+  depends_on 'libunwind'
+  depends_on 'pango'
+  depends_on 'dbus'
+  depends_on 'libxxf86vm'
+  depends_on 'llvm' => :build
+  depends_on 'xdg_base'
+  depends_on 'libwebp'
+  depends_on 'libva'
+  depends_on 'gstreamer'
+  depends_on 'gst_plugins_base'
+  depends_on 'libwacom'
 
   def self.build
-    ENV['CFLAGS'] = '-fuse-ld=lld'
-    ENV['CXXFLAGS'] = '-fuse-ld=lld'
-    system "meson #{CREW_MESON_OPTIONS} -Dshell-ivi=false -Dremoting=false -Dbackend-default=wayland -Dbackend-drm=false -Dpipewire=false -Dcolor-management-colord=false -Dcolor-management-lcms=false -Dbackend-rdp=false -Dlauncher-logind=false -Dweston-launch=false -Dsystemd=false -Dxwayland-path=#{CREW_PREFIX}/bin/Xwayland build"
-    system 'meson configure build'
-    system 'ninja -C build'
+    system "LIBRARY_PATH=#{CREW_LIB_PREFIX} meson #{CREW_MESON_LTO_OPTIONS} \
+        -Dshell-ivi=false \
+        -Dremoting=true \
+        -Dbackend-default=wayland \
+        -Dbackend-drm=true \
+        -Dpipewire=false \
+        -Dcolor-management-colord=false \
+        -Dcolor-management-lcms=false \
+        -Dbackend-rdp=false \
+        -Dlauncher-logind=false \
+        -Dweston-launch=false \
+        -Dsystemd=false \
+        -Dxwayland-path=#{CREW_PREFIX}/bin/Xwayland \
+        builddir"
+
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
     system "cat <<'EOF'> weston.ini
 [core]
 xwayland=true
@@ -49,15 +69,15 @@ EOF"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja install -C build"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja install -C builddir"
     system "install -Dm644 weston.ini #{CREW_DEST_HOME}/.config/weston.ini"
   end
 
   def self.postinstall
     puts
-    puts "To run weston with xwayland try something like this:".lightblue
-    puts "export WAYLAND_DISPLAY=wayland-1".lightblue
-    puts "WAYLAND_DISPLAY=wayland-0 weston -Swayland-1 --xwayland".lightblue
+    puts 'To run weston with xwayland try something like this:'.lightblue
+    puts 'export WAYLAND_DISPLAY=wayland-1'.lightblue
+    puts 'WAYLAND_DISPLAY=wayland-0 weston -Swayland-1 --xwayland'.lightblue
     puts
   end
 end


### PR DESCRIPTION
- This adds waypipe, which lets you 
- libwacom is rebuilt since it was pulling in the system libffi
- weston is rebuilt since it was pulling in the old libwacom, and wasn't building on armv7l.


Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686

Example usage when the other side also has weston and waypipe (of the same version) installed:

```waypipe --compress lz4 ssh user@remotehost "weston-terminal &"```

or for a more complicated example:

```waypipe --compress lz4 ssh user@remotehost "/usr/bin/dbus-launch /usr/bin/gnome-terminal &"```