### PR TITLE
[ncurses]: Avoid prefix on built programs (fixes #5110)

### DIFF
--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -9,8 +9,16 @@ class Ncurses < Package
   source_sha256 'e5e83965329c85d8d28f9a35a71ab785fce015f42f491e7dcafbb9f36ad1eaea'
 
   binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-20210206-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-20210206-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-20210206-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-20210206-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
+    aarch64: 'f87816a803fdbb6403ecb03ea4faec04da8c3a829a1455a2c9e0a0686818ebb6',
+     armv7l: 'f87816a803fdbb6403ecb03ea4faec04da8c3a829a1455a2c9e0a0686818ebb6',
+       i686: 'ad1fb3a7d832d4fcf4e695cd5f5f7e023581c2d0529a2bf9729acd2cd96e44cd',
+     x86_64: 'd81416072e4e4454b585495db8b7e0767867c851e512afd4655fa8174d244c02'
   })
 
   def self.build

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -3,22 +3,14 @@ require 'package'
 class Ncurses < Package
   description 'The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0 (SVr4), and more.'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '6.2-20210206'
+  version '6.2-20210206-1'
   compatibility 'all'
   source_url 'https://github.com/mirror/ncurses/archive/b724cdc89cf31757ab43262ecefe5242b0edc450.zip'
   source_sha256 'e5e83965329c85d8d28f9a35a71ab785fce015f42f491e7dcafbb9f36ad1eaea'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-20210206-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-20210206-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-20210206-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ncurses-6.2-20210206-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'a91b249cdad5de1d9d12497b721f6ce88c1be445e9c40c915a93046ddb21e400',
-     armv7l: 'a91b249cdad5de1d9d12497b721f6ce88c1be445e9c40c915a93046ddb21e400',
-       i686: '2918cff85ec7730463ba5950d2039e09c1d8579238c8b0e6d9257b5bb1f7812f',
-     x86_64: '1fe01aa702bdba80d34a55f9596c60e577e54d93c0334a9e109a627210537185'
   })
 
   def self.build
@@ -28,6 +20,8 @@ class Ncurses < Package
       system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
         LDFLAGS='-flto=auto' ../configure \
         #{CREW_OPTIONS} \
+        --program-prefix='' \
+        --program-suffix='' \
         --with-shared \
         --with-cxx-shared \
         --without-debug \
@@ -45,6 +39,8 @@ class Ncurses < Package
       system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
         LDFLAGS='-flto=auto' ../configure \
          #{CREW_OPTIONS} \
+         --program-prefix='' \
+         --program-suffix='' \
          --with-shared \
          --with-cxx-shared \
          --without-debug \


### PR DESCRIPTION
Fixes #5110 

## Description
See #5110

Works properly:
- [x] x86_64
- [ ] aarch64 (no hardware I can use to test)
