### PR TITLE
crew: Allow to use external prebuilt binary (like .deb and .rpm)

### DIFF
--- a/crew
+++ b/crew
@@ -799,7 +799,7 @@ def install
     meta = download
     target_dir = unpack meta
     if meta[:source] == true
-      abort "You don't have a working C compiler. Run `crew install buildessential` to get one and try again.".lightred unless @external and system('gcc --version')
+      abort "You don't have a working C compiler. Run `crew install buildessential` to get one and try again.".lightred unless (@external or system('gcc --version'))
 
       # build from source and place binaries at CREW_DEST_DIR
       # CREW_DEST_DIR contains usr/local/... hierarchy

--- a/crew
+++ b/crew
@@ -799,7 +799,9 @@ def install
     meta = download
     target_dir = unpack meta
     if meta[:source] == true
-      (abort "You don't have a working C compiler. Run `crew install buildessential` to get one and try again.".lightred unless @external) unless system('gcc --version')
+      unless @external or system('gcc --version') then
+        abort "You don't have a working C compiler. Run `crew install buildessential` to get one and try again.".lightred
+      end
 
       # build from source and place binaries at CREW_DEST_DIR
       # CREW_DEST_DIR contains usr/local/... hierarchy

--- a/crew
+++ b/crew
@@ -495,7 +495,7 @@ end
 
 def download
   url = @pkg.get_url(@device[:architecture])
-  external = @pkg.is_external?
+  @external = @pkg.is_external?
   source = @pkg.is_source?(@device[:architecture])
 
   if !url
@@ -586,30 +586,33 @@ end
 
 def build_and_preconfigure (target_dir)
   Dir.chdir target_dir do
-    puts 'Building from source, this may take a while...'
+    unless @external then
+      puts 'Building from source, this may take a while...'
 
-    # Rename *.la files temporily to *.la_tmp to avoid
-    # libtool: link: '*.la' is not a valid libtool archive.
-    # See https://gnunet.org/faq-la-files and
-    # https://stackoverflow.com/questions/42963653/libquadmath-la-is-not-a-valid-libtool-archive-when-configuring-openmpi-with-g
-    puts 'Rename all *.la files to *.la_tmp'.lightblue
+      # Rename *.la files temporily to *.la_tmp to avoid
+      # libtool: link: '*.la' is not a valid libtool archive.
+      # See https://gnunet.org/faq-la-files and
+      # https://stackoverflow.com/questions/42963653/libquadmath-la-is-not-a-valid-libtool-archive-when-configuring-openmpi-with-g
+      puts 'Rename all *.la files to *.la_tmp'.lightblue
+      system "find #{CREW_LIB_PREFIX} -type f -name *.la -print0 | xargs --null -I{} mv #{@mv_verbose} {} {}_tmp"
+    end
     
-    system "find #{CREW_LIB_PREFIX} -type f -name *.la -print0 | xargs --null -I{} mv #{@mv_verbose} {} {}_tmp"
-
     @pkg.in_build = true
     @pkg.patch
-    @pkg.prebuild
-    @pkg.build
+    @pkg.prebuild unless @external
+    @pkg.build unless @external
     @pkg.in_build = false
     # wipe crew destdir
     FileUtils.rm_rf Dir.glob("#{CREW_DEST_DIR}/*"), verbose: @fileutils_verbose
     puts 'Preconfiguring package...'
     @pkg.install
 
-    # Rename all *.la_tmp back to *.la to avoid
-    # cannot access '*.la': No such file or directory
-    puts 'Rename all *.la_tmp files back to *.la'.lightblue
-    system "find #{CREW_LIB_PREFIX} -type f -name '*.la_tmp' -exec sh -c 'mv #{@mv_verbose} \"$1\" \"${1%.la_tmp}.la\"' _  {} \\;"
+    unless @external then
+      # Rename all *.la_tmp back to *.la to avoid
+      # cannot access '*.la': No such file or directory
+      puts 'Rename all *.la_tmp files back to *.la'.lightblue
+      system "find #{CREW_LIB_PREFIX} -type f -name '*.la_tmp' -exec sh -c 'mv #{@mv_verbose} \"$1\" \"${1%.la_tmp}.la\"' _  {} \\;"
+    end
   end
 end
 

--- a/crew
+++ b/crew
@@ -799,7 +799,7 @@ def install
     meta = download
     target_dir = unpack meta
     if meta[:source] == true
-      abort "You don't have a working C compiler. Run `crew install buildessential` to get one and try again.".lightred unless (@external or system('gcc --version'))
+      (abort "You don't have a working C compiler. Run `crew install buildessential` to get one and try again.".lightred unless @external) unless system('gcc --version')
 
       # build from source and place binaries at CREW_DEST_DIR
       # CREW_DEST_DIR contains usr/local/... hierarchy

--- a/crew
+++ b/crew
@@ -495,7 +495,7 @@ end
 
 def download
   url = @pkg.get_url(@device[:architecture])
-  external = @pkg.is_external(@device[:architecture])
+  external = @pkg.is_external
   source = @pkg.is_source?(@device[:architecture])
 
   if !url

--- a/crew
+++ b/crew
@@ -799,7 +799,7 @@ def install
     meta = download
     target_dir = unpack meta
     if meta[:source] == true
-      abort "You don't have a working C compiler. Run `crew install buildessential` to get one and try again.".lightred unless system('gcc --version')
+      abort "You don't have a working C compiler. Run `crew install buildessential` to get one and try again.".lightred unless @external and system('gcc --version')
 
       # build from source and place binaries at CREW_DEST_DIR
       # CREW_DEST_DIR contains usr/local/... hierarchy

--- a/crew
+++ b/crew
@@ -495,7 +495,7 @@ end
 
 def download
   url = @pkg.get_url(@device[:architecture])
-  external = @pkg.is_external
+  external = @pkg.is_external?
   source = @pkg.is_source?(@device[:architecture])
 
   if !url

--- a/crew
+++ b/crew
@@ -510,7 +510,7 @@ def download
 
   uri = URI.parse url
   filename = File.basename(uri.path)
-  if source
+  if source and !external
     sha256sum = @pkg.source_sha256
   else
     sha256sum = @pkg.binary_sha256[@device[:architecture]]

--- a/crew
+++ b/crew
@@ -500,7 +500,7 @@ def download
 
   if !url
     abort "No precompiled binary or source is available for #{@device[:architecture]}.".lightred
-  elsif !source or external
+  elsif !source or @external
     puts "Precompiled binary available, downloading..."
   elsif @pkg.build_from_source
     puts "Downloading source..."
@@ -510,7 +510,7 @@ def download
 
   uri = URI.parse url
   filename = File.basename(uri.path)
-  if source and !external
+  if source and !@external
     sha256sum = @pkg.source_sha256
   else
     sha256sum = @pkg.binary_sha256[@device[:architecture]]

--- a/crew
+++ b/crew
@@ -495,11 +495,12 @@ end
 
 def download
   url = @pkg.get_url(@device[:architecture])
+  external = @pkg.is_external(@device[:architecture])
   source = @pkg.is_source?(@device[:architecture])
 
   if !url
     abort "No precompiled binary or source is available for #{@device[:architecture]}.".lightred
-  elsif !source
+  elsif !source or external
     puts "Precompiled binary available, downloading..."
   elsif @pkg.build_from_source
     puts "Downloading source..."

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.8'
+CREW_VERSION = '1.7.9'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -1,10 +1,10 @@
 require 'package_helpers'
 
 class Package
-  property :description, :homepage, :version, :compatibility, :binary_url, :binary_sha1, :binary_sha256, :source_url, :source_sha1, :source_sha256, :is_fake
+  property :description, :homepage, :version, :compatibility, :binary_url, :binary_sha1, :binary_sha256, :source_url, :source_sha1, :source_sha256, :is_fake, :is_external
 
   class << self
-    attr_reader :is_fake
+    attr_reader :is_fake, :is_external
     attr_accessor :name, :in_build, :build_from_source
     attr_accessor :in_upgrade
   end
@@ -38,7 +38,7 @@ class Package
   end
 
   def self.get_url (architecture)
-    if !@build_from_source && @binary_url && @binary_url.has_key?(architecture)
+    if !@build_from_source and @binary_url and @binary_url.has_key?(architecture)
       return @binary_url[architecture]
     else
       return @source_url
@@ -46,7 +46,7 @@ class Package
   end
 
   def self.is_binary? (architecture)
-    if !@build_from_source && @binary_url && @binary_url.has_key?(architecture)
+    if !@build_from_source and @binary_url and @binary_url.has_key?(architecture) and !@is_external
       return true
     else
       return false
@@ -54,7 +54,7 @@ class Package
   end
 
   def self.is_source? (architecture)
-    if is_binary?(architecture) || is_fake?
+    if (is_binary?(architecture) or is_fake?) and !@is_external
       return false
     else
       return true
@@ -64,9 +64,17 @@ class Package
   def self.is_fake
     @is_fake = true
   end
-
+  
+  def self.is_external
+    @is_external = true
+  end
+  
   def self.is_fake?
-    @is_fake
+    return @is_fake
+  end
+  
+  def self.is_external?
+    return @is_external
   end
 
   # Function to perform patch operations prior to build from source.


### PR DESCRIPTION
Package need to execute `is_external` to use external binary

Tested on `x86_64`