### PR TITLE
Remove need for wget

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.9'
+  version '1.10'
   license 'GPL-3+'
   compatibility 'all'
 

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -45,7 +45,7 @@ class Buildessential < Package
   depends_on 'flex'
   depends_on 'util_macros'
   depends_on 'gettext'
-  depends_on 'wget' # in some cases, patches might be required and can be downloaded using wget
+#  depends_on 'wget' # use 'curl -#LO' instead
   depends_on 'mawk'
 
   # compression utilities

--- a/packages/dr.rb
+++ b/packages/dr.rb
@@ -14,7 +14,7 @@ class Dr < Package
   depends_on 'setuptools'
 
   def self.install
-    system 'curl -#LO dr/dr https://github.com/Ewpratten/dr/releases/download/2.0-cros/dr'
+    system 'curl -#Lo dr/dr https://github.com/Ewpratten/dr/releases/download/2.0-cros/dr'
     abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('dr/dr') ) == '4e39a28f947ac044e28349fb10ffb423100fb00acb0ab819e931d931e3f0b02f'
     system "install -Dm755 dr/dr #{CREW_DEST_PREFIX}/bin/dr"
     system "pip3 install . --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR} --upgrade --no-cache-dir -r requirements.txt"

--- a/packages/dr.rb
+++ b/packages/dr.rb
@@ -14,7 +14,7 @@ class Dr < Package
   depends_on 'setuptools'
 
   def self.install
-    system 'wget -O dr/dr https://github.com/Ewpratten/dr/releases/download/2.0-cros/dr'
+    system 'curl -#LO dr/dr https://github.com/Ewpratten/dr/releases/download/2.0-cros/dr'
     abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('dr/dr') ) == '4e39a28f947ac044e28349fb10ffb423100fb00acb0ab819e931d931e3f0b02f'
     system "install -Dm755 dr/dr #{CREW_DEST_PREFIX}/bin/dr"
     system "pip3 install . --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR} --upgrade --no-cache-dir -r requirements.txt"

--- a/packages/iniparser.rb
+++ b/packages/iniparser.rb
@@ -24,7 +24,7 @@ class Iniparser < Package
 
   def self.patch
     # Fix buffer overflow vulnerabilities
-    system 'wget', 'https://github.com/ndevilla/iniparser/commit/a249509544972d60f5077bfde554af480bd82594.patch'
+    system 'curl -#LO https://github.com/ndevilla/iniparser/commit/a249509544972d60f5077bfde554af480bd82594.patch'
     abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('a249509544972d60f5077bfde554af480bd82594.patch') ) == '1b1fe5d2faf6eb5bed51b80b046d4699c09b14b3e5e5277aed790a8741fcad8b'
     system 'patch', '-Np1', '-i', 'a249509544972d60f5077bfde554af480bd82594.patch'
     # Fix libdir

--- a/packages/js78.rb
+++ b/packages/js78.rb
@@ -40,7 +40,7 @@ class Js78 < Package
     patch_url = 'http://archive.ubuntu.com/ubuntu/pool/main/m/mozjs78/mozjs78_78.4.0-2.debian.tar.xz'
     patch_sha256 = 'dcf2eec86c275448656cf18b3c142c3a2067dc8fdeff029211b66182b9179d21'
 
-    system('wget', '--continue', '--no-check-certificate', patch_url, '-O', 'unzippatches.tar.xz')
+    system('curl -#L', patch_url, '-o', 'unzippatches.tar.xz')
     unless Digest::SHA256.hexdigest(File.read('./unzippatches.tar.xz')) == patch_sha256
       abort 'Checksum mismatch :/ try again'
     end

--- a/packages/nmon.rb
+++ b/packages/nmon.rb
@@ -25,7 +25,7 @@ class Nmon < Package
   depends_on 'ncurses'
 
   def self.build
-    system 'wget http://downloads.sourceforge.net/project/nmon/lmon16g.c'
+    system 'curl -#LO http://downloads.sourceforge.net/project/nmon/lmon16g.c'
     abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('lmon16g.c') ) == 'da82dd693b503b062854dfe7dbb5d36b347872ab44a4aa05b97e9d577747f688'
     system "sed -i 's,<ncurses.h>,<#{CREW_PREFIX}/include/ncurses/ncurses.h>,' lmon16g.c"
     system 'cc -o nmon lmon16g.c -g -O3 -Wall -D JFS -D GETUSER -D LARGEMEM -lncurses -lm -g -D POWER'

--- a/packages/wp_cli.rb
+++ b/packages/wp_cli.rb
@@ -12,7 +12,7 @@ class Wp_cli < Package
   depends_on 'php74' unless File.exists? "#{CREW_PREFIX}/bin/php"
 
   def self.build
-    system "wget https://github.com/wp-cli/wp-cli/releases/download/v#{version}/wp-cli-#{version}.phar"
+    system "curl -#LO https://github.com/wp-cli/wp-cli/releases/download/v#{version}/wp-cli-#{version}.phar"
     abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("wp-cli-#{version}.phar") ) == '139dcc86ed39ef751679efbdaf57a53528f1afda972c4e3622667cc27397b540'
   end
 

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -85,7 +85,6 @@ trousers
 uchardet
 unzip
 util_macros
-wget
 xorg_proto
 xzutils
 zip


### PR DESCRIPTION
For a while I've wondered why we had `wget` in our core packages list since we have curl.
This removes wget from the core package list and removes the requirement for the package in that list entirely. 