### PR TITLE
add signal_desktop prereqs

### DIFF
--- a/packages/cargo_c.rb
+++ b/packages/cargo_c.rb
@@ -1,0 +1,51 @@
+# Adapted from Arch Linux cargo-c PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/cargo-c/trunk/PKGBUILD
+
+require 'package'
+
+class Cargo_c < Package
+  description 'A cargo subcommand to build and install C-ABI compatibile dynamic and static libraries'
+  homepage 'https://github.com/lu-zero/cargo-c/'
+  version '0.7.3'
+  compatibility 'all'
+  source_url 'https://github.com/lu-zero/cargo-c/archive/v0.7.3/cargo-c-0.7.3.tar.gz'
+  source_sha256 '533c65d555330e86b91415753efc140ffdb900abd59b5b6403352c4264941a99'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cargo_c-0.7.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cargo_c-0.7.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cargo_c-0.7.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cargo_c-0.7.3-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '9063b96616c64d564f99cd16611ca86f8b8a72a88f5afd03582aaba51941acea',
+     armv7l: '9063b96616c64d564f99cd16611ca86f8b8a72a88f5afd03582aaba51941acea',
+       i686: '3618f6dc7d77a526c22ed2dd05ea46af032b812d01c5f93c1f8546192d41acbf',
+     x86_64: 'de92ff24a09ed7d26f0b8490e174c83ff9941ab33b417a8d20243d0f85d18ef3'
+  })
+
+  depends_on 'rust' => ':build'
+
+  def self.build
+    system "cargo fetch \
+      --manifest-path Cargo.toml"
+    system "cargo build \
+      --release \
+      --frozen \
+      --manifest-path Cargo.toml"
+  end
+
+  def self.install
+    system "cargo install \
+      --frozen \
+      --offline \
+      --no-track \
+      --path . \
+      --root #{CREW_DEST_PREFIX}"
+    # Dir.glob("#{CREW_DEST_PREFIX}/bin/*") do |filename|
+    # new_filename = filename.sub('cargo-', '')
+    # puts "Renaming #{filename} to #{new_filename} ..."
+    # File.rename(filename, new_filename)
+    # end
+  end
+end

--- a/packages/cargo_c.rb
+++ b/packages/cargo_c.rb
@@ -42,10 +42,5 @@ class Cargo_c < Package
       --no-track \
       --path . \
       --root #{CREW_DEST_PREFIX}"
-    # Dir.glob("#{CREW_DEST_PREFIX}/bin/*") do |filename|
-    # new_filename = filename.sub('cargo-', '')
-    # puts "Renaming #{filename} to #{new_filename} ..."
-    # File.rename(filename, new_filename)
-    # end
   end
 end

--- a/packages/cfitsio.rb
+++ b/packages/cfitsio.rb
@@ -1,6 +1,3 @@
-# Adapted from Arch Linux cfitsio PKGBUILD at:
-# https://github.com/archlinux/svntogit-packages/raw/packages/cfitsio/trunk/PKGBUILD
-
 require 'package'
 
 class Cfitsio < Package
@@ -24,8 +21,11 @@ class Cfitsio < Package
      x86_64: '9957f638dd3ea9188ded8bbee7970955947784d51633033a3693ebb746158330'
   })
 
+  def self.patch
+     system "sed -e 's|LDFLAGS=.*|LDFLAGS=$LDFLAGS|g' -i configure.in # Fix LDFLAGS"
+  end
+  
   def self.build
-    system "sed -e 's|LDFLAGS=.*|LDFLAGS=$LDFLAGS|g' -i configure.in # Fix LDFLAGS"
     system 'autoreconf -vi'
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \

--- a/packages/cfitsio.rb
+++ b/packages/cfitsio.rb
@@ -1,0 +1,41 @@
+# Adapted from Arch Linux cfitsio PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/cfitsio/trunk/PKGBUILD
+
+require 'package'
+
+class Cfitsio < Package
+  description 'A library of C and Fortran subroutines for reading and writing data files in FITS Flexible Image Transport System data format'
+  homepage 'https://heasarc.gsfc.nasa.gov/fitsio/'
+  version '3.49'
+  compatibility 'all'
+  source_url 'https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-3.49.tar.gz'
+  source_sha256 '5b65a20d5c53494ec8f638267fca4a629836b7ac8dd0ef0266834eab270ed4b3'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cfitsio-3.49-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cfitsio-3.49-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cfitsio-3.49-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cfitsio-3.49-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '0d24de398a86b55b04f5601e856f872cccbe1e9d347bf918f7ad18af8bae776e',
+     armv7l: '0d24de398a86b55b04f5601e856f872cccbe1e9d347bf918f7ad18af8bae776e',
+       i686: '728f1602789e0eacf81236e0739d59dd27dca649c6c57a9c9947a730d0aa2d25',
+     x86_64: '9957f638dd3ea9188ded8bbee7970955947784d51633033a3693ebb746158330'
+  })
+
+  def self.build
+    system "sed -e 's|LDFLAGS=.*|LDFLAGS=$LDFLAGS|g' -i configure.in # Fix LDFLAGS"
+    system 'autoreconf -vi'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS} --enable-reentrant"
+    system 'make shared'
+    system 'make utils'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/fftw.rb
+++ b/packages/fftw.rb
@@ -3,30 +3,32 @@ require 'package'
 class Fftw < Package
   description 'FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data'
   homepage 'http://www.fftw.org/'
-  version '3.3.8'
+  @_ver = '3.3.9'
+  version @_ver
   compatibility 'all'
-  source_url 'http://www.fftw.org/fftw-3.3.8.tar.gz'
-  source_sha256 '6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303'
+  source_url "http://www.fftw.org/fftw-#{@_ver}.tar.gz"
+  source_sha256 'bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.8-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fftw-3.3.9-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'f3e94c3a07e8966eafe02daa3673de462bab1fbbb0f1aefcc844ffbc53c84307',
-     armv7l: 'f3e94c3a07e8966eafe02daa3673de462bab1fbbb0f1aefcc844ffbc53c84307',
-       i686: '03800193d0be4a716331a27a948022d0a6ac94183a6b2fe0a988f5d94e3e8ff9',
-     x86_64: '47c9b73133cf16339ab6c229ba74ec73155f0fc1bf01bfd0e4e2c6ac7c46f78e',
+  binary_sha256({
+    aarch64: '6c5328195b9c1fccaa1ed40c642706d4681bc7cf77429cefcab3b44280db1428',
+     armv7l: '6c5328195b9c1fccaa1ed40c642706d4681bc7cf77429cefcab3b44280db1428',
+       i686: 'dab931ee59bb137e8a8f644670cc3d645a59cc2ca765b055aa35a8dc51a52344',
+     x86_64: '095ec26abe2d9ede1c9c3016850b5e5be43706a102a184de26f93928014e7740'
   })
 
   def self.build
-    system './configure',
-           '--enable-shared=yes',
-           '--disable-maintainer-mode',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS} \
+      --enable-shared=yes \
+      --disable-maintainer-mode"
     system 'make'
   end
 

--- a/packages/git_lfs.rb
+++ b/packages/git_lfs.rb
@@ -2,34 +2,47 @@ require 'package'
 
 class Git_lfs < Package
   description 'Git extension for versioning large files'
-  homepage 'https://git-lfs.github.com/'
-  version '2.2.1'
+  homepage 'https://git-lfs.github.com'
+  @_ver = '2.13.2'
+  version @_ver
   compatibility 'all'
-  source_url 'https://github.com/git-lfs/git-lfs/archive/v2.2.1.tar.gz'
-  source_sha256 'fede2b31b0539fd4a580f831867caac1b5d5dc4405e938c4ee0bfeacfb78ad7a'
+  source_url "https://github.com/git-lfs/git-lfs/releases/download/v#{@_ver}/git-lfs-v#{@_ver}.tar.gz"
+  source_sha256 '782e6275df9ca370730945112e16a0b8c64b9819f0b61fae52ba1ebbc8dce2d5'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/git_lfs-2.2.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/git_lfs-2.2.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/git_lfs-2.2.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/git_lfs-2.2.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/git_lfs-2.13.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/git_lfs-2.13.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/git_lfs-2.13.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/git_lfs-2.13.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '7b4b7371e813ca12a6c2261602c3e55f52d3b856869d65f2f7f20aa86762e130',
-     armv7l: '7b4b7371e813ca12a6c2261602c3e55f52d3b856869d65f2f7f20aa86762e130',
-       i686: '67fac00c8c74a5e7bd756b387275b9d33200de3e36474c5b29e91400745caad6',
-     x86_64: '10a0ed5b9ec97692c89314d2fbfb38e173e23414d6724464b71a310db11c18be',
+  binary_sha256({
+    aarch64: '28dd4fe263e71d34c1af024f7955e975a7baa239b25d8fed9982cce213248d5a',
+     armv7l: '28dd4fe263e71d34c1af024f7955e975a7baa239b25d8fed9982cce213248d5a',
+       i686: 'df546bc44ec2978165ffa8c0b31bad8504df93e86e52aac58288df707692a4af',
+     x86_64: '6078b2db1ac18189f96da4aa5cd9ddd78db5575e89080e85824a08b2dc21e958'
   })
 
-  depends_on 'go'
+  depends_on 'go' => ':build'
+  depends_on 'go_tools' => ':build'
 
   def self.build
-    ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
-    system 'script/bootstrap'
+    system 'gem install -N ronn'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CGO_CPPFLAGS=${CXXFLAGS} \
+      CGO_CFLAGS=${CFLAGS} \
+      CGO_CXXFLAGS=${CXXFLAGS} \
+      CGO_LDFLAGS=${LDFLAGS} \
+      GOFLAGS='-buildmode=pie -trimpath -mod=vendor -modcacherw -ldflags=-linkmode=external' \
+      go generate ./commands && go build ."
+    system 'make man'
+    system 'gem uninstall --ignore-dependencies ronn'
   end
 
   def self.install
-    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
-    system "cp -r bin/ #{CREW_DEST_PREFIX}"
+    system "install -Dm755 git-lfs #{CREW_DEST_PREFIX}/bin/git-lfs"
+    system "install -Dm644 -t #{CREW_DEST_MAN_PREFIX}/man1 man/*.1"
+    system "install -Dm644 -t #{CREW_DEST_MAN_PREFIX}/man5 man/*.5"
   end
 end

--- a/packages/go.rb
+++ b/packages/go.rb
@@ -3,58 +3,79 @@ require 'package'
 class Go < Package
   description 'Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.'
   homepage 'https://golang.org/'
-  version '1.15.5'
+  @_ver = '1.16'
+  version @_ver
   compatibility 'all'
-  source_url 'https://dl.google.com/go/go1.15.5.src.tar.gz'
-  source_sha256 'c1076b90cf94b73ebed62a81d802cd84d43d02dea8c07abdc922c57a071c84f1'
+  source_url "https://dl.google.com/go/go#{@_ver}.src.tar.gz"
+  source_sha256 '7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.15.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.15.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.15.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.15.5-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.16-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.16-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.16-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/go-1.16-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '272f22f883fc7215ae6d5fb5edfa77b0d7b569fe4505ca7d7cf02ad0b594ebeb',
-     armv7l: '272f22f883fc7215ae6d5fb5edfa77b0d7b569fe4505ca7d7cf02ad0b594ebeb',
-       i686: 'd93951d4ba4c9dc07ed89db5eaa7f62b9e60d70c49712c5cc24a8debe28fb66c',
-     x86_64: '228376a806cec3c5ddc6e4276fabfcd1bc002d57f84dd2124d49bf2c0907ddfa',
+  binary_sha256({
+    aarch64: '5c8a7c1dba8d2d58cf474e6d0dfbe0d327268b3795fa6d59c84cf7e578c890e5',
+     armv7l: '5c8a7c1dba8d2d58cf474e6d0dfbe0d327268b3795fa6d59c84cf7e578c890e5',
+       i686: 'c1e8ef3998c06c069e49703af7f8c8bc719dcbd3c488322d9b3c3db765ee4dc8',
+     x86_64: '163773e1e201b0829189724b6781c6aa8e78eccf2041aa3cb09f07d7bc44e777'
   })
+
+  @env ||= ''
 
   # Tests require perl
-  depends_on 'perl' => :build
   # go is required to build versions of go > 1.4
-  unless File.exist? "#{CREW_PREFIX}/share/go/bin/go"
-    depends_on 'go_bootstrap' => :build
+  case ARCH
+  when 'x86_64'
+    @go_bootstrap_url = "https://golang.org/dl/go#{@_ver}.linux-amd64.tar.gz"
+  when 'i686'
+    @go_bootstrap_url = "https://golang.org/dl/go#{@_ver}.linux-386.tar.gz"
+  when 'aarch64', 'armv7l'
+    unless File.exist? "#{CREW_PREFIX}/share/go/bin/go"
+      depends_on 'go_bootstrap' => :build
+      @env += " PATH=$PATH:#{CREW_PREFIX}/share/go_bootstrap/go/bin"
+    end
   end
 
   def self.build
-    FileUtils.cd 'src' do
-      ENV['GOROOT'] = '..'
-      ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
-      ENV['GOROOT_FINAL'] = "#{CREW_PREFIX}/share/go"
-      ENV['GOHOSTARCH'] = 'arm' if ARCH == 'aarch64'
-      # install with go_bootstrap if go is not in the path
-      unless File.exist? "#{CREW_PREFIX}/share/go/bin/go"
-        ENV['GOROOT_BOOTSTRAP'] = "#{CREW_PREFIX}/share/go_bootstrap/go"
-        ENV['PATH'] = ENV['PATH'] + ":#{CREW_PREFIX}/share/go_bootstrap/go/bin"
-      else
-        ENV['GOROOT_BOOTSTRAP'] = "#{CREW_PREFIX}/share/go"
+    # Binaries not available for armv7l, so build those.
+    case ARCH
+    when 'aarch64', 'armv7l'
+      FileUtils.cd 'src' do
+        @env += "GOROOT='..'"
+        @env += " TMPDIR=#{CREW_PREFIX}/tmp"
+        @env += " GOROOT_FINAL=#{CREW_PREFIX}/share/go"
+        @env += ' GOHOSTARCH=arm' if ARCH == 'aarch64'
+        # install with go_bootstrap if go is not in the path
+        if File.exist? "#{CREW_PREFIX}/share/go/bin/go"
+          @env += " GOROOT_BOOTSTRAP=#{CREW_PREFIX}/share/go"
+        else
+          @env += " GOROOT_BOOTSTRAP=#{CREW_PREFIX}/share/go_bootstrap/go"
+          @env += " PATH=$PATH:#{CREW_PREFIX}/share/go_bootstrap/go/bin"
+        end
+        system "env #{@env} ./make.bash"
       end
-      system './make.bash'
     end
   end
 
   def self.check
-    FileUtils.cd 'src' do
-      system "PATH=\"#{Dir.pwd}/../bin:$PATH\" GOROOT=\"#{Dir.pwd}/..\" TMPDIR=\"#{CREW_PREFIX}/tmp\" go tool dist test"
+    case ARCH
+    when 'aarch64', 'armv7l'
+      Dir.chdir 'src' do
+        system "PATH=\"#{Dir.pwd}/../bin:$PATH\" GOROOT=\"#{Dir.pwd}/..\" TMPDIR=\"#{CREW_PREFIX}/tmp\" go tool dist test"
+      end
     end
   end
 
   def self.install
-    dest = "#{CREW_DEST_PREFIX}/share/"
-    FileUtils.mkdir_p dest
-    FileUtils.cp_r Dir.pwd, dest
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
+    case ARCH
+    when 'i686', 'x86_64'
+      system "curl -Ls #{@go_bootstrap_url} | tar -C #{CREW_DEST_PREFIX}/share/ -zxf -"
+    when 'aarch64', 'armv7l'
+      FileUtils.cp_r Dir.pwd, "#{CREW_DEST_PREFIX}/share/"
+    end
 
     # make a symbolic link for #{CREW_PREFIX}/bin/{go,gofmt}
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
@@ -66,13 +87,13 @@ class Go < Package
     puts
     puts "Installed Go for #{ARCH} in #{CREW_PREFIX}/share/go".lightblue
     puts
-    puts "To use `go run`, execute the following:".lightblue
+    puts 'To use `go run`, execute the following:'.lightblue
     puts "export TMPDIR=#{CREW_PREFIX}/tmp".lightblue
     puts
-    puts "To develop with `go`, execute the following:".lightblue
+    puts 'To develop with `go`, execute the following:'.lightblue
     puts "mkdir -p #{CREW_PREFIX}/work/go".lightblue
     puts "ln -s #{CREW_PREFIX}/work/go $HOME/go".lightblue
-    puts "export PATH=\"$HOME/go/bin:$PATH\"".lightblue
+    puts 'export PATH="$HOME/go/bin:$PATH"'.lightblue
     puts "export TMPDIR=#{CREW_PREFIX}/tmp".lightblue
     puts
   end

--- a/packages/go_tools.rb
+++ b/packages/go_tools.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Go_tools < Package
+  description 'Developer tools for the Go programming language'
+  homepage 'https://github.com/golang/tools'
+  @_ver = '0.6.6'
+  version @_ver
+  compatibility 'all'
+  source_url 'file:///dev/null'
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/go_tools-0.6.6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/go_tools-0.6.6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/go_tools-0.6.6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/go_tools-0.6.6-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '5c938388e815f2d03343301f391640a1cbc11fac3b31e20fc74b77c0963723df',
+     armv7l: '5c938388e815f2d03343301f391640a1cbc11fac3b31e20fc74b77c0963723df',
+       i686: '02e41321fa7030598a80a396887289027889ad08784bf04c68f38196f33f02ec',
+     x86_64: '61c25f3eae11e32d625f917f8d853e134a24581a555b5edd47e76fcef96f565d'
+  })
+
+  depends_on 'go' => ':build'
+
+  def self.install
+    @git_dir = 'go_tools_git'
+    @git_hash = "gopls/v#{@_ver}"
+    @git_url = 'https://github.com/golang/tools/'
+    FileUtils.rm_rf(@git_dir)
+    FileUtils.mkdir_p(@git_dir)
+    Dir.chdir @git_dir do
+      system 'git init'
+      system "git remote add origin #{@git_url}"
+      system "git fetch --depth 1 origin #{@git_hash}"
+      system 'git checkout FETCH_HEAD'
+      system "GOBIN=#{CREW_DEST_PREFIX}/bin go install ./cmd..."
+    end
+  end
+end

--- a/packages/graphviz.rb
+++ b/packages/graphviz.rb
@@ -3,44 +3,45 @@ require 'package'
 class Graphviz < Package
   description 'Graphviz is open source graph visualization software.'
   homepage 'https://www.graphviz.org/'
-  version '2.44.1'
+  @_ver = '2.46.1'
+  version @_ver
   compatibility 'all'
-  source_url 'https://gitlab.com/graphviz/graphviz/-/archive/2.44.1/graphviz-2.44.1.tar.bz2'
-  source_sha256 '0f8f3fbeaddd474e0a270dc9bb0e247a1ae4284ae35125af4adceffae5c7ae9b'
+  source_url "https://gitlab.com/graphviz/graphviz/-/archive/#{@_ver}/graphviz-#{@_ver}.tar.bz2"
+  source_sha256 'e5d7580b3dfcbeb0b86f28dd3c2df76f32086bb428f67c8ae8512e5fd969324d'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.44.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.44.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.44.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.44.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.46.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.46.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.46.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/graphviz-2.46.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'da98580f38a3061a10b951562da06f0802dc7524e7d17bbc1b33f57f6913a441',
-     armv7l: 'da98580f38a3061a10b951562da06f0802dc7524e7d17bbc1b33f57f6913a441',
-       i686: '3178c12127d2256d6859975726039c1d81ae3a53f07346dd6d2b1d457889e3e4',
-     x86_64: '42842a1c3fc77efe32ee82cea9edd29c5024019053103347a4d4ff9da5d6fd2f',
+  binary_sha256({
+    aarch64: 'd0cef37f5ff984c4dd87a9c8c99fca254b19764bd898b46a79665668dc812857',
+     armv7l: 'd0cef37f5ff984c4dd87a9c8c99fca254b19764bd898b46a79665668dc812857',
+       i686: '39f81cec1ac499d981af16aa448e0130a71a4ea5ac8d28eeee19a920d8366bd1',
+     x86_64: '23ee20353fee590a3fe35c5185c0404c32f6f82749b2ecf612b8658f21c5ebdb'
   })
 
   depends_on 'libgd'
   depends_on 'pango'
 
   def self.build
-    Dir.mkdir 'build'
-    Dir.chdir 'build' do
-      system 'cmake',
-             "-DGLIBCONFIG_INCLUDE_DIR=#{CREW_LIB_PREFIX}/glib-2.0/include",
-             "-DCMAKE_C_FLAGS='-I#{CREW_PREFIX}/include/harfbuzz'",
-             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
-             '-DCMAKE_BUILD_TYPE=Release',
-             '..'
-      system 'make'
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -I#{CREW_PREFIX}/include/harfbuzz' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      AWK=#{CREW_PREFIX}/bin/mawk \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        .."
     end
+    system 'ninja -C builddir'
   end
 
   def self.install
-    Dir.chdir 'build' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
     Dir.chdir CREW_DEST_PREFIX do
       FileUtils.mv 'lib', 'lib64' if ARCH == 'x86_64'
     end

--- a/packages/imagemagick.rb
+++ b/packages/imagemagick.rb
@@ -3,7 +3,7 @@ require 'package'
 class Imagemagick < Package
   description 'Use ImageMagick to create, edit, compose, or convert bitmap images.'
   homepage 'http://www.imagemagick.org/script/index.php'
-  version '6.9.11-29-7.0.10-29'
+  version '6.9.11-29-7.0.11-2'
   compatibility 'all'
 
   is_fake
@@ -14,7 +14,7 @@ class Imagemagick < Package
     puts
     puts "  Select the version to install:"
     puts "  6 = ImageMagick 6.9.11-29"
-    puts "  7 = ImageMagick 7.0.10-29"
+    puts "  7 = ImageMagick 7.0.11-2"
     puts "  0 = Cancel"
 
     while version = STDIN.gets.chomp

--- a/packages/imagemagick7.rb
+++ b/packages/imagemagick7.rb
@@ -3,47 +3,45 @@ require 'package'
 class Imagemagick7 < Package
   description 'Use ImageMagick to create, edit, compose, or convert bitmap images.'
   homepage 'http://www.imagemagick.org/script/index.php'
-  version '7.0.10-29'
-  compatibility 'aarch64,armv7l,x86_64'
-  case ARCH
-  when 'aarch64', 'armv7l', 'x86_64'
-    source_url 'https://github.com/ImageMagick/ImageMagick/archive/7.0.10-29.tar.gz'
-    source_sha256 '7a3a3347e8b0dae2396663c879644cebcb8d4ed115645b4c9dba66494022b2fd'
-    depends_on 'flif'
-    depends_on 'freeimage'
-    depends_on 'freetype'
-    depends_on 'ghostscript'
-    depends_on 'graphviz'
-    depends_on 'jbigkit'
-    depends_on 'jemalloc'
-    depends_on 'lzma'
-    depends_on 'libheif'
-    depends_on 'librsvg'
-    depends_on 'libwebp'
-    depends_on 'libwmf'
-    depends_on 'msttcorefonts'
-    depends_on 'openexr'
-    depends_on 'openjpeg'
-    depends_on 'pango'
-    depends_on 'python27'
-    depends_on 'zstd'
-    depends_on 'sommelier'
-  end
+  @_ver = '7.0.11-2'
+  version @_ver
+  compatibility 'all'
+  source_url "https://github.com/ImageMagick/ImageMagick/archive/#{@_ver}.tar.gz"
+  source_sha256 '936959ba77bb9d8fdab4d9c69f90316c02a7e2467dea3790ad36b4d500c31a22'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/imagemagick7-7.0.10-29-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/imagemagick7-7.0.10-29-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/imagemagick7-7.0.10-29-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/imagemagick7-7.0.11-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/imagemagick7-7.0.11-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/imagemagick7-7.0.11-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/imagemagick7-7.0.11-2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '2b36714b61050e4da65ccaf8860cf654d13f530122edbb21edd5e633f07db297',
-     armv7l: '2b36714b61050e4da65ccaf8860cf654d13f530122edbb21edd5e633f07db297',
-     x86_64: '8557c63c17dcfe443d9ed6e8d78aa555cf032b4165ec39157bb209581c0daf41',
+  binary_sha256({
+    aarch64: '04025f5ae6e216cf6e79f2c1a6eccc79ee4a3228eb4d13d9475938a031bb1986',
+     armv7l: '04025f5ae6e216cf6e79f2c1a6eccc79ee4a3228eb4d13d9475938a031bb1986',
+       i686: '2a8cae3b4c308c75078f199e8bb9b005baf0babfdce0ff9f5b5f52b23ca71fa0',
+     x86_64: '8bc32c289e65e5499660cda89afab1dfb68b14de9c70b4f3e82924fa3dafe80a'
   })
+
+  depends_on 'flif'
+  depends_on 'freeimage'
+  depends_on 'freetype'
+  depends_on 'ghostscript'
+  depends_on 'graphviz'
+  depends_on 'jbigkit'
+  depends_on 'jemalloc'
+  depends_on 'lzma'
+  depends_on 'libheif'
+  depends_on 'librsvg'
+  depends_on 'libwebp'
+  depends_on 'libwmf'
+  depends_on 'msttcorefonts'
+  depends_on 'openexr'
+  depends_on 'openjpeg'
+  depends_on 'pango'
 
   def self.preinstall
     imver = `stream -version 2> /dev/null | head -1 | cut -d' ' -f3`.chomp
-    abort "ImageMagick version #{imver} already installed.".lightgreen unless "#{imver}" == ""
+    abort "ImageMagick version #{imver} already installed.".lightgreen unless imver.to_s == ''
   end
 
   def self.patch
@@ -51,19 +49,24 @@ class Imagemagick7 < Package
   end
 
   def self.build
-    system "./configure",
-           "CFLAGS=-I#{CREW_PREFIX}/include/gdk-pixbuf-2.0 -I#{CREW_PREFIX}/include/c++/v1/support/xlocale",
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--mandir=#{CREW_MAN_PREFIX}",
-           "--with-windows-font-dir=#{CREW_PREFIX}/share/fonts/truetype/msttcorefonts",
-           '--disable-dependency-tracking',
-           '--with-jemalloc',
-           '--with-modules',
-           '--enable-hdri',
-           '--with-perl',
-           '--with-rsvg',
-           '--with-x'
+    system "env CFLAGS='-pipe -flto=auto -fno-stack-protector -U_FORTIFY_SOURCE \
+      -I#{CREW_PREFIX}/include/gdk-pixbuf-2.0 \
+      -I#{CREW_PREFIX}/include/c++/v1/support/xlocale' \
+      CXXFLAGS='-pipe -flto=auto -fno-stack-protector -U_FORTIFY_SOURCE' \
+      LDFLAGS='-flto=auto -fno-stack-protector -U_FORTIFY_SOURCE' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --mandir=#{CREW_MAN_PREFIX} \
+      --program-prefix='' \
+      --with-windows-font-dir=#{CREW_PREFIX}/share/fonts/truetype/msttcorefonts \
+      --disable-dependency-tracking \
+      --enable-hugepages \
+      --with-jemalloc \
+      --with-modules \
+      --enable-hdri \
+      --with-perl \
+      --with-rsvg \
+      --with-x"
     system 'make'
   end
 

--- a/packages/libaom.rb
+++ b/packages/libaom.rb
@@ -1,0 +1,72 @@
+require 'package'
+
+class Libaom < Package
+  description 'AV1 video codec from Alliance for Open Media'
+  homepage 'https://aomedia.org/'
+  version '1.0.0'
+  compatibility 'all'
+  source_url 'file:///dev/null'
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libaom-1.0.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libaom-1.0.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libaom-1.0.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libaom-1.0.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '333119009f00f96ab6fda4ea900eb19bf81bd8c446775d6b073a4ac56a0d2066',
+     armv7l: '333119009f00f96ab6fda4ea900eb19bf81bd8c446775d6b073a4ac56a0d2066',
+       i686: 'cdece1990fc30a8f45847ae13aa2e6dab6f9321365bb9412283d00586f23489f',
+     x86_64: 'c7bb9de577e4ff32458c47d9bf2c3a329a6011368f3f3bbde8e072fd9530d5c8'
+  })
+
+  depends_on 'yasm' => ':build'
+
+  def self.prebuild
+    @git_dir = 'aom_git'
+    @git_hash = '8b6eaa4d37b992efffe432fa513889e6d11ae04f'
+    @git_url = 'https://aomedia.googlesource.com/aom'
+    FileUtils.rm_rf(@git_dir)
+    FileUtils.mkdir_p(@git_dir)
+    Dir.chdir @git_dir do
+      system 'git init'
+      system "git remote add origin #{@git_url}"
+      system "git fetch --depth 1 origin #{@git_hash}"
+      system 'git checkout FETCH_HEAD'
+    end
+  end
+
+  def self.build
+    Dir.mkdir 'aom_git/builddir'
+    Dir.chdir 'aom_git/builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DBUILD_SHARED_LIBS:BOOL='ON' \
+        -DCMAKE_COLOR_MAKEFILE:BOOL='ON' \
+        -DENABLE_CCACHE:BOOL='OFF' \
+        -DENABLE_DECODE_PERF_TESTS:BOOL='OFF' \
+        -DENABLE_EXAMPLES:BOOL='ON' \
+        -DENABLE_DISTCC:BOOL='OFF' \
+        -DENABLE_DOCS:BOOL='ON' \
+        -DENABLE_GOMA:BOOL='OFF' \
+        -DENABLE_NASM:BOOL='ON' \
+        -DENABLE_TESTS:BOOL='OFF' \
+        -DENABLE_TOOLS:BOOL='ON' \
+        -DENABLE_WERROR:BOOL='OFF' \
+        -DINCLUDE_INSTALL_DIR:PATH='#{CREW_PREFIX}/include' \
+        -DLIB_INSTALL_DIR:PATH='#{CREW_LIB_PREFIX}' \
+        -Wno-dev \
+        .."
+    end
+    system 'ninja -C aom_git/builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C aom_git/builddir install"
+  end
+end

--- a/packages/libavif.rb
+++ b/packages/libavif.rb
@@ -1,0 +1,65 @@
+# Adapted from Arch Linux libavif PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libavif/trunk/PKGBUILD
+
+require 'package'
+
+class Libavif < Package
+  description 'Library for encoding and decoding .avif files'
+  homepage 'https://github.com/AOMediaCodec/libavif'
+  @_ver = '0.9.0'
+  version @_ver
+  compatibility 'all'
+  source_url "https://github.com/AOMediaCodec/libavif/archive/v#{@_ver}.tar.gz"
+  source_sha256 'ea1603fc18e7dd20cf01f0b405156576886ecb5df84db8c0e87187cd2f8a00f4'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libavif-0.9.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libavif-0.9.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libavif-0.9.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libavif-0.9.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '1f61a3c2509df65e7206ddc4ac79c5e4328f5f369d59da384c3f76fef87aa287',
+     armv7l: '1f61a3c2509df65e7206ddc4ac79c5e4328f5f369d59da384c3f76fef87aa287',
+       i686: 'd519816e462351cb38c44734dd9ce82fc8ed553614ca40a2683e88c710bd15fd',
+     x86_64: '639ba89c4a63d68f714bcf1bb56314594bd5eb5e41ba764424a5e115c97ce6c7'
+  })
+
+  depends_on 'libaom'
+  depends_on 'dav1d'
+  depends_on 'rav1e' unless ARCH == 'i686'
+  depends_on 'svt_av1' if ARCH == 'x86_64'
+  depends_on 'libpng'
+  depends_on 'libjpeg'
+  depends_on 'libyuv'
+  depends_on 'nasm' => ':build'
+  depends_on 'pkgconf' => ':build'
+  depends_on 'gdk_pixbuf' => ':build'
+
+  def self.build
+    ARCH == 'i686' ? (@rav1e = 'OFF') : (@rav1e = 'ON')
+    ARCH == 'x86_64' ? (@svt = 'ON') : (@svt = 'OFF')
+
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -I#{CREW_PREFIX}/include/harfbuzz' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DAVIF_BUILD_APPS=ON \
+        -DAVIF_CODEC_AOM=ON \
+        -DAVIF_CODEC_DAV1D=ON \
+        -DAVIF_CODEC_RAV1E=#{@rav1e} \
+        -DAVIF_CODEC_SVT=#{@svt} \
+        -DAVIF_BUILD_GDK_PIXBUF=ON \
+        .."
+    end
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/libde265.rb
+++ b/packages/libde265.rb
@@ -3,33 +3,40 @@ require 'package'
 class Libde265 < Package
   description 'Open h.265 video codec implementation.'
   homepage 'https://github.com/strukturag/libde265'
-  version '1.0.3'
+  @_ver = '1.0.8'
+  version @_ver
   compatibility 'all'
-  source_url 'https://github.com/strukturag/libde265/releases/download/v1.0.3/libde265-1.0.3.tar.gz'
-  source_sha256 'e4206185a7c67d3b797d6537df8dcaa6e5fd5a5f93bd14e65a755c33cd645f7a'
+  source_url "https://github.com/strukturag/libde265/releases/download/v#{@_ver}/libde265-#{@_ver}.tar.gz"
+  source_sha256 '24c791dd334fa521762320ff54f0febfd3c09fc978880a8c5fbc40a88f21d905'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libde265-1.0.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libde265-1.0.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libde265-1.0.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libde265-1.0.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libde265-1.0.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libde265-1.0.8-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libde265-1.0.8-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libde265-1.0.8-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '851a496c32ead6b6da9cf6f1ec14ae991f47592d400fa714151cf72552a4a58d',
-     armv7l: '851a496c32ead6b6da9cf6f1ec14ae991f47592d400fa714151cf72552a4a58d',
-       i686: '8a70ce6f43f78f6edba1f50e47cd17956ee21d92c534454785de4f143d3a5775',
-     x86_64: '0833d3f548c83b9706fe7a8797f0b695c907fac1f2aebbbabb936d0aea440f8a',
+  binary_sha256({
+    aarch64: 'f2ca6f26fd80159a03e6dc9e3ba62f24ab690c98b03444dc0bad602461643fde',
+     armv7l: 'f2ca6f26fd80159a03e6dc9e3ba62f24ab690c98b03444dc0bad602461643fde',
+       i686: 'b08e6380514f8c61a026f74bba03cc29eeefddbd3b430065de0c42da5a28d105',
+     x86_64: '4d4f93fd7b4cc7ac4003fba0a8a1a42edc43045fae6496b72a78b6f312b1e6cb'
   })
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-dependency-tracking'
-    system 'make'
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        .."
+    end
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/libgd.rb
+++ b/packages/libgd.rb
@@ -3,38 +3,45 @@ require 'package'
 class Libgd < Package
   description 'GD is an open source code library for the dynamic creation of images by programmers.'
   homepage 'https://libgd.github.io/'
-  version '2.3.0'
+  @_ver = '2.3.2'
+  version @_ver
   compatibility 'all'
-  source_url 'https://github.com/libgd/libgd/releases/download/gd-2.3.0/libgd-2.3.0.tar.gz'
-  source_sha256 '32590e361a1ea6c93915d2448ab0041792c11bae7b18ee812514fe08b2c6a342'
+  source_url "https://github.com/libgd/libgd/archive/gd-#{@_ver}.tar.gz"
+  source_sha256 'dcc22244d775f469bee21dce1ea42552adbb72ba0cc423f9fa6a64601b3a1893'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgd-2.3.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'f08ad9e3eea1b99d9c1528337d1a6fb0e764c35abcc82908acfd8d7635aa5890',
-     armv7l: 'f08ad9e3eea1b99d9c1528337d1a6fb0e764c35abcc82908acfd8d7635aa5890',
-       i686: 'ae9c98c5282c68e9f1e089281669c9e3e8a02c92a4398bb7725b9fe32ee92a65',
-     x86_64: '8e5ade77f722c7e76e8448483d1f6dc9119269173a642368f15fca9322cba14e',
+  binary_sha256({
+    aarch64: 'af41a2f68397421ae6d8974b1caaf41e559ddfce9b381dfa45ad235b8f912f1c',
+     armv7l: 'af41a2f68397421ae6d8974b1caaf41e559ddfce9b381dfa45ad235b8f912f1c',
+       i686: 'd6a56c32366bb5014e5cf04bd7a0ad4e9eb0038bb95df2e2ec7793d67111e4bc',
+     x86_64: '41a0e61d953cca647d9a31bf88c294918f7f089689f3552fb93cf2903aadeabe'
   })
 
-  depends_on 'cmake'
   depends_on 'libpng'
+  depends_on 'libavif'
+  depends_on 'libheif'
 
   def self.build
-    FileUtils.mkdir('build')
-    FileUtils.cd('build') do
-      system "cmake -DCMAKE_INCLUDE_PATH=#{CREW_PREFIX}/include -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} .."
-      system "make"
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -I#{CREW_PREFIX}/include/harfbuzz' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DCMAKE_INCLUDE_PATH=#{CREW_PREFIX}/include \
+        .."
     end
+    system 'ninja -C builddir'
   end
 
   def self.install
-    FileUtils.cd('build') do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/libgsf.rb
+++ b/packages/libgsf.rb
@@ -3,37 +3,41 @@ require 'package'
 class Libgsf < Package
   description 'The G Structured File Library'
   homepage 'https://gitlab.gnome.org/GNOME/libgsf'
-  version '1.14.44'
+  @_ver = '1.14.47'
+  @_ver_prelastdot = @_ver.rpartition('.')[0]
+  version @_ver
   compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/libgsf/1.14/libgsf-1.14.44.tar.xz'
-  source_sha256 '68bede10037164764992970b4cb57cd6add6986a846d04657af9d5fac774ffde'
+  source_url "https://download.gnome.org/sources/libgsf/#{@_ver_prelastdot}/libgsf-#{@_ver}.tar.xz"
+  source_sha256 'd188ebd3787b5375a8fd38ee6f761a2007de5e98fa0cf5623f271daa67ba774d'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgsf-1.14.44-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgsf-1.14.44-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgsf-1.14.44-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgsf-1.14.44-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgsf-1.14.47-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgsf-1.14.47-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgsf-1.14.47-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgsf-1.14.47-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '2ddd44b20669d3a473e11a3404533c18555c4b42d8809862a8cb0343c733606d',
-     armv7l: '2ddd44b20669d3a473e11a3404533c18555c4b42d8809862a8cb0343c733606d',
-       i686: '511a6260e66c54dd62eea8cb31bf372a746ac1d0757c718f76cd8553631ecb55',
-     x86_64: 'd120538959fa7d352b23aeaf8d9eb637d73ba9c38c0002dfb495b7bf1b086589',
+  binary_sha256({
+    aarch64: 'fdb327f0c46a75e3cd5c5e4bc7e2701fe5b622881837894f9b2314bcc4b29501',
+     armv7l: 'fdb327f0c46a75e3cd5c5e4bc7e2701fe5b622881837894f9b2314bcc4b29501',
+       i686: '200b8890ef591be47d6554bb280d4a60fcf2798bf2f970910207e3471c733842',
+     x86_64: '8d8c0cf26f3bad537ddc82020078ebb52062f83c7a33709f1b2c4cac0abc33c6'
   })
 
   depends_on 'gdk_pixbuf'
   depends_on 'gtk_doc'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-maintainer-mode',
-           '--enable-introspection'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS} \
+      --enable-shared=yes \
+      --disable-maintainer-mode \
+      --enable-introspection"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libimagequant.rb
+++ b/packages/libimagequant.rb
@@ -1,0 +1,37 @@
+# Adapted from Arch Linux libimagequant PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libimagequant/trunk/PKGBUILD
+
+require 'package'
+
+class Libimagequant < Package
+  description 'Library for high-quality conversion of RGBA images to 8-bit indexed-color palette images'
+  homepage 'https://pngquant.org/lib/'
+  version '2.14.1'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/ImageOptim/libimagequant/archive/2.14.1/libimagequant-2.14.1.tar.gz'
+  source_sha256 'b5fa27da1f3cf3e8255dd02778bb6a51dc71ce9f99a4fc930ea69b83200a7c74'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'eeff7663ff38b663fef766a1244ea4c0be6c465cd216f9f5b0409affd9f03ae3',
+     armv7l: 'eeff7663ff38b663fef766a1244ea4c0be6c465cd216f9f5b0409affd9f03ae3',
+     x86_64: 'a684ca8eeeb2a38a696eb8a1b3395e0d08929ef219c17df23ac87fbd6989d963'
+  })
+
+  def self.build
+    # system "sed -r 's/^install:.*/install:/;/install.*STATICLIB/d' -i Makefile"
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS} --with-openmp"
+    system 'make shared imagequant.pc'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} PREFIX=/usr install"
+  end
+end

--- a/packages/libsoup.rb
+++ b/packages/libsoup.rb
@@ -3,29 +3,28 @@ require 'package'
 class Libsoup < Package
   description 'libsoup is an HTTP client/server library for GNOME.'
   homepage 'https://wiki.gnome.org/Projects/libsoup'
-  version '2.72-2'
+  @_ver = '2.99.1'
+  @_ver_prelastdot = @_ver.rpartition('.')[0]
+  version @_ver
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/libsoup/2.72/libsoup-2.72.0.tar.xz'
-  source_sha256 '170c3f8446b0f65f8e4b93603349172b1085fb8917c181d10962f02bb85f5387'
+  source_url "https://download.gnome.org/sources/libsoup/#{@_ver_prelastdot}/libsoup-#{@_ver}.tar.xz"
+  source_sha256 '9703c09e1b41d413bc17b5a3b8baac7cd8be1aa89ebd628de802d9a572dc8d44'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.72-2-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.72-2-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.72-2-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.72-2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.99.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.99.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.99.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup-2.99.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: 'b400c7ec6e46aa72743e94f1f04c1e91dfac90f4c6af9a02a7b1b7fd7ae1b9c2',
-      armv7l: 'b400c7ec6e46aa72743e94f1f04c1e91dfac90f4c6af9a02a7b1b7fd7ae1b9c2',
-        i686: '4e3fd0b050b6d9f6897df32eb13922ceeeac11934fbbfb1df65fd0677ff9af54',
-      x86_64: '0a16a6d71b389a7196a93af1c4d29fa8c5c2d68dff6cd1b80b909de1d499de26',
+  binary_sha256({
+    aarch64: '94593ee64f8dfa68a432dd827f81ab189016a375541c5b52408ba6cd941fdcc6',
+     armv7l: '94593ee64f8dfa68a432dd827f81ab189016a375541c5b52408ba6cd941fdcc6',
+       i686: 'c1aac13d94d0a7ab3621a8d8cf75ce3d16afbab6de2452314913136b86213efc',
+     x86_64: 'e471e82d56d33f1ea7765d287184c481528b1c7277bc703f00bca36a8c928400'
   })
 
   depends_on 'glib_networking'
-  depends_on 'libpsl'
-  depends_on 'sqlite'
   depends_on 'vala'
-  depends_on 'llvm'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \

--- a/packages/libvips.rb
+++ b/packages/libvips.rb
@@ -1,0 +1,47 @@
+require 'package'
+
+class Libvips < Package
+  description 'A fast image processing library with low memory needs'
+  homepage 'https://libvips.github.io/libvips/'
+  @_ver = '8.10.6-beta'
+  version @_ver
+  compatibility 'all'
+  source_url "https://github.com/libvips/libvips/archive/v#{@_ver}.tar.gz"
+  source_sha256 '975371c3650dbfedbde012b6573034338b0bb8f03d5df8d031abb80c3b4c9014'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '64f9cad9ad9287b1c57086adec379640676a4a456b3e753d9e7797fe0ee92ec7',
+     armv7l: '64f9cad9ad9287b1c57086adec379640676a4a456b3e753d9e7797fe0ee92ec7',
+       i686: '504779b4a009c269dc19dc4f3bb0ad60512dc53da38bfbba3507c959540e3d37',
+     x86_64: '3d719741999b3e75ab54788b99d0468217b539ec9e79d1f672a71f14002a6c96'
+  })
+
+  depends_on 'cfitsio'
+  depends_on 'fftw'
+  depends_on 'imagemagick'
+  depends_on 'libexif'
+  depends_on 'libgsf'
+  depends_on 'libheif'
+  depends_on 'libimagequant'
+  depends_on 'librsvg'
+
+  def self.build
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system 'filefix'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/libxss.rb
+++ b/packages/libxss.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Libxss < Package
+  description 'X11 Screen Saver extension library'
+  homepage 'https://gitlab.freedesktop.org/xorg/lib/libxscrnsaver'
+  @_ver = '1.2.3'
+  version @_ver
+  compatibility 'all'
+  source_url "https://xorg.freedesktop.org/releases/individual/lib/libXScrnSaver-#{@_ver}.tar.bz2"
+  source_sha256 'f917075a1b7b5a38d67a8b0238eaab14acd2557679835b154cf2bca576e89bf8'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libxss-1.2.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libxss-1.2.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libxss-1.2.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libxss-1.2.3-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'cec3f0b92f4c56b7ec262ec05356f6304b6e5e651f3074abdb08177a4ef10099',
+     armv7l: 'cec3f0b92f4c56b7ec262ec05356f6304b6e5e651f3074abdb08177a4ef10099',
+       i686: 'a7c94cac209cda5532aba55897b7334586881757f47eeaaf136e64b9f5cdeb0a',
+     x86_64: '4de949279407adf9abf83328e51e7d86c0630ec2eae6925aa3fc02fe4a0166a5'
+  })
+
+  depends_on 'libxext'
+  depends_on 'util_macros' => ':build'
+
+  def self.build
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS} \
+      --sysconfdir=#{CREW_PREFIX}/etc"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/libyuv.rb
+++ b/packages/libyuv.rb
@@ -1,0 +1,61 @@
+require 'package'
+
+class Libyuv < Package
+  description 'Library for YUV scaling'
+  homepage 'https://chromium.googlesource.com/libyuv/libyuv/'
+  version 'd470'
+  compatibility 'all'
+  source_url 'file:///dev/null'
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libyuv-d470-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libyuv-d470-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libyuv-d470-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libyuv-d470-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '7fa394f0b0e7da7ccb54fa49dd04ee1fc794eee1518c6a9a39743ab006ca7dd0',
+     armv7l: '7fa394f0b0e7da7ccb54fa49dd04ee1fc794eee1518c6a9a39743ab006ca7dd0',
+       i686: '15f7bb558997c8a437997d61aa7a16aed327a87cf50e0d7504373ba9b6796c79',
+     x86_64: 'e4a3761380386ef8fa07c95b195eedfd4cae05616d5ee3af4e55ae761010efff'
+  })
+
+  depends_on 'libjpeg'
+
+  def self.prebuild
+    @git_dir = 'libyuv_git'
+    @git_hash = 'd47031c0d42efa8f10842e36f7b8135b52bcd3d0'
+    @git_url = 'https://chromium.googlesource.com/libyuv/libyuv'
+    FileUtils.rm_rf(@git_dir)
+    FileUtils.mkdir_p(@git_dir)
+    Dir.chdir @git_dir do
+      system 'git init'
+      system "git remote add origin #{@git_url}"
+      system "git fetch --depth 1 origin #{@git_hash}"
+      system 'git checkout FETCH_HEAD'
+    end
+  end
+
+  def self.build
+    Dir.mkdir 'libyuv_git/builddir'
+    Dir.chdir 'libyuv_git/builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        .."
+    end
+    system 'ninja -C libyuv_git/builddir'
+    system 'du -a libyuv_git/builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C libyuv_git/builddir install"
+    Dir.chdir CREW_DEST_PREFIX do
+      FileUtils.mv 'lib', 'lib64' if ARCH == 'x86_64'
+    end
+  end
+end

--- a/packages/rav1e.rb
+++ b/packages/rav1e.rb
@@ -1,0 +1,54 @@
+require 'package'
+
+class Rav1e < Package
+  description 'An AV1 encoder focused on speed and safety'
+  homepage 'https://github.com/xiph/rav1e/'
+  @_ver = '0.5.0-alpha'
+  version @_ver
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url "https://github.com/xiph/rav1e/archive/v#{@_ver}.tar.gz"
+  source_sha256 'fd884fa387d01860eaf22a0a97353525221eb32bf6b9154bbfa21b6cce5988c8'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/rav1e-0.5.0-alpha-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/rav1e-0.5.0-alpha-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/rav1e-0.5.0-alpha-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'd02192b1152145b31bb1192d79ca40cb722d3c550b7471020e30bfac69448571',
+     armv7l: 'd02192b1152145b31bb1192d79ca40cb722d3c550b7471020e30bfac69448571',
+     x86_64: '2c05f46c0361e5fc0b2e40fbd62561c0383eb2dd2b140a3d77a1fd3fc263a07f'
+  })
+
+  depends_on 'rust' => :build
+  depends_on 'cargo_c' => :build
+
+  def self.build
+    system "cargo fetch \
+      --manifest-path Cargo.toml"
+    system "cargo build \
+      --release \
+      --frozen \
+      --manifest-path Cargo.toml"
+    system "cargo cbuild \
+      --release \
+      --frozen \
+      --prefix=#{CREW_PREFIX} \
+      --manifest-path Cargo.toml"
+  end
+
+  def self.install
+    system "cargo install \
+      --frozen \
+      --offline \
+      --no-track \
+      --path . \
+      --root #{CREW_DEST_PREFIX}"
+    system "cargo cinstall \
+      --frozen \
+      --offline \
+      --prefix=#{CREW_PREFIX} \
+      --destdir=#{CREW_DEST_DIR} \
+      --libdir=#{CREW_LIB_PREFIX}"
+  end
+end

--- a/packages/sccache.rb
+++ b/packages/sccache.rb
@@ -1,0 +1,44 @@
+require 'package'
+
+class Sccache < Package
+  description 'Shared Compilation Cache'
+  homepage 'https://github.com/mozilla/sccache/'
+  @_ver = '0.2.15'
+  version @_ver
+  compatibility 'all'
+  source_url "https://github.com/mozilla/sccache/archive/v#{@_ver}.tar.gz"
+  source_sha256 '7dbe71012f9b0b57d8475de6b36a9a3b4802e44a135e886f32c5ad1b0eb506e0'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/sccache-0.2.15-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/sccache-0.2.15-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/sccache-0.2.15-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/sccache-0.2.15-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '0c5c81c8fb17e91e420cd2ab261800d5640519956a40c3feb74469bee303ec4e',
+     armv7l: '0c5c81c8fb17e91e420cd2ab261800d5640519956a40c3feb74469bee303ec4e',
+       i686: '817d47a4b92fc15e60c3f1f920965b8d6adbb0913f635abcd31135bc3ff0cde3',
+     x86_64: 'abbede3efe1a1cdee32be218ec2b86781da6074a262d7c07ac23b247610b8262'
+  })
+
+  depends_on 'rust' => ':build'
+
+  def self.build
+    system "cargo fetch \
+      --manifest-path Cargo.toml"
+    system "cargo build \
+      --release \
+      --frozen \
+      --manifest-path Cargo.toml"
+  end
+
+  def self.install
+    system "cargo install \
+      --frozen \
+      --offline \
+      --no-track \
+      --path . \
+      --root #{CREW_DEST_PREFIX}"
+  end
+end

--- a/packages/svt_av1.rb
+++ b/packages/svt_av1.rb
@@ -1,0 +1,40 @@
+# Not supported on 32-bit architectures.
+
+require 'package'
+
+class Svt_av1 < Package
+  description 'Scalable Video Technology AV1 encoder and decoder'
+  homepage 'https://gitlab.com/AOMediaCodec/SVT-AV1'
+  @_ver = '0.8.6'
+  version @_ver
+  compatibility 'x86_64'
+  source_url "https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v#{@_ver}/SVT-AV1-v#{@_ver}.tar.bz2"
+  source_sha256 'e942959be6b062f4adea33fd5dbfbd5581b178ce87b4baf9bd84283fbc8203e1'
+
+  binary_url({
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/svt_av1-0.8.6-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    x86_64: 'aae2d184ceaefd583dc310342497e01f334d6abf65bfd123a96ea8d4d535a8e0'
+  })
+
+  def self.build
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -I#{CREW_PREFIX}/include/harfbuzz' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DBUILD_SHARED_LIBS=ON \
+        -DNATIVE=OFF \
+        .."
+    end
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/util_macros.rb
+++ b/packages/util_macros.rb
@@ -3,29 +3,34 @@ require 'package'
 class Util_macros < Package
   description 'The util-macros package contains the m4 macros used by all of the Xorg packages'
   homepage 'https://www.linuxfromscratch.org/blfs/view/svn/util-macros.html'
-  version '1.19.2'
+  @_ver = '1.19.3'
+  version @_ver
   compatibility 'all'
-  source_url 'https://www.x.org/archive/individual/util/util-macros-1.19.2.tar.bz2'
-  source_sha256 'd7e43376ad220411499a79735020f9d145fdc159284867e99467e0d771f3e712'
+  source_url "https://xorg.freedesktop.org/releases/individual/util/util-macros-#{@_ver}.tar.bz2"
+  source_sha256 '0f812e6e9d2786ba8f54b960ee563c0663ddbe2434bf24ff193f5feab1f31971'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/util_macros-1.19.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/util_macros-1.19.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/util_macros-1.19.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/util_macros-1.19.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_util_macros-1.19.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_util_macros-1.19.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_util_macros-1.19.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_util_macros-1.19.3-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '13b77fca072e19dec38d98c18ac41a1574a1ef87c7b59266dd0f8ebf5bc93689',
-     armv7l: '13b77fca072e19dec38d98c18ac41a1574a1ef87c7b59266dd0f8ebf5bc93689',
-       i686: 'd1940387af9ebedd3153b18c7b3a1f0618c9fa2992877bc47396089e3ce4c6ac',
-     x86_64: '88f9f8686f46ec54844d02d140a1db97dabbd48a615a90c4388d1e5b7c63b644',
+  binary_sha256({
+    aarch64: '5ff671e17592e9c7d771aa0c80674aa64c457b6bff87a9553de198d4664e8ee5',
+     armv7l: '5ff671e17592e9c7d771aa0c80674aa64c457b6bff87a9553de198d4664e8ee5',
+       i686: 'e9feda16b4fd408253af38a2f2687db4fbde3b8a5a24125a317d859c389a75c9',
+     x86_64: '22cae36ecdc1686f1f8f82c4d7d7de442b0f0eac70c549a72a9ec73f50dd01c5'
   })
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/util_macros.rb
+++ b/packages/util_macros.rb
@@ -10,16 +10,16 @@ class Util_macros < Package
   source_sha256 '0f812e6e9d2786ba8f54b960ee563c0663ddbe2434bf24ff193f5feab1f31971'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_util_macros-1.19.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_util_macros-1.19.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_util_macros-1.19.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/xorg_util_macros-1.19.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/util_macros-1.19.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/util_macros-1.19.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/util_macros-1.19.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/util_macros-1.19.3-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '5ff671e17592e9c7d771aa0c80674aa64c457b6bff87a9553de198d4664e8ee5',
-     armv7l: '5ff671e17592e9c7d771aa0c80674aa64c457b6bff87a9553de198d4664e8ee5',
-       i686: 'e9feda16b4fd408253af38a2f2687db4fbde3b8a5a24125a317d859c389a75c9',
-     x86_64: '22cae36ecdc1686f1f8f82c4d7d7de442b0f0eac70c549a72a9ec73f50dd01c5'
+    aarch64: '42bfc95875cfcee649d1a66cfea163f64d3426cbc07b37c05af920a0d5e54cf9',
+     armv7l: '42bfc95875cfcee649d1a66cfea163f64d3426cbc07b37c05af920a0d5e54cf9',
+       i686: 'ab596326234a9a8be37027980f9c63abda60705a85ae2edfc6e891a862f74519',
+     x86_64: 'c2fe3d08599cb0a2b4a0a23b5647f2e8e9959073c0d817157814d05be49ddc83'
   })
 
   def self.build


### PR DESCRIPTION
- updates go and uses prebuilt binaries for i686 & x86_64, still building for armv7l.
- updates imagemagick7
-  Adds sccache

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686