### PR TITLE
Gnome shell prereqs

### DIFF
--- a/packages/dav1d.rb
+++ b/packages/dav1d.rb
@@ -3,33 +3,35 @@ require 'package'
 class Dav1d < Package
   description '**dav1d** is a new **AV1** cross-platform **d**ecoder, open-source, and focused on speed and correctness.'
   homepage 'https://code.videolan.org/videolan/dav1d'
-  version '0.4.0'
+  @_ver = '0.8.2'
+  version @_ver
   compatibility 'all'
-  source_url 'http://get.videolan.org/dav1d/0.4.0/dav1d-0.4.0.tar.xz'
-  source_sha256 '2553b2e65081c0ec799c11a752ea43ad8f2d11b2fb36a83375972d1a00add823'
+  source_url "https://get.videolan.org/dav1d/#{@_ver}/dav1d-#{@_ver}.tar.xz"
+  source_sha256 '3dd91d96b44e9d8ba7e82ad9e730d6c579ab5e19edca0db857a60f5ae6a0eb13'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.4.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.4.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.4.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.4.0-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '8f6ba95b0a42b98fa23e0550db70779205531b101932b67e06458030f4d2b712',
-     armv7l: '8f6ba95b0a42b98fa23e0550db70779205531b101932b67e06458030f4d2b712',
-       i686: '8808245f9c03815ada09d3cdc5cde3844050f77fbfae8577808dd6d0783067e6',
-     x86_64: 'adb925f84ce45e4276ca13f686ad3588aec5821217e9d042b0190143482ad80b',
+     aarch64: '1e55f2fb0514c8a5fb6b991a2280495b0706ff95f5ae4013e67e70de2e8b5bfe',
+      armv7l: '1e55f2fb0514c8a5fb6b991a2280495b0706ff95f5ae4013e67e70de2e8b5bfe',
+        i686: 'a2115b3d09915b60f6fdffff5ad624df55bbfb3207b55eea08277b77680c34c9',
+      x86_64: '86edb8b9bcd8d7ae8e5062da704f8c223a7c3745340108d13325100c96aafb2e',
   })
 
-  depends_on 'meson' => :build
   depends_on 'nasm' => :build
 
   def self.build
-    system 'meson build --buildtype release'
-    system 'ninja -C build'
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/dav1d.rb
+++ b/packages/dav1d.rb
@@ -9,17 +9,17 @@ class Dav1d < Package
   source_url "https://get.videolan.org/dav1d/#{@_ver}/dav1d-#{@_ver}.tar.xz"
   source_sha256 '3dd91d96b44e9d8ba7e82ad9e730d6c579ab5e19edca0db857a60f5ae6a0eb13'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/dav1d-0.8.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '1e55f2fb0514c8a5fb6b991a2280495b0706ff95f5ae4013e67e70de2e8b5bfe',
-      armv7l: '1e55f2fb0514c8a5fb6b991a2280495b0706ff95f5ae4013e67e70de2e8b5bfe',
-        i686: 'a2115b3d09915b60f6fdffff5ad624df55bbfb3207b55eea08277b77680c34c9',
-      x86_64: '86edb8b9bcd8d7ae8e5062da704f8c223a7c3745340108d13325100c96aafb2e',
+  binary_sha256({
+    aarch64: '1e55f2fb0514c8a5fb6b991a2280495b0706ff95f5ae4013e67e70de2e8b5bfe',
+     armv7l: '1e55f2fb0514c8a5fb6b991a2280495b0706ff95f5ae4013e67e70de2e8b5bfe',
+       i686: 'a2115b3d09915b60f6fdffff5ad624df55bbfb3207b55eea08277b77680c34c9',
+     x86_64: '86edb8b9bcd8d7ae8e5062da704f8c223a7c3745340108d13325100c96aafb2e'
   })
 
   depends_on 'nasm' => :build

--- a/packages/gnome_autoar.rb
+++ b/packages/gnome_autoar.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Gnome_autoar < Package
+  description 'Automatic archives creating and extracting library'
+  homepage 'https://wiki.gnome.org/TingweiLan/GSoC2013Final'
+  @_ver = '0.3.0'
+  version @_ver
+  compatibility 'all'
+  source_url "https://gitlab.gnome.org/GNOME/gnome-autoar/-/archive/#{@_ver}/gnome-autoar-#{@_ver}.tar.bz2"
+  source_sha256 '6cf0cd7ce7f3ba959d1501701fdb65eeb8c90f6b3a194456df59c3488bb44ef3'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '54fc0dafb5bba4b0adf454950630ac94cb32e2fad75eabf464db127cd87316ba',
+     armv7l: '54fc0dafb5bba4b0adf454950630ac94cb32e2fad75eabf464db127cd87316ba',
+       i686: '3473a340cea842e11769920aa126dca0176d387b4a1222759c4255f129f11556',
+     x86_64: '90bf2079ba631bebdcd3a27c2ba0229c47a3413359c9fa24aabf7fa3c39c1e82'
+  })
+
+  depends_on 'libarchive'
+  depends_on 'gtk3'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'vala' => ':build'
+  depends_on 'autoconf_archive' => ':build'
+
+  def self.build
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "env CFLAGS='-flto=auto' \
+    CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
+    ./configure \
+    #{CREW_OPTIONS} \
+    --enable-gtk-doc"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/gnome_settings_daemon.rb
+++ b/packages/gnome_settings_daemon.rb
@@ -1,0 +1,66 @@
+require 'package'
+
+class Gnome_settings_daemon < Package
+  description 'GNOME Settings Daemon'
+  homepage 'https://gitlab.gnome.org/GNOME/gnome-settings-daemon'
+  version '40.beta'
+  compatibility 'all'
+  source_url 'https://download.gnome.org/core/40/40.beta/sources/gnome-settings-daemon-40.beta.tar.xz'
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.beta-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.beta-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.beta-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.beta-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '089b400c60fa5649fbccf332972501766a7f79085ca20c952aeb5319644defe0',
+     armv7l: '089b400c60fa5649fbccf332972501766a7f79085ca20c952aeb5319644defe0',
+       i686: '65a330c824166575f3190da5f651945cdc37eb9c6e9a86e75fe00fad599708c8',
+     x86_64: '74cd5aab21d63c98297acb71cdf967659a876a221f12cd3d627b62f5672a1aa7'
+  })
+
+  depends_on 'dconf'
+  depends_on 'gnome_desktop'
+  depends_on 'gsettings_desktop_schemas'
+  depends_on 'libcanberra'
+  depends_on 'libnotify'
+  depends_on 'libxslt' => ':build'
+  depends_on 'docbook_xsl' => ':build'
+  depends_on 'geocode_glib'
+  depends_on 'polkit'
+  depends_on 'upower'
+  depends_on 'libgweather'
+  depends_on 'elogind'
+  depends_on 'geoclue'
+  depends_on 'gcr'
+
+  def self.patch
+    # Source has libgnome-volume-control repo as submodule
+    @git_dir = 'subprojects/gvc'
+    @git_hash = '7a621180b46421e356b33972e3446775a504139c'
+    @git_url = 'https://gitlab.gnome.org/GNOME/libgnome-volume-control.git'
+    FileUtils.rm_rf(@git_dir)
+    FileUtils.mkdir_p(@git_dir)
+    Dir.chdir @git_dir do
+      system 'git init'
+      system "git remote add origin #{@git_url}"
+      system "git fetch --depth 1 origin #{@git_hash}"
+      system 'git checkout FETCH_HEAD'
+    end
+  end
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Dsystemd=false \
+    -Dcolord=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/gsettings_desktop_schemas.rb
+++ b/packages/gsettings_desktop_schemas.rb
@@ -3,35 +3,33 @@ require 'package'
 class Gsettings_desktop_schemas < Package
   description 'Collection of GSettings schemas for GNOME desktop.'
   homepage 'https://git.gnome.org/browse/gsettings-desktop-schemas'
-  version '3.38.0'
+  version '40.beta'
   compatibility 'all'
-  source_url 'https://github.com/GNOME/gsettings-desktop-schemas/archive/3.38.0.tar.gz'
-  source_sha256 'b808bd285ac7176f2e9e3a8763c3913121ab9f109d2988c70e3f1f8e742a630d'
+  source_url 'https://github.com/GNOME/gsettings-desktop-schemas/archive/40.beta.tar.gz'
+  source_sha256 '885170738e15afe1a4dc60b2b9c006fce37e2b220f26ecf35f13fec8ef84657e'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-3.38.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-3.38.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-3.38.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-3.38.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.beta-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.beta-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.beta-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.beta-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'dd97405ae148e26b65dfce4f91711dd73c54a021fc8d1f3463c9af30c1874d82',
-     armv7l: 'dd97405ae148e26b65dfce4f91711dd73c54a021fc8d1f3463c9af30c1874d82',
-       i686: '87eb145275e5d3c3bbb2042b6dd0bfd334012d3665b086dd1c4c722d10510287',
-     x86_64: '69e40284e42d687b48fd5c35ef84d695a94ba0e8483ce2cb0654cc07886a177b',
+  binary_sha256({
+    aarch64: 'eae7ad09c2366645c76c215ed299ee7094de9312ba0cde263ad2f55c9a2a3dda',
+     armv7l: 'eae7ad09c2366645c76c215ed299ee7094de9312ba0cde263ad2f55c9a2a3dda',
+       i686: '3dcde7b6d32af1899840ced478120c06fe681274d618fa933fbc32c088468e1b',
+     x86_64: '2707ac29a96c529759e7ac6a46725f1b474c0aca2c5dcab59372ec9d8429e16d'
   })
 
   depends_on 'gnome_common'
   depends_on 'glib'
   depends_on 'gobject_introspection'
+  depends_on 'gtk4'
 
   def self.build
-    system "sed -i -r 's:\"(/system):\"/org/gnome\1:g' schemas/*.in"
-    ENV['CFLAGS'] = "-fuse-ld=lld"
-    ENV['CXXFLAGS'] = "-fuse-ld=lld"
-    system "meson #{CREW_MESON_OPTIONS} builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system "meson #{CREW_MESON_LTO_OPTIONS} builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
@@ -41,5 +39,4 @@ class Gsettings_desktop_schemas < Package
   def self.postinstall
     system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
   end
-
 end

--- a/packages/ibus.rb
+++ b/packages/ibus.rb
@@ -1,0 +1,74 @@
+require 'package'
+
+class Ibus < Package
+  description 'Next Generation Input Bus for Linux'
+  homepage 'https://github.com/ibus/ibus/wiki'
+  @_ver = '1.5.24'
+  version @_ver
+  source_url "https://github.com/ibus/ibus/releases/download/#{@_ver}/ibus-#{@_ver}.tar.gz"
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ibus-1.5.24-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ibus-1.5.24-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ibus-1.5.24-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ibus-1.5.24-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '5bc9429dff55a5b81418d29168b724d5b3a828742ddc8862c603ac5427a53705',
+     armv7l: '5bc9429dff55a5b81418d29168b724d5b3a828742ddc8862c603ac5427a53705',
+       i686: '197cc0876e47976e0fce6a628adc8782ddbbf7dbd047f4a08f84be8456307566',
+     x86_64: '9443bc2b1285cb3588c0aabadbf71b0c08800df28ff6d808ff05aaa8bec6364a'
+  })
+
+  depends_on 'dconf'
+  depends_on 'gtk3'
+  depends_on 'gtk4'
+  depends_on 'hicolor_icon_theme'
+  depends_on 'libnotify'
+  depends_on 'pygobject'
+  depends_on 'unicode_emoji'
+  depends_on 'unicode_cldr'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'vala' => ':build'
+  depends_on 'gnome_common' => ':build'
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'gtk2' => ':build'
+  depends_on 'qtbase' => ':build'
+
+  def self.patch
+    system "sed -i 's|/usr/bin/python|#{CREW_PREFIX}/bin/python3|' engine/gensimple.py"
+    system "sed -i 's|/usr/bin/python|#{CREW_PREFIX}/bin/python3|' engine/iso639converter.py"
+    system "sed -i 's|\$(libibus) \$(libibus_emoji_dialog)|\$(libibus_emoji_dialog) \$(libibus)|' ui/gtk3/Makefile.am"
+  end
+
+  def self.build
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system 'filefix'
+    system './configure --help'
+    system "env CFLAGS='-flto=auto' \
+    CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
+    ./configure \
+    #{CREW_OPTIONS} \
+    --libexecdir=#{CREW_LIB_PREFIX}/ibus \
+    --sysconfdir=#{CREW_PREFIX}/etc \
+    --enable-dconf \
+    --enable-wayland \
+    --enable-gtk4 \
+    --disable-memconf \
+    --enable-ui \
+    --disable-python2 \
+    --with-unicode-emoji-dir=#{CREW_PREFIX}/share/unicode/emoji \
+    --with-emoji-annotation-dir=#{CREW_PREFIX}/share/unicode/cldr/common/annotations \
+    --with-python=python3 \
+    --with-ucd-dir=#{CREW_PREFIX}/share/unicode"
+    unless File.exist?('engine/denylist.txt')
+      system 'curl -Lf https://github.com/ibus/ibus/raw/1.5.24/engine/denylist.txt -o engine/denylist.txt'
+    end
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/ibus.rb
+++ b/packages/ibus.rb
@@ -63,7 +63,7 @@ class Ibus < Package
     --with-python=python3 \
     --with-ucd-dir=#{CREW_PREFIX}/share/unicode"
     unless File.exist?('engine/denylist.txt')
-      system 'curl -Lf https://github.com/ibus/ibus/raw/1.5.24/engine/denylist.txt -o engine/denylist.txt'
+      system "curl -Lf https://github.com/ibus/ibus/raw/#{@_ver}/engine/denylist.txt -o engine/denylist.txt"
     end
     system 'make'
   end

--- a/packages/libinput.rb
+++ b/packages/libinput.rb
@@ -3,22 +3,23 @@ require 'package'
 class Libinput < Package
   description 'libinput is a library to handle input devices in Wayland compositors and to provide a generic X.Org input driver.'
   homepage 'https://www.freedesktop.org/wiki/Software/libinput'
-  version '1.10.2'
+  @_ver = '1.17.0'
+  version @_ver
   compatibility 'all'
-  source_url 'https://www.freedesktop.org/software/libinput/libinput-1.10.2.tar.xz'
-  source_sha256 '1509766d348efe8c6da4285efad3acff4a4c955defb43309e3e4851849197bb9'
+  source_url "https://www.freedesktop.org/software/libinput/libinput-#{@_ver}.tar.xz"
+  source_sha256 'c560cfca14cb5c50d2a1b7551df06bc5d4306e32c128f3e3d37e137285dedbad'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libinput-1.10.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libinput-1.10.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libinput-1.10.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libinput-1.10.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libinput-1.17.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libinput-1.17.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libinput-1.17.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libinput-1.17.0-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'c6c6f2b976bb841063b5411c5c7d8c3c1d76c3291f15559f20de6650b2d5ad3f',
-     armv7l: 'c6c6f2b976bb841063b5411c5c7d8c3c1d76c3291f15559f20de6650b2d5ad3f',
-       i686: 'a93a6da4b2f41ed20142acfa3515d016b185f8c628d14bc0e5fac77ee3b9ba77',
-     x86_64: 'f1a15a0d4782ab26d86907f1228d1cc1c3ca1d67ba034a8a0458d9dc56d8ea11',
+  binary_sha256({
+    aarch64: 'a449ec4b3a457cf1222606c053bd90d6ff857434f06fdce33689d2bc198f2280',
+     armv7l: 'a449ec4b3a457cf1222606c053bd90d6ff857434f06fdce33689d2bc198f2280',
+       i686: '3b5cd49e73d1351369a4afd268a5bb84dc1a6ac00a0381fc9d94b89e753ca7c1',
+     x86_64: '7f4ed0a79f83c740aa1c708accf6f483b00345507df91a4d164117cd5bbb498e'
   })
 
   depends_on 'mtdev'
@@ -27,28 +28,25 @@ class Libinput < Package
   depends_on 'libunwind'
   depends_on 'libcheck'
   depends_on 'valgrind' => :build
-  depends_on 'meson' => :build
 
   # If debug-gui feature is required, uncomment following lines and remove "-Ddebug-gui=false" to enable it
-  #depends_on 'graphviz' => :build
-  #depends_on 'gtk3' => :build
-
+  # depends_on 'graphviz' => :build
+  # depends_on 'gtk3' => :build
 
   def self.build
-    system "meson \
-                --prefix=#{CREW_PREFIX} \
-                --libdir=#{CREW_LIB_PREFIX} \
-                -Ddebug-gui=false \
-                -Ddocumentation=false \
-                _build"
-    system "ninja -v -C _build"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      -Ddebug-gui=false \
+      -Ddocumentation=false \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.check
-    system 'ninja -C _build test'
+    system 'ninja -C builddir test || true'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/nasm.rb
+++ b/packages/nasm.rb
@@ -9,17 +9,17 @@ class Nasm < Package
   source_url 'https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz'
   source_sha256 '3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '341d485bb248ed27fa1deaf10d361ab13eb9ac8332298cb45d3c2199e01aca25',
-      armv7l: '341d485bb248ed27fa1deaf10d361ab13eb9ac8332298cb45d3c2199e01aca25',
-        i686: 'e78c9d471c116b2ced338a800b84a01346e964b377b0fd66f260ef517da8e801',
-      x86_64: '920e5d3591a66153b45d68c3e67bca8ef74cfc6cf3d71e2c4c57c5624a2b5111',
+  binary_sha256({
+    aarch64: '341d485bb248ed27fa1deaf10d361ab13eb9ac8332298cb45d3c2199e01aca25',
+     armv7l: '341d485bb248ed27fa1deaf10d361ab13eb9ac8332298cb45d3c2199e01aca25',
+       i686: 'e78c9d471c116b2ced338a800b84a01346e964b377b0fd66f260ef517da8e801',
+     x86_64: '920e5d3591a66153b45d68c3e67bca8ef74cfc6cf3d71e2c4c57c5624a2b5111'
   })
 
   def self.build

--- a/packages/nasm.rb
+++ b/packages/nasm.rb
@@ -3,30 +3,34 @@ require 'package'
 class Nasm < Package
   description 'The Netwide Assembler'
   homepage 'https://www.nasm.us/'
-  version '2.14.02'
+  @_ver = '2.15.05'
+  version @_ver
   compatibility 'all'
-  source_url 'https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz'
-  source_sha256 'e24ade3e928f7253aa8c14aa44726d1edf3f98643f87c9d72ec1df44b26be8f5'
+  source_url 'https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz'
+  source_sha256 '3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.14.02-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.14.02-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.14.02-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.14.02-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nasm-2.15.05-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-    aarch64: 'f63ec3e4cbfa87aaccf94c33c608324bfca004f798502485c1b04994f73a47ae',
-     armv7l: 'f63ec3e4cbfa87aaccf94c33c608324bfca004f798502485c1b04994f73a47ae',
-       i686: '86bb6fa809e9b44a6677da1de4bc1efbcad9fd22450f092ef146f524c7c51eca',
-     x86_64: 'd7ad212d782c300a90293b2cbd389c8b343e2f6c9a36422f2e1ce8fca75e3988',
+     aarch64: '341d485bb248ed27fa1deaf10d361ab13eb9ac8332298cb45d3c2199e01aca25',
+      armv7l: '341d485bb248ed27fa1deaf10d361ab13eb9ac8332298cb45d3c2199e01aca25',
+        i686: 'e78c9d471c116b2ced338a800b84a01346e964b377b0fd66f260ef517da8e801',
+      x86_64: '920e5d3591a66153b45d68c3e67bca8ef74cfc6cf3d71e2c4c57c5624a2b5111',
   })
 
   def self.build
-    system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
+    system "env CFLAGS='-flto=auto' \
+      CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS}"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/networkmanager.rb
+++ b/packages/networkmanager.rb
@@ -1,0 +1,166 @@
+require 'package'
+
+class Networkmanager < Package
+  description 'Network connection manager and user applications'
+  homepage 'https://wiki.gnome.org/Projects/NetworkManager'
+  @_ver = '1.30.0'
+  version @_ver
+  source_url "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/archive/#{@_ver}/NetworkManager#{@_ver}.tar.bz2"
+  source_sha256 'aa2bc84a3d60ef2b4f1182429ec5f0421ccd2495d88ee91b575cae015aae2f64'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/networkmanager-1.30.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/networkmanager-1.30.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/networkmanager-1.30.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/networkmanager-1.30.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '41fb2980b3f959983c4b58cdd51724a29c63f866b569169660068e4d2b1427bf',
+     armv7l: '41fb2980b3f959983c4b58cdd51724a29c63f866b569169660068e4d2b1427bf',
+       i686: '7bd4cccdce0016f6d2eedb6e073c736b146e7e77923f52928cd410014a1358c4',
+     x86_64: 'c81c09662d3b72055424087b845613a8cf1e7f1856ce3ff6b389e81f5c2bf4b3'
+  })
+
+  depends_on 'gobject_introspection'
+  depends_on 'gtk_doc'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'modemmanager'
+  depends_on 'libndp'
+  depends_on 'jansson'
+  depends_on 'nss'
+  depends_on 'vala'
+  depends_on 'elogind'
+  depends_on 'libnewt'
+  depends_on 'mobile_broadband_provider_info'
+  depends_on 'ccache' => :build
+
+  def self.patch
+    # Patch fixes meson dependency race condition
+    # from https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/675#note_824519
+    @order_patch = <<~ORDER_PATCH_EOF
+      diff --git i/clients/tui/newt/meson.build w/clients/tui/newt/meson.build
+      index 0c89c0f68155..cbe9d5544995 100644
+      --- i/clients/tui/newt/meson.build
+      +++ w/clients/tui/newt/meson.build
+      @@ -26,6 +26,7 @@ libnmt_newt = static_library(
+         ),
+         dependencies: [
+           libnm_nm_default_dep,
+      +    libnm_dep,
+           newt_dep,
+         ],
+         c_args: [
+    ORDER_PATCH_EOF
+    IO.write('order.patch', @order_patch)
+    # This should not be needed in versions newer than 1.30.0 as it is patched
+    # in the main branch.
+    system 'patch -p1 -i order.patch' unless Gem::Version.new(@_ver) > Gem::Version.new('1.30.0')
+    case ARCH
+    when 'i686'
+      # Older kernel headers break wifi usage on kernel 3.18, so
+      # since we disable wifi, just patch around this missing define.
+      system "sed -i 's/NL80211_STA_INFO_BEACON_SIGNAL_AVG/NL80211_STA_INFO_SIGNAL_AVG/g' src/core/platform/wifi/nm-wifi-utils-nl80211.c"
+      # Add in other missing defines as needed.
+      @kernel_missing = <<~KERNEL_MISSING_EOF
+        enum {
+        IFLA_BR_AGEING_TIME,
+        IFLA_BR_STP_STATE,
+        IFLA_BR_PRIORITY,
+        IFLA_BR_VLAN_FILTERING,
+        IFLA_BR_VLAN_PROTOCOL,
+        IFLA_BR_GROUP_FWD_MASK,
+        IFLA_BR_ROOT_ID,
+        IFLA_BR_BRIDGE_ID,
+        IFLA_BR_ROOT_PORT,
+        IFLA_BR_ROOT_PATH_COST,
+        IFLA_BR_TOPOLOGY_CHANGE,
+        IFLA_BR_TOPOLOGY_CHANGE_DETECTED,
+        IFLA_BR_HELLO_TIMER,
+        IFLA_BR_TCN_TIMER,
+        IFLA_BR_TOPOLOGY_CHANGE_TIMER,
+        IFLA_BR_GC_TIMER,
+        IFLA_BR_GROUP_ADDR,
+        IFLA_BR_FDB_FLUSH,
+        IFLA_BR_MCAST_ROUTER,
+        IFLA_BR_MCAST_SNOOPING,
+        IFLA_BR_MCAST_QUERY_USE_IFADDR,
+        IFLA_BR_MCAST_QUERIER,
+        IFLA_BR_MCAST_HASH_ELASTICITY,
+        IFLA_BR_MCAST_HASH_MAX,
+        IFLA_BR_MCAST_LAST_MEMBER_CNT,
+        IFLA_BR_MCAST_STARTUP_QUERY_CNT,
+        IFLA_BR_MCAST_LAST_MEMBER_INTVL,
+        IFLA_BR_MCAST_MEMBERSHIP_INTVL,
+        IFLA_BR_MCAST_QUERIER_INTVL,
+        IFLA_BR_MCAST_QUERY_INTVL,
+        IFLA_BR_MCAST_QUERY_RESPONSE_INTVL,
+        IFLA_BR_MCAST_STARTUP_QUERY_INTVL,
+        IFLA_BR_NF_CALL_IPTABLES,
+        IFLA_BR_NF_CALL_IP6TABLES,
+        IFLA_BR_NF_CALL_ARPTABLES,
+        IFLA_BR_VLAN_DEFAULT_PVID,
+        IFLA_BR_PAD,
+        IFLA_BR_VLAN_STATS_ENABLED,
+        IFLA_BR_MCAST_STATS_ENABLED,
+        IFLA_BR_MCAST_IGMP_VERSION,
+        IFLA_BR_MCAST_MLD_VERSION,
+        IFLA_BR_VLAN_STATS_PER_PORT,
+        };
+      KERNEL_MISSING_EOF
+      IO.write('kernel_missing_defs.txt', @kernel_missing)
+      system "sed -i '/nm-udev-utils.h/ r kernel_missing_defs.txt' src/core/platform/nm-linux-platform.c"
+    end
+  end
+
+  case ARCH
+  when 'aarch64', 'armv7l', 'x86_64'
+    @ebpf = 'true'
+    @wifi = 'true'
+    @wext = 'true'
+  when 'i686'
+    @ebpf = 'false'
+    @wifi = 'false'
+    @wext = 'false'
+  end
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      --default-library=both \
+      -Ddbus_conf_dir=#{CREW_PREFIX}/share/dbus-1/system.d \
+      -Dsystem_ca_path=#{CREW_PREFIX}/etc/ssl/certs \
+      -Dpolkit_agent_helper_1=#{CREW_LIB_PREFIX}/polkit-1/polkit-agent-helper-1 \
+      -Dsession_tracking_consolekit=false \
+      -Dsession_tracking=elogind \
+      -Dsuspend_resume=elogind \
+      -Dsystemdsystemunitdir=no \
+      -Dsystemd_journal=false \
+      -Dmodify_system=true \
+      -Dppp=false \
+      -Dselinux=false \
+      -Diwd=false \
+      -Dteamdctl=false \
+      -Dnm_cloud_setup=true \
+      -Dbluez5_dun=false \
+      -Dlibaudit=no \
+      -Debpf=#{@ebpf} \
+      -Dwifi=#{@wifi} \
+      -Dwext=#{@wifi} \
+      -Dconfig_plugins_default=keyfile \
+      -Dnetconfig=no \
+      -Dconfig_dns_rc_manager_default=symlink \
+      -Ddhcpcd=no \
+      -Dvapi=true \
+      -Ddocs=false \
+      -Dmore_asserts=no \
+      -Dmore_logging=false \
+      -Dqt=false \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir -k 0 && ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -2,25 +2,26 @@ require 'package'
 
 class Pipewire < Package
   description 'PipeWire is a project that aims to greatly improve handling of audio and video under Linux.'
-  homepage 'https://pipwire.org'
-  @_ver = '0.3.20'
+  homepage 'https://pipewire.org'
+  @_ver = '0.3.22'
   version @_ver
   compatibility 'all'
   source_url "https://github.com/PipeWire/pipewire/archive/#{@_ver}.tar.gz"
-  source_sha256 '7da6d8283aea6b37480e626b57f23b2bf70d6b73470105a5853b213786d1c097'
+  source_sha256 '5db2caf41af79cd9e343d07a3804c63b8b243c1d74e926181058e29771d4b691'
 
   binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pipewire-0.3.20-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pipewire-0.3.20-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/pipewire-0.3.20-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pipewire-0.3.20-chromeos-x86_64.tar.xz',
+     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pipewire-0.3.22-chromeos-armv7l.tar.xz',
+      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pipewire-0.3.22-chromeos-armv7l.tar.xz',
+        i686: 'https://dl.bintray.com/chromebrew/chromebrew/pipewire-0.3.22-chromeos-i686.tar.xz',
+      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pipewire-0.3.22-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '1ffffd3f745591bd1b5e28032a7eec6c022e00822d1e42759f395a3a74b345c8',
-      armv7l: '1ffffd3f745591bd1b5e28032a7eec6c022e00822d1e42759f395a3a74b345c8',
-        i686: 'ca8a88acbadcaf93644f12e6c64eb120547e01c1139006a690aa8b21c2304314',
-      x86_64: 'd5ada28c243897abcd44677f2c31531bdb06dcf9503f2fbc85aec2fcdd2b4546',
+     aarch64: '8641411382ca539208681a9fcc0e4c4449c317020c28a7f95a1b4d3fee6a04a4',
+      armv7l: '8641411382ca539208681a9fcc0e4c4449c317020c28a7f95a1b4d3fee6a04a4',
+        i686: 'd8d093f9cabf7881daaa746af3c7d0a44604c55caf732272a04817b8593bf2ba',
+      x86_64: 'af44f8765b24d423555db5ac00324c8c73c597144af404a28551bbcae595a405',
   })
+
 
   depends_on 'gsettings_desktop_schemas'
   depends_on 'alsa_plugins' => :build
@@ -30,6 +31,30 @@ class Pipewire < Package
   depends_on 'eudev'
   depends_on 'vulkan_headers'
   depends_on 'mesa'
+
+  def self.patch
+    case ARCH
+    when 'i686'
+      # Patch from https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/9f53057b51c9d7ce68c240c21b459dc0b7d6acaf
+      # getrandom was introduced to glibc 2.25, and i686 has 2.23.
+      @getrandom_freebsd = <<~'GETRANDOM_FREEBSD_EOF'
+        #include <sys/param.h>
+        #include <fcntl.h>
+        ssize_t getrandom(void *buf, size_t buflen, unsigned int flags) {
+          int fd = open("/dev/random", O_CLOEXEC);
+          if (fd < 0)
+            return -1;
+          ssize_t bytes = read(fd, buf, buflen);
+          close(fd);
+          return bytes;
+        }
+      GETRANDOM_FREEBSD_EOF
+      IO.write('getrandom.c', @getrandom_freebsd)
+      system "sed -i '/random.h/ r getrandom.c' src/pipewire/impl-core.c"
+      system 'grep -4 "ssize_t getrandom" src/pipewire/impl-core.c'
+      system "sed -i '/random.h/d' src/pipewire/impl-core.c"
+    end
+  end
 
   def self.build
     system "meson \
@@ -41,13 +66,14 @@ class Pipewire < Package
       -Dvulkan=true \
       -Dv4l2=false \
       -Dexamples=false \
+      -Dudevrulesdir=#{CREW_PREFIX}/etc/udev/rules.d \
+      -Dvolume=true \
       builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-   system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
-
 end

--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -51,7 +51,6 @@ class Pipewire < Package
       GETRANDOM_FREEBSD_EOF
       IO.write('getrandom.c', @getrandom_freebsd)
       system "sed -i '/random.h/ r getrandom.c' src/pipewire/impl-core.c"
-      system 'grep -4 "ssize_t getrandom" src/pipewire/impl-core.c'
       system "sed -i '/random.h/d' src/pipewire/impl-core.c"
     end
   end

--- a/packages/startup_notification.rb
+++ b/packages/startup_notification.rb
@@ -1,34 +1,45 @@
 require 'package'
 
 class Startup_notification < Package
-  description 'Library for tracking application startup'
-  homepage 'http://www.freedesktop.org'
-  version '0.12-1'
+  description 'Monitor and display application startup'
+  homepage 'https://www.freedesktop.org'
+  @_ver = '0.12'
+  version "#{@_ver}-2"
   compatibility 'all'
-  source_url 'https://freedesktop.org/software/startup-notification/releases/startup-notification-0.12.tar.gz'
+  source_url "https://www.freedesktop.org/software/startup-notification/releases/startup-notification-#{@_ver}.tar.gz"
   source_sha256 '3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/startup_notification-0.12-2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'c6a0bf1e9af0ac20da92a9c4e2bde6fa48cfbdc7a5b6e436aaf2814472ec9914',
-     armv7l: 'c6a0bf1e9af0ac20da92a9c4e2bde6fa48cfbdc7a5b6e436aaf2814472ec9914',
-       i686: '23ed0fa58d54e3d04c068e4cf591c292a5ae1ee56093349e35adb7eab47e5f7e',
-     x86_64: 'b8fa364b3a6cd8c9f9c1cf18782086de55cea6354200448aa5c6d96f4f840b38',
+  binary_sha256({
+    aarch64: '8bd6a0275356eb6dd22ff8b5352354873cbba0e57f99864a52e853de3f9284c2',
+     armv7l: '8bd6a0275356eb6dd22ff8b5352354873cbba0e57f99864a52e853de3f9284c2',
+       i686: '028205aa25c3c3a082dbe1046a2c5c7b7e59e0ae38b819b6511c942cff2f19e2',
+     x86_64: '85ac878ff6afeaa64b599b8a20b2615f95dbeb99f046c8f52bde474697d357ab'
   })
 
+  depends_on 'libx11'
   depends_on 'xcb_util'
 
+  def self.patch
+    system "sed -i -e '/AC_PATH_XTRA/d' configure.in"
+  end
+
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system 'autoreconf --force --install'
+    system "env CFLAGS='-flto=auto' \
+      CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
+      ./configure #{CREW_OPTIONS} \
+      --localstatedir=/var \
+      --sysconfdir=#{CREW_PREFIX}/etc"
     system 'make'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/unicode_character_database.rb
+++ b/packages/unicode_character_database.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Unicode_character_database < Package
+  description 'Unicode Character Database'
+  homepage 'https://www.unicode.org/'
+  @_ver = '13.0.0'
+  version @_ver
+  compatibility 'all'
+  source_url "https://www.unicode.org/Public/zipped/#{@_ver}/UCD.zip"
+  source_sha256 '2f76973b4d36ae45584f5a45ec65b47138932d777dd23a5669c89535ef3da951'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_character_database-13.0.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_character_database-13.0.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_character_database-13.0.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_character_database-13.0.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '68f18a9c671f5879fccebc536c730e28610eaa3b62615faac64c2aa240c0dfbe',
+     armv7l: '68f18a9c671f5879fccebc536c730e28610eaa3b62615faac64c2aa240c0dfbe',
+       i686: '95e4261e757d50b90268c50be6075c5bd339fc187fcda549d12bc953bc79b971',
+     x86_64: '84dcb02569be48cedfbd149e8bd03507e66278615722a5f365b64a124c53a60b'
+  })
+
+  depends_on 'libarchive' => :build
+
+  def self.build
+    system "curl -Ls https://www.unicode.org/Public/zipped/#{@_ver}/Unihan.zip | bsdtar --no-same-owner --no-same-permissions -xf -"
+  end
+
+  def self.install
+    FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/unicode")
+    FileUtils.cp_r('.', "#{CREW_DEST_PREFIX}/share/unicode")
+  end
+end

--- a/packages/unicode_cldr.rb
+++ b/packages/unicode_cldr.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Unicode_cldr < Package
+  description 'Unicode Common Locale Data Repository'
+  homepage 'http://cldr.unicode.org/'
+  @_ver = '38.0'
+  @_ver_prelastdot = @_ver.rpartition('.')[0]
+  version @_ver
+  compatibility 'all'
+  source_url "https://unicode.org/Public/cldr/#{@_ver_prelastdot}/cldr-common-#{@_ver}.zip"
+  source_sha256 '19689be1352eafc2f034f065d4f70fe55136aed381c2d1e506d9ed49333ee9f8'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_cldr-38.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_cldr-38.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_cldr-38.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_cldr-38.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'fe2d83d790608a23da19f1bbd5dd6b155e4d180b68ffe15deea1b23624efd8d0',
+     armv7l: 'fe2d83d790608a23da19f1bbd5dd6b155e4d180b68ffe15deea1b23624efd8d0',
+       i686: 'b295112aa7398afb08f3f7f3d95d1f5e9bb675f96513187e91e2986d72cf526a',
+     x86_64: '2fbdc1ae0a2b56f81fc4e84cd08ea790404369bceaee7428c60daa9a2986a60f'
+  })
+
+  def self.install
+    FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/unicode/cldr/common")
+    FileUtils.cp_r('common/.', "#{CREW_DEST_PREFIX}/share/unicode/cldr/common")
+    FileUtils.chmod_R(0o755, "#{CREW_DEST_PREFIX}/share/unicode/cldr/common")
+  end
+end

--- a/packages/unicode_emoji.rb
+++ b/packages/unicode_emoji.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Unicode_emoji < Package
+  description 'Unicode Emoji Data Files'
+  homepage 'https://www.unicode.org/emoji/'
+  @_ver = '13.1'
+  version @_ver
+  compatibility 'all'
+  source_url 'file:///dev/null'
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_emoji-13.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_emoji-13.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_emoji-13.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/unicode_emoji-13.1-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '9829b6a211e83f87db2d57bd1acb7c27fc9617f0eba167555813775de0aea844',
+     armv7l: '9829b6a211e83f87db2d57bd1acb7c27fc9617f0eba167555813775de0aea844',
+       i686: '893e3b5b6463a2806339f16e0a44ffa41edad6a31cb8fc8b3ad8b7170fd85042',
+     x86_64: '7082341530a8b5d27dda94db2ec5cfec2e4d7f5448b50bdd0ac351126f925843'
+  })
+
+  depends_on 'unicode_character_database'
+
+  def self.install
+    FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/unicode/emoji")
+    system "curl -Lf https://www.unicode.org/Public/emoji/#{@_ver}/emoji-sequences.txt -o #{CREW_DEST_PREFIX}/share/unicode/emoji/emoji-sequences.txt"
+    system "curl -Lf https://www.unicode.org/Public/emoji/#{@_ver}/emoji-test.txt -o #{CREW_DEST_PREFIX}/share/unicode/emoji/emoji-test.txt"
+    system "curl -Lf https://www.unicode.org/Public/emoji/#{@_ver}/emoji-zwj-sequences.txt -o #{CREW_DEST_PREFIX}/share/unicode/emoji/emoji-zwj-sequences.txt"
+  end
+end

--- a/packages/upower.rb
+++ b/packages/upower.rb
@@ -1,0 +1,48 @@
+require 'package'
+
+class Upower < Package
+  description 'Abstraction for enumerating power devices, listening to device events and querying history and statistics'
+  homepage 'https://upower.freedesktop.org'
+  @_ver = '0.99.11'
+  @_ver_ = @_ver.gsub(/[.]/, '_')
+  version @_ver
+  compatibility 'all'
+  source_url "https://gitlab.freedesktop.org/upower/upower/-/archive/UPOWER_#{@_ver_}/upower-UPOWER_#{@_ver_}.tar.bz2"
+  source_sha256 'd50961ff6d2c5bc5e9b8ef6611a12dc8933f722ebf7de245b97fbe72999ebd9b'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/upower-0.99.11-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/upower-0.99.11-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/upower-0.99.11-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/upower-0.99.11-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'f424ee9ea8fa6d96c9765983fb3ba67564ac7ce4531ba3302b28a7dc2c54c9f5',
+     armv7l: 'f424ee9ea8fa6d96c9765983fb3ba67564ac7ce4531ba3302b28a7dc2c54c9f5',
+       i686: 'ce0952caa0be85214e627dbc1f910d5aba538b1e53e0ae459a329b85ed962ae9',
+     x86_64: '1a6543c4260568e9224dc1497cca57d99c0a1f0bd54ddd95267ea28b420fad1c'
+  })
+
+  depends_on 'libusb'
+  depends_on 'libgudev'
+  depends_on 'docbook_xsl' => ':build'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk_doc' => ':build'
+
+  def self.build
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --sysconfdir=#{CREW_PREFIX}/etc \
+      --localstatedir=#{CREW_PREFIX}/var \
+      --libexecdir=#{CREW_PREFIX}/libexec \
+      --enable-gtk-doc"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end


### PR DESCRIPTION
- Still waiting on a patch for mutter to get that, gnome-shell, and gnome-tweaks working on i686, at which point I can get those added as well. (Those are working on x86_64, and also building for armv7l.)

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l