### PR TITLE
fix moreutils deps

### DIFF
--- a/packages/moreutils.rb
+++ b/packages/moreutils.rb
@@ -22,8 +22,8 @@ class Moreutils < Package
       x86_64: '55222b8e4293e548f812542fa7447e5420c1b7098c0ae481e1f0a0357dd84ed9',
   })
 
-  depends_on 'docbook_xml'
-  depends_on 'libxslt'
+  depends_on 'docbook_xml' => :build
+  depends_on 'libxslt' => :build
 
   def self.build
     system "sed -i 's,PREFIX?=/usr,PREFIX?=#{CREW_PREFIX},' Makefile"


### PR DESCRIPTION
- fix moreutils deps, as none of the binaries generated actually depend on the `depends_on` libraries at runtime.

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l