### PR TITLE
add readline dep to libxml2

### DIFF
--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -22,6 +22,7 @@ class Libxml2 < Package
   })
 
   depends_on 'zlibpkg'
+  depends_on 'readline'
 
   def self.patch
     # Fix encoding.c:1961:31: error: ‘TRUE’ undeclared (first use in this function)


### PR DESCRIPTION
- xmlcatalog needs readline libraries
- (part of first pass at generating dependency tree)

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l