### PR TITLE
gtk4 => 4.2, add icon-cache command to gtk{3,4}

### DIFF
--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -90,8 +90,10 @@ class Gtk3 < Package
 
   def self.postinstall
     # generate schemas
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
+    system "#{CREW_PREFIX}/bin/glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
     # update mime database
-    system "update-mime-database #{CREW_PREFIX}/share/mime"
+    system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
+    # update icon cache
+    system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/*"
   end
 end

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -3,45 +3,66 @@ require 'package'
 class Gtk4 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk4/'
-  @_ver = '4.1.2'
+  @_ver = '4.2.0'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/gtk/-/archive/#{@_ver}/gtk-#{@_ver}.tar.bz2"
-  # source_url "https://download.gnome.org/sources/gtk/#{@_ver_prelastdot}/gtk-#{@_ver}.tar.xz"
-  source_sha256 '64b042592ba48c63535a47ed087d161290620e1de9e577ff89ea3afabf1a4edb'
+  source_sha256 'ea817483d35cd5f5d949a61b15c904ee3157fe5befb98e084a241921562f1838'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.1.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '771dd5ef30a4daadfd1d1c1c8a592c70158924ae1cb18d25677723d62e0efec2',
-     armv7l: '771dd5ef30a4daadfd1d1c1c8a592c70158924ae1cb18d25677723d62e0efec2',
-       i686: 'eca9a807e1ea3308f54213d836df9ddb3ca0c0c085db2e928e60e774368ef2db',
-     x86_64: 'b8bf6a435d4e361f96f30d254f199a9d8bf3bd20c90d78ae701c661b0d29b784'
+    aarch64: 'e1fd8f30f7f5c8f5e0032939746fdc5daa35d2bea56ff6d4829cdd6a84a86e20',
+     armv7l: 'e1fd8f30f7f5c8f5e0032939746fdc5daa35d2bea56ff6d4829cdd6a84a86e20',
+       i686: 'e03f5b99a2b39a579ac6e6cb936116b2fa4518f17bc5b4f5ed754959143b6d32',
+     x86_64: '1515611d769fbd1c95e9a5c5ffccab9116f1d793d0df98076ae60610e7d03fab'
   })
 
   depends_on 'adwaita_icon_theme'
   depends_on 'at_spi2_atk'
+  depends_on 'cairo'
   depends_on 'cantarell_fonts'
   depends_on 'cups'
   depends_on 'ffmpeg'
+  depends_on 'fontconfig'
+  depends_on 'fribidi'
   depends_on 'gdk_pixbuf'
+  depends_on 'glib'
   depends_on 'gnome_icon_theme'
   depends_on 'gobject_introspection'
   depends_on 'graphene'
+  depends_on 'gst_plugins_bad'
+  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
+  depends_on 'harfbuzz'
   depends_on 'hicolor_icon_theme'
   depends_on 'iso_codes'
   depends_on 'json_glib'
   depends_on 'libepoxy'
+  depends_on 'libx11'
+  depends_on 'libxcomposite'
+  depends_on 'libxcursor'
+  depends_on 'libxdamage'
+  depends_on 'libxext'
+  depends_on 'libxfixes'
+  depends_on 'libxi'
+  depends_on 'libxinerama'
   depends_on 'libxkbcommon'
+  depends_on 'libxrandr'
+  depends_on 'pango'
   depends_on 'pygments' => :build
+  depends_on 'rest'
   depends_on 'shared_mime_info'
   depends_on 'six' => :build
+  depends_on 'vulkan_headers' => :build
+  depends_on 'vulkan_icd_loader'
+  depends_on 'wayland'
   depends_on 'xdg_base'
 
   def self.patch
@@ -82,8 +103,10 @@ class Gtk4 < Package
 
   def self.postinstall
     # generate schemas
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
+    system "#{CREW_PREFIX}/bin/glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
     # update mime database
-    system "update-mime-database #{CREW_PREFIX}/share/mime"
+    system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
+    # update icon cache
+    system "#{CREW_PREFIX}/bin/gtk4-update-icon-cache -ft #{CREW_PREFIX}/share/icons/*"
   end
 end


### PR DESCRIPTION
- gtk4 -> 4.2.0
- add update-icon cache commands to gtk3, gtk4
- no need to update gtk3 binaries

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l