### PR TITLE
Pulsaudio updates

### DIFF
--- a/packages/abseil_cpp.rb
+++ b/packages/abseil_cpp.rb
@@ -1,0 +1,47 @@
+require 'package'
+
+class Abseil_cpp < Package
+  description 'Abseil Common Libraries C++'
+  homepage 'https://abseil.io/'
+  @_ver = '20200923.3'
+  version @_ver
+  compatibility 'all'
+  source_url "https://github.com/abseil/abseil-cpp/archive/#{@_ver}.tar.gz"
+  source_sha256 'ebe2ad1480d27383e4bf4211e2ca2ef312d5e6a09eba869fd2e8a5c5d553ded2'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/abseil_cpp-20200923.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/abseil_cpp-20200923.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/abseil_cpp-20200923.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/abseil_cpp-20200923.3-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '0bcfb2b4924b1c782d918805edf2e6b200ec9547ae362d09ed1122003dd64c49',
+     armv7l: '0bcfb2b4924b1c782d918805edf2e6b200ec9547ae362d09ed1122003dd64c49',
+       i686: '751aa86540e5a3d70a53217488bb4cb8ca7fc2d37846e2ddf2aa363998e8cb77',
+     x86_64: 'ff09779acf76c9d83f69f07dcdcc0dd262beca43b2c74c48a9b9d4fd3ec6a5c0'
+  })
+
+  def self.build
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+        cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DABSL_CXX_STANDARD=17 \
+        -DABSL_USE_GOOGLETEST_HEAD=ON \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DABSL_ENABLE_INSTALL=ON \
+        -DCMAKE_MODULE_LINKER_FLAGS=\"-Wl,--no-undefined -Wl,--no-undefined\" \
+        -DBUILD_SHARED_LIBS=ON \
+        .."
+    end
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/pavucontrol.rb
+++ b/packages/pavucontrol.rb
@@ -3,36 +3,35 @@ require 'package'
 class Pavucontrol < Package
   description 'PulseAudio Volume Control'
   homepage 'https://freedesktop.org/software/pulseaudio/pavucontrol/'
-  version "4.0-381b"
+  @_ver = '4.0'
+  version "#{@_ver}-381b-1"
   compatibility 'all'
   source_url 'https://github.com/pulseaudio/pavucontrol/archive/381b708202e87e40347a57f8a627014199cde266.zip'
   source_sha256 'aa6c5814e77a8f36d8ed50b70381fbfbab2ebbf0fb62548ec8b8b935527d527e'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pavucontrol-4.0-381b-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '55d3cc7504a483f9af794daccea92fcd261cbc8f1a4d4332f99c8a28226ea63d',
-      armv7l: '55d3cc7504a483f9af794daccea92fcd261cbc8f1a4d4332f99c8a28226ea63d',
-        i686: '2cd937784abe38291a6c0fbc7bd4a6e18626909390b4b1d0f460274dc0fce26d',
-      x86_64: 'b9ca4e77191fc33eda5a2dc15e9329862c33af5b096bd5c8dc9ebc7778da69ad',
+  binary_sha256({
+    aarch64: '2773e569e8fef5cbc3d2adadf9d94abdbb7122393baff840e6f743ebe669f1b9',
+     armv7l: '2773e569e8fef5cbc3d2adadf9d94abdbb7122393baff840e6f743ebe669f1b9',
+       i686: '7854e1bc1d712dff60a60e91fdaeaf29ddc11cb558245e91aaebdb10cf9893bc',
+     x86_64: '01f0d27fac88490d8d4b149a3396e8e0fd85e2c5763a08f4367245e10b6ea303'
   })
-
 
   depends_on 'libcanberra'
   depends_on 'gtkmm3'
   depends_on 'libsigcplusplus'
   depends_on 'pulseaudio'
   depends_on 'pygtk'
-  depends_on 'pulseaudio'
   depends_on 'glibmm'
 
   def self.build
     system 'NOCONFIGURE=1 ./bootstrap.sh'
-    system "env CFLAGS='-flto=auto -ltinfo' CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
+    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
     ./configure \
     #{CREW_OPTIONS} \
     --disable-lynx"

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -51,7 +51,6 @@ class Pulseaudio < Package
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
     --default-library=both \
-    -Dcpp_args='-I#{CREW_PREFIX}/include' \
     -Dsystem_user=chronos \
     -Dsystem_group=cras \
     -Daccess_group=cras \

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -44,7 +44,6 @@ class Pulseaudio < Package
   depends_on 'gst_plugins_base'
   depends_on 'gst_plugins_good'
   depends_on 'gst_plugins_bad'
-  depends_on 'gst_plugins_bad'
   depends_on 'check' => :build
   depends_on 'webrtc_audio_processing'
 

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -86,7 +86,7 @@ class Pulseaudio < Package
       exit-idle-time = 10 # Exit as soon as unneeded
       flat-volumes = yes # Prevent messing with the master volume
     PAUDIO_DAEMON_CONF_HEREDOC
-    IO.write("#{CREW_DEST_PREFIX}/etc/pulse/daemon.conf", @pulseaudio_daemon_conf, perm: 0o555)
+    IO.write("#{CREW_DEST_PREFIX}/etc/pulse/daemon.conf", @pulseaudio_daemon_conf, perm: 0o666)
     @pulseaudio_client_conf = <<~PAUDIO_CLIENT_CONF_HEREDOC
       # Replace these with the proper values
 
@@ -95,7 +95,7 @@ class Pulseaudio < Package
       # exit-idle-time setting in daemon.conf
       autospawn = yes
     PAUDIO_CLIENT_CONF_HEREDOC
-    IO.write("#{CREW_DEST_PREFIX}/etc/pulse/client.conf", @pulseaudio_client_conf, perm: 0o555)
+    IO.write("#{CREW_DEST_PREFIX}/etc/pulse/client.conf", @pulseaudio_client_conf, perm: 0o666)
     @pulseaudio_default_pa = <<~PAUDIO_DEFAULT_PA_HEREDOC
       # Replace the *entire* content of this file with these few lines and
       # read the comments
@@ -123,6 +123,6 @@ class Pulseaudio < Package
           load-module module-x11-publish
       .endif
     PAUDIO_DEFAULT_PA_HEREDOC
-    IO.write("#{CREW_DEST_PREFIX}/etc/pulse/default.pa", @pulseaudio_default_pa, perm: 0o555)
+    IO.write("#{CREW_DEST_PREFIX}/etc/pulse/default.pa", @pulseaudio_default_pa, perm: 0o666)
   end
 end

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -4,22 +4,22 @@ class Pulseaudio < Package
   description 'PulseAudio is a sound system for POSIX OSes, meaning that it is a proxy for your sound applications.'
   homepage 'https://www.freedesktop.org/wiki/Software/PulseAudio/'
   @_ver = '14.2'
-  version @_ver
+  version "#{@_ver}-1"
   compatibility 'all'
   source_url "https://freedesktop.org/software/pulseaudio/releases/pulseaudio-#{@_ver}.tar.xz"
   source_sha256 '75d3f7742c1ae449049a4c88900e454b8b350ecaa8c544f3488a2562a9ff66f1'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pulseaudio-14.2-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '5229ace51bc615012d3ad2d0e00a587344d036f911819a6c3929c693e94eec9c',
-     armv7l: '5229ace51bc615012d3ad2d0e00a587344d036f911819a6c3929c693e94eec9c',
-       i686: 'cd9fd9ba81591a09bfd175d461918a8724c5edfa6059abf545f78d24385a3677',
-     x86_64: 'c9aff79692b3beb4d210f3ad3eef87ec92dd64480e476a0cf1808c2a7ef3a0c3'
+    aarch64: '9f10feb9805320b1c710d93a78a706d0ecc9c8a2b06e82008369b938c7fa6ea7',
+     armv7l: '9f10feb9805320b1c710d93a78a706d0ecc9c8a2b06e82008369b938c7fa6ea7',
+       i686: '816c9dae258d6c3f10fd72bbf621253891cb01915746460d8b806784fe6647c0',
+     x86_64: '89be113223767b5c7af0b6f064efbb65338aac39208018b489152e1654185a33'
   })
 
   depends_on 'gsettings_desktop_schemas'
@@ -36,23 +36,95 @@ class Pulseaudio < Package
   depends_on 'gtk3'
   depends_on 'dbus'
   depends_on 'tdb'
+  depends_on 'cras'
+  depends_on 'orc'
+  depends_on 'jack'
+  depends_on 'avahi'
+  depends_on 'gstreamer'
+  depends_on 'gst_plugins_base'
+  depends_on 'gst_plugins_good'
+  depends_on 'gst_plugins_bad'
+  depends_on 'gst_plugins_bad'
   depends_on 'check' => :build
+  depends_on 'webrtc_audio_processing'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
     --default-library=both \
+    -Dcpp_args='-I#{CREW_PREFIX}/include' \
     -Dsystem_user=chronos \
     -Dsystem_group=cras \
     -Daccess_group=cras \
     -Dbluez5=false \
     -Dalsa=enabled \
+    -Dgstreamer=enabled \
+    -Dtests=true \
     -Dudevrulesdir=#{CREW_PREFIX}/libexec/rules.d \
+    -Dalsadatadir=#{CREW_PREFIX}/share/alsa-card-profile \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end
 
+  def self.check
+    # Only test failure is on armv7l:
+    # 39/50 thread-test                                                                                                   FAIL             4.02s   exit status 1
+    # >>> MALLOC_PERTURB_=232 MAKE_CHECK=1 /usr/local/tmp/crew/pulseaudio-14.2.tar.xz.dir/pulseaudio-14.2/builddir/src/tests/thread-test
+    # ――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――
+    # stdout:
+    # Running suite(s): Thread
+    # 0%: Checks: 1, Failures: 0, Errors: 1
+    # ../src/tests/thread-test.c:108:E:thread:thread_test:0: (after this point) Test timeout expired
+    # stderr:
+    # loop-init
+    # once!
+    system 'ninja -C builddir test || true'
+  end
+
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    @pulseaudio_daemon_conf = <<~PAUDIO_DAEMON_CONF_HEREDOC
+      # Replace these with the proper values
+      exit-idle-time = 10 # Exit as soon as unneeded
+      flat-volumes = yes # Prevent messing with the master volume
+    PAUDIO_DAEMON_CONF_HEREDOC
+    IO.write("#{CREW_DEST_PREFIX}/etc/pulse/daemon.conf", @pulseaudio_daemon_conf, perm: 0o555)
+    @pulseaudio_client_conf = <<~PAUDIO_CLIENT_CONF_HEREDOC
+      # Replace these with the proper values
+
+      # Applications that uses PulseAudio *directly* will spawn it,
+      # use it, and pulse will exit itself when done because of the
+      # exit-idle-time setting in daemon.conf
+      autospawn = yes
+    PAUDIO_CLIENT_CONF_HEREDOC
+    IO.write("#{CREW_DEST_PREFIX}/etc/pulse/client.conf", @pulseaudio_client_conf, perm: 0o555)
+    @pulseaudio_default_pa = <<~PAUDIO_DEFAULT_PA_HEREDOC
+      # Replace the *entire* content of this file with these few lines and
+      # read the comments
+
+      .fail
+          # Set tsched=0 here if you experience glitchy playback. This will
+          # revert back to interrupt-based scheduling and should fix it.
+          #
+          # Replace the device= part if you want pulse to use a specific device
+          # such as "dmix" and "dsnoop" so it doesn't lock an hw: device.
+
+          # INPUT/RECORD
+          load-module module-alsa-source device="default" tsched=1
+
+          # OUTPUT/PLAYBACK
+          load-module module-alsa-sink device="default" tsched=1
+
+          # Accept clients -- very important
+          load-module module-native-protocol-unix
+
+      .nofail
+      .ifexists module-x11-publish.so
+          # Publish to X11 so the clients know how to connect to Pulse. Will
+          # clear itself on unload.
+          load-module module-x11-publish
+      .endif
+    PAUDIO_DEFAULT_PA_HEREDOC
+    IO.write("#{CREW_DEST_PREFIX}/etc/pulse/default.pa", @pulseaudio_default_pa, perm: 0o555)
   end
 end

--- a/packages/webrtc_audio_processing.rb
+++ b/packages/webrtc_audio_processing.rb
@@ -12,12 +12,12 @@ class Webrtc_audio_processing < Package
   binary_url({
     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-1.0-8ac0-chromeos-armv7l.tar.xz',
      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-1.0-8ac0-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-1.0-8ac0-chromeos-x86_64.tar.xz'
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew//webrtc_audio_processing-1.0-8ac0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
     aarch64: 'e912396b63680e7a7fc0608310e420d6968a8cd0405e1bfea3111afd40d6786c',
      armv7l: 'e912396b63680e7a7fc0608310e420d6968a8cd0405e1bfea3111afd40d6786c',
-     x86_64: '800d2d86e111b34191d0c29ebb33a6e0d9b09e3334363c7a7bb926fe4734c308'
+     x86_64: '8570e9f6c376a0dd0b477ab87d80f65ebc3f5ab0414af499aeb82a4467876a1c'
   })
 
   depends_on 'abseil_cpp'

--- a/packages/webrtc_audio_processing.rb
+++ b/packages/webrtc_audio_processing.rb
@@ -3,40 +3,38 @@ require 'package'
 class Webrtc_audio_processing < Package
   description 'AudioProcessing library based on Googles implementation of WebRTC'
   homepage 'https://freedesktop.org/software/pulseaudio/webrtc-audio-processing/'
-  @_ver = '1.0'
-  version "#{@_ver}-8ac0"
-  compatibility 'aarch64,armv7l,x86_64'
-  source_url 'https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/archive/8ac052ad6ffd5ba1328c44160ec6571dfd9b930d/webrtc-audio-processing-8ac052ad6ffd5ba1328c44160ec6571dfd9b930d.tar.bz2'
+  @_ver = '0.3.1'
+  version @_ver
+  compatibility 'all'
+  source_url 'https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/archive/v0.3.1/webrtc-audio-processing-v0.3.1.tar.bz2'
   source_sha256 '70d56051f73e8e4ac95fb392ce15de6c633b2c3ae492359aecc72fc663c9bdda'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-1.0-8ac0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-1.0-8ac0-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew//webrtc_audio_processing-1.0-8ac0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-0.3.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-0.3.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-0.3.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-0.3.1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'e912396b63680e7a7fc0608310e420d6968a8cd0405e1bfea3111afd40d6786c',
-     armv7l: 'e912396b63680e7a7fc0608310e420d6968a8cd0405e1bfea3111afd40d6786c',
-     x86_64: '8570e9f6c376a0dd0b477ab87d80f65ebc3f5ab0414af499aeb82a4467876a1c'
+    aarch64: 'dd57ac67021298092cd969fc347a277158662a2aeff1dd4f0f21dfa2f8d52f8f',
+     armv7l: 'dd57ac67021298092cd969fc347a277158662a2aeff1dd4f0f21dfa2f8d52f8f',
+       i686: 'c03f83448134a4c6b9a647a1ac10d14455c3500b8b661d506265ba3ecf1364c0',
+     x86_64: 'c18e97b21ba7472d92e2746da7c377e21198da23a01f218ec268241742ee5820'
   })
 
   depends_on 'abseil_cpp'
 
-  def self.patch
-    system "sed -i '/vector/a #include <memory>' webrtc/modules/audio_processing/aec3/reverb_model_estimator.h"
-  end
-
   def self.build
-    system "meson \
-    #{CREW_MESON_LTO_OPTIONS} \
-    -Dc_std=c17 \
-    -Dcpp_std=c++17 \
-     builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system 'filefix'
+    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto -std=c++17' \
+     LDFLAGS='-flto=auto' \
+     ./configure \
+     #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/webrtc_audio_processing.rb
+++ b/packages/webrtc_audio_processing.rb
@@ -1,0 +1,42 @@
+require 'package'
+
+class Webrtc_audio_processing < Package
+  description 'AudioProcessing library based on Googles implementation of WebRTC'
+  homepage 'https://freedesktop.org/software/pulseaudio/webrtc-audio-processing/'
+  @_ver = '1.0'
+  version "#{@_ver}-8ac0"
+  compatibility 'aarch64,armv7l,x86_64'
+  source_url 'https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/archive/8ac052ad6ffd5ba1328c44160ec6571dfd9b930d/webrtc-audio-processing-8ac052ad6ffd5ba1328c44160ec6571dfd9b930d.tar.bz2'
+  source_sha256 '70d56051f73e8e4ac95fb392ce15de6c633b2c3ae492359aecc72fc663c9bdda'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-1.0-8ac0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-1.0-8ac0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/webrtc_audio_processing-1.0-8ac0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'e912396b63680e7a7fc0608310e420d6968a8cd0405e1bfea3111afd40d6786c',
+     armv7l: 'e912396b63680e7a7fc0608310e420d6968a8cd0405e1bfea3111afd40d6786c',
+     x86_64: '800d2d86e111b34191d0c29ebb33a6e0d9b09e3334363c7a7bb926fe4734c308'
+  })
+
+  depends_on 'abseil_cpp'
+
+  def self.patch
+    system "sed -i '/vector/a #include <memory>' webrtc/modules/audio_processing/aec3/reverb_model_estimator.h"
+  end
+
+  def self.build
+    system "meson \
+    #{CREW_MESON_LTO_OPTIONS} \
+    -Dc_std=c17 \
+    -Dcpp_std=c++17 \
+     builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end


### PR DESCRIPTION
- This adds webrtc echo cancellation to pulseaudio.
- This lets flatpak output to pulseaudio
- BUT still no connection between pulseaudio and alsa.
- also adds abseil_cpp, which is needed for webrtc
- this WILL overwrite the default pulseaudio configs... but if that isn't working for anyone anyways....
- testing is reenabled in pukseaudio.

FYI
- Newer versions of webrtc are broken on i686, and also don't work with pulseaudio yet.

**Please help me get pulseaudio outputting to alsa devices...**

Works properly:
- [x] x86_64

Comnpiles properly:
- [x] x86_64
- [x] i686
- [x] armv7l
