### PR TITLE
bz2: new gnome upstream

### DIFF
--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -2,61 +2,33 @@ require 'package'
 
 class Bz2 < Package
   description 'bzip2 is a freely available, patent free, high-quality data compressor.'
-  homepage 'http://www.bzip.org/'
-  version '1.0.8'
+  homepage 'https://gitlab.com/federicomenaquintero/bzip2/'
+  version '1.0.7-6211'
   compatibility 'all'
-  source_url 'https://fossies.org/linux/misc/bzip2-1.0.8.tar.gz'
-  source_sha256 'ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269'
+  source_url 'https://gitlab.com/federicomenaquintero/bzip2/-/archive/6211b6500c8bec13a17707440d3a84ca8b34eed5/bzip2-6211b6500c8bec13a17707440d3a84ca8b34eed5.tar.bz2'
+  source_sha256 'a374472b955db5194c236d38d53c5d56dd1035f1c735941503228b16065a08b3'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.8-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.7-6211-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.7-6211-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.7-6211-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bz2-1.0.7-6211-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '11fbd7bb0897446cfda34be28db698ecdcbfbcb70e23311fe405edf1aa9abec4',
-     armv7l: '11fbd7bb0897446cfda34be28db698ecdcbfbcb70e23311fe405edf1aa9abec4',
-       i686: '82f0c8f531c14cef34d9b2a7b1c3a8f1783d43fad87a3da19a12da91abf03857',
-     x86_64: '418cff679b9753a9f247a77bf0d61994fc73ee473e6eaed49cd8aa4a159166a7',
+  binary_sha256({
+    aarch64: 'fb273654412a427737f20bf369104c8dd13aa5b367bc847657e4eb71d40574b1',
+     armv7l: 'fb273654412a427737f20bf369104c8dd13aa5b367bc847657e4eb71d40574b1',
+       i686: 'df400e541bdf375878fed304ca3b9e1faad458f0ec8f717851f7b8bc5f3eea7d',
+     x86_64: 'a8cd2fb0d892f298f614c15980f5f0be9a7c65a964ddaef3c092fd6596c6ca97'
   })
 
   def self.build
-    system "make -f Makefile-libbz2_so"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    # bz2 Makefile doesn't have DESTDIR, so we need several tricks
-    # to make it install files correctly.
-
-    # Modify Makefile from "ln -s $(PREFIX)/bin/xxx $(PREFIX)/bin/yyy" to
-    # "ln -s xxx $(PREFIX)/bin/yyy"
-    system "sed -i Makefile -e '/ln -s/s:$(PREFIX)/bin/::'"
-
-    # Use PREFIX instead of DESTDIR
-    system "make", "PREFIX=#{CREW_DEST_PREFIX}", "install"
-
-    # Remove static library
-    system "rm #{CREW_DEST_PREFIX}/lib/libbz2.a"
-
-    # Install bzip2 using shared library by hand
-    system "cp -p bzip2-shared bzip2"
-    system "install -Dm755 bzip2 #{CREW_DEST_PREFIX}/bin/bzip2"
-    system "ln -sf bzip2 #{CREW_DEST_PREFIX}/bin/bunzip2"
-    system "ln -sf bzip2 #{CREW_DEST_PREFIX}/bin/bzcat"
-
-    # Install shared library by hand
-    system "install -Dm644 libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0.8"
-    system "ln -s libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0"
-    system "ln -s libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1"
-    system "ln -s libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so"
-
-    # Move manpages
-    FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share")
-    system "mv #{CREW_DEST_PREFIX}/man #{CREW_DEST_PREFIX}/share/"
-  end
-
-  def self.check
-    system "make", "test"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end


### PR DESCRIPTION
- New Gnome Upstream
- Has meson support, vastly simplifying install.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

```
bz2: bzip2 is a freely available, patent free, high-quality data compressor.
/usr/local/bin/bunzip2
/usr/local/bin/bzcat
/usr/local/bin/bzcmp
/usr/local/bin/bzdiff
/usr/local/bin/bzegrep
/usr/local/bin/bzfgrep
/usr/local/bin/bzgrep
/usr/local/bin/bzip2
/usr/local/bin/bzip2recover
/usr/local/bin/bzless
/usr/local/bin/bzmore
/usr/local/include/bzlib.h
/usr/local/lib64/libbz2.so
/usr/local/lib64/libbz2.so.1
/usr/local/lib64/libbz2.so.1.0.7
/usr/local/lib64/pkgconfig/bz2.pc
/usr/local/share/man/man1/bunzip2.1.gz
/usr/local/share/man/man1/bzcat.gz
/usr/local/share/man/man1/bzcmp.1.gz
/usr/local/share/man/man1/bzdiff.1.gz
/usr/local/share/man/man1/bzegrep.1.gz
/usr/local/share/man/man1/bzfgrep.1.gz
/usr/local/share/man/man1/bzgrep.1.gz
/usr/local/share/man/man1/bzip2.1.gz
/usr/local/share/man/man1/bzless.1.gz
/usr/local/share/man/man1/bzmore.1.gz
Total found: 26
Disk usage: 196KB
```