### PR TITLE
Remove mawk from buildessential

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -46,7 +46,6 @@ class Buildessential < Package
   depends_on 'util_macros'
   depends_on 'gettext'
   depends_on 'wget' # in some cases, patches might be required and can be downloaded using wget
-  depends_on 'mawk'
 
   # compression utilities
   depends_on 'lzip'

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -57,7 +57,6 @@ m4
 make
 mandb
 manpages
-mawk
 meson
 most
 mpc


### PR DESCRIPTION
ChromeOS provides mawk at `/usr/bin/mawk`. We can remove mawk from the core package list and just use ChromeOS's version. Works on x86_64