### PR TITLE
Bind9 -> 9.17.10 & Binutils 2.36.1 , Libuv 1.39.0, zlibpkg lto

### DIFF
--- a/packages/bind.rb
+++ b/packages/bind.rb
@@ -3,42 +3,46 @@ require 'package'
 class Bind < Package
   description 'BIND is open source software that enables you to publish your Domain Name System (DNS) information on the Internet, and to resolve DNS queries for your users.'
   homepage 'https://www.isc.org/downloads/bind/'
-  version '9.17.8'
+  @_ver = '9.17.10'
+  version @_ver
   compatibility 'all'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.8-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.8-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.8-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.8-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/bind-9.17.10-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: 'c757c886c9760396405166ee258b1953935ea3a61e40e6490c44aecbf64a5041',
-      armv7l: 'c757c886c9760396405166ee258b1953935ea3a61e40e6490c44aecbf64a5041',
-        i686: '54a28fd25b2602ac2fec3781e148c6ce9222537978b6ab79bc9457a0ab5ce534',
-      x86_64: '0d5568f9e16d5b76fd8da2815efce5dbbecb435ee99e8757141c10e8edd9539c',
+  binary_sha256({
+    aarch64: '0655729fa11a71e11da25627a813aabb4110a1e8b694d0ac711adcdec7bf19c9',
+     armv7l: '0655729fa11a71e11da25627a813aabb4110a1e8b694d0ac711adcdec7bf19c9',
+       i686: '0fc34d77bd997d9b771ef9309f6a62a61cebbd4878889a383790e57f4b8fd0b4',
+     x86_64: '052251db56246ff7701b00ad91e868b602e400bf1cba2001fff96026f2fc493a'
   })
 
   depends_on 'libcap'
   depends_on 'libseccomp'
   depends_on 'libuv'
-  depends_on 'libidn2'
 
   def self.build
-    system "git config --global advice.detachedHead false"
-    system 'git clone --depth=1 -b v9_17_8 https://gitlab.isc.org/isc-projects/bind9.git'
+    system 'git config --global advice.detachedHead false'
+    @_ver_ = @_ver.gsub(/[.]/, '_')
+    system "git clone --depth=1 -b v#{@_ver_} https://gitlab.isc.org/isc-projects/bind9.git"
     Dir.chdir 'bind9' do
       system 'pip3 install ply==3.11'
       system 'autoreconf -fi'
-      system "env CFLAGS='-DDIG_SIGCHASE -flto=auto' ./configure \
-              #{CREW_OPTIONS} \
-               --enable-fixed-rrset \
-               --enable-full-report \
-               --with-openssl \
-               --with-libidn2 \
-               --disable-maintainer-mode"
+      system "env CFLAGS='-DDIG_SIGCHASE -flto=auto' \
+        CXXFLAGS='-pipe -flto=auto' \
+        LDFLAGS='-flto=auto' \
+        ./configure \
+        #{CREW_OPTIONS} \
+         --enable-fixed-rrset \
+         --enable-full-report \
+         --with-openssl \
+         --with-libidn2 \
+         --disable-maintainer-mode"
       system 'make'
     end
   end

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,34 +3,33 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
-  @_ver = '2.36'
+  @_ver = '2.36.1'
   version @_ver
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/binutils/binutils-#{@_ver}.tar.xz"
-  source_sha256 '5788292cc5bbcca0848545af05986f6b17058b105be59e99ba7d0f9eb5336fb8'
+  source_sha256 'e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.36-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.36-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.36-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.36-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.36.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.36.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.36.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/binutils-2.36.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: 'fd86f02633b27be6d0eaf1ca5f30c0d1e93b4b6e0c08311972bf9f74892b1dcf',
-      armv7l: 'fd86f02633b27be6d0eaf1ca5f30c0d1e93b4b6e0c08311972bf9f74892b1dcf',
-        i686: '1ce06b9e18bd84abe16156e61a68f67e35c749d88733e8d6d69d8b4a14f1aa70',
-      x86_64: '10738895b575f9a41a463c8d0a67a18ba0c134bdf71c9388c1a7d6706e5479fd',
+  binary_sha256({
+    aarch64: '22a88c3eb29672805441c78fa2c37414a4d49bec790252391c1caf45edc20426',
+     armv7l: '22a88c3eb29672805441c78fa2c37414a4d49bec790252391c1caf45edc20426',
+       i686: '7f47210024759db0485292d7695f46532ae0c4c579c03ba0c6450a5174ce9f6f',
+     x86_64: '624fb52ce022d6caea7c99a8c6a08f872e51fe0c8be09bb3c3f72e186ad60d3a'
   })
-
-  depends_on 'filecmd'
-  depends_on 'texinfo'
 
   def self.build
     system 'filefix'
     Dir.mkdir 'build'
     Dir.chdir 'build' do
       system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+        LDFLAGS='-flto=auto' \
         ../configure #{CREW_OPTIONS} \
+        --with-system-zlib \
         --disable-maintainer-mode \
         --enable-shared \
         --enable-gold \

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -3,29 +3,31 @@ require 'package'
 class Libuv < Package
   description 'libuv is a multi-platform support library with a focus on asynchronous I/O.'
   homepage 'http://libuv.org/'
-  version '1.33.1'
+  @_ver = '1.39.0'
+  version @_ver
   compatibility 'all'
-  source_url 'https://dist.libuv.org/dist/v1.33.1/libuv-v1.33.1.tar.gz'
-  source_sha256 'b4b5dc15103f7bbfecb81a0a9575841fdb7217b9f709634be8118972c1c8ce27'
+  source_url "https://dist.libuv.org/dist/v#{@_ver}/libuv-v#{@_ver}.tar.gz"
+  source_sha256 '5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.33.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.33.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.33.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.33.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.39.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.39.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.39.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libuv-1.39.0-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'a03bac49ca23048badd32c4bcdebd9a1acb948e87c1e8a44011214ebbd946c07',
-     armv7l: 'a03bac49ca23048badd32c4bcdebd9a1acb948e87c1e8a44011214ebbd946c07',
-       i686: '44c2c3146a1123a82588183f6291d9365e10a9497b7854a7e8e89d564c875052',
-     x86_64: '679bc3ae5d4ff33b335840fff43087fc2144619eeb678f5c047689c74840faf8',
+  binary_sha256({
+    aarch64: '4b844ba4a96f39e12b4a691c96d76726de85ced70ca4eda8dcc5f6f02fc56b13',
+     armv7l: '4b844ba4a96f39e12b4a691c96d76726de85ced70ca4eda8dcc5f6f02fc56b13',
+       i686: '49ad521137cca7a9384d84f3bf88b232edabf9ad9e26f40d1c543ea6975ed5ce',
+     x86_64: '49f142a0b9e09c4b48a6d9dbac1b20fb2e579536af9391d04c06fb0ef9693844'
   })
 
   def self.build
     system './autogen.sh'
-    system './configure',
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}"
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -3,29 +3,31 @@ require 'package'
 class Zlibpkg < Package
   description 'zlib is a massively spiffy yet delicately unobtrusive compression library.'
   homepage 'http://www.zlib.net/'
-  version '1.2.11-3'
+  @_ver = '1.2.11'
+  version "#{@_ver}-4"
   compatibility 'all'
-  source_url 'http://www.zlib.net/zlib-1.2.11.tar.gz'
+  source_url "http://www.zlib.net/zlib-#{@_ver}.tar.gz"
   source_sha256 'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/zlibpkg-1.2.11-3-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/zlibpkg-1.2.11-3-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/zlibpkg-1.2.11-3-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/zlibpkg-1.2.11-3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/zlibpkg-1.2.11-4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/zlibpkg-1.2.11-4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/zlibpkg-1.2.11-4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/zlibpkg-1.2.11-4-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '32adce95047eab53e31ee93794255159cc839ef5cdac1da46ed0ff5a15812df4',
-      armv7l: '32adce95047eab53e31ee93794255159cc839ef5cdac1da46ed0ff5a15812df4',
-        i686: 'd74959077aadf86030e2acd969923d23fa042d67bf5f1fe1cc91af09816f70e6',
-      x86_64: '8fab32aaf18449efe4140af1cd2af1abaf7543314524508b888d7ef4019d581f',
+  binary_sha256({
+    aarch64: '4b9c8b7ae88784f0c2744f268cc31afa1bb467f2ea964a7cb601509f12fceee7',
+     armv7l: '4b9c8b7ae88784f0c2744f268cc31afa1bb467f2ea964a7cb601509f12fceee7',
+       i686: 'fdd119fa2214635decf1a926a762cffc6e76a9ee4986d3a601c2afee05b150b8',
+     x86_64: '16c5a9c26c5ba526ae48dfaf277bb31c471bde9982747035f3e7594f4da710e8'
   })
-
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure \
+      --prefix=#{CREW_PREFIX} \
+      --libdir=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 


### PR DESCRIPTION
- rebuilt zlib using lto and have binutils using chromebrew built external zlib
- CREW_OPTIONS does not work for zlibpkg

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686