### PR TITLE
Default bin/python to python3

### DIFF
--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -65,5 +65,9 @@ class Python27 < Package
     #puts "Upgrading pip...".lightblue
     #system 'pip2 install --upgrade pip'
     #puts
+    if File.exist? "#{CREW_PREFIX}/bin/python3" 
+      FileUtils.rm "#{CREW_PREFIX}/bin/python"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/python3","#{CREW_PREFIX}/bin/python"
+    end
   end
 end

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -67,7 +67,7 @@ class Python27 < Package
     #puts
     FileUtils.ln_sf "#{CREW_PREFIX}/bin/python3", "#{CREW_PREFIX}/bin/python" \
       if File.exist? "#{CREW_PREFIX}/bin/python3"
-    FileUtils.cp "#{CREW_PREFIX}/bin/pip3", "#{CREW_PREFIX}/bin/pip" \
+    FileUtils.ln_sf "#{CREW_PREFIX}/bin/pip3", "#{CREW_PREFIX}/bin/pip" \
       if File.exist? "#{CREW_PREFIX}/bin/pip3"
   end
 end

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -65,9 +65,9 @@ class Python27 < Package
     #puts "Upgrading pip...".lightblue
     #system 'pip2 install --upgrade pip'
     #puts
-    if File.exist? "#{CREW_PREFIX}/bin/python3" 
-      FileUtils.rm "#{CREW_PREFIX}/bin/python"
-      FileUtils.ln_s "#{CREW_PREFIX}/bin/python3","#{CREW_PREFIX}/bin/python"
-    end
+    FileUtils.ln_sf "#{CREW_PREFIX}/bin/python3", "#{CREW_PREFIX}/bin/python" \
+      if File.exist? "#{CREW_PREFIX}/bin/python3"
+    FileUtils.cp "#{CREW_PREFIX}/bin/pip3", "#{CREW_PREFIX}/bin/pip" \
+      if File.exist? "#{CREW_PREFIX}/bin/pip3"
   end
 end


### PR DESCRIPTION
- Python2 is deprecated. Set default to python3.
- We will have to fix packages as people complain, but this is better than defaulting to a package no longer updated.
- This makes no changes to the binaries in the python 2.7 package.
- Should we also default pip to pip3 and leave pip2 as the version for python2?

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l