### PR TITLE
fix gcalculator package file

### DIFF
--- a/packages/gcalculator.rb
+++ b/packages/gcalculator.rb
@@ -2,7 +2,7 @@ require 'package'
 
 class Gcalculator < Package
   description 'GNOME desktop calculator'
-  homepage 'https://wiki.gnome.org/Apps/Calculator'compatibility 'all'
+  homepage 'https://wiki.gnome.org/Apps/Calculator'
   @_app = 'gnome-calculator'
   @_fullver = '3.38.2'
   @_mainver = @_fullver.rpartition('.')[0]


### PR DESCRIPTION
Fixes
```
 crew update
remote: Enumerating objects: 1722, done.
remote: Counting objects: 100% (1722/1722), done.
remote: Compressing objects: 100% (25/25), done.
remote: Total 1902 (delta 1703), reused 1705 (delta 1697), pack-reused 180
Receiving objects: 100% (1902/1902), 351.31 KiB | 3.08 MiB/s, done.
Resolving deltas: 100% (1797/1797), completed with 1521 local objects.
From https://github.com/skycocker/chromebrew
 * branch              master     -> FETCH_HEAD
   f0d7114d..797fa92f  master     -> origin/master
HEAD is now at 797fa92f Fix problems from crew-license-framework (#5459)
Package lists, crew, and library updated.
Generating compatible packages...
<internal:/usr/local/lib64/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': /usr/local/lib/crew/packages/gcalculator.rb:5: syntax error, unexpected local variable or method, expecting `end' (SyntaxError)
...g/Apps/Calculator'compatibility 'all'
...                  ^~~~~~~~~~~~~
        from <internal:/usr/local/lib64/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /usr/local/bin/crew:137:in `set_package'
        from /usr/local/bin/crew:195:in `block in generate_compatible'
        from /usr/local/bin/crew:193:in `each'
        from /usr/local/bin/crew:193:in `generate_compatible'
        from /usr/local/bin/crew:433:in `update'
        from /usr/local/bin/crew:1086:in `update_command'
        from /usr/local/bin/crew:1114:in `<main>'
```

Works properly:
- [x] x86_64
