### PR TITLE
Gcc doesn't depend on gawk

### DIFF
--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -23,7 +23,7 @@ class Gcc10 < Package
   })
 
   depends_on 'unzip' => :build
-  depends_on 'gawk' => :build
+  depends_on 'mawk' => :build
   depends_on 'dejagnu' => :build # for test
   depends_on 'icu4c' => :build
   depends_on 'python27' => :build

--- a/packages/gcc7.rb
+++ b/packages/gcc7.rb
@@ -23,7 +23,7 @@ class Gcc7 < Package
   })
 
   depends_on 'unzip' => :build
-  depends_on 'gawk' => :build
+  depends_on 'mawk' => :build
   depends_on 'dejagnu' => :build # for test
   depends_on 'icu4c' => :build
   depends_on 'python27' => :build

--- a/packages/gcc8.rb
+++ b/packages/gcc8.rb
@@ -23,7 +23,7 @@ class Gcc8 < Package
   })
 
   depends_on 'unzip' => :build
-  depends_on 'gawk' => :build
+  depends_on 'mawk' => :build
   depends_on 'dejagnu' => :build # for test
   depends_on 'icu4c' => :build
   depends_on 'python27' => :build


### PR DESCRIPTION
gcc doesn't require gawk, in fact none of the core packages do (except glibc)

Since mawk is now the default awk, this seems appropriate.