### PR TITLE
remove most core package

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ esac
 crew_folders="bin cache doc docbook etc include lib lib$LIB_SUFFIX libexec man sbin share tmp var"
 for folder in $crew_folders
 do
-  if [ -d "${CREW_PREFIX}"/"${folder}" ]; then 
+  if [ -d "${CREW_PREFIX}"/"${folder}" ]; then
     sudo chown -R "$(id -u)":"$(id -g)" "${CREW_PREFIX}"/"${folder}"
   fi
 done
@@ -198,7 +198,7 @@ git reset --hard origin/"${BRANCH}"
 crew update
 
 # install a base set of essential packages
-yes | crew install buildessential less most
+yes | crew install buildessential less
 
 echo
 if [[ "${CREW_PREFIX}" != "/usr/local" ]]; then
@@ -215,9 +215,7 @@ source ~/.bashrc
 ${RESET}"
 fi
 echo -e "${BLUE}
-To set the default PAGER environment variable to use less:
-echo \"export PAGER='less'\" >> ~/.bashrc && . ~/.bashrc
-
+Your default PAGER is less.
 Alternatively, you could use most.  Why settle for less, right?
 echo \"export PAGER='most'\" >> ~/.bashrc && . ~/.bashrc
 

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -69,4 +69,6 @@ class Buildessential < Package
   # perl module build ?
   # depends_on 'perl_module_build'
 
+  depends_on 'slang'
+
 end

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -27,6 +27,7 @@ class Mandb < Package
   depends_on 'groff'
   depends_on 'libpipeline'
   depends_on 'libseccomp'
+  depends_on 'less' => :build
 
   def self.patch
     system "sed -i 's,/usr/man,#{CREW_PREFIX}/share/man,g' src/man_db.conf.in"
@@ -71,7 +72,7 @@ class Mandb < Package
       --enable-static \
       --without-libiconv-prefix \
       --disable-rpath \
-      --with-pager=#{CREW_PREFIX}/bin/most"
+      --with-pager=#{CREW_PREFIX}/bin/less"
     system 'make'
   end
 
@@ -84,8 +85,8 @@ class Mandb < Package
     system "env MANPATH=#{CREW_MAN_PREFIX} mandb -psc"
     pager_in_bashrc = `grep -c "PAGER" ~/.bashrc || true`
     unless pager_in_bashrc.to_i.positive?
-      puts 'Putting PAGER=most in ~/.bashrc'.lightblue
-      system "echo 'export PAGER=most' >> ~/.bashrc"
+      puts 'Putting PAGER=less in ~/.bashrc'.lightblue
+      system "echo 'export PAGER=less' >> ~/.bashrc"
       puts 'To complete the installation, execute the following:'.orange
       puts 'source ~/.bashrc'.orange
     end

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -59,7 +59,6 @@ mandb
 manpages
 mawk
 meson
-most
 mpc
 mpfr
 ncurses


### PR DESCRIPTION
This set of fixes removes the need for most as a pager and in core packages. Let's face it: most is extra, and no linux distros use most as their default pager. They all opt for GNU less, busybox less, or GNU more. Using most as the default pager would be like using exa instead of ls by default. It's unnecessary.