### PR TITLE
fontconfig: keep postinstall failure from breaking other builds

### DIFF
--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -77,6 +77,8 @@ class Fontconfig < Package
       puts 'To complete the installation, execute the following:'.orange
       puts 'source ~/.bashrc'.orange
     end
-    system "env FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts fc-cache -fv"
+    # The following postinstall fails if graphite isn't installed when fontconfig
+    # is being installed.
+    system "env FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts fc-cache -fv || true"
   end
 end


### PR DESCRIPTION
- Despite fontconfig having a graphite dependency, if fontconfig is installed before graphite, the post-install will fail.
- This breaks other installs, so keep that post-install failure from breaking builds.
- The long term solution would be to unbreak dependency installs.

Works properly:
- [x] x86_64'
- [x] i686
- [x] armv7l