### PR TITLE
Split gtksourceview and add libadwaita

### DIFF
--- a/packages/gtksourceview.rb
+++ b/packages/gtksourceview.rb
@@ -3,44 +3,12 @@ require 'package'
 class Gtksourceview < Package
   description 'Source code editing widget'
   homepage 'https://wiki.gnome.org/Projects/GtkSourceView'
-  @_ver = '4.8.1'
-  version @_ver
+  version '1.0'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://github.com/GNOME/gtksourceview/archive/#{@_ver}.tar.gz"
-  source_sha256 'cbfde42161662525805be4a38102b085db5e991fe1263171a28a78c7da253760'
 
-  binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview-4.8.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview-4.8.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview-4.8.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview-4.8.1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '8847fb32a4b6b814dbe1f58cdc0487ab75c781daffca97ee1b965da1786b498b',
-     armv7l: '8847fb32a4b6b814dbe1f58cdc0487ab75c781daffca97ee1b965da1786b498b',
-       i686: '409401c64604dfd3f827cef4345c53415c3ff1c7af5f19b720ed5fb5bb3bdd11',
-     x86_64: '8839be6b737b4555bddb5b6a9aaba47da81b7432c672b6b3b5c7ccf7a7a80ddb'
-  })
+  is_fake
 
-  depends_on 'setuptools' => :build
-  depends_on 'vala'
-  depends_on 'gtk3'
-  depends_on 'libsoup'
-  depends_on 'glib'
-
-  def self.build
-    system "env CC=clang CXX=clang++ \
-    meson #{CREW_MESON_OPTIONS} \
-    -Db_asneeded=false \
-    -Dc_args='-fno-stack-protector -flto=thin -fuse-ld=lld' \
-    -Dc_link_args='-fno-stack-protector -flto=thin -fuse-ld=lld' \
-    builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  depends_on 'gtksourceview_4'
+  depends_on 'gtksourceview_5'
 end

--- a/packages/gtksourceview_4.rb
+++ b/packages/gtksourceview_4.rb
@@ -1,0 +1,57 @@
+require 'package'
+
+class Gtksourceview_4 < Package
+  description 'Source code editing widget'
+  homepage 'https://wiki.gnome.org/Projects/GtkSourceView'
+  @_ver = '4.8.1'
+  version @_ver
+  license 'LGPL-2.1+'
+  compatibility 'all'
+  source_url "https://gitlab.gnome.org/GNOME/gtksourceview/-/archive/#{@_ver}/gtksourceview-#{@_ver}.tar.bz2"
+  source_sha256 'ec16a6a61d643e278d3a02828257a59d802d4ae740247bf03fdebf10d9401635'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview_4-4.8.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview_4-4.8.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview_4-4.8.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview_4-4.8.1-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'b6e5a158eaf5853eadcc5fcf3057c84b60800113358e3db76b1c9b716faec11e',
+     armv7l: 'b6e5a158eaf5853eadcc5fcf3057c84b60800113358e3db76b1c9b716faec11e',
+       i686: 'c0799e84f28569699b968f501a45f37e21b38ee0257774e87075139e54308094',
+     x86_64: '68b3cea57e7cd0edf6712b9ad3b8c9c1e3b2b7723d7a1cc070178b04db597d82'
+  })
+
+  depends_on 'atk'
+  depends_on 'cairo'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
+  depends_on 'fribidi'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'graphene'
+  depends_on 'gtk3'
+  depends_on 'gtk4'
+  depends_on 'harfbuzz'
+  depends_on 'libsoup'
+  depends_on 'pango'
+  depends_on 'vala'
+  depends_on 'vulkan_icd_loader'
+
+  def self.patch
+    system "sed -i 's/-fstack-protector-strong/-flto/g' meson.build"
+  end
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Db_asneeded=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/gtksourceview_5.rb
+++ b/packages/gtksourceview_5.rb
@@ -1,0 +1,57 @@
+require 'package'
+
+class Gtksourceview_5 < Package
+  description 'Source code editing widget'
+  homepage 'https://wiki.gnome.org/Projects/GtkSourceView'
+  @_ver = '5.0.0'
+  version @_ver
+  license 'LGPL-2.1+'
+  compatibility 'all'
+  source_url "https://gitlab.gnome.org/GNOME/gtksourceview/-/archive/#{@_ver}/gtksourceview-#{@_ver}.tar.bz2"
+  source_sha256 'b97ee7f2404d00ba607b865a838ee7c90053811c16c633a6359dace4ee1f218c'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview_5-5.0.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview_5-5.0.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview_5-5.0.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtksourceview_5-5.0.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '0e1f4e4d940074837e075f5008dd5178b5e9c6b4bcf2f8eabd16002adf7adb8c',
+     armv7l: '0e1f4e4d940074837e075f5008dd5178b5e9c6b4bcf2f8eabd16002adf7adb8c',
+       i686: 'd27b36e8275ba473c3758ae708eebd1aa80a34a346db5a44593d196f9f2f96a7',
+     x86_64: '455fb554c60675f9c15b77510cab48ed1986caba9f7c9cabe6f6d945bb30962e'
+  })
+
+  depends_on 'atk'
+  depends_on 'cairo'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
+  depends_on 'fribidi'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'graphene'
+  depends_on 'gtk3'
+  depends_on 'gtk4'
+  depends_on 'harfbuzz'
+  depends_on 'libsoup'
+  depends_on 'pango'
+  depends_on 'vala'
+  depends_on 'vulkan_icd_loader'
+
+  def self.patch
+    system "sed -i 's/-fstack-protector-strong/-flto/g' meson.build"
+  end
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Db_asneeded=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -1,0 +1,50 @@
+require 'package'
+
+class Libadwaita < Package
+  description 'Library full of GTK+ widgets for mobile phones'
+  homepage 'https://gitlab.gnome.org/exalm/libadwaita'
+  version '1.1.0-73c1'
+  license 'LGPL-2.1+'
+  compatibility 'all'
+  source_url 'https://gitlab.gnome.org/exalm/libadwaita/-/archive/73c17e0b36ad882d1a25e90926fe648e326e6b41/libadwaita-73c17e0b36ad882d1a25e90926fe648e326e6b41.tar.bz2'
+  source_sha256 '99730e57870ffc0f5e801ae5dac074e1a5b6f7d8e622f837b4f6a8439a328604'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-73c1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-73c1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-73c1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-73c1-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '22ea80100a4e12c031c09f62abbf54341950fa80801f458676e7d0146f11be11',
+     armv7l: '22ea80100a4e12c031c09f62abbf54341950fa80801f458676e7d0146f11be11',
+       i686: '63712e4bb09455822116e346132b6b64ab660b212c48a600bb611025e1b3fc2d',
+     x86_64: 'daaa26d53f8c8b3e3f15724eaa16122e4b3358185342df7a66160c229caf4d0c'
+  })
+
+  depends_on 'cairo'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'graphene'
+  depends_on 'gtk4'
+  depends_on 'pango'
+  depends_on 'vala' => ':build'
+
+  def self.patch
+    system "sed -i 's/-fstack-protector-strong/-flto/g' meson.build"
+  end
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      -Drequire_all_tests=false \
+      -Duser_documentation=false \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end


### PR DESCRIPTION
- Some gnome apps require a newer version of gtksourceview (gtksourceview-5) , but let's not make installs that require the older one break.
- Also remove llvm dep for gtksourceview build
- Add libadwaita, which is not the same as the adwaita theme, and is also being asked for by some packages (e.g. gnome-text-editor)

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l