### PR TITLE
Fix vim packages

### DIFF
--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -27,12 +27,12 @@ class Gvim < Package
   depends_on 'sommelier'
   
   def self.preflight
-    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
-    vim = `which vim 2> /dev/null`.chomp
+    vim = `which #{CREW_PREFIX}/bin/vim 2> /dev/null`.chomp
     abort "vim version #{version} already installed.".lightgreen unless vim.to_s == ''
   end
 
   def self.patch
+    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
     # set the system-wide vimrc path
     FileUtils.cd('src') do
       system 'sed', '-i', "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|",

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -25,12 +25,12 @@ class Vim < Package
   depends_on 'vim_runtime'
 
   def self.preflight
-    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
-    gvim = `which gvim 2> /dev/null`.chomp
+    gvim = `which #{CREW_PREFIX}/bin/gvim 2> /dev/null`.chomp
     abort "gvim version #{version} already installed.".lightgreen unless gvim.to_s == ''
   end
 
   def self.patch
+    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
     # set the system-wide vimrc path
     FileUtils.cd('src') do
       system 'sed', '-i', "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|",

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -22,11 +22,10 @@ class Vim_runtime < Package
      x86_64: '9b8e3d8e1e7455d049000342972c9dfb09ad1fb0b98ef665dde381aa646f9951'
   })
 
-  def self.preflight
-    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
-  end
+  depends_on 'gpm'
 
   def self.patch
+    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
     # set the system-wide vimrc path
     FileUtils.cd('src') do
       system 'sed', '-i', "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|",


### PR DESCRIPTION
Fixes 2 issues.
1) If libiconv is installed, the vim packages cannot be installed or upgraded
```
$ crew upgrade vim_runtime
vim_runtime: Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (shared runtime)
Updating vim_runtime...
Please remove libiconv before building.
$ crew install vim_runtime
vim_runtime: Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (shared runtime)
http://www.vim.org/
Version: 8.2.2580
Please remove libiconv before building.
```
2) Even if vim is not installed, it was impossible to install gvim since the system vim returns a version.