### PR TITLE
Gnome 40.0 updates

### DIFF
--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,25 +3,25 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.67.6'
+  @_ver = '2.68.0'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://download.gnome.org/sources/glib/#{@_ver_prelastdot}/glib-#{@_ver}.tar.xz"
-  source_sha256 'dd7f563509b410e8f94ef2d4cc7f74620a6b29d7c5d529fedec53c5e8018d9c5'
+  source_sha256 '67734f584f3a05a2872f57e9a8db38f3b06c7087fb531c5a839d9171968103ea'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.6-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.6-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.67.6-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.68.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.68.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.68.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/glib-2.68.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'fe820f8369ab9c33f818bcd62e4a95bb8c5d28b7285a8781821ab25ec9ded416',
-     armv7l: 'fe820f8369ab9c33f818bcd62e4a95bb8c5d28b7285a8781821ab25ec9ded416',
-       i686: '26cc4995d5da3a24ef3fdbdc2135c086eedd12e59096f04ebe0e760e47f20657',
-     x86_64: '74965074bd9480e0a8a9076bc9bdf092f5b97b47df74bf0a852ac16e1c5be208'
+    aarch64: '074bbda5881173ce7d9cb01849cd9c1919ff3e111e3d40c4abbe655b1de6aa55',
+     armv7l: '074bbda5881173ce7d9cb01849cd9c1919ff3e111e3d40c4abbe655b1de6aa55',
+       i686: '4b4236243277ef9e2e1671090b9c5eb761fcbc1f4df43cbe54cffe19f838a922',
+     x86_64: '7c2bca7c57a8552eb0be3bac923d984eb01449d329b4d1a061b2dc42aacece82'
   })
 
   depends_on 'pcre'

--- a/packages/gnome_settings_daemon.rb
+++ b/packages/gnome_settings_daemon.rb
@@ -3,24 +3,24 @@ require 'package'
 class Gnome_settings_daemon < Package
   description 'GNOME Settings Daemon'
   homepage 'https://gitlab.gnome.org/GNOME/gnome-settings-daemon'
-  @_ver = '40.rc'
+  @_ver = '40.0'
   version @_ver
   license 'GPL-2+ and LGPL-2+'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/archive/#{@_ver}/gnome-settings-daemon-#{@_ver}.tar.bz2"
-  source_sha256 'dc057f3c73112bae2b74207bf764258019acd2f40109a43ee163b95feceb9187'
+  source_sha256 'ea6351b9f82c507e431cea15a69e7bb0574b8003618c48ff8c07e04969516e7f'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.rc-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.rc-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.rc-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.rc-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_settings_daemon-40.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '8e7277690364585e888e6accfddb83baf15c3c8d66ce70c050aac68949ea5af5',
-     armv7l: '8e7277690364585e888e6accfddb83baf15c3c8d66ce70c050aac68949ea5af5',
-       i686: 'e9ba7c3c497d399bf6ab0230c31aa1accd6399cfa14cf20d0c5e23096207ce49',
-     x86_64: '2c92223eb1a97973cdd4d3b0be828be63ac17103afa72004bc6c3dcc07adbe48'
+    aarch64: 'ae054caa58411bbf1f00729e748aaf0974913bff99ff77d24797f3814e4c5387',
+     armv7l: 'ae054caa58411bbf1f00729e748aaf0974913bff99ff77d24797f3814e4c5387',
+       i686: '90a5725eb84e76c5a23bd80fb670a569e63315a6ae8a599ef92cf8ec499f3aec',
+     x86_64: '294b8c533a037a62c14971e49d909b5a48c62b7717734bdc3b0ab20ee981be11'
   })
 
   depends_on 'dconf'

--- a/packages/gnome_shell.rb
+++ b/packages/gnome_shell.rb
@@ -3,21 +3,21 @@ require 'package'
 class Gnome_shell < Package
   description 'Next generation desktop shell'
   homepage 'https://wiki.gnome.org/Projects/GnomeShell'
-  version '40.rc'
+  version '40.0'
   license 'GPL-2+ and LGPL-2+'
   compatibility 'x86_64 aarch64 armv7l'
   source_url "https://github.com/GNOME/gnome-shell/archive/#{version}.tar.gz"
-  source_sha256 '76fcbb7d4ac829a1a1287feea40f3bcebc8e5ba225bb8231707cee09f53d44a0'
+  source_sha256 '29567d94787e4b8db2723caeaf230ee1eba6b53072592c9269a24973909aaca3'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_shell-40.rc-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_shell-40.rc-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_shell-40.rc-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_shell-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_shell-40.0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_shell-40.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '6bdc526bcf41f9348522a17ca9aefe8f437b87ba06bdb552dfc22607b5256f77',
-     armv7l: '6bdc526bcf41f9348522a17ca9aefe8f437b87ba06bdb552dfc22607b5256f77',
-     x86_64: '30b92776aaa8345bb32084d14675ffe60a01d985cee4eeecd304fdc27d693f8b'
+    aarch64: '31335a6996bc1638c4e63497684b7f3f9b90eb016e10aedaa9c96848190609c0',
+     armv7l: '31335a6996bc1638c4e63497684b7f3f9b90eb016e10aedaa9c96848190609c0',
+     x86_64: '4e933fabbc5cab93e25579de3958cdcde55d7d11c1ef13a6902c5775fb0d925c'
   })
 
   depends_on 'gcr'

--- a/packages/gsettings_desktop_schemas.rb
+++ b/packages/gsettings_desktop_schemas.rb
@@ -3,24 +3,24 @@ require 'package'
 class Gsettings_desktop_schemas < Package
   description 'Collection of GSettings schemas for GNOME desktop.'
   homepage 'https://git.gnome.org/browse/gsettings-desktop-schemas'
-  @_ver = '40.rc'
+  @_ver = '40.0'
   version @_ver
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/-/archive/#{@_ver}/gsettings-desktop-schemas-#{@_ver}.tar.bz2"
-  source_sha256 '555613c51b149053eba790a47b9f8cab1bb5a3a9263af0b6c3e1ac357b0913da'
+  source_sha256 'ce1d57e98ba6e460f9764e4a48a28ebe1866423e54c1eeceff6a3c90feb41bc6'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.rc-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.rc-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.rc-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.rc-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gsettings_desktop_schemas-40.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '458fa293a11a0b1b0cdc98e801b9f18ea82e9f9311e1c1a09b7a867d1e777b06',
-     armv7l: '458fa293a11a0b1b0cdc98e801b9f18ea82e9f9311e1c1a09b7a867d1e777b06',
-       i686: '6f81026e2e2b32e5b1af8097d9d0ca3060629ba2056d5834db50bd8c309c3908',
-     x86_64: '89c1ee720a176bf6ab96bcb783c0eba0da16ff82cfc4387b254c3420639dd1d3'
+    aarch64: '2b7288bf9e021ae99686f1a09521154c1e12f8ccb6e370797fe345c729e80c76',
+     armv7l: '2b7288bf9e021ae99686f1a09521154c1e12f8ccb6e370797fe345c729e80c76',
+       i686: '1e109b5a0d7bb4fbe8e81135835a3916acc0b6a73b18c837df16e11e87ef1d48',
+     x86_64: 'dc5237b94506cbf20080be7d1af759053dbdabde617329f08714a849eb4fc7c3'
   })
 
   depends_on 'gnome_common'

--- a/packages/libressl.rb
+++ b/packages/libressl.rb
@@ -15,4 +15,5 @@ class Libressl < Package
     puts
     puts 'Chromebrew\'s libressl is a fake package pointing to openssl.'.lightblue
     puts
+  end
 end

--- a/packages/mutter.rb
+++ b/packages/mutter.rb
@@ -3,22 +3,21 @@ require 'package'
 class Mutter < Package
   description 'A window manager for GNOME'
   homepage 'https://wiki.gnome.org/Projects/Mutter'
-  version '40.rc'
+  version '40.0'
   license 'GPL-2+'
   compatibility 'x86_64 aarch64 armv7l'
   source_url "https://gitlab.gnome.org/GNOME/mutter/-/archive/#{version}/mutter-#{version}.tar.bz2"
-  # source_url "https://download.gnome.org/core/#{version}/sources/mutter-#{version}.tar.xz"
-  source_sha256 '8652c2d4c95a845d26b37d8fc8edbfa1261273405317103dbc3216d1ee66db99'
+  source_sha256 '3f56768113d536f5842ea6db14d1d9c48f8c87cd240891f9b9305116e425771e'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mutter-40.rc-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mutter-40.rc-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mutter-40.rc-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mutter-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mutter-40.0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mutter-40.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '7432e3824c27a0f92351e7f9888ddba7416b0513ec6e103bffa9f2f6a70b01bd',
-     armv7l: '7432e3824c27a0f92351e7f9888ddba7416b0513ec6e103bffa9f2f6a70b01bd',
-     x86_64: 'bc61662e93ad4e540f957efce8b3af3183422b19b838f87878931e9e35a87dd5'
+    aarch64: '4738981bc3b25f189e376e9398f892063e4434881b364abfb471ae2671c5518c',
+     armv7l: '4738981bc3b25f189e376e9398f892063e4434881b364abfb471ae2671c5518c',
+     x86_64: '245503f395c5a138e279d71fee7bdd98b2244bc682a90a373f742a3b78f190f2'
   })
 
   depends_on 'dconf'

--- a/packages/pyconfigure.rb
+++ b/packages/pyconfigure.rb
@@ -1,4 +1,4 @@
-lrequire 'package'
+require 'package'
 
 class Pyconfigure < Package
   description 'GNU pyconfigure provides developers with file templates for implementing standard configure scripts and Makefile recipes for their Python packages.'

--- a/packages/sl.rb
+++ b/packages/sl.rb
@@ -24,4 +24,5 @@ class Sl < Package
     puts 'To disable this "feature", run'
     puts 'echo "alias sl=\'sl -e\'" >> ~/.bashrc && source ~/.bashrc'
     puts
+  end
 end

--- a/packages/vte.rb
+++ b/packages/vte.rb
@@ -4,7 +4,7 @@ class Vte < Package
   description 'Virtual Terminal Emulator widget for use with GTK'
   homepage 'https://wiki.gnome.org/Apps/Terminal/VTE'
   version '0.63.91'
-  licene 'LGPL-2+ and GPL-3+'
+  license 'LGPL-2+ and GPL-3+'
   compatibility 'all'
   source_url 'https://download.gnome.org/sources/vte/0.63/vte-0.63.91.tar.xz'
   source_sha256 '2a6f58470148d2a16bac387da12525d061e5984b68fc1ff8d068d10d4f1716ab'


### PR DESCRIPTION
- Gnome 40 Updates

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686 (except mutter & gnome_shell)


---

## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
