### PR TITLE
Remove symlink to libtinfo.so.6 in libtinfo

### DIFF
--- a/packages/libtinfo.rb
+++ b/packages/libtinfo.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libtinfo < Package
   description 'Missing ncurses library reference.'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '6.2'
+  version '6.2-1'
   compatibility 'all'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
@@ -20,6 +20,5 @@ class Libtinfo < Package
     # See also http://www.linuxforums.org/forum/installation/6251-libtinfo-so-5-a.html.
     FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libncurses.so.6", "#{CREW_DEST_LIB_PREFIX}/libtinfo.so.5"
-    FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libncurses.so.6", "#{CREW_DEST_LIB_PREFIX}/libtinfo.so.6"
   end
 end


### PR DESCRIPTION
Fixes #5270.

This removes the conflicting file/symlink in libtinfo and ncurses.

```
$ crew whatprovides libtinfo.so
libtinfo: /usr/local/lib64/libtinfo.so.5
libtinfo: /usr/local/lib64/libtinfo.so.6
ncurses: /usr/local/lib64/libtinfo.so
ncurses: /usr/local/lib64/libtinfo.so.6
ncurses: /usr/local/lib64/libtinfo.so.6.2

Total found: 5
```