### PR TITLE
Zoneinfo: add binaries

### DIFF
--- a/packages/symlinks.rb
+++ b/packages/symlinks.rb
@@ -35,6 +35,6 @@ class Symlinks < Package
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man8"
     FileUtils.install 'symlinks', "#{CREW_DEST_PREFIX}/bin/symlinks", mode: 0o755
-    FileUtils.install 'symlinks.8', "#{CREW_DEST_PREFIX}/share/man/man8/symlinks.8", mode: 0o644
+    FileUtils.install 'symlinks.8', "#{CREW_DEST_MAN_PREFIX}/man8/symlinks.8", mode: 0o644
   end
 end

--- a/packages/symlinks.rb
+++ b/packages/symlinks.rb
@@ -33,7 +33,7 @@ class Symlinks < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/man/man8"
+    FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man8"
     FileUtils.install 'symlinks', "#{CREW_DEST_PREFIX}/bin/symlinks", mode: 0o755
     FileUtils.install 'symlinks.8', "#{CREW_DEST_PREFIX}/share/man/man8/symlinks.8", mode: 0o644
   end

--- a/packages/symlinks.rb
+++ b/packages/symlinks.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Symlinks < Package
+  description 'scan/change symbolic links'
+  homepage 'https://metadata.ftp-master.debian.org/changelogs//main/s/symlinks/symlinks_1.4-4_copyright'
+  @_ver = '1.4-4'
+  version @_ver
+  compatibility 'all'
+  source_url "https://salsa.debian.org/debian/symlinks/-/archive/debian/#{@_ver}/symlinks-debian-#{@_ver}.tar.bz2"
+  source_sha256 'f4469a9f366ccfaa7273b1f78bd540b8a6fa96f8b2b81a95d131944fb77efdd4'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/symlinks-1.4-4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/symlinks-1.4-4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/symlinks-1.4-4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/symlinks-1.4-4-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '75676c7daebaa9a32ddf2053a47fde8e9cfb19ef774388b577b352514d98925d',
+     armv7l: '75676c7daebaa9a32ddf2053a47fde8e9cfb19ef774388b577b352514d98925d',
+       i686: '94c62cf190ad07a4c38c9fe15875ba819b17d9be306ed907aa4643a7a24d1e49',
+     x86_64: '39fe5a53a1c557aa71cfd6d7760e069c0421931e3e5345c57696e1cf79bf8e39'
+  })
+
+  def self.patch
+    system('for i in `cat debian/patches/series`; do patch -p 1 < debian/patches/$i; done')
+    system "sed -i 's,/usr/local,#{CREW_DEST_PREFIX},g' Makefile"
+  end
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/man/man8"
+    FileUtils.install 'symlinks', "#{CREW_DEST_PREFIX}/bin/symlinks", mode: 0o755
+    FileUtils.install 'symlinks.8', "#{CREW_DEST_PREFIX}/share/man/man8/symlinks.8", mode: 0o644
+  end
+end

--- a/packages/zoneinfo.rb
+++ b/packages/zoneinfo.rb
@@ -49,7 +49,7 @@ class Zoneinfo < Package
     puts "Add `TZ='<timezone>'` to your ~/.bashrc file".lightblue
     puts 'Where <timezone> is the timezone displayed above'.lightblue
     puts 'e.g. `TZ=America/New_York` or `TZ=Etc/UTC`'.lightblue
-    puts "This won't affect the timezone of non-chromebrew ChromeOS apps."
+    puts "This won't affect the timezone of non-chromebrew ChromeOS apps.".lightblue
     puts
   end
 end

--- a/packages/zoneinfo.rb
+++ b/packages/zoneinfo.rb
@@ -8,29 +8,47 @@ class Zoneinfo < Package
   source_url 'https://data.iana.org/time-zones/releases/tzdb-2021a.tar.lz'
   source_sha256 '21bf125de7b0c486cb57f1ba61b39584c949b2e6cac0a03a6425435d9bff37d0'
 
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/zoneinfo-2021a-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/zoneinfo-2021a-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/zoneinfo-2021a-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/zoneinfo-2021a-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '90df3fefec5c3a6c74dc8f5ebc9c71eedafe4d8640c4925bbe06add4a860c4b4',
+     armv7l: '90df3fefec5c3a6c74dc8f5ebc9c71eedafe4d8640c4925bbe06add4a860c4b4',
+       i686: '90525ed6a5f9ffd5428c626c24e1cf57442568720388a646846ceb86a1c725d2',
+     x86_64: '09996f9d306829c341d5959bb2a8c59064c2e89c547b160edc6b0244f54bf0d7'
+  })
+
   def self.patch
     system "sed -i 's:TZDEFAULT = $(TOPDIR)/etc/localtime:TZDEFAULT = #{CREW_PREFIX}/etc/localtime:g' Makefile"
     system "sed -i 's:USRDIR = usr:USRDIR = usr/local:g' Makefile"
   end
 
   def self.build
-    system "make"
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      make ALL"
+    # This fixed failure of make check on i686 & armv7l.
+    system 'make force_tzs'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'INSTALL'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
-  
+
   def self.postinstall
-    system "tzselect"
+    # Do not run tzselect if shell is non-interactive.
+    system('tty -s || tzselect ;;')
     puts
     puts "Add `TZ='<timezone>'` to your ~/.bashrc file".lightblue
-    puts "Where <timezone> is the timezone displayed above".lightblue
-    puts "e.g. `TZ=America/New_York` or `TZ=Etc/UTC`".lightblue
+    puts 'Where <timezone> is the timezone displayed above'.lightblue
+    puts 'e.g. `TZ=America/New_York` or `TZ=Etc/UTC`'.lightblue
     puts "This won't affect the timezone of non-chromebrew ChromeOS apps."
     puts
   end


### PR DESCRIPTION
Fixes #5228

- adds symlinks package (used by the debian zoneinfo package, which I came close to implementing the logic from before finding a simpler zoneinfo fix.)

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686