### PR TITLE
[Upgrade] fop 2.2 => 2.6

### DIFF
--- a/packages/fop.rb
+++ b/packages/fop.rb
@@ -6,7 +6,7 @@ class Fop < Package
   version '2.6'
   license 'Apache-2.0'
   compatibility 'all'
-  source_url 'https://mirror.olnevhost.net/pub/apache/xmlgraphics/fop/binaries/fop-2.6-bin.tar.gz'
+  source_url 'https://downloads.apache.org/xmlgraphics/fop/binaries/fop-2.6-bin.tar.gz'
   source_sha256 'ccfd7a1d4e5a04e76723946efa1147ffa9a8715ce2b58d2a27085a8e744520f8'
 
   depends_on 'jdk8'

--- a/packages/fop.rb
+++ b/packages/fop.rb
@@ -3,24 +3,11 @@ require 'package'
 class Fop < Package
   description 'Apache FOP (Formatting Objects Processor) is a print formatter driven by XSL formatting objects (XSL-FO) and an output independent formatter.'
   homepage 'https://xmlgraphics.apache.org/fop/'
-  version '2.2'
+  version '2.6'
   license 'Apache-2.0'
   compatibility 'all'
-  source_url 'http://apache.forsale.plus/xmlgraphics/fop/binaries/fop-2.2-bin.tar.gz'
-  source_sha256 '9dc1f9d1cb9acf5b3352116924c0b7678a88703b1214d537bc027c6867ec4dfe'
-
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fop-2.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fop-2.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fop-2.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fop-2.2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '5ae3c47bba798fdc6a0eec6b613fb9f25d6015b27adb5845ab90ce46b16be0da',
-     armv7l: '5ae3c47bba798fdc6a0eec6b613fb9f25d6015b27adb5845ab90ce46b16be0da',
-       i686: '06c576e9fe57ff1efec61ae76a9f82c34f5def02c658e469866ad6256ef79ef5',
-     x86_64: '84e05f40cee9b05976efe47579718b3eb6ffa5080e65a3aa98a558a8b46e1934',
-  })
+  source_url 'https://mirror.olnevhost.net/pub/apache/xmlgraphics/fop/binaries/fop-2.6-bin.tar.gz'
+  source_sha256 'ccfd7a1d4e5a04e76723946efa1147ffa9a8715ce2b58d2a27085a8e744520f8'
 
   depends_on 'jdk8'
 


### PR DESCRIPTION
This package doesn't really need binaries since the source itself is a binary. Chromebrew rearranges the binary in less than 7 seconds on my machine.