### PR TITLE
unixodbc and freetds update

### DIFF
--- a/packages/freetds.rb
+++ b/packages/freetds.rb
@@ -3,34 +3,37 @@ require 'package'
 class Freetds < Package
   description 'FreeTDS is a set of libraries for Unix and Linux that allows your programs to natively talk to Microsoft SQL Server and Sybase databases.'
   homepage 'http://www.freetds.org/'
-  version '1.2.9'
+  version '1.2.18'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.2.9.tar.bz2'
-  source_sha256 '90d7c2553d86fcca0029f118a2d61b48d69eed193549c4ff7306c5f8e132c2f5'
+  source_url "ftp://ftp.freetds.org/pub/freetds/stable/freetds-#{version}.tar.gz"
+  source_sha256 'a02c27802da15a3ade85bbaab6197713cd286f036409af9bba2ab4c63bdf57c3'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freetds-1.2.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freetds-1.2.9-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freetds-1.2.9-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freetds-1.2.9-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/freetds-1.2.18-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/freetds-1.2.18-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/freetds-1.2.18-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/freetds-1.2.18-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '94f48cce54a8548a73f5a387eea6ad90ffcbc6c1f5003d3066a1c7a9f8bdc2b4',
-     armv7l: '94f48cce54a8548a73f5a387eea6ad90ffcbc6c1f5003d3066a1c7a9f8bdc2b4',
-       i686: 'df276d4a6252b9723a594450d07849371188a136b9a106a1f3924a40b3e504cc',
-     x86_64: '5f272856bfc561fd1fd848b1487e41ce69e19d80af72cbec53076442733702b0',
+  binary_sha256({
+    aarch64: 'a31c467c683a3b574fb59cd45d8511e1a5824d5ea9ab93b3fe4816b42447d041',
+     armv7l: 'a31c467c683a3b574fb59cd45d8511e1a5824d5ea9ab93b3fe4816b42447d041',
+       i686: '2e908be34fae3b20fdbb9b1b947576a14496f8b48b57c095511f50e12f84240d',
+     x86_64: '1ecd9180df531b7c85b28719d9685820f2427e516f26787b51cab750e4ce8bf9'
   })
 
   depends_on 'unixodbc'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.postinstall

--- a/packages/unixodbc.rb
+++ b/packages/unixodbc.rb
@@ -22,10 +22,6 @@ class Unixodbc < Package
      x86_64: '705488db5fc32fe2062da25e4650ac090983404525c9d06f32646058a76cfb2a'
   })
   
-  depends_on 'libtool'
-  depends_on 'glibc'
-  depends_on 'readline'
-  
   def self.build
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \

--- a/packages/unixodbc.rb
+++ b/packages/unixodbc.rb
@@ -3,34 +3,39 @@ require 'package'
 class Unixodbc < Package
   description 'ODBC is an open specification for providing application developers with a predictable API with which to access Data Sources.'
   homepage 'http://www.unixodbc.org/'
-  version '2.3.7'
+  version '2.3.9'
   license 'LGPL-2+'
   compatibility 'all'
-  source_url 'http://www.unixodbc.org/unixODBC-2.3.7.tar.gz'
-  source_sha256 '45f169ba1f454a72b8fcbb82abd832630a3bf93baa84731cf2949f449e1e3e77'
+  source_url "http://www.unixodbc.org/unixODBC-#{version}.tar.gz"
+  source_sha256 '52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/unixodbc-2.3.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/unixodbc-2.3.7-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/unixodbc-2.3.7-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/unixodbc-2.3.7-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/unixodbc-2.3.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/unixodbc-2.3.9-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/unixodbc-2.3.9-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/unixodbc-2.3.9-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '4d97ddf6e1d78b18f90fa8ee4e8698a2c10e111cd294c6a4ee479b0ba734a1b8',
-     armv7l: '4d97ddf6e1d78b18f90fa8ee4e8698a2c10e111cd294c6a4ee479b0ba734a1b8',
-       i686: '987033a506015196dee6951e25d0860a23c5deadf74068590be5b913d1bfca3d',
-     x86_64: 'ecae202a4367725ceb7124b374f5e80335cfde85b6cdc296beaff735ddea3331',
+  binary_sha256({
+    aarch64: '6f04ee2e7fcc4e8c37db45e05fe51a5dcac345b7c61d440b791762ae7609b578',
+     armv7l: '6f04ee2e7fcc4e8c37db45e05fe51a5dcac345b7c61d440b791762ae7609b578',
+       i686: '590762ad9a2cd402ae52da0382c652d8e08a6b049f875ae99ec792f228331cd8',
+     x86_64: '705488db5fc32fe2062da25e4650ac090983404525c9d06f32646058a76cfb2a'
   })
-
+  
+  depends_on 'libtool'
+  depends_on 'glibc'
+  depends_on 'readline'
+  
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-maintainer-mode'
+    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      ./configure #{CREW_OPTIONS} \
+      --disable-maintainer-mode"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
- freetds was build with Libressl, this is now built with OpenSSL.
- also updated unixodbc dependency

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686