### PR TITLE
gemacs rebuild for new imagemagick7

### DIFF
--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -3,20 +3,23 @@ require 'package'
 class Gemacs < Package
   description 'An extensible, customizable, free/libre text editor - and more.'
   homepage 'https://www.gnu.org/software/emacs/'
-  version '27.1-1'
+  @_ver = '27.1'
+  version "#{@_ver}-2"
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/emacs/emacs-27.1.tar.xz'
+  source_url "https://ftpmirror.gnu.org/emacs/emacs-#{@_ver}.tar.xz"
   source_sha256 '4a4c128f915fc937d61edfc273c98106711b540c9be3cd5d2e2b9b5b2f172e41'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-1-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '5d238f878cd80fa41dc83a3abc4a956466c08b336c2e01025a1bc2eb5532be72',
-     armv7l: '5d238f878cd80fa41dc83a3abc4a956466c08b336c2e01025a1bc2eb5532be72',
-     x86_64: '427c6f1c7143c449f7d2e53d82c82d191e87fed49d2e921916fc7aef2584ac0d',
+  binary_sha256({
+    aarch64: '270c65753da8ff73172aaecf8696eef4645204904d2345620ea54d24a880a814',
+     armv7l: '270c65753da8ff73172aaecf8696eef4645204904d2345620ea54d24a880a814',
+       i686: '2b94b8c5016dbf1e39cdaf4d78e8678a9414232bac93701e0ba2e10e7864b428',
+     x86_64: '5055031715b416892f0da3c5d3faf0ff535e1ca74d57be96e8d2c0956de79794'
   })
 
   depends_on 'giflib'
@@ -27,18 +30,20 @@ class Gemacs < Package
   depends_on 'sommelier'
 
   def self.build
-    system "./configure \
-            --prefix=#{CREW_PREFIX} \
-            --localstatedir=#{CREW_PREFIX}/share \
-            --without-selinux \
-            --with-modules \
-            --with-imagemagick \
-            --with-x=yes \
-            --with-x-toolkit=gtk3 \
-            --with-gif=yes \
-            --with-jpeg=yes \
-            --with-png=yes \
-            --with-rsvg=yes"
+    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure \
+      --prefix=#{CREW_PREFIX} \
+      --localstatedir=#{CREW_PREFIX}/share \
+      --without-selinux \
+      --with-modules \
+      --with-imagemagick \
+      --with-x=yes \
+      --with-x-toolkit=gtk3 \
+      --with-gif=yes \
+      --with-jpeg=yes \
+      --with-png=yes \
+      --with-rsvg=yes"
     system 'make'
   end
 


### PR DESCRIPTION
Fixes #5424

- rebuild for new imagemagick7

Works properly:
- [?] x86_64 (my sommelier is currently broken, but this does appear to try to open a X window w/o complaining of library issues.)

This looks good though:
```
ldd `which gemacs`
        linux-vdso.so.1 (0x00007ffe1951b000)
        libtiff.so.5 => /usr/local/lib64/libtiff.so.5 (0x000079f05031b000)
        libjpeg.so.8 => /usr/local/lib64/libjpeg.so.8 (0x000079f0502c0000)
        libpng16.so.16 => /usr/local/lib64/libpng16.so.16 (0x000079f05028b000)
        libz.so.1 => /usr/local/lib64/libz.so.1 (0x000079f05026c000)
        libgif.so.7 => /usr/local/lib64/libgif.so.7 (0x000079f050261000)
        libXpm.so.4 => /usr/local/lib64/libXpm.so.4 (0x000079f050050000)
        libgtk-3.so.0 => /usr/local/lib64/libgtk-3.so.0 (0x000079f04f85f000)
        libgdk-3.so.0 => /usr/local/lib64/libgdk-3.so.0 (0x000079f04f75b000)
        libpangocairo-1.0.so.0 => /usr/local/lib64/libpangocairo-1.0.so.0 (0x000079f04f74b000)
        libpango-1.0.so.0 => /usr/local/lib64/libpango-1.0.so.0 (0x000079f04f6f5000)
        libharfbuzz.so.0 => /usr/local/lib64/libharfbuzz.so.0 (0x000079f04f60a000)
        libatk-1.0.so.0 => /usr/local/lib64/libatk-1.0.so.0 (0x000079f04f5e0000)
        libcairo-gobject.so.2 => /usr/local/lib64/libcairo-gobject.so.2 (0x000079f04f5d4000)
        libcairo.so.2 => /usr/local/lib64/libcairo.so.2 (0x000079f04f472000)
        libgdk_pixbuf-2.0.so.0 => /usr/local/lib64/libgdk_pixbuf-2.0.so.0 (0x000079f04f424000)
        libgio-2.0.so.0 => /usr/local/lib64/libgio-2.0.so.0 (0x000079f04f25c000)
        libgobject-2.0.so.0 => /usr/local/lib64/libgobject-2.0.so.0 (0x000079f04f1fb000)
        libglib-2.0.so.0 => /usr/local/lib64/libglib-2.0.so.0 (0x000079f04f0b5000)
        libSM.so.6 => /usr/local/lib64/libSM.so.6 (0x000079f04eeac000)
        libICE.so.6 => /usr/local/lib64/libICE.so.6 (0x000079f04ec90000)
        libX11.so.6 => /usr/local/lib64/libX11.so.6 (0x000079f04eb21000)
        libX11-xcb.so.1 => /usr/local/lib64/libX11-xcb.so.1 (0x000079f04eb1d000)
        libxcb.so.1 => /usr/local/lib64/libxcb.so.1 (0x000079f04eae9000)
        libXft.so.2 => /usr/local/lib64/libXft.so.2 (0x000079f04ead1000)
        libXrender.so.1 => /usr/local/lib64/libXrender.so.1 (0x000079f04e8c5000)
        libasound.so.2 => /usr/local/lib64/libasound.so.2 (0x000079f04e7b4000)
        librsvg-2.so.2 => /usr/local/lib64/librsvg-2.so.2 (0x000079f04ddc3000)
        libm.so.6 => /usr/local/lib64/libm.so.6 (0x000079f04dc6a000)
        libMagickWand-7.Q16HDRI.so.9 => /usr/local/lib64/libMagickWand-7.Q16HDRI.so.9 (0x000079f04da51000)
        libMagickCore-7.Q16HDRI.so.9 => /usr/local/lib64/libMagickCore-7.Q16HDRI.so.9 (0x000079f04d70c000)
        libacl.so.1 => /usr/local/lib64/libacl.so.1 (0x000079f04d6ff000)
        librt.so.1 => /usr/local/lib64/librt.so.1 (0x000079f04d6f5000)
        libdbus-1.so.3 => /usr/local/lib64/libdbus-1.so.3 (0x000079f04d691000)
        libXrandr.so.2 => /usr/local/lib64/libXrandr.so.2 (0x000079f04d681000)
        libXinerama.so.1 => /usr/local/lib64/libXinerama.so.1 (0x000079f04d67c000)
        libXfixes.so.3 => /usr/local/lib64/libXfixes.so.3 (0x000079f04d476000)
        libXext.so.6 => /usr/local/lib64/libXext.so.6 (0x000079f04d45d000)
        libxml2.so.2 => /usr/local/lib64/libxml2.so.2 (0x000079f04d29e000)
        libgpm.so.2 => /usr/local/lib64/libgpm.so.2 (0x000079f04d295000)
        libtinfo.so.6 => /usr/local/lib64/libtinfo.so.6 (0x000079f04d263000)
        libfreetype.so.6 => /usr/local/lib64/libfreetype.so.6 (0x000079f04d172000)
        libfontconfig.so.1 => /usr/local/lib64/libfontconfig.so.1 (0x000079f04d118000)
        libgnutls.so.30 => /usr/local/lib64/libgnutls.so.30 (0x000079f04ce94000)
        libpthread.so.0 => /usr/local/lib64/libpthread.so.0 (0x000079f04ce74000)
        libanl.so.1 => /usr/local/lib64/libanl.so.1 (0x000079f04ce6e000)
        liblcms2.so.2 => /usr/local/lib64/liblcms2.so.2 (0x000079f04cdf8000)
        libdl.so.2 => /usr/local/lib64/libdl.so.2 (0x000079f04cdf2000)
        libgmp.so.10 => /usr/local/lib64/libgmp.so.10 (0x000079f04cd7a000)
        libomp.so => /usr/local/lib64/libomp.so (0x000079f04cc97000)
        libc.so.6 => /usr/local/lib64/libc.so.6 (0x000079f04caec000)
        libwebp.so.7 => /usr/local/lib64/libwebp.so.7 (0x000079f04ca2c000)
        libzstd.so.1 => /usr/local/lib64/libzstd.so.1 (0x000079f04c971000)
        liblzma.so.5 => /usr/local/lib64/liblzma.so.5 (0x000079f04c94a000)
        libdeflate.so.0 => /usr/local/lib64/libdeflate.so.0 (0x000079f04c93b000)
        libgmodule-2.0.so.0 => /usr/local/lib64/libgmodule-2.0.so.0 (0x000079f04c934000)
        libpangoft2-1.0.so.0 => /usr/local/lib64/libpangoft2-1.0.so.0 (0x000079f04c91b000)
        libfribidi.so.0 => /usr/local/lib64/libfribidi.so.0 (0x000079f04c8fc000)
        libepoxy.so.0 => /usr/local/lib64/libepoxy.so.0 (0x000079f04c7c7000)
        libXi.so.6 => /usr/local/lib64/libXi.so.6 (0x000079f04c7ae000)
        libatk-bridge-2.0.so.0 => /usr/local/lib64/libatk-bridge-2.0.so.0 (0x000079f04c775000)
        libxkbcommon.so.0 => /usr/local/lib64/libxkbcommon.so.0 (0x000079f04c72b000)
        libwayland-client.so.0 => /usr/local/lib64/libwayland-client.so.0 (0x000079f04c719000)
        libwayland-cursor.so.0 => /usr/local/lib64/libwayland-cursor.so.0 (0x000079f04c70f000)
        libwayland-egl.so.1 => /usr/local/lib64/libwayland-egl.so.1 (0x000079f04c70a000)
        libXcursor.so.1 => /usr/local/lib64/libXcursor.so.1 (0x000079f04c6fc000)
        libXdamage.so.1 => /usr/local/lib64/libXdamage.so.1 (0x000079f04c6f5000)
        libXcomposite.so.1 => /usr/local/lib64/libXcomposite.so.1 (0x000079f04c6ef000)
        libgraphite2.so.3 => /usr/local/lib64/libgraphite2.so.3 (0x000079f04c6c6000)
        libxcb-render.so.0 => /usr/local/lib64/libxcb-render.so.0 (0x000079f04c6b3000)
        libxcb-shm.so.0 => /usr/local/lib64/libxcb-shm.so.0 (0x000079f04c6ae000)
        libGL.so.1 => /usr/local/lib64/libGL.so.1 (0x000079f04c624000)
        libEGL.so.1 => /usr/local/lib64/libEGL.so.1 (0x000079f04c5d7000)
        libpixman-1.so.0 => /usr/local/lib64/libpixman-1.so.0 (0x000079f04c218000)
        libgcc_s.so.1 => /usr/local/lib64/libgcc_s.so.1 (0x000079f04c1fe000)
        libmount.so.1 => /usr/local/lib64/libmount.so.1 (0x000079f04c198000)
        libresolv.so.2 => /usr/local/lib64/libresolv.so.2 (0x000079f04c17c000)
        libffi.so.7 => /usr/local/lib64/libffi.so.7 (0x000079f04c16b000)
        libpcre.so.1 => /usr/local/lib64/libpcre.so.1 (0x000079f04c0e1000)
        libbsd.so.0 => /usr/local/lib64/libbsd.so.0 (0x000079f04c0c8000)
        libuuid.so.1 => /usr/local/lib64/libuuid.so.1 (0x000079f04c0be000)
        libXau.so.6 => /usr/local/lib64/libXau.so.6 (0x000079f04c0b6000)
        /lib64/ld-linux-x86-64.so.2 => /usr/local/lib64/ld-linux-x86-64.so.2 (0x000079f0503a4000)
        libfftw3.so.3 => /usr/local/lib64/libfftw3.so.3 (0x000079f04bed3000)
        libflif.so.0 => /usr/local/lib64/libflif.so.0 (0x000079f04bd7b000)
        libXt.so.6 => /usr/local/lib64/libXt.so.6 (0x000079f04bb13000)
        libbz2.so.1.0 => /usr/local/lib64/libbz2.so.1.0 (0x000079f04bb01000)
        libltdl.so.7 => /usr/local/lib64/libltdl.so.7 (0x000079f04baf4000)
        libjemalloc.so.2 => /usr/local/lib64/libjemalloc.so.2 (0x000079f04b856000)
        libattr.so.1 => /usr/local/lib64/libattr.so.1 (0x000079f04b84e000)
        libicui18n.so.68 => /usr/local/lib64/libicui18n.so.68 (0x000079f04b4d2000)
        libicuuc.so.68 => /usr/local/lib64/libicuuc.so.68 (0x000079f04b29d000)
        libicudata.so.68 => /usr/local/lib64/libicudata.so.68 (0x000079f04975a000)
        libncurses.so.6 => /usr/local/lib64/libncurses.so.6 (0x000079f04972b000)
        libbrotlidec.so.1 => /usr/local/lib64/libbrotlidec.so.1 (0x000079f04971d000)
        libexpat.so.1 => /usr/local/lib64/libexpat.so.1 (0x000079f0496e2000)
        libp11-kit.so.0 => /usr/local/lib64/libp11-kit.so.0 (0x000079f0495a7000)
        libidn2.so.0 => /usr/local/lib64/libidn2.so.0 (0x000079f049582000)
        libunistring.so.2 => /usr/local/lib64/libunistring.so.2 (0x000079f0493ff000)
        libtasn1.so.6 => /usr/local/lib64/libtasn1.so.6 (0x000079f0493e6000)
        libnettle.so.8 => /usr/local/lib64/libnettle.so.8 (0x000079f049390000)
        libhogweed.so.6 => /usr/local/lib64/libhogweed.so.6 (0x000079f04933f000)
        libatspi.so.0 => /usr/local/lib64/libatspi.so.0 (0x000079f0492ff000)
        libglapi.so.0 => /usr/local/lib64/libglapi.so.0 (0x000079f0492c6000)
        libdrm.so.2 => /usr/local/lib64/libdrm.so.2 (0x000079f0492b1000)
        libxcb-glx.so.0 => /usr/local/lib64/libxcb-glx.so.0 (0x000079f04928e000)
        libxcb-dri2.so.0 => /usr/local/lib64/libxcb-dri2.so.0 (0x000079f049287000)
        libXxf86vm.so.1 => /usr/local/lib64/libXxf86vm.so.1 (0x000079f04907f000)
        libxcb-dri3.so.0 => /usr/local/lib64/libxcb-dri3.so.0 (0x000079f049078000)
        libxcb-present.so.0 => /usr/local/lib64/libxcb-present.so.0 (0x000079f049073000)
        libxcb-sync.so.1 => /usr/local/lib64/libxcb-sync.so.1 (0x000079f049069000)
        libxshmfence.so.1 => /usr/local/lib64/libxshmfence.so.1 (0x000079f048e67000)
        libxcb-xfixes.so.0 => /usr/local/lib64/libxcb-xfixes.so.0 (0x000079f048e5d000)
        libunwind.so.8 => /usr/local/lib64/libunwind.so.8 (0x000079f048e3b000)
        libstdc++.so.6 => /usr/local/lib64/libstdc++.so.6 (0x000079f048c66000)
        libgbm.so.1 => /usr/local/lib64/libgbm.so.1 (0x000079f048c57000)
        libwayland-server.so.0 => /usr/local/lib64/libwayland-server.so.0 (0x000079f048c3f000)
        libblkid.so.1 => /usr/local/lib64/libblkid.so.1 (0x000079f048be0000)
        libbrotlicommon.so.1 => /usr/local/lib64/libbrotlicommon.so.1 (0x000079f048bbb000)
```