### PR TITLE
Fix crew whatprovides

### DIFF
--- a/crew
+++ b/crew
@@ -384,7 +384,7 @@ def whatprovides (pkgName)
       if packageList[/\.filelist$/]
         packageName = File.basename packageList, '.filelist'
         File.readlines(packageList).each do |line|
-          found = line[/#{Regexp.new(pkgName)}/]
+          found = line[/#{pkgName}/] if line.ascii_only?
           if found
             fileLine = packageName + ': ' + line
             if not fileArray.include? fileLine

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.9'
+CREW_VERSION = '1.7.10'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Fixes #5294.

The problem is due to non-ascii characters in files from the ca_certificates package.  Since there is a high probability that anybody can (or would want to) search for specific certificate files, this fix should be sufficient.  If somebody needs to check the certificates, they can always execute `crew files ca_certificates` to list all the files.