### PR TITLE
Use valid ruby in inetutils.rb package

### DIFF
--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -43,30 +43,33 @@ class Inetutils < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    
+
     system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/ping"
     system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/ping6"
     system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/bin/traceroute"
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping", "#{CREW_DEST_PREFIX}/bin/ping.elf", mode: 0o755
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/ping6", "#{CREW_DEST_PREFIX}/bin/ping6.elf", mode: 0o755
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/traceroute", "#{CREW_DEST_PREFIX}/bin/traceroute.elf", mode: 0o755
-    "#{CREW_DEST_PREFIX}/bin/ping" = <~EOF
+    @PING_SH = <<~PING_HEREDOC
       #!/bin/bash
       sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
           --keep=1 --user=nobody --addamb=cap_net_raw -- \\
           -c "#{CREW_PREFIX}/bin/ping.elf \$@"
-EOF
-    "#{CREW_DEST_PREFIX}/bin/ping6" = <~EOF
+    PING_HEREDOC
+    IO.write("#{CREW_DEST_PREFIX}/bin/ping", @PING_SH, perm: 0o755)
+    @PING6_SH = <<~PING6_HEREDOC
       #!/bin/bash
       sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
           --keep=1 --user=nobody --addamb=cap_net_raw -- \\
           -c "#{CREW_PREFIX}/bin/ping6.elf \$@"
-EOF
-    "#{CREW_DEST_PREFIX}/bin/traceroute" = <~EOF
+    PING6_HEREDOC
+    IO.write("#{CREW_DEST_PREFIX}/bin/ping6", @PING6_SH, perm: 0o755)
+    @TRACEROUTE_SH = <<~TRACEROUTE_HEREDOC
       #!/bin/bash
       sudo -E #{CREW_PREFIX}/sbin/capsh --caps='cap_net_raw+eip cap_setpcap,cap_setuid,cap_setgid+ep' \\
           --keep=1 --user=nobody --addamb=cap_net_raw -- \\
           -c "#{CREW_PREFIX}/bin/traceroute.elf \$@"
-EOF
+    TRACEROUTE_HEREDOC
+    IO.write("#{CREW_DEST_PREFIX}/bin/traceroute", @TRACEROUTE_SH, perm: 0o755)
   end
 end


### PR DESCRIPTION
Turns out that it is useful to run rubodoc after changes are made...

Works properly:
- [x] x86_64