### PR TITLE
Add krb5 to EARLY_PACKAGES

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 
 EARLY_PACKAGES="gcc10 llvm brotli c_ares libcyrussasl libiconv libidn2 \
 libmetalink libnghttp2 libpsl libssh2 libtirpc libunistring openldap \
-rtmpdump zstd ncurses ca_certificates ruby libffi openssl nettle curl \
+rtmpdump zstd ncurses ca_certificates ruby libffi openssl nettle krb5 curl \
 git icu4c libedit"
 
 ARCH="$(uname -m)"

--- a/packages/krb5.rb
+++ b/packages/krb5.rb
@@ -3,38 +3,38 @@ require 'package'
 class Krb5 < Package
   description 'Kerberos is a network authentication protocol.'
   homepage 'https://web.mit.edu/kerberos'
-  version '1.18.3'
+  version '1.19'
   compatibility 'all'
-  source_url 'http://web.mit.edu/kerberos/dist/krb5/1.18/krb5-1.18.3.tar.gz'
-  source_sha256 'e61783c292b5efd9afb45c555a80dd267ac67eebabca42185362bee6c4fbd719'
+  source_url 'https://web.mit.edu/kerberos/dist/krb5/1.19/krb5-1.19.tar.gz'
+  source_sha256 'bc7862dd1342c04e1c17c984a268d50f29c0a658a59a22bd308ffa007d532a2e'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/krb5-1.18.3-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/krb5-1.18.3-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/krb5-1.18.3-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/krb5-1.18.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/krb5-1.19-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/krb5-1.19-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/krb5-1.19-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/krb5-1.19-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '3e67fe4422bf86829978f6a1b3ceb2dc62975d1a7eb9a3c6158f6f6deb09cbf1',
-      armv7l: '3e67fe4422bf86829978f6a1b3ceb2dc62975d1a7eb9a3c6158f6f6deb09cbf1',
-        i686: '60cb4f6e17bac1ce4b92c2c4c5e010101e6855db6b5cb8f5da7368cf793b12fe',
-      x86_64: 'f1d105384743a241f172c4d267a35e1ffb49159f4bc76c3ca5e5dbc27f69cc28',
+  binary_sha256({
+    aarch64: '69f5fdec7c6c2c409b2d328c325954fdc8f8cf21024f84059968f052437c160a',
+     armv7l: '69f5fdec7c6c2c409b2d328c325954fdc8f8cf21024f84059968f052437c160a',
+       i686: '09f43b2cb5ba53b6699f9db04b7886c4d1a1ffbb6d4510aa3f79b67f77187434',
+     x86_64: '1a3963a507e42b7b2d9faa21724c2945d028b6a1f717a4ba0d48dee206698f33'
   })
-
-  depends_on 'gawk'
 
   def self.build
-    Dir.chdir "src" do
-      system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+    Dir.chdir 'src' do
+      system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
       ./configure #{CREW_OPTIONS} \
+      --localstatedir=#{CREW_PREFIX}/var/krb5kdc \
       --without-system-verto"
-      system "make"
+      system 'make'
     end
   end
 
   def self.install
-    Dir.chdir "src" do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    Dir.chdir 'src' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
   end
 end


### PR DESCRIPTION
Fixes #5129 (unless there are other libraries which are needed.)
- krb5 is needed by curl, since it provides ```libcom_err.so.3```
- krb5 needed to be recompiled with ```localstatedir``` set. That is where the krb5kdc folder is, which was defaulting to ```/run/krb5kdc```, which is not a writable folder for tar on most systems, and since install.sh exits on error, this was causing install.sh crash otherwise.
- Normal installs through crew don't show the files outside /usr/local, so we don't see this issue otherwise.
- This PR has krb5 1.19 compiled with localstatedir, and the new package appears to only use files in folders under /usr/local.

```
crew whatprovides libcom_err
e2fsprogs: /usr/local/lib64/libcom_err.a
krb5: /usr/local/lib64/libcom_err.so
krb5: /usr/local/lib64/libcom_err.so.3
krb5: /usr/local/lib64/libcom_err.so.3.0
```
@saltedcoffii  Can you try installing with this: https://github.com/satmandu/chromebrew/blob/add_k5b5_to_install.sh/install.sh