### PR TITLE
Python3 updates

### DIFF
--- a/packages/gdbm.rb
+++ b/packages/gdbm.rb
@@ -3,31 +3,30 @@ require 'package'
 class Gdbm < Package
   description 'GNU dbm is a set of database routines that use extensible hashing.'
   homepage 'https://www.gnu.org/software/gdbm/'
-  version '1.18.1'
+  @_ver = '1.19'
+  version @_ver
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/gdbm/gdbm-1.18.1.tar.gz'
-  source_sha256 '86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc'
+  source_url "https://ftpmirror.gnu.org/gdbm/gdbm-#{@_ver}.tar.gz"
+  source_sha256 '37ed12214122b972e18a0d94995039e57748191939ef74115b1d41d8811364bc'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.18.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.18.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.18.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.18.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.19-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.19-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.19-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gdbm-1.19-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'b7d1eefc792b5250b4a1e1c6cf7845cb965944c5f2f4468b63201e6dc7374d66',
-     armv7l: 'b7d1eefc792b5250b4a1e1c6cf7845cb965944c5f2f4468b63201e6dc7374d66',
-       i686: '60deef61ee53f9aab9a94767a8902ee29920302e113ca115567f3b2d428ae582',
-     x86_64: 'b52cde5502c9bf35fe485776d976d1a44a872e2ffee8964297ac2fe3ef0d064e',
+  binary_sha256({
+    aarch64: '34ed01ff6f5ce4af6e8d89f54acbd74cd2b33c585c4409d5d6d77fcbedf0562b',
+     armv7l: '34ed01ff6f5ce4af6e8d89f54acbd74cd2b33c585c4409d5d6d77fcbedf0562b',
+       i686: '1042907927b4b62f49ec959f317273b27a380d264a5ea690070b4643528e33f8',
+     x86_64: '79ffa73dfefefdec13bfd9ccaac27f24e6bd6b86da4efd6b0544f45a6828ad51'
   })
-
-  depends_on 'readline'
 
   def self.build
-    system './configure',
-           '--disable-static',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -108,8 +108,7 @@ class Python3 < Package
     puts 'Upgrading pip...'.lightblue
     system "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} python3 get-pip.py -U"
     puts 'Setting Python3 as default python...'.lightblue
-    FileUtils.ln_s "#{CREW_PREFIX}/bin/python3", "#{CREW_PREFIX}/bin/python"
-    FileUtils.rm "#{CREW_PREFIX}/bin/pip"
-    FileUtils.cp "#{CREW_PREFIX}/bin/pip3", "#{CREW_PREFIX}/bin/pip"
+    FileUtils.ln_sf "#{CREW_PREFIX}/bin/python3", "#{CREW_PREFIX}/bin/python"
+    FileUtils.ln_sf "#{CREW_PREFIX}/bin/pip3", "#{CREW_PREFIX}/bin/pip"
   end
 end

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -108,7 +108,6 @@ class Python3 < Package
     puts 'Upgrading pip...'.lightblue
     system "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} python3 get-pip.py -U"
     puts 'Setting Python3 as default python...'.lightblue
-    FileUtils.rm "#{CREW_PREFIX}/bin/python"
     FileUtils.ln_s "#{CREW_PREFIX}/bin/python3", "#{CREW_PREFIX}/bin/python"
     FileUtils.rm "#{CREW_PREFIX}/bin/pip"
     FileUtils.cp "#{CREW_PREFIX}/bin/pip3", "#{CREW_PREFIX}/bin/pip"

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -3,22 +3,23 @@ require 'package'
 class Python3 < Package
   description 'Python is a programming language that lets you work quickly and integrate systems more effectively.'
   homepage 'https://www.python.org/'
-  version '3.9.1-1'
+  @_ver = '3.9.2'
+  version @_ver
   compatibility 'all'
-  source_url 'https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz'
-  source_sha256 '991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff'
+  source_url "https://www.python.org/ftp/python/#{@_ver}/Python-#{@_ver}.tar.xz"
+  source_sha256 '3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.1-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.1-1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.1-1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.1-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/python3-3.9.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '5c2ba15dd9a1faf833650194d581edeccfd026bc3d0dcfabb4f91d67bc2bd4a6',
-      armv7l: '5c2ba15dd9a1faf833650194d581edeccfd026bc3d0dcfabb4f91d67bc2bd4a6',
-        i686: 'aa8499cf18b0879e0912ff8890389a2a6f3b242e92af23b53466b8f107da707b',
-      x86_64: 'cdad81e681b3dc40ef54e7190ef23167e1036ecd3c0530fca9cf9666c93234bd',
+  binary_sha256({
+    aarch64: '83b292381a6fcda63f3c8c6c4b682694be673b42ed14eb1482e5cfe6f1c0f835',
+     armv7l: '83b292381a6fcda63f3c8c6c4b682694be673b42ed14eb1482e5cfe6f1c0f835',
+       i686: '8f3ba22ea8824a958aafe9127e8fa078406323a6d9785e2986d3dc4ac45f671a',
+     x86_64: 'd3195034ad9d26e9e4c0c08c35bff6f551cc5661b970284c96deb81f32d34fb8'
   })
 
   depends_on 'bz2'
@@ -26,6 +27,8 @@ class Python3 < Package
   depends_on 'sqlite'
   depends_on 'krb5'
   depends_on 'libtirpc'
+  depends_on 'tk' => :build # yes this creates a circular dependency.
+  depends_on 'gdbm' => :build
 
   def self.preinstall
     # Fix ImportError: cannot import name 'PackageFinder'.
@@ -33,53 +36,65 @@ class Python3 < Package
     FileUtils.rm_rf Dir.glob("#{CREW_PREFIX}/lib/python3.9/site-packages/pip*")
   end
 
-  # Using /tmp breaks test_distutils, test_subprocess.
-  # Proxy setting breaks test_httpservers, test_ssl,
-  # test_urllib, test_urllib2, test_urllib2_localnet.
-  # So, modifying environment variable to make pass tests.
-  ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
-
   def self.build
     # IMPORTANT: Do not build with python3 already installed or pip3 will not be included.
+    raise StandardError, 'Please remove python3 before building.' if File.exist?("#{CREW_PREFIX}/bin/python3")
+
+    @cppflags = "-fno-semantic-interposition -I#{CREW_PREFIX}/include/ncursesw"
     # python requires /usr/local/lib, so leave as is but specify -rpath
-    system './configure', "CPPFLAGS=-I#{CREW_PREFIX}/include/ncurses -I#{CREW_PREFIX}/include/ncursesw",
-      "LDFLAGS=-Wl,-rpath,-L#{CREW_LIB_PREFIX}",
-      '--with-ensurepip=install',
-      '--enable-optimizations',
-      '--enable-shared'
+    @ldflags = "-fno-semantic-interposition -Wl,-rpath,-L#{CREW_LIB_PREFIX}"
+
+    # Using /tmp breaks test_distutils, test_subprocess.
+    # Proxy setting breaks test_httpservers, test_ssl,
+    # test_urllib, test_urllib2, test_urllib2_localnet.
+    # So, modifying environment variable to make pass tests.
+
+    system "env TMPDIR=#{CREW_PREFIX}/tmp \
+      CFLAGS='' \
+      CXXFLAGS='' \
+      CC='gcc -pthread' \
+      CPPFLAGS='#{@cppflags}' \
+      LDFLAGS='#{@ldflags}' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --with-ensurepip=install \
+      --enable-optimizations \
+      --with-lto \
+      --with-platlibdir='lib#{CREW_LIB_SUFFIX}' \
+      --enable-shared"
     system 'make'
   end
 
   def self.check
     # Chromebook doesn't allow SIGHUP, so disable SIGHUP test
-    system "sed", "-i", "Lib/test/test_asyncio/test_events.py", "-e", "/Don't have SIGHUP/s/win32/linux/"
-    system "sed", "-i", "Lib/test/test_asyncio/test_subprocess.py", "-e", "/Don't have SIGHUP/s/win32/linux/"
+    system 'sed', '-i', 'Lib/test/test_asyncio/test_events.py', '-e', "/Don't have SIGHUP/s/win32/linux/"
+    system 'sed', '-i', 'Lib/test/test_asyncio/test_subprocess.py', '-e', "/Don't have SIGHUP/s/win32/linux/"
 
     # Chromebook returns EINVAL for F_NOTIFY DN_MULTISHOT, so disable test_fcntl_64_bit
-    system "sed", "-i", "Lib/test/test_fcntl.py", "-e", '/ARM Linux returns EINVAL for F_NOTIFY DN_MULTISHOT/s/$/\
+    system 'sed', '-i', 'Lib/test/test_fcntl.py', '-e', '/ARM Linux returns EINVAL for F_NOTIFY DN_MULTISHOT/s/$/\
     @unittest.skipIf(platform.system() == '"'Linux'"', "Chromeos returns EINVAL for F_NOTIFY DN_MULTISHOT")/'
 
     # imaplib test used to use a kind of security hole on a server in university and the hole is closed now.
     # See https://bugs.python.org/issue30175 and https://github.com/python/cpython/pull/1320/files for details.
-    system "sed", "-i", "Lib/test/test_imaplib.py",
-        "-e", '/test_logincapa_with_client_certfile/i\ \ \ \ @unittest.skipIf(True,\
+    system 'sed', '-i', 'Lib/test/test_imaplib.py',
+           '-e', '/test_logincapa_with_client_certfile/i\ \ \ \ @unittest.skipIf(True,\
                      "bpo-30175: FIXME: cyrus.andrew.cmu.edu doesn\'t accept "\
                      "our randomly generated client x509 certificate anymore")',
-        "-e", '/test_logincapa_with_client_ssl_context/i\ \ \ \ @unittest.skipIf(True,\
+           '-e', '/test_logincapa_with_client_ssl_context/i\ \ \ \ @unittest.skipIf(True,\
                      "bpo-30175: FIXME: cyrus.andrew.cmu.edu doesn\'t accept "\
                      "our randomly generated client x509 certificate anymore")'
 
     # Using /tmp breaks test_distutils, test_subprocess
     # Proxy setting breaks test_httpservers, test_ssl,
     # test_urllib, test_urllib2, test_urllib2_localnet
-    #system "TMPDIR=#{CREW_PREFIX}/tmp http_proxy= https_proxy= ftp_proxy= make test"
+    # system "TMPDIR=#{CREW_PREFIX}/tmp http_proxy= https_proxy= ftp_proxy= make test"
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
 
     # remove static libraries
-    system "find #{CREW_DEST_PREFIX} -name 'libpython*.a' -print | xargs -r rm"
+    # system "find #{CREW_DEST_PREFIX} -name 'libpython*.a' -print | xargs -r rm"
 
     # create symbolic links in lib64 for other applications which use libpython
     unless Dir.exist? CREW_DEST_LIB_PREFIX
@@ -90,8 +105,12 @@ class Python3 < Package
 
   def self.postinstall
     puts
-    puts "Upgrading pip...".lightblue
+    puts 'Upgrading pip...'.lightblue
     system "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} python3 get-pip.py -U"
-    puts
+    puts 'Setting Python3 as default python...'.lightblue
+    FileUtils.rm "#{CREW_PREFIX}/bin/python"
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/python3", "#{CREW_PREFIX}/bin/python"
+    FileUtils.rm "#{CREW_PREFIX}/bin/pip"
+    FileUtils.cp "#{CREW_PREFIX}/bin/pip3", "#{CREW_PREFIX}/bin/pip"
   end
 end

--- a/packages/tcl.rb
+++ b/packages/tcl.rb
@@ -3,24 +3,26 @@ require 'package'
 class Tcl < Package
   description 'Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language, suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more.'
   homepage 'http://www.tcl.tk/'
-  version '8.6.10-1'
+  @_ver = '8.6.11'
+  version @_ver
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/project/tcl/Tcl/8.6.10/tcl8.6.10-src.tar.gz'
-  source_sha256 '5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed'
+  source_url "https://downloads.sourceforge.net/project/tcl/Tcl/#{@_ver}/tcl#{@_ver}-src.tar.gz"
+  source_sha256 '8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.10-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.10-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.10-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.10-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.11-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.11-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.11-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tcl-8.6.11-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '0e41b09a26a2213ca6cab5ce257a591e067c005c980c0781511d52af1caca117',
-     armv7l: '0e41b09a26a2213ca6cab5ce257a591e067c005c980c0781511d52af1caca117',
-       i686: '7ba00dfdf973d0cef0b32f73e1a6f29856836b523ff7de021e598db3a2ab4127',
-     x86_64: '83c4b53eedb3ea5c7497884749ef7492c5bd547cf32c2afad0f76250d0c8c410',
+  binary_sha256({
+    aarch64: 'd1a9f91c71af31f9c862ae92836a9ec4c84c9d0213c1ce85d996a69213e1be7c',
+     armv7l: 'd1a9f91c71af31f9c862ae92836a9ec4c84c9d0213c1ce85d996a69213e1be7c',
+       i686: '6581a445fa9c0a57b66bd4f32cac09f6b9e3a002b377e97163cfba10ff73f230',
+     x86_64: '502238e6785c264e145b19fec1267104a839ecd4ab6cce9e21802810c601e591'
   })
 
+  # tk breaks if tcl is built with lto
   def self.build
     FileUtils.chdir('unix') do
       if ARCH == 'x86_64'
@@ -40,10 +42,14 @@ class Tcl < Package
       FileUtils.ln_s "#{CREW_LIB_PREFIX}/itcl4.2.0/libitcl4.2.0.so", "#{CREW_DEST_LIB_PREFIX}/libitcl4.2.0.so"
       FileUtils.ln_s "#{CREW_LIB_PREFIX}/tdbc1.1.1/libtdbc1.1.1.so", "#{CREW_DEST_LIB_PREFIX}/libtdbc1.1.1.so"
       FileUtils.ln_s "#{CREW_LIB_PREFIX}/thread2.8.5/libthread2.8.5.so", "#{CREW_DEST_LIB_PREFIX}/libthread2.8.5.so"
-      FileUtils.ln_s "#{CREW_LIB_PREFIX}/tdbcodbc1.1.1/libtdbcodbc1.1.1.so", "#{CREW_DEST_LIB_PREFIX}/libtdbcodbc1.1.1.so"
-      FileUtils.ln_s "#{CREW_LIB_PREFIX}/sqlite3.30.1.2/libsqlite3.30.1.2.so", "#{CREW_DEST_LIB_PREFIX}/libsqlite3.30.1.2.so"
-      FileUtils.ln_s "#{CREW_LIB_PREFIX}/tdbcmysql1.1.1/libtdbcmysql1.1.1.so", "#{CREW_DEST_LIB_PREFIX}/libtdbcmysql1.1.1.so"
-      FileUtils.ln_s "#{CREW_LIB_PREFIX}/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.so", "#{CREW_DEST_LIB_PREFIX}/libtdbcpostgres1.1.1.so"
+      FileUtils.ln_s "#{CREW_LIB_PREFIX}/tdbcodbc1.1.1/libtdbcodbc1.1.1.so",
+                     "#{CREW_DEST_LIB_PREFIX}/libtdbcodbc1.1.1.so"
+      FileUtils.ln_s "#{CREW_LIB_PREFIX}/sqlite3.30.1.2/libsqlite3.30.1.2.so",
+                     "#{CREW_DEST_LIB_PREFIX}/libsqlite3.30.1.2.so"
+      FileUtils.ln_s "#{CREW_LIB_PREFIX}/tdbcmysql1.1.1/libtdbcmysql1.1.1.so",
+                     "#{CREW_DEST_LIB_PREFIX}/libtdbcmysql1.1.1.so"
+      FileUtils.ln_s "#{CREW_LIB_PREFIX}/tdbcpostgres1.1.1/libtdbcpostgres1.1.1.so",
+                     "#{CREW_DEST_LIB_PREFIX}/libtdbcpostgres1.1.1.so"
     end
   end
 end

--- a/packages/tk.rb
+++ b/packages/tk.rb
@@ -32,9 +32,7 @@ class Tk < Package
           CXXFLAGS='-flto=auto -pipe -fuse-ld=gold' \
           LDFLAGS='-flto=auto' \
           ./configure \
-          --prefix=#{CREW_PREFIX} \
-          --libdir=#{CREW_LIB_PREFIX} \
-          --mandir=#{CREW_PREFIX}/share/man \
+          #{CREW_OPTIONS} \
           --with-tcl=#{CREW_LIB_PREFIX} \
           --enable-threads \
           --enable-64bit"
@@ -43,9 +41,7 @@ class Tk < Package
           CXXFLAGS='-flto=auto -pipe -fuse-ld=gold' \
           LDFLAGS='-flto=auto' \
           ./configure \
-          --prefix=#{CREW_PREFIX} \
-          --libdir=#{CREW_LIB_PREFIX} \
-          --mandir=#{CREW_PREFIX}/share/man \
+          #{CREW_OPTIONS} \
           --with-tcl=#{CREW_LIB_PREFIX} \
           --enable-threads \
           --disable-64bit"

--- a/packages/tk.rb
+++ b/packages/tk.rb
@@ -3,22 +3,23 @@ require 'package'
 class Tk < Package
   description 'Tk is a graphical user interface toolkit that takes developing desktop applications to a higher level than conventional approaches.'
   homepage 'http://www.tcl.tk/'
-  version '8.6.10'
+  @_ver = '8.6.11'
+  version @_ver
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/project/tcl/Tcl/8.6.10/tk8.6.10-src.tar.gz'
-  source_sha256 '63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386'
+  source_url "https://downloads.sourceforge.net/project/tcl/Tcl/#{@_ver}/tk#{@_ver}-src.tar.gz"
+  source_sha256 '5228a8187a7f70fa0791ef0f975270f068ba9557f57456f51eb02d9d4ea31282'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.10-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.10-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.10-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.10-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.11-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.11-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.11-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tk-8.6.11-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '6d785178ad707132d9afdec648b992717d48690497da95d3969629b208e38f96',
-     armv7l: '6d785178ad707132d9afdec648b992717d48690497da95d3969629b208e38f96',
-       i686: '3ec13ce5720f008c8075fa8a6965b4a764f0993d9dadda2aa9268af2a563c400',
-     x86_64: 'd75b2657048e3f258826eb8ff1d9d4924021fe7869c41a6ac618a2df7df281ca',
+  binary_sha256({
+    aarch64: 'a8866147a504c56cd834f71e078d6ca080f52873e673cbc55c7a7939991c6d3b',
+     armv7l: 'a8866147a504c56cd834f71e078d6ca080f52873e673cbc55c7a7939991c6d3b',
+       i686: '8a4afe834eaf7fb966714513becbde55e10125e1c3018e2db61aabb5565526fe',
+     x86_64: 'dac36fa0385f8958676b71ee2dc10278fa7e5ebf7aa6ae3a3e04ea1b85fa9443'
   })
 
   depends_on 'xorg_lib'
@@ -27,21 +28,27 @@ class Tk < Package
   def self.build
     FileUtils.chdir('unix') do
       if ARCH == 'x86_64'
-        system './configure',
-               "--prefix=#{CREW_PREFIX}",
-               "--libdir=#{CREW_LIB_PREFIX}",
-               "--mandir=#{CREW_PREFIX}/share/man",
-               "--with-tcl=#{CREW_LIB_PREFIX}",
-               '--enable-threads',
-               '--enable-64bit'
+        system "env CFLAGS='-flto=auto -pipe -fuse-ld=gold' \
+          CXXFLAGS='-flto=auto -pipe -fuse-ld=gold' \
+          LDFLAGS='-flto=auto' \
+          ./configure \
+                 --prefix=#{CREW_PREFIX} \
+                 --libdir=#{CREW_LIB_PREFIX} \
+                 --mandir=#{CREW_PREFIX}/share/man \
+                 --with-tcl=#{CREW_LIB_PREFIX} \
+                 --enable-threads \
+                 --enable-64bit"
       else
-        system './configure',
-               "--prefix=#{CREW_PREFIX}",
-               "--libdir=#{CREW_LIB_PREFIX}",
-               "--mandir=#{CREW_PREFIX}/share/man",
-               "--with-tcl=#{CREW_LIB_PREFIX}",
-               '--enable-threads',
-               '--disable-64bit'
+        system "env CFLAGS='-flto=auto -pipe -fuse-ld=gold' \
+          CXXFLAGS='-flto=auto -pipe -fuse-ld=gold' \
+          LDFLAGS='-flto=auto' \
+          ./configure \
+                 --prefix=#{CREW_PREFIX} \
+                 --libdir=#{CREW_LIB_PREFIX} \
+                 --mandir=#{CREW_PREFIX}/share/man \
+                 --with-tcl=#{CREW_LIB_PREFIX} \
+                 --enable-threads \
+                 --disable-64bit"
       end
       system 'make'
     end

--- a/packages/tk.rb
+++ b/packages/tk.rb
@@ -32,23 +32,23 @@ class Tk < Package
           CXXFLAGS='-flto=auto -pipe -fuse-ld=gold' \
           LDFLAGS='-flto=auto' \
           ./configure \
-                 --prefix=#{CREW_PREFIX} \
-                 --libdir=#{CREW_LIB_PREFIX} \
-                 --mandir=#{CREW_PREFIX}/share/man \
-                 --with-tcl=#{CREW_LIB_PREFIX} \
-                 --enable-threads \
-                 --enable-64bit"
+          --prefix=#{CREW_PREFIX} \
+          --libdir=#{CREW_LIB_PREFIX} \
+          --mandir=#{CREW_PREFIX}/share/man \
+          --with-tcl=#{CREW_LIB_PREFIX} \
+          --enable-threads \
+          --enable-64bit"
       else
         system "env CFLAGS='-flto=auto -pipe -fuse-ld=gold' \
           CXXFLAGS='-flto=auto -pipe -fuse-ld=gold' \
           LDFLAGS='-flto=auto' \
           ./configure \
-                 --prefix=#{CREW_PREFIX} \
-                 --libdir=#{CREW_LIB_PREFIX} \
-                 --mandir=#{CREW_PREFIX}/share/man \
-                 --with-tcl=#{CREW_LIB_PREFIX} \
-                 --enable-threads \
-                 --disable-64bit"
+          --prefix=#{CREW_PREFIX} \
+          --libdir=#{CREW_LIB_PREFIX} \
+          --mandir=#{CREW_PREFIX}/share/man \
+          --with-tcl=#{CREW_LIB_PREFIX} \
+          --enable-threads \
+          --disable-64bit"
       end
       system 'make'
     end


### PR DESCRIPTION
- updates for gdbm, tcl, tk (python was complaining about them not being available.)
- Python -> 3.9.2
- compiled with lto enabled
- compiled with ```-fno-semantic-interposition``` as per [redhat](https://bugzilla.redhat.com/show_bug.cgi?id=1779341) there is a 27% speed improvement at the expense of a longer compile time.

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l