### PR TITLE
Crew options fixes

### DIFF
--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -4,29 +4,31 @@ class Aria2 < Package
   description 'aria2 is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.'
   homepage 'https://aria2.github.io/'
   @_ver = '1.35.0'
-  version @_ver + '-1'
+  version "#{@_ver}-2"
   compatibility 'all'
   source_url "https://github.com/aria2/aria2/releases/download/release-#{@_ver}/aria2-#{@_ver}.tar.xz"
   source_sha256 '1e2b7fd08d6af228856e51c07173cfcf987528f1ac97e04c5af4a47642617dfd'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/aria2-1.35.0-2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '423e0f0ce0893269aca65177a9eaee299eef8b1be2e728c77988ae3e9e741037',
-      armv7l: '423e0f0ce0893269aca65177a9eaee299eef8b1be2e728c77988ae3e9e741037',
-        i686: 'a083bbc6d31677f4eb795433bffbe75468783f0d2d3fe9d95db9140f09ab7ce2',
-      x86_64: '2a7c0fc6c91b8b4217d7b69b0fa607a963ecbf17c689008c989841c89a610160',
+  binary_sha256({
+    aarch64: 'b8082b1a4f9b8941f2891564046415abf544f113a452650d139c64253f4378f1',
+     armv7l: 'b8082b1a4f9b8941f2891564046415abf544f113a452650d139c64253f4378f1',
+       i686: '0e3b881cd0505eed0edb1ab898e5a272a3d9d950f9e9c9fd5ebc4d1d9a8c66d9',
+     x86_64: '20cb509c94ac4776c39172fbf8b13c80088249ab6deffce4c4eb6d40081bbd71'
   })
 
   depends_on 'libgcrypt'
 
   def self.build
     system "env CFLAGS='-fuse-ld=gold -flto' CXXFLAGS='-fuse-ld=gold -flto' \
+     LDFLAGS='-flto' \
      ./configure #{CREW_OPTIONS} \
+      --program-prefix='' --program-suffix='' \
       --without-libnettle \
       --with-libgcrypt \
       --disable-dependency-tracking"
@@ -35,6 +37,5 @@ class Aria2 < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    FileUtils.ln_s "#{CREW_PREFIX}/bin/#{CREW_BUILD}-aria2c", "#{CREW_DEST_PREFIX}/bin/aria2c"
   end
 end

--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -28,7 +28,6 @@ class Aria2 < Package
     system "env CFLAGS='-fuse-ld=gold -flto' CXXFLAGS='-fuse-ld=gold -flto' \
      LDFLAGS='-flto' \
      ./configure #{CREW_OPTIONS} \
-      --program-prefix='' --program-suffix='' \
       --without-libnettle \
       --with-libgcrypt \
       --disable-dependency-tracking"

--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -3,26 +3,33 @@ require 'package'
 class Libffi < Package
   description 'The libffi library provides a portable, high level programming interface to various calling conventions.'
   homepage 'https://sourceware.org/libffi/'
-  version '3.3'
+  version '3.3-1'
   compatibility 'all'
   source_url 'https://sourceware.org/pub/libffi/libffi-3.3.tar.gz'
   source_sha256 '72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libffi-3.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libffi-3.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libffi-3.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libffi-3.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libffi-3.3-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libffi-3.3-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libffi-3.3-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libffi-3.3-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '22a2ec5efcbcf5b587f34f35489ee0976f5a1ed256f47a4ac87a240f804c0d02',
-     armv7l: '22a2ec5efcbcf5b587f34f35489ee0976f5a1ed256f47a4ac87a240f804c0d02',
-       i686: '8041e3401d2b9721a2dd87d31aff2b1b5380f7946c092d9a3c18f573ca6422f8',
-     x86_64: 'aecc094eb0e5b961106ee3d4086f120a30555cb82b3b8263107d9cab4e6c278f',
+  binary_sha256({
+    aarch64: 'feed096aa4b48a2ccaa2be5f8998f775eeeab873fc2d582b06c15acd1a380d74',
+     armv7l: 'feed096aa4b48a2ccaa2be5f8998f775eeeab873fc2d582b06c15acd1a380d74',
+       i686: 'd76faf5d8917ad57be1414cdbd915a70f978494aac09fcdd73f80c3db8fb21e4',
+     x86_64: 'acd8ad06dbc7a6f83b8bdce10aa53b72817ab5468548bb4d09a715ab1b1b9b68'
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-shared --disable-static --with-pic --disable-debug --disable-dependency-tracking"
+    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure #{CREW_OPTIONS} \
+      --enable-shared \
+      --with-pic \
+      --disable-debug \
+      --disable-dependency-tracking \
+      --program-prefix='' --program-suffix='' "
     system 'make'
   end
 

--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -28,8 +28,7 @@ class Libffi < Package
       --enable-shared \
       --with-pic \
       --disable-debug \
-      --disable-dependency-tracking \
-      --program-prefix='' --program-suffix='' "
+      --disable-dependency-tracking"
     system 'make'
   end
 

--- a/packages/libmetalink.rb
+++ b/packages/libmetalink.rb
@@ -38,8 +38,7 @@ class Libmetalink < Package
       LDFLAGS='-flto=auto' \
       ./configure #{CREW_OPTIONS} \
       --with-libxml2\
-      --without-libexpat \
-      --program-prefix='' --program-suffix='' "
+      --without-libexpat"
     system 'make'
   end
 

--- a/packages/libmetalink.rb
+++ b/packages/libmetalink.rb
@@ -1,33 +1,32 @@
-
 require 'package'
 
 class Libmetalink < Package
   description 'libmetalink is a Metalink library written in C language.'
   homepage 'https://launchpad.net/libmetalink/'
   compatibility 'all'
-  version '0.1.3-1'
+  version '0.1.3-2'
   source_url 'https://launchpad.net/libmetalink/trunk/libmetalink-0.1.3/+download/libmetalink-0.1.3.tar.xz'
   source_sha256 '86312620c5b64c694b91f9cc355eabbd358fa92195b3e99517504076bf9fe33a'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libmetalink-0.1.3-2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '25b93f3304ee1cf1a06c582de5c053436322b08fb27a576d132130bf73ef436b',
-     armv7l: '25b93f3304ee1cf1a06c582de5c053436322b08fb27a576d132130bf73ef436b',
-       i686: 'd10d7a95750b93be70f457d6c5db8935e30f85a726bf154d2953d075bd28d216',
-     x86_64: '6e1e4b07e44e4b8cf1c436a6594f333bf339803c4c04a6c5a4f1762e00409479',
+  binary_sha256({
+    aarch64: 'b47564f58da6ce1215010fd9ad152a568f5cae15a466b43b59b871d1469efb25',
+     armv7l: 'b47564f58da6ce1215010fd9ad152a568f5cae15a466b43b59b871d1469efb25',
+       i686: 'f216916b8b89a717f923adb72f446c45c97c057347a71c1b7326224c49d25257',
+     x86_64: '01d87388e27c2d918fa29e885d2818956a7c42297df9d08da772f52f12ff5249'
   })
-
-  depends_on 'libxml2'
 
   def self.patch
     puts 'Downloading patch...'
     system 'curl', '--progress-bar', '-LO', 'https://launchpadlibrarian.net/380798344/0001-fix-covscan-issues.patch'
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('0001-fix-covscan-issues.patch') ) == 'd236dfa0d4a1938a40ff2ce4dd348c42b74ad68807df0f1b6ea69c11725fd9cf'
+    unless Digest::SHA256.hexdigest(File.read('0001-fix-covscan-issues.patch')) == 'd236dfa0d4a1938a40ff2ce4dd348c42b74ad68807df0f1b6ea69c11725fd9cf'
+      abort 'Checksum mismatch. :/ Try again.'.lightred
+    end
     puts 'Done!'.lightgreen
     puts 'Applying patch...'
     system 'patch', '-Np1', '-i', '0001-fix-covscan-issues.patch'
@@ -35,7 +34,12 @@ class Libmetalink < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --with-libxml2 --disable-static --without-libexpat"
+    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure #{CREW_OPTIONS} \
+      --with-libxml2\
+      --without-libexpat \
+      --program-prefix='' --program-suffix='' "
     system 'make'
   end
 

--- a/packages/mono.rb
+++ b/packages/mono.rb
@@ -31,15 +31,5 @@ class Mono < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
-      system "for f in \$(ls #{CREW_BUILD}-*); do g=\$(echo \$f | sed 's,#{CREW_BUILD}-,,'); ln -sf \$f \$g; done"
-      FileUtils.ln_sf "#{CREW_BUILD}-mono-sgen", 'mono'
-    end
-    Dir.chdir "#{CREW_DEST_MAN_PREFIX}/man1" do
-      system "for f in \$(ls #{CREW_BUILD}-*); do g=\$(echo \$f | sed 's,#{CREW_BUILD}-,,'); ln -sf \$f \$g; done"
-    end
-    Dir.chdir "#{CREW_DEST_MAN_PREFIX}/man5" do
-      system "for f in \$(ls #{CREW_BUILD}-*); do g=\$(echo \$f | sed 's,#{CREW_BUILD}-,,'); ln -sf \$f \$g; done"
-    end
   end
 end

--- a/packages/mono.rb
+++ b/packages/mono.rb
@@ -24,8 +24,7 @@ class Mono < Package
               --disable-maintainer-mode \
               --enable-ninja \
               --with-x \
-              --with-libgdiplus \
-              --program-prefix='' --program-suffix='' "
+              --with-libgdiplus"
     system 'make || make' # Make might fail the first time. This is a known upstream bug.
   end
 

--- a/packages/mono.rb
+++ b/packages/mono.rb
@@ -14,17 +14,18 @@ class Mono < Package
   depends_on 'imake' => :build
 
   def self.prebuild
-    system "if [ ! -f /proc/config.gz ]; then sudo modprobe configs -v; fi"
-    system "cat /proc/config.gz | gunzip | grep SYSVIPC=y || false" # Mono build hangs without this feature enabled.
+    system 'if [ ! -f /proc/config.gz ]; then sudo modprobe configs -v; fi'
+    system 'cat /proc/config.gz | gunzip | grep SYSVIPC=y || false' # Mono build hangs without this feature enabled.
   end
-  
+
   def self.build
     system "env XMKMF=#{CREW_PREFIX}/bin/xmkmf \
             ./configure #{CREW_OPTIONS} \
               --disable-maintainer-mode \
               --enable-ninja \
               --with-x \
-              --with-libgdiplus"
+              --with-libgdiplus \
+              --program-prefix='' --program-suffix='' "
     system 'make || make' # Make might fail the first time. This is a known upstream bug.
   end
 

--- a/packages/trousers.rb
+++ b/packages/trousers.rb
@@ -4,33 +4,32 @@ class Trousers < Package
   description 'The open-source TCG Software Stack.'
   homepage 'http://trousers.sourceforge.net/'
   @_ver = '0.3.15'
-  version @_ver
+  version "#{@_ver}-1"
   compatibility 'all'
   source_url "https://downloads.sourceforge.net/project/trousers/trousers/#{@_ver}/trousers-#{@_ver}.tar.gz"
   source_sha256 '1e5be93e518372acf1d92d2f567d01a46fdb0b730487e544e6fb896c59cac77f'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/trousers-0.3.15-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: 'd9f1c2a10973b25b26576c8c7c913b4ff898417a6f425732a81b22b4c8daa566',
-      armv7l: 'd9f1c2a10973b25b26576c8c7c913b4ff898417a6f425732a81b22b4c8daa566',
-        i686: 'bc2f18fada6ff3dc0203aa87d7a2e3b001d18db59aae3d094f2341bffa530c24',
-      x86_64: '40601f6366e0d308ece858293e0cc61fcc31ce568b796ea37beb3c3e34ab370f',
+  binary_sha256({
+    aarch64: '3f164e9a58f163ccb8105c8932a0aef22b15d1e425307948e80ea052c2b60989',
+     armv7l: '3f164e9a58f163ccb8105c8932a0aef22b15d1e425307948e80ea052c2b60989',
+       i686: '2f62ba92301c5fc9753b5d159b783bd00d109bac32e0b198309acee2ec01a2b2',
+     x86_64: 'ae6c76c54c1337dc41efc95b6017e45999a56a3470620420d95f76e7e671a0d2'
   })
-
-  depends_on 'openssl'
-  depends_on 'libtool'
-  depends_on 'pkgconfig'
 
   def self.build
-    system "./bootstrap.sh"
-    system "CFLAGS='-fcommon -flto -pipe' ./configure \
+    system './bootstrap.sh'
+    system "CFLAGS='-flto=auto' CXXFLAGS='-flto=auto'
+      LDFLAGS='-flto=auto' \
+      ./configure \
       #{CREW_OPTIONS} \
-      --with-gui=none"
+      --with-gui=none \
+      --program-prefix='' --program-suffix='' "
     system 'make'
   end
 

--- a/packages/trousers.rb
+++ b/packages/trousers.rb
@@ -28,8 +28,7 @@ class Trousers < Package
       LDFLAGS='-flto=auto' \
       ./configure \
       #{CREW_OPTIONS} \
-      --with-gui=none \
-      --program-prefix='' --program-suffix='' "
+      --with-gui=none"
     system 'make'
   end
 


### PR DESCRIPTION
- CREW_OPTIONS sometimes makes packages append the build info to the app binaries as prefixes.
- These packages have had configure options added to prevent that.
- Binaries added for all but Mono. (That should be done on actual hardware, as it errors out due to container protections.)


e.g.
Before:
```
chronos@localhost ~ $ crew files libffi
libffi: The libffi library provides a portable, high level programming interface to various calling conventions.
(snip)
/usr/local/share/man/man3/x86_64-cros-linux-gnu-ffi.3.gz
/usr/local/share/man/man3/x86_64-cros-linux-gnu-ffi_call.3.gz
/usr/local/share/man/man3/x86_64-cros-linux-gnu-ffi_prep_cif.3.gz
/usr/local/share/man/man3/x86_64-cros-linux-gnu-ffi_prep_cif_var.3.gz
```
After:
```
chronos@localhost ~ $ crew files libffi
libffi: The libffi library provides a portable, high level programming interface to various calling conventions.
(snip)
/usr/local/share/man/man3/ffi.3.gz
/usr/local/share/man/man3/ffi_call.3.gz
/usr/local/share/man/man3/ffi_prep_cif.3.gz
/usr/local/share/man/man3/ffi_prep_cif_var.3.gz
```

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686

There may be other packages affected.

Here's a quick script to find them:

```
#!/bin/bash
installed=$(crew list installed |  sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
for i in $installed
do 
  echo $i
  crew files "$i" | grep x86_64-cros-linux-gnu
done
```