### PR TITLE
Add preflight function

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -108,6 +108,9 @@ class Template < Package # Notice the capitals, EG: 'I3' - would be used for an 
   depends_on '#' => :build # Only required when the package
   is built from source
             # Notice the newline
+  def self.preflight # For preflight checks, not required
+    system '#'  # Replace '#' with a disk space check, for example
+  end
   def self.prebuild # For sed operations, not required
     system '#'  # Replace '#' with a sed operation
   end

--- a/crew
+++ b/crew
@@ -740,6 +740,7 @@ def expand_dependencies
 end
 
 def resolve_dependencies
+  @pkg.preflight
   expand_dependencies
 
   # leave only not installed packages in dependencies

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.10'
+CREW_VERSION = '1.7.11'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -69,6 +69,11 @@ class Package
     @is_fake
   end
 
+  # Function to perform pre-flight operations prior to dependency checks.
+  def self.preflight
+
+  end
+
   # Function to perform patch operations prior to build from source.
   def self.patch
 

--- a/packages/template.rb.template
+++ b/packages/template.rb.template
@@ -30,6 +30,11 @@ class Template < Package
   # depends_on '*'
   #
 
+  # Function to perform pre-flight operations prior to dependency checks.
+  def self.preflight
+
+  end
+
 
   # Function to perform patch operations prior to build from source.
   def self.patch


### PR DESCRIPTION
Currently, some packages have checks in the preinstall section that determine if installation should continue. The problem is this requires a dependency check, the entire binary or source to be downloaded and then extracted unnecessarily first. This new function will enable us to perform checks and abort the installation prior to the dependency check which should save time and unneeded extra processing.