### PR TITLE
install.sh: Add more early packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,8 +17,8 @@ CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 
 EARLY_PACKAGES="gcc10 llvm brotli c_ares libcyrussasl libiconv libidn2 \
 libmetalink libnghttp2 libpsl libssh2 libtirpc libunistring openldap \
-rtmpdump zstd ncurses ca_certificates ruby libffi openssl nettle krb5 curl \
-git icu4c libedit"
+rtmpdump zstd ncurses ca_certificates ruby libffi openssl nettle krb5 \
+p11kit libtasn1 gnutls curl git icu4c libedit"
 
 ARCH="$(uname -m)"
 


### PR DESCRIPTION
Fixes #5129
 - as per discussion in https://github.com/skycocker/chromebrew/issues/5129 adding ```p11kit libtasn1 gnutls``` before curl to ```EARLY_PACKAGES```
