### PR TITLE
Remove extra dependencies in firefox

### DIFF
--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -15,29 +15,7 @@ class Firefox < Package
     source_sha256 '3c9207bee0a998634c4fd12293acfae207d16508749ad405bf1e8717d06acf02'
   end
 
-  depends_on 'atk'
-  depends_on 'cairo'
-  depends_on 'dbus'
-  depends_on 'dbus_glib'
-  depends_on 'fontconfig'
-  depends_on 'freetype'
-  depends_on 'gdk_pixbuf'
-  depends_on 'glib'
   depends_on 'gtk2'
-  depends_on 'gtk3'
-  depends_on 'libx11'
-  depends_on 'libxcb'
-  depends_on 'libxcomposite'
-  depends_on 'libxcursor'
-  depends_on 'libxdamage'
-  depends_on 'libxext'
-  depends_on 'libxfixes'
-  depends_on 'libxi'
-  depends_on 'libxrender'
-  depends_on 'libxt'
-  depends_on 'pango'
-  depends_on 'pulseaudio'
-  depends_on 'sommelier'
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"


### PR DESCRIPTION
All other dependencies come along for the ride with gtk2.  Just tested on a fresh install.