### PR TITLE
Glib 2.67.4 + gtk3 binary add

### DIFF
--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,22 +3,22 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  version '2.67.3'
+  version '2.67.4'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/glib/2.67/glib-2.67.3.tar.xz'
-  source_sha256 'b8e5f7397bc399d8134f3cdab7323b2210dd202510cf62a517e00dcca3488b78'
+  source_url 'https://download.gnome.org/sources/glib/2.67/glib-2.67.4.tar.xz'
+  source_sha256 '8d87b962032dadfcae8df62d248aa91fed2c7a43faf2c6d8b9107eb6c50e5b14'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.4-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '9d38ac3744e0ce1477d804a4404a841df8df298df1d639206f16830e0c5e9f20',
-     armv7l: '9d38ac3744e0ce1477d804a4404a841df8df298df1d639206f16830e0c5e9f20',
-       i686: '100eec0254ae2ffc34d3903da688f740bad38fec9ac3e443a2bb9c75d76337f3',
-     x86_64: 'f31c6a72ee5495d2121983ee475475f45b03918e7f01f5115c4047ff216c7b82'
+    aarch64: '7d15e68503124e82d4ad52755dda9ff290572c84d17fc7d56d6eebdb4e261ae3',
+     armv7l: '7d15e68503124e82d4ad52755dda9ff290572c84d17fc7d56d6eebdb4e261ae3',
+       i686: '9031f7b19185505460005ea15589a6e52f7cc5ace50760b9154772d1c8951244',
+     x86_64: '1d2e776143a13ea6b2e6b12709f72f4be628e55323dd39cea69ba0a7e92c43ca'
   })
 
   depends_on 'shared_mime_info'

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -7,9 +7,21 @@ class Gtk3 < Package
   version @_ver
   compatibility 'all'
   source_url "https://download.gnome.org/sources/gtk+/3.24/gtk+-#{@_ver}.tar.xz"
-  source_sha256 `curl -Ls https://download.gnome.org/sources/gtk+/3.24/gtk+-#{@_ver}.sha256sum |\
-                 tail -n1 | cut -d ' ' -f1`.chomp
-  
+  source_sha256 '87e26b111d3b8a85ff218980a56f3e814257b8dd11e5c4d9a2803b423b08297c'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.25-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.25-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.25-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.25-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '2ac48ac4e7afae50082113a5ee02887e8e275a63caa551308009e4778eef8509',
+     armv7l: '2ac48ac4e7afae50082113a5ee02887e8e275a63caa551308009e4778eef8509',
+       i686: '6295abdfb026ea717b3e46b5cf86b42228e223c2e92160263cc36974eaf0a340',
+     x86_64: '274d6fd9d16cd2a4dc60a07b9212fb643851c37fe788f373ba46b644ba5272dc'
+  })
+
   depends_on 'cups'
   depends_on 'at_spi2_atk'
   depends_on 'gnome_icon_theme'
@@ -28,8 +40,7 @@ class Gtk3 < Package
   depends_on 'graphite'
 
   def self.build
-    system "env CFLAGS='-fuse-ld=lld' CXXFLAGS='-fuse-ld=lld' \
-            meson #{CREW_MESON_LTO_OPTIONS} \
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
             -Dbroadway_backend=true \
             -Dgtk_doc=false \
             -Ddemos=false \
@@ -37,13 +48,13 @@ class Gtk3 < Package
             builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
-    @file = <<~EOF
+    @file = <<~GTK3_CONFIG_HEREDOC
       [Settings]
       gtk-application-prefer-dark-theme = false
       gtk-icon-theme-name = hicolor
       gtk-fallback-icon-theme = gnome
       gtk-font-name = Arial 10
-    EOF
+    GTK3_CONFIG_HEREDOC
   end
 
   def self.install


### PR DESCRIPTION
- add binaries to gtk3, lint package file, add hash to package file
- update glib

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686