### PR TITLE
Add preunpack function

### DIFF
--- a/crew
+++ b/crew
@@ -740,6 +740,7 @@ def expand_dependencies
 end
 
 def resolve_dependencies
+  @pkg.preunpack
   expand_dependencies
 
   # leave only not installed packages in dependencies

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.10'
+CREW_VERSION = '1.7.11'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -69,6 +69,11 @@ class Package
     @is_fake
   end
 
+  # Function to perform pre-unpack operations prior to binary or source extraction.
+  def self.preunpack
+
+  end
+
   # Function to perform patch operations prior to build from source.
   def self.patch
 


### PR DESCRIPTION
Currently, some packages have checks in the preinstall section that determine if installation should continue.  The problem is this requires a dependency check, the entire binary or source to be downloaded and then extracted unnecessarily first.  This new function will enable us to perform checks and abort the installation prior to the dependency check which should save time and unneeded extra processing.