### PR TITLE
Add pythons to buildessential

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,11 +3,10 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.8'
+  version '1.9'
   compatibility 'all'
 
   is_fake
-
 
   #install first to get ldconfig
   depends_on 'glibc'
@@ -58,6 +57,10 @@ class Buildessential < Package
 
   # xorg protocols headers
   #depends_on 'xorg_proto'
+  
+  # Python
+  depends_on 'python27'
+  depends_on 'python3'
 
   # maybe meson build system ?
   depends_on 'meson'


### PR DESCRIPTION
- Establish pythons as a core dependency of buildessential

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l