### PR TITLE
Add squashfuse

### DIFF
--- a/packages/squashfuse.rb
+++ b/packages/squashfuse.rb
@@ -1,0 +1,42 @@
+# Adapted from Arch Linux squashfuse PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/squashfuse/trunk/PKGBUILD
+
+require 'package'
+
+class Squashfuse < Package
+  description 'FUSE filesystem to mount squashfs archives'
+  homepage 'https://github.com/vasi/squashfuse'
+  version '0.1.104'
+  license 'custom'
+  compatibility 'all'
+  source_url 'https://github.com/vasi/squashfuse/releases/download/0.1.104/squashfuse-0.1.104.tar.gz'
+  source_sha256 'aa52460559e0d0b1753f6b1af5c68cfb777ca5a13913285e93f4f9b7aa894b3a'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/squashfuse-0.1.104-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/squashfuse-0.1.104-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/squashfuse-0.1.104-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/squashfuse-0.1.104-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '83bad067dece48c952a5fd510fdc2f62d4a790d6134f0015eb1c958bb66a4507',
+     armv7l: '83bad067dece48c952a5fd510fdc2f62d4a790d6134f0015eb1c958bb66a4507',
+       i686: 'afb0d28b2ee43ebc540e6b1d3c4cc56324a3356bd33cea66e47d2ba3797bf5ca',
+     x86_64: 'df130e28a509798c98213a139936e6711b7d6d97b2510f3194820cb47e22631d'
+  })
+
+  depends_on 'fuse'
+  depends_on 'lzo'
+
+  def self.build
+    system "env CFLAGS='-pipe -flto=auto' \
+      CXXFLAGS='-pipe -flto=auto' \
+      LDFLAGS='-flto=auto' \
+      ./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end


### PR DESCRIPTION
Allows Conty to work using lz4 compressed files.

How to tell which compression is supported for you natively:

```
sudo modprobe configs
gunzip -c /proc/config.gz | grep CONFIG_SQUASHFS
CONFIG_SQUASHFS=y
# CONFIG_SQUASHFS_FILE_CACHE is not set
CONFIG_SQUASHFS_FILE_DIRECT=y
CONFIG_SQUASHFS_DECOMP_SINGLE=y
# CONFIG_SQUASHFS_DECOMP_MULTI is not set
# CONFIG_SQUASHFS_DECOMP_MULTI_PERCPU is not set
CONFIG_SQUASHFS_XATTR=y
CONFIG_SQUASHFS_ZLIB=y
CONFIG_SQUASHFS_LZ4=y
CONFIG_SQUASHFS_LZO=y
# CONFIG_SQUASHFS_XZ is not set
CONFIG_SQUASHFS_4K_DEVBLK_SIZE=y
# CONFIG_SQUASHFS_EMBEDDED is not set
CONFIG_SQUASHFS_FRAGMENT_CACHE_SIZE=3
```

Usage with conty:
```
crew install squashfuse bubblewrap
cd /usr/local && curl -OLf https://github.com/Kron4ek/Conty/releases/download/1.5/conty_lite_lz4.sh
chmod +x conty_lite_lz4.sh && SUDO_MOUNT=1 USE_SYS_UTILS=1 ./conty_lite_lz4.sh glxinfo -B
SUDO_MOUNT=1 USE_SYS_UTILS=1 ./conty_lite_lz4.sh ls /usr/bin
```
Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686