### PR TITLE
Split glibmm, pangomm, cairomm, add gnome_tweaks, gnome_terminal update

### DIFF
--- a/packages/cairomm.rb
+++ b/packages/cairomm.rb
@@ -4,41 +4,10 @@ class Cairomm < Package
   description 'The Cairomm package provides a C++ interface to Cairo.'
   homepage 'https://www.cairographics.org/'
   version '1.16.0'
-  license 'LGPL-2+'
   compatibility 'all'
-  source_url 'https://www.cairographics.org/releases/cairomm-1.16.0.tar.xz'
-  source_sha256 '7e881492c5f9f546688c31160deb742c166fc4c68b6b8eb9920c00a0f0f144f9'
 
-  binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.16.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.16.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.16.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm-1.16.0-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'c1d71ead86e471d5a7197385f9265c7c9b18cbe875bb1b44d21e8d7db455b42e',
-     armv7l: 'c1d71ead86e471d5a7197385f9265c7c9b18cbe875bb1b44d21e8d7db455b42e',
-       i686: 'ca252ba384eaa24a2cce9d3e8d05071b90f15bab7a714acd85af0b518c87495a',
-     x86_64: '84355939a5c61018943d37073c9c364295598a205769d15bd9d7c5d820a50778'
-  })
+  is_fake
 
-  depends_on 'cairo'
-  depends_on 'libsigcplusplus3'
-  depends_on 'libxxf86vm'
-  depends_on 'libxrender'
-
-  def self.build
-    system "meson #{CREW_MESON_LTO_OPTIONS} \
-    --default-library=both \
-    -Dbuild-documentation=false \
-    -Dbuild-examples=false \
-    -Dbuild-tests=false \
-    builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  depends_on 'cairomm_1_0'
+  depends_on 'cairomm_1_16'
 end

--- a/packages/cairomm.rb
+++ b/packages/cairomm.rb
@@ -3,7 +3,8 @@ require 'package'
 class Cairomm < Package
   description 'The Cairomm package provides a C++ interface to Cairo.'
   homepage 'https://www.cairographics.org/'
-  version '1.16.0'
+  version '1.0'
+  license 'LGPL-2+'
   compatibility 'all'
 
   is_fake

--- a/packages/cairomm_1_0.rb
+++ b/packages/cairomm_1_0.rb
@@ -5,6 +5,7 @@ class Cairomm_1_0 < Package
   homepage 'https://www.cairographics.org/'
   @_ver = '1.14.2'
   version @_ver
+  license 'LGPL-2+'
   compatibility 'all'
   source_url "https://www.cairographics.org/releases/cairomm-#{@_ver}.tar.xz"
   source_sha256 '0126b9cc295dc36bc9c0860d5b720cb5469fd78d5620c8f10cc5f0c07b928de3'

--- a/packages/cairomm_1_0.rb
+++ b/packages/cairomm_1_0.rb
@@ -1,0 +1,44 @@
+require 'package'
+
+class Cairomm_1_0 < Package
+  description 'The Cairomm package provides a C++ interface to Cairo.'
+  homepage 'https://www.cairographics.org/'
+  @_ver = '1.14.2'
+  version @_ver
+  compatibility 'all'
+  source_url "https://www.cairographics.org/releases/cairomm-#{@_ver}.tar.xz"
+  source_sha256 '0126b9cc295dc36bc9c0860d5b720cb5469fd78d5620c8f10cc5f0c07b928de3'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm_1_0-1.14.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm_1_0-1.14.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm_1_0-1.14.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm_1_0-1.14.2-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '43377afdfd60e5d6de950d883d7053c5f21dc2fe7b87b99d60b51de2c16e480d',
+     armv7l: '43377afdfd60e5d6de950d883d7053c5f21dc2fe7b87b99d60b51de2c16e480d',
+       i686: 'b66a27aae76d273e8d365d764efafb4a01703d087dde1f63401b3feff0257ad0',
+     x86_64: '3ec47e52333e93b341c65d1af2d58bb51c6d60a9b4023b20b2b8c04fd5a42b5e'
+  })
+
+  depends_on 'cairo'
+  depends_on 'libsigcplusplus3'
+  depends_on 'libxxf86vm'
+  depends_on 'libxrender'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    --default-library=both \
+    -Dbuild-documentation=false \
+    -Dbuild-examples=false \
+    -Dbuild-tests=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/cairomm_1_16.rb
+++ b/packages/cairomm_1_16.rb
@@ -5,6 +5,7 @@ class Cairomm_1_16 < Package
   homepage 'https://www.cairographics.org/'
   @_ver = '1.16.0'
   version @_ver
+  license 'LGPL-2+'
   compatibility 'all'
   source_url "https://www.cairographics.org/releases/cairomm-#{@_ver}.tar.xz"
   source_sha256 '7e881492c5f9f546688c31160deb742c166fc4c68b6b8eb9920c00a0f0f144f9'

--- a/packages/cairomm_1_16.rb
+++ b/packages/cairomm_1_16.rb
@@ -1,0 +1,44 @@
+require 'package'
+
+class Cairomm_1_16 < Package
+  description 'The Cairomm package provides a C++ interface to Cairo.'
+  homepage 'https://www.cairographics.org/'
+  @_ver = '1.16.0'
+  version @_ver
+  compatibility 'all'
+  source_url "https://www.cairographics.org/releases/cairomm-#{@_ver}.tar.xz"
+  source_sha256 '7e881492c5f9f546688c31160deb742c166fc4c68b6b8eb9920c00a0f0f144f9'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm_1_16-1.16.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm_1_16-1.16.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm_1_16-1.16.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/cairomm_1_16-1.16.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '59ca0664657952e1296639082e8352e26ad1b9792208b4a2b713c64178f73e77',
+     armv7l: '59ca0664657952e1296639082e8352e26ad1b9792208b4a2b713c64178f73e77',
+       i686: 'e874a3fc54b12a36625063808ac69fe76dbd77eed044f300cf51170359f4bd4a',
+     x86_64: '69ad2d194716615b38b13eb321bd019c61cceb1124c787a990524d792d1eac6d'
+  })
+
+  depends_on 'cairo'
+  depends_on 'libsigcplusplus3'
+  depends_on 'libxxf86vm'
+  depends_on 'libxrender'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    --default-library=both \
+    -Dbuild-documentation=false \
+    -Dbuild-examples=false \
+    -Dbuild-tests=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/glibmm.rb
+++ b/packages/glibmm.rb
@@ -3,40 +3,11 @@ require 'package'
 class Glibmm < Package
   description 'C++ bindings for GLib'
   homepage 'https://www.gtkmm.org'
-  version '2.68.0'
-  license 'LGPL-2.1+'
+  version '1.0'
   compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.68/glibmm-2.68.0.tar.xz'
-  source_sha256 'c1f38573191dceed85a05600888cf4cf4695941f339715bd67d51c2416f4f375'
 
-  binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.68.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.68.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.68.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm-2.68.0-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'a9e342573e021fd5ce8fe3a31a00eae0ea8bb4468986556c5333b5e404d1377a',
-     armv7l: 'a9e342573e021fd5ce8fe3a31a00eae0ea8bb4468986556c5333b5e404d1377a',
-       i686: '97befe025c500e4b94c7d5d82a422e9cbb1772f2f688d1531ce861dbcabbe7b6',
-     x86_64: '42beab5465b595e90359d71e05ef6c90b66846b5fbe64108cf8568fe2658ca8f'
-  })
+  is_fake
 
-  depends_on 'libsigcplusplus3'
-  depends_on 'mm_common' => :build
-
-  def self.build
-    system "meson #{CREW_MESON_LTO_OPTIONS} \
-    --default-library=both \
-    -Dbuild-documentation=false \
-    -Dbuild-demos=false \
-    -Dbuild-tests=false \
-    builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  depends_on 'glibmm_2_4'
+  depends_on 'glibmm_2_68'
 end

--- a/packages/glibmm.rb
+++ b/packages/glibmm.rb
@@ -4,6 +4,7 @@ class Glibmm < Package
   description 'C++ bindings for GLib'
   homepage 'https://www.gtkmm.org'
   version '1.0'
+  license 'LGPL-2.1+'
   compatibility 'all'
 
   is_fake

--- a/packages/glibmm_2_4.rb
+++ b/packages/glibmm_2_4.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Glibmm_2_4 < Package
+  description 'C++ bindings for GLib'
+  homepage 'https://www.gtkmm.org'
+  @_ver = '2.66.0'
+  @_ver_prelastdot = @_ver.rpartition('.')[0]
+  version @_ver
+  compatibility 'all'
+  source_url "https://ftp.gnome.org/pub/GNOME/sources/glibmm/#{@_ver_prelastdot}/glibmm-#{@_ver}.tar.xz"
+  source_sha256 '9e1db7d43d2e2d4dfa2771354e21a69a6beec7c446b711619cf8c779e13a581e'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm_2_4-2.66.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm_2_4-2.66.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm_2_4-2.66.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm_2_4-2.66.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'c6c0459c412f133ac1d581a4db4a8d4c6ae69227755f191822d59272502d0455',
+     armv7l: 'c6c0459c412f133ac1d581a4db4a8d4c6ae69227755f191822d59272502d0455',
+       i686: '8a3dade9644c0be55d3fb3ddf21f470466562020e5313e3f97557e2243db42fe',
+     x86_64: 'cd9b610bceadc050a09099d80815cfe4c092cb5cb8b67d0bc73c5d71e2f5f63c'
+  })
+
+  depends_on 'libsigcplusplus'
+  depends_on 'mm_common' => :build
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    --default-library=both \
+    -Dbuild-documentation=false \
+    -Dbuild-demos=false \
+    -Dbuild-tests=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/glibmm_2_4.rb
+++ b/packages/glibmm_2_4.rb
@@ -6,6 +6,7 @@ class Glibmm_2_4 < Package
   @_ver = '2.66.0'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
+  license 'LGPL-2.1+'
   compatibility 'all'
   source_url "https://ftp.gnome.org/pub/GNOME/sources/glibmm/#{@_ver_prelastdot}/glibmm-#{@_ver}.tar.xz"
   source_sha256 '9e1db7d43d2e2d4dfa2771354e21a69a6beec7c446b711619cf8c779e13a581e'

--- a/packages/glibmm_2_68.rb
+++ b/packages/glibmm_2_68.rb
@@ -6,6 +6,7 @@ class Glibmm_2_68 < Package
   @_ver = '2.68.0'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
+  license 'LGPL-2.1+'
   compatibility 'all'
   source_url "https://ftp.gnome.org/pub/GNOME/sources/glibmm/#{@_ver_prelastdot}/glibmm-#{@_ver}.tar.xz"
   source_sha256 'c1f38573191dceed85a05600888cf4cf4695941f339715bd67d51c2416f4f375'

--- a/packages/glibmm_2_68.rb
+++ b/packages/glibmm_2_68.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Glibmm_2_68 < Package
+  description 'C++ bindings for GLib'
+  homepage 'https://www.gtkmm.org'
+  @_ver = '2.68.0'
+  @_ver_prelastdot = @_ver.rpartition('.')[0]
+  version @_ver
+  compatibility 'all'
+  source_url "https://ftp.gnome.org/pub/GNOME/sources/glibmm/#{@_ver_prelastdot}/glibmm-#{@_ver}.tar.xz"
+  source_sha256 'c1f38573191dceed85a05600888cf4cf4695941f339715bd67d51c2416f4f375'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm_2_68-2.68.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm_2_68-2.68.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm_2_68-2.68.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glibmm_2_68-2.68.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'ac6be3527b1b77d5a31c0f9af2a382c8793805541c30d0c1050fde4da99d110a',
+     armv7l: 'ac6be3527b1b77d5a31c0f9af2a382c8793805541c30d0c1050fde4da99d110a',
+       i686: 'ffe1dae2a2d674a62d07c00798b329203680442424623c7dc3ed5efa2747f3f0',
+     x86_64: '71c115fd638c96c9244602f149709876e83f31f245a4ec8b843fa054d4dbcac5'
+  })
+
+  depends_on 'libsigcplusplus3'
+  depends_on 'mm_common' => :build
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    --default-library=both \
+    -Dbuild-documentation=false \
+    -Dbuild-demos=false \
+    -Dbuild-tests=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/gnome_terminal.rb
+++ b/packages/gnome_terminal.rb
@@ -5,6 +5,7 @@ class Gnome_terminal < Package
   homepage 'https://wiki.gnome.org/Apps/Terminal'
   @_ver = '3.41.0-3b79'
   version @_ver
+  license 'GPL-3+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-terminal/-/archive/3b79354a357970147ae276a02ca2222db98a0d28/gnome-terminal-3b79354a357970147ae276a02ca2222db98a0d28.tar.bz2'
   source_sha256 'ad56dc0f1c6d75ed9ef6a1238e963141d7ba609ad3bffb376bfe43a37f0d308e'

--- a/packages/gnome_terminal.rb
+++ b/packages/gnome_terminal.rb
@@ -3,23 +3,23 @@ require 'package'
 class Gnome_terminal < Package
   description 'The GNOME Terminal Emulator'
   homepage 'https://wiki.gnome.org/Apps/Terminal'
-  version '3.39.90'
-  license 'GPL-3+'
+  @_ver = '3.41.0-3b79'
+  version @_ver
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/gnome-terminal/3.39/gnome-terminal-3.39.90.tar.xz'
-  source_sha256 '68bbd2b20c533f1648d4ba5625dbcb35270e5c958713faaad30ea0167c3d8199'
+  source_url 'https://gitlab.gnome.org/GNOME/gnome-terminal/-/archive/3b79354a357970147ae276a02ca2222db98a0d28/gnome-terminal-3b79354a357970147ae276a02ca2222db98a0d28.tar.bz2'
+  source_sha256 'ad56dc0f1c6d75ed9ef6a1238e963141d7ba609ad3bffb376bfe43a37f0d308e'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_terminal-3.39.90-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_terminal-3.39.90-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_terminal-3.39.90-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_terminal-3.39.90-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_terminal-3.41.0-3b79-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_terminal-3.41.0-3b79-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_terminal-3.41.0-3b79-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_terminal-3.41.0-3b79-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '64e9b60071ff95ecca092aa1468a8c2c4f82913e531b2ea456c525007634e426',
-     armv7l: '64e9b60071ff95ecca092aa1468a8c2c4f82913e531b2ea456c525007634e426',
-       i686: '22c50f78a594fded61c48656aaae5e8b378086ca1a339c2ceebb6838ffaed425',
-     x86_64: '9745dded864e889d64e5e3e04215240765ee0be748fbad5a9c3db84f58ec91c5'
+    aarch64: '127a7ebff88b54baca1e813e7a46b3b649e99e4c8395e47320ef9e534931d73a',
+     armv7l: '127a7ebff88b54baca1e813e7a46b3b649e99e4c8395e47320ef9e534931d73a',
+       i686: '8312ce51a47c2ced1d38700c18ade1ab65f471f989ac0d5336065865059e906a',
+     x86_64: '7439c90a81a8ee6951021254a7d5ce1540b1aea95779fdcbf55ca507dbbd6cb6'
   })
 
   depends_on 'gtk3'
@@ -28,20 +28,21 @@ class Gnome_terminal < Package
   depends_on 'desktop_file_utilities'
   depends_on 'gsettings_desktop_schemas'
   depends_on 'yelp_tools'
-  depends_on 'sommelier'
+  depends_on 'gtk_doc'
 
   def self.build
-    system "env CFLAGS='-pipe -flto' \
-      CXXFLAGS='-pipe -flto' \
-      LDFLAGS='-flto' \
-      ./configure #{CREW_OPTIONS} \
-      --disable-search-provider \
-      --without-nautilus-extension \
-      --with-gtk=3.0"
-    system 'make'
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    --default-library=both \
+    -Dsearch_provider=false \
+    -Dnautilus_extension=false \
+    -Dc_args='-flto -fno-stack-protector -U_FORTIFY_SOURCE -fuse-ld=gold -pipe' \
+    -Dcpp_args='-flto -fno-stack-protector -U_FORTIFY_SOURCE -fuse-ld=gold -pipe' \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/gnome_tweaks.rb
+++ b/packages/gnome_tweaks.rb
@@ -4,6 +4,7 @@ class Gnome_tweaks < Package
   description 'Graphical interface for advanced GNOME 3 settings Tweak Tool'
   @_ver = '40.beta-4cbb'
   version @_ver
+  license 'GPL-3+ and CC0-1.0'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-tweaks/-/archive/4cbb4a44743b64df5c688e84f28befe28da012ba/gnome-tweaks-4cbb4a44743b64df5c688e84f28befe28da012ba.tar.bz2'
   # source_url "https://gitlab.gnome.org/GNOME/gnome-tweaks/-/archive/#{@_ver}/gnome-tweaks-#{@_ver}.tar.bz2"

--- a/packages/gnome_tweaks.rb
+++ b/packages/gnome_tweaks.rb
@@ -2,22 +2,24 @@ require 'package'
 
 class Gnome_tweaks < Package
   description 'Graphical interface for advanced GNOME 3 settings Tweak Tool'
-  @_ver = '40.beta'
+  @_ver = '40.beta-4cbb'
   version @_ver
-  license 'GPL-3+ and CC0-1.0'
-  compatibility 'x86_64 aarch64 armv7l'
-  source_url "https://gitlab.gnome.org/GNOME/gnome-tweaks/-/archive/#{@_ver}/gnome-tweaks-#{@_ver}.tar.bz2"
-  source_sha256 'b274a4a9bf93405bd487f5a2bb93fc15bfe0312b21dbebfe5088b8d477d63416'
+  compatibility 'all'
+  source_url 'https://gitlab.gnome.org/GNOME/gnome-tweaks/-/archive/4cbb4a44743b64df5c688e84f28befe28da012ba/gnome-tweaks-4cbb4a44743b64df5c688e84f28befe28da012ba.tar.bz2'
+  # source_url "https://gitlab.gnome.org/GNOME/gnome-tweaks/-/archive/#{@_ver}/gnome-tweaks-#{@_ver}.tar.bz2"
+  source_sha256 '4b0548176772ce999531f6f873ee147420f9dc95980a11a3c2faa052b76119e5'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_tweaks-40.beta-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_tweaks-40.beta-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_tweaks-40.beta-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_tweaks-40.beta-4cbb-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_tweaks-40.beta-4cbb-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_tweaks-40.beta-4cbb-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_tweaks-40.beta-4cbb-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'fb04b6ae9e7bc37672bd78e1c4776d98d4b0e9dce170d0c68efbb06cc779b684',
-     armv7l: 'fb04b6ae9e7bc37672bd78e1c4776d98d4b0e9dce170d0c68efbb06cc779b684',
-     x86_64: 'b6088a18bd9568a8b6c6a6f983e85e3e8df5efc084283035eff6b6d5cbbe2f28'
+    aarch64: '490cce3a691eef0f388a464bb18900da5fa1f898a10d2d39fa59d023a89e229e',
+     armv7l: '490cce3a691eef0f388a464bb18900da5fa1f898a10d2d39fa59d023a89e229e',
+       i686: '16cab78294026cdc82fe297a3e1ec0fb2e9fa918d6e4c5bea75152bf18ead989',
+     x86_64: '32c252ce5bc50847b2552a2625dce0aa89f48f568c9d3fc6cdd3e1d4d241fc06'
   })
 
   depends_on 'gnome_settings_daemon'

--- a/packages/pangomm.rb
+++ b/packages/pangomm.rb
@@ -4,6 +4,7 @@ class Pangomm < Package
   description 'pangomm is the official C++ interface for the Pango font layout library.'
   homepage 'https://developer.gnome.org/pangomm/stable/'
   version '1.0'
+  license 'LGPL-2.1+'
   compatibility 'all'
 
   is_fake

--- a/packages/pangomm.rb
+++ b/packages/pangomm.rb
@@ -3,42 +3,11 @@ require 'package'
 class Pangomm < Package
   description 'pangomm is the official C++ interface for the Pango font layout library.'
   homepage 'https://developer.gnome.org/pangomm/stable/'
-  @_ver = '2.48.0'
-  version @_ver
-  license 'LGPL-2.1+'
+  version '1.0'
   compatibility 'all'
-  source_url "https://github.com/GNOME/pangomm/archive/#{@_ver}.tar.gz"
-  source_sha256 '65130bc4e3662071b4332d1fdae792282764705abf00c0d80a9eb4e8b5886d59'
 
-  binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.48.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.48.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.48.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm-2.48.0-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'f8dbb1e8258270285d3cbdea5e07369f955d663f4233d6afbedaf2a8e26080b7',
-     armv7l: 'f8dbb1e8258270285d3cbdea5e07369f955d663f4233d6afbedaf2a8e26080b7',
-       i686: '7fd81bfa703ec364ff24b863c98cf5f80c843d0cc35ab247598cb7d515c4758d',
-     x86_64: '986d79798b3e7f91c07ee7afac45652b2d157e22d7cf71c3087bd481f674b8a7'
-  })
+  is_fake
 
-  depends_on 'glibmm'
-  depends_on 'cairomm'
-  depends_on 'pango'
-  depends_on 'graphite'
-  depends_on 'mm_common'
-
-  def self.build
-    system "meson #{CREW_MESON_LTO_OPTIONS} \
-    -Dmaintainer-mode=true \
-    -Dbuild-documentation=false \
-    builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  depends_on 'pangomm_1_4'
+  depends_on 'pangomm_2_48'
 end

--- a/packages/pangomm_1_4.rb
+++ b/packages/pangomm_1_4.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Pangomm_1_4 < Package
+  description 'pangomm is the official C++ interface for the Pango font layout library.'
+  homepage 'https://developer.gnome.org/pangomm/stable/'
+  @_ver = '2.46.0'
+  version @_ver
+  compatibility 'all'
+  source_url "https://gitlab.gnome.org/GNOME/pangomm/-/archive/#{@_ver}/pangomm-#{@_ver}.tar.bz2"
+  source_sha256 '9582d961e71d5134aeadc73de63baa27424f76ab6d04280d6b6c9177c4b653a9'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm_1_4-2.46.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm_1_4-2.46.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm_1_4-2.46.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm_1_4-2.46.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '36bd8512279d1f7fe1e33d2a69ec7488404bedd879bd021485ffee036dbc376e',
+     armv7l: '36bd8512279d1f7fe1e33d2a69ec7488404bedd879bd021485ffee036dbc376e',
+       i686: '28c625ea2df998071dfd1bba523b01989b8e8d8c1dbbdb381d2ca4ac298cbdf9',
+     x86_64: 'c29af342514e22182c03946216f4faa04975bcff142c859ba9f5f5b19b8cfcf0'
+  })
+
+  depends_on 'glibmm'
+  depends_on 'cairomm'
+  depends_on 'pango'
+  depends_on 'graphite'
+  depends_on 'mm_common'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Dmaintainer-mode=true \
+    -Dbuild-documentation=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/pangomm_1_4.rb
+++ b/packages/pangomm_1_4.rb
@@ -5,6 +5,7 @@ class Pangomm_1_4 < Package
   homepage 'https://developer.gnome.org/pangomm/stable/'
   @_ver = '2.46.0'
   version @_ver
+  license 'LGPL-2.1+'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/pangomm/-/archive/#{@_ver}/pangomm-#{@_ver}.tar.bz2"
   source_sha256 '9582d961e71d5134aeadc73de63baa27424f76ab6d04280d6b6c9177c4b653a9'

--- a/packages/pangomm_2_48.rb
+++ b/packages/pangomm_2_48.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Pangomm_2_48 < Package
+  description 'pangomm is the official C++ interface for the Pango font layout library.'
+  homepage 'https://developer.gnome.org/pangomm/stable/'
+  @_ver = '2.48.0'
+  version @_ver
+  compatibility 'all'
+  source_url "https://gitlab.gnome.org/GNOME/pangomm/-/archive/#{@_ver}/pangomm-#{@_ver}.tar.bz2"
+  source_sha256 '744ba9156ca642f6cbbe049f965c741319c9f71629b153b6888dbca239fa770b'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm_2_48-2.48.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm_2_48-2.48.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm_2_48-2.48.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/pangomm_2_48-2.48.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '720f11d212bf078bbac66bf6751ebc24e5040fa2d7d5908a637b3d6c83a8d28d',
+     armv7l: '720f11d212bf078bbac66bf6751ebc24e5040fa2d7d5908a637b3d6c83a8d28d',
+       i686: '8aab1853da7476426c766f453535056e9d57c8bac1b9eb575bbb3b4f3ed37ceb',
+     x86_64: 'e6093416abe7406abfe366d07850591d2da70bc0c90591ce00b438b5f9598a32'
+  })
+
+  depends_on 'glibmm'
+  depends_on 'cairomm'
+  depends_on 'pango'
+  depends_on 'graphite'
+  depends_on 'mm_common'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Dmaintainer-mode=true \
+    -Dbuild-documentation=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/pangomm_2_48.rb
+++ b/packages/pangomm_2_48.rb
@@ -5,6 +5,7 @@ class Pangomm_2_48 < Package
   homepage 'https://developer.gnome.org/pangomm/stable/'
   @_ver = '2.48.0'
   version @_ver
+  license 'LGPL-2.1+'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/pangomm/-/archive/#{@_ver}/pangomm-#{@_ver}.tar.bz2"
   source_sha256 '744ba9156ca642f6cbbe049f965c741319c9f71629b153b6888dbca239fa770b'


### PR DESCRIPTION
- Solves issues with non-overlapping newer and older libraries 
- Add gnome-terminal version using meson
- Rebuild gnome-tweaks.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l