### PR TITLE
[Fix Package] rsync

### DIFF
--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -23,6 +23,7 @@ class Rsync < Package
   })
 
   depends_on 'xxhash'
+  depends_on 'lz4'
 
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \


### PR DESCRIPTION
Fixes this configuretime error when building from source:
```
checking whether to enable LZ4 compression... no

Configure found the following issues:

- Failed to find lz4.h for lz4 compression support.

See the INSTALL file for hints on how to install the missing libraries and/or
how to generate (or fetch) man pages:
    https://github.com/WayneD/rsync/blob/master/INSTALL.md

To disable one or more features, the relevant configure options are:
    --disable-lz4

configure.sh: error: Aborting configure run
rsync failed to install: `env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto'       LDFLAGS='-flto=auto'       ./configure --prefix=/usr/local --libdir=/usr/local/lib64 --mandir=/usr/local/share/man --build=x86_64-cros-linux-gnu --host=x86_64-cros-linux-gnu --target=x86_64-cros-linux-gnu --program-prefix='' --program-suffix='' --disable-maintainer-mode` exited with 1
```

And this runtime error from the prebuilt binary:
```
$ rsync
rsync: error while loading shared libraries: liblz4.so.1: cannot open shared object file: No such file or directory
```