### PR TITLE
glib -> 2.67.6

### DIFF
--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,24 +3,24 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.67.5'
+  @_ver = '2.67.6'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   compatibility 'all'
   source_url "https://download.gnome.org/sources/glib/#{@_ver_prelastdot}/glib-#{@_ver}.tar.xz"
-  source_sha256 '9d2ad4303ce25ae7cfde77409d8364508ac6072a868cfca2e78333c6cdfa05e6'
+  source_sha256 'dd7f563509b410e8f94ef2d4cc7f74620a6b29d7c5d529fedec53c5e8018d9c5'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.5-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.6-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'bde7d35943c70e260e52a3688ba88e114717e461bad41b5c90942f46205345c2',
-     armv7l: 'bde7d35943c70e260e52a3688ba88e114717e461bad41b5c90942f46205345c2',
-       i686: '2ac0cb8ac4a6b92ff84a31f670b1d915b95137d797778ea962fa143dd1c9df81',
-     x86_64: '5e5ac89b2b53a90b34da77fe8b26dece4c30c4c772a6232eb229751307bf4cef'
+    aarch64: 'fe820f8369ab9c33f818bcd62e4a95bb8c5d28b7285a8781821ab25ec9ded416',
+     armv7l: 'fe820f8369ab9c33f818bcd62e4a95bb8c5d28b7285a8781821ab25ec9ded416',
+       i686: '26cc4995d5da3a24ef3fdbdc2135c086eedd12e59096f04ebe0e760e47f20657',
+     x86_64: '74965074bd9480e0a8a9076bc9bdf092f5b97b47df74bf0a852ac16e1c5be208'
   })
 
   depends_on 'pcre'


### PR DESCRIPTION
- missed this gnome 40.rc update

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686