### PR TITLE
mandb: Add gdbm dep

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -23,6 +23,7 @@ class Mandb < Package
   })
 
   depends_on 'libseccomp'
+  depends_on 'gdbm'
   
   def self.patch
     system "sed -i 's,/usr/man,#{CREW_PREFIX}/share/man,g' src/man_db.conf.in"


### PR DESCRIPTION
Should fix `mandb: error while loading shared libraries: libgdbm.so.6: cannot open shared object file: No such file or directory` when installing mandb at initial install?

Works properly:
- [x] x86_64 (this is hard to test)

(alternately could add gdbm to `early_packages` in `install.sh`)
