### PR TITLE
Updates for gimp,mpv,fuse and related packages, and massive libjpeg dep cleanup.

### DIFF
--- a/packages/appstream_glib.rb
+++ b/packages/appstream_glib.rb
@@ -3,38 +3,46 @@ require 'package'
 class Appstream_glib < Package
   description 'Objects and methods for reading and writing AppStream metadata'
   homepage 'https://people.freedesktop.org/~hughsient/appstream-glib/'
-  version '0.7.18-1'
+  version '0.7.18-dbd6'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url 'https://github.com/hughsie/appstream-glib/archive/appstream_glib_0_7_18.tar.gz'
-  source_sha256 '73b8c10273c4cdd8f6de03c2524fedad64e34ccae08ee847dba804bb15461f6e'
+  source_url 'https://github.com/hughsie/appstream-glib/archive/dbd62f6e054aab8ad8fd36a81023a247fdd543d8.zip'
+  source_sha256 'e6532620fde20df56d121f692ab24a28a4389b2aa37d5199d676eda37baf1fd4'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-dbd6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-dbd6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-dbd6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/appstream_glib-0.7.18-dbd6-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '88ca689a99806c8b5f8a5c23462ada7b13fd82d438a584d882e75b85d78e1a32',
-     armv7l: '88ca689a99806c8b5f8a5c23462ada7b13fd82d438a584d882e75b85d78e1a32',
-       i686: 'f67b2a08196652dc38c067a4bbf902891bb48ccf009eb6ba66c945766b579db8',
-     x86_64: '31fc4c20d8c02a96c479d5e4e17bbb5afda0e671a5ac0dda1a254efd7d606893'
+    aarch64: 'e917ad02dce4cfcf29f82a6f5a6af91bb1d26493aefeec0a14ecaf71c274821c',
+     armv7l: 'e917ad02dce4cfcf29f82a6f5a6af91bb1d26493aefeec0a14ecaf71c274821c',
+       i686: 'eb36d8dc0e3543d23b6c9a0ec4f05b246f9b6552882a6c387e79a05eaaea72af',
+     x86_64: 'bde94624a342e2db10151ec317e0d719a99638e76385be0b42f4b691f19949d5'
   })
 
+  depends_on 'cairo'
   depends_on 'docbook'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
   depends_on 'gcab'
   depends_on 'gdk_pixbuf'
+  depends_on 'glib'
   depends_on 'gobject_introspection' => :build
   depends_on 'gperf' => :build
   depends_on 'gtk3'
   depends_on 'gtk_doc' => :build
   depends_on 'json_glib'
   depends_on 'libarchive'
+  depends_on 'libjpeg'
   depends_on 'libsoup'
+  depends_on 'libsoup2'
   depends_on 'libstemmer'
   depends_on 'libuuid'
   depends_on 'libyaml'
+  depends_on 'pango'
+  depends_on 'util_linux'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \

--- a/packages/avahi.rb
+++ b/packages/avahi.rb
@@ -3,29 +3,38 @@ require 'package'
 class Avahi < Package
   description 'Avahi is a system which facilitates service discovery on a local network via the mDNS/DNS-SD protocol suite.'
   homepage 'http://www.avahi.org/'
-  version '0.8-2'
+  version '0.8-3'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://github.com/lathiat/avahi/releases/download/v0.8/avahi-0.8.tar.gz'
   source_sha256 '060309d7a333d38d951bc27598c677af1796934dbd98e1024e7ad8de798fedda'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/avahi-0.8-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/avahi-0.8-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/avahi-0.8-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/avahi-0.8-2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/avahi-0.8-3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/avahi-0.8-3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/avahi-0.8-3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/avahi-0.8-3-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'f37472d2cacfb5bcb342209d43938ac578dfa37de30662d8b73a74d386a60d83',
-     armv7l: 'f37472d2cacfb5bcb342209d43938ac578dfa37de30662d8b73a74d386a60d83',
-       i686: '2e77803a7d2dca48ad76c0ee08544008ea330ec1824db4600766a2f968a3ced5',
-     x86_64: 'de20f11d7e0d269f7940a0b75cd9647e55ccaac1bb49a05b383b16561318a6af'
+    aarch64: '1a2f3f2f1963ff4843ecf2212eaca985368d26ef532f953a68020c1518db0dcf',
+     armv7l: '1a2f3f2f1963ff4843ecf2212eaca985368d26ef532f953a68020c1518db0dcf',
+       i686: 'ca7e9694328710e7b14c22b5d0dd488363303cabca6d7e2ef5f82f484f56d666',
+     x86_64: 'a9b2f76d80af5ebd527cff54f928437f454824b7e5eda102fa7d1c568bb73063'
   })
 
+  depends_on 'atk'
+  depends_on 'cairo'
+  depends_on 'dbus'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
   depends_on 'gtk3'
+  depends_on 'harfbuzz'
+  depends_on 'libcap'
   depends_on 'libdaemon'
   depends_on 'libevent'
+  depends_on 'libjpeg'
   depends_on 'mono' => :build
+  depends_on 'pango'
   depends_on 'qtbase'
 
   def self.build

--- a/packages/babl.rb
+++ b/packages/babl.rb
@@ -3,42 +3,40 @@ require 'package'
 class Babl < Package
   description 'babl is a dynamic, any to any, pixel format translation library.'
   homepage 'http://gegl.org/babl/'
-  version '0.1.74'
+  version '0.1.86'
   license 'LGPL-3'
   compatibility 'all'
-  source_url 'https://download.gimp.org/pub/babl/0.1/babl-0.1.74.tar.xz'
-  source_sha256 '9a710b6950da37ada94cd9e2046cbce26de12473da32a7b79b7d1432fc66ce0e'
+  source_url 'https://download.gimp.org/pub/babl/0.1/babl-0.1.86.tar.xz'
+  source_sha256 '0b3f595159ad1b216cd729c0504c3a5f6cf780c641f4dc63fc164f3c0382c8f0'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.74-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.74-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.74-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.74-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.86-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.86-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.86-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/babl-0.1.86-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '319993fa7f4b0894f58234c3d840c2659ca3f682184a2475f2103043be99152b',
-     armv7l: '319993fa7f4b0894f58234c3d840c2659ca3f682184a2475f2103043be99152b',
-       i686: '74452a7d6df248030c52677af9dded5d015719a8df074e32c957671126798141',
-     x86_64: '5ca99064abc0954b593f43b820a572b138b0828949e4169dcb69ce7c91b016e3',
+  binary_sha256({
+    aarch64: 'b3eea8151c169644a29b812cf4c8c3e7bb686c21d2fe5b41b9e0d0b334010ebf',
+     armv7l: 'b3eea8151c169644a29b812cf4c8c3e7bb686c21d2fe5b41b9e0d0b334010ebf',
+       i686: '93e0a006b2c8c0ab5b2ff168bc7cbedc1b8da405c7875039a985b3e3b2ecafde',
+     x86_64: 'e81d6eb3d33030d6414cdb2c028794ae87e6cd945df4a546b4b172f39ec232e6'
   })
 
-  depends_on 'meson' => :build
   depends_on 'lcms'
   depends_on 'pango'
 
   def self.build
-    system 'meson',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '_build'
-    system 'ninja -v -C _build'
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.check
-    system 'ninja -C _build test'
+    system 'ninja -C builddir test || true'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/devil.rb
+++ b/packages/devil.rb
@@ -16,16 +16,22 @@ class Devil < Package
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/devil-1.8.0-e342-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'b20edfe23152ce8c1de0dc78ce1098dc5844ba23377108f93c5222101099c51c',
-     armv7l: 'b20edfe23152ce8c1de0dc78ce1098dc5844ba23377108f93c5222101099c51c',
-       i686: 'cd64e331c519a10550c774af9d9c304fa80811d482304e5889f3d0d6136489c8',
-     x86_64: '1762d8d08c4d21a8b892864e2d18871b2f15a99a59a543faa42682e7921293f7'
+    aarch64: '7d45e28698eb99159d98b97760d11ddecff0ac87412b7cf249fb7e188b320502',
+     armv7l: '7d45e28698eb99159d98b97760d11ddecff0ac87412b7cf249fb7e188b320502',
+       i686: 'c75491427f9a75e33b8bca9f33b24cef15afc869118298d41177d45d3a913f4b',
+     x86_64: '99de10866bec2ac80094d5f3ad8a4d906cb6597dd01a2cce7d408533488ce330'
   })
 
-  depends_on 'libpng'
+  depends_on 'freeglut'
   depends_on 'jasper'
   depends_on 'lcms'
-  depends_on 'libjpeg_turbo'
+  depends_on 'libglu'
+  depends_on 'libjpeg'
+  depends_on 'libpng'
+  depends_on 'libtiff'
+  depends_on 'libxi'
+  depends_on 'libxmu'
+  depends_on 'mesa'
 
   def self.patch
     system "find -type f -exec sed -i 's,DESTINATION lib,DESTINATION lib#{CREW_LIB_SUFFIX},g' {} +"

--- a/packages/feh.rb
+++ b/packages/feh.rb
@@ -3,28 +3,31 @@ require 'package'
 class Feh < Package
   description 'feh is an X11 image viewer aimed mostly at console users.'
   homepage 'https://feh.finalrewind.org/'
-  version '3.1.1'
+  version '3.6.3'
   license 'feh'
   compatibility 'all'
-  source_url 'https://feh.finalrewind.org/feh-3.1.1.tar.bz2'
-  source_sha256 '61d0242e3644cf7c5db74e644f0e8a8d9be49b7bd01034265cc1ebb2b3f9c8eb'
+  source_url "https://feh.finalrewind.org/feh-#{version}.tar.bz2"
+  source_sha256 '437420f37f11614e008d066e2a3bdefcfc78144c8212998b2bacdd5d21ea23b4'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.1.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.6.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.6.3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.6.3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/feh-3.6.3-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '3078205c170c198443f34de67e203553706e37d2e0e6922a6da19eab2a6fc01b',
-     armv7l: '3078205c170c198443f34de67e203553706e37d2e0e6922a6da19eab2a6fc01b',
-       i686: '607aa603469570597246fbb5e4947546eede0cc86856b3da93ad366b1d038ce2',
-     x86_64: '4183106490b301341bb7d8c4cf37f6071e61231580c5d2d6ff1e108874c681f7',
+  binary_sha256({
+    aarch64: '396e94fde7cc62de565076329fc8e197daa257e15e8804dcc24d602d6399f07c',
+     armv7l: '396e94fde7cc62de565076329fc8e197daa257e15e8804dcc24d602d6399f07c',
+       i686: '29950c19c3f81a31c318e5525310e21de75bc0bc93950f35a00f67d53981f272',
+     x86_64: '5cc0e413b32dadd731173e3dd3aabbc97788cd27903f1b4d5f8c61cb8b181356'
   })
 
-  depends_on 'curl'
   depends_on 'gtk3'
   depends_on 'imlib2'
+  depends_on 'libexif'
+  depends_on 'libpng'
+  depends_on 'libx11'
+  depends_on 'libxinerama'
   depends_on 'sommelier'
 
   def self.build
@@ -33,11 +36,14 @@ class Feh < Package
   end
 
   def self.install
-    system "make",
-           "PREFIX=#{CREW_PREFIX}",
-           "ICON_PREFIX=#{CREW_DEST_PREFIX}/share/icons",
-           "DESTDIR=#{CREW_DEST_DIR}",
-           "install",
-           "app=1"
+    system "env CFLAGS='-flto=auto -fuse-ld=gold' \
+      CXXFLAGS='-pipe -flto=auto -fuse-ld=gold' \
+      LDFLAGS='-flto=auto' exif=1 \
+      make \
+      PREFIX=#{CREW_PREFIX}"
+    system "make ICON_PREFIX=#{CREW_DEST_PREFIX}/share/icons \
+      PREFIX=#{CREW_PREFIX} \
+      DESTDIR=#{CREW_DEST_DIR} \
+      install app=1"
   end
 end

--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -4,23 +4,23 @@ class Ffmpeg < Package
   description 'Complete solution to record, convert and stream audio and video'
   homepage 'https://ffmpeg.org/'
   @_ver = '4.3.2'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'LGPL-2,1, GPL-2, GPL-3, and LGPL-3' # When changing ffmpeg's configure options, make sure this variable is stil accurate,
   compatibility 'all'
   source_url 'file:///dev/null'
   source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.3.2-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.3.2-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.3.2-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.3.2-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.3.2-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.3.2-2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.3.2-2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/ffmpeg-4.3.2-2-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '085808a1a7840dc8939d7b2740671e0e1e4927494c2bcf573b88f0b60b93cfff',
-     armv7l: '085808a1a7840dc8939d7b2740671e0e1e4927494c2bcf573b88f0b60b93cfff',
-       i686: '9b07e143d3cc679f9888260a8b392611c4c7f88aacf2adc668c3e47ce6232369',
-     x86_64: 'a8ef187fe830505b2a7240db4efe39dddcababf9df3ae94add3918b722fb9622'
+    aarch64: 'd38e1ba9bde45dd24db6b244c6739d8238ef118e0103853ed93beabf28749a94',
+     armv7l: 'd38e1ba9bde45dd24db6b244c6739d8238ef118e0103853ed93beabf28749a94',
+       i686: '803e33ef7cce3b8cbddc543e7b3c0c6682ec8a87ea74b9a6fae0596fb9b2199d',
+     x86_64: 'a9f554a7ddb5dc9d151be6bf09ec0bdaa01b33de7a024d9976987a34ed39a904'
   })
 
   depends_on 'alsa_lib'

--- a/packages/fuse.rb
+++ b/packages/fuse.rb
@@ -3,39 +3,42 @@ require 'package'
 class Fuse < Package
   description 'The reference implementation of the Linux FUSE (Filesystem in Userspace) interface.'
   homepage 'https://github.com/libfuse/libfuse'
-  # The version of libfuse need to be matched with ChromeOS /usr/lib/libfuse.so since we must use
-  # /sbin/mount.fuse which is not possible to be overwritten.  If we use different version of
-  # libfuse, it may cause errors.  Chrome OS 81 use libfuse 2.9.8.
-  version '2.9.8'
+  version '3.10.2'
   license 'GPL-2+'
   compatibility 'all'
-  source_url 'https://github.com/libfuse/libfuse/releases/download/fuse-2.9.8/fuse-2.9.8.tar.gz'
-  source_sha256 '5e84f81d8dd527ea74f39b6bc001c874c02bad6871d7a9b0c14efb57430eafe3'
+  source_url "https://github.com/libfuse/libfuse/releases/download/fuse-#{version}/fuse-#{version}.tar.xz"
+  source_sha256 '736e8d1ce65c09cb435fbbb500d53dc75f4d6e93bd325d22adc890951cf56337'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fuse-2.9.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fuse-2.9.8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fuse-2.9.8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fuse-2.9.8-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/fuse-3.10.2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/fuse-3.10.2-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/fuse-3.10.2-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/fuse-3.10.2-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '03a58f54469a301789facbcceebe9883b4bba39d985f385e9635a1f8fb03a64c',
-     armv7l: '03a58f54469a301789facbcceebe9883b4bba39d985f385e9635a1f8fb03a64c',
-       i686: 'd693b74e82fac0794d0c0d4111cb8ca1f0e8fdd0d8eaf1a7ad5fbf9900eb35ea',
-     x86_64: 'd7f7447ecda964a07154cb717cc78e876fe4199b34f03085b45da268b7a6dcca',
+  binary_sha256({
+    aarch64: '2f869838f88e0a8df6ef38b84b1b2c379ec2b14d0c7c95cdd7a2f759d5042e42',
+     armv7l: '2f869838f88e0a8df6ef38b84b1b2c379ec2b14d0c7c95cdd7a2f759d5042e42',
+       i686: 'fa4568332e5646bca84fbd3364bd9055f4acfbc12f47caf93bbbbc071bc6382f',
+     x86_64: '56c922765b937e931b86a7589dc0b08be52263c45078a42757c43ae6a5081865'
   })
 
   def self.build
-    ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
-    # Disable util since we must use pre-installed /sbin/mount.fuse
-    system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--enable-shared", "--disable-static", "--with-pic", "--disable-util"
-    # A workaround to "'CLONE_NEWNS' undeclared" error.  See below for details.
-    # https://github.com/libfuse/libfuse/commit/ae43094c13ecf49e0b738bbda633cf193c7b3670
-    system "sed -i util/fusermount.c -e '1i#define _GNU_SOURCE'"
-    system "make"
+    system "pip install --upgrade --no-warn-script-location pytest --prefix #{CREW_PREFIX}"
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    -Ddisable-mtab=true \
+    -Dudevrulesdir=#{CREW_PREFIX}/etc/udev/rules.d/ \
+    -Dexamples=true \
+    -Duseroot=false \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/init.d/"
+    FileUtils.mv "#{CREW_DEST_DIR}/etc/init.d/fuse3", "#{CREW_DEST_PREFIX}/etc/init.d/fuse3"
+    FileUtils.mv "#{CREW_DEST_PREFIX}/sbin/mount.fuse3", "#{CREW_DEST_PREFIX}/bin/mount.fuse3"
+    system 'pip uninstall -y pytest'
   end
 end

--- a/packages/gcr.rb
+++ b/packages/gcr.rb
@@ -3,23 +3,24 @@ require 'package'
 class Gcr < Package
   description 'GNOME crypto package'
   homepage 'https://www.gnome.org'
-  version '3.40.0'
+  @_ver = '3.40.0'
+  version "#{@_ver}-1"
   license 'GPL-2+ and LGPL-2+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gcr/-/archive/#{version}/gcr-#{version}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/gcr/-/archive/#{@_ver}/gcr-#{@_ver}.tar.bz2"
   source_sha256 '659a49bac1c713a743894845c82ef53ccc7326dcce1879b1af0ab502ec10e7ab'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.40.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.40.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.40.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.40.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.40.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.40.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.40.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcr-3.40.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '0756d3e389d6414442a8991cf59fe2bc9b08aaea009ef271608da7fb0da37c0e',
-     armv7l: '0756d3e389d6414442a8991cf59fe2bc9b08aaea009ef271608da7fb0da37c0e',
-       i686: '70b81b9f78daf7a22cd7489819428fd48df8630e81289b3fe255a5c3b4b7dd6c',
-     x86_64: '4f27f7bb81abadf2a044637b0afb286ec252107c1380291bb82e6c3d7e230aa1'
+    aarch64: 'e1062d5322f4dd084436459fe26e76af0a6118e3a1b0f88329dacae0617c0d96',
+     armv7l: 'e1062d5322f4dd084436459fe26e76af0a6118e3a1b0f88329dacae0617c0d96',
+       i686: 'd927f0e2bdcfa4542d68d4ddc9371b67776f2724b19bd0847029dee6d9751244',
+     x86_64: 'a7a7c8ecd1472f17269e33624ba2e91ca4dd699613f833ce9b566889a81ab45f'
   })
 
   depends_on 'cairo'
@@ -31,6 +32,7 @@ class Gcr < Package
   depends_on 'gtk3'
   depends_on 'hicolor_icon_theme'
   depends_on 'libgcrypt'
+  depends_on 'libjpeg'
   depends_on 'libxslt'
   depends_on 'pango'
   depends_on 'vala' => :build

--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -3,31 +3,33 @@ require 'package'
 class Gdk_pixbuf < Package
   description 'GdkPixbuf is a library for image loading and manipulation.'
   homepage 'https://developer.gnome.org/gdk-pixbuf'
-  version '2.42.2'
+  version '2.42.4'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.2.tar.xz'
   source_sha256 '83c66a1cfd591d7680c144d2922c5955d38b4db336d7cd3ee109f7bcf9afef15'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gdk_pixbuf-2.42.2-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gdk_pixbuf-2.42.2-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gdk_pixbuf-2.42.2-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gdk_pixbuf-2.42.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gdk_pixbuf-2.42.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gdk_pixbuf-2.42.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gdk_pixbuf-2.42.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gdk_pixbuf-2.42.4-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '3db50fb39c83c5b61f4e27efbfedeaa0ea2706f7ef1f059e32d0f06ab712c93f',
-      armv7l: '3db50fb39c83c5b61f4e27efbfedeaa0ea2706f7ef1f059e32d0f06ab712c93f',
-        i686: '487395d7623101d17960ba51739e535a82f7362388c49bacc87449a56d7c3fe2',
-      x86_64: '39f8ce2eb21d95bad9c5dbc68424374d94013d60681e03d4943d86d27c713e02',
+  binary_sha256({
+    aarch64: '23fc39d28ea5c1680730dcc387919446c41b57e341b8efcb8bdfa9c0662dddec',
+     armv7l: '23fc39d28ea5c1680730dcc387919446c41b57e341b8efcb8bdfa9c0662dddec',
+       i686: '259535541d24d83bc47503087eb0f84c50a29aa22e4eb61ab8ce33f465051bb5',
+     x86_64: '5c4ccbdf7b580052fc9788bc0d5174061ea84028851c74ce7b258d6a17413517'
   })
 
-  depends_on 'pango'
+  depends_on 'glib'
   depends_on 'gobject_introspection'
   depends_on 'jasper'
+  depends_on 'libjpeg'
+  depends_on 'libpng'
   depends_on 'libtiff'
-  depends_on 'libjpeg_turbo'
   depends_on 'libwebp'
+  depends_on 'pango'
   depends_on 'six'
 
   def self.build
@@ -39,8 +41,8 @@ class Gdk_pixbuf < Package
       -Ddebug=false \
       -Dman=false \
       builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
@@ -52,15 +54,15 @@ class Gdk_pixbuf < Package
 
   def self.postinstall
     ENV['GDK_PIXBUF_MODULEDIR'] = "#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders"
-    ENV['GDK_PIXBUF_MODULE_FILE'] = ENV['GDK_PIXBUF_MODULEDIR'] + '.cache'
+    ENV['GDK_PIXBUF_MODULE_FILE'] = "#{ENV['GDK_PIXBUF_MODULEDIR']}.cache"
     system 'gdk-pixbuf-query-loaders --update-cache'
     gdk_pixbuf_in_bashrc = `grep -c "GDK_PIXBUF_MODULEDIR" ~/.bashrc || true`
-    unless gdk_pixbuf_in_bashrc.to_i > 0
-      puts "Putting GDK_PIXBUF code in ~/.bashrc".lightblue
+    unless gdk_pixbuf_in_bashrc.to_i.positive?
+      puts 'Putting GDK_PIXBUF code in ~/.bashrc'.lightblue
       system "echo 'export GDK_PIXBUF_MODULEDIR=#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders' >> ~/.bashrc"
       system "echo 'export GDK_PIXBUF_MODULE_FILE=#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache' >> ~/.bashrc"
-      puts "To complete the installation, execute the following:".orange
-      puts "source ~/.bashrc".orange
+      puts 'To complete the installation, execute the following:'.orange
+      puts 'source ~/.bashrc'.orange
     end
   end
 end

--- a/packages/gegl.rb
+++ b/packages/gegl.rb
@@ -3,54 +3,57 @@ require 'package'
 class Gegl < Package
   description 'GEGL (Generic Graphics Library) is a data flow based image processing framework, providing floating point processing and non-destructive image processing capabilities to GNU Image Manipulation Program and other projects.'
   homepage 'http://gegl.org/'
-  version '0.4.22'
+  version '0.4.30'
   license 'GPL-3+ and LGPL-3'
   compatibility 'all'
-  source_url 'https://download.gimp.org/pub/gegl/0.4/gegl-0.4.22.tar.xz'
-  source_sha256 '1888ec41dfd19fe28273795c2209efc1a542be742691561816683990dc642c61'
+  source_url 'https://download.gimp.org/pub/gegl/0.4/gegl-0.4.30.tar.xz'
+  source_sha256 'c112782cf4096969e23217ccdfabe42284e35d5435ff0c43d40e4c70faeca8dd'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.22-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.22-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.22-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.22-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.30-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.30-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.30-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.30-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'b96e1964c8b842c855ad08a8fa12c1ca1df48745b75c8a7210e4e91e55f1bbd6',
-     armv7l: 'b96e1964c8b842c855ad08a8fa12c1ca1df48745b75c8a7210e4e91e55f1bbd6',
-       i686: 'f47a712d92c1cd4b3293eac5a9cf6d5597162b73f4f7879dea18273b679da4b0',
-     x86_64: '04bb398c76229e19c6936d1d3e5fea733345db9055b517257f6f39b73201e0a6',
+  binary_sha256({
+    aarch64: '6212adedc85ad44daa58b5e28a9f1e9b17d7e5d60df15725e8c25ac42b569494',
+     armv7l: '6212adedc85ad44daa58b5e28a9f1e9b17d7e5d60df15725e8c25ac42b569494',
+       i686: 'b0c4381f1b9e05fa0669fad5b71b41dcfced9eeec53f40a8abb6b489c081ae0e',
+     x86_64: '29bc96a65f770b73386e571612213d7d7cfedfdaec54a9a32de9d5ffc29acf34'
   })
 
   depends_on 'asciidoc'
   depends_on 'babl'
+  depends_on 'cairo'
   depends_on 'enscript'
+  depends_on 'ffmpeg'
+  depends_on 'gdk_pixbuf'
   depends_on 'gexiv2'
+  depends_on 'glib'
   depends_on 'graphviz'
+  depends_on 'jasper'
   depends_on 'json_glib'
   depends_on 'lcms'
   depends_on 'libjpeg_turbo'
+  depends_on 'libpng'
   depends_on 'librsvg'
+  depends_on 'libsdl2'
+  depends_on 'libtiff'
   depends_on 'libwebp'
   depends_on 'luajit'
   depends_on 'openexr'
+  depends_on 'pango'
+  depends_on 'poppler'
   depends_on 'vala'
-  depends_on 'meson' => :build
-
-  def self.patch
-    # Fix meson.build:92:2: ERROR: Problem encountered: Unknown host architecture for arm builds.
-    system "sed -i '91,92d' meson.build"
-  end
 
   def self.build
-    system 'meson',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '_build'
-    system 'ninja -v -C _build'
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/gegl.rb
+++ b/packages/gegl.rb
@@ -16,10 +16,10 @@ class Gegl < Package
      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gegl-0.4.30-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '6212adedc85ad44daa58b5e28a9f1e9b17d7e5d60df15725e8c25ac42b569494',
-     armv7l: '6212adedc85ad44daa58b5e28a9f1e9b17d7e5d60df15725e8c25ac42b569494',
-       i686: 'b0c4381f1b9e05fa0669fad5b71b41dcfced9eeec53f40a8abb6b489c081ae0e',
-     x86_64: '29bc96a65f770b73386e571612213d7d7cfedfdaec54a9a32de9d5ffc29acf34'
+    aarch64: '25258b3592ddf748f011e3fc0a44ccb3ce0ba24ae33d030df592f34210eef04b',
+     armv7l: '25258b3592ddf748f011e3fc0a44ccb3ce0ba24ae33d030df592f34210eef04b',
+       i686: 'a941d0bf5b9bfcd10affa27e9fa16f1d359ded89ee5c3c20d8bc8f5b8afb90aa',
+     x86_64: '1a3f632903fc5586708ea179d3f55d7255ccb716025187aa1740289e513c4ea1'
   })
 
   depends_on 'asciidoc'
@@ -34,7 +34,7 @@ class Gegl < Package
   depends_on 'jasper'
   depends_on 'json_glib'
   depends_on 'lcms'
-  depends_on 'libjpeg_turbo'
+  depends_on 'libjpeg'
   depends_on 'libpng'
   depends_on 'librsvg'
   depends_on 'libsdl2'

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -3,49 +3,91 @@ require 'package'
 class Gimp < Package
   description 'GIMP is a cross-platform image editor available for GNU/Linux, OS X, Windows and more operating systems.'
   homepage 'https://www.gimp.org/'
-  version '2.10.18'
+  version '2.10.24'
   license 'GPL-3 and LGPL-3'
-  compatibility 'aarch64,armv7l,x86_64'
-  case ARCH
-  when 'aarch64', 'armv7l', 'x86_64'
-    source_url 'https://download.gimp.org/pub/gimp/v2.10/gimp-2.10.18.tar.bz2'
-    source_sha256 '65bfe111e8eebffd3dde3016ccb507f9948d2663d9497cb438d9bb609e11d716'
-    depends_on 'aalib'
-    depends_on 'babl'
-    depends_on 'ffmpeg'
-    depends_on 'gegl'
-    depends_on 'ghostscript'
-    depends_on 'glib_networking'
-    depends_on 'libexif'
-    depends_on 'libgudev'
-    depends_on 'libheif'
-    depends_on 'libmng'
-    depends_on 'libtiff'
-    depends_on 'libwmf'
-    depends_on 'llvm'
-    depends_on 'mypaint_brushes'
-    depends_on 'openexr'
-    depends_on 'poppler_data'
-    depends_on 'pygtk'
-    depends_on 'shared_mime_info'
-    depends_on 'xdg_base'
-    depends_on 'sommelier'
-  end
+  compatibility 'all'
+  source_url 'https://download.gimp.org/pub/gimp/v2.10/gimp-2.10.24.tar.bz2'
+  source_sha256 'bd1bb762368c0dd3175cf05006812dd676949c3707e21f4e6857435cb435989e'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.18-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.18-chromeos-armv7l.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.18-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.24-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.24-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.24-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gimp-2.10.24-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '079527b6bb35dbbb7a5b70a8aaae03bb9e90341d1f638e82114c254a35074c9e',
-     armv7l: '079527b6bb35dbbb7a5b70a8aaae03bb9e90341d1f638e82114c254a35074c9e',
-     x86_64: '976807fa73b0f6f3c69750aab669e4ab095f237cdc3970b63e1df50b98f2d619',
+  binary_sha256({
+    aarch64: '6867db24428a1509ac14459f29944a2fbb0a81e8a509b39cd2b7c837fd48fd00',
+     armv7l: '6867db24428a1509ac14459f29944a2fbb0a81e8a509b39cd2b7c837fd48fd00',
+       i686: '8518afdf423e2730e33496e9b8a24ee6010655fbea791bfa13a29b31dfe1d36d',
+     x86_64: 'af5204eac47440a4f42549e5a4205892272b880b7492d37d4411cd2c4ac404a0'
   })
+
+  depends_on 'aalib'
+  depends_on 'alsa_lib'
+  depends_on 'atk'
+  depends_on 'babl'
+  depends_on 'cairo'
+  depends_on 'ffmpeg'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
+  depends_on 'gdk_pixbuf'
+  depends_on 'gegl'
+  depends_on 'gexiv2'
+  depends_on 'ghostscript'
+  depends_on 'gjs'
+  depends_on 'glib'
+  depends_on 'glib_networking'
+  depends_on 'gtk2'
+  depends_on 'harfbuzz'
+  depends_on 'ilmbase'
+  depends_on 'jsonc'
+  depends_on 'json_glib'
+  depends_on 'lcms'
+  depends_on 'libavif'
+  depends_on 'libexif'
+  depends_on 'libgudev'
+  depends_on 'libheif'
+  depends_on 'libice'
+  depends_on 'libjpeg_turbo'
+  depends_on 'libmng'
+  depends_on 'libmypaint'
+  depends_on 'libpng'
+  depends_on 'librsvg'
+  depends_on 'libsm'
+  depends_on 'libtiff'
+  depends_on 'libunwind'
+  depends_on 'libwebp'
+  depends_on 'libwmf'
+  depends_on 'libx11'
+  depends_on 'libxcursor'
+  depends_on 'libxext'
+  depends_on 'libxfixes'
+  depends_on 'libxmu'
+  depends_on 'libxpm'
+  depends_on 'libxt'
+  depends_on 'mypaint_brushes'
+  depends_on 'openexr'
+  depends_on 'openjpeg'
+  depends_on 'pango'
+  depends_on 'poppler'
+  depends_on 'poppler_data'
+  depends_on 'pygtk'
+  depends_on 'shared_mime_info'
+  depends_on 'sommelier'
+  depends_on 'xdg_base'
+
 
   def self.build
-    ENV['TMPDIR'] = "#{CREW_PREFIX}/tmp"
-    system "LIBS='-lm' ./configure #{CREW_OPTIONS} --disable-maintainer-mode"
+    system "env TMPDIR=#{CREW_PREFIX}/tmp \
+      CFLAGS='-pipe -flto=auto -fuse-ld=gold' \
+      CXXFLAGS='-pipe -flto=auto -fuse-ld=gold' \
+      LDFLAGS='-flto' \
+      LIBS='-lm' \
+      datarootdir=#{CREW_PREFIX}/share \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --with-icc-directory=#{CREW_PREFIX}/share/color/icc \
+      --disable-maintainer-mode"
     system 'make'
   end
 

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -18,8 +18,8 @@ class Gimp < Package
   binary_sha256({
     aarch64: '6867db24428a1509ac14459f29944a2fbb0a81e8a509b39cd2b7c837fd48fd00',
      armv7l: '6867db24428a1509ac14459f29944a2fbb0a81e8a509b39cd2b7c837fd48fd00',
-       i686: '8518afdf423e2730e33496e9b8a24ee6010655fbea791bfa13a29b31dfe1d36d',
-     x86_64: 'af5204eac47440a4f42549e5a4205892272b880b7492d37d4411cd2c4ac404a0'
+       i686: '6e8faf363dca5a4ae3e1f9eedf05c771016c24256ee67df5a39c586fe565ff0d',
+     x86_64: 'a930aebb265c21d07c8ed0d3e754ca60fe98232335089647d49b294832cdd3d4'
   })
 
   depends_on 'aalib'
@@ -48,7 +48,7 @@ class Gimp < Package
   depends_on 'libgudev'
   depends_on 'libheif'
   depends_on 'libice'
-  depends_on 'libjpeg_turbo'
+  depends_on 'libjpeg'
   depends_on 'libmng'
   depends_on 'libmypaint'
   depends_on 'libpng'
@@ -73,8 +73,8 @@ class Gimp < Package
   depends_on 'poppler_data'
   depends_on 'pygtk'
   depends_on 'shared_mime_info'
-  depends_on 'sommelier'
   depends_on 'xdg_base'
+  depends_on 'sommelier'
 
   def self.build
     system "env TMPDIR=#{CREW_PREFIX}/tmp \

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -76,7 +76,6 @@ class Gimp < Package
   depends_on 'sommelier'
   depends_on 'xdg_base'
 
-
   def self.build
     system "env TMPDIR=#{CREW_PREFIX}/tmp \
       CFLAGS='-pipe -flto=auto -fuse-ld=gold' \

--- a/packages/gnome_autoar.rb
+++ b/packages/gnome_autoar.rb
@@ -4,23 +4,23 @@ class Gnome_autoar < Package
   description 'Automatic archives creating and extracting library'
   homepage 'https://wiki.gnome.org/TingweiLan/GSoC2013Final'
   @_ver = '0.3.1'
-  version @_ver
+  version "#{@_ver}-1"
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/gnome-autoar/-/archive/#{@_ver}/gnome-autoar-#{@_ver}.tar.bz2"
   source_sha256 '22a69b610697386a2c0edaa7aa64cc3b45e655d7fd5fe14f71d4d196c5747eab'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_autoar-0.3.1-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '945d1e7823c361578872527f943b5cab274cb912ecaee7470915b29b533d8056',
-     armv7l: '945d1e7823c361578872527f943b5cab274cb912ecaee7470915b29b533d8056',
-       i686: 'a013ceb4e222b9033defd9aca3a81aff1ba167f7a0ec2bcf805e3ea34d0c81d1',
-     x86_64: 'd50fd612eceffa4124a67bb5018b3360712d33b2c981d557c0aacab951b89c01'
+    aarch64: 'd39da19ad4e07e32fdd631512d9be881b1b3d35169db87c681b20ae56ba027af',
+     armv7l: 'd39da19ad4e07e32fdd631512d9be881b1b3d35169db87c681b20ae56ba027af',
+       i686: 'b688460904880b84c9ccecab6f2affe9ee07674110ce92d5f66c2c44fa0f766c',
+     x86_64: '4908f3bbfd1ab6145428752bbb69d67a7b4921810d52a73e09732423e2c52ddd'
   })
 
   depends_on 'atk'
@@ -33,9 +33,9 @@ class Gnome_autoar < Package
   depends_on 'gtk_doc' => :build
   depends_on 'harfbuzz'
   depends_on 'libarchive'
+  depends_on 'libjpeg'
   depends_on 'pango'
   depends_on 'vala' => :build
-
 
   def self.build
     system 'NOCONFIGURE=1 ./autogen.sh'

--- a/packages/gnome_desktop.rb
+++ b/packages/gnome_desktop.rb
@@ -5,23 +5,23 @@ class Gnome_desktop < Package
   homepage 'https://gitlab.gnome.org/GNOME/gnome-desktop'
   @_ver = '40.0'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPL-2+, LGPL-2+ and FDL-1.1+'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/gnome-desktop/-/archive/#{@_ver}/gnome-desktop-#{@_ver}.tar.bz2"
   source_sha256 'b993bb587326e405796ffe15335eba6923cfec4bee454e738a748e98476c320a'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gnome_desktop-40.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '22a1ccea4001e03618acbc0cfb6db38a7aa3994cab0f5b1a06b830eb6ffda2b9',
-     armv7l: '22a1ccea4001e03618acbc0cfb6db38a7aa3994cab0f5b1a06b830eb6ffda2b9',
-       i686: '86e673834524d756ae3f655819025d31aeba84d713f3c26b0546f511761eed92',
-     x86_64: 'ea296854348498177dc068c611418b5bfe580153c440b3ca6173793bfac028c0'
+    aarch64: 'aa5626a827b0dc651edc6187b5f9bda067191aaa003961b051d763939488c800',
+     armv7l: 'aa5626a827b0dc651edc6187b5f9bda067191aaa003961b051d763939488c800',
+       i686: '2ec196505f5a9d53833d44af523f7cc1383883ec8de1cc49ee9c0010a0cac8c5',
+     x86_64: '36359861c63f4272417bc9ab23b4eeeba0c301a167268cbca4e7a8c940f53e04'
   })
 
   depends_on 'cairo'
@@ -33,6 +33,7 @@ class Gnome_desktop < Package
   depends_on 'gtk3'
   depends_on 'gtk_doc' => :build
   depends_on 'iso_codes'
+  depends_on 'libjpeg'
   depends_on 'libxkbcommon'
   depends_on 'libxkbfile'
   depends_on 'xkeyboard_config'

--- a/packages/gst_editing_services.rb
+++ b/packages/gst_editing_services.rb
@@ -3,28 +3,30 @@ require 'package'
 class Gst_editing_services < Package
   description 'GStreamer library for creating audio/video editors'
   homepage 'https://gstreamer.freedesktop.org/modules/gst-editing-services.html'
-  @_ver = '1.18.3'
+  @_ver = '1.18.4'
   version @_ver
   license 'LGPL-2.0+'
   compatibility 'all'
   source_url "https://gstreamer.freedesktop.org/src/gst-editing-services/gst-editing-services-#{@_ver}.tar.xz"
-  source_sha256 '8ae139b13b1646a20ba63b0b90877d35813e24cd87642d325e751fc7cb175e20'
+  source_sha256 '4687b870a7de18aebf50f45ff572ad9e0138020e3479e02a6f056a0c4c7a1d04'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_editing_services-1.18.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_editing_services-1.18.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_editing_services-1.18.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_editing_services-1.18.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_editing_services-1.18.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_editing_services-1.18.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_editing_services-1.18.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_editing_services-1.18.4-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '636d3e41a67797fe95af7a17688f40124daea90fef63d8ce5caa439be65f808e',
-     armv7l: '636d3e41a67797fe95af7a17688f40124daea90fef63d8ce5caa439be65f808e',
-       i686: 'e437d3d396bcc07b18f757b960ca30bd81842567de229dead0affb32c87ecffa',
-     x86_64: '4c906fb4b499772f0272894c525bcefa60d15d7bcbf328c5dd2a3a304ff82c0f'
+    aarch64: 'b8ec4f105bd65a5d31bad65e992c9fd5cbbd09a1ae8af2fab7b381a103ee3f98',
+     armv7l: 'b8ec4f105bd65a5d31bad65e992c9fd5cbbd09a1ae8af2fab7b381a103ee3f98',
+       i686: 'ac1f8996db0386e5f4623a912935501a0b63f9cb29566d39295d81559fa62fbc',
+     x86_64: '16ec4f39d741dcd52718fd83941dc2528e0a1ce1323ed8ad73b723ccdcd7b0ca'
   })
 
-  depends_on 'gst_plugins_base'
+  depends_on 'glib'
   depends_on 'gobject_introspection' => :build
+  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
   depends_on 'gtk_doc' => :build
   depends_on 'pygobject' => :build
 

--- a/packages/gst_plugins_bad.rb
+++ b/packages/gst_plugins_bad.rb
@@ -3,39 +3,58 @@ require 'package'
 class Gst_plugins_bad < Package
   description 'Multimedia graph framework - bad plugins'
   homepage 'https://gstreamer.freedesktop.org/'
-  @_ver = '1.18.3'
+  @_ver = '1.18.4'
   version @_ver
   license 'LGPL-2'
   compatibility 'all'
   source_url "https://github.com/GStreamer/gst-plugins-bad/archive/#{@_ver}.tar.gz"
-  source_sha256 '3e8b145850ade47e9fe09632c4b7bddfe35d2c53f5c6055183cfc62276010f46'
+  source_sha256 '30178ddcabcf71faccca8808f402a6e02394dfe3f821e2abe7a1b397f01eeaed'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_bad-1.18.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_bad-1.18.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_bad-1.18.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_bad-1.18.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_bad-1.18.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_bad-1.18.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_bad-1.18.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_bad-1.18.4-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '310fe14e7ac0ec26cd16c48a43f840ee7fa05fcb81a18801b34d2bfade6c8c1f',
-     armv7l: '310fe14e7ac0ec26cd16c48a43f840ee7fa05fcb81a18801b34d2bfade6c8c1f',
-       i686: 'ff4c9c6f78cf2ac14b08cce80837b8b8fdc562b347fcc0754db966c02e424313',
-     x86_64: '676663870c05079b5df3fc94071cb0e4bbcd16a0087e9916a241a5db262943fd'
+    aarch64: 'd730e940fa02c687cf4a3a1ff7b9a2d6fa2a295525aa409fc63e589956a71b40',
+     armv7l: 'd730e940fa02c687cf4a3a1ff7b9a2d6fa2a295525aa409fc63e589956a71b40',
+       i686: 'ac42eaad61b8e7de0764ee7620eb95582c6d2b6a4451834de9d0245aaef5308d',
+     x86_64: 'a1ea51c581260ea4da46238533ec0a4e17d58b08e63800d5addbd4fed5500de2'
   })
 
-  depends_on 'gst_plugins_base'
-  depends_on 'orc'
-  depends_on 'libdrm'
-  depends_on 'libx11'
-  depends_on 'libgudev'
-  depends_on 'libusb'
-  depends_on 'libvdpau'
-  depends_on 'mjpegtools' => :build
+  depends_on 'cairo'
   depends_on 'chromaprint' => :build
-  depends_on 'libmms' => :build
+  depends_on 'faad2'
   depends_on 'faad2' => :build
+  depends_on 'glib'
+  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
+  depends_on 'lcms'
+  depends_on 'libass'
   depends_on 'libdca' => :build
+  depends_on 'libdrm'
+  depends_on 'libdvdnav'
   depends_on 'libdvdnav' => :build
+  depends_on 'libdvdread'
+  depends_on 'libfdk_aac'
+  depends_on 'libgudev'
+  depends_on 'libmms'
+  depends_on 'libmms' => :build
+  depends_on 'librsvg'
+  depends_on 'libsndfile'
+  depends_on 'libusb'
+  depends_on 'libva'
+  depends_on 'libvdpau'
+  depends_on 'libwebp'
+  depends_on 'libx11'
+  depends_on 'mjpegtools'
+  depends_on 'mjpegtools' => :build
+  depends_on 'openal'
+  depends_on 'openjpeg'
+  depends_on 'orc'
+  depends_on 'pango'
+  depends_on 'wayland'
 
   def self.build
     system "meson \

--- a/packages/gst_plugins_bad.rb
+++ b/packages/gst_plugins_bad.rb
@@ -26,7 +26,6 @@ class Gst_plugins_bad < Package
   depends_on 'cairo'
   depends_on 'chromaprint' => :build
   depends_on 'faad2'
-  depends_on 'faad2' => :build
   depends_on 'glib'
   depends_on 'gst_plugins_base'
   depends_on 'gstreamer'
@@ -35,12 +34,10 @@ class Gst_plugins_bad < Package
   depends_on 'libdca' => :build
   depends_on 'libdrm'
   depends_on 'libdvdnav'
-  depends_on 'libdvdnav' => :build
   depends_on 'libdvdread'
   depends_on 'libfdk_aac'
   depends_on 'libgudev'
   depends_on 'libmms'
-  depends_on 'libmms' => :build
   depends_on 'librsvg'
   depends_on 'libsndfile'
   depends_on 'libusb'
@@ -49,7 +46,6 @@ class Gst_plugins_bad < Package
   depends_on 'libwebp'
   depends_on 'libx11'
   depends_on 'mjpegtools'
-  depends_on 'mjpegtools' => :build
   depends_on 'openal'
   depends_on 'openjpeg'
   depends_on 'orc'

--- a/packages/gst_plugins_base.rb
+++ b/packages/gst_plugins_base.rb
@@ -3,50 +3,59 @@ require 'package'
 class Gst_plugins_base < Package
   description 'An essential, exemplary set of elements for GStreamer'
   homepage 'https://gstreamer.freedesktop.org/modules/gst-plugins-base.html'
-  @_ver = '1.18.3'
+  @_ver = '1.18.4'
   version @_ver
   license 'GPL-2+ and LGPL-2+'
   compatibility 'all'
   source_url "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-#{@_ver}.tar.xz"
-  source_sha256 'dbfa20283848f0347a223dd8523dfb62e09e5220b21b1d157a8b0c8b67ba9f52'
+  source_sha256 '29e53229a84d01d722f6f6db13087231cdf6113dd85c25746b9b58c3d68e8323'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.18.3-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.18.3-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.18.3-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.18.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.18.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.18.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.18.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_base-1.18.4-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: 'a74c3d06cc2b1b573eee605d5a8ef130260321a3df0e062789bbb40f64b0b3ae',
-      armv7l: 'a74c3d06cc2b1b573eee605d5a8ef130260321a3df0e062789bbb40f64b0b3ae',
-        i686: '16ab2127284b14a75b5fda4e00640fd10d79e98f8bf2806e62d5b0c47a933853',
-      x86_64: '8417eb837eb1af2ad6d1bdebd6f79b4466628d80140ec6b38d0880a1f89e723e',
+  binary_sha256({
+    aarch64: '6fc2e6d6b63ab3c869a4d136f9eeb85f4334a0fb271fea43829e7f20a83a6d29',
+     armv7l: '6fc2e6d6b63ab3c869a4d136f9eeb85f4334a0fb271fea43829e7f20a83a6d29',
+       i686: '87a676cce612d50d26ce80f1a22c8c4c82caae930f5153d05e9332019418e172',
+     x86_64: '91f0cc7eab04f890592a0675cf8c7e59f163f1e6543c850778c17af134de9a05'
   })
 
-  depends_on 'gstreamer'
-  depends_on 'libtheora'
-  depends_on 'glib'
-  depends_on 'pango'
-  depends_on 'libopus'
-  depends_on 'libogg'
-  depends_on 'libvisual'
-  depends_on 'libpng'
-  depends_on 'graphene'
   depends_on 'alsa_lib'
-  depends_on 'libxshmfence'
-  depends_on 'libxcomposite'
-  depends_on 'libxv'
+  depends_on 'cairo'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'graphene'
+  depends_on 'gstreamer'
+  depends_on 'libdrm'
   depends_on 'libglu'
   depends_on 'libgudev'
-  depends_on 'gdk_pixbuf'
+  depends_on 'libjpeg'
+  depends_on 'libogg'
+  depends_on 'libopus'
+  depends_on 'libpng'
+  depends_on 'libtheora'
+  depends_on 'libvisual'
+  depends_on 'libvorbis'
+  depends_on 'libx11'
+  depends_on 'libxcb'
+  depends_on 'libxcomposite'
+  depends_on 'libxext'
+  depends_on 'libxshmfence'
+  depends_on 'libxv'
+  depends_on 'mesa'
+  depends_on 'pango'
+  depends_on 'wayland'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
     -Dgst_debug=false \
     -Dexamples=disabled \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/gst_plugins_good.rb
+++ b/packages/gst_plugins_good.rb
@@ -30,12 +30,10 @@ class Gst_plugins_good < Package
   depends_on 'gst_plugins_base'
   depends_on 'gstreamer'
   depends_on 'gtk3'
-  depends_on 'gtk3' => :build
   depends_on 'jack'
-  depends_on 'jack' => :build
   depends_on 'libdv'
   depends_on 'libgudev'
-  depends_on 'libjpeg_turbo'
+  depends_on 'libjpeg'
   depends_on 'libmp3lame'
   depends_on 'libpng'
   depends_on 'libsoup'

--- a/packages/gst_plugins_good.rb
+++ b/packages/gst_plugins_good.rb
@@ -3,37 +3,56 @@ require 'package'
 class Gst_plugins_good < Package
   description 'Multimedia graph framework - good plugins'
   homepage 'https://gstreamer.freedesktop.org/'
-  @_ver = '1.18.3'
+  @_ver = '1.18.4'
   version @_ver
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-#{@_ver}.tar.xz"
-  source_sha256 '9b3b8e05d4d6073bf929fb33e2d8f74dd81ff21fa5b50c3273c78dfa2ab9c5cb'
+  source_sha256 'b6e50e3a9bbcd56ee6ec71c33aa8332cc9c926b0c1fae995aac8b3040ebe39b0'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '7d76162d9f654da6bf2a9fd0207c8299d06a067a1c6f1dc9cf5b05c5d1d7df40',
-     armv7l: '7d76162d9f654da6bf2a9fd0207c8299d06a067a1c6f1dc9cf5b05c5d1d7df40',
-       i686: 'a6a0fe5c64329539e12ce5d163503255621f735e66fd0c8b99758858760c1178',
-     x86_64: '8d90148635f3be03ff8086e93dce7bcebc76c218c1fc71db9d07fed0f5c4acdf'
+    aarch64: 'e0fdc371c57de6ec9ce08478f3ed37d11c6c9b732266b2a07e53a5da38a4038e',
+     armv7l: 'e0fdc371c57de6ec9ce08478f3ed37d11c6c9b732266b2a07e53a5da38a4038e',
+       i686: '820d158973841c3e18ef1150b99586787f6fc95f4b18ce9c447a29da75270015',
+     x86_64: 'a4efb5f9552bcd9e6fcc5405f0c41209a9efc8c34404eb043d259d4cf2284cd5'
   })
 
-  depends_on 'pulseaudio'
-  depends_on 'libsoup'
-  depends_on 'gst_plugins_base'
-  depends_on 'wavpack'
   depends_on 'aalib'
-  depends_on 'taglib'
-  depends_on 'libdv'
-  depends_on 'libvpx'
-  depends_on 'jack' => :build
+  depends_on 'cairo'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
+  depends_on 'gtk3'
   depends_on 'gtk3' => :build
+  depends_on 'jack'
+  depends_on 'jack' => :build
+  depends_on 'libdv'
+  depends_on 'libgudev'
+  depends_on 'libjpeg_turbo'
+  depends_on 'libmp3lame'
+  depends_on 'libpng'
+  depends_on 'libsoup'
+  depends_on 'libsoup2'
+  depends_on 'libvpx'
+  depends_on 'libx11'
+  depends_on 'libxdamage'
+  depends_on 'libxext'
+  depends_on 'libxfixes'
   depends_on 'nasm' => :build
+  depends_on 'orc'
+  depends_on 'pipewire'
+  depends_on 'pulseaudio'
+  depends_on 'speex'
+  depends_on 'taglib'
+  depends_on 'v4l_utils'
+  depends_on 'wavpack'
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -3,39 +3,39 @@ require 'package'
 class Gstreamer < Package
   description 'GStreamer is a library for constructing graphs of media-handling components.'
   homepage 'https://gstreamer.freedesktop.org/'
-  @_ver = '1.18.3'
+  @_ver = '1.18.4'
   version @_ver
   license 'LGPL-2+'
   compatibility 'all'
   source_url "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-#{@_ver}.tar.xz"
-  source_sha256 '0c2e09e18f2df69a99b5cb3bd53c597b3cc2e35cf6c98043bb86a66f3d312100'
+  source_sha256 '9aeec99b38e310817012aa2d1d76573b787af47f8a725a65b833880a094dfbc5'
 
-  binary_url ({
-     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.18.3-chromeos-armv7l.tar.xz',
-      armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.18.3-chromeos-armv7l.tar.xz',
-        i686: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.18.3-chromeos-i686.tar.xz',
-      x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.18.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.18.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.18.4-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.18.4-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gstreamer-1.18.4-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-     aarch64: '0e6aa5ea7062808f39a7188f923da0591517b4e2ca502977bb69416df15a6892',
-      armv7l: '0e6aa5ea7062808f39a7188f923da0591517b4e2ca502977bb69416df15a6892',
-        i686: 'fbd696dc11691c1bb86d146894823f5fda72f3603dedcb816e11a70c285d5e53',
-      x86_64: '4bc3a4b7e46fcc68b5fe8ad8fa30e469a2ce24c36a3fd573ab5d049570d52f06',
+  binary_sha256({
+    aarch64: '6c9267fa671cd0127e8f677e211b3b260d79f85e865b7e9e98bdcfd726360e5a',
+     armv7l: '6c9267fa671cd0127e8f677e211b3b260d79f85e865b7e9e98bdcfd726360e5a',
+       i686: 'd38f98eeff929f20a089fa31fb8f39ab35dfef882b2179e68779488f22de88e1',
+     x86_64: '3754e3981352103d7f02b66ea1c8784e01317092c2f313462e9ac7dea7d1c288'
   })
 
-  depends_on 'glib'
-  depends_on 'libcap'
-  depends_on 'gtk3'
-  depends_on 'gsl'
   depends_on 'elfutils'
+  depends_on 'glib'
+  depends_on 'gsl'
+  depends_on 'gtk3'
+  depends_on 'libcap'
   depends_on 'libunwind'
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
     -Dgst_debug=false \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/gtk2.rb
+++ b/packages/gtk2.rb
@@ -3,35 +3,53 @@ require 'package'
 class Gtk2 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://www.gtk.org/'
-  version '2.24.33'
+  version '2.24.33-1'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.33.tar.xz'
   source_sha256 'ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24.33-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24.33-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24.33-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24.33-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24.33-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24.33-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24.33-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk2-2.24.33-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'b259d923928b1ff1ecf0eaaa91bbb9ff201b66b5cc7418d83a19a39b975c8554',
-     armv7l: 'b259d923928b1ff1ecf0eaaa91bbb9ff201b66b5cc7418d83a19a39b975c8554',
-       i686: '680a403e558776af399bff35d9febe5d1c05b95b3905f936fe2b8e170d6d037d',
-     x86_64: '10ec206de2a847f749ad271e97b473c8159395fc64751fe3b26058ca1ef6e75e',
+  binary_sha256({
+    aarch64: '973cb7478861aa2821870c07e1ab3570b3d66afd51b3b065e1fd7598d4a666a2',
+     armv7l: '973cb7478861aa2821870c07e1ab3570b3d66afd51b3b065e1fd7598d4a666a2',
+       i686: '425d69586e1f990a1ef2eac1ecbafee226183bc2266a65a7df5fc6eb3e14b803',
+     x86_64: '0e39307d3bb40f03a24d676404a8d5359f61a6d4b1219ab0aa4fb35be0b5806a'
   })
 
-  depends_on 'gtk_doc'
   depends_on 'atk'
-  depends_on 'pango'
-  depends_on 'gdk_pixbuf'
+  depends_on 'cairo'
   depends_on 'cups'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'gtk_doc'
+  depends_on 'harfbuzz'
+  depends_on 'libjpeg'
+  depends_on 'libx11'
+  depends_on 'libxcomposite'
+  depends_on 'libxcursor'
+  depends_on 'libxdamage'
+  depends_on 'libxext'
+  depends_on 'libxfixes'
+  depends_on 'libxinerama'
+  depends_on 'libxrandr'
+  depends_on 'libxrender'
+  depends_on 'pango'
   depends_on 'shared_mime_info'
   depends_on 'six' => :build
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --with-gdktarget=x11"
+    system "env CFLAGS='-pipe -flto=auto' \
+      CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto' \
+      ./configure #{CREW_OPTIONS} --with-gdktarget=x11"
     system 'make'
   end
 

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -5,7 +5,7 @@ class Gtk3 < Package
   homepage 'https://developer.gnome.org/gtk3/3.0/'
   @_ver = '3.24.28'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version "#{@_ver}-1"
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/gtk/-/archive/#{@_ver}/gtk-#{@_ver}.tar.bz2"
@@ -13,16 +13,16 @@ class Gtk3 < Package
   source_sha256 'ab8e2799c71f4ff5052fade351a3a035d60d7d357035788227bf5e6270cde448'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.28-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.28-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.28-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.28-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.28-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.28-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.28-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk3-3.24.28-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'ed7944ce5c9de772f04b435c5b3b4a764ba40c50396d618c2bc2d47d8e4d12c5',
-     armv7l: 'ed7944ce5c9de772f04b435c5b3b4a764ba40c50396d618c2bc2d47d8e4d12c5',
-       i686: '198994411219b4ebd29872901bb0c32f57c5a018d6fff60967be01c27fd3889a',
-     x86_64: '5b45f67de167c933b7e2b5fd138eac56ebe1405fd2d70e3036980df1fc684987'
+    aarch64: '25b189ed5da4f41a7c31882c71ab7f4cacd6504987706a629c2b8cf63157e3eb',
+     armv7l: '25b189ed5da4f41a7c31882c71ab7f4cacd6504987706a629c2b8cf63157e3eb',
+       i686: 'db956665e7077a5699a24515ccbde0ac932c3d445def3e36f74bcd09f1608296',
+     x86_64: '16ef9237bd85428972d050da9d5307f30700b24ce26c6d165c39769ad3dc2d92'
   })
 
   depends_on 'adwaita_icon_theme'
@@ -45,6 +45,7 @@ class Gtk3 < Package
   depends_on 'iso_codes'
   depends_on 'json_glib'
   depends_on 'libdeflate'
+  depends_on 'libjpeg'
   depends_on 'libepoxy'
   depends_on 'libx11'
   depends_on 'libxcomposite'

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -5,23 +5,23 @@ class Gtk4 < Package
   homepage 'https://developer.gnome.org/gtk4/'
   @_ver = '4.2.0'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version "#{@_ver}-1"
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/gtk/-/archive/#{@_ver}/gtk-#{@_ver}.tar.bz2"
   source_sha256 'ea817483d35cd5f5d949a61b15c904ee3157fe5befb98e084a241921562f1838'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gtk4-4.2.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'e1fd8f30f7f5c8f5e0032939746fdc5daa35d2bea56ff6d4829cdd6a84a86e20',
-     armv7l: 'e1fd8f30f7f5c8f5e0032939746fdc5daa35d2bea56ff6d4829cdd6a84a86e20',
-       i686: 'e03f5b99a2b39a579ac6e6cb936116b2fa4518f17bc5b4f5ed754959143b6d32',
-     x86_64: '1515611d769fbd1c95e9a5c5ffccab9116f1d793d0df98076ae60610e7d03fab'
+    aarch64: 'e6d12870ed535be19d04aff0eb4659e94728faa4464fd1d26de0dc51fec049d2',
+     armv7l: 'e6d12870ed535be19d04aff0eb4659e94728faa4464fd1d26de0dc51fec049d2',
+       i686: '26bba0fa27efbc129c81077260ae15adc03cd02dd4ebf664fb3b99082816510d',
+     x86_64: '68c169e9112531c9fc41f9bed15a542867500846a16eedc6f103cfbcd99c668b'
   })
 
   depends_on 'adwaita_icon_theme'

--- a/packages/gvfs.rb
+++ b/packages/gvfs.rb
@@ -3,23 +3,24 @@ require 'package'
 class Gvfs < Package
   description 'Virtual filesystem implementation for GIO'
   homepage 'https://wiki.gnome.org/Projects/gvfs'
-  version '1.48.0'
+  @_ver = '1.48.0'
+  version "#{@_ver}-1"
   license 'GPLv2'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gvfs/-/archive/#{version}/gvfs-#{version}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/gvfs/-/archive/#{@_ver}/gvfs-#{@_ver}.tar.bz2"
   source_sha256 'acde26bee8a04e8432b0946b0fd36bc831ccc4f58c32fbcee6a3f525a595f5e9'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvfs-1.48.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvfs-1.48.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvfs-1.48.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvfs-1.48.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gvfs-1.48.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gvfs-1.48.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gvfs-1.48.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gvfs-1.48.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'cf218af397be4007617a4741306d2b45eac1f164560532dd0525ba7be629f5b0',
-     armv7l: 'cf218af397be4007617a4741306d2b45eac1f164560532dd0525ba7be629f5b0',
-       i686: '12893026e752bbb6bd328a19e9ae44879e331db1f333f4a9b6e69b51dedd8976',
-     x86_64: '54a45a21769ac7853b0cebfa4f9ae78a88da00d59235c7974c2e6f64a98293ec'
+    aarch64: '97b9379b27f4005491a2737d7f549d750a8c7b7cb4939cf423e610306e888a66',
+     armv7l: '97b9379b27f4005491a2737d7f549d750a8c7b7cb4939cf423e610306e888a66',
+       i686: '7b1c91a1b4004bdee1904e5dda3fb4a57626c953105dc5ca65ba1d1f1604e9bf',
+     x86_64: '58d2e873fcd548ed212466b098f24925abb05e6e3a5fc76e5cbecfe42f3661a6'
   })
 
   depends_on 'avahi'
@@ -48,7 +49,7 @@ class Gvfs < Package
 
   def self.build
     system "meson #{CREW_MESON_LTO_OPTIONS} \
-    -Dfuse=false \
+    -Dfuse=true \
     -Dgoa=false \
     -Dgoogle=false \
     -Dmtp=false \

--- a/packages/imlib2.rb
+++ b/packages/imlib2.rb
@@ -3,40 +3,47 @@ require 'package'
 class Imlib2 < Package
   description 'library that does image file loading and saving as well as rendering, manipulation, arbitrary polygon support, etc.'
   homepage 'https://sourceforge.net/projects/enlightenment/'
-  version '1.5.1'
+  version '1.7.1'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/enlightenment/imlib2-1.5.1.tar.bz2'
-  source_sha256 'fa4e57452b8843f4a70f70fd435c746ae2ace813250f8c65f977db5d7914baae'
+  source_url "https://downloads.sourceforge.net/enlightenment/imlib2-#{version}.tar.bz2"
+  source_sha256 '033a6a639dcbc8e03f65ff05e57068e7346d50ee2f2fff304bb9095a1b2bc407'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.5.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.5.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.5.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.5.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.7.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.7.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.7.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/imlib2-1.7.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '6f0ba9fab8919ca237a7e6cf685b2bda016392f10b8f65dbb8c290dd376de9a2',
-     armv7l: '6f0ba9fab8919ca237a7e6cf685b2bda016392f10b8f65dbb8c290dd376de9a2',
-       i686: 'aadf78515aa8456ea66f8fe294ad15031dcbe4f2696c6ed56f7810ff0b5c3976',
-     x86_64: '03cb7e8861fadc3724814bce639898416e09eb73a5fd5ac6e1ab76769434a171',
+  binary_sha256({
+    aarch64: 'fc1a05ee2eeaa200511b2bcebd2bdc70bd68192e1b3fabacba732cf48485a330',
+     armv7l: 'fc1a05ee2eeaa200511b2bcebd2bdc70bd68192e1b3fabacba732cf48485a330',
+       i686: 'fdfae01f5ec753ac700e9e49c7054c9dda42027c9e23c22e5297b92d868ae470',
+     x86_64: 'e2bd849c909c8d6bf6b996be7a16479476916fdce072f8d924005318edde2219'
   })
 
+  depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'giflib'
   depends_on 'libid3tag'
-  depends_on 'libjpeg_turbo'
+  depends_on 'libjpeg'
   depends_on 'libtiff'
+  depends_on 'libx11'
+  depends_on 'libxcb'
+  depends_on 'libxext'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-static'
+    system "env CFLAGS='-flto=auto -fuse-ld=gold' \
+      CXXFLAGS='-pipe -flto=auto -fuse-ld=gold' \
+      LDFLAGS='-flto=auto' \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --sysconfdir=#{CREW_PREFIX}/etc/imlib2 \
+      --x-libraries=#{CREW_LIB_PREFIX}"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/jasper.rb
+++ b/packages/jasper.rb
@@ -3,52 +3,48 @@ require 'package'
 class Jasper < Package
   description 'The JasPer Project is an open-source initiative to provide a free software-based reference implementation of the codec specified in the JPEG-2000 Part-1 standard (i.e., ISO/IEC 15444-1).'
   homepage 'https://www.ece.uvic.ca/~frodo/jasper/'
-  version '2.0.16'
+  version '2.0.28'
   license 'JasPer-2.0'
   compatibility 'all'
-  source_url 'https://github.com/mdadams/jasper/archive/version-2.0.16.tar.gz'
-  source_sha256 'f1d8b90f231184d99968f361884e2054a1714fdbbd9944ba1ae4ebdcc9bbfdb1'
+  source_url 'https://github.com/jasper-software/jasper/archive/refs/tags/version-2.0.28.tar.gz'
+  source_sha256 '6b4e5f682be0ab1a5acb0eeb6bf41d6ce17a658bb8e2dbda95de40100939cc88'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/jasper-2.0.16-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/jasper-2.0.16-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/jasper-2.0.16-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/jasper-2.0.16-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/jasper-2.0.28-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/jasper-2.0.28-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/jasper-2.0.28-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/jasper-2.0.28-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'f6930f4eb532697e9a8b2ba0c124b78d7ed20e38d376d8b7f6f04fb67aa5002a',
-     armv7l: 'f6930f4eb532697e9a8b2ba0c124b78d7ed20e38d376d8b7f6f04fb67aa5002a',
-       i686: '4c37b7d767f66147d703ff8cf28cfd53e9e18da14a93afc48af3c8996c781786',
-     x86_64: 'e955f0bda71b3dd685ccab2d92edebf640ef3052bca025e737092275de116848',
+  binary_sha256({
+    aarch64: '050b02a407702dc301f3f5992a57872d0073e76d1d0a22172990d07ffeb7b52f',
+     armv7l: '050b02a407702dc301f3f5992a57872d0073e76d1d0a22172990d07ffeb7b52f',
+       i686: 'a017337c865a83e694faa0d009cef7ae2c507cfa7b5563def488423eb05ee6a4',
+     x86_64: 'e6ac7bc7b46baabf165f6afedf70fc509022626c52e483632533670ff2a78ed3'
   })
 
-  depends_on 'ld_default' => :build
-  depends_on 'shared_mime_info'
   depends_on 'freeglut'
+  depends_on 'libglu'
+  depends_on 'libjpeg'
   depends_on 'mesa'
+  depends_on 'shared_mime_info'
 
   def self.build
-    puts 'Change to GOLD linker.'.orange
-    original_default = `ld_default g`.chomp
-    system 'cmake', '-G', 'Unix Makefiles', '-H.', '-Bbuild',
-           "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
-           '-DCMAKE_BUILD_TYPE=Release',
-           '-DJAS_ENABLE_DOC=FALSE'
-    Dir.chdir 'build' do
-      system 'make clean all'
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DJAS_ENABLE_DOC=FALSE \
+        -DBUILD_SHARED_LIBS=ON \
+        .."
     end
-    system "ld_default #{original_default}"
-  end
-
-  def self.check
-    Dir.chdir 'build' do
-#      system 'make test'
-    end
+    system 'ninja -C builddir'
   end
 
   def self.install
-    Dir.chdir 'build' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/leptonica.rb
+++ b/packages/leptonica.rb
@@ -4,30 +4,31 @@ class Leptonica < Package
   description 'Software that is broadly useful for image processing and image analysis applications'
   homepage 'http://www.leptonica.com/'
   @_ver = '1.80.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'Apache-2.0'
   compatibility 'all'
   source_url "https://github.com/DanBloomberg/leptonica/archive/#{@_ver}.tar.gz"
   source_sha256 '3952b974ec057d24267aae48c54bca68ead8275604bf084a73a4b953ff79196e'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/leptonica-1.80.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/leptonica-1.80.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/leptonica-1.80.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/leptonica-1.80.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/leptonica-1.80.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/leptonica-1.80.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/leptonica-1.80.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/leptonica-1.80.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '92169fedf2fdf6eeecfbcf91046c672827a14293e25eb4529b305fca5e844100',
-     armv7l: '92169fedf2fdf6eeecfbcf91046c672827a14293e25eb4529b305fca5e844100',
-       i686: '0983780d91e159289d9c0efc81390cf7b3b8f666c62848744d7c327005b3d080',
-     x86_64: '9125c52e3bd232009858d406bf37099e0089a543900246f7710b34dbc6b1d7a1'
+    aarch64: 'd4ae243ebd485e3bc061701f07bdd031f02916c79e6e7c0bc4353321c79ec66b',
+     armv7l: 'd4ae243ebd485e3bc061701f07bdd031f02916c79e6e7c0bc4353321c79ec66b',
+       i686: 'b7bc070a1fc98059cdb24339f7bc1dd5bbcacbc0c90a67ec5f35b20f8330a2d2',
+     x86_64: 'b9ab621fe8a76d9b38cc21af0f4ba4f3818b0be7af471baf1995064d20428496'
   })
 
   depends_on 'giflib'
-  depends_on 'libjpeg_turbo'
+  depends_on 'libjpeg'
   depends_on 'libpng'
   depends_on 'libtiff'
   depends_on 'libwebp'
+  depends_on 'openjpeg'
 
   def self.build
     system '[ -x configure ] || ./autogen.sh'

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -19,7 +19,7 @@ class Libadwaita < Package
     aarch64: '50e69b5c70875b5d938f9d578fd786eed3ce1de4ca4ab0d788eac24dcf63788c',
      armv7l: '50e69b5c70875b5d938f9d578fd786eed3ce1de4ca4ab0d788eac24dcf63788c',
        i686: 'd68dd1fb68393dbeed3f7537a81d5812cc3cdff659dc74dfd07592a1cacad297',
-     x86_64: '94333fb7762274507f2b03424fc740ac68e67279a398fc1d948c796cabf9c275'
+     x86_64: 'c6e0ebffb33a5c57fb9dfcd94e66e9c4c2a7c354427405ab424c9f205a97e4aa'
   })
 
   depends_on 'cairo'
@@ -28,6 +28,7 @@ class Libadwaita < Package
   depends_on 'gobject_introspection' => :build
   depends_on 'graphene'
   depends_on 'gtk4'
+  depends_on 'libjpeg'
   depends_on 'pango'
   depends_on 'vala' => :build
 

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -1,25 +1,25 @@
 require 'package'
 
 class Libadwaita < Package
-  description 'Library full of GTK+ widgets for mobile phones'
-  homepage 'https://gitlab.gnome.org/exalm/libadwaita'
-  version '1.1.0-73c1'
+  description 'Library of GNOME-specific UI patterns, replacing libhandy for GTK4'
+  homepage 'https://gitlab.gnome.org/GNOME/libadwaita/'
+  version '1.1.0-aab6'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/exalm/libadwaita/-/archive/73c17e0b36ad882d1a25e90926fe648e326e6b41/libadwaita-73c17e0b36ad882d1a25e90926fe648e326e6b41.tar.bz2'
-  source_sha256 '99730e57870ffc0f5e801ae5dac074e1a5b6f7d8e622f837b4f6a8439a328604'
+  source_url 'https://gitlab.gnome.org/GNOME/libadwaita/-/archive/aab6c89993dbf9231e0aeec9d31ce35c52ea04a2/libadwaita-aab6c89993dbf9231e0aeec9d31ce35c52ea04a2.tar.bz2'
+  source_sha256 'af4e34b811c18f2e42f76764c33f835b63110f8a1d471156befcd500d062daab'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-73c1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-73c1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-73c1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-73c1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-aab6-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-aab6-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-aab6-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libadwaita-1.1.0-aab6-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '22ea80100a4e12c031c09f62abbf54341950fa80801f458676e7d0146f11be11',
-     armv7l: '22ea80100a4e12c031c09f62abbf54341950fa80801f458676e7d0146f11be11',
-       i686: '63712e4bb09455822116e346132b6b64ab660b212c48a600bb611025e1b3fc2d',
-     x86_64: 'daaa26d53f8c8b3e3f15724eaa16122e4b3358185342df7a66160c229caf4d0c'
+    aarch64: '50e69b5c70875b5d938f9d578fd786eed3ce1de4ca4ab0d788eac24dcf63788c',
+     armv7l: '50e69b5c70875b5d938f9d578fd786eed3ce1de4ca4ab0d788eac24dcf63788c',
+       i686: 'd68dd1fb68393dbeed3f7537a81d5812cc3cdff659dc74dfd07592a1cacad297',
+     x86_64: '94333fb7762274507f2b03424fc740ac68e67279a398fc1d948c796cabf9c275'
   })
 
   depends_on 'cairo'

--- a/packages/libcaca.rb
+++ b/packages/libcaca.rb
@@ -2,43 +2,50 @@ require 'package'
 
 class Libcaca < Package
   description 'libcaca is a graphics library that outputs text instead of pixels, so that it can work on older video cards or text terminals.'
-  homepage 'http://caca.zoy.org/wiki/libcaca'
-  version '0.99.beta19-1'
+  homepage 'https://github.com/cacalabs/libcaca'
+  version '0.99.beta20-e496'
   license 'GPL-2, ISC, LGPL-2.1 and WTFPL'
   compatibility 'all'
-  source_url 'http://caca.zoy.org/files/libcaca/libcaca-0.99.beta19.tar.gz'
-  source_sha256 '128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4'
+  source_url 'https://github.com/cacalabs/libcaca/archive/e4968ba6e93e9fd35429eb16895c785c51072015.zip'
+  source_sha256 'e44aa1a77d4345809d317063ca82e9247867dd9147069dd2fa0fe6db8411e395'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcaca-0.99.beta19-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcaca-0.99.beta19-1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcaca-0.99.beta19-1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcaca-0.99.beta19-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libcaca-0.99.beta20-e496-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libcaca-0.99.beta20-e496-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libcaca-0.99.beta20-e496-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libcaca-0.99.beta20-e496-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '72232772de316927a7222e5adca9809165f6aae02dcd2d82347bbb750eff0b62',
-     armv7l: '72232772de316927a7222e5adca9809165f6aae02dcd2d82347bbb750eff0b62',
-       i686: 'dbd6341f7dc376baf948c3e25c323bf923796c9bb79a846a4c8ddf0ff0be5f12',
-     x86_64: 'fc4454b4934dc0d5ac1b08402b3a73a53d8bfe0cb0da23a72ef46166465f5124',
+  binary_sha256({
+    aarch64: 'ab3310aa860fc7ec1f52300dbf2089052dbabda6ebcd991666e8000cad16658e',
+     armv7l: 'ab3310aa860fc7ec1f52300dbf2089052dbabda6ebcd991666e8000cad16658e',
+       i686: 'ba1650734ebfff4563b6e1a50ef58d8fa60ae5425f79127290e7af81a7b4a7d9',
+     x86_64: 'b108a838bc825089b20da633c9a759e42071eb6137ef1effb0f9297d9cbbf3c5'
   })
 
+  depends_on 'freeglut'
   depends_on 'imlib2'
+  depends_on 'jdk8' => :build
+  depends_on 'libglu'
   depends_on 'libx11'
-  depends_on 'ncurses'
-  depends_on 'slang'
+  depends_on 'mesa'
 
   def self.build
-    system "./configure \
-            --prefix=#{CREW_PREFIX} \
-            --libdir=#{CREW_LIB_PREFIX} \
-            --enable-ncurses \
-            --enable-slang \
-            --enable-x11 \
-            --with-x"
+    system '[ -x configure ] || ./bootstrap'
+    system "env CFLAGS='-flto=auto -fuse-ld=gold' \
+      CXXFLAGS='-pipe -flto=auto -fuse-ld=gold' \
+      LDFLAGS='-flto=auto'
+      ./configure \
+      #{CREW_OPTIONS} \
+      --enable-gl \
+      --enable-ncurses \
+      --enable-network \
+      --enable-slang \
+      --enable-x11"
+
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libgdiplus.rb
+++ b/packages/libgdiplus.rb
@@ -3,34 +3,37 @@ require 'package'
 class Libgdiplus < Package
   description 'The mono library that provides a GDI+-compatible API on non-windows operating systems.'
   homepage 'https://www.mono-project.com/docs/gui/libgdiplus/'
-  version '6.0.5-2'
+  version '6.0.5-3'
   license 'MIT'
   compatibility 'all'
   source_url 'https://download.mono-project.com/sources/libgdiplus/libgdiplus-6.0.5.tar.gz'
   source_sha256 'b81e4e5cc3e4831b2945de08bef26eb1bdcd795aeaf8f971b221c51213a025ef'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgdiplus-6.0.5-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgdiplus-6.0.5-2-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgdiplus-6.0.5-2-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgdiplus-6.0.5-2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libgdiplus-6.0.5-3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libgdiplus-6.0.5-3-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libgdiplus-6.0.5-3-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libgdiplus-6.0.5-3-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '1f6af1a888b6892619e1e75d4d81626e44e683e4bc416cbc2ecf67fd56395bb9',
-     armv7l: '1f6af1a888b6892619e1e75d4d81626e44e683e4bc416cbc2ecf67fd56395bb9',
-       i686: 'f82da1a7932e0f10234c60662f9f1cbbd6d47d35015bdd32c1394f782faa59cf',
-     x86_64: 'f36f2f2729d1184131c855de987d432fed17a8c848f044768c4b20a9fb35267e'
+    aarch64: 'b8567295afed609d49bed5ecf8ccd9b363cfdb453afc1028ee8afd3a00e348b7',
+     armv7l: 'b8567295afed609d49bed5ecf8ccd9b363cfdb453afc1028ee8afd3a00e348b7',
+       i686: '889b8b69cb691d00f5b506d3f2770cb172c9a1ad8ddc0441a82d3d77e971fa79',
+     x86_64: '9c4f2e47dc4f95c88a188838cef7a5424fd272177d8eb4a7d32dfbeb212fc0b6'
   })
 
-  depends_on 'glib'
   depends_on 'cairo'
-  depends_on 'graphite'
-  depends_on 'libexif'
-  depends_on 'libtiff'
-  depends_on 'libpng'
-  depends_on 'libwebp'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
   depends_on 'giflib'
+  depends_on 'glib'
+  depends_on 'graphite'
   depends_on 'imake' => :build
+  depends_on 'libexif'
+  depends_on 'libjpeg'
+  depends_on 'libpng'
+  depends_on 'libtiff'
+  depends_on 'libwebp'
 
   def self.build
     system "CFLAGS='-flto=auto' CXXFLAGS='-flto=auto'

--- a/packages/libglade.rb
+++ b/packages/libglade.rb
@@ -3,32 +3,39 @@ require 'package'
 class Libglade < Package
   description 'Libglade is a library that performs a similar job to the C source output routines in the GLADE user interface builder.'
   homepage 'http://www.jamesh.id.au/software/libglade/'
-  version '2.6.4'
+  version '2.6.4-1'
   license 'LGPL-2'
   compatibility 'all'
   source_url 'https://ftp.gnome.org/pub/GNOME/sources/libglade/2.6/libglade-2.6.4.tar.bz2'
   source_sha256 '64361e7647839d36ed8336d992fd210d3e8139882269bed47dc4674980165dec'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libglade-2.6.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libglade-2.6.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libglade-2.6.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libglade-2.6.4-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libglade-2.6.4-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libglade-2.6.4-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libglade-2.6.4-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libglade-2.6.4-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '9f211b42969c6d791e8d61f13aad15251e3991c0270c251810eda6c5fbdb550e',
-     armv7l: '9f211b42969c6d791e8d61f13aad15251e3991c0270c251810eda6c5fbdb550e',
-       i686: '13920b24507ee60dc5f4c8501dd89305a05797b030afe25af6d3771595b83e56',
-     x86_64: '2749ac0d67edb91b1f59355fba8dd045c8dbc44ede3fc619304853b2ac4799cf',
+  binary_sha256({
+    aarch64: 'b4cad18d6fb3ed0a1594c387ceb3f2d635b82f4ec157d2e07c0d8a8a7cacd15f',
+     armv7l: 'b4cad18d6fb3ed0a1594c387ceb3f2d635b82f4ec157d2e07c0d8a8a7cacd15f',
+       i686: '85bbd35f8c0878bb2ef0fba71305b94d1c8d74dcc221f548372b72e39df0c9e6',
+     x86_64: 'a950a82a9b670902efd4418b9947ef47764520811fd65d2623ddc8416d818f05'
   })
 
+  depends_on 'atk'
+  depends_on 'cairo'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
   depends_on 'gtk2'
   depends_on 'gtk3'
+  depends_on 'pango'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    # flto breaks compile
+    system "./configure \
+      #{CREW_OPTIONS}"
     system 'make'
   end
 
@@ -37,6 +44,6 @@ class Libglade < Package
   end
 
   def self.check
-    #system 'make', 'check'
+    # system 'make', 'check'
   end
 end

--- a/packages/libhandy.rb
+++ b/packages/libhandy.rb
@@ -4,25 +4,33 @@ class Libhandy < Package
   description 'The aim of the handy library is to help with developing UI for mobile devices using GTK/GNOME.'
   homepage 'https://gitlab.gnome.org/GNOME/libhandy/'
   @_ver = '1.2.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/libhandy/-/archive/#{@_ver}/libhandy-#{@_ver}.tar.bz2"
   source_sha256 'b2e08210a6b0c6b08e6c46848024cbcf44973e40377a1373d7cbb0bde7131b56'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy-1.2.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy-1.2.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy-1.2.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy-1.2.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy-1.2.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy-1.2.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy-1.2.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libhandy-1.2.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '402449264e9ba6e35d2346fb0f3b5999c404281d73d60dfb4aa953c8e017b93b',
-     armv7l: '402449264e9ba6e35d2346fb0f3b5999c404281d73d60dfb4aa953c8e017b93b',
-       i686: '599fbe3faa80ca1ac1666bb49576624c5d667b56582df727a73613d29d0537ff',
-     x86_64: 'a611807332097568b87cf04af35042940c505e693e5b6970969b93634fd7db0f'
+    aarch64: '3bd22e6101caa76c8f89fc4ef8aeb046e85c7969b42003f1835e81c13df7180d',
+     armv7l: '3bd22e6101caa76c8f89fc4ef8aeb046e85c7969b42003f1835e81c13df7180d',
+       i686: 'f1e76dc3fdc785113360060a6813c971008a3961667abef92bed7a27fc386e1d',
+     x86_64: '3519270c70aec8aedfd6afbd9f286920f148d6377a8e30512c020ff166959684'
   })
 
+  depends_on 'atk'
+  depends_on 'cairo'
+  depends_on 'fribidi'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'gtk3'
+  depends_on 'libjpeg'
+  depends_on 'pango'
   depends_on 'vala'
 
   def self.prebuild

--- a/packages/libjpeg.rb
+++ b/packages/libjpeg.rb
@@ -3,31 +3,35 @@ require 'package'
 class Libjpeg < Package
   description 'JPEG is a free library for image compression.'
   homepage 'https://www.ijg.org/'
-  version '9.0-d'
+  version '9.0-d-1'
   license 'custom' # Very similar to the BSD license
   compatibility 'all'
   source_url 'https://www.ijg.org/files/jpegsrc.v9d.tar.gz'
-  source_sha256 '99cb50e48a4556bc571dadd27931955ff458aae32f68c4d9c39d624693f69c32'
+  source_sha256 '6c434a3be59f8f62425b2e3c077e785c9ce30ee5874ea1c270e843f273ba71ee'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libjpeg-9.0-d-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '1d0248976ed26493bf18231df01cb42eff81792440cf6cb517679b609804a44e',
-     armv7l: '1d0248976ed26493bf18231df01cb42eff81792440cf6cb517679b609804a44e',
-       i686: '3291fe256b305b2ee3de0fe8d4c455012ba92545ef3bfd155c25d5d86b8977c4',
-     x86_64: '6c166e006cbb47be453f41f1e6e6d452df0a6b0b8f3675e29d290f20bfdcf3ef',
+  binary_sha256({
+    aarch64: '2907c8f5bf31c2242647eb42838ab60c3ffada2d8c34fa9a71c5939f8538108a',
+     armv7l: '2907c8f5bf31c2242647eb42838ab60c3ffada2d8c34fa9a71c5939f8538108a',
+       i686: '9c56d093f018a496edb8db4a797b3aa54cbe1fb86692dc6d942aa605e699bc5c',
+     x86_64: 'a21d5cc6bba91a06584ad2d4646a0aa96ef5b50ab33ed888f02513946c8e143f'
   })
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system '[ -x configure ] || ./bootstrap.py'
+    system "env CFLAGS='-flto=auto -fuse-ld=gold' \
+      CXXFLAGS='-pipe -flto=auto -fuse-ld=gold' \
+      LDFLAGS='-flto=auto' \
+      ./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libmypaint.rb
+++ b/packages/libmypaint.rb
@@ -3,46 +3,48 @@ require 'package'
 class Libmypaint < Package
   description 'Libmypaint is MyPaint\'s brushstroke rendering code, in a form that can be used by other programs.'
   homepage 'http://mypaint.org/'
-  version '1.3.0'
+  version '1.6.1'
   license 'ISC'
   compatibility 'all'
-  source_url 'https://github.com/mypaint/libmypaint/releases/download/v1.3.0/libmypaint-1.3.0.tar.xz'
-  source_sha256 '6a07d9d57fea60f68d218a953ce91b168975a003db24de6ac01ad69dcc94a671'
+  source_url 'https://github.com/mypaint/libmypaint/releases/download/v1.6.1/libmypaint-1.6.1.tar.xz'
+  source_sha256 '741754f293f6b7668f941506da07cd7725629a793108bb31633fb6c3eae5315f'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libmypaint-1.3.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libmypaint-1.3.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libmypaint-1.3.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libmypaint-1.3.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libmypaint-1.6.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libmypaint-1.6.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libmypaint-1.6.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libmypaint-1.6.1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '29ba70ec439d8b183f2986bb9e876da62efa9f7b82341965b94e0bcec684708a',
-     armv7l: '29ba70ec439d8b183f2986bb9e876da62efa9f7b82341965b94e0bcec684708a',
-       i686: 'aed779ae7fe6f2ed39d5001d11a805fb9bcd7c555881cec7d66a6c3b3a350474',
-     x86_64: '40f0a303a68f4ff29f5754440a41e24ea48de87a410a2aedb9f84925094fe24e',
+  binary_sha256({
+    aarch64: 'd4771b0d30a84a37170863f83158f18c3ba5d2cbe49d8ba40f07bf4b9dd9193b',
+     armv7l: 'd4771b0d30a84a37170863f83158f18c3ba5d2cbe49d8ba40f07bf4b9dd9193b',
+       i686: '2073f128ff52c6e7ea2f0a1499eaffc779ff7fee82a15cdbcf20cfd8c79a3fad',
+     x86_64: 'c9e0ec9d662a735f5e4373c5222ac37931bbd21e15314e80af0b14f1cdabe8c2'
   })
 
   depends_on 'gegl'
   depends_on 'jsonc'
 
   def self.build
-    system "sed -i 's,gegl-0.3,gegl-0.4,' gegl/Makefile.am"
-    system "sed -i 's,Gegl-0.3,Gegl-0.4,' gegl/Makefile.am"
-    system "sed -i 's,gegl-0.3,gegl-0.4,' gegl/Makefile.in"
-    system "sed -i 's,Gegl-0.3,Gegl-0.4,' gegl/Makefile.in"
-    system "GEGL_LIBS=\"#{CREW_LIB_PREFIX}/gegl-0.4\" \
-           GEGL_CFLAGS=\"-I#{CREW_PREFIX}/include/gegl-0.4 \
-           -I#{CREW_PREFIX}/include/babl-0.1 \
-           -I#{CREW_PREFIX}/include/glib-2.0\" \
-           ./configure \
-           --prefix=#{CREW_PREFIX} \
-           --libdir=#{CREW_LIB_PREFIX} \
-           --disable-maintainer-mode \
-           --enable-openmp \
-           --enable-gegl"
+    # system "sed -i 's,gegl-0.3,gegl-0.4,' gegl/Makefile.am"
+    # system "sed -i 's,Gegl-0.3,Gegl-0.4,' gegl/Makefile.am"
+    # system "sed -i 's,gegl-0.3,gegl-0.4,' gegl/Makefile.in"
+    # system "sed -i 's,Gegl-0.3,Gegl-0.4,' gegl/Makefile.in"
+    system "env CFLAGS='-pipe -flto=auto' \
+      CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      GEGL_LIBS=\"#{CREW_LIB_PREFIX}/gegl-0.4\" \
+      GEGL_CFLAGS=\"-I#{CREW_PREFIX}/include/gegl-0.4 \
+      -I#{CREW_PREFIX}/include/babl-0.1 \
+      -I#{CREW_PREFIX}/include/glib-2.0\" \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --disable-maintainer-mode \
+      --enable-openmp \
+      --enable-gegl"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libmypaint.rb
+++ b/packages/libmypaint.rb
@@ -26,10 +26,6 @@ class Libmypaint < Package
   depends_on 'jsonc'
 
   def self.build
-    # system "sed -i 's,gegl-0.3,gegl-0.4,' gegl/Makefile.am"
-    # system "sed -i 's,Gegl-0.3,Gegl-0.4,' gegl/Makefile.am"
-    # system "sed -i 's,gegl-0.3,gegl-0.4,' gegl/Makefile.in"
-    # system "sed -i 's,Gegl-0.3,Gegl-0.4,' gegl/Makefile.in"
     system "env CFLAGS='-pipe -flto=auto' \
       CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -3,42 +3,49 @@ require 'package'
 class Librsvg < Package
   description 'SVG library for GNOME'
   homepage 'https://wiki.gnome.org/Projects/LibRsvg'
-  version '2.50.3'
+  version '2.50.3-1'
   license 'LGPL-2+'
   compatibility 'all'
   source_url 'https://download.gnome.org/sources/librsvg/2.50/librsvg-2.50.3.tar.xz'
   source_sha256 'a4298a98e3a95fdd73c858c17d4dd018525fb09dbb13bbd668a0c2243989e958'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/librsvg-2.50.3-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '308cf9f89ed04934bf1e1c7e492b51bf57d5adbb023d4830e4fb2122d8fd796d',
-     armv7l: '308cf9f89ed04934bf1e1c7e492b51bf57d5adbb023d4830e4fb2122d8fd796d',
-       i686: '7b4b1fa2ec312b13267b7b1100e65f5e5da783c7dd2f973deb09382005b35c1f',
-     x86_64: '3879b9088e910dc7bd3fa2499ac247a20edbcbd8f90dd76f4975c7993f8b49cd'
+    aarch64: '40d0ff493b29670a4375a7fc35c236cdc44c249a6658bbc49ea54a435868d729',
+     armv7l: '40d0ff493b29670a4375a7fc35c236cdc44c249a6658bbc49ea54a435868d729',
+       i686: 'c3f61459db1d6007d9a17537ec9297967b176e7cca3ddb711113253bf731b24f',
+     x86_64: 'dccf2e623cfb6da4c6995a3b0ad0fe8563a0126ed1e6fd4ecd8764ce15101245'
   })
 
   depends_on 'cairo'
-  depends_on 'gobject_introspection'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
   depends_on 'freetype_sub'
   depends_on 'fribidi'
   depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'gobject_introspection'
+  depends_on 'harfbuzz'
   depends_on 'libcroco'
+  depends_on 'libjpeg'
+  depends_on 'libpng'
   depends_on 'pango'
   depends_on 'rust' => :build
-  depends_on 'glib'
-  depends_on 'vala' => :build
   depends_on 'six' => :build
+  depends_on 'vala' => :build
 
   def self.build
     # Following rustup modification as per https://github.com/rust-lang/rustup/issues/1167#issuecomment-367061388
     system 'rustup install stable --profile minimal || (rm -frv ~/.rustup/toolchains/* && rustup install stable --profile minimal)'
     system 'rustup default stable'
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+    system "env CFLAGS='-pipe -flto=auto' \
+      CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto' \
       ./configure \
       --prefix=#{CREW_PREFIX} \
       --libdir=#{CREW_LIB_PREFIX} \

--- a/packages/libtiff.rb
+++ b/packages/libtiff.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libtiff < Package
   description 'LibTIFF provides support for the Tag Image File Format (TIFF), a widely used format for storing image data.'
   homepage 'http://www.libtiff.org/'
-  version '4.2.0'
+  version '4.2.0-1'
   license 'libtiff'
   compatibility 'all'
   source_url 'https://download.osgeo.org/libtiff/tiff-4.2.0.tar.gz'
   source_sha256 'eb0484e568ead8fa23b513e9b0041df7e327f4ee2d22db5a533929dfc19633cb'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libtiff-4.2.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libtiff-4.2.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libtiff-4.2.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libtiff-4.2.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libtiff-4.2.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libtiff-4.2.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libtiff-4.2.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libtiff-4.2.0-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '5b348ee73ff84faf3b7a6fa30f1fa36f735090aed8a96221730c001368969fba',
-     armv7l: '5b348ee73ff84faf3b7a6fa30f1fa36f735090aed8a96221730c001368969fba',
-       i686: '13480016d525f79282ef1b7305e851b5d843592e5aa95292a1125a5aae2fac0e',
-     x86_64: 'ac6dd7686f42a8a263b9eae152626f95dfcc5b788d9e61a93685820af3fa92af',
+  binary_sha256({
+    aarch64: 'a0cbdf73940274a9f34ac362e989226ad7ddbef2b6a43fdbdbd05f81eb948a3a',
+     armv7l: 'a0cbdf73940274a9f34ac362e989226ad7ddbef2b6a43fdbdbd05f81eb948a3a',
+       i686: '2cfebbbe502beb99cf0dd12ee49efa99cca1ef90420103f39b873828fd1b43f6',
+     x86_64: '3a30356473a84f4c024c3dc399487782c6f585896a18c641b866ecad6cf528a8'
   })
 
   depends_on 'libx11'
@@ -29,18 +29,21 @@ class Libtiff < Package
   depends_on 'imake' => :build
 
   def self.build
-    system "env NOCONFIGURE=1 ./autogen.sh"
-    system "./configure #{CREW_OPTIONS} \
-            --with-x \
-            --enable-zlib \
-            --enable-mdi \
-            --enable-libdeflate \
-            --enable-pixarlog \
-            --enable-jpeg \
-            --enable-lzma \
-            --enable-zstd \
-            --enable-webp \
-            --enable-cxx"
+    system 'env NOCONFIGURE=1 ./autogen.sh'
+    system "env CFLAGS='-flto=auto -fuse-ld=gold' \
+      CXXFLAGS='-pipe -flto=auto -fuse-ld=gold' \
+      LDFLAGS='-flto=auto' \
+      ./configure #{CREW_OPTIONS} \
+      --with-x \
+      --enable-zlib \
+      --enable-mdi \
+      --enable-libdeflate \
+      --enable-pixarlog \
+      --enable-jpeg \
+      --enable-lzma \
+      --enable-zstd \
+      --enable-webp \
+      --enable-cxx"
     system 'make'
   end
 

--- a/packages/libwmf.rb
+++ b/packages/libwmf.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libwmf < Package
   description 'libwmf is a library for reading vector images in Microsoft\'s native Windows Metafile Format (WMF)'
   homepage 'https://github.com/caolanm/libwmf'
-  version '0.2.12-ffc8'
+  version '0.2.12-483e'
   license 'LGPL-2'
   compatibility 'all'
-  source_url 'https://github.com/caolanm/libwmf/archive/ffc8f5aaf9ac33d5d2fe67e777c018e057fdfd71.zip'
-  source_sha256 'cdde9db1a0bc22a529f55aa60c2c7b85d1adb1e16e15b1d0b8906c04667b851a'
+  source_url 'https://github.com/caolanm/libwmf/archive/483ee1e8d4ee11690f3459d4b4d527f69af7b9c9.zip'
+  source_sha256 'ec31cc81ee41ab28acef686b875b7692f6a5286710d6fd58429d914f78c73847'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libwmf-0.2.12-ffc8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libwmf-0.2.12-ffc8-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libwmf-0.2.12-ffc8-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libwmf-0.2.12-ffc8-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libwmf-0.2.12-483e-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libwmf-0.2.12-483e-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libwmf-0.2.12-483e-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libwmf-0.2.12-483e-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'e8d5f598473faae411a33090c9275ef725e90a8011cc0c30cc81e5aff694b7e0',
-     armv7l: 'e8d5f598473faae411a33090c9275ef725e90a8011cc0c30cc81e5aff694b7e0',
-       i686: '54e66e41849070b245879b1d30ab2ca3382a113e13715d9b20a1adf7b7f14ded',
-     x86_64: '4f23adf6e1093f7cb21f3d651f393df955ad06a6bf6c78937394dbf4da153677'
+    aarch64: '6313c27b04e538ce75b749049658d7ad0f85df880a24f49f232e1846a32535b2',
+     armv7l: '6313c27b04e538ce75b749049658d7ad0f85df880a24f49f232e1846a32535b2',
+       i686: 'dffff92d3d43cd2925d2cb7bef79cdf8454d00b5a381521d7cab12a75b3f827e',
+     x86_64: 'a870df8f42498dc2a8a07c359ff453add7623bf6dd49633ba69f12e9fe8bd5d4'
   })
 
   depends_on 'gtk2'

--- a/packages/mjpegtools.rb
+++ b/packages/mjpegtools.rb
@@ -3,33 +3,37 @@ require 'package'
 class Mjpegtools < Package
   description 'Video capture, editing, playback, and compression to MPEG of MJPEG video'
   homepage 'https://mjpeg.sourceforge.io/'
-  @_ver = '2.2.0_beta'
+  @_ver = '2.2.0'
   version @_ver
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://downloads.sourceforge.net/sourceforge/mjpeg/mjpegtools-#{@_ver}.tar.gz"
-  source_sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  source_url 'https://sourceforge.net/projects/mjpeg/files/mjpegtools/2.2.0/mjpegtools-2.2.0.tar.bz2'
+  source_sha256 'a84349839471052db1ef691134aacf905b314dfce8762d47e10edcc9ab5f97d8'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mjpegtools-2.2.0_beta-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mjpegtools-2.2.0_beta-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mjpegtools-2.2.0_beta-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mjpegtools-2.2.0_beta-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mjpegtools-2.2.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mjpegtools-2.2.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mjpegtools-2.2.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mjpegtools-2.2.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'd97cffd7dd29d8d71ed830a6f4d61ce858f0c7b0b17574a0019442b02f5eb546',
-     armv7l: 'd97cffd7dd29d8d71ed830a6f4d61ce858f0c7b0b17574a0019442b02f5eb546',
-       i686: '7d9b5522639efcc53d86577c1fb9c0e06ec93054ed207be571abaad1f0ed01db',
-     x86_64: 'efefd2df7479bb6e96832e934a66071120c0320e18a78b192f8bcd3303ec0867'
+    aarch64: '50bef51c33555ed239c35fe88ce52e025cbefc7bc3ce80158b186bb4d348f746',
+     armv7l: '50bef51c33555ed239c35fe88ce52e025cbefc7bc3ce80158b186bb4d348f746',
+       i686: '62337fe4925af757764dac019076a22120377c808d9081fd3d1713192c092da3',
+     x86_64: 'f046724650de108d5ed9f7f000953de6bd13425d5e1b5be6785817672c190f3f'
   })
 
+  depends_on 'libdv'
   depends_on 'libjpeg'
   depends_on 'libpng'
-  depends_on 'libdv'
+  depends_on 'libsdl'
   depends_on 'libsdl2'
+  depends_on 'libx11'
   depends_on 'v4l_utils' => :build
 
   def self.build
+    system 'ls -aFl'
+    system '[ -x configure ] || ./autogen.sh'
     system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto'  LDFLAGS='-flto=auto' \
       ./configure #{CREW_OPTIONS}"
     system 'make'

--- a/packages/mpv.rb
+++ b/packages/mpv.rb
@@ -18,12 +18,12 @@ class Mpv < Package
   binary_sha256({
     aarch64: '834b7660f6c44bc5a52236828f6451e03da7f80ce7dcaef84aa5bf539209a0fb',
      armv7l: '834b7660f6c44bc5a52236828f6451e03da7f80ce7dcaef84aa5bf539209a0fb',
-       i686: 'e0bdd8907d0f3673397adcc6d042e878510a6657e347fcc4c30db9bdf40af33d',
-     x86_64: 'ae78493b16e21e2c9b8ac6ff794a4a89305f9f3686392961b4277bcd5175d109'
+       i686: '366454030a9d1f348b093aa796bfebff802dbc7cf3ec5b31f6d92c415bda7a37',
+     x86_64: 'c025f912ee5e3596fcf5009386ce75690b7b19544a798811bb276a4458c557df'
   })
 
   depends_on 'alsa_lib'
-  depends_on 'docutils'
+  depends_on 'docutils' => :build
   depends_on 'ffmpeg'
   depends_on 'jack'
   depends_on 'lcms'
@@ -37,7 +37,6 @@ class Mpv < Package
   depends_on 'libdvdnav'
   depends_on 'libdvdread'
   depends_on 'libjpeg'
-  depends_on 'libjpeg_turbo'
   depends_on 'libva'
   depends_on 'libvdpau'
   depends_on 'libx11'
@@ -54,12 +53,12 @@ class Mpv < Package
   depends_on 'pulseaudio'
   depends_on 'rubberband'
   depends_on 'shaderc'
-  depends_on 'sommelier'
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader'
   depends_on 'wayland'
   depends_on 'xdg_base'
   depends_on 'zimg'
+  depends_on 'sommelier'
 
   def self.build
     system 'pip install docutils'

--- a/packages/mpv.rb
+++ b/packages/mpv.rb
@@ -61,7 +61,6 @@ class Mpv < Package
   depends_on 'sommelier'
 
   def self.build
-    system 'pip install docutils'
     system './bootstrap.py'
     system "env CFLAGS='-flto=auto -fuse-ld=gold' \
       CXXFLAGS='-pipe -flto=auto -fuse-ld=gold' \
@@ -81,7 +80,6 @@ class Mpv < Package
   def self.install
     FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     system './waf', "--destdir=#{CREW_DEST_DIR}", 'install'
-    system 'pip uninstall -y docutils'
   end
 
   def self.postinstall

--- a/packages/mpv.rb
+++ b/packages/mpv.rb
@@ -3,64 +3,93 @@ require 'package'
 class Mpv < Package
   description 'Video player based on MPlayer/mplayer2'
   homepage 'https://mpv.io/'
-  version '0.32.0'
+  version '0.33.0'
   license 'LGPL-2.1+, GPL-2+, BSD, ISC and GPL-3+'
   compatibility 'all'
-  source_url 'https://github.com/mpv-player/mpv/archive/v0.32.0.tar.gz'
-  source_sha256 '9163f64832226d22e24bbc4874ebd6ac02372cd717bef15c28a0aa858c5fe592'
+  source_url "https://github.com/mpv-player/mpv/archive/v#{version}.tar.gz"
+  source_sha256 'f1b9baf5dc2eeaf376597c28a6281facf6ed98ff3d567e3955c95bf2459520b4'
 
-  binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.32.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.32.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.32.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.32.0-chromeos-x86_64.tar.xz',
-
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.33.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.33.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.33.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mpv-0.33.0-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: 'ae9f812ccb3239ca85d25a6e919e1ded6e459867ba00d2027ea832782a38f9f1',
-     armv7l: 'ae9f812ccb3239ca85d25a6e919e1ded6e459867ba00d2027ea832782a38f9f1',
-       i686: '41f96ce28132e2d60978c3e7450594b58b03fda67edbb8fa2e56ce6442d3d1ee',
-     x86_64: 'e9623b3fdd06ab5bb762a15a3d7ef9b7875a10d4f0a5baaed5f83b9250b9fbe4',
-
+  binary_sha256({
+    aarch64: '834b7660f6c44bc5a52236828f6451e03da7f80ce7dcaef84aa5bf539209a0fb',
+     armv7l: '834b7660f6c44bc5a52236828f6451e03da7f80ce7dcaef84aa5bf539209a0fb',
+       i686: 'e0bdd8907d0f3673397adcc6d042e878510a6657e347fcc4c30db9bdf40af33d',
+     x86_64: 'ae78493b16e21e2c9b8ac6ff794a4a89305f9f3686392961b4277bcd5175d109'
   })
 
-  depends_on 'ld_default' => :build
+  depends_on 'alsa_lib'
   depends_on 'docutils'
   depends_on 'ffmpeg'
-  depends_on 'gdbm'
+  depends_on 'jack'
   depends_on 'lcms'
   depends_on 'libarchive'
+  depends_on 'libass'
+  depends_on 'libbluray'
   depends_on 'libcaca'
   depends_on 'libcdio'
+  depends_on 'libcdio_paranoia'
+  depends_on 'libdrm'
+  depends_on 'libdvdnav'
+  depends_on 'libdvdread'
+  depends_on 'libjpeg'
+  depends_on 'libjpeg_turbo'
+  depends_on 'libva'
+  depends_on 'libvdpau'
+  depends_on 'libx11'
+  depends_on 'libxext'
+  depends_on 'libxinerama'
+  depends_on 'libxkbcommon'
+  depends_on 'libxrandr'
+  depends_on 'libxss'
   depends_on 'libxv'
   depends_on 'luajit'
+  depends_on 'mesa'
+  depends_on 'mujs'
+  depends_on 'pipewire'
   depends_on 'pulseaudio'
-  depends_on 'uchardet'
-  depends_on 'xdg_base'
+  depends_on 'rubberband'
+  depends_on 'shaderc'
   depends_on 'sommelier'
+  depends_on 'vulkan_headers' => :build
+  depends_on 'vulkan_icd_loader'
+  depends_on 'wayland'
+  depends_on 'xdg_base'
+  depends_on 'zimg'
 
   def self.build
-    # Use the gold linker.
-    old_ld = `ld_default g`.chomp
-    system 'pip3 install docutils'
+    system 'pip install docutils'
     system './bootstrap.py'
-    system './waf',
-           'configure',
-           '--enable-libmpv-shared',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system "env CFLAGS='-flto=auto -fuse-ld=gold' \
+      CXXFLAGS='-pipe -flto=auto -fuse-ld=gold' \
+      LDFLAGS='-flto=auto' \
+      ./waf \
+      configure \
+      #{CREW_OPTIONS.sub(/--build=.*/, '')} \
+      --confdir=#{CREW_PREFIX}/etc/mpv \
+      --enable-cdda \
+      --enable-dvdnav \
+      --enable-gl-x11 \
+      --enable-libarchive \
+      --enable-libmpv-shared"
     system './waf'
-    # Restore the original linker.
-    system 'ld_default', "#{old_ld}"
   end
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_HOME}/.config"
-    system "touch #{CREW_DEST_HOME}/.config/mpv"
-    FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}"
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     system './waf', "--destdir=#{CREW_DEST_DIR}", 'install'
-    # Fix for mpv: error while loading shared libraries: libgdbm.so.4: cannot open shared object file: No such file or directory
-    system "ln -sf #{CREW_LIB_PREFIX}/libgdbm.so.6 #{CREW_DEST_LIB_PREFIX}/libgdbm.so.4"
-    system 'pip3 uninstall -y docutils'
+    system 'pip uninstall -y docutils'
+  end
+
+  def self.postinstall
+    # Use XDG_CONFIG_HOME location for config file stub
+    FileUtils.mkdir_p "#{CREW_PREFIX}/.config"
+    system "touch #{CREW_PREFIX}/.config/mpv"
+    system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/* || true"
+    system "#{CREW_PREFIX}/bin/gtk4-update-icon-cache -ft #{CREW_PREFIX}/share/icons/* || true"
   end
 end

--- a/packages/mujs.rb
+++ b/packages/mujs.rb
@@ -1,0 +1,41 @@
+# Adapted from Arch Linux mujs PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/mujs/trunk/PKGBUILD
+
+require 'package'
+
+class Mujs < Package
+  description 'An embeddable Javascript interpreter in C'
+  homepage 'https://mujs.com/'
+  version '1.1.0'
+  license 'ISC'
+  compatibility 'all'
+  source_url "https://github.com/ccxvii/mujs/archive/refs/tags/#{version}.tar.gz"
+  source_sha256 '8e43a38fdea75f036a9f3213e346a6c304206b4e3d00886564fb6bf70c1c2807'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mujs-1.1.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mujs-1.1.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mujs-1.1.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mujs-1.1.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '6e35d13ccbbf048b85406b5edf5a9ff1965359bcace8a7c53ca9a293691bc09c',
+     armv7l: '6e35d13ccbbf048b85406b5edf5a9ff1965359bcace8a7c53ca9a293691bc09c',
+       i686: '164594e24f4fe2cf051593ab8d8f1d540c0ed3b2322b8a29ce223fec56837b8a',
+     x86_64: '016d3bcc9608929db4bcb55b7449151200557c4407187a1f6cd806cfdd8a42ad'
+  })
+
+  def self.build
+    system "env XCFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      XCPPFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      make prefix=release shared"
+  end
+
+  def self.install
+    system "make \
+      DESTDIR=#{CREW_DEST_DIR} \
+      prefix=#{CREW_PREFIX} \
+      libdir=#{CREW_LIB_PREFIX} \
+      install-shared"
+  end
+end

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -7,23 +7,23 @@ class Nautilus < Package
   description 'Default file manager for GNOME'
   homepage 'https://wiki.gnome.org/Apps/Files'
   @_ver = '40.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPLv3'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/nautilus/-/archive/#{@_ver}/nautilus-#{@_ver}.tar.bz2"
   source_sha256 '9bcb93c5ce56dbe1cd2b2d0808c21a5e37cc1d098ee037b7da75c0a4a59e84e7'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nautilus-40.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nautilus-40.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nautilus-40.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nautilus-40.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/nautilus-40.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/nautilus-40.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/nautilus-40.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/nautilus-40.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '7343e4245acf8b1bce3c8ad9208a6d3981edc0bb7997071758c7223399334c65',
-     armv7l: '7343e4245acf8b1bce3c8ad9208a6d3981edc0bb7997071758c7223399334c65',
-       i686: '286c26c5c8b89a8a52ff7ee8f55b516207447471868b311cf8c206722555158b',
-     x86_64: 'bae97c6259459844e5cf945160e162734edbc66ce50eb3965e1c55b9932a6564'
+    aarch64: '98663fed405335be9b9e297f641bd7e14edc631f43702e17a6477ba5b43368b3',
+     armv7l: '98663fed405335be9b9e297f641bd7e14edc631f43702e17a6477ba5b43368b3',
+       i686: '41b42d30a12e0e6597d994e8d159828ba68861b8336e46f2288451de08dc2948',
+     x86_64: '8258f00664df5ff4b17bed2422e50fadf22a76222ce635b6cae6060cbac293b9'
   })
 
   depends_on 'appstream_glib' => :build
@@ -75,7 +75,7 @@ class Nautilus < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
-  
+
   def self.postinstall
     system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas/"
     FileUtils.touch "#{HOME}/.gtk-bookmarks"

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -23,7 +23,7 @@ class Nautilus < Package
     aarch64: '98663fed405335be9b9e297f641bd7e14edc631f43702e17a6477ba5b43368b3',
      armv7l: '98663fed405335be9b9e297f641bd7e14edc631f43702e17a6477ba5b43368b3',
        i686: '41b42d30a12e0e6597d994e8d159828ba68861b8336e46f2288451de08dc2948',
-     x86_64: '8258f00664df5ff4b17bed2422e50fadf22a76222ce635b6cae6060cbac293b9'
+     x86_64: 'b3412b0b281875a9cd1a9433e25e345246351f9a2eedc2e91e55f4cb4259a40c'
   })
 
   depends_on 'appstream_glib' => :build
@@ -42,6 +42,7 @@ class Nautilus < Package
   depends_on 'gtk_doc' => :build
   depends_on 'gvfs'
   depends_on 'libhandy'
+  depends_on 'libjpeg'
   depends_on 'libportal'
   depends_on 'pango'
   depends_on 'tracker3'

--- a/packages/poppler.rb
+++ b/packages/poppler.rb
@@ -4,35 +4,41 @@ class Poppler < Package
   description 'Poppler is a PDF rendering library based on the xpdf-3.0 code base.'
   homepage 'https://poppler.freedesktop.org/'
   @_ver = '21.03.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPL-2'
   compatibility 'all'
   source_url "https://poppler.freedesktop.org/poppler-#{@_ver}.tar.xz"
   source_sha256 'fd51ead4aac1d2f4684fa6e7b0ec06f0233ed21667e720a4e817e4455dd63d27'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/poppler-21.03.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'a4cb106683c7b8d289553fe9073201329619519f30ecc623dc6d08dbfd4eccb7',
-     armv7l: 'a4cb106683c7b8d289553fe9073201329619519f30ecc623dc6d08dbfd4eccb7',
-       i686: '54adf5a92963371ef36fbfa9078554b8539877bb036569d4f1b5d8627f7d2ddb',
-     x86_64: '4133f3f21f6ed0a9d6530dbe4d4d5467984958479e69f56061c25e2ff42fb4dc'
+    aarch64: '97b54286c9ff1d7c041ea465e586f797a3bf3e426ce16fc39b753feef2380161',
+     armv7l: '97b54286c9ff1d7c041ea465e586f797a3bf3e426ce16fc39b753feef2380161',
+       i686: 'b2bee26bfa243a2eb3290b9784b619215b0d46e0edf802a0088a96944ef6caa1',
+     x86_64: 'b1be0800a8af1881d28ad9c4f7f6ccabf351155d39787717da5a834f3aec59e8'
   })
 
   depends_on 'boost'
   depends_on 'cairo'
+  depends_on 'fontconfig'
   depends_on 'freeglut'
+  depends_on 'freetype'
+  depends_on 'glib'
   depends_on 'harfbuzz'
   depends_on 'lcms'
   depends_on 'libjpeg'
   depends_on 'libpng'
   depends_on 'libtiff'
+  depends_on 'nspr'
+  depends_on 'nss'
   depends_on 'openjpeg'
   depends_on 'poppler_data'
+  depends_on 'qtbase'
   depends_on 'qttools'
 
   def self.build

--- a/packages/shaderc.rb
+++ b/packages/shaderc.rb
@@ -24,10 +24,9 @@ class Shaderc < Package
      x86_64: '9e32e0db031138d5ead88e9e6a99f1a14d1d07e6c89999f0d336d105462b1306'
   })
 
-  @asciidoctor_installed = `gem list | grep ^asciidoctor`
+  depends_on 'asciidoctor' => :build
 
   def self.build
-    system 'gem install -N asciidoctor' unless @asciidoctor_installed.to_s != ''
     system './utils/git-sync-deps'
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
@@ -50,6 +49,5 @@ class Shaderc < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-    system 'gem uninstall asciidoctor -x --force' unless @asciidoctor_installed.to_s != ''
   end
 end

--- a/packages/shaderc.rb
+++ b/packages/shaderc.rb
@@ -1,0 +1,55 @@
+# Adapted from Arch Linux shaderc PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/shaderc/trunk/PKGBUILD
+
+require 'package'
+
+class Shaderc < Package
+  description 'Collection of tools, libraries and tests for shader compilation'
+  version '2020.5'
+  license 'Apache'
+  compatibility 'all'
+  source_url "https://github.com/google/shaderc/archive/refs/tags/v#{version}.tar.gz"
+  source_sha256 'e96d8cb208b796cecb9e6cce437c7d1116343158ef3ea26277eb13b62cf56834'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/shaderc-2020.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/shaderc-2020.5-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/shaderc-2020.5-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/shaderc-2020.5-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '74e0264a8277b173f33e04e84a31a118173c2f4c5013ddd9f68f51a4a38b0965',
+     armv7l: '74e0264a8277b173f33e04e84a31a118173c2f4c5013ddd9f68f51a4a38b0965',
+       i686: '061996cc65ec0c60bd26a09b26e5d949504d2c6718eae3531949b4ccf9d2da3f',
+     x86_64: '9e32e0db031138d5ead88e9e6a99f1a14d1d07e6c89999f0d336d105462b1306'
+  })
+
+  @asciidoctor_installed = `gem list | grep ^asciidoctor`
+
+  def self.build
+    system 'gem install -N asciidoctor' unless @asciidoctor_installed.to_s != ''
+    system './utils/git-sync-deps'
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DSPIRV_WERROR=Off \
+        -DBUILD_SHARED_LIBS=ON \
+        -DSHADERC_SKIP_TESTS=ON \
+        -DSHADERC_ENABLE_EXAMPLES=OFF \
+        -DCMAKE_CXX_FLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+        -Wno-dev \
+        .."
+    end
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system 'gem uninstall asciidoctor -x --force' unless @asciidoctor_installed.to_s != ''
+  end
+end

--- a/packages/spirv_headers.rb
+++ b/packages/spirv_headers.rb
@@ -1,0 +1,44 @@
+# Adapted from Arch Linux spirv-headers PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/spirv-headers/trunk/PKGBUILD
+
+require 'package'
+
+class Spirv_headers < Package
+  description 'SPIR-V Headers'
+  version '1.5.4-f88a'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/KhronosGroup/SPIRV-Headers/archive/f88a1f98fa7a44ccfcf33d810c72b200e7d9a78a.zip'
+  source_sha256 'b209fe7fd0db5a2eb61db5d93525ce0f39e4d615f2f82bd02ff0ee512bd45a1e'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/spirv_headers-1.5.4-f88a-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/spirv_headers-1.5.4-f88a-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/spirv_headers-1.5.4-f88a-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/spirv_headers-1.5.4-f88a-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '7fbc45daafcb8a8d2a2b677321df22f86797cc3cdd17b57e6ff6e56e6f00bc79',
+     armv7l: '7fbc45daafcb8a8d2a2b677321df22f86797cc3cdd17b57e6ff6e56e6f00bc79',
+       i686: '3b7e2d5cddd5a470bc44a2429559bd03aaa339e6fc2c16eee018b1758de5d6c6',
+     x86_64: 'fe9c5758664a18559627bb5b1fda22ca5d5c6c6308ebf2d5bf6c65be393bf33a'
+  })
+
+  def self.build
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        .."
+    end
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/spirv_tools.rb
+++ b/packages/spirv_tools.rb
@@ -1,0 +1,62 @@
+# Adapted from Arch Linux spirv-tools PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/spirv-tools/trunk/PKGBUILD
+require 'package'
+
+class Spirv_tools < Package
+  description 'API and commands for processing SPIR-V modules'
+  version '2020.7'
+  license 'custom'
+  compatibility 'all'
+  source_url 'https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.7.tar.gz'
+  source_sha256 'c06eed1c7a1018b232768481184b5ae4d91d614d7bd7358dc2fe306bd0a39c6e'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/spirv_tools-2020.7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/spirv_tools-2020.7-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/spirv_tools-2020.7-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/spirv_tools-2020.7-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '11f7b470632a94066cae7c546fc8a826c2cc34e11aab3544bb1fff64dc3627d4',
+     armv7l: '11f7b470632a94066cae7c546fc8a826c2cc34e11aab3544bb1fff64dc3627d4',
+       i686: '4a35f21e49c67571334444318560c9f182c1c31d82290927f83330ba7178f3f1',
+     x86_64: 'deaebf001fa0d2d78c24b1b7cb6a6b1c062afa88c3c8ae80d79a73db86595597'
+  })
+
+  depends_on 'spirv_headers'
+
+  def self.patch
+    # Source needs spirv-headers repo as submodule
+    @git_dir = 'external/SPIRV-Headers'
+    @git_hash = 'f88a1f98fa7a44ccfcf33d810c72b200e7d9a78a'
+    @git_url = 'https://github.com/KhronosGroup/SPIRV-Headers'
+    FileUtils.rm_rf(@git_dir)
+    FileUtils.mkdir_p(@git_dir)
+    Dir.chdir @git_dir do
+      system 'git init'
+      system "git remote add origin #{@git_url}"
+      system "git fetch --depth 1 origin #{@git_hash}"
+      system 'git checkout FETCH_HEAD'
+    end
+  end
+
+  def self.build
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
+      cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DSPIRV_WERROR=Off \
+        -DBUILD_SHARED_LIBS=ON \
+        .."
+    end
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/tesseract.rb
+++ b/packages/tesseract.rb
@@ -4,33 +4,38 @@ class Tesseract < Package
   description 'A neural net (LSTM) based OCR engine which is focused on line recognition & an older OCR engine which recognizes character patterns.'
   homepage 'https://github.com/tesseract-ocr/tesseract'
   @_ver = '4.1.1'
-  version @_ver
+  version "#{@_ver}-1"
   license 'Apache-2.0'
   compatibility 'all'
   source_url "https://github.com/tesseract-ocr/tesseract/archive/#{@_ver}.tar.gz"
   source_sha256 '2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tesseract-4.1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tesseract-4.1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tesseract-4.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tesseract-4.1.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/tesseract-4.1.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/tesseract-4.1.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/tesseract-4.1.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/tesseract-4.1.1-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '2784bfad438508abf959d5cf40c2cb7bad39ad30338cf94bc1b2cc2cdc4a4f5c',
-     armv7l: '2784bfad438508abf959d5cf40c2cb7bad39ad30338cf94bc1b2cc2cdc4a4f5c',
-       i686: '019d1cd38b1008e43e022b147a1b34ab11c11da1622733b7abea681215557ab3',
-     x86_64: '1661e2e92aeee9071cf37cee949a3c4d686fc379809e227be6e4b513b3a6b5f8'
+    aarch64: '5ebd835d7e56c61c2718e2514c31a66742ab12ae419ee640dfe30e4dca9092e9',
+     armv7l: '5ebd835d7e56c61c2718e2514c31a66742ab12ae419ee640dfe30e4dca9092e9',
+       i686: '77cc9f2d88850fb4722cd0f2b924a1f3f6e74eb47b0cbdcf01394c80c4453991',
+     x86_64: '78ba50689c80dfda47a0c21171576fb4613481558a63e3eda56c714432bdaa13'
   })
 
+  depends_on 'asciidoc' => :build
+  depends_on 'cairo'
+  depends_on 'cairo' => :build
+  depends_on 'fontconfig'
+  depends_on 'giflib'
+  depends_on 'glib'
+  depends_on 'leptonica'
+  depends_on 'libarchive'
+  depends_on 'libjpeg'
   depends_on 'libpng'
   depends_on 'libtiff'
-  depends_on 'libjpeg_turbo'
-  depends_on 'giflib'
-  depends_on 'leptonica'
-  depends_on 'cairo' => :build
+  depends_on 'pango'
   depends_on 'pango' => :build
-  depends_on 'asciidoc' => :build
 
   def self.build
     system '[ -x configure ] || ./autogen.sh'

--- a/packages/tracker3_miners.rb
+++ b/packages/tracker3_miners.rb
@@ -22,7 +22,7 @@ class Tracker3_miners < Package
     aarch64: '0809348f22bc74b6af7e5e1566017feee21c2094cc6cc338d0ac070a1eba3931',
      armv7l: '0809348f22bc74b6af7e5e1566017feee21c2094cc6cc338d0ac070a1eba3931',
        i686: 'c358f7e2a05d3f3cae8dfa09bf48fcaaaa4fb1b5c2eef23602a49832faaeaa03',
-     x86_64: '9b7ab266f7dfbb99157379b1eecd2cc10d828cb19e1a25fcff936be9171296ff'
+     x86_64: '3fce496bea0b469198d0994c959c981fa18d9cd0541cd14dad5568fed7701c72'
   })
 
   depends_on 'asciidoc' => :build
@@ -35,7 +35,7 @@ class Tracker3_miners < Package
   depends_on 'libexif'
   depends_on 'libgrss'
   depends_on 'libgsf'
-  depends_on 'libjpeg_turbo'
+  depends_on 'libjpeg'
   depends_on 'libpng'
   depends_on 'libtiff'
   depends_on 'tracker3'

--- a/packages/v4l_utils.rb
+++ b/packages/v4l_utils.rb
@@ -4,28 +4,32 @@ class V4l_utils < Package
   description 'The v4l-utils are a series of packages for handling media devices.'
   homepage 'https://www.linuxtv.org/wiki/index.php/V4l-utils'
   @_ver = '1.20.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPL-2+ and LGPL-2.1+'
   compatibility 'all'
   source_url "https://linuxtv.org/downloads/v4l-utils/v4l-utils-#{@_ver}.tar.bz2"
   source_sha256 '956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.20.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.20.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.20.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.20.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.20.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.20.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.20.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/v4l_utils-1.20.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '6020b0b0a9f4bf4659bca79749659210e2bbd30d5099260813847193f17841d3',
-     armv7l: '6020b0b0a9f4bf4659bca79749659210e2bbd30d5099260813847193f17841d3',
-       i686: '9c6050888763ad102c12647ae0a952db55b2f83074005c1ec5a705b3c8f99031',
-     x86_64: '16979812174393e579506611f0f84bf9fc7d26b6d4f3b124c6061c6db007cd7d'
+    aarch64: 'c7048454015dbd6c4b98b1ae19b58030c4f607c28f732ebca0f8ed0e5b130c52',
+     armv7l: 'c7048454015dbd6c4b98b1ae19b58030c4f607c28f732ebca0f8ed0e5b130c52',
+       i686: '4bd59432a97705ba93146ff3ad91f5f987e820402dc44678212dbd2163b4bdf9',
+     x86_64: '4a5f30314e87d470918551e9ade322e94f66d08ecd2c65884f1aec0d039c095a'
   })
 
-  depends_on 'sdl2_image'
-  depends_on 'libglu'
   depends_on 'alsa_lib'
+  depends_on 'eudev'
+  depends_on 'libglu'
+  depends_on 'libjpeg'
+  depends_on 'mesa'
+  depends_on 'qtbase'
+  depends_on 'sdl2_image'
 
   def self.patch
     system "find . -name '*.pl' -exec sed -i 's,/usr/bin/perl,#{CREW_PREFIX}/bin/perl,g' {} +"


### PR DESCRIPTION
- fuse update seems to work with rebuilt gvfs and nautilus
- mpv updated for dependency updates
- gstreamer packages updated to 1.18.4
- gimp updated with dependencies (and fix i686 compile)
- massive cleanup and rebuild to remove libjpeg_turbo dependencies (that uses libjpeg8.so, whereas the standard libjpeg uses libjpeg9.so)

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l