### PR TITLE
vim rebuild sans nls

### DIFF
--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -44,7 +44,6 @@ class Gvim < Package
   end
 
   def self.build
-    system './configure --help'
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -3,58 +3,78 @@ require 'package'
 class Gvim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (with advanced features, such as a GUI)'
   homepage 'http://www.vim.org/'
-  version '8.2.1976'
+  @_ver = '8.2.2580'
+  version @_ver
   compatibility 'all'
-  source_url 'https://github.com/vim/vim/archive/v8.2.1976.tar.gz'
-  source_sha256 'd2d8bc28e28e9c5a63be570cdb44be39470621bb57dcbace5abbd86e15690678'
+  source_url 'https://github.com/vim/vim/archive/v8.2.2580.tar.gz'
+  source_sha256 'd0a508ca9726c8ff69bc5f5ab1ebe251c256e01e730f7b36afd03a66c89fcf79'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.1976-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.1976-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.1976-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.1976-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.2580-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.2580-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.2580-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvim-8.2.2580-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '3bec0434e49ab556c45b6755e858d8a1bf917f238e2906a35a7fbcffebe575bb',
-     armv7l: '3bec0434e49ab556c45b6755e858d8a1bf917f238e2906a35a7fbcffebe575bb',
-       i686: '62a0405196e9e701f54025447bfe23e59554e5c5abe298d080246384378a6a28',
-     x86_64: '087edd65ce9f13039ab9d8d9a8c6a5c9d6c02f47ad9a2c519970085d8999473f',
+  binary_sha256({
+    aarch64: 'c06a89c4a40a50d68232218248bce92fe6613cf7e1ec88711f3ac9fcc25e8d9d',
+     armv7l: 'c06a89c4a40a50d68232218248bce92fe6613cf7e1ec88711f3ac9fcc25e8d9d',
+       i686: 'ec59a0ce5aea951488100381333ef8e30f11880b2fadc66cbc9a90db06c7ff31',
+     x86_64: 'a3fa1854b694e1ae034086950a51909825bdd5886dbb7ed29e8651dc53673458'
   })
 
   depends_on 'vim_runtime'
   depends_on 'gtk3'
   depends_on 'sommelier'
+  
+  def self.preflight
+    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+    vim = `which vim 2> /dev/null`.chomp
+    abort "vim version #{version} already installed.".lightgreen unless vim.to_s == ''
+  end
 
   def self.patch
     # set the system-wide vimrc path
     FileUtils.cd('src') do
-      system "sed", "-i", "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|", "feature.h"
-      system "sed", "-i", "s|^.*#define SYS_GVIMRC_FILE.*$|#define SYS_GVIMRC_FILE \"#{CREW_PREFIX}/etc/gvimrc\"|", "feature.h"
+      system 'sed', '-i', "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|",
+             'feature.h'
+      system 'sed', '-i', "s|^.*#define SYS_GVIMRC_FILE.*$|#define SYS_GVIMRC_FILE \"#{CREW_PREFIX}/etc/gvimrc\"|",
+             'feature.h'
       system 'autoconf'
     end
   end
 
   def self.build
-    system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--localstatedir=#{CREW_PREFIX}/var/lib/vim",
-           '--with-features=huge',
-           "--with-compiledby='Chromebrew'",
-           '--with-x=yes',
-           '--enable-gui=gtk3',
-           '--enable-multibyte',
-           '--enable-cscope',
-           '--enable-fontset',
-           '--enable-perlinterp=dynamic',
-           '--enable-pythoninterp=dynamic',
-           '--enable-python3interp=dynamic',
-           '--enable-rubyinterp=dynamic',
-           '--disable-selinux'
+    system './configure --help'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --localstatedir=#{CREW_PREFIX}/var/lib/vim \
+      --with-features=huge \
+      --with-compiledby='Chromebrew' \
+      --enable-gpm \
+      --enable-acl \
+      --with-x=yes \
+      --enable-gnome-check \
+      --enable-multibyte \
+      --enable-cscope \
+      --enable-netbeans \
+      --enable-perlinterp=dynamic \
+      --enable-pythoninterp=dynamic \
+      --enable-python3interp=dynamic \
+      --enable-rubyinterp=dynamic \
+      --enable-luainterp=dynamic \
+      --enable-tclinterp=dynamic \
+      --disable-canberra \
+      --disable-selinux \
+      --disable-nls"
     system 'make'
   end
 
   def self.install
     system 'make', "VIMRCLOC=#{CREW_PREFIX}/etc", "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/vim", "#{CREW_DEST_PREFIX}/bin/vi"
 
     # these are provided by 'vim_runtime'
     FileUtils.rm_r "#{CREW_DEST_PREFIX}/share/vim"
@@ -63,9 +83,9 @@ class Gvim < Package
   def self.postinstall
     puts
     puts "The config files are located in #{CREW_PREFIX}/etc".lightblue
-    puts "User-specific configuration should go in ~/.gvimrc".lightblue
+    puts 'User-specific configuration should go in ~/.gvimrc'.lightblue
     puts
-    puts "If you are upgrading from an earlier version, edit ~/.bashrc".orange
+    puts 'If you are upgrading from an earlier version, edit ~/.bashrc'.orange
     puts "and remove the 'export VIMRUNTIME' and 'export LC_ALL=C' lines.".orange
     puts
   end

--- a/packages/libcroco.rb
+++ b/packages/libcroco.rb
@@ -3,34 +3,39 @@ require 'package'
 class Libcroco < Package
   description 'Generic Cascading Style Sheet (CSS) parsing and manipulation toolkit.'
   homepage 'https://git.gnome.org/browse/libcroco/'
-  version '0.6.12'
+  @_ver = '0.6.13'
+  @_ver_prelastdot = @_ver.rpartition('.')[0]
+  version @_ver
   compatibility 'all'
-  source_url 'http://ftp.gnome.org/pub/gnome/sources/libcroco/0.6/libcroco-0.6.12.tar.xz'
-  source_sha256 'ddc4b5546c9fb4280a5017e2707fbd4839034ed1aba5b7d4372212f34f84f860'
+  source_url "http://ftp.gnome.org/pub/gnome/sources/libcroco/#{@_ver_prelastdot}/libcroco-#{@_ver}.tar.xz"
+  source_sha256 '767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcroco-0.6.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcroco-0.6.12-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcroco-0.6.12-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcroco-0.6.12-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcroco-0.6.13-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcroco-0.6.13-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcroco-0.6.13-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcroco-0.6.13-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '1997e3255d0cc8495c869a6f1de7dc9e6b7e83c066bf9fda0c07d8d808b59a2a',
-     armv7l: '1997e3255d0cc8495c869a6f1de7dc9e6b7e83c066bf9fda0c07d8d808b59a2a',
-       i686: '913d41daf21e307c5c06d04d82b0f55e3a14fa31baf552475380217748ba3455',
-     x86_64: '21b8c0b44777da7c607c08b85732f1a91a805f248a1937351f4c92ec50444975',
+  binary_sha256({
+    aarch64: '60fc1383b5e017354c7c2125a8357d5856c13eea76a765b92bf64e3f92df5341',
+     armv7l: '60fc1383b5e017354c7c2125a8357d5856c13eea76a765b92bf64e3f92df5341',
+       i686: '68afcab6e597a792079edfd6090a51ac49daac65cc45b20aca79c678e77328b7',
+     x86_64: '2d3dd17c43cb509d6c4ed2f5b5e1b29e7f54d63f673c2cc2beac549efcd5e748'
   })
 
   depends_on 'gtk_doc'
   depends_on 'six' => :build
 
   def self.build
-    system "sh autogen.sh"
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system 'sh autogen.sh'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -25,10 +25,7 @@ class Vim < Package
   depends_on 'vim_runtime'
 
   def self.preflight
-    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
-  end
-
-  def self.preinstall
+    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so"
     gvim = `which gvim 2> /dev/null`.chomp
     abort "gvim version #{version} already installed.".lightgreen unless gvim.to_s == ''
   end

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -3,61 +3,79 @@ require 'package'
 class Vim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.'
   homepage 'http://www.vim.org/'
-  version '8.2.1976'
+  @_ver = '8.2.2580'
+  version @_ver
   compatibility 'all'
-  source_url 'https://github.com/vim/vim/archive/v8.2.1976.tar.gz'
-  source_sha256 'd2d8bc28e28e9c5a63be570cdb44be39470621bb57dcbace5abbd86e15690678'
+  source_url 'https://github.com/vim/vim/archive/v8.2.2580.tar.gz'
+  source_sha256 'd0a508ca9726c8ff69bc5f5ab1ebe251c256e01e730f7b36afd03a66c89fcf79'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.1976-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.1976-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.1976-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.1976-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.2580-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.2580-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.2580-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim-8.2.2580-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'd7f92124ba6fc6d6188ab872205fe8e9a866475b6dec9e4a7e88933620284068',
-     armv7l: 'd7f92124ba6fc6d6188ab872205fe8e9a866475b6dec9e4a7e88933620284068',
-       i686: '4439db5c399b4ed5a82128c2a97ca16125be842f0bad4a234566083c239ccd96',
-     x86_64: '7e5660fa1d751e53a6012727fed17e3b4dea23ec3adc1750a1189d9b5908e579',
+  binary_sha256({
+    aarch64: 'fc753eff299bb106dde43f55f7b52d40852f3f2b0651eb869afad92eb1c5132c',
+     armv7l: 'fc753eff299bb106dde43f55f7b52d40852f3f2b0651eb869afad92eb1c5132c',
+       i686: 'a830cb5b36fe8752b90829f5b97dc382868d7dfda4462ed7cb3e37eebd27939a',
+     x86_64: '27f86977743855f0f77f9797a80674eda93977a4309a02bff399364237984104'
   })
 
   depends_on 'vim_runtime'
 
+  def self.preflight
+    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+  end
+
   def self.preinstall
     gvim = `which gvim 2> /dev/null`.chomp
-    abort "gvim version #{version} already installed.".lightgreen unless "#{gvim}" == ""
+    abort "gvim version #{version} already installed.".lightgreen unless gvim.to_s == ''
   end
 
   def self.patch
     # set the system-wide vimrc path
     FileUtils.cd('src') do
-      system "sed", "-i", "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|", "feature.h"
-      system "sed", "-i", "s|^.*#define SYS_GVIMRC_FILE.*$|#define SYS_GVIMRC_FILE \"#{CREW_PREFIX}/etc/gvimrc\"|", "feature.h"
+      system 'sed', '-i', "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|",
+             'feature.h'
+      system 'sed', '-i', "s|^.*#define SYS_GVIMRC_FILE.*$|#define SYS_GVIMRC_FILE \"#{CREW_PREFIX}/etc/gvimrc\"|",
+             'feature.h'
       system 'autoconf'
     end
   end
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--localstatedir=#{CREW_PREFIX}/var/lib/vim",
-           '--with-features=huge',
-           "--with-compiledby='Chromebrew'",
-           '--with-x=no',
-           '--disable-gui',
-           '--enable-multibyte',
-           '--enable-cscope',
-           '--enable-fontset',
-           '--enable-perlinterp=dynamic',
-           '--enable-pythoninterp=dynamic',
-           '--enable-python3interp=dynamic',
-           '--enable-rubyinterp=dynamic',
-           '--disable-selinux'
+    system './configure --help'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --localstatedir=#{CREW_PREFIX}/var/lib/vim \
+      --with-features=huge \
+      --with-compiledby='Chromebrew' \
+      --enable-gpm \
+      --enable-acl \
+      --with-x=no \
+      --disable-gui \
+      --enable-multibyte \
+      --enable-cscope \
+      --enable-netbeans \
+      --enable-perlinterp=dynamic \
+      --enable-pythoninterp=dynamic \
+      --enable-python3interp=dynamic \
+      --enable-rubyinterp=dynamic \
+      --enable-luainterp=dynamic \
+      --enable-tclinterp=dynamic \
+      --disable-canberra \
+      --disable-selinux \
+      --disable-nls"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", "VIMRCLOC=#{CREW_PREFIX}/etc", 'install'
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/vim", "#{CREW_DEST_PREFIX}/bin/vi"
 
     # these are provided by 'vim_runtime'
     FileUtils.rm_r "#{CREW_DEST_PREFIX}/share/vim"
@@ -70,9 +88,9 @@ class Vim < Package
   def self.postinstall
     puts
     puts "The config files are located in #{CREW_PREFIX}/etc.".lightblue
-    puts "User-specific configuration should go in ~/.vimrc.".lightblue
+    puts 'User-specific configuration should go in ~/.vimrc.'.lightblue
     puts
-    puts "If you are upgrading from an earlier version, edit ~/.bashrc".orange
+    puts 'If you are upgrading from an earlier version, edit ~/.bashrc'.orange
     puts "and remove the 'export VIMRUNTIME' and 'export LC_ALL=C' lines.".orange
     puts
   end

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -25,7 +25,7 @@ class Vim < Package
   depends_on 'vim_runtime'
 
   def self.preflight
-    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
   end
 
   def self.preinstall

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -16,10 +16,10 @@ class Vim_runtime < Package
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.2580-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '89f2375c66810417550d4ab2d2fbf90a6953e3c585b8e0baaa1240b7e0187c99',
-     armv7l: '89f2375c66810417550d4ab2d2fbf90a6953e3c585b8e0baaa1240b7e0187c99',
-       i686: '0b7505d98e974e45d621f33fcaa19f14d907422d3b04f41bfdb0d9143776d61d',
-     x86_64: 'a2ee9fcb92bc566200d21a176ea7bfec6ef7d5b3fbe3fc3c0244ed31e6168d14'
+    aarch64: '8cc4833ea1a19af223e899b5aa7edfa7a7258f33080008d39783acf92d22e2e3',
+     armv7l: '8cc4833ea1a19af223e899b5aa7edfa7a7258f33080008d39783acf92d22e2e3',
+       i686: '1cefc1026dfdac9d039bb82629ab9287c2bd9a6704f4929f120766d436e7c237',
+     x86_64: '9b8e3d8e1e7455d049000342972c9dfb09ad1fb0b98ef665dde381aa646f9951'
   })
 
   def self.preflight

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -23,7 +23,7 @@ class Vim_runtime < Package
   })
 
   def self.preflight
-    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
   end
 
   def self.patch

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -3,49 +3,66 @@ require 'package'
 class Vim_runtime < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (shared runtime)'
   homepage 'http://www.vim.org/'
-  version '8.2.1976'
+  @_ver = '8.2.2580'
+  version @_ver
   compatibility 'all'
-  source_url 'https://github.com/vim/vim/archive/v8.2.1976.tar.gz'
-  source_sha256 'd2d8bc28e28e9c5a63be570cdb44be39470621bb57dcbace5abbd86e15690678'
+  source_url 'https://github.com/vim/vim/archive/v8.2.2580.tar.gz'
+  source_sha256 'd0a508ca9726c8ff69bc5f5ab1ebe251c256e01e730f7b36afd03a66c89fcf79'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.1976-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.1976-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.1976-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.1976-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.2580-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.2580-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.2580-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/vim_runtime-8.2.2580-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '681fbb6f06cfb300a1a1ba529bc9596ae3fc183e5ccc5e77a8bfb5869da4c281',
-     armv7l: '681fbb6f06cfb300a1a1ba529bc9596ae3fc183e5ccc5e77a8bfb5869da4c281',
-       i686: 'd6c5b6b3518c4a7856df53fac5f18af5bf6d48094bf1dc11d46018ba92cb2298',
-     x86_64: '588ce10bf392d363ce9de709f763ab79ef35a5e8e5eb67e278eec894b6fa04ed',
+  binary_sha256({
+    aarch64: '89f2375c66810417550d4ab2d2fbf90a6953e3c585b8e0baaa1240b7e0187c99',
+     armv7l: '89f2375c66810417550d4ab2d2fbf90a6953e3c585b8e0baaa1240b7e0187c99',
+       i686: '0b7505d98e974e45d621f33fcaa19f14d907422d3b04f41bfdb0d9143776d61d',
+     x86_64: 'a2ee9fcb92bc566200d21a176ea7bfec6ef7d5b3fbe3fc3c0244ed31e6168d14'
   })
+
+  def self.preflight
+    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
+  end
 
   def self.patch
     # set the system-wide vimrc path
     FileUtils.cd('src') do
-      system "sed", "-i", "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|", "feature.h"
-      system "sed", "-i", "s|^.*#define SYS_GVIMRC_FILE.*$|#define SYS_GVIMRC_FILE \"#{CREW_PREFIX}/etc/gvimrc\"|", "feature.h"
+      system 'sed', '-i', "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|",
+             'feature.h'
+      system 'sed', '-i', "s|^.*#define SYS_GVIMRC_FILE.*$|#define SYS_GVIMRC_FILE \"#{CREW_PREFIX}/etc/gvimrc\"|",
+             'feature.h'
       system 'autoconf'
     end
   end
 
   def self.build
-    system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--localstatedir=#{CREW_PREFIX}/var/lib/vim",
-           '--with-features=huge',
-           "--with-compiledby='Chromebrew'",
-           '--with-x=no',
-           '--disable-gui',
-           '--enable-multibyte',
-           '--enable-cscope',
-           '--enable-fontset',
-           '--enable-perlinterp=dynamic',
-           '--enable-pythoninterp=dynamic',
-           '--enable-python3interp=dynamic',
-           '--enable-rubyinterp=dynamic',
-           '--disable-selinux'
+    system './configure --help'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --localstatedir=#{CREW_PREFIX}/var/lib/vim \
+      --with-features=huge \
+      --with-compiledby='Chromebrew' \
+      --enable-gpm \
+      --enable-acl \
+      --with-x=no \
+      --disable-gui \
+      --enable-multibyte \
+      --enable-cscope \
+      --enable-netbeans \
+      --enable-perlinterp=dynamic \
+      --enable-pythoninterp=dynamic \
+      --enable-python3interp=dynamic \
+      --enable-rubyinterp=dynamic \
+      --enable-luainterp=dynamic \
+      --enable-tclinterp=dynamic \
+      --disable-canberra \
+      --disable-selinux \
+      --disable-nls"
     system 'make'
   end
 
@@ -107,7 +124,7 @@ class Vim_runtime < Package
   def self.postinstall
     vimrc = "#{CREW_PREFIX}/etc/vimrc"
     # keep user changes by writing to a new file
-    vimrc += ".new" if File.exists?(vimrc)
+    vimrc += '.new' if File.exist?(vimrc)
     # by default we will load the global config
     File.write(vimrc, <<~EOF)
       " System-wide defaults are in #{CREW_PREFIX}/share/vim/vimfiles/chromebrew.vim


### PR DESCRIPTION
Fixes #5342

- issue was due to nls not working due to import from gettext which was no longer using libiconv.
- Maybe this is a problem with the older glibc not providing a good enough iconv? (or maybe vim just wants more for nls support?)
- solution was to just disable nls in the vim build.
- Also added a symlink for vi -> vim
- Finally, updated libcroco, which is a dep of gettext as per arch.
- using shiny new preflight

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686