### PR TITLE
use CAPSH wrapper scripts to avoid setuid and root ownership of inetutils {ping,ping6,traceroute}

### DIFF
--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -4,30 +4,32 @@ class Inetutils < Package
   description 'The Inetutils package contains programs for basic networking. Such as dnsdomainname, ftp, hostname, ifconfig, ping, ping6, talk, telnet, tftp, traceroute'
   homepage 'https://www.gnu.org/software/inetutils/'
   @_ver = '2.0'
-  version @_ver
+  version "#{@_ver}-1"
   compatibility 'all'
   source_url "https://ftp.gnu.org/gnu/inetutils/inetutils-#{@_ver}.tar.xz"
   source_sha256 'e573d566e55393940099862e7f8994164a0ed12f5a86c3345380842bdc124722'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '7446162e65febe771bc8c88efc9d27865e7ef0d35d03c8ca90ffd4046e7eb925',
-      armv7l: '7446162e65febe771bc8c88efc9d27865e7ef0d35d03c8ca90ffd4046e7eb925',
-        i686: 'ed0cd237ca49f613d3398704c9cde04f78af14113458cef775bc4908db9b3f38',
-      x86_64: 'cef8fbdd17ac33c31587420b5291dd9738d5fa4849140c046bb1cce9d0861d70',
+  binary_sha256({
+    aarch64: '9761fd87ab7276ef701071a52cea3eed86819c4cb6a6bbd01a0062cc51a2a6d3',
+     armv7l: '9761fd87ab7276ef701071a52cea3eed86819c4cb6a6bbd01a0062cc51a2a6d3',
+       i686: '254bdff9f045a1909111b71c248483b86671a0564ad3fd273168ef6f1f6dc595',
+     x86_64: 'bc795eea585ce49e7f041ba850450b67c74e49d9141ba1f27d58614597af208d'
   })
 
   depends_on 'linux_pam'
+  depends_on 'patchelf'
 
   def self.build
     system "env CFLAGS='-flto=auto -ltinfo' CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      LIBRARY_PATH=#{CREW_LIB_PREFIX} ./configure #{CREW_OPTIONS} \
       --with-krb5=#{CREW_PREFIX} \
+      --disable-rpath \
       --with-wrap \
       --with-pam \
       --disable-rexec \
@@ -40,5 +42,27 @@ class Inetutils < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/ping"
+    system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/ping6"
+    system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/traceroute"
+  end
+
+  def self.preinstall
+    system "sudo chown chronos #{CREW_PREFIX}/bin/ping" \
+      if File.exist? "#{CREW_PREFIX}/bin/ping"
+    system "sudo chown chronos #{CREW_PREFIX}/bin/ping6" \
+      if File.exist? "#{CREW_PREFIX}/bin/ping6"
+    system "sudo chown chronos #{CREW_PREFIX}/bin/traceroute" \
+      if File.exist? "#{CREW_PREFIX}/bin/traceroute"
+  end
+
+  def self.postinstall
+    puts 'Settings permissions for utilities using sudo'.orange
+    system "sudo chown root #{CREW_PREFIX}/bin/ping"
+    system "sudo chown root #{CREW_PREFIX}/bin/ping6"
+    system "sudo chown root #{CREW_PREFIX}/bin/traceroute"
+    system "sudo chmod 4755 #{CREW_PREFIX}/bin/ping"
+    system "sudo chmod 4755 #{CREW_PREFIX}/bin/ping6"
+    system "sudo chmod 4755 #{CREW_PREFIX}/bin/traceroute"
   end
 end

--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -39,39 +39,37 @@ class Inetutils < Package
       --enable-authentication \
       --disable-servers"
     system 'make'
-    PING_SH = <<EOF
-#!/bin/bash
-sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
-    --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-    -c "#{CREW_PREFIX}/bin/ping.elf \$@"
-EOF
-IO.write('ping_', PING_SH, perm: 0755)
-    PING6_SH = <<EOF
-#!/bin/bash
-sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
-    --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-    -c "#{CREW_PREFIX}/bin/ping6.elf \$@"
-EOF
-IO.write('ping6_', PING6_SH, perm: 0755)
-    TRACEROUTE_SH = <<EOF
-#!/bin/bash
-sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
-    --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-    -c "#{CREW_PREFIX}/bin/traceroute.elf \$@"
-EOF
-IO.write('traceroute_', TRACEROUTE_SH, perm: 0755)
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    
     system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/ping"
     system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/ping6"
     system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/traceroute"
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping", "#{CREW_DEST_PREFIX}/bin/ping.elf", mode: 0o755
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping6", "#{CREW_DEST_PREFIX}/bin/ping6.elf", mode: 0o755
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/traceroute", "#{CREW_DEST_PREFIX}/bin/traceroute.elf", mode: 0o755
-    FileUtils.install 'ping_', "#{CREW_DEST_PREFIX}/bin/ping", mode: 0o755
-    FileUtils.install 'ping6_', "#{CREW_DEST_PREFIX}/bin/ping6", mode: 0o755
-    FileUtils.install 'traceroute_', "#{CREW_DEST_PREFIX}/bin/traceroute", mode: 0o755
+    PING_SH = <<EOF
+#!/bin/bash
+sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
+    --keep=1 --user=nobody --addamb=cap_net_raw -- \\
+    -c "#{CREW_PREFIX}/bin/ping.elf \$@"
+EOF
+IO.write("#{CREW_DEST_PREFIX}/bin/ping", PING_SH, perm: 0755)
+    PING6_SH = <<EOF
+#!/bin/bash
+sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
+    --keep=1 --user=nobody --addamb=cap_net_raw -- \\
+    -c "#{CREW_PREFIX}/bin/ping6.elf \$@"
+EOF
+IO.write("#{CREW_DEST_PREFIX}/bin/ping6", PING6_SH, perm: 0755)
+    TRACEROUTE_SH = <<EOF
+#!/bin/bash
+sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
+    --keep=1 --user=nobody --addamb=cap_net_raw -- \\
+    -c "#{CREW_PREFIX}/bin/traceroute.elf \$@"
+EOF
+IO.write("#{CREW_DEST_PREFIX}/bin/traceroute", TRACEROUTE_SH, perm: 0755)
   end
 end

--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -50,26 +50,23 @@ class Inetutils < Package
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping", "#{CREW_DEST_PREFIX}/bin/ping.elf", mode: 0o755
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping6", "#{CREW_DEST_PREFIX}/bin/ping6.elf", mode: 0o755
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/traceroute", "#{CREW_DEST_PREFIX}/bin/traceroute.elf", mode: 0o755
-    PING_SH = <<~EOF
-  #!/bin/bash
-  sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
-      --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-      -c "#{CREW_PREFIX}/bin/ping.elf \$@"
+    "#{CREW_DEST_PREFIX}/bin/ping" = <~EOF
+      #!/bin/bash
+      sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
+          --keep=1 --user=nobody --addamb=cap_net_raw -- \\
+          -c "#{CREW_PREFIX}/bin/ping.elf \$@"
 EOF
-IO.write("#{CREW_DEST_PREFIX}/bin/ping", PING_SH, perm: 0755)
-    PING6_SH = <<~EOF
-  #!/bin/bash
-  sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
-      --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-      -c "#{CREW_PREFIX}/bin/ping6.elf \$@"
+    "#{CREW_DEST_PREFIX}/bin/ping6" = <~EOF
+      #!/bin/bash
+      sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
+          --keep=1 --user=nobody --addamb=cap_net_raw -- \\
+          -c "#{CREW_PREFIX}/bin/ping6.elf \$@"
 EOF
-IO.write("#{CREW_DEST_PREFIX}/bin/ping6", PING6_SH, perm: 0755)
-    TRACEROUTE_SH = <<~EOF
-  #!/bin/bash
-  sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
-      --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-      -c "#{CREW_PREFIX}/bin/traceroute.elf \$@"
+    "#{CREW_DEST_PREFIX}/bin/traceroute" = <~EOF
+      #!/bin/bash
+      sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
+          --keep=1 --user=nobody --addamb=cap_net_raw -- \\
+          -c "#{CREW_PREFIX}/bin/traceroute.elf \$@"
 EOF
-IO.write("#{CREW_DEST_PREFIX}/bin/traceroute", TRACEROUTE_SH, perm: 0755)
   end
 end

--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -50,25 +50,25 @@ class Inetutils < Package
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping", "#{CREW_DEST_PREFIX}/bin/ping.elf", mode: 0o755
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping6", "#{CREW_DEST_PREFIX}/bin/ping6.elf", mode: 0o755
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/traceroute", "#{CREW_DEST_PREFIX}/bin/traceroute.elf", mode: 0o755
-    PING_SH = <<EOF
-#!/bin/bash
-sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
-    --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-    -c "#{CREW_PREFIX}/bin/ping.elf \$@"
+    PING_SH = <<~EOF
+  #!/bin/bash
+  sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
+      --keep=1 --user=nobody --addamb=cap_net_raw -- \\
+      -c "#{CREW_PREFIX}/bin/ping.elf \$@"
 EOF
 IO.write("#{CREW_DEST_PREFIX}/bin/ping", PING_SH, perm: 0755)
-    PING6_SH = <<EOF
-#!/bin/bash
-sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
-    --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-    -c "#{CREW_PREFIX}/bin/ping6.elf \$@"
+    PING6_SH = <<~EOF
+  #!/bin/bash
+  sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
+      --keep=1 --user=nobody --addamb=cap_net_raw -- \\
+      -c "#{CREW_PREFIX}/bin/ping6.elf \$@"
 EOF
 IO.write("#{CREW_DEST_PREFIX}/bin/ping6", PING6_SH, perm: 0755)
-    TRACEROUTE_SH = <<EOF
-#!/bin/bash
-sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
-    --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-    -c "#{CREW_PREFIX}/bin/traceroute.elf \$@"
+    TRACEROUTE_SH = <<~EOF
+  #!/bin/bash
+  sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
+      --keep=1 --user=nobody --addamb=cap_net_raw -- \\
+      -c "#{CREW_PREFIX}/bin/traceroute.elf \$@"
 EOF
 IO.write("#{CREW_DEST_PREFIX}/bin/traceroute", TRACEROUTE_SH, perm: 0755)
   end

--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -39,24 +39,27 @@ class Inetutils < Package
       --enable-authentication \
       --disable-servers"
     system 'make'
-    system "cat <<'EOF'> ping_
+    PING_SH = <<EOF
 #!/bin/bash
-sudo -E #{CREW_PREFIX}/sbin/capsh --caps=\"cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep\" \\
+sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
     --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-    -c \"#{CREW_PREFIX}/bin/ping.elf \$@\"
-EOF"
-    system "cat <<'EOF'> ping6_
+    -c "#{CREW_PREFIX}/bin/ping.elf \$@"
+EOF
+IO.write('ping_', PING_SH, perm: 0755)
+    PING6_SH = <<EOF
 #!/bin/bash
-sudo -E #{CREW_PREFIX}/sbin/capsh --caps=\"cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep\" \\
+sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
     --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-    -c \"#{CREW_PREFIX}/bin/ping6.elf \$@\"
-EOF"
-    system "cat <<'EOF'> traceroute_
+    -c "#{CREW_PREFIX}/bin/ping6.elf \$@"
+EOF
+IO.write('ping6_', PING6_SH, perm: 0755)
+    TRACEROUTE_SH = <<EOF
 #!/bin/bash
-sudo -E #{CREW_PREFIX}/sbin/capsh --caps=\"cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep\" \\
+sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
     --keep=1 --user=nobody --addamb=cap_net_raw -- \\
-    -c \"#{CREW_PREFIX}/bin/traceroute.elf \$@\"
-EOF"
+    -c "#{CREW_PREFIX}/bin/traceroute.elf \$@"
+EOF
+IO.write('traceroute_', TRACEROUTE_SH, perm: 0755)
   end
 
   def self.install

--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -9,6 +9,19 @@ class Inetutils < Package
   source_url "https://ftp.gnu.org/gnu/inetutils/inetutils-#{@_ver}.tar.xz"
   source_sha256 'e573d566e55393940099862e7f8994164a0ed12f5a86c3345380842bdc124722'
 
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/inetutils-2.0-1-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '8e4e1d3e987ed40aa8c63a8a794f1fd74ce390aee6e63795cb1936ff36ffd176',
+     armv7l: '8e4e1d3e987ed40aa8c63a8a794f1fd74ce390aee6e63795cb1936ff36ffd176',
+       i686: '7553ad07ca3e4994469efd85d7b48cbcf1d375fde0cc07495cb9cf8dabfe564d',
+     x86_64: 'ad1bf386ab4ecc3d1f799c845b4f4b9451039fc0608d0ed5dcae15410815e265'
+  })
+
   depends_on 'linux_pam'
   depends_on 'patchelf'
   depends_on 'libcap'
@@ -51,9 +64,9 @@ EOF"
     system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/ping"
     system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/ping6"
     system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/traceroute"
-    FileUtils.mv "#{CREW_DEST_PREFIX}/bin/ping", "#{CREW_DEST_PREFIX}/bin/ping.elf"
-    FileUtils.mv "#{CREW_DEST_PREFIX}/bin/ping6", "#{CREW_DEST_PREFIX}/bin/ping6.elf"
-    FileUtils.mv "#{CREW_DEST_PREFIX}/bin/traceroute", "#{CREW_DEST_PREFIX}/bin/traceroute.elf"
+    FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping", "#{CREW_DEST_PREFIX}/bin/ping.elf", mode: 0o755
+    FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping6", "#{CREW_DEST_PREFIX}/bin/ping6.elf", mode: 0o755
+    FileUtils.install "#{CREW_DEST_PREFIX}/bin/traceroute", "#{CREW_DEST_PREFIX}/bin/traceroute.elf", mode: 0o755
     FileUtils.install 'ping_', "#{CREW_DEST_PREFIX}/bin/ping", mode: 0o755
     FileUtils.install 'ping6_', "#{CREW_DEST_PREFIX}/bin/ping6", mode: 0o755
     FileUtils.install 'traceroute_', "#{CREW_DEST_PREFIX}/bin/traceroute", mode: 0o755


### PR DESCRIPTION
- Use sudo wrapper scripts for  ping, ping6, and traceroute so that capsh can be used to give these apps the necessary ```cap_net_raw``` capabilities.
- use patchelf to set ```rpath``` so if run using sudo w/o setuid the environment doesn't change the LD_LIBRARY_PATH.



Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686