### PR TITLE
crew: modify ldconfig & curl usage

### DIFF
--- a/crew
+++ b/crew
@@ -51,6 +51,9 @@ DOCOPT
 # If CREW_XZ_OPT is defined, use it by default.  Use `-7e`, otherwise.
 ENV["XZ_OPT"] = ENV['CREW_XZ_OPT'] || "-7e -T #{CREW_NPROC}"
 
+# If CURL environment variable exists use it in lieu of curl.
+CURL = ENV['CURL'] || 'curl'
+
 # Parse arguments using docopt
 require_relative 'lib/docopt'
 begin
@@ -327,6 +330,7 @@ def const (var)
       'ARCH',
       'ARCH_LIB',
       'CHROMEOS_RELEASE',
+      'CURL',
       'CREW_BREW_DIR',
       'CREW_BUILD',
       'CREW_CMAKE_LIBSUFFIX_OPTIONS',
@@ -529,7 +533,7 @@ def download
       end
     end
 
-    system "curl --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
+    system "#{CURL} --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
 
     abort 'Checksum mismatch. :/ Try again.'.lightred unless
       Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum
@@ -836,7 +840,8 @@ def install
     file.write JSON.pretty_generate(output)
   end
   # Update shared library cache after install is complete.
-  system "#{CREW_PREFIX}/sbin/ldconfig || true"
+  system "echo #{CREW_LIB_PREFIX} > #{CREW_PREFIX}/etc/ld.so.conf"
+  system "#{CREW_PREFIX}/sbin/ldconfig -f #{CREW_PREFIX}/etc/ld.so.conf -C #{CREW_PREFIX}/etc/ld.so.cache"
 end
 
 def resolve_dependencies_and_build

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.8'
+CREW_VERSION = '1.7.9'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- followup to prior install.sh PR, modifying crew to pull in the `CURL` environment variable and use it if it exists.
- populates a `CREW_PREFIX/etc/ld.so.conf` with `CREW_LIB_PREFIX` and has `ldconfig` use that, also specifying `ld.so.cache` to be used as `CREW_PREFIX/etc/ld.so.cache`

Works properly:
- [x] x86_64
