### PR TITLE
create nautilus bookmarks file.

### DIFF
--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -78,5 +78,6 @@ class Nautilus < Package
   
   def self.postinstall
     system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas/"
+    FileUtils.touch "#{CREW_DEST_HOME}/.gtk-bookmarks"
   end
 end

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -78,6 +78,6 @@ class Nautilus < Package
   
   def self.postinstall
     system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas/"
-    FileUtils.touch "#{CREW_DEST_HOME}/.gtk-bookmarks"
+    FileUtils.touch "#{HOME}/.gtk-bookmarks"
   end
 end


### PR DESCRIPTION
- stops console error from missing file appearing.
- don't want to do this in install, since you don't want to overwrite on reinstall.

Works properly:
- [x] x86_64
