### PR TITLE
rebuild gemacs from emacs feature/pgtk branch,  add libotf dep, and hashpipe

### DIFF
--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -3,53 +3,90 @@ require 'package'
 class Gemacs < Package
   description 'An extensible, customizable, free/libre text editor - and more.'
   homepage 'https://www.gnu.org/software/emacs/'
-  @_ver = '27.1'
-  version "#{@_ver}-2"
+  @_ver = '28.0.50.1'
+  version "#{@_ver}-7a7b"
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/emacs/emacs-#{@_ver}.tar.xz"
-  source_sha256 '4a4c128f915fc937d61edfc273c98106711b540c9be3cd5d2e2b9b5b2f172e41'
+  source_url 'file:///dev/null'
+  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-27.1-2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-28.0.50.1-7a7b-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-28.0.50.1-7a7b-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-28.0.50.1-7a7b-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gemacs-28.0.50.1-7a7b-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '270c65753da8ff73172aaecf8696eef4645204904d2345620ea54d24a880a814',
-     armv7l: '270c65753da8ff73172aaecf8696eef4645204904d2345620ea54d24a880a814',
-       i686: '2b94b8c5016dbf1e39cdaf4d78e8678a9414232bac93701e0ba2e10e7864b428',
-     x86_64: '5055031715b416892f0da3c5d3faf0ff535e1ca74d57be96e8d2c0956de79794'
+    aarch64: '74066f8609ca1403609962454feff1a85aedb24a3d56dbfcae4a3aad8d00f836',
+     armv7l: '74066f8609ca1403609962454feff1a85aedb24a3d56dbfcae4a3aad8d00f836',
+       i686: '401243600795df8a6c375a7e581b939e258d1697595e9a43573860fca34656c0',
+     x86_64: '702ac1d56095b1032d387a2e4736e6f8ac49d4d16a165cbc1142cb5ffe394454'
   })
 
+  depends_on 'alsa_lib'
+  depends_on 'cairo'
   depends_on 'giflib'
+  depends_on 'gpm'
+  depends_on 'gtk3'
+  depends_on 'harfbuzz'
+  depends_on 'jansson'
   depends_on 'libjpeg'
+  depends_on 'libotf'
   depends_on 'libpng'
+  depends_on 'librsvg'
   depends_on 'libtiff'
-  depends_on 'imagemagick7'
-  depends_on 'sommelier'
+  depends_on 'texinfo'
+  depends_on 'webkit2gtk'
+
+  def self.prebuild
+    @git_dir = 'emacs_git'
+    @git_branch = 'feature/pgtk'
+    @git_hash = '7a7bc15242896b20c7af49f77f0e22c3d78e4d88'
+    @git_url = 'https://git.savannah.gnu.org/git/emacs.git'
+    FileUtils.rm_rf(@git_dir)
+    FileUtils.mkdir_p(@git_dir)
+    Dir.chdir @git_dir do
+      system 'git init'
+      system "git remote add origin #{@git_url}"
+      system "git remote set-branches origin '#{@git_branch}'"
+      system "git fetch --depth 1 origin #{@git_hash}"
+      system 'git checkout FETCH_HEAD'
+    end
+  end
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
-      --prefix=#{CREW_PREFIX} \
-      --localstatedir=#{CREW_PREFIX}/share \
-      --without-selinux \
-      --with-modules \
-      --with-imagemagick \
-      --with-x=yes \
-      --with-x-toolkit=gtk3 \
-      --with-gif=yes \
-      --with-jpeg=yes \
-      --with-png=yes \
-      --with-rsvg=yes"
-    system 'make'
+    Dir.chdir 'emacs_git' do
+      system 'NOCONFIGURE=1 ./autogen.sh'
+      system "env CFLAGS='-pipe -fuse-ld=gold -flto=auto' CXXFLAGS='-pipe -fuse-ld=gold -flto=auto' \
+        LDFLAGS='-flto=auto' \
+        ./configure \
+        --enable-link-time-optimization \
+        --localstatedir=#{CREW_PREFIX}/share \
+        --prefix=#{CREW_PREFIX} \
+        --with-cairo \
+        --with-gif=ifavailable \
+        --with-jpeg=yes \
+        --with-modules \
+        --with-native-compilation \
+        --without-gconf \
+        --without-gsettings \
+        --without-selinux \
+        --without-x \
+        --with-pgtk \
+        --with-png=yes \
+        --with-rsvg=yes \
+        --with-sound=alsa \
+        --with-tiff=ifavailable \
+        --with-x-toolkit=gtk3 \
+        --with-xwidgets"
+      system 'make'
+    end
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    system "install -Dm755 src/emacs #{CREW_DEST_PREFIX}/bin/gemacs"
-    system "install -Dm755 src/emacs-27.1.1 #{CREW_DEST_PREFIX}/bin/gemacs-27.1.1"
+    Dir.chdir 'emacs_git' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+      system "install -Dm755 src/emacs #{CREW_DEST_PREFIX}/bin/gemacs"
+      system "install -Dm755 src/emacs-#{@_ver} #{CREW_DEST_PREFIX}/bin/gemacs-#{@_ver}"
+    end
   end
 end

--- a/packages/hashpipe.rb
+++ b/packages/hashpipe.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Hashpipe < Package
+  description 'Hash in a pipe'
+  homepage 'https://git.zx2c4.com/hashpipe/about/#hashpipe'
+  version '1.0'
+  compatibility 'all'
+  source_url 'https://git.zx2c4.com/hashpipe/snapshot/hashpipe-dc11b6262f4717e61e55760cb2bd637ff1c0f6a9.tar.xz'
+  source_sha256 '6b3931d7c46332be2a6c07f94f91924065ba7988edd2e8a471123c77d3c614f6'
+
+  def self.build
+    system "make PREFIX=#{CREW_PREFIX}"
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} make PREFIX=#{CREW_PREFIX} install"
+  end
+end

--- a/packages/hashpipe.rb
+++ b/packages/hashpipe.rb
@@ -8,6 +8,19 @@ class Hashpipe < Package
   source_url 'https://git.zx2c4.com/hashpipe/snapshot/hashpipe-dc11b6262f4717e61e55760cb2bd637ff1c0f6a9.tar.xz'
   source_sha256 '6b3931d7c46332be2a6c07f94f91924065ba7988edd2e8a471123c77d3c614f6'
 
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '6285f0a271d517f5a945626d9d84378546cd463d3ef2d6bcb6cdc189b8beed25',
+     armv7l: '6285f0a271d517f5a945626d9d84378546cd463d3ef2d6bcb6cdc189b8beed25',
+       i686: 'd03e7e5b7990c41bd8f25e17469db59bf3f1575a00ffb10f5fb441217ddabee9',
+     x86_64: 'fa770efb0a691063e7b2f581abde45d9bacf0822ff9643136d9bf99dd5d42f6b'
+  })
+
   def self.build
     system "make PREFIX=#{CREW_PREFIX}"
   end

--- a/packages/libotf.rb
+++ b/packages/libotf.rb
@@ -24,9 +24,10 @@ class Libotf < Package
 
   depends_on 'libxaw'
   depends_on 'freetype'
+  depends_on 'hashpipe'
 
   def self.patch
-    system 'curl -Ls https://github.com/archlinux/svntogit-packages/raw/a67b940a19f1e7e47e7d8553ed31158ed70f1286/libotf/trunk/replace-freetype-config.patch | patch -p1 -b'
+    system 'curl -Ls https://github.com/archlinux/svntogit-packages/raw/a67b940a19f1e7e47e7d8553ed31158ed70f1286/libotf/trunk/replace-freetype-config.patch | hashpipe sha256 edd0f86332f4d809dfb0ab66da547c946e5d79a907a7eaddc4d2166c78205668 | patch -p1 -b'
   end
 
   def self.build

--- a/packages/libotf.rb
+++ b/packages/libotf.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Libotf < Package
+  description 'OpenType Font library'
+  homepage 'https://www.nongnu.org/m17n/'
+  version '0.9.16'
+  compatibility 'all'
+  source_url 'https://download.savannah.gnu.org/releases/m17n/libotf-0.9.16.tar.gz'
+  source_sha256 '68db0ca3cda2d46a663a92ec26e6eb5adc392ea5191bcda74268f0aefa78066b'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libotf-0.9.16-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libotf-0.9.16-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libotf-0.9.16-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libotf-0.9.16-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '48ea420876299f2de783c250b6def3c2a87e7bf8c16695a63b7561efbb9594f8',
+     armv7l: '48ea420876299f2de783c250b6def3c2a87e7bf8c16695a63b7561efbb9594f8',
+       i686: '487c98f04bdc12c06a2afd32087222150ee652d9fc3c6233daee341c41718406',
+     x86_64: '8ec1c9f4e8b99482323e3bf444cca95b5e3d0abb90b8ea278d1461b29470e340'
+  })
+
+  depends_on 'libxaw'
+  depends_on 'freetype'
+
+  def self.patch
+    system 'curl -Ls https://github.com/archlinux/svntogit-packages/raw/a67b940a19f1e7e47e7d8553ed31158ed70f1286/libotf/trunk/replace-freetype-config.patch | patch -p1 -b'
+  end
+
+  def self.build
+    system 'autoreconf -i'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/libotf.rb
+++ b/packages/libotf.rb
@@ -3,9 +3,10 @@ require 'package'
 class Libotf < Package
   description 'OpenType Font library'
   homepage 'https://www.nongnu.org/m17n/'
-  version '0.9.16'
+  @_ver = '0.9.16'
+  version @_ver
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/m17n/libotf-0.9.16.tar.gz'
+  source_url 'https://download.savannah.gnu.org/releases/m17n/libotf-#{@_ver}.tar.gz'
   source_sha256 '68db0ca3cda2d46a663a92ec26e6eb5adc392ea5191bcda74268f0aefa78066b'
 
   binary_url({


### PR DESCRIPTION
Fixes #5424 

- gemacs actually works with Wayland now
- adds libotf
- adds hashpipe for easy one line sha256sum in-pipe checking.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l