### PR TITLE
Docbook Updates

### DIFF
--- a/packages/docbook.rb
+++ b/packages/docbook.rb
@@ -3,26 +3,13 @@ require 'package'
 class Docbook < Package
   description 'DocBook is an XML vocabulary that lets you create documents in a presentation-neutral form that captures the logical structure of your content.'
   homepage 'http://docbook.sourceforge.net/'
-  version '1.79.1-1'
+  version '1.79.1-2'
   compatibility 'all'
-  source_url 'https://prdownloads.sourceforge.net/project/docbook/docbook-xsl/1.79.1/docbook-xsl-1.79.1.tar.bz2'
-  source_sha256 '725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968'
+ 
+  is_fake
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook-1.79.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook-1.79.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook-1.79.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook-1.79.1-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '478699b1b1daf061aa64cb71ae22c504d4901aac407525574d48d36cd4f085e4',
-     armv7l: '478699b1b1daf061aa64cb71ae22c504d4901aac407525574d48d36cd4f085e4',
-       i686: 'bbea3f2d4dbfff96e903d4ba085d1b7242e490b415f6ce629abd1f9046852596',
-     x86_64: 'dd7a1d8bee46badac46d233176bc660d47c56cb9e3b4488b6107661bda90e83e',
-  })
-
-  def self.install
-    system "mkdir -p #{CREW_DEST_PREFIX}/docbook"
-    system "cp -r . #{CREW_DEST_PREFIX}/docbook"
-  end
+  depends_on 'docbook_xml'
+  depends_on 'docbook_xsl'
+  depends_on 'docbook_xsl_nons'
+  
 end

--- a/packages/docbook_xml.rb
+++ b/packages/docbook_xml.rb
@@ -4,15 +4,31 @@ class Docbook_xml < Package
   description 'Meta package for all versions of docbook_xml'
   compatibility 'all'
   homepage 'http://www.docbook.org'
-  version '5.1-1'
-
-  depends_on 'docbook_xml51'
-  depends_on 'docbook_xml50'
-  depends_on 'docbook_xml45'
-  depends_on 'docbook_xml44'
-  depends_on 'docbook_xml43'
-  depends_on 'docbook_xml42'
+  version '5.1-2'
 
   is_fake
 
+  # Docbook common postinstall block
+  ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+  xml_catalog_files_in_bashrc = `grep -c "XML_CATALOG_FILES" ~/.bashrc || true`
+  unless xml_catalog_files_in_bashrc.to_i.positive?
+    puts "Putting \"export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog\" in ~/.bashrc".lightblue
+    system "echo 'export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog' >> ~/.bashrc"
+    puts 'To complete the installation, execute the following:'.orange
+    puts 'source ~/.bashrc'.orange
+  end
+  # End Docbook common postinstall block
+
+  depends_on 'xmlcatmgr'
+  depends_on 'docbook_xml412'
+  depends_on 'docbook_xml42'
+  depends_on 'docbook_xml43'
+  depends_on 'docbook_xml44'
+  depends_on 'docbook_xml45'
+  depends_on 'docbook_xml50'
+  depends_on 'docbook_xml51'
+  # These are probably needed at the same time too.
+  depends_on 'docbook_xsl'
+  depends_on 'docbook_xsl_nons'
 end

--- a/packages/docbook_xml42.rb
+++ b/packages/docbook_xml42.rb
@@ -1,43 +1,104 @@
 require 'package'
 
 class Docbook_xml42 < Package
-  description 'Version 4.2 - document type definitions for verification of XML data files against the DocBook rule set'
+  description 'A widely used XML scheme for writing documentation and help'
+  homepage 'https://www.oasis-open.org/docbook/'
+  @_ver = '4.2'
+  version "#{@_ver}-1"
   compatibility 'all'
-  homepage 'http://www.docbook.org'
-  version '4.2'
-  source_url 'http://www.oasis-open.org/docbook/xml/4.2/docbook-xml-4.2.zip'
+  source_url "https://docbook.org/xml/#{@_ver}/docbook-xml-#{@_ver}.zip"
   source_sha256 'acc4601e4f97a196076b7e64b368d9248b07c7abf26b34a02cca40eeebe60fa2'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml42-4.2-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '3f0deabad453e1c61893206ec60921ec1a1fbb2ea76f22bd144a9bfa932a40a1',
-     armv7l: '3f0deabad453e1c61893206ec60921ec1a1fbb2ea76f22bd144a9bfa932a40a1',
-       i686: '6166d954c4ae7d0832213fa924e2c17b2b211c8b3a95caab6f708219a114bc7b',
-     x86_64: '6864f9733627d85e8088c87dc098a74ad3d1d6503c28e3b6c2ed78f3ac57dde6',
+  binary_sha256({
+    aarch64: '05fe3d73273b67a566e9ac769ddbb88e63a5b9f20abf9483fd3374e3c815a9c9',
+     armv7l: '05fe3d73273b67a566e9ac769ddbb88e63a5b9f20abf9483fd3374e3c815a9c9',
+       i686: 'fe49fe7837f831e821c118ba9df5e1ab3551f95de51f1933e3ce41624852fcf9',
+     x86_64: '9485891895d1a7004f62350a9eb8d806bea66d40fa19274c5b8e69e130ba0fe1'
   })
 
-  depends_on 'docbook_xml51'
-  depends_on 'docbook_xsl' # Requires the catalog.xml created within this package
-
-  def self.prebuild
-    system "cat << EOF > ./remove_add.sh
-sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.2//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.1.2//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.2//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.2/catalog.xml'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.1.2//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.2/catalog.xml'
-EOF"
-    system 'bash ./remove_add.sh'
-  end
+  depends_on 'libxml2'
+  depends_on 'xmlcatmgr'
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
-    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    system "cp -dr docbook.cat *.dtd ent/ *.mod #{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/xml"
+  end
+
+  def self.preinstall
+    # Docbook common preinstall block
+    FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
+    end
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
+    end
+    # End Docbook common preinstall block
+  end
+
+  def self.postinstall
+    # Docbook common postinstall block
+    ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+    xml_catalog_files_in_bashrc = `grep -c "XML_CATALOG_FILES" ~/.bashrc || true`
+    unless xml_catalog_files_in_bashrc.to_i.positive?
+      puts "Putting \"export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog\" in ~/.bashrc".lightblue
+      system "echo 'export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog' >> ~/.bashrc"
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
+    end
+    # End Docbook common postinstall block
+
+    system "xmlcatalog --noout --add rewriteSystem \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add rewriteURI \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//DTD DocBook XML V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/docbookx.dtd' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+
+    system "xmlcatalog --noout --add delegatePublic \
+        \"-//OASIS//ENTITIES DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//DTD DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegateSystem\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegateURI\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
   end
 end
-

--- a/packages/docbook_xml43.rb
+++ b/packages/docbook_xml43.rb
@@ -1,43 +1,104 @@
 require 'package'
 
 class Docbook_xml43 < Package
-  description 'document type definitions for verification of XML data files against the DocBook rule set'
+  description 'A widely used XML scheme for writing documentation and help'
+  homepage 'https://www.oasis-open.org/docbook/'
+  @_ver = '4.3'
+  version "#{@_ver}-1"
   compatibility 'all'
-  homepage 'http://www.docbook.org'
-  version '4.3'
-  source_url 'http://www.oasis-open.org/docbook/xml/4.3/docbook-xml-4.3.zip'
+  source_url "https://docbook.org/xml/#{@_ver}/docbook-xml-#{@_ver}.zip"
   source_sha256 '23068a94ea6fd484b004c5a73ec36a66aa47ea8f0d6b62cc1695931f5c143464'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml43-4.3-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '7c4339228b5d7840b588aa434e3bfaf22830a3479e1f8edb166384a1ec61d8c4',
-     armv7l: '7c4339228b5d7840b588aa434e3bfaf22830a3479e1f8edb166384a1ec61d8c4',
-       i686: '7dd4c1bc19666b1932f451e1ca90c7e13820149b0ff4b80c31bb850128bfdb9c',
-     x86_64: '56826d7a6b5abde5b17f1df6f32d6b97222f6e00c4f8fc0b50bfb1467489a208',
+  binary_sha256({
+    aarch64: '16ed890cc5e2e95597cd7d160e074dbc195448a2e5cfc579846877a5d4cb521a',
+     armv7l: '16ed890cc5e2e95597cd7d160e074dbc195448a2e5cfc579846877a5d4cb521a',
+       i686: '15f2467c23c7f284d227551c896745be966a1cd4c5c526fb635b03602e6224e2',
+     x86_64: 'b61ffe4d472085897c3d1fa991d260f50afae7d8c97a73318b19444a66d817e9'
   })
 
-  depends_on 'docbook'
+  depends_on 'libxml2'
   depends_on 'xmlcatmgr'
-  depends_on 'docbook_xml'
-  depends_on 'docbook_xsl'
-
-  def self.prebuild
-    system "cat << EOF > ./remove_add.sh
-sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.3//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.3//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.3/catalog.xml'
-EOF"
-    system 'bash ./remove_add.sh'
-  end
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/4.3/"
-    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/4.3/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    system "cp -dr docbook.cat *.dtd ent/ *.mod #{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/xml"
+  end
+
+  def self.preinstall
+    # Docbook common preinstall block
+    FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
+    end
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
+    end
+    # End Docbook common preinstall block
+  end
+
+  def self.postinstall
+    # Docbook common postinstall block
+    ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+    xml_catalog_files_in_bashrc = `grep -c "XML_CATALOG_FILES" ~/.bashrc || true`
+    unless xml_catalog_files_in_bashrc.to_i.positive?
+      puts "Putting \"export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog\" in ~/.bashrc".lightblue
+      system "echo 'export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog' >> ~/.bashrc"
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
+    end
+    # End Docbook common postinstall block
+
+    system "xmlcatalog --noout --add rewriteSystem \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add rewriteURI \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//DTD DocBook XML V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/docbookx.dtd' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//ENTITIES DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//DTD DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegateSystem\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegateURI\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
   end
 end
-

--- a/packages/docbook_xml44.rb
+++ b/packages/docbook_xml44.rb
@@ -1,40 +1,109 @@
 require 'package'
 
 class Docbook_xml44 < Package
-  description 'Version 4.4 - document type definitions for verification of XML data files against the DocBook rule set'
+  description 'A widely used XML scheme for writing documentation and help'
+  homepage 'https://www.oasis-open.org/docbook/'
+  @_ver = '4.4'
+  version "#{@_ver}-1"
   compatibility 'all'
-  homepage 'http://www.docbook.org'
-  version '4.4'
-  source_url 'http://www.oasis-open.org/docbook/xml/4.4/docbook-xml-4.4.zip'
+  source_url "https://docbook.org/xml/#{@_ver}/docbook-xml-#{@_ver}.zip"
   source_sha256 '02f159eb88c4254d95e831c51c144b1863b216d909b5ff45743a1ce6f5273090'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml44-4.4-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'f56b6c50394ce4ba7cc71097954872461835a2f4502c133b6ca9d815821caa0c',
-     armv7l: 'f56b6c50394ce4ba7cc71097954872461835a2f4502c133b6ca9d815821caa0c',
-       i686: 'c285506ebd3e12e15c03907e6d289f5a8d60e98e76175119960c9b9c78c687b3',
-     x86_64: 'bce18b425d7180f3cf1d1f3b4a1b4aba30916ed0743bc38b126857d9e92ea45a',
+  binary_sha256({
+    aarch64: '0781dda33ce4845ca3f18d533469ca888c5823f8b1c5b41fa9c633e25569d971',
+     armv7l: '0781dda33ce4845ca3f18d533469ca888c5823f8b1c5b41fa9c633e25569d971',
+       i686: 'f681134f0aa6bee29744c33612c5d5b71d52601777a00af170fc3528d9af9474',
+     x86_64: '46f1158d117549d339ace891d87e2ac27a0cc5d778f75991c462201e57f11e0b'
   })
 
-  depends_on 'docbook_xml51'
-  depends_on 'docbook_xsl'
-
-  def self.prebuild
-    system "cat << EOF > ./remove_add.sh
-sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.4//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.4//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.4/catalog.xml'
-EOF"
-    system 'bash ./remove_add.sh'
-  end
+  depends_on 'libxml2'
+  depends_on 'xmlcatmgr'
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
-    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    system "cp -dr docbook.cat *.dtd ent/ *.mod #{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/xml"
+  end
+
+  def self.preinstall
+    # Docbook common preinstall block
+    FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
+    end
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
+    end
+    # End Docbook common preinstall block
+  end
+
+  def self.postinstall
+    # Docbook common postinstall block
+    ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+    xml_catalog_files_in_bashrc = `grep -c "XML_CATALOG_FILES" ~/.bashrc || true`
+    unless xml_catalog_files_in_bashrc.to_i.positive?
+      puts "Putting \"export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog\" in ~/.bashrc".lightblue
+      system "echo 'export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog' >> ~/.bashrc"
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
+    end
+    # End Docbook common postinstall block
+
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//ELEMENTS DocBook XML HTML Tables V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/htmltblx.mod' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+
+    system "xmlcatalog --noout --add rewriteSystem \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add rewriteURI \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//DTD DocBook XML V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/docbookx.dtd' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//ENTITIES DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//DTD DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegateSystem\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegateURI\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
   end
 end

--- a/packages/docbook_xml45.rb
+++ b/packages/docbook_xml45.rb
@@ -1,41 +1,110 @@
 require 'package'
 
 class Docbook_xml45 < Package
-  description 'Version 4.5 -document type definitions for verification of XML data files against the DocBook rule set'
+  description 'A widely used XML scheme for writing documentation and help'
+  homepage 'https://www.oasis-open.org/docbook/'
+  @_ver = '4.5'
+  version "#{@_ver}-1"
   compatibility 'all'
-  homepage 'http://www.docbook.org'
-  version '4.5'
-  source_url 'http://www.oasis-open.org/docbook/xml/4.5/docbook-xml-4.5.zip'
+  source_url "https://docbook.org/xml/#{@_ver}/docbook-xml-#{@_ver}.zip"
   source_sha256 '4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml45-4.5-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'b328c89d8af6d6230a1d6e336601fa85f78486e28e9e4afdc085c38b94196857',
-     armv7l: 'b328c89d8af6d6230a1d6e336601fa85f78486e28e9e4afdc085c38b94196857',
-       i686: 'a79e4186e7f8bbe0f9d09cf8f7ad2116c4f3a07f654c968b303b0f307c0bb439',
-     x86_64: 'a6330711188580cae005ed58e79b7c4eb39532f20cbd8e847d7ba4299b32533f',
+  binary_sha256({
+    aarch64: 'e7463d14aad6712597f6eff575042128392a6783da2c471b36fb61395405cb1b',
+     armv7l: 'e7463d14aad6712597f6eff575042128392a6783da2c471b36fb61395405cb1b',
+       i686: '168de1189b9d953c7a8e09196af78867dc73f3e16931c6f2bb4f2f8d3c0fc747',
+     x86_64: '715699ab3ffddc03de0b8d950c129a6f79b062b82983f9e1e795dc6b9ad5c42c'
   })
 
-  depends_on 'docbook_xml51'
-  depends_on 'docbook_xsl'
-
-  def self.prebuild
-    system "cat << EOF > ./remove_add.sh
-sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V4.5//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V4.5//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/4.5/catalog.xml'
-EOF"
-    system 'bash ./remove_add.sh'
-  end
+  depends_on 'libxml2'
+  depends_on 'xmlcatmgr'
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
-    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    system "cp -dr docbook.cat *.dtd ent/ *.mod #{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/xml"
+  end
+
+  def self.preinstall
+    # Docbook common preinstall block
+    FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
+    end
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
+    end
+
+    # End Docbook common preinstall block
+  end
+
+  def self.postinstall
+    # Docbook common postinstall block
+    ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+    xml_catalog_files_in_bashrc = `grep -c "XML_CATALOG_FILES" ~/.bashrc || true`
+    unless xml_catalog_files_in_bashrc.to_i.positive?
+      puts "Putting \"export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog\" in ~/.bashrc".lightblue
+      system "echo 'export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog' >> ~/.bashrc"
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
+    end
+    # End Docbook common postinstall block
+
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//ELEMENTS DocBook XML HTML Tables V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/htmltblx.mod' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+
+    system "xmlcatalog --noout --add rewriteSystem \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add rewriteURI \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//DTD DocBook XML V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/docbookx.dtd' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//ENTITIES DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//DTD DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegateSystem\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+
+    system "xmlcatalog --noout --add \"delegateURI\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
   end
 end
-

--- a/packages/docbook_xml50.rb
+++ b/packages/docbook_xml50.rb
@@ -26,8 +26,6 @@ class Docbook_xml50 < Package
   depends_on 'xmlcatmgr'
   depends_on 'bash'
 
-  def self.build; end
-
   def self.install
     system "xmlcatalog --noout --create docbook-#{@_ver}.xml"
     # DTD

--- a/packages/docbook_xml50.rb
+++ b/packages/docbook_xml50.rb
@@ -1,40 +1,262 @@
 require 'package'
 
 class Docbook_xml50 < Package
-  description 'Version 50 - document type definitions for verification of XML data files against the DocBook rule set'
+  description 'A widely used XML scheme for writing documentation and help'
+  homepage 'https://www.oasis-open.org/docbook/'
+  @_ver = '5.0'
+  version "#{@_ver}-1"
   compatibility 'all'
-  homepage 'http://www.docbook.org'
-  version '5.0'
-  source_url 'https://docbook.org/xml/5.0/docbook-5.0.zip'
+  source_url "https://docbook.org/xml/#{@_ver}/docbook-#{@_ver}.zip"
   source_sha256 '3dcd65e1f5d9c0c891b3be204fa2bb418ce485d32310e1ca052e81d36623208e'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml50-5.0-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'f8ffcb93e529832869efcaa84bbd38e449ec040d4a8592b2a0ec9a575ce12194',
-     armv7l: 'f8ffcb93e529832869efcaa84bbd38e449ec040d4a8592b2a0ec9a575ce12194',
-       i686: '68f0e60692f7af3303df137fe4dbad87d39146257c719e968ad8747d2c90f324',
-     x86_64: 'fcb2668caca391127e526c0a568ccc3ed0ec0f9903180ebb8483795ed12ea5e6',
+  binary_sha256({
+    aarch64: '51e16312877f682c6b57120323e4102a02daf4220758eec6282f6ace6102dcbe',
+     armv7l: '51e16312877f682c6b57120323e4102a02daf4220758eec6282f6ace6102dcbe',
+       i686: 'd9460092816d125fdfc9cdabefef96756a0d7aa02edbb266193f33c2c8ec22c0',
+     x86_64: '990c2eff642a37031031a31d349e977788ba9aab72e76885c88cfec7f201a4c0'
   })
 
-  depends_on 'docbook_xml51'
-  depends_on 'docbook_xsl'
+  depends_on 'libxml2'
+  depends_on 'xmlcatmgr'
+  depends_on 'bash'
 
-  def self.prebuild
-    system "cat << EOF > ./remove_add.sh
-sed -i -e 's,<!-- .* -->,,g' #{CREW_PREFIX}/etc/xml/catalog.xml
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml remove public '-//OASIS//DTD DocBook XML V5.0//EN'
-xmlcatmgr -c #{CREW_PREFIX}/etc/xml/docbook.xml add public '-//OASIS//DTD DocBook XML V5.0//EN' 'file://#{CREW_PREFIX}/share/xml/docbook/5.0/catalog.xml'
-EOF"
-    system 'bash ./remove_add.sh'
-  end
+  def self.build; end
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
-    FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/share/xml/docbook/#{version}/"
+    system "xmlcatalog --noout --create docbook-#{@_ver}.xml"
+    # DTD
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//DTD DocBook XML #{@_ver}//EN' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/dtd/#{@_ver}/docbook.dtd' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'system' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/dtd/docbook.dtd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/dtd/#{@_ver}/docbook.dtd' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'system' \
+      'http://docbook.org/xml/#{@_ver}/dtd/docbook.dtd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/dtd/#{@_ver}/docbook.dtd' docbook-#{@_ver}.xml"
+    # RNG
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/rng/docbook.rng' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbook.rng' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/rng/docbook.rng' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbook.rng' docbook-#{@_ver}.xml"
+    # RNG+XInclude
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/rng/docbookxi.rng' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbookxi.rng' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/rng/docbookxi.rng' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbookxi.rng' docbook-#{@_ver}.xml"
+    # RNC
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/rnc/docbook.rnc' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbook.rnc' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/rng/docbook.rnc' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbook.rnc' docbook-#{@_ver}.xml"
+    # RNC+XInclude
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/rnc/docbookxi.rnc' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbookxi.rnc' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/rng/docbookxi.rnc' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbookxi.rnc' docbook-#{@_ver}.xml"
+    # XSD
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/xsd/docbook.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/docbook.xsd' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/xsd/docbook.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/docbook.xsd' docbook-#{@_ver}.xml"
+    # XSD + XInclude
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/xsd/docbookxi.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/docbookxi.xsd' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/xsd/docbookxi.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/docbookxi.xsd' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/xsd/xi.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/xi.xsd' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/xsd/xi.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/xi.xsd' docbook-#{@_ver}.xml"
+    # XLink + XML
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/xsd/xlink.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/xlink.xsd' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/xsd/xlink.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/xlink.xsd' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/xsd/xml.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/xml.xsd' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/xsd/xml.xsd' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/xsd/#{@_ver}/xml.xsd' docbook-#{@_ver}.xml"
+    # Schematron
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/sch/docbook.sch' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/sch/#{@_ver}/docbook.sch' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/sch/docbook.sch' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/sch/#{@_ver}/docbook.sch' docbook-#{@_ver}.xml"
+    # Build XML catalog files for each Schema
+    @ADDFILES_SH = <<~ADDFILES_HEREDOC
+      for s in dtd rng sch xsd; do
+        _schema_catalog=${s}/catalog.xml
+        xmlcatalog --noout --create ${_schema_catalog}
+        case $s in
+          dtd)
+            xmlcatalog --noout --add 'public' \
+              '-//OASIS//DTD DocBook XML #{@_ver}//EN' \
+              'docbook.dtd' ${_schema_catalog}
+            xmlcatalog --noout --add 'system' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/dtd/docbook.dtd' \
+              'docbook.dtd' ${_schema_catalog}
+            ;;
+          sch)
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            ;;
+          rng)
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbookxi.${s}' \
+              'docbookxi.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbookxi.${s}' \
+              'docbookxi.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbook.rnc' \
+              'docbook.rnc' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbook.rnc' \
+              'docbook.rnc' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbookxi.rnc' \
+              'docbookxi.rnc' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbookxi.rnc' \
+              'docbookxi.rnc' ${_schema_catalog}
+            ;;
+          xsd)
+            # https://docbook.org/xml/5.0/xsd/docbook.xsd
+            # https://docbook.org/xml/5.0/xsd/xml.xsd
+            # https://docbook.org/xml/5.0/xsd/xlink.xsd
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbookxi.${s}' \
+              'docbookxi.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbookxi.${s}' \
+              'docbookxi.${s}' ${_schema_catalog}
+            # XLink + XML:
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/xlink.xsd' \
+              'xlink.xsd' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/xlink.xsd' \
+              'xlink.xsd' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/xml.xsd' \
+              'xml.xsd' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/xml.xsd' \
+              'xml.xsd' ${_schema_catalog}
+            ;;
+        esac
+      done
+    ADDFILES_HEREDOC
+    IO.write('add_files.sh', @ADDFILES_SH, perm: 0o755)
+    system "#{CREW_PREFIX}/bin/bash -x ./add_files.sh | true"
+
+    system "#{CREW_PREFIX}/bin/bash -c \"for type in dtd rng sch xsd; do
+      mkdir -p #{CREW_DEST_PREFIX}/share/xml/docbook/schema/\\\${type}/#{@_ver}
+      install -m644 \\\${type}/* #{CREW_DEST_PREFIX}/share/xml/docbook/schema/\\\${type}/#{@_ver}
+    done\""
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    system "install -m755 tools/db4-entities.pl #{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/stylesheet/docbook5"
+    system "install -m644 tools/db4-upgrade.xsl #{CREW_DEST_PREFIX}/share/xml/docbook/stylesheet/docbook5/"
+
+    # catalog configuration
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/xml"
+    system "install -m644 docbook-#{@_ver}.xml  #{CREW_DEST_PREFIX}/etc/xml/docbook-#{@_ver}.xml"
+  end
+
+  def self.preinstall
+    # Docbook common preinstall block
+    FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
+    end
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
+    end
+
+    # End Docbook common preinstall block
+  end
+
+  def self.postinstall
+    # Docbook common postinstall block
+    ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+    xml_catalog_files_in_bashrc = `grep -c "XML_CATALOG_FILES" ~/.bashrc || true`
+    unless xml_catalog_files_in_bashrc.to_i.positive?
+      puts "Putting \"export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog\" in ~/.bashrc".lightblue
+      system "echo 'export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog' >> ~/.bashrc"
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
+    end
+    # End Docbook common postinstall block
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//ENTITIES DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//DTD DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+    system "xmlcatalog --noout --add \"delegateSystem\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+    system "xmlcatalog --noout --add \"delegateURI\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
   end
 end

--- a/packages/docbook_xml51.rb
+++ b/packages/docbook_xml51.rb
@@ -1,103 +1,178 @@
 require 'package'
 
-# from LFS: http://www.linuxfromscratch.org/blfs/view/cvs/pst/docbook.html
-
 class Docbook_xml51 < Package
-  description 'Version 5.1 - document type definitions for verification of XML data files against the DocBook rule set'
+  description 'A widely used XML scheme for writing documentation and help'
+  homepage 'https://www.oasis-open.org/docbook/'
+  @_ver = '5.1'
+  version "#{@_ver}-1"
   compatibility 'all'
-  homepage 'http://www.docbook.org'
-  version '5.1'
-  source_url 'https://docbook.org/xml/5.1/docbook-v5.1-os.zip'
+  source_url "https://docbook.org/xml/#{@_ver}/docbook-v#{@_ver}-os.zip"
   source_sha256 'b3f3413654003c1e773360d7fc60ebb8abd0e8c9af8e7d6c4b55f124f34d1e7f'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml51-5.1-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '8bf41dbd91624c154972a4b0adf16ba0edbc77cdddf579baccd7877a8b9fddbf',
-     armv7l: '8bf41dbd91624c154972a4b0adf16ba0edbc77cdddf579baccd7877a8b9fddbf',
-       i686: '3512b6df3df4e420df0b265dd02dbfb76d6b7d4cbcdcdd18dfd54e0d03d869b3',
-     x86_64: '718587a22a3fa9e91d8b974e5e02d4f21223d7699b7f4cae91faba1f7ea25358',
+  binary_sha256({
+    aarch64: '0f54fe99ab568f5675eeef905925192f0f96ce5bfb6c4b0c9ec597429352940d',
+     armv7l: '0f54fe99ab568f5675eeef905925192f0f96ce5bfb6c4b0c9ec597429352940d',
+       i686: '9d0331c233cc88d7302c99130df4edcb633f1944800ead2e0d6f2b6f5bb9fb42',
+     x86_64: '95b7ffdb3797cb550d7da3195aeedbee5336a58e14cf8dae765248370698162c'
   })
 
-  depends_on 'docbook'
-  depends_on 'sgml_common'
+  depends_on 'libxml2'
+  depends_on 'xmlcatmgr'
+  depends_on 'bash'
 
   def self.install
+    system "xmlcatalog --noout --create docbook-#{@_ver}.xml"
+    # RNG
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/rng/docbook.rng' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbook.rng' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/rng/docbook.rng' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbook.rng' docbook-#{@_ver}.xml"
+    # RNG+XInclude
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/rng/docbookxi.rng' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbookxi.rng' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/rng/docbookxi.rng' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbookxi.rng' docbook-#{@_ver}.xml"
+    # RNC
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/rnc/docbook.rnc' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbook.rnc' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/rng/docbook.rnc' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbook.rnc' docbook-#{@_ver}.xml"
+    # RNC+XInclude
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/rnc/docbookxi.rnc' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbookxi.rnc' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/rng/docbookxi.rnc' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/rng/#{@_ver}/docbookxi.rnc' docbook-#{@_ver}.xml"
+    # Schematron
+    system "xmlcatalog --noout --add 'uri' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/sch/docbook.sch' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/sch/#{@_ver}/docbook.sch' docbook-#{@_ver}.xml"
+    system "xmlcatalog --noout --add 'uri' \
+      'http://docbook.org/xml/#{@_ver}/sch/docbook.sch' \
+      'file://#{CREW_PREFIX}/share/xml/docbook/schema/sch/#{@_ver}/docbook.sch' docbook-#{@_ver}.xml"
+    # Build XML catalog files for each Schema
+    @ADDFILES_SH = <<~ADDFILES_HEREDOC
+      for s in schemas/rng schemas/sch; do
+        _schema_catalog=${s}/catalog.xml
+        xmlcatalog --noout --create ${_schema_catalog}
+        case $s in
+          sch)
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            ;;
+          rng)
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbook.${s}' \
+              'docbook.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbookxi.${s}' \
+              'docbookxi.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbookxi.${s}' \
+              'docbookxi.${s}' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbook.rnc' \
+              'docbook.rnc' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbook.rnc' \
+              'docbook.rnc' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://docbook.org/xml/#{@_ver}/${s}/docbookxi.rnc' \
+              'docbookxi.rnc' ${_schema_catalog}
+            xmlcatalog --noout --add 'uri' \
+              'http://www.oasis-open.org/docbook/xml/#{@_ver}/${s}/docbookxi.rnc' \
+              'docbookxi.rnc' ${_schema_catalog}
+            ;;
+        esac
+      done
+    ADDFILES_HEREDOC
+    IO.write('add_files.sh', @ADDFILES_SH, perm: 0o755)
+    system "#{CREW_PREFIX}/bin/bash -x ./add_files.sh | true"
 
-    xml_version = '5.1'
-    xml_dtd = "xml-dtd-#{xml_version}"
+    system "#{CREW_PREFIX}/bin/bash -c \"for type in rng sch ; do
+      mkdir -p #{CREW_DEST_PREFIX}/share/xml/docbook/schema/\\\${type}/#{@_ver}
+      install -m644 schemas/\\\${type}/* #{CREW_DEST_PREFIX}/share/xml/docbook/schema/\\\${type}/#{@_ver}
+    done\""
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    system "install -m755 tools/db4-entities.pl #{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/stylesheet/docbook5"
+    system "install -m644 tools/db4-upgrade.xsl #{CREW_DEST_PREFIX}/share/xml/docbook/stylesheet/docbook5/"
 
-    system "install -v -d -m755 #{CREW_DEST_PREFIX}/share/xml/docbook/#{xml_dtd}"
-    system "install -v -d -m755 #{CREW_DEST_PREFIX}/etc/xml"
-    system "cp -rpa . #{CREW_DEST_PREFIX}/share/xml/docbook/#{xml_dtd}/"
-    system "rm -f #{CREW_PREFIX}/etc/xml/docbook* && \
-                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/docbook.xml && \
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//DTD DocBook XML V#{xml_version}//EN' \
-                'http://www.oasis-open.org/docbook/xml/#{xml_version}/docbookx.dtd' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//DTD DocBook XML CALS Table Model V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/calstblx.dtd' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//DTD XML Exchange Table Model 19990315//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/soextblx.dtd' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ELEMENTS DocBook XML Information Pool V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbpoolx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ELEMENTS DocBook XML Document Hierarchy V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbhierx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ELEMENTS DocBook XML HTML Tables V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/htmltblx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ENTITIES DocBook XML Notations V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbnotnx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ENTITIES DocBook XML Character Entities V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbcentx.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'public' \
-                '-//OASIS//ENTITIES DocBook XML Additional General Entities V#{xml_version}//EN' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}/dbgenent.mod' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'rewriteSystem' \
-                'http://www.oasis-open.org/docbook/xml/#{xml_version}' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml &&
-            xmlcatalog --noout --add 'rewriteURI' \
-                'http://www.oasis-open.org/docbook/xml/#{xml_version}' \
-                'file://#{CREW_PREFIX}/share/xml/docbook/#{xml_dtd}' \
-                #{CREW_DEST_PREFIX}/etc/xml/docbook.xml"
+    # catalog configuration
+    system "mkdir -p #{CREW_DEST_PREFIX}/etc/xml"
+    system "install -m644 docbook-#{@_ver}.xml  #{CREW_DEST_PREFIX}/etc/xml/docbook-#{@_ver}.xml"
+  end
 
-    system "rm -f #{CREW_PREFIX}/etc/xml/catalog* && \
-                xmlcatalog --noout --create #{CREW_DEST_PREFIX}/etc/xml/catalog.xml && \
-            xmlcatalog --noout --add 'delegatePublic' \
-                '-//OASIS//ENTITIES DocBook XML' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook.xml' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog.xml &&
-            xmlcatalog --noout --add 'delegatePublic' \
-                '-//OASIS//DTD DocBook XML' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook.xml' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog.xml &&
-            xmlcatalog --noout --add 'delegateSystem' \
-                'http://www.oasis-open.org/docbook/' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook.xml' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog.xml &&
-            xmlcatalog --noout --add 'delegateURI' \
-                'http://www.oasis-open.org/docbook/' \
-                'file://#{CREW_PREFIX}/etc/xml/docbook.xml' \
-                #{CREW_DEST_PREFIX}/etc/xml/catalog.xml"
+  def self.preinstall
+    # Docbook common preinstall block
+    FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
+    end
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
+    end
+    # End Docbook common preinstall block
+  end
+
+  def self.postinstall
+    # Docbook common postinstall block
+    ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+    xml_catalog_files_in_bashrc = `grep -c "XML_CATALOG_FILES" ~/.bashrc || true`
+    unless xml_catalog_files_in_bashrc.to_i.positive?
+      puts "Putting \"export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog\" in ~/.bashrc".lightblue
+      system "echo 'export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog' >> ~/.bashrc"
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
+    end
+    # End Docbook common postinstall block
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//ENTITIES DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//DTD DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+    system "xmlcatalog --noout --add \"delegateSystem\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
+    system "xmlcatalog --noout --add \"delegateURI\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        '#{CREW_PREFIX}/etc/xml/catalog'"
   end
 end

--- a/packages/docbook_xsl.rb
+++ b/packages/docbook_xsl.rb
@@ -2,28 +2,27 @@ require 'package'
 
 class Docbook_xsl < Package
   description 'The DocBook XSL Stylesheets package contains XSL stylesheets. These are useful for performing transformations on XML DocBook files.'
-  compatibility 'all'
   homepage 'https://github.com/docbook/xslt10-stylesheets'
   @_ver = '1.79.2'
-  version @_ver
+  version "#{@_ver}-1"
+  compatibility 'all'
   source_url "https://github.com/docbook/xslt10-stylesheets/releases/download/release/#{@_ver}/docbook-xsl-#{@_ver}.zip"
   source_sha256 '853dce096f5b32fe0b157d8018d8fecf92022e9c79b5947a98b365679c7e31d7'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl-1.79.2-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '78f0e12c3db339ebd0d9f7d78016c89aaaa94d0649d9dc8ac342211cf09f25ad',
-     armv7l: '78f0e12c3db339ebd0d9f7d78016c89aaaa94d0649d9dc8ac342211cf09f25ad',
-       i686: '1e125577e569c168d646544bc8547eecc76e21b6ad6f85088e74711b8421d88d',
-     x86_64: 'dbba4c5f2c095d0254664db90aaf921d1f182f570a66fb7cf1e4f36732e58e54'
+    aarch64: '7cf8ba8618ed326bec14312fd16d60df6ecaf64d93f4e366936a0631969244bd',
+     armv7l: '7cf8ba8618ed326bec14312fd16d60df6ecaf64d93f4e366936a0631969244bd',
+       i686: '99b4735572497dc97dc37ea1d84da16be4994508ea7293f1fca678b17a3419a8',
+     x86_64: '508cfde5de02091ea5d26aec1e50bd5faff48493a4036d5014f9b3e71bfefa71'
   })
 
   depends_on 'xmlcatmgr'
-  depends_on 'docbook_xsl_nons'
   depends_on 'bash'
 
   def self.patch

--- a/packages/docbook_xsl_nons.rb
+++ b/packages/docbook_xsl_nons.rb
@@ -1,0 +1,101 @@
+require 'package'
+
+class Docbook_xsl_nons < Package
+  description 'The DocBook XSL Stylesheets package contains XSL stylesheets. These are useful for performing transformations on XML DocBook files.'
+  compatibility 'all'
+  homepage 'https://github.com/docbook/xslt10-stylesheets'
+  @_ver = '1.79.2'
+  version @_ver
+  source_url "https://github.com/docbook/xslt10-stylesheets/releases/download/release/#{@_ver}/docbook-xsl-nons-#{@_ver}.zip"
+  source_sha256 'ba41126fbf4021e38952f3074dc87cdf1e50f3981280c7a619f88acf31456822'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl_nons-1.79.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl_nons-1.79.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl_nons-1.79.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xsl_nons-1.79.2-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '591c6a68855b291d26463cb039b72b6100a10b02f29e4b61a8177df9ffc7694c',
+     armv7l: '591c6a68855b291d26463cb039b72b6100a10b02f29e4b61a8177df9ffc7694c',
+       i686: '96082d7311387dddc7e9751f5d4458168a782be88eacf4789cebd1962406fba7',
+     x86_64: '358b905b77951ab9e81272628b87e4f43152869f1a7a894e2e1139309f0ff4b1'
+  })
+
+  depends_on 'xmlcatmgr'
+  depends_on 'bash'
+
+  def self.patch
+    system 'curl -OLf "https://github.com/archlinux/svntogit-packages/raw/packages/docbook-xsl/trunk/765567_non-recursive_string_subst.patch"'
+    unless Digest::SHA256.hexdigest(File.read('765567_non-recursive_string_subst.patch')) == '193ec26dcb37bdf12037ed4ea98d68bd550500c8e96b719685d76d7096c3f9b3'
+      abort 'Checksum mismatch. :/ Try again.'.lightred
+    end
+    system 'patch -Np2 -i 765567_non-recursive_string_subst.patch'
+  end
+
+  def self.install
+    ENV['XML_CATALOG_FILES'] = "#{CREW_DEST_PREFIX}/etc/xml/catalog"
+    @pkgroot = "#{CREW_DEST_PREFIX}/share/xml/docbook/xsl-stylesheets-#{@_ver}-nons"
+    @ADDFILES_SH = <<~ADDFILES_HEREDOC
+      install -Dt @pkgroot -m644 VERSION{,.xsl}
+      (
+        shopt -s nullglob  # ignore missing files
+        echo "ignore missing files"
+        for fn in assembly catalog.xml common docsrc eclipse epub epub3 \
+        extensions fo highlighting html htmlhelp images javahelp lib log \
+        manpages params profiling roundtrip slides template tests tools \
+        webhelp website xhtml xhtml-1_1 xhtml5
+        do
+        install -Dt "#{@pkgroot}"/"$fn" -m644 "$fn"/*.{xml,xsl,dtd,ent}
+        done
+      )
+    ADDFILES_HEREDOC
+    IO.write('add_files.sh', @ADDFILES_SH, perm: 0o755)
+    system "#{CREW_PREFIX}/bin/bash ./add_files.sh || true"
+  end
+
+  def self.preinstall
+    # Docbook common preinstall block
+    FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
+    end
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
+    end
+
+    # End Docbook common preinstall block
+  end
+
+  def self.postinstall
+    # Docbook common postinstall block
+    ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+    xml_catalog_files_in_bashrc = `grep -c "XML_CATALOG_FILES" ~/.bashrc || true`
+    unless xml_catalog_files_in_bashrc.to_i.positive?
+      puts "Putting \"export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog\" in ~/.bashrc".lightblue
+      system "echo 'export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog' >> ~/.bashrc"
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
+    end
+    # End Docbook common postinstall block
+
+    system "xmlcatalog --noout --add rewriteSystem https://cdn.docbook.org/release/xsl-nons/#{@_ver} #{CREW_PREFIX}/share/xml/docbook/xsl-stylesheets-#{@_ver}-nons '#{CREW_PREFIX}/etc/xml/catalog'"
+    system "xmlcatalog --noout --add rewriteURI https://cdn.docbook.org/release/xsl-nons/#{@_ver} #{CREW_PREFIX}/share/xml/docbook/xsl-stylesheets-#{@_ver}-nons '#{CREW_PREFIX}/etc/xml/catalog'"
+    system "xmlcatalog --noout --add rewriteSystem https://cdn.docbook.org/release/xsl-nons/current #{CREW_PREFIX}/share/xml/docbook/xsl-stylesheets-#{@_ver}-nons '#{CREW_PREFIX}/etc/xml/catalog'"
+    system "xmlcatalog --noout --add rewriteURI https://cdn.docbook.org/release/xsl-nons/current #{CREW_PREFIX}/share/xml/docbook/xsl-stylesheets-#{@_ver}-nons '#{CREW_PREFIX}/etc/xml/catalog'"
+    # Check:
+    system 'xmlcatalog', "#{CREW_PREFIX}/etc/xml/catalog", 'https://cdn.docbook.org/release/xsl-nons/current/'
+    system 'xmlcatalog', "#{CREW_PREFIX}/etc/xml/catalog", "https://cdn.docbook.org/release/xsl-nons/#{@_ver}/"
+  end
+end

--- a/packages/docbook_xsl_nons.rb
+++ b/packages/docbook_xsl_nons.rb
@@ -2,10 +2,10 @@ require 'package'
 
 class Docbook_xsl_nons < Package
   description 'The DocBook XSL Stylesheets package contains XSL stylesheets. These are useful for performing transformations on XML DocBook files.'
-  compatibility 'all'
   homepage 'https://github.com/docbook/xslt10-stylesheets'
   @_ver = '1.79.2'
   version @_ver
+  compatibility 'all'
   source_url "https://github.com/docbook/xslt10-stylesheets/releases/download/release/#{@_ver}/docbook-xsl-nons-#{@_ver}.zip"
   source_sha256 'ba41126fbf4021e38952f3074dc87cdf1e50f3981280c7a619f88acf31456822'
 

--- a/packages/dookbook_xml412.rb
+++ b/packages/dookbook_xml412.rb
@@ -1,0 +1,137 @@
+require 'package'
+
+class Docbook_xml412 < Package
+  description 'A widely used XML scheme for writing documentation and help'
+  homepage 'https://www.oasis-open.org/docbook/'
+  @_ver = '4.1.2'
+  version @_ver
+  compatibility 'all'
+  source_url 'https://docbook.org/xml/4.1.2/docbkx412.zip'
+  source_sha256 '30f0644064e0ea71751438251940b1431f46acada814a062870f486c772e7772'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml412-4.1.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml412-4.1.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml412-4.1.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/docbook_xml412-4.1.2-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '7a71988ef51b7480522c314559f76c3c9334c1a55f6981dcea536badafe3ffd9',
+     armv7l: '7a71988ef51b7480522c314559f76c3c9334c1a55f6981dcea536badafe3ffd9',
+       i686: 'a760d0c0a67601560012cc48bd88c5e45b853d6f8636a20ab8532729cbcfeb5b',
+     x86_64: 'e61afc55e0d7d2e4b09df2185f64edb55e0cbea828fed2ac682906589911cfaf'
+  })
+
+  depends_on 'libxml2'
+  depends_on 'xmlcatmgr'
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    system "cp -dr docbook.cat *.dtd ent/ *.mod #{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/xml"
+  end
+
+  def self.preinstall
+    # Docbook common preinstall block
+    FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
+    end
+
+    if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+    else
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
+      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
+    end
+    # End Docbook common preinstall block
+  end
+
+  def self.postinstall
+    # Docbook common postinstall block
+    ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
+
+    xml_catalog_files_in_bashrc = `grep -c "XML_CATALOG_FILES" ~/.bashrc || true`
+    unless xml_catalog_files_in_bashrc.to_i.positive?
+      puts "Putting \"export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog\" in ~/.bashrc".lightblue
+      system "echo 'export XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog' >> ~/.bashrc"
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
+    end
+    # End Docbook common postinstall block
+
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//DTD DocBook XML V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/docbookx.dtd' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//DTD DocBookXML CALS Table Model V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/calstblx.dtd' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//DTD XML Exchange Table Model 19990315//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/soextblx.dtd' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//ELEMENTS DocBookXML Information Pool V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/dbpoolx.mod' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//ELEMENTS DocBookXML Document Hierarchy V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/dbhierx.mod' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//ENTITIES DocBookXML Additional General Entities V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/dbgenent.mod' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//ENTITIES DocBookXML Notations V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/dbnotnx.mod' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//ENTITIES DocBookXML Character Entities V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/dbcentx.mod' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+
+    system "xmlcatalog --noout --add rewriteSystem \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add rewriteURI \
+      http://www.oasis-open.org/docbook/xml/#{@_ver} \
+      #{CREW_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver} \
+      #{CREW_PREFIX}/etc/xml/docbook-xml"
+
+    system "xmlcatalog --noout --add 'public' \
+      '-//OASIS//DTD DocBook XML V#{@_ver}//EN' \
+      'http://www.oasis-open.org/docbook/xml/#{@_ver}/docbookx.dtd' \
+      '#{CREW_PREFIX}/etc/xml/docbook-xml'"
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//ENTITIES DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        #{CREW_PREFIX}/etc/xml/catalog"
+
+    system "xmlcatalog --noout --add \"delegatePublic\" \
+        \"-//OASIS//DTD DocBook XML\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        #{CREW_PREFIX}/etc/xml/catalog"
+
+    system "xmlcatalog --noout --add \"delegateSystem\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        #{CREW_PREFIX}/etc/xml/catalog"
+
+    system "xmlcatalog --noout --add \"delegateURI\" \
+        \"http://www.oasis-open.org/docbook/\" \
+        \"file://#{CREW_PREFIX}/etc/xml/docbook-xml\" \
+        #{CREW_PREFIX}/etc/xml/catalog"
+  end
+end

--- a/packages/moreutils.rb
+++ b/packages/moreutils.rb
@@ -3,35 +3,37 @@ require 'package'
 class Moreutils < Package
   description 'moreutils is a growing collection of the unix tools that nobody thought to write long ago when unix was young.'
   homepage 'https://joeyh.name/code/moreutils/'
-  version '0.60'
+  @_ver = '0.65'
+  version @_ver
   compatibility 'all'
-  source_url 'http://http.debian.net/debian/pool/main/m/moreutils/moreutils_0.60.orig.tar.xz'
-  source_sha256 'e42d18bacbd2d003779a55fb3542befa5d1d217ee37c1874e8c497581ebc17c5'
+  source_url "http://http.debian.net/debian/pool/main/m/moreutils/moreutils_#{@_ver}.orig.tar.xz"
+  source_sha256 'ba0cfaa1ff6ead2b15c62a67292de66a366f9b815a09697b54677f7e15f5a2b2'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/moreutils-0.60-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/moreutils-0.60-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/moreutils-0.60-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/moreutils-0.60-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/moreutils-0.65-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/moreutils-0.65-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/moreutils-0.65-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/moreutils-0.65-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '0c7f2b822e06c806969e5666069933e9d97932320d9759713217e700ad3b1d4d',
-     armv7l: '0c7f2b822e06c806969e5666069933e9d97932320d9759713217e700ad3b1d4d',
-       i686: '63f39101b144273c158aa38e88aa3af2ca84925c52793fdd9beed85da865aa6b',
-     x86_64: 'dea55d855398f5b88d255ab185f44446acb57ae0d1108057755278f68dc1f4f8',
+     aarch64: 'af2d40444fb74ae8e2151b76d61417ddee993b69b8e6b6b30a65218612a8f523',
+      armv7l: 'af2d40444fb74ae8e2151b76d61417ddee993b69b8e6b6b30a65218612a8f523',
+        i686: '5bb54745aa76aa985f0cc0a6dd2a7c6efdcd314774df9d535183b657247c9540',
+      x86_64: '55222b8e4293e548f812542fa7447e5420c1b7098c0ae481e1f0a0357dd84ed9',
   })
 
-  depends_on 'docbook'
+  depends_on 'docbook_xml'
   depends_on 'libxslt'
 
   def self.build
     system "sed -i 's,PREFIX?=/usr,PREFIX?=#{CREW_PREFIX},' Makefile"
-    system "sed -i 's,DOCBOOKXSL?=/usr/share/xml/docbook/stylesheet/docbook-xsl,DOCBOOKXSL?=#{CREW_PREFIX}/docbook,' Makefile"
+    system "sed -i 's,DOCBOOKXSL?=/usr/share/xml/docbook/stylesheet/docbook-xsl,DOCBOOKXSL?=#{CREW_PREFIX}/share/xml/docbook/stylesheet/docbook-xsl,' Makefile"
     system "sed -i 's,share/man,man,g' Makefile"
-    system 'make'
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+      make"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
- This fixes the rewrite hell which plagued packages.
- Also fakes out the docbook.rb which only moreutils was using
- And thus also updates moreutils.
- put together after consulting both the arch and homebrew package files

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686

(everything except binaries in docbook_xsl are uploaded.)