### PR TITLE
Use mawk instead of gawk

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -46,7 +46,7 @@ class Buildessential < Package
   depends_on 'util_macros'
   depends_on 'gettext'
   depends_on 'wget' # in some cases, patches might be required and can be downloaded using wget
-  depends_on 'gawk'
+  depends_on 'mawk'
 
   # compression utilities
   depends_on 'lzip'

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.8'
+  version '1.8-1'
   compatibility 'all'
 
   is_fake

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.8-1'
+  version '1.9'
   compatibility 'all'
 
   is_fake

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -16,7 +16,6 @@ doxygen
 expat
 filecmd
 flex
-gawk
 gcc10
 gcc_tools
 gdbm
@@ -59,6 +58,7 @@ m4
 make
 mandb
 manpages
+mawk
 meson
 most
 mpc


### PR DESCRIPTION
So this might seem like a really weird change, but it has its place.
`gawk` is the GNU awk interpreter. It has features that POSIX awk doesn't have like network access, however these aren't needed by any configure script I've seen.
`mawk` is a POSIX compatible awk interpreter from the debian project. It runs, in my tests, about twice as fast as `gawk` and works in every configure script in place of `gawk`. I've been testing this for about two weeks now and haven't run into a problem.

If you're worried about packages requiring `gawk` specifically, I only found one, `translate_shell`, and it needs `gawk` for execution as its binaries are written in awk. Configure scripts and makefiles run way faster with `mawk`.

Should this be merged, I'll update `mawk`'s package file with a symlink linking `mawk` with `awk` for compatibility purposes with scripts as `gawk` is currently linked, and update `translate_shell`'s dependency list as well.