### PR TITLE
Added builds + deps for Gnome updates

### DIFF
--- a/packages/at_spi2_core.rb
+++ b/packages/at_spi2_core.rb
@@ -1,39 +1,37 @@
 require 'package'
-  
+
 class At_spi2_core < Package
   description 'This is over DBus, tookit widgets provide their content to screen readers such as Orca'
   homepage 'http://www.freedesktop.org/'
-  version '2.39.1'
+  version '2.39.90.1'
   compatibility 'all'
-  source_url 'https://github.com/GNOME/at-spi2-core/archive/AT_SPI2_CORE_2_39_1.tar.gz'
-  source_sha256 '01db93c5f145492e973ddbace66ce85f6487a1e0cdd1b0ecdb8b67e0fbda5a45'
+  source_url 'https://download.gnome.org/core/40/40.beta/sources/at-spi2-core-2.39.90.1.tar.xz'
+  source_sha256 '2e8a9098e64dc66478ca095d3ca91657626eb778dc75e64bff6294be7ceaa4ba'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/at_spi2_core-2.39.1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/at_spi2_core-2.39.1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/at_spi2_core-2.39.1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/at_spi2_core-2.39.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/at_spi2_core-2.39.90.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/at_spi2_core-2.39.90.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/at_spi2_core-2.39.90.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/at_spi2_core-2.39.90.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '601ffb2a4fa4d39fb0d91778b6d51e5b8cb6f1d594d816f663185bbc41946b64',
-      armv7l: '601ffb2a4fa4d39fb0d91778b6d51e5b8cb6f1d594d816f663185bbc41946b64',
-        i686: '212e32fbb4d303f51519b0f83673ad763b9e06eff185f6fffe2ce621068d68b3',
-      x86_64: '43d3d871bb8ee30719b69a740ec6be0e005a6e10acf6858abf250de5e0f38832',
+  binary_sha256({
+    aarch64: 'b29ccd5984ad407ca52ce7890e315ab9bbafcfc5eae1151f017385c8f5e181f8',
+     armv7l: 'b29ccd5984ad407ca52ce7890e315ab9bbafcfc5eae1151f017385c8f5e181f8',
+       i686: '6f90a42303579e980393fd221f39a8dddacd9dba601c9d24bfe46e50bc9e5b16',
+     x86_64: '2e9227ff4ea9dcad67fce2b5de279d493a776b68df7fb5c9fbd3dae9aaa9c892'
   })
 
-  depends_on 'automake' => :build
   depends_on 'libxtst'
   depends_on 'dbus'
   depends_on 'glib'
   depends_on 'gobject_introspection'
   depends_on 'libxcb'
   depends_on 'gtk_doc'
-  depends_on 'libtool'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/baobab.rb
+++ b/packages/baobab.rb
@@ -8,17 +8,17 @@ class Baobab < Package
   source_url 'https://ftp.gnome.org/pub/gnome/sources/baobab/3.35/baobab-3.35.1.tar.xz'
   source_sha256 '1b6b5e533802a9293bd061cd0a49049664c310f814e39e40b310ae954342fe83'
 
-  binary_url ({
+  binary_url({
     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/baobab-3.35.1-chromeos-armv7l.tar.xz',
      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/baobab-3.35.1-chromeos-armv7l.tar.xz',
        i686: 'https://dl.bintray.com/chromebrew/chromebrew/baobab-3.35.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/baobab-3.35.1-chromeos-x86_64.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/baobab-3.35.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
+  binary_sha256({
     aarch64: 'c71f8f044a796984990f52b33953c22e9a197ca547123f65cad0b810bd04a53f',
      armv7l: 'c71f8f044a796984990f52b33953c22e9a197ca547123f65cad0b810bd04a53f',
        i686: '5eda1f765da12d94fdc6b8e9de37b62608edf215e7b07941b3328523a3ebb074',
-     x86_64: '0fac89defc368a81745bc7fae11dd16c9ea0008820a0bafabbf85d837426f9ae',
+     x86_64: '0fac89defc368a81745bc7fae11dd16c9ea0008820a0bafabbf85d837426f9ae'
   })
 
   depends_on 'gtk3'
@@ -29,7 +29,7 @@ class Baobab < Package
 
   def self.build
     system "meson  --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
-    system "ninja -C builddir"
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -3,22 +3,22 @@ require 'package'
 class Cairo < Package
   description 'Cairo is a 2D graphics library with support for multiple output devices.'
   homepage 'https://www.cairographics.org'
-  version '1.16.0'
+  version '1.17.4'
   compatibility 'all'
-  source_url 'https://www.cairographics.org/releases/cairo-1.16.0.tar.xz'
-  source_sha256 '5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331'
+  source_url 'https://cairographics.org/snapshots/cairo-1.17.4.tar.xz'
+  source_sha256 '74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cairo-1.16.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cairo-1.16.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cairo-1.16.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cairo-1.16.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cairo-1.17.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cairo-1.17.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cairo-1.17.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cairo-1.17.4-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '8c6ac7612bd9aac77a38fa2a6bc519ff3f0bc94e46cd3fd5d0f75c68e41876e4',
-     armv7l: '8c6ac7612bd9aac77a38fa2a6bc519ff3f0bc94e46cd3fd5d0f75c68e41876e4',
-       i686: '93e54aec50db4895b4897745b89d7f3876ba25fb1941333063fd1ec335a0977a',
-     x86_64: '0f0655202da77ecbcd2259a0f6367ac5f33fffb8e2af3698ea652967b2926461',
+  binary_sha256({
+    aarch64: '9ff5df66de2bf89670852e030379a6c1873dfc2e154e86fe0992ee6ebebe4be9',
+     armv7l: '9ff5df66de2bf89670852e030379a6c1873dfc2e154e86fe0992ee6ebebe4be9',
+       i686: 'f0fb7bee8a0311b73b1a8b5a877b9a276d4bce929a267dd2be9542437cbc12bb',
+     x86_64: 'b12d21a683f06db69052f2d927039f6e893aecdc993de1b384af9267d25ff93e'
   })
 
   depends_on 'libpng'
@@ -27,26 +27,19 @@ class Cairo < Package
   depends_on 'mesa'
 
   def self.build
-    system './configure',
-           '--enable-ft',
-           '--enable-fc',
-           '--enable-xml',
-           '--enable-tee',
-           '--enable-xcb',
-           '--enable-egl',
-           '--enable-xlib',
-           '--enable-glesv3',
-           '--enable-gobject',
-           '--enable-pthread',
-           '--enable-xcb-shm',
-           '--enable-xlib-xcb',
-           '--enable-xlib-xrender',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    --default-library=both \
+    -Dgl-backend=auto \
+    -Dglesv3=enabled \
+    -Dxlib-xcb=enabled \
+    -Dtee=enabled \
+    -Dtests=disabled \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/cairomm.rb
+++ b/packages/cairomm.rb
@@ -3,40 +3,41 @@ require 'package'
 class Cairomm < Package
   description 'The Cairomm package provides a C++ interface to Cairo.'
   homepage 'https://www.cairographics.org/'
-  version '1.12.2-1'
+  version '1.16.0'
   compatibility 'all'
-  source_url 'https://www.cairographics.org/releases/cairomm-1.12.2.tar.gz'
-  source_sha256 '45c47fd4d0aa77464a75cdca011143fea3ef795c4753f6e860057da5fb8bd599'
+  source_url 'https://www.cairographics.org/releases/cairomm-1.16.0.tar.xz'
+  source_sha256 '7e881492c5f9f546688c31160deb742c166fc4c68b6b8eb9920c00a0f0f144f9'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.12.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.12.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.12.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.12.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.16.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.16.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.16.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.16.0-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '24b1da59d5156446baa4b524a194cb1f1f446b9377452e83b132127b3b4bfe1f',
-     armv7l: '24b1da59d5156446baa4b524a194cb1f1f446b9377452e83b132127b3b4bfe1f',
-       i686: 'd37adb6a92ba92cccfc58a70b868b2e2deab20f8b397bfdb2ba2ee30f8310623',
-     x86_64: 'd5510efba06f2543a15761be7b9d7a08f980db22022f84b011436f1faf787b33',
+  binary_sha256({
+    aarch64: 'c1d71ead86e471d5a7197385f9265c7c9b18cbe875bb1b44d21e8d7db455b42e',
+     armv7l: 'c1d71ead86e471d5a7197385f9265c7c9b18cbe875bb1b44d21e8d7db455b42e',
+       i686: 'ca252ba384eaa24a2cce9d3e8d05071b90f15bab7a714acd85af0b518c87495a',
+     x86_64: '84355939a5c61018943d37073c9c364295598a205769d15bd9d7c5d820a50778'
   })
 
   depends_on 'cairo'
-  depends_on 'libsigcplusplus'
+  depends_on 'libsigcplusplus3'
   depends_on 'libxxf86vm'
   depends_on 'libxrender'
 
   def self.build
-    system "sed -e '/^libdocdir =/ s/$(book_name)/cairomm-1.12.2/' \
-    -i docs/Makefile.in"
-    system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    --default-library=both \
+    -Dbuild-documentation=false \
+    -Dbuild-examples=false \
+    -Dbuild-tests=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
- end
-
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
 end

--- a/packages/dconf.rb
+++ b/packages/dconf.rb
@@ -3,37 +3,38 @@ require 'package'
 class Dconf < Package
   description 'The DConf package contains a low-level configuration system.'
   homepage 'https://wiki.gnome.org/Projects/dconf'
-  version '0.28.0'
+  version '0.39.1'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/dconf/0.28/dconf-0.28.0.tar.xz'
-  source_sha256 '61d3b3865ef58b729c3b39aa0979f886c014aa8362f93dcfc74bf5648ed9c742'
+  source_url 'https://download.gnome.org/core/40/40.beta/sources/dconf-0.39.1.tar.xz'
+  source_sha256 '9a3870bf07b8e0452e22ce068d51c7f19c1e1cfeacd9883c03523822afdff665'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dconf-0.28.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dconf-0.28.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/dconf-0.28.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dconf-0.28.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dconf-0.39.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dconf-0.39.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/dconf-0.39.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dconf-0.39.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '3c83656c8b7a90338c2541e382f04ffc4980939aeb7950c34a1c9ddeff8b3543',
-     armv7l: '3c83656c8b7a90338c2541e382f04ffc4980939aeb7950c34a1c9ddeff8b3543',
-       i686: '145346b92e7fc48399c9b0d60ebe5ccca0ad38e62ab090aeb9aecb04fda62656',
-     x86_64: 'f8c04c675b235a94baea2b9dce74c7d36fa493a79963c41b708fdaa4944e0124',
+  binary_sha256({
+    aarch64: 'a6bc274c2a1bc39ac0ee01e9b6d1121378a7c3e5a7abf3c60c3762248f504888',
+     armv7l: 'a6bc274c2a1bc39ac0ee01e9b6d1121378a7c3e5a7abf3c60c3762248f504888',
+       i686: 'b640f46b95ca5286068c640e6969278e85d6c5e96277b9bcd9510f9d59df8be1',
+     x86_64: '3073982a22ecba46620ef73aae362e8925019d075260fb0cbc9ce0a64463dc6e'
   })
 
-  depends_on 'dbus'  => :build
+  depends_on 'dbus' => :build
   depends_on 'gtk_doc' => :build
   depends_on 'glib'  # version 2
-  depends_on 'meson'  => :build
-  depends_on 'vala'  => :build
+  depends_on 'vala' => :build
+  depends_on 'bash_completion' => :build
 
   def self.build
-    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
-    system "ninja -C builddir"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
-
 end

--- a/packages/evolution_data_server.rb
+++ b/packages/evolution_data_server.rb
@@ -1,0 +1,61 @@
+require 'package'
+
+class Evolution_data_server < Package
+  description 'Centralized access to appointments and contacts'
+  @_ver = '3.39.2'
+  version @_ver
+  compatibility 'all'
+  source_url "https://github.com/GNOME/evolution-data-server/archive/#{@_ver}.tar.gz"
+  source_sha256 '38c41f6698ef50fc7a1857ac69e29d95157bb1c4cf2111d9a14d03ed2cbf592e'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/evolution_data_server-3.39.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/evolution_data_server-3.39.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/evolution_data_server-3.39.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/evolution_data_server-3.39.2-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '279a6cc3c29e1915ceac2643da60a058ad58f972d4690e5e9de724465bf1936a',
+     armv7l: '279a6cc3c29e1915ceac2643da60a058ad58f972d4690e5e9de724465bf1936a',
+       i686: 'c5fb88a2cc1e0919a793f183a0ccb513b8eb3e2f27eef682100347ffbdfc1c6b',
+     x86_64: '159279d09980d97e288ef803ac8692671edc3fe9ee69014f0d9d12c470b80c30'
+  })
+
+  depends_on 'nss'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'vala' => ':build'
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'nspr'
+  depends_on 'libsoup'
+  depends_on 'gcr'
+  depends_on 'libical'
+  depends_on 'libsecret'
+
+  def self.build
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} \
+      CFLAGS='-pipe -flto=auto -I#{CREW_PREFIX}/include/gnu-libiconv' CXXFLAGS='-pipe -flto=auto -I#{CREW_PREFIX}/include/gnu-libiconv' \
+      LDFLAGS='-flto=auto -L#{CREW_LIB_PREFIX}' \
+      cmake #{CREW_CMAKE_OPTIONS} .. -G Ninja \
+      -DENABLE_INTROSPECTION=OFF \
+      -DENABLE_VALA_BINDINGS=OFF \
+      -DENABLE_GTK_DOC=OFF \
+      -DWITH_PHONENUMBER=OFF \
+      -DWITH_NSPR_INCLUDES=#{CREW_PREFIX}/include/nspr \
+      -DWITH_NSS_INCLUDES=#{CREW_PREFIX}/include/nss \
+      -DENABLE_OAUTH2=OFF \
+      -DENABLE_GOA=OFF \
+      -DENABLE_WEATHER=OFF \
+      -DENABLE_GOOGLE=OFF \
+      -DENABLE_EXAMPLES=OFF \
+      -DENABLE_CANBERRA=OFF \
+      -DCMAKE_VERBOSE_MAKEFILE=ON"
+    end
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/evolution_data_server.rb
+++ b/packages/evolution_data_server.rb
@@ -25,7 +25,6 @@ class Evolution_data_server < Package
   depends_on 'gobject_introspection' => ':build'
   depends_on 'vala' => ':build'
   depends_on 'gtk_doc' => ':build'
-  depends_on 'nspr'
   depends_on 'libsoup'
   depends_on 'gcr'
   depends_on 'libical'

--- a/packages/gcr.rb
+++ b/packages/gcr.rb
@@ -8,29 +8,29 @@ class Gcr < Package
   source_url 'https://download.gnome.org/sources/gcr/3.38/gcr-3.38.1.tar.xz'
   source_sha256 '17fcaf9c4a93a65fb1c72b82643bb102c13344084687d5886ea66313868d9ec9'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.38.1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.38.1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.38.1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.38.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.38.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.38.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.38.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.38.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: 'a61f2009bc3bc00b18480b3f79954c4963bba4829f898e8247d1222322277fc5',
-      armv7l: 'a61f2009bc3bc00b18480b3f79954c4963bba4829f898e8247d1222322277fc5',
-        i686: '3790b41ac9f7e88192a1f59199d62c2d31d4f09edd60ce04f7d4f0a71750f1d4',
-      x86_64: '9ed6176ff86030e47818c147ff2d54fa16aab1da29997caff364387b7858a7a5',
+  binary_sha256({
+    aarch64: 'a61f2009bc3bc00b18480b3f79954c4963bba4829f898e8247d1222322277fc5',
+     armv7l: 'a61f2009bc3bc00b18480b3f79954c4963bba4829f898e8247d1222322277fc5',
+       i686: '3790b41ac9f7e88192a1f59199d62c2d31d4f09edd60ce04f7d4f0a71750f1d4',
+     x86_64: '9ed6176ff86030e47818c147ff2d54fa16aab1da29997caff364387b7858a7a5'
   })
-  
-    depends_on 'libgcrypt'
-    depends_on 'libxslt'
-    depends_on 'desktop_file_utilities'
-    depends_on 'hicolor_icon_theme'
-    depends_on 'gnupg'
-    depends_on 'gnupg'
-    depends_on 'libxslt'
-    depends_on 'vala' => :build
-    depends_on 'gtk3'
-    depends_on 'graphite'
+  depends_on 'libgcrypt'
+  depends_on 'libxslt'
+  depends_on 'desktop_file_utilities'
+  depends_on 'hicolor_icon_theme'
+  depends_on 'gnupg'
+  depends_on 'glib'
+  depends_on 'gnupg'
+  depends_on 'libxslt'
+  depends_on 'vala' => :build
+  depends_on 'gtk3'
+  depends_on 'graphite'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \

--- a/packages/geoclue.rb
+++ b/packages/geoclue.rb
@@ -1,39 +1,47 @@
 require 'package'
 
 class Geoclue < Package
-  description 'GeoClue location framework'
-  homepage 'https://gitlab.freedesktop.org/geoclue/geoclue'
-  version '2.5.3'
+  description 'Modular geoinformation service built on the D-Bus messaging system'
+  homepage 'https://www.freedesktop.org/wiki/Software/GeoClue/'
+  version '2.5.7'
   compatibility 'all'
-  source_url 'https://gitlab.freedesktop.org/geoclue/geoclue/-/archive/2.5.3/geoclue-2.5.3.tar.bz2'
-  source_sha256 'a626f6adaff15d88fd0561344e614e371900e4a64a1fe9ddfcdd40d39712e78b'
+  source_url 'https://gitlab.freedesktop.org/geoclue/geoclue/-/archive/2.5.7/geoclue-2.5.7.tar.bz2'
+  source_sha256 '6cc7dbe4177b4e7f3532f7fe42262049789a3cd6c55afe60a3564d7394119c27'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/geoclue-2.5.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/geoclue-2.5.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/geoclue-2.5.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/geoclue-2.5.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/geoclue-2.5.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/geoclue-2.5.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/geoclue-2.5.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/geoclue-2.5.7-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '9a4e92261cfe8cf57ca41164eb36956cff8f4c7ac1be4e4369939a75a5448a25',
-     armv7l: '9a4e92261cfe8cf57ca41164eb36956cff8f4c7ac1be4e4369939a75a5448a25',
-       i686: 'c881ab65cd5fc0d0468312d59f521b9c4add00cc79eff2fbda1bcf83610c2b6f',
-     x86_64: '38a2a7982d13e84597fb0745800e8204a7ba7a1309e3cce5a5cb30a623926270',
+  binary_sha256({
+    aarch64: 'ca4c050657f094f10ccf46f4cba13d309d0757830c4be084e8190d72e3ca8949',
+     armv7l: 'ca4c050657f094f10ccf46f4cba13d309d0757830c4be084e8190d72e3ca8949',
+       i686: 'cb9adf521670add9b3d4d0e4491daa10965ab2638f0b5da89ea81a8df0870688',
+     x86_64: '85a1879573e68dea80192fade6cdd52934ea0b2c02c22e959ec3a88b029f144b'
   })
 
-  depends_on 'avahi'
-  depends_on 'json_glib'
-  depends_on 'libnotify'
   depends_on 'libsoup'
+  depends_on 'json_glib'
+  depends_on 'avahi'
+  depends_on 'geocode_glib'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'libnotify' => ':build'
   depends_on 'modemmanager'
-  depends_on 'meson' => :build
 
   def self.build
-    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --sysconfdir #{CREW_PREFIX}/etc -Ddbus-srv-user=#{USER} -Dgtk-doc=false build"
-    system 'ninja -C build'
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      -Dsystemd=disabled \
+      -D3g-source=false \
+      -Dcdma-source=false \
+      -Dmodem-gps-source=false \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/gjs.rb
+++ b/packages/gjs.rb
@@ -2,22 +2,22 @@ require 'package'
 
 class Gjs < Package
   description 'Javascript Bindings for GNOME'
-  version '1.67.1'
+  version '1.67.2'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/gjs/1.67/gjs-1.67.1.tar.xz'
-  source_sha256 '28af0b28efd9d11009b007401e9f96dbff0d988799c15edc812b6d57dd3edbd9'
+  source_url 'https://download.gnome.org/sources/gjs/1.67/gjs-1.67.2.tar.xz'
+  source_sha256 '4d9a4b8580a6871239e227338e3bc54f7d119057306fec56a364d90da69e1ce6'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gjs-1.67.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gjs-1.67.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gjs-1.67.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gjs-1.67.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gjs-1.67.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gjs-1.67.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gjs-1.67.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gjs-1.67.2-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '77e917bd0b8f07b3b573682789419e55c03fdbbf0f26ad5ab0714aba6eed7a28',
-     armv7l: '77e917bd0b8f07b3b573682789419e55c03fdbbf0f26ad5ab0714aba6eed7a28',
-       i686: 'ea54f17dad4f34e4cf5dc1ba4e2e4c2d2c48c6ac310dc38255cd4abc6dbf2644',
-     x86_64: '5e75223729786f2dba2f74148db6d2225965e0029fd814d5222134f82607bae3'
+    aarch64: 'db807d23b09a122d9ffd02699cc301f4b6aa5668076d610c45cf4c6f1bf981c6',
+     armv7l: 'db807d23b09a122d9ffd02699cc301f4b6aa5668076d610c45cf4c6f1bf981c6',
+       i686: '8377ad2a8e958df5fa9182f0d0a7138e22ca82a814c9bc4ba265d5edf55a55cb',
+     x86_64: 'e5d3274313176202aee2dbf0fc2d2c4277be1bde67f93d5e9b10c0d3fac20dd5'
   })
 
   depends_on 'cairo'

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -17,14 +17,216 @@ class Glib < Package
   binary_sha256({
     aarch64: '7d15e68503124e82d4ad52755dda9ff290572c84d17fc7d56d6eebdb4e261ae3',
      armv7l: '7d15e68503124e82d4ad52755dda9ff290572c84d17fc7d56d6eebdb4e261ae3',
-       i686: '9031f7b19185505460005ea15589a6e52f7cc5ace50760b9154772d1c8951244',
-     x86_64: '1d2e776143a13ea6b2e6b12709f72f4be628e55323dd39cea69ba0a7e92c43ca'
+       i686: '8a23142aa67d25f96074715e3578c8e572277f2112b3825339dbf3d7ad740126',
+     x86_64: 'b4e806b51a601a6fd68cad72e1b450059da5ec015fd5e227518c100f41fadae1'
   })
 
   depends_on 'shared_mime_info'
   depends_on 'util_linux'
   depends_on 'six'
   depends_on 'pygments'
+
+  def self.patch
+    # Patch from:
+    # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1958.patch
+    @gsubprocesslauncher_patch = <<~GLIB_PATCH_HEREDOC
+            From 1e74c52a6349c9c4f265b9b89fffc32730b9cd24 Mon Sep 17 00:00:00 2001
+            From: Philip Withnall <pwithnall@endlessos.org>
+            Date: Fri, 19 Feb 2021 18:19:53 +0000
+            Subject: [PATCH 1/3] gsubprocesslauncher: Improve documentation formatting
+             slightly
+      #{'      '}
+            Signed-off-by: Philip Withnall <pwithnall@endlessos.org>
+            ---
+             gio/gsubprocesslauncher.c | 8 ++++----
+             1 file changed, 4 insertions(+), 4 deletions(-)
+      #{'      '}
+            diff --git a/gio/gsubprocesslauncher.c b/gio/gsubprocesslauncher.c
+            index b7257f453..16c47d542 100644
+            --- a/gio/gsubprocesslauncher.c
+            +++ b/gio/gsubprocesslauncher.c
+            @@ -596,16 +596,16 @@ g_subprocess_launcher_take_stderr_fd (GSubprocessLauncher *self,
+              * @target_fd: Target descriptor for child process
+              *
+              * Transfer an arbitrary file descriptor from parent process to the
+            - * child.  This function takes "ownership" of the fd; it will be closed
+            + * child.  This function takes ownership of the @source_fd; it will be closed
+              * in the parent when @self is freed.
+              *
+              * By default, all file descriptors from the parent will be closed.
+            - * This function allows you to create (for example) a custom pipe() or
+            - * socketpair() before launching the process, and choose the target
+            + * This function allows you to create (for example) a custom `pipe()` or
+            + * `socketpair()` before launching the process, and choose the target
+              * descriptor in the child.
+              *
+              * An example use case is GNUPG, which has a command line argument
+            - * --passphrase-fd providing a file descriptor number where it expects
+            + * `--passphrase-fd` providing a file descriptor number where it expects
+              * the passphrase to be written.
+              */
+             void
+            --#{' '}
+            GitLab
+      #{'      '}
+      #{'      '}
+            From 55a75590d0c7e703f32513cc409d6e20a7b761ea Mon Sep 17 00:00:00 2001
+            From: Philip Withnall <pwithnall@endlessos.org>
+            Date: Fri, 19 Feb 2021 18:20:25 +0000
+            Subject: [PATCH 2/3] =?UTF-8?q?gsubprocesslauncher:=20Don=E2=80=99t=20clos?=
+             =?UTF-8?q?e=20target=20FDs=20in=20close()=20method?=
+            MIME-Version: 1.0
+            Content-Type: text/plain; charset=UTF-8
+            Content-Transfer-Encoding: 8bit
+      #{'      '}
+            This is a regression introduced in commit 67a589e505311. Previously, the
+            source/target FD pairs were stored in `needdup_fd_assignments`, in
+            consecutive entries, so source FDs had even indices and target FDs had
+            odd indices.
+      #{'      '}
+            I didnâ€™t notice that the array index was being incremented by 2 when
+            closing FDs, when porting from the old code. So previously the code was
+            only closing the source FDs; after the port, it was closing source and
+            target FDs.
+      #{'      '}
+            Thatâ€™s incorrect, as the target FDs are just integers in the parent
+            process. Itâ€™s only in the child process where they are actually FDs â€”
+            and `g_subprocess_launcher_close()` is never called in the child
+            process.
+      #{'      '}
+            This resulted in some strange misbehaviours in any process which used
+            `g_subprocess_launcher_take_fd()` with target FDs which could have
+            possibly aliased with other FDs in the parent process (and which werenâ€™t
+            equal to their mapped source FDs).
+      #{'      '}
+            Thanks to Olivier Fourdan for the detailed bug report.
+      #{'      '}
+            Signed-off-by: Philip Withnall <pwithnall@endlessos.org>
+      #{'      '}
+            Fixes: #2332
+            ---
+             gio/gsubprocesslauncher-private.h | 4 ++--
+             gio/gsubprocesslauncher.c         | 8 ++++----
+             2 files changed, 6 insertions(+), 6 deletions(-)
+      #{'      '}
+            diff --git a/gio/gsubprocesslauncher-private.h b/gio/gsubprocesslauncher-private.h
+            index f8a6516c5..d6fe0d784 100644
+            --- a/gio/gsubprocesslauncher-private.h
+            +++ b/gio/gsubprocesslauncher-private.h
+            @@ -42,8 +42,8 @@ struct _GSubprocessLauncher
+               gint stderr_fd;
+               gchar *stderr_path;
+      #{'       '}
+            -  GArray *source_fds;
+            -  GArray *target_fds;  /* always the same length as source_fds */
+            +  GArray *source_fds;  /* GSubprocessLauncher has ownership of the FD elements */
+            +  GArray *target_fds;  /* always the same length as source_fds; elements are just integers and not FDs in this process */
+               gboolean closed_fd;
+      #{'       '}
+               GSpawnChildSetupFunc child_setup_func;
+            diff --git a/gio/gsubprocesslauncher.c b/gio/gsubprocesslauncher.c
+            index 16c47d542..a1c65e947 100644
+            --- a/gio/gsubprocesslauncher.c
+            +++ b/gio/gsubprocesslauncher.c
+            @@ -661,11 +661,11 @@ g_subprocess_launcher_close (GSubprocessLauncher *self)
+                   g_assert (self->target_fds != NULL);
+                   g_assert (self->source_fds->len == self->target_fds->len);
+      #{'       '}
+            +      /* Note: Donâ€™t close the target_fds, as theyâ€™re only valid FDs in the
+            +       * child process. This code never executes in the child process. */
+                   for (i = 0; i < self->source_fds->len; i++)
+            -        {
+            -          (void) close (g_array_index (self->source_fds, int, i));
+            -          (void) close (g_array_index (self->target_fds, int, i));
+            -        }
+            +        (void) close (g_array_index (self->source_fds, int, i));
+            +
+                   g_clear_pointer (&self->source_fds, g_array_unref);
+                   g_clear_pointer (&self->target_fds, g_array_unref);
+                 }
+            --#{' '}
+            GitLab
+      #{'      '}
+      #{'      '}
+            From 50cf90dc562d10efa3288357202e8cc04571292c Mon Sep 17 00:00:00 2001
+            From: Philip Withnall <pwithnall@endlessos.org>
+            Date: Fri, 19 Feb 2021 18:09:42 +0000
+            Subject: [PATCH 3/3] =?UTF-8?q?tests:=20Test=20g=5Fsubprocess=5Flauncher?=
+             =?UTF-8?q?=5Fclose()=20doesn=E2=80=99t=20close=20too=20many=20FDs?=
+            MIME-Version: 1.0
+            Content-Type: text/plain; charset=UTF-8
+            Content-Transfer-Encoding: 8bit
+      #{'      '}
+            Expand an existing unit test to check that the target FD of a
+            `g_subprocess_launcher_take_fd()` call doesnâ€™t get closed when
+            `g_subprocess_launcher_close()` is called. Only the source FD should be
+            closed by the parent process.
+      #{'      '}
+            Signed-off-by: Philip Withnall <pwithnall@endlessos.org>
+      #{'      '}
+            Helps: #2332
+            ---
+             gio/tests/gsubprocess.c | 27 ++++++++++++++++++++++++---
+             1 file changed, 24 insertions(+), 3 deletions(-)
+      #{'      '}
+            diff --git a/gio/tests/gsubprocess.c b/gio/tests/gsubprocess.c
+            index 3c248e610..7e22678ec 100644
+            --- a/gio/tests/gsubprocess.c
+            +++ b/gio/tests/gsubprocess.c
+            @@ -1494,23 +1494,44 @@ test_subprocess_launcher_close (void)
+               GSubprocessLauncher *launcher;
+               GSubprocess *proc;
+               GPtrArray *args;
+            -  int fd;
+            +  int fd, fd2;
+               gboolean is_open;
+      #{'       '}
+            -  fd = dup(0);
+            +  /* Open two arbitrary FDs. One of them, @fd, will be transferred to the
+            +   * launcher, and the otherâ€™s FD integer will be used as its target FD, giving
+            +   * the mapping `fd â†’ fd2` if a child process were to be spawned.
+            +   *
+            +   * The launcher will then be closed, which should close @fd but *not* @fd2,
+            +   * as the value of @fd2 is only valid as an FD in a child process. (A child
+            +   * process is not actually spawned in this test.)
+            +   */
+            +  fd = dup (0);
+            +  fd2 = dup (0);
+               launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_NONE);
+            -  g_subprocess_launcher_take_fd (launcher, fd, fd);
+            +  g_subprocess_launcher_take_fd (launcher, fd, fd2);
+            +
+               is_open = fcntl (fd, F_GETFD) != -1;
+               g_assert_true (is_open);
+            +  is_open = fcntl (fd2, F_GETFD) != -1;
+            +  g_assert_true (is_open);
+            +
+               g_subprocess_launcher_close (launcher);
+            +
+               is_open = fcntl (fd, F_GETFD) != -1;
+               g_assert_false (is_open);
+            +  is_open = fcntl (fd2, F_GETFD) != -1;
+            +  g_assert_true (is_open);
+            +
+            +  /* Now test that actually trying to spawn the child gives %G_IO_ERROR_CLOSED,
+            +   * as g_subprocess_launcher_close() has been called. */
+               args = get_test_subprocess_args ("cat", NULL);
+               proc = g_subprocess_launcher_spawnv (launcher, (const gchar * const *) args->pdata, error);
+               g_ptr_array_free (args, TRUE);
+               g_assert_null (proc);
+               g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_CLOSED);
+               g_clear_error (error);
+            +
+            +  close (fd2);
+               g_object_unref (launcher);
+             }
+      #{'       '}
+            --#{' '}
+            GitLab
+    GLIB_PATCH_HEREDOC
+    IO.write('1958.patch', @gsubprocesslauncher_patch)
+    system 'patch -p1 < 1958.patch'
+  end
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \

--- a/packages/glibmm.rb
+++ b/packages/glibmm.rb
@@ -3,25 +3,25 @@ require 'package'
 class Glibmm < Package
   description 'C++ bindings for GLib'
   homepage 'https://www.gtkmm.org'
-  version '2.64.5'
+  version '2.68.0'
   compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.64/glibmm-2.64.5.tar.xz'
-  source_sha256 '508fc86e2c9141198aa16c225b16fd6b911917c0d3817602652844d0973ea386'
+  source_url 'https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.68/glibmm-2.68.0.tar.xz'
+  source_sha256 'c1f38573191dceed85a05600888cf4cf4695941f339715bd67d51c2416f4f375'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.64.5-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.64.5-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.64.5-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.64.5-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.68.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.68.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.68.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.68.0-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '08d942541e0df0a351f6d748051cc7deb18c4aa21c7950d9b166780ad86f2327',
-      armv7l: '08d942541e0df0a351f6d748051cc7deb18c4aa21c7950d9b166780ad86f2327',
-        i686: 'f0be0860b956388e55cc8d6d5cfb67f6ff547e653a06570ea0aa72e0e7121913',
-      x86_64: '2f050d4abd5cda7efa15e8df5dedc713bc18eb60141982c6b322b21d742ea233',
+  binary_sha256({
+    aarch64: 'a9e342573e021fd5ce8fe3a31a00eae0ea8bb4468986556c5333b5e404d1377a',
+     armv7l: 'a9e342573e021fd5ce8fe3a31a00eae0ea8bb4468986556c5333b5e404d1377a',
+       i686: '97befe025c500e4b94c7d5d82a422e9cbb1772f2f688d1531ce861dbcabbe7b6',
+     x86_64: '42beab5465b595e90359d71e05ef6c90b66846b5fbe64108cf8568fe2658ca8f'
   })
 
-  depends_on 'libsigcplusplus'
+  depends_on 'libsigcplusplus3'
   depends_on 'mm_common' => :build
 
   def self.build
@@ -31,8 +31,8 @@ class Glibmm < Package
     -Dbuild-demos=false \
     -Dbuild-tests=false \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/gnome_desktop.rb
+++ b/packages/gnome_desktop.rb
@@ -1,0 +1,44 @@
+require 'package'
+
+class Gnome_desktop < Package
+  description 'Library with common API for various GNOME modules'
+  homepage 'https://gitlab.gnome.org/GNOME/gnome-desktop'
+  version '40.beta'
+  compatibility 'all'
+  source_url 'https://github.com/GNOME/gnome-desktop/archive/40.beta.tar.gz'
+  source_sha256 'a982cbaa68aabfcaef0d6db69c936ee45d8f23475a4dd2bad60a49f0bb920451'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.beta-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.beta-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.beta-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.beta-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'd93d85cfdd762b023f8815be575e84707564aa7c279b92e4d1812253db13b964',
+     armv7l: 'd93d85cfdd762b023f8815be575e84707564aa7c279b92e4d1812253db13b964',
+       i686: '7f810e184dc981a419942ba4fe18070fb4b51be23044f9632da9b3fee66224c8',
+     x86_64: '60d206c6594c4da2c9081784d7d4fec46553aa8f92ce228187de72dfec1e40fe'
+  })
+
+  depends_on 'gsettings_desktop_schemas'
+  depends_on 'gtk3'
+  depends_on 'libxkbfile'
+  depends_on 'xkeyboard_config'
+  depends_on 'iso_codes'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'yelp_tools' => ':build'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Dsystemd=disabled \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/gnome_weather.rb
+++ b/packages/gnome_weather.rb
@@ -1,0 +1,44 @@
+require 'package'
+
+class Gnome_weather < Package
+  description 'Access current weather conditions and forecasts'
+  homepage 'https://wiki.gnome.org/Apps/Weather'
+  version '40.beta'
+  compatibility 'all'
+  source_url 'https://github.com/GNOME/gnome-weather/archive/40.beta.tar.gz'
+  source_sha256 '281b35ab677a143d0aa0118a2c7c3be6a76837d01ea0dd5f862c628b8ef1579a'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.beta-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.beta-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.beta-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.beta-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '25aafe9b86f33ab398694d3068924e67096b1c0a7b76fae3b522debf73e1d96f',
+     armv7l: '25aafe9b86f33ab398694d3068924e67096b1c0a7b76fae3b522debf73e1d96f',
+       i686: 'ecc3074e962ca1e123278a4730d44bfe76b096b88b33edc8953f8a1efb8455b7',
+     x86_64: 'fa99714935ad0dcb81bf158f10714ed657dcaeb4bbeec281ada143f37341633a'
+  })
+
+  depends_on 'gtk3'
+  depends_on 'gjs'
+  depends_on 'libgweather'
+  depends_on 'geoclue'
+  depends_on 'gnome_desktop'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'appstream_glib' => ':build'
+  depends_on 'libhandy1'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Dsystemd=disabled \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -3,23 +3,23 @@ require 'package'
 class Gtk3 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk3/3.0/'
-  @_ver = '3.24.25'
+  @_ver = '3.24.26'
   version @_ver
   compatibility 'all'
   source_url "https://download.gnome.org/sources/gtk+/3.24/gtk+-#{@_ver}.tar.xz"
-  source_sha256 '87e26b111d3b8a85ff218980a56f3e814257b8dd11e5c4d9a2803b423b08297c'
+  source_sha256 '2cc1b2dc5cad15d25b6abd115c55ffd8331e8d4677745dd3ce6db725b4fff1e9'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.25-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.25-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.25-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.25-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.26-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.26-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.26-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.26-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '2ac48ac4e7afae50082113a5ee02887e8e275a63caa551308009e4778eef8509',
-     armv7l: '2ac48ac4e7afae50082113a5ee02887e8e275a63caa551308009e4778eef8509',
-       i686: '6295abdfb026ea717b3e46b5cf86b42228e223c2e92160263cc36974eaf0a340',
-     x86_64: '274d6fd9d16cd2a4dc60a07b9212fb643851c37fe788f373ba46b644ba5272dc'
+    aarch64: 'f53f6e97f2929af71f497f14869d83ce20f62469aa387d460b43c94105ecd0d1',
+     armv7l: 'f53f6e97f2929af71f497f14869d83ce20f62469aa387d460b43c94105ecd0d1',
+       i686: '9402509ba5d7af3da372b804e28f9c8213768e3bc3a16f811162dd278e0900d4',
+     x86_64: '0e594d1b3661938b5d586670588ffd0b3a6327e697fc01a68e77d101192d9962'
   })
 
   depends_on 'cups'
@@ -38,6 +38,7 @@ class Gtk3 < Package
   depends_on 'xdg_base'
   depends_on 'atk'
   depends_on 'graphite'
+  depends_on 'libdeflate'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \

--- a/packages/gtkmm3.rb
+++ b/packages/gtkmm3.rb
@@ -3,28 +3,28 @@ require 'package'
 class Gtkmm3 < Package
   description 'The Gtkmm3 package provides a C++ interface to GTK+ 3.'
   homepage 'https://www.gtkmm.org/'
-  version '3.24.3'
+  version '3.24.4'
   compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/gtkmm/3.24/gtkmm-3.24.3.tar.xz'
-  source_sha256 '60497c4f7f354c3bd2557485f0254f8b7b4cf4bebc9fee0be26a77744eacd435'
+  source_url 'https://ftp.gnome.org/pub/gnome/sources/gtkmm/3.24/gtkmm-3.24.4.tar.xz'
+  source_sha256 '9beb71c3e90cfcfb790396b51e3f5e7169966751efd4f3ef9697114be3be6743'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.3-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.3-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.3-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm3-3.24.4-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: 'd296af5a49ecf3c541c9bd572a362fad38725878a4b40aa162d78218d1e241fa',
-      armv7l: 'd296af5a49ecf3c541c9bd572a362fad38725878a4b40aa162d78218d1e241fa',
-        i686: 'd10e9165ad434e818c47bb72c1e6eda5f619fdd946b43d114363919ccc0b0d5a',
-      x86_64: '9122aca97e3de40447e8fe3d0c3c88194b0f2ad885c4b3957db947fdce3d79c4',
+  binary_sha256({
+    aarch64: 'df6763cd6810ef3b578f97525e5455dcf1dc37a2eeca0a282412dc269f75446e',
+     armv7l: 'df6763cd6810ef3b578f97525e5455dcf1dc37a2eeca0a282412dc269f75446e',
+       i686: '57287908562c48a645942a700fe9fc81a9fec23a9c5ee2c03b25c1d28b73be6d',
+     x86_64: '9c6c186cf88f779ee435f6995d3c583278d267e381e00d1f2f5013397f703390'
   })
 
   depends_on 'atkmm'
   depends_on 'gtk3'
   depends_on 'pangomm'
-  
+
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
     --default-library=both \
@@ -32,8 +32,8 @@ class Gtkmm3 < Package
     -Dbuild-demos=false \
     -Dbuild-tests=false \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/gtkmm4.rb
+++ b/packages/gtkmm4.rb
@@ -1,0 +1,39 @@
+require 'package'
+
+class Gtkmm4 < Package
+  description 'The Gtkmm3 package provides a C++ interface to GTK+ 3.'
+  homepage 'https://www.gtkmm.org/'
+  version '4.0.1'
+  compatibility 'all'
+  source_url 'https://download.gnome.org/sources/gtkmm/4.0/gtkmm-4.0.1.tar.xz'
+  source_sha256 '8973d9bc7848e02cb2051e05f3ee3a4baffe2feb4af4a5487f0e3132eec03884'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm4-4.0.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm4-4.0.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm4-4.0.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtkmm4-4.0.1-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '1d2640f81201631586b082735b8ad82a229ff9502233acc4ed628ba88dd46278',
+     armv7l: '1d2640f81201631586b082735b8ad82a229ff9502233acc4ed628ba88dd46278',
+       i686: '2672ac3748735b14decae069d71fc25e2e19b298638e422c11c6424a5763bec0',
+     x86_64: 'd6b5659e5e00d16442c9368db8c7baf610fb62f43111ed6f6cd93dfb0417fbf1'
+  })
+
+  depends_on 'atkmm'
+  depends_on 'gtk4'
+  depends_on 'pangomm'
+  depends_on 'cairomm'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/json_glib.rb
+++ b/packages/json_glib.rb
@@ -3,39 +3,42 @@ require 'package'
 class Json_glib < Package
   description 'JSON-GLib implements a full suite of JSON-related tools using GLib and GObject.'
   homepage 'https://wiki.gnome.org/Projects/JsonGlib'
-  version '1.4.2'
+  version '1.6.2'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/json-glib/1.4/json-glib-1.4.2.tar.xz'
-  source_sha256 '2d7709a44749c7318599a6829322e081915bdc73f5be5045882ed120bb686dc8'
+  source_url 'https://download.gnome.org/core/40/40.beta/sources/json-glib-1.6.2.tar.xz'
+  source_sha256 'a33d66c6d038bda46b910c6c6d59c4e15db014e363dc997a0414c2e07d134f24'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/json_glib-1.4.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/json_glib-1.4.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/json_glib-1.4.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/json_glib-1.4.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/json_glib-1.6.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/json_glib-1.6.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/json_glib-1.6.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/json_glib-1.6.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'beebd6ecd278f1c591eb95f23068c39ad83dddb9fc34cf420baea4d4c59a32ba',
-     armv7l: 'beebd6ecd278f1c591eb95f23068c39ad83dddb9fc34cf420baea4d4c59a32ba',
-       i686: 'ba63448663fd24715d510c689e41ffea14062108bfd0fc76399c15ad9c1a4dd2',
-     x86_64: '5e79363b10f04e8b6240d69d323ea78595271cbaaac5df9acaf09f07f52e1939',
+  binary_sha256({
+    aarch64: '455dcfbda9d20fc22e4ce2ccb33ac87776acd82cdc515ce7bf26af0e0118cd89',
+     armv7l: '455dcfbda9d20fc22e4ce2ccb33ac87776acd82cdc515ce7bf26af0e0118cd89',
+       i686: '2df0c4c6ba784caa9d308cf25b815ca25b2ad4c8ea410f7105568aecfc5b79ef',
+     x86_64: '4ce5550617d0c6a6c61317cf74deba81a0674f0b315f7741db67c3b11b36e3fb'
   })
 
-  depends_on 'meson'
   depends_on 'gtk_doc'
   depends_on 'glib'
   depends_on 'gobject_introspection'
 
   def self.build
-    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} _build"
-    system "ninja -C _build"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
-  def self.check
-    system "meson test -C _build"
-  end
+  # Ticket opened at 
+  # https://gitlab.gnome.org/GNOME/json-glib/-/issues/59
+  # def self.check
+  # system 'ninja test -C builddir'
+  # end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/libgweather.rb
+++ b/packages/libgweather.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Libgweather < Package
+  description 'Location and timezone database and weather-lookup library'
+  homepage 'https://wiki.gnome.org/Projects/LibGWeather'
+  version '40.beta'
+  compatibility 'all'
+  source_url 'https://github.com/GNOME/libgweather/archive/40.beta.tar.gz'
+  source_sha256 '89eebe5a83177f094c017a484be3a27b5e418fec2d9aaea1937bdc6ddc430627'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgweather-40.beta-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgweather-40.beta-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgweather-40.beta-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgweather-40.beta-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'eb3d11bb2bd6fcc03b232c52e018851ae3e4aa6008dc4676c3f99218a6a62b77',
+     armv7l: 'eb3d11bb2bd6fcc03b232c52e018851ae3e4aa6008dc4676c3f99218a6a62b77',
+       i686: '544a1b6fe84b39e108bb4baeec800d8b3e84796c738b445d7e5a95d2bf2e843e',
+     x86_64: 'fd210e31135860d1e84e55ddbc64ada18deb731b7815e3471d78e00b24e56ee3'
+  })
+
+  depends_on 'libsoup'
+  depends_on 'gtk3'
+  depends_on 'geocode_glib'
+  depends_on 'dconf'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'glade' => ':build'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Dsystemd=disabled \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/libhandy1.rb
+++ b/packages/libhandy1.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Libhandy1 < Package
+  description 'The aim of the handy library is to help with developing UI for mobile devices using GTK/GNOME.'
+  homepage 'https://gitlab.gnome.org/GNOME/libhandy/'
+  @_ver = '1.1.90'
+  version @_ver
+  compatibility 'all'
+  source_url "https://gitlab.gnome.org/GNOME/libhandy/-/archive/#{@_ver}/libhandy-#{@_ver}.tar.bz2"
+  source_sha256 '6ddac98a287e4e9b31e3ec3d72dae756c4ef6e12f3b1150db7ec2ee339750bde'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy1-1.1.90-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy1-1.1.90-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy1-1.1.90-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy1-1.1.90-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '790a2510e89e4712c6d82cb07326b2fd5c9c34cc2e0f4fefe257d5fcc0c84615',
+     armv7l: '790a2510e89e4712c6d82cb07326b2fd5c9c34cc2e0f4fefe257d5fcc0c84615',
+       i686: 'fa28e0f5fdde0cc2cb79bf8cfff0222f3afe3de97025ffbd3f754722c4c3eb6c',
+     x86_64: 'df36a10a4e9e86c84d98142bfbbec8e0431162002ffce3d0b837042d13a67d9f'
+  })
+
+  depends_on 'vala'
+
+  def self.prebuild
+    system "sed -i 's,-fstack-protector-strong,-fno-stack-protector,' meson.build"
+  end
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/libndp.rb
+++ b/packages/libndp.rb
@@ -1,0 +1,38 @@
+require 'package'
+
+class Libndp < Package
+  description 'Library for Neighbor Discovery Protocol'
+  homepage 'http://libndp.org/'
+  version '1.7-3fc2'
+  compatibility 'all'
+  source_url 'https://github.com/jpirko/libndp/archive/3fc2ed78edb5deae0381d022bedc22ffd00d50cb.zip'
+  source_sha256 '53fd7da8fc840900238f1699e98a7e3e60cd6c68489015303e84b19c9dd2bb3a'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libndp-1.7-3fc2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libndp-1.7-3fc2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libndp-1.7-3fc2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libndp-1.7-3fc2-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'cd1c2dc1ba0d66e86f335a9003a21c5cdb83f617b95fc9cee3f47cedaac44776',
+     armv7l: 'cd1c2dc1ba0d66e86f335a9003a21c5cdb83f617b95fc9cee3f47cedaac44776',
+       i686: '362f65de766cd934bf1e99db75ffdac99715b9a05e90f97b89784ad6d952f369',
+     x86_64: '17fb4275c5ef57c0c5e058721381fa4f836fae81076114ebd81dea0e0facaa41'
+  })
+
+  def self.build
+    system './autogen.sh'
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+    LDFLAGS='-pipe -flto=auto' \
+    ./configure #{CREW_OPTIONS} \
+    --sysconfdir=#{CREW_PREFIX}/etc \
+    --localstatedir=/var \
+    --libexecdir=#{CREW_LIB_PREFIX}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -3,22 +3,22 @@ require 'package'
 class Librsvg < Package
   description 'SVG library for GNOME'
   homepage 'https://wiki.gnome.org/Projects/LibRsvg'
-  version '2.50.2'
+  version '2.50.3'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/librsvg/2.50/librsvg-2.50.2.tar.xz'
-  source_sha256 '6211f271ce4cd44a7318190d36712e9cea384a933d3e3570004edeb210a056d3'
+  source_url 'https://download.gnome.org/sources/librsvg/2.50/librsvg-2.50.3.tar.xz'
+  source_sha256 'a4298a98e3a95fdd73c858c17d4dd018525fb09dbb13bbd668a0c2243989e958'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.2-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.2-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.2-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '4ae81db4da7f1a37c0be24d6539326726364d4226b2ca43c583aac4b8a62af4c',
-      armv7l: '4ae81db4da7f1a37c0be24d6539326726364d4226b2ca43c583aac4b8a62af4c',
-        i686: '84acfe19e47585b1698cb1cd4ba9f4a8a6ccf45007baccaedf72a94e8bf91b52',
-      x86_64: '54a837bd7569101d7ef3151d8832729a8f5bdadd00ded2bc34f67b9df85247ef',
+  binary_sha256({
+    aarch64: '308cf9f89ed04934bf1e1c7e492b51bf57d5adbb023d4830e4fb2122d8fd796d',
+     armv7l: '308cf9f89ed04934bf1e1c7e492b51bf57d5adbb023d4830e4fb2122d8fd796d',
+       i686: '7b4b1fa2ec312b13267b7b1100e65f5e5da783c7dd2f973deb09382005b35c1f',
+     x86_64: '3879b9088e910dc7bd3fa2499ac247a20edbcbd8f90dd76f4975c7993f8b49cd'
   })
 
   depends_on 'cairo'
@@ -35,8 +35,8 @@ class Librsvg < Package
 
   def self.build
     # Following rustup modification as per https://github.com/rust-lang/rustup/issues/1167#issuecomment-367061388
-    system "rustup install stable --profile minimal || (rm -frv ~/.rustup/toolchains/* && rustup install stable --profile minimal)"
-    system "rustup default stable"
+    system 'rustup install stable --profile minimal || (rm -frv ~/.rustup/toolchains/* && rustup install stable --profile minimal)'
+    system 'rustup default stable'
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
       ./configure \
       --prefix=#{CREW_PREFIX} \
@@ -56,9 +56,9 @@ class Librsvg < Package
   def self.install
     system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
-  
+
   def self.postinstall
     # gdk_pixbuf should be setting the correct env variables
-    system "gdk-pixbuf-query-loaders"
+    system 'gdk-pixbuf-query-loaders'
   end
 end

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -3,33 +3,32 @@ require 'package'
 class Pango < Package
   description 'Pango is a library for laying out and rendering of text, with an emphasis on internationalization.'
   homepage 'http://www.pango.org/'
-  version '1.48.1'
+  version '1.48.2'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/pango/1.48/pango-1.48.1.tar.xz'
+  source_url 'https://download.gnome.org/sources/pango/1.48/pango-1.48.2.tar.xz'
   source_sha256 '08c2d550a96559f15fb317d7167b96df57ef743fef946f4e274bd8b6f2918058'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.48.1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.48.1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.48.1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.48.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.48.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.48.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.48.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pango-1.48.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: 'daa7da13785e86b3bfada7e83bcf17c89d5660e709f8a347aa86e3ccae932ab7',
-      armv7l: 'daa7da13785e86b3bfada7e83bcf17c89d5660e709f8a347aa86e3ccae932ab7',
-        i686: '8b6c14849997167ba526680b9876ce47dcf11509b0790ca8d00c74af1575ddcc',
-      x86_64: 'a0fd7fd131fad159aeae6412a33bf23334966421808e279aaaa0881a216a1721',
+  binary_sha256({
+    aarch64: '48c6277c278e0bc48c09dd3e688a0ca2e36f79765c90ecddfd6d5b46869feff9',
+     armv7l: '48c6277c278e0bc48c09dd3e688a0ca2e36f79765c90ecddfd6d5b46869feff9',
+       i686: 'acef25d5de3d7c3f5c889a04cc29dff6192a66244fdce95306da40319b06cd1b',
+     x86_64: '16c912f1381ecdf1fd5329ee8fd9e5c18cec87b91e714a899f17384b7ae5684b'
   })
 
   depends_on 'harfbuzz'
   depends_on 'freetype'
   depends_on 'cairo'
   depends_on 'glib'
-  depends_on 'gobject_introspection'   # add this package to build gtk+, avoid compilation error
+  depends_on 'gobject_introspection' # add this package to build gtk+, avoid compilation error
   depends_on 'libxrender'
   depends_on 'fribidi' # Gets built inside install automatically.
   depends_on 'six'
-  depends_on 'llvm' => ':build'
   depends_on 'fontconfig'
 
   def self.build
@@ -39,8 +38,8 @@ class Pango < Package
     -Dfreetype=enabled \
     -Dfontconfig=enabled \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/pangomm.rb
+++ b/packages/pangomm.rb
@@ -3,23 +3,23 @@ require 'package'
 class Pangomm < Package
   description 'pangomm is the official C++ interface for the Pango font layout library.'
   homepage 'https://developer.gnome.org/pangomm/stable/'
-  @_ver = '2.42.2'
+  @_ver = '2.48.0'
   version @_ver
   compatibility 'all'
   source_url "https://github.com/GNOME/pangomm/archive/#{@_ver}.tar.gz"
-  source_sha256 '51f0a8a60a80630ea008ca42b0c64fa1712c50ac2c56497ee0f59d740c19692f'
+  source_sha256 '65130bc4e3662071b4332d1fdae792282764705abf00c0d80a9eb4e8b5886d59'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.42.2-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.42.2-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.42.2-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.42.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.48.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.48.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.48.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.48.0-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '8b7cf6b5aa32027410cf52af25f7729b1ed7b5ef0304108128f87632a804c51c',
-      armv7l: '8b7cf6b5aa32027410cf52af25f7729b1ed7b5ef0304108128f87632a804c51c',
-        i686: 'f35a2334b5576ab8ea16dde6506685605e15f1c06e20d107cba8e184dae15d2f',
-      x86_64: 'f3dafb0c75d0205ed574988498aa3407d422d621a226114924e4558054d5c38e',
+  binary_sha256({
+    aarch64: 'f8dbb1e8258270285d3cbdea5e07369f955d663f4233d6afbedaf2a8e26080b7',
+     armv7l: 'f8dbb1e8258270285d3cbdea5e07369f955d663f4233d6afbedaf2a8e26080b7',
+       i686: '7fd81bfa703ec364ff24b863c98cf5f80c843d0cc35ab247598cb7d515c4758d',
+     x86_64: '986d79798b3e7f91c07ee7afac45652b2d157e22d7cf71c3087bd481f674b8a7'
   })
 
   depends_on 'glibmm'
@@ -27,14 +27,14 @@ class Pangomm < Package
   depends_on 'pango'
   depends_on 'graphite'
   depends_on 'mm_common'
-  
+
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
     -Dmaintainer-mode=true \
     -Dbuild-documentation=false \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/vala.rb
+++ b/packages/vala.rb
@@ -3,25 +3,24 @@ require 'package'
 class Vala < Package
   description 'Vala is a programming language that aims to bring modern programming language features to GNOME developers.'
   homepage 'https://wiki.gnome.org/Projects/Vala'
-  version '0.50.3'
+  version '0.51.2'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/vala/0.50/vala-0.50.3.tar.xz'
-  source_sha256 '6165c1b42beca4856e2fb9a31c5e81949d76fa670e2f0cfc8389ce9b95eca5db'
+  source_url 'https://download.gnome.org/core/40/40.beta/sources/vala-0.51.2.tar.xz'
+  source_sha256 'a1db75bfdc7e8ffa08d2c4a8a4b561fb24f3e9516d712531b8d14a74695a37b2'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.50.3-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.50.3-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.50.3-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.50.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.51.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.51.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.51.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vala-0.51.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '6a7d6ae85c7105e34c471b4c3218af328e30e613bafe6fd5ff1a40d8fc9e0d1d',
-      armv7l: '6a7d6ae85c7105e34c471b4c3218af328e30e613bafe6fd5ff1a40d8fc9e0d1d',
-        i686: 'b86a4c43e82f55cf974e0d60aa664ee719d1f266446167d61e6aa00976c1bd74',
-      x86_64: 'a3fe7fae478aa276d36a1e1268b4215257e37c1965dfbeb1d52b7ef4bd47f130',
+  binary_sha256({
+    aarch64: '322bf1ba49dad18e92a07ff0371d1ecf5ef50658cff4854c866484d0636209cd',
+     armv7l: '322bf1ba49dad18e92a07ff0371d1ecf5ef50658cff4854c866484d0636209cd',
+       i686: '5637fb96d07390df272e5d0864b91442bb9aac4b934d69215eafc4e0e81fdca4',
+     x86_64: '977183724a7552da5c055540d01d702c0887ecd1b0cdb05220718ce964037042'
   })
 
-  depends_on 'flex'
   depends_on 'graphviz'
   depends_on 'libxslt'
   depends_on 'glib'
@@ -29,6 +28,7 @@ class Vala < Package
 
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+    LDFLAGS='-pipe -flto=auto' \
       ./configure #{CREW_OPTIONS} \
       --disable-maintainer-mode \
       --disable-valadoc"

--- a/packages/webkit2gtk.rb
+++ b/packages/webkit2gtk.rb
@@ -3,23 +3,23 @@ require 'package'
 class Webkit2gtk < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'
-  @_ver = '2.30.4'
+  @_ver = '2.30.5'
   version @_ver
   compatibility 'all'
   source_url "https://webkitgtk.org/releases/webkitgtk-#{@_ver}.tar.xz"
-  source_sha256 'd595a37c5001ff787266b155e303a5f2e5b48a6d466f2714c2f30c11392f7b24'
+  source_sha256 '7d0dab08e3c5ae07bec80b2822ef42e952765d5724cac86eb23999bfed5a7f1f'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.4-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.5-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '436805dc8bc10da1f84fd9874fb79b98ee56b433e78eba6b668e523c28c87f83',
-     armv7l: '436805dc8bc10da1f84fd9874fb79b98ee56b433e78eba6b668e523c28c87f83',
-       i686: '754535d0b5e01e458052800e28f9ccdf6b5f10a07c8c08903201f369ef19eb8d',
-     x86_64: '415da1b2619e82937d52364e16308d72f1f6e99c4305443f11e0b97ed5bf3c6b'
+    aarch64: 'b7124c084ab583574893195e4d295d4fd79c2468770d29ca524474c1a5b8bb33',
+     armv7l: 'b7124c084ab583574893195e4d295d4fd79c2468770d29ca524474c1a5b8bb33',
+       i686: 'b6f3fac281c5ddfed66957f210ba226b422b8ffe1935c844d4e9934a32347f78',
+     x86_64: '6c4dd4d6c1625f87950d8d38e99398b670edf1deb758f4efdf53dca7b9b1e57d'
   })
 
   depends_on 'cairo'

--- a/packages/yelp.rb
+++ b/packages/yelp.rb
@@ -1,0 +1,49 @@
+require 'package'
+
+class Yelp < Package
+  description 'Get help with GNOME'
+  homepage 'https://wiki.gnome.org/Apps/Yelp'
+  @_ver = '40.beta'
+  version @_ver
+  compatibility 'all'
+  source_url "https://github.com/GNOME/yelp/archive/#{@_ver}.tar.gz"
+  source_sha256 '7e4716182f368be298c0cf8c6963c2731a21b8def17612b5b05f36230747e6dd'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.beta-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.beta-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.beta-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.beta-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '9adf9c294d016bb777e5e9cfff6a38edc44ee26fd6b68900db05df01e7f63ad0',
+     armv7l: '9adf9c294d016bb777e5e9cfff6a38edc44ee26fd6b68900db05df01e7f63ad0',
+       i686: 'a84bde1a08b64269c8a29f70538c869bb8fa8a7890df74b2a0535063279310a5',
+     x86_64: 'e0c245e4c2683219ba37118040a1c2dfc60e71a4d45a21aa611633291f0e1121'
+  })
+
+  depends_on 'webkit2gtk'
+  depends_on 'yelp_xsl'
+  depends_on 'libxslt'
+  depends_on 'appstream_glib'
+
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'itstool' => ':build'
+  depends_on 'xorg_server' => ':build'
+
+  def self.build
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+    ./configure #{CREW_OPTIONS} \
+    --enable-compile-warnings=minimum \
+    --enable-debug=no \
+    --disable-dependency-tracking"
+    # Documentation generation segfaults without X11"
+    # system "xvfb-run -s '-screen 0 1920x1080x24 -nolisten local' make"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/yelp_tools.rb
+++ b/packages/yelp_tools.rb
@@ -3,22 +3,22 @@ require 'package'
 class Yelp_tools < Package
   description 'yelp-tools is a collection of scripts and build utilities to help create, manage, and publish documentation for Yelp and the web'
   homepage 'https://github.com/GNOME/yelp-tools'
-  version '40.alpha'
+  version '40.beta'
   compatibility 'all'
-  source_url 'https://github.com/GNOME/yelp-tools/archive/40.alpha.tar.gz'
-  source_sha256 '24a7b7f6e48f52935049732eae729fbbd7bcb45b413b620c9b51ea058cddd7ee'
+  source_url 'https://github.com/GNOME/yelp-tools/archive/40.beta.tar.gz'
+  source_sha256 '57f80c0853a3bb44249e5febe39424876bb08f7c58650133dd5bc1a0b9a40808'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.alpha-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.alpha-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.alpha-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.alpha-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.beta-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.beta-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.beta-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.beta-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '78e2341e954e05cca61b8221de01996e8a0817ace9476c83143593c0668d12e7',
-     armv7l: '78e2341e954e05cca61b8221de01996e8a0817ace9476c83143593c0668d12e7',
-       i686: 'dc7cf4e135dd0e84e1da4189c7514d4915d93c3e960d79bcb185ab223625a51b',
-     x86_64: '1cb4bc720a7cd8b4845dcf832458ecf2fd1096f3fb156d9266bb215f867f5588'
+    aarch64: 'c8f68b2451729b757df1c9638cf96011590bda3964053784a0e70b02f3448df7',
+     armv7l: 'c8f68b2451729b757df1c9638cf96011590bda3964053784a0e70b02f3448df7',
+       i686: '3a10cfae2a539cd99705fb39b4e3f76fa8d9ffe149e4fa45b8ae23168f1fde7d',
+     x86_64: 'cce94aa4c0dfd87c505e1194976fd59eb0c0654f36748fa3fad3ece67e5a1ed1'
   })
 
   depends_on 'yelp_xsl'

--- a/packages/yelp_xsl.rb
+++ b/packages/yelp_xsl.rb
@@ -3,8 +3,8 @@ require 'package'
 class Yelp_xsl < Package
   description 'yelp-xsl is a collection of programs and data files to help you build, maintain, and distribute documentation'
   homepage 'https://github.com/GNOME/yelp-xsl'
-  compatibility 'all'
   version '40.beta'
+  compatibility 'all'
   source_url 'https://github.com/GNOME/yelp-xsl/archive/40.beta.tar.gz'
   source_sha256 'f9145e36148ff473d501a5393e9d3b34c4450281cd6d6b8dac2c24aad4883d03'
 

--- a/packages/yelp_xsl.rb
+++ b/packages/yelp_xsl.rb
@@ -1,25 +1,24 @@
-
 require 'package'
 
 class Yelp_xsl < Package
   description 'yelp-xsl is a collection of programs and data files to help you build, maintain, and distribute documentation'
   homepage 'https://github.com/GNOME/yelp-xsl'
   compatibility 'all'
-  version '3.38.2'
-  source_url 'https://github.com/GNOME/yelp-xsl/archive/3.38.2.tar.gz'
-  source_sha256 'd9e9cc02fc7bb442601515c68fccc4bfbee69860166ca318be9e6b37525943ad'
+  version '40.beta'
+  source_url 'https://github.com/GNOME/yelp-xsl/archive/40.beta.tar.gz'
+  source_sha256 'f9145e36148ff473d501a5393e9d3b34c4450281cd6d6b8dac2c24aad4883d03'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-3.38.2-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-3.38.2-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-3.38.2-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-3.38.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.beta-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.beta-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.beta-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.beta-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '3dfe0bdcddbbdc0bd1cd85890919bdec6962d24894fe39db49686c5655d61674',
-      armv7l: '3dfe0bdcddbbdc0bd1cd85890919bdec6962d24894fe39db49686c5655d61674',
-        i686: 'f3a4d2c7155e43b8a43e8188686abfa3e5a195e6479325f5172fa2192ef84977',
-      x86_64: '652e4331e8a136bf3f492618c372063ae86b9feddb407f1edca24fec4362027b',
+  binary_sha256({
+    aarch64: '74ffc820d0c3cea9be8d2f299f6552223668226174aebba9a9d5921df56ba8ca',
+     armv7l: '74ffc820d0c3cea9be8d2f299f6552223668226174aebba9a9d5921df56ba8ca',
+       i686: '836738f78988eb6ca1331d08da02b365f4840001e3a131e15ea36516ec6ba55b',
+     x86_64: '1bce675f4168fa9f44b7fc10ca7b33c7f6139b02671d891290c94f1f5069795e'
   })
 
   depends_on 'itstool'
@@ -27,6 +26,7 @@ class Yelp_xsl < Package
   def self.build
     system './autogen.sh'
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
       ./configure #{CREW_OPTIONS}"
     system 'make'
   end


### PR DESCRIPTION
- Updates multiple Gnome packages to current builds, and also adds libhandy1, libndp.
- Getting closer to building all of Gnome 40
- json_glib has problems with all tests. Have opened a [ticket open with upstream about that](https://gitlab.gnome.org/GNOME/json-glib/-/issues/59).

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686