### PR TITLE
mandb rebuild

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -4,30 +4,32 @@ class Mandb < Package
   description 'mandb is used to initialize or manually update index database caches that are usually maintained by man.'
   homepage 'https://man-db.nongnu.org/'
   @_ver = '2.9.4'
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPL-3'
   compatibility 'all'
   source_url "https://download.savannah.gnu.org/releases/man-db/man-db-#{@_ver}.tar.xz"
   source_sha256 'b66c99edfad16ad928c889f87cf76380263c1609323c280b3a9e6963fdb16756'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/mandb-2.9.4-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'ccd36d83dc2dcb04d003a79fd503273ebd06a77d4da618f7033d537fda537d4e',
-     armv7l: 'ccd36d83dc2dcb04d003a79fd503273ebd06a77d4da618f7033d537fda537d4e',
-       i686: '97a79a235a9ab3c3f077ddf462a79d9d17ff3ff6cd35145321d790253775387f',
-     x86_64: '30939c206bd1adc66a33a8157d749b288a3726a995a8eb318c057104807c138d'
+    aarch64: '1380c9d892dee58035943cd45e0fbdde24076ecff95d217a244b23d29530fda2',
+     armv7l: '1380c9d892dee58035943cd45e0fbdde24076ecff95d217a244b23d29530fda2',
+       i686: '860f38f174b9843b2d83116ba3a56b3a8735f1a084b30b3edde385e852d91699',
+     x86_64: 'cae256c6989d0654bd9c73bb84e2fd0a98f1497e1499cc2f48f928cdfbcf32fb'
   })
 
   depends_on 'gdbm'
-  depends_on 'groff'
+  depends_on 'glibc'
+  depends_on 'groff' => :build
   depends_on 'libpipeline'
   depends_on 'libseccomp'
-
+  depends_on 'zlibpkg'
+  
   def self.patch
     system "sed -i 's,/usr/man,#{CREW_PREFIX}/share/man,g' src/man_db.conf.in"
     [
@@ -70,8 +72,7 @@ class Mandb < Package
       --enable-automatic-create \
       --enable-static \
       --without-libiconv-prefix \
-      --disable-rpath \
-      --with-pager=#{CREW_PREFIX}/bin/most"
+      --disable-rpath"
     system 'make'
   end
 


### PR DESCRIPTION
- rebuild mandb, bump version, get rid of pager line, list runtime deps

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686