### PR TITLE
gtk3 & gtk4 update

### DIFF
--- a/packages/adwaita_icon_theme.rb
+++ b/packages/adwaita_icon_theme.rb
@@ -4,17 +4,21 @@ class Adwaita_icon_theme < Package
   description 'Theme consisting of a set of icons for GTK+'
   homepage 'https://gitlab.gnome.org/GNOME/adwaita-icon-theme'
   version '3.38.0-c5be'
-  compatibility 'x86_64'
+  compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/archive/c5bed6840332a7539b175feb4ec7ecf957fb1399/adwaita-icon-theme-c5bed6840332a7539b175feb4ec7ecf957fb1399.tar.bz2'
   source_sha256 '54d67549cb7b295dd649460a22af9d2f436dd73386068eb20ce888f6f4bee0fb'
 
   binary_url({
-    i686: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-c5be-chromeos-i686.tar.xz',
-  x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-c5be-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-c5be-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-c5be-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-c5be-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-c5be-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    i686: 'f5e0d629d2b99eb18cfa2a6d991a33e0efb4efe206b6510d884bf8d96ee3d9af',
-  x86_64: 'bd03ca46fc6310ea449362b95e0032e800fdda4f86252e02f64502407cd29adc'
+    aarch64: 'c2d4e312434a6ee7ece0a044d16e36a2b582e54c1a4bbad246bc7e6f1c327271',
+     armv7l: 'c2d4e312434a6ee7ece0a044d16e36a2b582e54c1a4bbad246bc7e6f1c327271',
+       i686: 'f5e0d629d2b99eb18cfa2a6d991a33e0efb4efe206b6510d884bf8d96ee3d9af',
+     x86_64: 'bd03ca46fc6310ea449362b95e0032e800fdda4f86252e02f64502407cd29adc'
   })
 
   depends_on 'cantarell_fonts'

--- a/packages/adwaita_icon_theme.rb
+++ b/packages/adwaita_icon_theme.rb
@@ -3,58 +3,41 @@ require 'package'
 class Adwaita_icon_theme < Package
   description 'Theme consisting of a set of icons for GTK+'
   homepage 'https://gitlab.gnome.org/GNOME/adwaita-icon-theme'
-  version '3.38.0'
-  compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/GNOME/sources/adwaita-icon-theme/3.38/adwaita-icon-theme-3.38.0.tar.xz'
-  source_sha256 '6683a1aaf2430ccd9ea638dd4bfe1002bc92b412050c3dba20e480f979faaf97'
+  version '3.38.0-c5be'
+  compatibility 'x86_64'
+  source_url 'https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/archive/c5bed6840332a7539b175feb4ec7ecf957fb1399/adwaita-icon-theme-c5bed6840332a7539b175feb4ec7ecf957fb1399.tar.bz2'
+  source_sha256 '54d67549cb7b295dd649460a22af9d2f436dd73386068eb20ce888f6f4bee0fb'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    i686: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-c5be-chromeos-i686.tar.xz',
+  x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/adwaita_icon_theme-3.38.0-c5be-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '14e772b1659a40a0021bc31592c844109514a5193af60771bdde68619d401773',
-     armv7l: '14e772b1659a40a0021bc31592c844109514a5193af60771bdde68619d401773',
-       i686: '80b7ddd46eab62bb102415ce354e8931362a0757cf498c6eefc1d80bcf55cb63',
-     x86_64: '049d7fdb6a435484ae5a2cca69b203dd6b8ee6bae088edb3a04c6de2c2c13ecf',
+  binary_sha256({
+    i686: 'f5e0d629d2b99eb18cfa2a6d991a33e0efb4efe206b6510d884bf8d96ee3d9af',
+  x86_64: 'bd03ca46fc6310ea449362b95e0032e800fdda4f86252e02f64502407cd29adc'
   })
 
+  depends_on 'cantarell_fonts'
   depends_on 'gtk3'
   depends_on 'librsvg'
   depends_on 'gdk_pixbuf'
   depends_on 'vala' => :build
-  depends_on 'llvm' => :build
   depends_on 'xdg_base'
 
   def self.build
-    ENV['CFLAGS'] = "-fuse-ld=lld"
-    ENV['CXXFLAGS'] = "-fuse-ld=lld"
-    ENV['GDK_PIXBUF_MODULEDIR'] = "#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders"
-    ENV['GDK_PIXBUF_MODULE_FILE'] = "#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
-    ENV['LIBRARY_PATH'] = "#{CREW_LIB_PREFIX}:/usr/#{ARCH_LIB}:/#{ARCH_LIB}"
     # Need to make sure svg support is properly loaded otherwise build fails.
-    system "gdk-pixbuf-query-loaders > #{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
-    system "./configure #{CREW_OPTIONS} "
+    system "env GDK_PIXBUF_MODULEDIR='#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders' \
+    GDK_PIXBUF_MODULE_FILE='#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache' \
+    gdk-pixbuf-query-loaders > #{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS}"
     system 'make'
   end
+
   def self.install
     system "make install DESTDIR=#{CREW_DEST_DIR}"
-  end
-
-    def self.postinstall
-    puts "To add basic settings, execute the following:".lightblue
-    puts "Note that this will overwrite any existing ~/.config/gtk-3.0/settings.ini file!".lightred
-    puts
-    puts "mkdir #{HOME}/.config/gtk-3.0".lightblue
-    puts "cat << 'EOF' > #{HOME}/.config/gtk-3.0/settings.ini
-[Settings]
-gtk-application-prefer-dark-theme = false
-gtk-icon-theme-name = adwaita
-gtk-fallback-icon-theme = gnome
-gtk-font-name = Arial 10
-EOF".lightblue
-    puts
   end
 end

--- a/packages/cantarell_fonts.rb
+++ b/packages/cantarell_fonts.rb
@@ -1,0 +1,46 @@
+require 'package'
+
+class Cantarell_fonts < Package
+  description 'Humanist sans serif font'
+  homepage 'https://gitlab.gnome.org/GNOME/cantarell-fonts'
+  @_ver = '0.301'
+  version @_ver
+  compatibility 'all'
+  source_url "https://download.gnome.org/sources/cantarell-fonts/#{@_ver}/cantarell-fonts-#{@_ver}.tar.xz"
+  source_sha256 '3d35db0ac03f9e6b0d5a53577591b714238985f4cfc31a0aa17f26cd74675e83'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cantarell_fonts-0.301-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cantarell_fonts-0.301-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cantarell_fonts-0.301-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cantarell_fonts-0.301-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'fb8107d41047d58c73a5c3152ed6319d5ce841a73f1f5d90d6bfff0c988ce9d7',
+     armv7l: 'fb8107d41047d58c73a5c3152ed6319d5ce841a73f1f5d90d6bfff0c988ce9d7',
+       i686: 'de3629bda1254054edcc86a50f50bf06f2d6bb258af6331850bdb862d37066d5',
+     x86_64: '412ea866e38936691a7a16dcdd460a684e925007ed7fbb964eeb4c7c9873a4e9'
+  })
+
+  depends_on 'appstream_glib'
+  depends_on 'fontconfig' => ':build'
+  depends_on 'graphite' => ':build'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      -Duseprebuilt=true \
+      -Dfontsdir=#{CREW_PREFIX}/share/fonts/opentype/cantarell \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_PREFIX}/share/fonts/opentype/cantarell"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+
+  def self.postinstall
+    system "env FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts fc-cache -fv || true"
+  end
+end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -56,8 +56,6 @@ class Gtk3 < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
     system "sed -i 's,null,,g'  #{CREW_DEST_LIB_PREFIX}/pkgconfig/gtk*.pc"
-    FileUtils.mkdir_p("#{CREW_DEST_HOME}/.config/gtk-3.0")
-    File.write("#{CREW_DEST_HOME}/.config/gtk-3.0/settings.ini", @gtk3settings)
   end
 
   def self.postinstall

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -11,44 +11,32 @@ class Gtk3 < Package
   # source_url "https://download.gnome.org/sources/gtk/#{@_ver_prelastdot}/gtk-#{@_ver}.tar.xz"
   source_sha256 'dbc3b14ae0d8e44bc8caeac91d62b4d2403a881d837cb4e9bcfb8d138712c3a3'
 
-  binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '840b06f1ccf18e6b85e7944e1af74e9a08385053a46f0277c8f395fa02c20f2a',
-     armv7l: '840b06f1ccf18e6b85e7944e1af74e9a08385053a46f0277c8f395fa02c20f2a',
-       i686: 'f07416c233166be3cf0777be1745d61ed6f3574137a7918c300779acc39593d8',
-     x86_64: 'bdd162ae2fd29f1500e2dd6a7ed7378023b2e20d3af73c42c3017ef10f4d905f'
-  })
-
-  depends_on 'cups'
+  depends_on 'atk'
   depends_on 'at_spi2_atk'
+  depends_on 'cantarell_fonts'
+  depends_on 'cups'
+  depends_on 'gdk_pixbuf'
   depends_on 'gnome_icon_theme'
   depends_on 'gobject_introspection'
-  depends_on 'gdk_pixbuf'
   depends_on 'graphene'
+  depends_on 'graphite'
   depends_on 'hicolor_icon_theme'
   depends_on 'iso_codes'
   depends_on 'json_glib'
+  depends_on 'libdeflate'
   depends_on 'libepoxy'
   depends_on 'libxkbcommon'
   depends_on 'shared_mime_info'
   depends_on 'six' => :build
   depends_on 'xdg_base'
-  depends_on 'atk'
-  depends_on 'graphite'
-  depends_on 'libdeflate'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
-            -Dbroadway_backend=true \
-            -Dgtk_doc=false \
-            -Ddemos=false \
-            -Dexamples=false \
-            builddir"
+      -Dbroadway_backend=true \
+      -Ddemos=false \
+      -Dexamples=false \
+      -Dgtk_doc=false \
+      builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end
@@ -56,6 +44,16 @@ class Gtk3 < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
     system "sed -i 's,null,,g'  #{CREW_DEST_LIB_PREFIX}/pkgconfig/gtk*.pc"
+    @gtk3settings = <<~GTK3_CONFIG_HEREDOC
+      [Settings]
+      gtk-icon-theme-name = Adwaita
+      gtk-fallback-icon-theme = gnome
+      gtk-theme-name = Adwaita
+      gtk-font-name = Cantarell 11
+      gtk-application-prefer-dark-theme = false
+    GTK3_CONFIG_HEREDOC
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/gtk-3.0"
+    File.write("#{CREW_DEST_PREFIX}/etc/gtk-3.0/settings.ini", @gtk3settings)
   end
 
   def self.postinstall
@@ -63,19 +61,5 @@ class Gtk3 < Package
     system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
     # update mime database
     system "update-mime-database #{CREW_PREFIX}/share/mime"
-    @xdg_config_home = ENV['XDG_CONFIG_HOME']
-    @gtk3settings = <<~GTK3_CONFIG_HEREDOC
-      [Settings]
-      gtk-application-prefer-dark-theme = false
-      gtk-icon-theme-name = hicolor
-      gtk-fallback-icon-theme = gnome
-      gtk-font-name = Arial 10
-    GTK3_CONFIG_HEREDOC
-    unless File.exist?("#{@xdg_config_home}/gtk-3.0/settings.ini")
-      puts
-      puts 'Adding basic gtk4 settings to XDG_CONFIG_HOME/gtk-3.0/settings.ini'.lightblue
-      FileUtils.mkdir_p "#{@xdg_config_home}/gtk-3.0"
-      File.write("#{@xdg_config_home}/gtk-3.0/settings.ini", @gtk3settings)
-    end
   end
 end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -11,6 +11,20 @@ class Gtk3 < Package
   # source_url "https://download.gnome.org/sources/gtk/#{@_ver_prelastdot}/gtk-#{@_ver}.tar.xz"
   source_sha256 'dbc3b14ae0d8e44bc8caeac91d62b4d2403a881d837cb4e9bcfb8d138712c3a3'
 
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '29a4642e0887f09c4d9950fd9ca7ac7246c455ae91aeed25268658857c66a39e',
+     armv7l: '29a4642e0887f09c4d9950fd9ca7ac7246c455ae91aeed25268658857c66a39e',
+       i686: '0022f857e4697bad885232d246de0e12403ec6a99e63ef43f292882c0becc467',
+     x86_64: '59e5324c659a0c9803e906717eebd82c6a3818539d1336beae603fd591ca0e9c'
+  })
+
+  depends_on 'adwaita_icon_theme'
   depends_on 'atk'
   depends_on 'at_spi2_atk'
   depends_on 'cantarell_fonts'

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -53,11 +53,6 @@ class Gtk3 < Package
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-    system "sed -i 's,null,,g'  #{CREW_DEST_LIB_PREFIX}/pkgconfig/gtk*.pc"
     @gtk3settings = <<~GTK3_CONFIG_HEREDOC
       [Settings]
       gtk-icon-theme-name = Adwaita
@@ -66,6 +61,11 @@ class Gtk3 < Package
       gtk-font-name = Cantarell 11
       gtk-application-prefer-dark-theme = false
     GTK3_CONFIG_HEREDOC
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "sed -i 's,null,,g'  #{CREW_DEST_LIB_PREFIX}/pkgconfig/gtk*.pc"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/gtk-3.0"
     File.write("#{CREW_DEST_PREFIX}/etc/gtk-3.0/settings.ini", @gtk3settings)
   end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -3,23 +3,25 @@ require 'package'
 class Gtk3 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk3/3.0/'
-  @_ver = '3.24.26'
+  @_ver = '3.24.27'
+  @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   compatibility 'all'
-  source_url "https://download.gnome.org/sources/gtk+/3.24/gtk+-#{@_ver}.tar.xz"
-  source_sha256 '2cc1b2dc5cad15d25b6abd115c55ffd8331e8d4677745dd3ce6db725b4fff1e9'
+  source_url "https://gitlab.gnome.org/GNOME/gtk/-/archive/#{@_ver}/gtk-#{@_ver}.tar.bz2"
+  # source_url "https://download.gnome.org/sources/gtk/#{@_ver_prelastdot}/gtk-#{@_ver}.tar.xz"
+  source_sha256 'dbc3b14ae0d8e44bc8caeac91d62b4d2403a881d837cb4e9bcfb8d138712c3a3'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.26-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.26-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.26-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.26-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.27-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'f53f6e97f2929af71f497f14869d83ce20f62469aa387d460b43c94105ecd0d1',
-     armv7l: 'f53f6e97f2929af71f497f14869d83ce20f62469aa387d460b43c94105ecd0d1',
-       i686: '9402509ba5d7af3da372b804e28f9c8213768e3bc3a16f811162dd278e0900d4',
-     x86_64: '0e594d1b3661938b5d586670588ffd0b3a6327e697fc01a68e77d101192d9962'
+    aarch64: '840b06f1ccf18e6b85e7944e1af74e9a08385053a46f0277c8f395fa02c20f2a',
+     armv7l: '840b06f1ccf18e6b85e7944e1af74e9a08385053a46f0277c8f395fa02c20f2a',
+       i686: 'f07416c233166be3cf0777be1745d61ed6f3574137a7918c300779acc39593d8',
+     x86_64: 'bdd162ae2fd29f1500e2dd6a7ed7378023b2e20d3af73c42c3017ef10f4d905f'
   })
 
   depends_on 'cups'
@@ -49,20 +51,13 @@ class Gtk3 < Package
             builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
-    @file = <<~GTK3_CONFIG_HEREDOC
-      [Settings]
-      gtk-application-prefer-dark-theme = false
-      gtk-icon-theme-name = hicolor
-      gtk-fallback-icon-theme = gnome
-      gtk-font-name = Arial 10
-    GTK3_CONFIG_HEREDOC
   end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
     system "sed -i 's,null,,g'  #{CREW_DEST_LIB_PREFIX}/pkgconfig/gtk*.pc"
     FileUtils.mkdir_p("#{CREW_DEST_HOME}/.config/gtk-3.0")
-    File.write("#{CREW_DEST_HOME}/.config/gtk-3.0/settings.ini", @file)
+    File.write("#{CREW_DEST_HOME}/.config/gtk-3.0/settings.ini", @gtk3settings)
   end
 
   def self.postinstall
@@ -70,5 +65,19 @@ class Gtk3 < Package
     system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
     # update mime database
     system "update-mime-database #{CREW_PREFIX}/share/mime"
+    @xdg_config_home = ENV['XDG_CONFIG_HOME']
+    @gtk3settings = <<~GTK3_CONFIG_HEREDOC
+      [Settings]
+      gtk-application-prefer-dark-theme = false
+      gtk-icon-theme-name = hicolor
+      gtk-fallback-icon-theme = gnome
+      gtk-font-name = Arial 10
+    GTK3_CONFIG_HEREDOC
+    unless File.exist?("#{@xdg_config_home}/gtk-3.0/settings.ini")
+      puts
+      puts 'Adding basic gtk4 settings to XDG_CONFIG_HOME/gtk-3.0/settings.ini'.lightblue
+      FileUtils.mkdir_p "#{@xdg_config_home}/gtk-3.0"
+      File.write("#{@xdg_config_home}/gtk-3.0/settings.ini", @gtk3settings)
+    end
   end
 end

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -65,16 +65,16 @@ class Gtk4 < Package
       build"
     system 'meson configure build'
     system 'ninja -C build'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
     @gtk4settings = <<~GTK4_CONFIG_HEREDOC
       [Settings]
       gtk-icon-theme-name = Adwaita
       gtk-theme-name = Adwaita
       gtk-font-name = Cantarell 11
     GTK4_CONFIG_HEREDOC
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/gtk-4.0"
     File.write("#{CREW_DEST_PREFIX}/etc/gtk-4.0/settings.ini", @gtk4settings)
   end

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -3,22 +3,25 @@ require 'package'
 class Gtk4 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk4/'
-  version '4.1.1'
+  @_ver = '4.1.2'
+  @_ver_prelastdot = @_ver.rpartition('.')[0]
+  version @_ver
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/gtk/4.1/gtk-4.1.1.tar.xz'
-  source_sha256 'f7e1789f6c637b091cffb17de08bd9c3986543282eecdff0750dd04f1673b737'
+  source_url "https://gitlab.gnome.org/GNOME/gtk/-/archive/#{@_ver}/gtk-#{@_ver}.tar.bz2"
+  # source_url "https://download.gnome.org/sources/gtk/#{@_ver_prelastdot}/gtk-#{@_ver}.tar.xz"
+  source_sha256 '64b042592ba48c63535a47ed087d161290620e1de9e577ff89ea3afabf1a4edb'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'dcce3aeb6954b2010a867f2bf84b11995d6d0433a1ece96313ee36d27af4819c',
-     armv7l: 'dcce3aeb6954b2010a867f2bf84b11995d6d0433a1ece96313ee36d27af4819c',
-       i686: '182fa221219f0a2b25b5ebe902e86dde0ed09e3e741bb1e52acdd120e8bcb308',
-     x86_64: '81fbb2bd61ff6c1f0729f686e9c1a21f39c24bfaf8d2bd0a92adb929e3f32475'
+    aarch64: 'f04e726a8c2a71d04c1a274a67b0727aa6ae318b40d9325f20546ca29064e37e',
+     armv7l: 'f04e726a8c2a71d04c1a274a67b0727aa6ae318b40d9325f20546ca29064e37e',
+       i686: '690f527ac11a4af784b299159350323e726a5be18b3443fabdfc41f83dcd10a4',
+     x86_64: '3d715f42be186839b936929deaec180a3bf13f3fb2f7e89dc21421d6b19988fa'
   })
 
   depends_on 'cups'
@@ -70,16 +73,18 @@ class Gtk4 < Package
     system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
     # update mime database
     system "update-mime-database #{CREW_PREFIX}/share/mime"
-    unless File.exist?("#{HOME}/.config/gtk-4.0/settings.ini")
+    @xdg_config_home = ENV['XDG_CONFIG_HOME']
+    @gtk4settings = <<~GTK4_CONFIG_HEREDOC
+      [Settings]
+      gtk-icon-theme-name = Adwaita
+      gtk-theme-name = Adwaita
+      gtk-font-name = Arimo 10
+    GTK4_CONFIG_HEREDOC
+    unless File.exist?("#{@xdg_config_home}/gtk-4.0/settings.ini")
       puts
-      puts 'Adding basic gtk4 settings to ~/.config/gtk-4.0/settings.ini'.lightblue
-      FileUtils.mkdir_p "#{HOME}/.config/gtk-4.0"
-      system "cat << 'EOF' > #{HOME}/.config/gtk-4.0/settings.ini
-[Settings]
-gtk-icon-theme-name = Adwaita
-gtk-theme-name = Adwaita
-gtk-font-name = Arimo 10
-EOF"
+      puts 'Adding basic gtk4 settings to XDG_CONFIG_HOME/gtk-4.0/settings.ini'.lightblue
+      FileUtils.mkdir_p "#{@xdg_config_home}/gtk-4.0"
+      File.write("#{@xdg_config_home}/gtk-4.0/settings.ini", @gtk4settings)
     end
   end
 end

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -11,19 +11,6 @@ class Gtk4 < Package
   # source_url "https://download.gnome.org/sources/gtk/#{@_ver_prelastdot}/gtk-#{@_ver}.tar.xz"
   source_sha256 '64b042592ba48c63535a47ed087d161290620e1de9e577ff89ea3afabf1a4edb'
 
-  binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'f04e726a8c2a71d04c1a274a67b0727aa6ae318b40d9325f20546ca29064e37e',
-     armv7l: 'f04e726a8c2a71d04c1a274a67b0727aa6ae318b40d9325f20546ca29064e37e',
-       i686: '690f527ac11a4af784b299159350323e726a5be18b3443fabdfc41f83dcd10a4',
-     x86_64: '3d715f42be186839b936929deaec180a3bf13f3fb2f7e89dc21421d6b19988fa'
-  })
-
   depends_on 'at_spi2_atk'
   depends_on 'cantarell_fonts'
   depends_on 'cups'

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -26,6 +26,7 @@ class Gtk4 < Package
 
   depends_on 'cups'
   depends_on 'at_spi2_atk'
+  depends_on 'cantarell_fonts'
   depends_on 'gnome_icon_theme'
   depends_on 'gobject_introspection'
   depends_on 'gdk_pixbuf'
@@ -78,7 +79,7 @@ class Gtk4 < Package
       [Settings]
       gtk-icon-theme-name = Adwaita
       gtk-theme-name = Adwaita
-      gtk-font-name = Arimo 10
+      gtk-font-name = Cantarell 11
     GTK4_CONFIG_HEREDOC
     unless File.exist?("#{@xdg_config_home}/gtk-4.0/settings.ini")
       puts

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -11,9 +11,24 @@ class Gtk4 < Package
   # source_url "https://download.gnome.org/sources/gtk/#{@_ver_prelastdot}/gtk-#{@_ver}.tar.xz"
   source_sha256 '64b042592ba48c63535a47ed087d161290620e1de9e577ff89ea3afabf1a4edb'
 
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '771dd5ef30a4daadfd1d1c1c8a592c70158924ae1cb18d25677723d62e0efec2',
+     armv7l: '771dd5ef30a4daadfd1d1c1c8a592c70158924ae1cb18d25677723d62e0efec2',
+       i686: 'eca9a807e1ea3308f54213d836df9ddb3ca0c0c085db2e928e60e774368ef2db',
+     x86_64: 'b8bf6a435d4e361f96f30d254f199a9d8bf3bd20c90d78ae701c661b0d29b784'
+  })
+
+  depends_on 'adwaita_icon_theme'
   depends_on 'at_spi2_atk'
   depends_on 'cantarell_fonts'
   depends_on 'cups'
+  depends_on 'ffmpeg'
   depends_on 'gdk_pixbuf'
   depends_on 'gnome_icon_theme'
   depends_on 'gobject_introspection'


### PR DESCRIPTION
- gtk3 => 3.24.27
- gtk4 => 4.1.2
- add cantarell fonts and mark them as the font to use for gtk4
- updated adwaita_icon_theme to not overwrite gtk settings file
- Also update settings file logic to conform to XDG paths

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686