### PR TITLE
Use LTO for igt_gpu_tools

### DIFF
--- a/packages/igt_gpu_tools.rb
+++ b/packages/igt_gpu_tools.rb
@@ -3,22 +3,19 @@ require 'package'
 class Igt_gpu_tools < Package
   description 'Tools for development and testing of the Intel DRM driver'
   homepage 'https://gitlab.freedesktop.org/drm/igt-gpu-tools'
-  version '1.25'
-  compatibility 'all'
-  source_url 'https://xorg.freedesktop.org/releases/individual/app/igt-gpu-tools-1.25.tar.xz'
+  @_ver = '1.25'
+  version "#{@_ver}-1"
+  compatibility 'x86_64 i686'
+  source_url "https://xorg.freedesktop.org/releases/individual/app/igt-gpu-tools-#{@_ver}.tar.xz"
   source_sha256 '40454d8f0484ea2477862007398a08eef78a6c252c4defce1c934548593fdd11'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/igt_gpu_tools-1.25-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/igt_gpu_tools-1.25-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/igt_gpu_tools-1.25-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/igt_gpu_tools-1.25-chromeos-x86_64.tar.xz',
+  binary_url({
+    i686: 'https://dl.bintray.com/chromebrew/chromebrew/igt_gpu_tools-1.25-1-chromeos-i686.tar.xz',
+  x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/igt_gpu_tools-1.25-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '51336627a5f9bb5a662785bbf5dff89a9be2b61b76a8c1312802ba2d1321539a',
-      armv7l: '51336627a5f9bb5a662785bbf5dff89a9be2b61b76a8c1312802ba2d1321539a',
-        i686: '367feaaf23ac996aef045a1749c4ade02297270cb2cfef325e132d965ffcb675',
-      x86_64: '83df59cfaf3e9c45f268b752ff3e7df823f367744a72d2b09c53ecc13f467ec4',
+  binary_sha256({
+    i686: 'eabf18c03916648a85b9f6211a197738ad51ad92900949cb257aeedc4e2bb2e3',
+  x86_64: '72bfc16dbd9532d049a67a8a8c328b50d8f5764f6922445bfe9899129735fcd1'
   })
 
   depends_on 'libdrm'
@@ -32,22 +29,18 @@ class Igt_gpu_tools < Package
   depends_on 'peg'
   depends_on 'swig' => ':build'
   depends_on 'gtk_doc' => ':build'
-  depends_on 'util_macros' => ':build'
-  depends_on 'xorg_proto' => ':build'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
-    -Dc_link_args='-fuse-ld=lld' \
-    -Db_asneeded=false \
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
     -Ddocs=disabled \
     -Dtests=disabled \
     -Doping=disabled \
     -Drunner=disabled \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
-  
+
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end


### PR DESCRIPTION
- rebuild with lto, and mark as for intel machines only.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686