### PR TITLE
PulseAudio 14.2 + pavucontrol 

### DIFF
--- a/packages/pavucontrol.rb
+++ b/packages/pavucontrol.rb
@@ -3,37 +3,43 @@ require 'package'
 class Pavucontrol < Package
   description 'PulseAudio Volume Control'
   homepage 'https://freedesktop.org/software/pulseaudio/pavucontrol/'
-  version '4.0'
+  version "4.0-381b"
   compatibility 'all'
-  source_url 'https://freedesktop.org/software/pulseaudio/pavucontrol//pavucontrol-4.0.tar.xz'
-  source_sha256 '8fc45bac9722aefa6f022999cbb76242d143c31b314e2dbb38f034f4069d14e2'
+  source_url 'https://github.com/pulseaudio/pavucontrol/archive/381b708202e87e40347a57f8a627014199cde266.zip'
+  source_sha256 'aa6c5814e77a8f36d8ed50b70381fbfbab2ebbf0fb62548ec8b8b935527d527e'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '97f4ff801cdca8a12c665e5d1467e1749f06803fb7f2ac4423be95c057fc8e13',
-     armv7l: '97f4ff801cdca8a12c665e5d1467e1749f06803fb7f2ac4423be95c057fc8e13',
-       i686: '1b536d2c99e5466a4939b82b25cd94f105ce2ca24cece37f868df3bc30078496',
-     x86_64: '91919320ed61fdc26730f8a7d1d19dbc712b158b16ddd2de4d77ad029b461b52',
+     aarch64: '55d3cc7504a483f9af794daccea92fcd261cbc8f1a4d4332f99c8a28226ea63d',
+      armv7l: '55d3cc7504a483f9af794daccea92fcd261cbc8f1a4d4332f99c8a28226ea63d',
+        i686: '2cd937784abe38291a6c0fbc7bd4a6e18626909390b4b1d0f460274dc0fce26d',
+      x86_64: 'b9ca4e77191fc33eda5a2dc15e9329862c33af5b096bd5c8dc9ebc7778da69ad',
   })
 
-  depends_on 'gtkmm2'
-  depends_on 'gtkmm3'
+
   depends_on 'libcanberra'
+  depends_on 'gtkmm3'
+  depends_on 'libsigcplusplus'
+  depends_on 'pulseaudio'
   depends_on 'pygtk'
   depends_on 'pulseaudio'
   depends_on 'glibmm'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
-    system "make -j#{CREW_NPROC} -lgtkmm-3.24" # Issue with gtkmm - gtk::builder
+    system 'NOCONFIGURE=1 ./bootstrap.sh'
+    system "env CFLAGS='-flto=auto -ltinfo' CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
+    ./configure \
+    #{CREW_OPTIONS} \
+    --disable-lynx"
+    system 'make'
   end
 
   def self.install
-    system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -3,22 +3,23 @@ require 'package'
 class Pulseaudio < Package
   description 'PulseAudio is a sound system for POSIX OSes, meaning that it is a proxy for your sound applications.'
   homepage 'https://www.freedesktop.org/wiki/Software/PulseAudio/'
-  version '13.99.3'
+  @_ver = '14.2'
+  version @_ver
   compatibility 'all'
-  source_url 'https://freedesktop.org/software/pulseaudio/releases/pulseaudio-13.99.3.tar.gz'
-  source_sha256 '2572543a7686c699654c40ec3945a598e6af50ff703f60de0446b7fbcd16ef01'
+  source_url "https://freedesktop.org/software/pulseaudio/releases/pulseaudio-#{@_ver}.tar.xz"
+  source_sha256 '75d3f7742c1ae449049a4c88900e454b8b350ecaa8c544f3488a2562a9ff66f1'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-13.99.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-13.99.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-13.99.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-13.99.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'ed785bbf45af02e5a96ed947740f1f5b055bdee39670f1006d15d6fd96876f24',
-     armv7l: 'ed785bbf45af02e5a96ed947740f1f5b055bdee39670f1006d15d6fd96876f24',
-       i686: '0e19e15a116395b9aa52977c3cd99c9e735d70365146435d54bdd9e300df7e3c',
-     x86_64: 'f346f11c323de6019f1f1189db6398d12671db5b493b68c18b1617e177faff68',
+  binary_sha256({
+    aarch64: '5229ace51bc615012d3ad2d0e00a587344d036f911819a6c3929c693e94eec9c',
+     armv7l: '5229ace51bc615012d3ad2d0e00a587344d036f911819a6c3929c693e94eec9c',
+       i686: 'cd9fd9ba81591a09bfd175d461918a8724c5edfa6059abf545f78d24385a3677',
+     x86_64: 'c9aff79692b3beb4d210f3ad3eef87ec92dd64480e476a0cf1808c2a7ef3a0c3'
   })
 
   depends_on 'gsettings_desktop_schemas'
@@ -34,19 +35,24 @@ class Pulseaudio < Package
   depends_on 'eudev'
   depends_on 'gtk3'
   depends_on 'dbus'
-  depends_on 'gdbm'
   depends_on 'tdb'
+  depends_on 'check' => :build
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
-    system "make -j#{CREW_NPROC}"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    --default-library=both \
+    -Dsystem_user=chronos \
+    -Dsystem_group=cras \
+    -Daccess_group=cras \
+    -Dbluez5=false \
+    -Dalsa=enabled \
+    -Dudevrulesdir=#{CREW_PREFIX}/libexec/rules.d \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.check
-    system 'make', 'check'
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end


### PR DESCRIPTION
- Pulseaudio isn't working with flatpak. This is an initial update of PulseAudio to current version, with the hope of getting it configured properly with cars. (We will probably have to check crouton to see how they are configuring this. It might just be a matter of getting pulseaudio configured properly with alsa, as alsamixer shows and modifies the volume properly.
- pavucontrol was also updated to a recent bugfix commit, and recompiled with PulseAudio 14.2

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l


![image](https://user-images.githubusercontent.com/1096701/108567927-250bd680-72d7-11eb-85f5-09ed44f6ded4.png)
