### PR TITLE
Mandb -> 2.9.4

### DIFF
--- a/packages/libpipeline.rb
+++ b/packages/libpipeline.rb
@@ -3,9 +3,9 @@ require 'package'
 class Libpipeline < Package
   description 'libpipeline is a C library for manipulating pipelines of subprocesses in a flexible and convenient way.'
   homepage 'http://libpipeline.nongnu.org/'
-  compatibility 'all'
   @_ver = '1.5.3'
   version @_ver
+  compatibility 'all'
   source_url "https://mirror.csclub.uwaterloo.ca/nongnu/libpipeline/libpipeline-#{@_ver}.tar.gz"
   source_sha256 '5dbf08faf50fad853754293e57fd4e6c69bb8e486f176596d682c67e02a0adb0'
 

--- a/packages/libpipeline.rb
+++ b/packages/libpipeline.rb
@@ -3,35 +3,40 @@ require 'package'
 class Libpipeline < Package
   description 'libpipeline is a C library for manipulating pipelines of subprocesses in a flexible and convenient way.'
   homepage 'http://libpipeline.nongnu.org/'
-
   compatibility 'all'
-  version '1.5.0'
-  source_url 'https://mirror.csclub.uwaterloo.ca/nongnu/libpipeline/libpipeline-1.5.0.tar.gz'
-  source_sha256 '0d72e12e4f2afff67fd7b9df0a24d7ba42b5a7c9211ac5b3dcccc5cd8b286f2b'
+  @_ver = '1.5.3'
+  version @_ver
+  source_url "https://mirror.csclub.uwaterloo.ca/nongnu/libpipeline/libpipeline-#{@_ver}.tar.gz"
+  source_sha256 '5dbf08faf50fad853754293e57fd4e6c69bb8e486f176596d682c67e02a0adb0'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpipeline-1.5.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpipeline-1.5.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpipeline-1.5.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpipeline-1.5.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpipeline-1.5.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpipeline-1.5.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpipeline-1.5.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpipeline-1.5.3-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'b22c978f504de0e8356772bdb6c775a6d4b9760cb5422ab540a70940d63e8cab',
-     armv7l: 'b22c978f504de0e8356772bdb6c775a6d4b9760cb5422ab540a70940d63e8cab',
-       i686: '5ab87ee758833b15d55b680fee6742f27f26e25394feaeeca5d1c2d6e069b1d5',
-     x86_64: '9cefcb70b634fa7d1ff081794712ca4e1448e0dbfd57d0be411bbef2a149bd78',
+  binary_sha256({
+    aarch64: '95c8b6b79ed89ff9214d8fcd8aa29af940517e5a77e369f509bb2e56a7518cd8',
+     armv7l: '95c8b6b79ed89ff9214d8fcd8aa29af940517e5a77e369f509bb2e56a7518cd8',
+       i686: 'f48dc0e7fa58b857de93c586c7eb80b473f1fb4b1ee617eec60304f76c280d22',
+     x86_64: 'bcdc10711b7697fd61d50f996a5df4467702914d36823d7fbc62590b1f0a5ece'
   })
 
   def self.build
-    system './configure', "--libdir=#{CREW_LIB_PREFIX}", '--disable-static', '--enable-shared', '--with-pic'
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --enable-shared \
+      --with-pic"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
 end

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -3,22 +3,23 @@ require 'package'
 class Mandb < Package
   description 'mandb is used to initialize or manually update index database caches that are usually maintained by man.'
   homepage 'http://man-db.nongnu.org/'
-  version '2.9.3'
+  @_ver = '2.9.4'
+  version @_ver
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/man-db/man-db-2.9.3.tar.xz'
-  source_sha256 'fa5aa11ab0692daf737e76947f45669225db310b2801a5911bceb7551c5597b8'
+  source_url "https://download.savannah.gnu.org/releases/man-db/man-db-#{@_ver}.tar.xz"
+  source_sha256 'b66c99edfad16ad928c889f87cf76380263c1609323c280b3a9e6963fdb16756'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '8bad5f96c6b1259cf8c13e72759bf13ddbd74cb76d3ea03a330b9b3b2da7bce6',
-     armv7l: '8bad5f96c6b1259cf8c13e72759bf13ddbd74cb76d3ea03a330b9b3b2da7bce6',
-       i686: '336d1b5cd1b6d0abfafd0b9c12e925ccd3e239acca9c55b09835fe9ada917736',
-     x86_64: 'e6023a153a255916cda39d0598c8cfa7b38345b6c69d5bf61babd54fec66f624',
+  binary_sha256({
+    aarch64: 'ccd36d83dc2dcb04d003a79fd503273ebd06a77d4da618f7033d537fda537d4e',
+     armv7l: 'ccd36d83dc2dcb04d003a79fd503273ebd06a77d4da618f7033d537fda537d4e',
+       i686: '97a79a235a9ab3c3f077ddf462a79d9d17ff3ff6cd35145321d790253775387f',
+     x86_64: '30939c206bd1adc66a33a8157d749b288a3726a995a8eb318c057104807c138d'
   })
 
   depends_on 'gdbm'
@@ -26,11 +27,24 @@ class Mandb < Package
   depends_on 'libpipeline'
 
   def self.build
-    system './configure',
-      "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}",
-      "--with-systemdtmpfilesdir=#{CREW_PREFIX}/etc/tmpfiles.d", # we can't write to /usr/lib/tmpfiles.d
-      '--disable-cache-owner',                                   # we can't create the user 'man'
-      "--with-pager=#{CREW_PREFIX}/bin/most"                     # the pager is not at the default location
+    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+
+    # we can't write to /usr/lib/tmpfiles.d
+    # we can't create the user 'man'
+    # the pager is not at the default location
+    system './configure --help'
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --with-systemdtmpfilesdir=#{CREW_PREFIX}/etc/tmpfiles.d \
+      --disable-cache-owner \
+      --disable-setuid \
+      --enable-automatic-create \
+      --enable-static \
+      --without-libiconv-prefix \
+      --disable-rpath \
+      --with-pager=#{CREW_PREFIX}/bin/most"
     system 'make'
   end
 
@@ -48,14 +62,23 @@ class Mandb < Package
       'man/man8/accessdb.man8',
       'man/man8/mandb.man8',
       'tools/chconfig'
-    ].each { |file|
+    ].each do |file|
       system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' #{file}"
-    }
+    end
     system "sed -i 's,/usr/share/man,#{CREW_PREFIX}/share/man,g' tools/chconfig"
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "sed -i 's,/usr/share/man,#{CREW_PREFIX}/share/man,g' #{CREW_DEST_PREFIX}/etc/man_db.conf"
+    system "sed -i 's,/usr/man,#{CREW_PREFIX}/share/man,g' #{CREW_DEST_PREFIX}/etc/man_db.conf"
   end
 
   def self.postinstall
-    system 'mandb -c'
+    system "env MANPATH=#{CREW_MAN_PREFIX} mandb -psc"
+    pager_in_bashrc = `grep -c "PAGER" ~/.bashrc || true`
+    unless pager_in_bashrc.to_i.positive?
+      puts 'Putting PAGER=most in ~/.bashrc'.lightblue
+      system "echo 'export PAGER=most' >> ~/.bashrc"
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
+    end
   end
 end

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -22,9 +22,30 @@ class Mandb < Package
      x86_64: '30939c206bd1adc66a33a8157d749b288a3726a995a8eb318c057104807c138d'
   })
 
-  depends_on 'gdbm'
-  depends_on 'groff'
-  depends_on 'libpipeline'
+  def self.patch
+    system "sed -i 's,/usr/man,#{CREW_PREFIX}/share/man,g' src/man_db.conf.in"
+    [
+      'src/man_db.conf.in',
+      'tools/chconfig'
+    ].each do |file|
+      system "sed -i 's,/usr/share/man,#{CREW_PREFIX}/share/man,g' #{file}"
+    end
+    [
+      'include/manconfig.h.in',
+      'src/manp.c',
+      'src/man_db.conf.in',
+      'manual/db.me',
+      'manual/files.me',
+      'man/man1/whatis.man1',
+      'man/man1/apropos.man1',
+      'man/man1/man.man1',
+      'man/man8/accessdb.man8',
+      'man/man8/mandb.man8',
+      'tools/chconfig'
+    ].each do |file|
+      system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' #{file}"
+    end
+  end
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
@@ -50,25 +71,7 @@ class Mandb < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/cache/man"
-    [
-      'include/manconfig.h.in',
-      'src/manp.c',
-      'src/man_db.conf.in',
-      'manual/db.me',
-      'manual/files.me',
-      'man/man1/whatis.man1',
-      'man/man1/apropos.man1',
-      'man/man1/man.man1',
-      'man/man8/accessdb.man8',
-      'man/man8/mandb.man8',
-      'tools/chconfig'
-    ].each do |file|
-      system "sed -i 's,/var/cache/man,#{CREW_PREFIX}/cache/man,g' #{file}"
-    end
-    system "sed -i 's,/usr/share/man,#{CREW_PREFIX}/share/man,g' tools/chconfig"
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    system "sed -i 's,/usr/share/man,#{CREW_PREFIX}/share/man,g' #{CREW_DEST_PREFIX}/etc/man_db.conf"
-    system "sed -i 's,/usr/man,#{CREW_PREFIX}/share/man,g' #{CREW_DEST_PREFIX}/etc/man_db.conf"
   end
 
   def self.postinstall


### PR DESCRIPTION
- removes libiconv dependency
- add PAGER variable to .bashrc 
- update libpipeline dep too.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686