### PR TITLE
libx265: fix i686 compile, add libsoup2 for older libsoup

### DIFF
--- a/packages/libsoup.rb
+++ b/packages/libsoup.rb
@@ -25,6 +25,7 @@ class Libsoup < Package
 
   depends_on 'glib_networking'
   depends_on 'vala'
+  depends_on 'libsoup2' # This way we make sure packages which need the older libsoup-2.4 library get it too.
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \

--- a/packages/libsoup2.rb
+++ b/packages/libsoup2.rb
@@ -8,11 +8,23 @@ class Libsoup2 < Package
   source_url 'https://download.gnome.org/sources/libsoup/2.72/libsoup-2.72.0.tar.xz'
   source_sha256 '170c3f8446b0f65f8e4b93603349172b1085fb8917c181d10962f02bb85f5387'
 
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup2-2.72-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup2-2.72-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup2-2.72-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libsoup2-2.72-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '5fe4849b14fab9bc1642f86faed10800d8693d5b1e73d591dcf2aacbaca962a5',
+     armv7l: '5fe4849b14fab9bc1642f86faed10800d8693d5b1e73d591dcf2aacbaca962a5',
+       i686: '17309548e1b4c495785bc70a5d87b985e28bbd47ef8c4aff0b665083d2bfc7ec',
+     x86_64: '3925e8f5ca246afdb7cc1dcca708eb5d61a07bc977d1eb2c8cf447526b326c52'
+  })
+
   depends_on 'glib_networking'
-  depends_on 'libpsl'
-  depends_on 'sqlite'
+  depends_on 'libevent'
+  depends_on 'qtbase'
   depends_on 'vala'
-  depends_on 'llvm'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \

--- a/packages/libsoup2.rb
+++ b/packages/libsoup2.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Libsoup2 < Package
+  description 'libsoup is an HTTP client/server library for GNOME.'
+  homepage 'https://wiki.gnome.org/Projects/libsoup'
+  version '2.72'
+  compatibility 'all'
+  source_url 'https://download.gnome.org/sources/libsoup/2.72/libsoup-2.72.0.tar.xz'
+  source_sha256 '170c3f8446b0f65f8e4b93603349172b1085fb8917c181d10962f02bb85f5387'
+
+  depends_on 'glib_networking'
+  depends_on 'libpsl'
+  depends_on 'sqlite'
+  depends_on 'vala'
+  depends_on 'llvm'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      -Dtests=false \
+      -Dsysprof=disabled \
+      -Dintrospection=enabled \
+      builddir"
+    system 'meson configure builddir'
+    system "sed -i 's#-R#-Wl,-rpath=#g' builddir/build.ninja"
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/libx265.rb
+++ b/packages/libx265.rb
@@ -5,63 +5,87 @@ class Libx265 < Package
   homepage 'http://x265.org/'
   @_ver = '3.4'
   version @_ver
-  compatibility 'x86_64 aarch64 armv7l'
-  unless ARCH == 'i686'
-    source_url "https://github.com/videolan/x265/archive/#{@_ver}.tar.gz"
-    source_sha256 '544d147bf146f8994a7bf8521ed878c93067ea1c7c6e93ab602389be3117eaaf'
-    depends_on 'nasm' => :build
-  end
+  compatibility 'all'
+  source_url "https://github.com/videolan/x265/archive/#{@_ver}.tar.gz"
+  source_sha256 '544d147bf146f8994a7bf8521ed878c93067ea1c7c6e93ab602389be3117eaaf'
 
   binary_url({
     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libx265-3.4-chromeos-armv7l.tar.xz',
      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libx265-3.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libx265-3.4-chromeos-i686.tar.xz',
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libx265-3.4-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
     aarch64: 'cf7548c97fb5774a3fea30a580ba1719f7b4efdfb4e5f6db91fac20d651d8442',
      armv7l: 'cf7548c97fb5774a3fea30a580ba1719f7b4efdfb4e5f6db91fac20d651d8442',
+       i686: 'dff1da6826ecf734d7012c4ec9cdd5d2c18e505968bcd6a9dcf6a5d7d1234c8d',
      x86_64: 'fc7647ea5a73c0fdbc2cea1f2c842de8a4a72db11b1fce5907ed79669e598ab4'
   })
 
+  depends_on 'nasm' => :build
+
   def self.build
-    Dir.mkdir 'build-12'
-    Dir.chdir 'build-12' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      cmake \
-        -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        -DLIB_INSTALL_DIR=lib#{CREW_LIB_SUFFIX} \
-        -DHIGH_BIT_DEPTH=TRUE \
-        -DMAIN12=TRUE \
-        -DEXPORT_C_API=FALSE \
-        -DENABLE_CLI=FALSE \
-        -DENABLE_SHARED=FALSE \
-        -Wno-dev \
-        ../source"
-    end
-    system 'ninja -C build-12'
-    Dir.mkdir 'build-10'
-    Dir.chdir 'build-10' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      cmake \
-        -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        -DLIB_INSTALL_DIR=lib#{CREW_LIB_SUFFIX} \
-        -DHIGH_BIT_DEPTH=TRUE \
-        -DEXPORT_C_API=FALSE \
-        -DENABLE_CLI=FALSE \
-        -DENABLE_SHARED=FALSE \
-        -Wno-dev \
-        ../source"
-    end
-    system 'ninja -C build-10'
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+    case ARCH
+    when 'x86_64', 'aarch64', 'armv7l'
+      Dir.mkdir 'build-12'
+      Dir.chdir 'build-12' do
+        system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        cmake \
+          -G Ninja \
+          #{CREW_CMAKE_OPTIONS} \
+          -DLIB_INSTALL_DIR=lib#{CREW_LIB_SUFFIX} \
+          -DHIGH_BIT_DEPTH=TRUE \
+          -DMAIN12=TRUE \
+          -DEXPORT_C_API=FALSE \
+          -DENABLE_CLI=FALSE \
+          -DENABLE_SHARED=FALSE \
+          -Wno-dev \
+          ../source"
+      end
+      system 'ninja -C build-12'
+      Dir.mkdir 'build-10'
+      Dir.chdir 'build-10' do
+        system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        cmake \
+          -G Ninja \
+          #{CREW_CMAKE_OPTIONS} \
+          -DLIB_INSTALL_DIR=lib#{CREW_LIB_SUFFIX} \
+          -DHIGH_BIT_DEPTH=TRUE \
+          -DEXPORT_C_API=FALSE \
+          -DENABLE_CLI=FALSE \
+          -DENABLE_SHARED=FALSE \
+          -Wno-dev \
+          ../source"
+      end
+      system 'ninja -C build-10'
+      Dir.mkdir 'builddir'
+      Dir.chdir 'builddir' do
+        system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        cmake \
+          -G Ninja \
+          #{CREW_CMAKE_OPTIONS} \
+          -DENABLE_SHARED=TRUE \
+          -DLIB_INSTALL_DIR=lib#{CREW_LIB_SUFFIX} \
+          -DENABLE_HDR10_PLUS=TRUE \
+          -DEXTRA_LIB='x265_main10.a;x265_main12.a' \
+          -DEXTRA_LINK_FLAGS='-L .' \
+          -DLINKED_10BIT=TRUE \
+          -DLINKED_12BIT=TRUE \
+          -Wno-dev \
+          ../source"
+      end
+      FileUtils.ln_s '../build-10/libx265.a', 'builddir/libx265_main10.a'
+      FileUtils.ln_s '../build-12/libx265.a', 'builddir/libx265_main12.a'
+    when 'i686'
+      Dir.mkdir 'builddir'
+      Dir.chdir 'builddir' do
+        system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       cmake \
@@ -69,16 +93,10 @@ class Libx265 < Package
         #{CREW_CMAKE_OPTIONS} \
         -DENABLE_SHARED=TRUE \
         -DLIB_INSTALL_DIR=lib#{CREW_LIB_SUFFIX} \
-        -DENABLE_HDR10_PLUS=TRUE \
-        -DEXTRA_LIB='x265_main10.a;x265_main12.a' \
-        -DEXTRA_LINK_FLAGS='-L .' \
-        -DLINKED_10BIT=TRUE \
-        -DLINKED_12BIT=TRUE \
         -Wno-dev \
         ../source"
+      end
     end
-    FileUtils.ln_s '../build-10/libx265.a', 'builddir/libx265_main10.a'
-    FileUtils.ln_s '../build-12/libx265.a', 'builddir/libx265_main12.a'
     system 'ninja -C builddir'
   end
 


### PR DESCRIPTION
- readds the older libsoup as libsoup2
- modifies libx265 build just for i686

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l