### PR TITLE
More Gnome 40.0 updates & split tepl package

### DIFF
--- a/packages/gedit.rb
+++ b/packages/gedit.rb
@@ -3,42 +3,66 @@ require 'package'
 class Gedit < Package
   description 'GNOME Text Editor'
   homepage 'https://wiki.gnome.org/Apps/Gedit'
-  version '3.38.1'
+  version '40.0'
   license 'GPL-2+ CC-BY-SA-3.0'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/gedit/3.38/gedit-3.38.1.tar.xz'
-  source_sha256 '0053853d2cd59cad8a1662f5b4fdcfab47b4c0940063bacd6790a9948642844d'
+  source_url "https://gitlab.gnome.org/GNOME/gedit/-/archive/#{version}/gedit-#{version}.tar.bz2"
+  source_sha256 'b7ac78774fe2eadd09a9d91d19b2596ebd3388f2d3d1cf3cbac81cba649c399a'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gedit-3.38.1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gedit-3.38.1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gedit-3.38.1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gedit-3.38.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gedit-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gedit-40.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gedit-40.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gedit-40.0-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '40be6aa1cbff4088e753298fc3f01194188347b942dd63ad16ad7450b158faa2',
-      armv7l: '40be6aa1cbff4088e753298fc3f01194188347b942dd63ad16ad7450b158faa2',
-        i686: 'a8f348c2e9b7fe96ec04d731d45b5af084b0545b6992a01dc44d6c468c8b20bb',
-      x86_64: 'bab2efd640855fdf964b706615b6b874d5bb144a4a509a47edc7e85088d0b8a6',
+  binary_sha256({
+    aarch64: '7f976a406dd8e8137d0aa7217c1d75fbee756a028c8315c386c41dfb4c3b57f6',
+     armv7l: '7f976a406dd8e8137d0aa7217c1d75fbee756a028c8315c386c41dfb4c3b57f6',
+       i686: '4c495f8e7e307103ded815bc217b8bc021e7957a760f0e820a587e59f53d9569',
+     x86_64: 'd908a24c2ba3085980ad3ff0afbdd3c3996bbffb21bc1c538cb3d21364a8acd5'
   })
 
-  depends_on 'gtksourceview'
+  depends_on 'amtk'
+  depends_on 'atk'
+  depends_on 'cairo'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'gobject_introspection'
   depends_on 'gsettings_desktop_schemas'
-  depends_on 'libpeas'
   depends_on 'gspell'
+  depends_on 'gtk3'
+  depends_on 'gtksourceview'
+  depends_on 'libpeas'
+  depends_on 'pango'
   depends_on 'pygobject'
-  depends_on 'yelp_tools' => ':build'
-  depends_on 'vala' => ':build'
+  depends_on 'tepl_6'
   depends_on 'gobject_introspection' => ':build'
   depends_on 'gtk_doc' => ':build'
+  depends_on 'vala' => ':build'
+  depends_on 'yelp_tools' => ':build'
+
+  def self.patch
+    # Source has libgd repo as submodule
+    @git_dir = 'subprojects/libgd'
+    @git_hash = 'c7c7ff4e05d3fe82854219091cf116cce6b19de0'
+    @git_url = 'https://gitlab.gnome.org/GNOME/libgd.git'
+    FileUtils.rm_rf(@git_dir)
+    FileUtils.mkdir_p(@git_dir)
+    Dir.chdir @git_dir do
+      system 'git init'
+      system "git remote add origin #{@git_url}"
+      system "git fetch --depth 1 origin #{@git_hash}"
+      system 'git checkout FETCH_HEAD'
+    end
+  end
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
     -Drequire_all_tests=false \
     -Duser_documentation=false \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/gnome_weather.rb
+++ b/packages/gnome_weather.rb
@@ -3,23 +3,23 @@ require 'package'
 class Gnome_weather < Package
   description 'Access current weather conditions and forecasts'
   homepage 'https://wiki.gnome.org/Apps/Weather'
-  version '40.beta'
+  version '40.0'
   license 'GPL-2+, LGPL-2+, MIT, CC-BY-3.0 and CC-BY-SA-3.0'
   compatibility 'all'
-  source_url 'https://github.com/GNOME/gnome-weather/archive/40.beta.tar.gz'
-  source_sha256 '281b35ab677a143d0aa0118a2c7c3be6a76837d01ea0dd5f862c628b8ef1579a'
+  source_url "https://gitlab.gnome.org/GNOME/gnome-weather/-/archive/#{version}/gnome-weather-#{version}.tar.bz2"
+  source_sha256 'f687caa96f357ec6bf7a4c3c376e82f7476d0b711b9e670a2f074a069c7531d8'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.beta-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.beta-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.beta-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.beta-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_weather-40.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '25aafe9b86f33ab398694d3068924e67096b1c0a7b76fae3b522debf73e1d96f',
-     armv7l: '25aafe9b86f33ab398694d3068924e67096b1c0a7b76fae3b522debf73e1d96f',
-       i686: 'ecc3074e962ca1e123278a4730d44bfe76b096b88b33edc8953f8a1efb8455b7',
-     x86_64: 'fa99714935ad0dcb81bf158f10714ed657dcaeb4bbeec281ada143f37341633a'
+    aarch64: 'f90c5fb9bb00e103e66017515f5b0206dc1baeb2650e329c16f4a20bde827ab5',
+     armv7l: 'f90c5fb9bb00e103e66017515f5b0206dc1baeb2650e329c16f4a20bde827ab5',
+       i686: 'ebd913d1c610d9124dcd16be06a4171807cbae7038cf300d1825ef7c0931be95',
+     x86_64: '6c388c10b42fdf5e9e59cdf373b9aa0340bd991107886543c873f7d6a8b281d9'
   })
 
   depends_on 'gtk3'

--- a/packages/tepl.rb
+++ b/packages/tepl.rb
@@ -3,39 +3,12 @@ require 'package'
 class Tepl < Package
   description 'Library that eases the development of GtkSourceView-based text editors and IDEs'
   homepage 'https://wiki.gnome.org/Projects/Tepl'
-  version '5.0.1'
+  version '1.0'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url 'https://github.com/GNOME/tepl/archive/5.0.1.tar.gz'
-  source_sha256 '2dda3ed2bd16742f6d0fc6d602448eaa2e40b9c967b88599add2338d6fa590e7'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tepl-5.0.1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tepl-5.0.1-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/tepl-5.0.1-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tepl-5.0.1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-     aarch64: 'fac5fa0cbfa9a258381e522e4f79470e26310e1229a82037e96371c1d626eaa4',
-      armv7l: 'fac5fa0cbfa9a258381e522e4f79470e26310e1229a82037e96371c1d626eaa4',
-        i686: 'a66efc98a81bb4e48a5ee3b5e508958ec4a66cde1732c68ca2ef87745e4da7d4',
-      x86_64: 'c66160cceeee02eeacc0f8f52391140bcf446dc616f87689a9c36c165683b799',
-  })
+  is_fake
 
-  depends_on 'amtk'
-  depends_on 'gtksourceview'
-  depends_on 'uchardet'
-  depends_on 'gobject_introspection' => ':build'
-  depends_on 'gtk_doc' => ':build'
-  depends_on 'vala' => ':build'
-
-  def self.build
-    system "meson #{CREW_MESON_LTO_OPTIONS} builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  depends_on 'tepl5'
+  depends_on 'tepl6'
 end

--- a/packages/tepl.rb
+++ b/packages/tepl.rb
@@ -9,6 +9,6 @@ class Tepl < Package
 
   is_fake
 
-  depends_on 'tepl5'
-  depends_on 'tepl6'
+  depends_on 'tepl_5'
+  depends_on 'tepl_6'
 end

--- a/packages/tepl_5.rb
+++ b/packages/tepl_5.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Tepl_5 < Package
+  description 'Library that eases the development of GtkSourceView-based text editors and IDEs'
+  homepage 'https://wiki.gnome.org/Projects/Tepl'
+  version '5.0.1'
+  license 'LGPL-2.1+'
+  compatibility 'all'
+  source_url 'https://github.com/GNOME/tepl/archive/5.0.1.tar.gz'
+  source_sha256 '2dda3ed2bd16742f6d0fc6d602448eaa2e40b9c967b88599add2338d6fa590e7'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tepl_5-5.0.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tepl_5-5.0.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tepl_5-5.0.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tepl_5-5.0.1-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '1c6bda4f08ad49244dd0e368858e43de9323adf54ab34d387754d0982a8af710',
+     armv7l: '1c6bda4f08ad49244dd0e368858e43de9323adf54ab34d387754d0982a8af710',
+       i686: '380fcc1fba9345a966726985dd7232d5bf1326bf62597f43b2bd194a40ce4a91',
+     x86_64: 'd41156324372ef2d95d056a4b58d10f177bd9c1cf176f5c5baafdc81b55d2c1a'
+  })
+
+  depends_on 'amtk'
+  depends_on 'cairo'
+  depends_on 'glib'
+  depends_on 'gtk3'
+  depends_on 'gtksourceview'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'vala' => ':build'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/tepl_6.rb
+++ b/packages/tepl_6.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Tepl_6 < Package
+  description 'Library that eases the development of GtkSourceView-based text editors and IDEs'
+  homepage 'https://wiki.gnome.org/Projects/Tepl'
+  version '5.99.0-d61f'
+  license 'LGPL-2.1+'
+  compatibility 'all'
+  source_url 'https://gitlab.gnome.org/GNOME/tepl/-/archive/d61f4f8c1c17299b75c2dffc67df81a25b9ed243/tepl-d61f4f8c1c17299b75c2dffc67df81a25b9ed243.tar.bz2'
+  source_sha256 '954c9e27d017bddc99788911019ca223222fd1c59e383c4e21be84e62906b662'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tepl_6-5.99.0-d61f-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tepl_6-5.99.0-d61f-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tepl_6-5.99.0-d61f-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tepl_6-5.99.0-d61f-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '928c126e8c0d2a87a6778dbe9d60fd1a31a0e3160ea384d5c0e36444b4936de9',
+     armv7l: '928c126e8c0d2a87a6778dbe9d60fd1a31a0e3160ea384d5c0e36444b4936de9',
+       i686: 'f98b0034642f3433f036107d710f7c466701f94cea809e83908ada8c98305bc2',
+     x86_64: 'f479f11290e064ad429f4708c22cea0ce498dfb440278e98be7bbfcb751ece1b'
+  })
+
+  depends_on 'amtk'
+  depends_on 'cairo'
+  depends_on 'glib'
+  depends_on 'gtk3'
+  depends_on 'gtksourceview'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk_doc' => ':build'
+  depends_on 'vala' => ':build'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/yelp.rb
+++ b/packages/yelp.rb
@@ -3,44 +3,49 @@ require 'package'
 class Yelp < Package
   description 'Get help with GNOME'
   homepage 'https://wiki.gnome.org/Apps/Yelp'
-  @_ver = '40.rc'
+  @_ver = '40.0'
   version @_ver
   license 'GPL-2+'
   compatibility 'all'
-  source_url "https://github.com/GNOME/yelp/archive/#{@_ver}.tar.gz"
-  source_sha256 '57cecf29edbe7b5701e5c21c345fe4492503e2c87fb7cc5ef4257b5fd77f8bde'
+  source_url "https://gitlab.gnome.org/GNOME/yelp/-/archive/#{@_ver}/yelp-#{@_ver}.tar.bz2"
+  source_sha256 'ec640d7a56970ab3ac6283d6c3a90ae45b7676c739671b303cbfb2f4323bf7af'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.rc-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.rc-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.rc-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.rc-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp-40.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'cfe4fb78c87d69ef4380e094c32dc3609fff239f506ef31db4d45d2400fadf82',
-     armv7l: 'cfe4fb78c87d69ef4380e094c32dc3609fff239f506ef31db4d45d2400fadf82',
-       i686: '3976c9f34a6edba4a43b35475e2ca9dfdffc885c8fa33f5d55da5a106d629d42',
-     x86_64: 'c476142c4a8ae47c3ffde56e6d931544707f8e88fb1dd44c409030a018812c56'
+    aarch64: '021a5a25255e9bd5c5f44fe170abc70bb18ecd6b72a5a312da295c1c2831420b',
+     armv7l: '021a5a25255e9bd5c5f44fe170abc70bb18ecd6b72a5a312da295c1c2831420b',
+       i686: '7425444ffefcb107ac34fb8d8bb12d0a3117e7aaae83f44f938ba37a732e7a8d',
+     x86_64: '33ef261b6056265b6fa65b81c3fef50f8c5792f7e70ace0639d65f453a7f2f69'
   })
 
+  depends_on 'appstream_glib'
+  depends_on 'atk'
+  depends_on 'cairo'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'gtk3'
+  depends_on 'harfbuzz'
+  depends_on 'libsoup2'
+  depends_on 'libxslt'
+  depends_on 'pango'
   depends_on 'webkit2gtk'
   depends_on 'yelp_xsl'
-  depends_on 'libxslt'
-  depends_on 'appstream_glib'
-
   depends_on 'gtk_doc' => ':build'
   depends_on 'itstool' => ':build'
   depends_on 'xorg_server' => ':build'
 
   def self.build
-    system 'NOCONFIGURE=1 ./autogen.sh'
+    system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
     ./configure #{CREW_OPTIONS} \
     --enable-compile-warnings=minimum \
     --enable-debug=no \
     --disable-dependency-tracking"
-    # Documentation generation segfaults without X11"
-    # system "xvfb-run -s '-screen 0 1920x1080x24 -nolisten local' make"
     system 'make'
   end
 

--- a/packages/yelp_tools.rb
+++ b/packages/yelp_tools.rb
@@ -3,23 +3,23 @@ require 'package'
 class Yelp_tools < Package
   description 'yelp-tools is a collection of scripts and build utilities to help create, manage, and publish documentation for Yelp and the web'
   homepage 'https://github.com/GNOME/yelp-tools'
-  version '40.rc'
+  version '40.0'
   license 'GPL-2+ or freedist and GPL-2+'
   compatibility 'all'
-  source_url 'https://github.com/GNOME/yelp-tools/archive/40.rc.tar.gz'
-  source_sha256 '072420dbbec6a7b5b3647fcfc15c284b02a21220c78ba140d727cd2992500902'
+  source_url "https://gitlab.gnome.org/GNOME/yelp-tools/-/archive/#{version}/yelp-tools-#{version}.tar.bz2"
+  source_sha256 'bada2afb5160066aef39e11f90eb5377f0bb161aa2b4dcd744c381e3c2ff77ce'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.rc-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.rc-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.rc-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.rc-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_tools-40.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '5dca4c043e28eb89a87a56cf4518c9d3e67f6ff0522c52cf7ce3cff38d4c8920',
-     armv7l: '5dca4c043e28eb89a87a56cf4518c9d3e67f6ff0522c52cf7ce3cff38d4c8920',
-       i686: '8cd244466690065e37ff4c5b2aea2680a506fb70195c30b0bde916b3f70bf3ba',
-     x86_64: '57b5663d5fcd6755d35fdf0973be36997cc22129b3d1ca7d2a4e4812d2922b01'
+    aarch64: '1317a7aa14db9fd3f3794ece39708c35320b2098a3265dfaad0b7d1e418b0319',
+     armv7l: '1317a7aa14db9fd3f3794ece39708c35320b2098a3265dfaad0b7d1e418b0319',
+       i686: '86378c2ee8f256700d241c977cf676c45607f0733bcdd811fa138ddc7114e834',
+     x86_64: '2c039b5bbc4aacf02f8e6892ce52e2cc334144c769b44ea2251429f2d91fc677'
   })
 
   depends_on 'yelp_xsl'

--- a/packages/yelp_xsl.rb
+++ b/packages/yelp_xsl.rb
@@ -3,30 +3,30 @@ require 'package'
 class Yelp_xsl < Package
   description 'yelp-xsl is a collection of programs and data files to help you build, maintain, and distribute documentation'
   homepage 'https://github.com/GNOME/yelp-xsl'
-  version '40.rc'
+  version '40.0'
+  compatibility 'all'
   license 'GPL-2+, LGPL-2.1+, MIT and FDL-1.1+'
   license 'GPL-2+ or freedist and GPL-2+'
-  compatibility 'all'
-  source_url 'https://github.com/GNOME/yelp-xsl/archive/40.rc.tar.gz'
-  source_sha256 'f158b5c899b32267dee796146deb8c2831272aa66bbe3cc103031b2ddd182fc8'
+  source_url "https://gitlab.gnome.org/GNOME/yelp-xsl/-/archive/#{version}/yelp-xsl-#{version}.tar.bz2"
+  source_sha256 '3938ae88880cdcc3bbd20db25a05bac03cd1324d60c2940ed85e56259725e7f7'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.rc-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.rc-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.rc-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.rc-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/yelp_xsl-40.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '945153ad9d4bea36d348411382dfbd5a6d492c491e17afb7f059901c6805d486',
-     armv7l: '945153ad9d4bea36d348411382dfbd5a6d492c491e17afb7f059901c6805d486',
-       i686: 'b5c6b4ac0658eac4717204b3c0a99d947a884a470b34b04251bb8214ce831547',
-     x86_64: '5f03c4a1a5606b16cfc8bdd4d421b01b222fe6368c04c9837eaeb9671598aed9'
+    aarch64: 'd98fe7c598a54bee90907294bca5ab24732ecbe3f2badc0953693e88007e49ba',
+     armv7l: 'd98fe7c598a54bee90907294bca5ab24732ecbe3f2badc0953693e88007e49ba',
+       i686: 'abe1c586c597739747c831fbf5a7ee7fe6658d519250d0404ce3bbfda2509c1f',
+     x86_64: 'b23d398de5907823b21dc15f0eba4ec6d6da33d9e42c399c48d8e36de4188d2d'
   })
 
   depends_on 'itstool'
 
   def self.build
-    system './autogen.sh'
+    system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
       ./configure #{CREW_OPTIONS}"

--- a/packages/yelp_xsl.rb
+++ b/packages/yelp_xsl.rb
@@ -4,9 +4,9 @@ class Yelp_xsl < Package
   description 'yelp-xsl is a collection of programs and data files to help you build, maintain, and distribute documentation'
   homepage 'https://github.com/GNOME/yelp-xsl'
   version '40.0'
-  compatibility 'all'
   license 'GPL-2+, LGPL-2.1+, MIT and FDL-1.1+'
   license 'GPL-2+ or freedist and GPL-2+'
+  compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/yelp-xsl/-/archive/#{version}/yelp-xsl-#{version}.tar.bz2"
   source_sha256 '3938ae88880cdcc3bbd20db25a05bac03cd1324d60c2940ed85e56259725e7f7'
 


### PR DESCRIPTION
- gedit 40.0 requires `tepl_6`. To prevent breakage of packages that need tepl_5, break those out into separate packages.
- also update some dependencies based upon libraries required by binaries.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686

![image](https://user-images.githubusercontent.com/1096701/112179363-01d39000-8bd1-11eb-97c0-73b5ea2e3918.png)



