### PR TITLE
fixes for lib64 libraries going in lib and deps updates for those packages

### DIFF
--- a/packages/libimagequant.rb
+++ b/packages/libimagequant.rb
@@ -1,34 +1,33 @@
-# Adapted from Arch Linux libimagequant PKGBUILD at:
-# https://github.com/archlinux/svntogit-community/raw/packages/libimagequant/trunk/PKGBUILD
-
 require 'package'
 
 class Libimagequant < Package
   description 'Library for high-quality conversion of RGBA images to 8-bit indexed-color palette images'
   homepage 'https://pngquant.org/lib/'
-  version '2.14.1'
-  compatibility 'x86_64 aarch64 armv7l'
-  source_url 'https://github.com/ImageOptim/libimagequant/archive/2.14.1/libimagequant-2.14.1.tar.gz'
+  @_ver = '2.14.1'
+  version "#{@_ver}-1"
+  compatibility 'all'
+  source_url "https://github.com/ImageOptim/libimagequant/archive/#{@_ver}/libimagequant-#{@_ver}.tar.gz"
   source_sha256 'b5fa27da1f3cf3e8255dd02778bb6a51dc71ce9f99a4fc930ea69b83200a7c74'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libimagequant-2.14.1-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'eeff7663ff38b663fef766a1244ea4c0be6c465cd216f9f5b0409affd9f03ae3',
-     armv7l: 'eeff7663ff38b663fef766a1244ea4c0be6c465cd216f9f5b0409affd9f03ae3',
-     x86_64: 'a684ca8eeeb2a38a696eb8a1b3395e0d08929ef219c17df23ac87fbd6989d963'
+    aarch64: '0f7ae09c69f1648bf6a77c6d269336fa246c2415ff0cb0bb9fb2bb55c46edafe',
+     armv7l: '0f7ae09c69f1648bf6a77c6d269336fa246c2415ff0cb0bb9fb2bb55c46edafe',
+       i686: '74d2e1a73b3d45f33200a7f84b921ed459b51cb83ba4767d90657d939ab8df41',
+     x86_64: '95a63c4b09e14a6c557bc4dfbced1414f1a07798dde25b1895bf5dfd1aae3223'
   })
 
   def self.build
-    # system "sed -r 's/^install:.*/install:/;/install.*STATICLIB/d' -i Makefile"
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       ./configure #{CREW_OPTIONS} --with-openmp"
-    system 'make shared imagequant.pc'
+    system 'make all imagequant.pc'
   end
 
   def self.install

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -22,6 +22,8 @@ class Libpng < Package
      x86_64: '703cb00f75ecdab4918029aa57ee9ed53f027d0a4be6cd6c29b9e4fbd25f7dfe'
   })
 
+  depends_on 'zlibpkg'
+
   def self.patch
     system 'filefix'
   end

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -3,37 +3,37 @@ require 'package'
 class Libpng < Package
   description 'libpng is the official PNG reference library.'
   homepage 'http://libpng.org/pub/png/libpng.html'
-  version '1.6.37'
+  @_ver = '1.6.37'
+  version "#{@_ver}-1"
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/project/libpng/libpng16/1.6.37/libpng-1.6.37.tar.xz'
+  source_url "https://downloads.sourceforge.net/project/libpng/libpng16/#{@_ver}/libpng-#{@_ver}.tar.xz"
   source_sha256 '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libpng-1.6.37-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '14240b27d54756682cfa2c75126cb1de443faead0232e6636f4b1e36322bb85e',
-     armv7l: '14240b27d54756682cfa2c75126cb1de443faead0232e6636f4b1e36322bb85e',
-       i686: '85d03e11ba20b635f24c6786b1f5050ee35c515d2e7b9a43464f8896945c3c13',
-     x86_64: 'bc1b016c4c947fa3fb70cc456be81b3859430579722e2189781f1403a4a96b83',
+  binary_sha256({
+    aarch64: 'addb9158594a38f2d4ecd90c5de111d43586d3cdd9ab1edc25536cfb3dc3b760',
+     armv7l: 'addb9158594a38f2d4ecd90c5de111d43586d3cdd9ab1edc25536cfb3dc3b760',
+       i686: '865eea143c0e553d9aea22f20fb02cdb89d2fb823cbf94b1e79b1f3a1124442f',
+     x86_64: '703cb00f75ecdab4918029aa57ee9ed53f027d0a4be6cd6c29b9e4fbd25f7dfe'
   })
-
-  depends_on 'zlibpkg'
 
   def self.patch
-    # Fix /usr/bin/file: No such file or directory
     system 'filefix'
   end
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-dependency-tracking',
-           '--disable-maintainer-mode'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --disable-dependency-tracking \
+      --disable-maintainer-mode"
     system 'make'
   end
 

--- a/packages/libvips.rb
+++ b/packages/libvips.rb
@@ -3,33 +3,38 @@ require 'package'
 class Libvips < Package
   description 'A fast image processing library with low memory needs'
   homepage 'https://libvips.github.io/libvips/'
-  @_ver = '8.10.6-beta'
+  @_ver = '8.10.6-beta2'
   version @_ver
   compatibility 'all'
   source_url "https://github.com/libvips/libvips/archive/v#{@_ver}.tar.gz"
-  source_sha256 '975371c3650dbfedbde012b6573034338b0bb8f03d5df8d031abb80c3b4c9014'
+  source_sha256 'b2412f580ba83129d55e57a73c7c4fdb53e60a39c48910acc5f0d80518deb7a5'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libvips-8.10.6-beta2-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '64f9cad9ad9287b1c57086adec379640676a4a456b3e753d9e7797fe0ee92ec7',
-     armv7l: '64f9cad9ad9287b1c57086adec379640676a4a456b3e753d9e7797fe0ee92ec7',
-       i686: '504779b4a009c269dc19dc4f3bb0ad60512dc53da38bfbba3507c959540e3d37',
-     x86_64: '3d719741999b3e75ab54788b99d0468217b539ec9e79d1f672a71f14002a6c96'
+    aarch64: '2d95674bfc951f232315ea0e93311d5982b9975c76f7f8d092f8d3fcfe6810b6',
+     armv7l: '2d95674bfc951f232315ea0e93311d5982b9975c76f7f8d092f8d3fcfe6810b6',
+       i686: '4bf07840cb30a398201160d0004530b909c48c691d21eb4bc35b2a4081c86f27',
+     x86_64: '3d2244043e9fd70c3a7429e98c825243cadac0e613a3c5443ee3a243721d8815'
   })
 
   depends_on 'cfitsio'
   depends_on 'fftw'
-  depends_on 'imagemagick'
+  depends_on 'imagemagick7'
+  depends_on 'lcms'
   depends_on 'libexif'
   depends_on 'libgsf'
   depends_on 'libheif'
   depends_on 'libimagequant'
   depends_on 'librsvg'
+  depends_on 'libtiff'
+  depends_on 'libwebp'
+  depends_on 'orc'
+  depends_on 'poppler'
 
   def self.build
     system 'NOCONFIGURE=1 ./autogen.sh'
@@ -37,7 +42,7 @@ class Libvips < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure"
+      ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/poppler.rb
+++ b/packages/poppler.rb
@@ -3,25 +3,27 @@ require 'package'
 class Poppler < Package
   description 'Poppler is a PDF rendering library based on the xpdf-3.0 code base.'
   homepage 'https://poppler.freedesktop.org/'
-  version '20.10.0'
-  compatibility 'aarch64,armv7l,x86_64'
-  source_url 'https://poppler.freedesktop.org/poppler-20.10.0.tar.xz'
-  source_sha256 '434ecbbb539c1a75955030a1c9b24c7b58200b7f68d2e4269e29acf2f8f13336'
+  @_ver = '21.03.0'
+  version @_ver
+  compatibility 'all'
+  source_url "https://poppler.freedesktop.org/poppler-#{@_ver}.tar.xz"
+  source_sha256 'fd51ead4aac1d2f4684fa6e7b0ec06f0233ed21667e720a4e817e4455dd63d27'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-20.10.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-20.10.0-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-20.10.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '18bcbd800629d2d04750a6a3837fc9bff16dcea458e90a7e0e2d06d04a05917d',
-     armv7l: '18bcbd800629d2d04750a6a3837fc9bff16dcea458e90a7e0e2d06d04a05917d',
-     x86_64: '3d61a2ad5cff366fab3f502159cd5bd042d690ca18a8a289dd2423ed862a745c',
+  binary_sha256({
+    aarch64: 'a4cb106683c7b8d289553fe9073201329619519f30ecc623dc6d08dbfd4eccb7',
+     armv7l: 'a4cb106683c7b8d289553fe9073201329619519f30ecc623dc6d08dbfd4eccb7',
+       i686: '54adf5a92963371ef36fbfa9078554b8539877bb036569d4f1b5d8627f7d2ddb',
+     x86_64: '4133f3f21f6ed0a9d6530dbe4d4d5467984958479e69f56061c25e2ff42fb4dc'
   })
 
   depends_on 'boost'
   depends_on 'cairo'
-  depends_on 'curl'
   depends_on 'freeglut'
   depends_on 'harfbuzz'
   depends_on 'lcms'
@@ -35,20 +37,19 @@ class Poppler < Package
   def self.build
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
-      system 'cmake',
-             "-DCMAKE_CXX_FLAGS='-std=c++11 -I#{CREW_PREFIX}/include/GL -I#{CREW_PREFIX}/include/openjpeg-2.3 -I#{CREW_PREFIX}/include'",
-             "-DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX}",
-             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
-             '-DCMAKE_BUILD_TYPE=Release',
-             '-DENABLE_UNSTABLE_API_ABI_HEADERS=on',
-             '..'
-      system 'make'
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} \
+      CFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto -L#{CREW_LIB_PREFIX}' \
+      cmake #{CREW_CMAKE_OPTIONS} .. -G Ninja \
+      -DCMAKE_CXX_FLAGS='-pipe -flto=auto -std=c++11 \
+      -I#{CREW_PREFIX}/include/GL -I#{CREW_PREFIX}/include/openjpeg-2.4 \
+      -I#{CREW_PREFIX}/include' \
+      -DENABLE_UNSTABLE_API_ABI_HEADERS=on"
     end
+    system 'ninja -C builddir'
   end
 
   def self.install
-    Dir.chdir 'builddir' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/poppler_data.rb
+++ b/packages/poppler_data.rb
@@ -3,25 +3,24 @@ require 'package'
 class Poppler_data < Package
   description 'This additional package consists of encoding files for use with Poppler.'
   homepage 'https://poppler.freedesktop.org/'
-  version '0.4.9'
+  @_ver = '0.4.10'
+  version @_ver
   compatibility 'all'
-  source_url 'https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz'
-  source_sha256 '1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012'
+  source_url "https://poppler.freedesktop.org/poppler-data-#{@_ver}.tar.gz"
+  source_sha256 '6e2fcef66ec8c44625f94292ccf8af9f1d918b410d5aa69c274ce67387967b30'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.9-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.10-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.10-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.10-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler_data-0.4.10-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'e87aab5e93dfef795acbc889688cee483685ceb1dae6623b77f3e902c676fc6e',
-     armv7l: 'e87aab5e93dfef795acbc889688cee483685ceb1dae6623b77f3e902c676fc6e',
-       i686: '45c2bfb58eae9b16e773a67d3c74a52f6d7096904d53495df6e710a1302bd41c',
-     x86_64: 'cb660cd7accbdb437feb6704133040c74e09f80065a3c2020959385e31f4eec4',
+  binary_sha256({
+    aarch64: '819a39d253b0e62d9e08f704e9d8d9bc551f48528393a82d988d87a64422ec63',
+     armv7l: '819a39d253b0e62d9e08f704e9d8d9bc551f48528393a82d988d87a64422ec63',
+       i686: '5982a173cc1a37ad97c0e5a79089e09ed9558acd11163d322b1b964dbf232d9b',
+     x86_64: '129a2d18480c9074f52a3bd2560f4fede057c065ec9823908c12f62b7c42bf20'
   })
-
-  depends_on 'poppler'
 
   def self.install
     system "make PREFIX=#{CREW_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"

--- a/packages/qttools.rb
+++ b/packages/qttools.rb
@@ -3,34 +3,35 @@ require 'package'
 class Qttools < Package
   description 'Qt Tools'
   homepage 'https://github.com/qt/qttools'
-  version '5.15.1'
-  compatibility 'aarch64,armv7l,x86_64'
-  source_url 'http://download.qt.io/official_releases/qt/5.15/5.15.1/submodules/qttools-everywhere-src-5.15.1.tar.xz'
-  source_sha256 'c98ee5f0f980bf68cbf0c94d62434816a92441733de50bd9adbe9b9055f03498'
+  version '5.15.2'
+  compatibility 'all'
+  source_url 'http://download.qt.io/official_releases/qt/5.15/5.15.2/submodules/qttools-everywhere-src-5.15.2.tar.xz'
+  source_sha256 'c189d0ce1ff7c739db9a3ace52ac3e24cb8fd6dbf234e49f075249b38f43c1cc'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.1-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/qttools-5.15.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'b800130b6db80652fc3c9bde2008b8fa64b1e5bab5dfe717c10b8fb04d686b94',
-     armv7l: 'b800130b6db80652fc3c9bde2008b8fa64b1e5bab5dfe717c10b8fb04d686b94',
-     x86_64: 'ca2818363c965077ae2eaf6430369f5a37f5288dd229bbf352072c2a8adffa03',
+  binary_sha256({
+    aarch64: '0d40cb342b8b31427bc976979dbc4c5bfcd8995e5bcc1e74a2a91cf4d84c2265',
+     armv7l: '0d40cb342b8b31427bc976979dbc4c5bfcd8995e5bcc1e74a2a91cf4d84c2265',
+       i686: '1f94a4b40c8f94d47b13445fd9dfb7abb50694cf0876d83e71287f59f36caeca',
+     x86_64: '4fe6c1fcd3b4bdfbdface915f9c7d71b6c73deadbb5bb20cb5d89af8d6d9d2d2'
   })
 
   depends_on 'qtbase'
   depends_on 'libtinfo'
-  depends_on 'llvm'
-  depends_on 'zstd'
-  depends_on 'sommelier'
 
   def self.build
-    system 'qmake && make'
+    # Note: This MAY NOT COMPILE with llvm installed on x86. Install dependencies,
+    # disable depends, and uninstall llvm before attempting compile.
+    system 'qmake -Wall -early QMAKE_CFLAGS=-flto -early QMAKE_CXXFLAGS=-flto && make'
   end
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}"
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
     system "cp -a lib/* #{CREW_DEST_LIB_PREFIX}"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/Qt-5"
     FileUtils.cp_r 'bin', "#{CREW_DEST_PREFIX}/share/Qt-5"

--- a/packages/yasm.rb
+++ b/packages/yasm.rb
@@ -1,28 +1,30 @@
 require 'package'
 
 class Yasm < Package
-  version '1.3.0'
   description 'Yasm is a complete rewrite of the NASM assembler under the new BSD License.'
   homepage 'http://yasm.tortall.net/'
+  version '1.3.0-1'
   compatibility 'all'
   source_url 'http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz'
   source_sha256 '3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yasm-1.3.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yasm-1.3.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yasm-1.3.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yasm-1.3.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yasm-1.3.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yasm-1.3.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yasm-1.3.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yasm-1.3.0-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '2d6cf322742d3737864b5ce42eb3bc58a655c1d0b69551be27342c4a5a0dcf22',
-     armv7l: '2d6cf322742d3737864b5ce42eb3bc58a655c1d0b69551be27342c4a5a0dcf22',
-       i686: 'd040103857bf2c0f6fb4cd6120e7ed6f45891297c148acb750d0355245c568e1',
-     x86_64: 'c83395c97dced0cc820642a7979c26ad830ab0f9b27eed6a8e3e13b5873bf082',
+  binary_sha256({
+    aarch64: '09315c4ce83e227350b3f515217a3b77285b42606a7414c80951eb2134937d77',
+     armv7l: '09315c4ce83e227350b3f515217a3b77285b42606a7414c80951eb2134937d77',
+       i686: '34ba6340b711261bbd5a3b0332fc858418b9eee0344ee12d1e235c049068291a',
+     x86_64: '8ec504db1d9c91adb6680f17e328daf6114758cbf2106fc4eb2e8028834b3737'
   })
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX}"
+    system "env CFLAGS='-pipe -flto=auto' CPPFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 


### PR DESCRIPTION
- Fixes for libvips, yasm, dropping libraries in `/usr/local/lib` on `x86_64`
- This led to rebuilding `libpng` (was linked to system libz on i686) & `libimagequant` (for i686), updating `qttools`, `poppler` (both deps for libvips)

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l