### PR TITLE
Remove glibc dependency from mandb

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -24,12 +24,11 @@ class Mandb < Package
   })
 
   depends_on 'gdbm'
-  depends_on 'glibc'
   depends_on 'groff' => :build
   depends_on 'libpipeline'
   depends_on 'libseccomp'
   depends_on 'zlibpkg'
-  
+
   def self.patch
     system "sed -i 's,/usr/man,#{CREW_PREFIX}/share/man,g' src/man_db.conf.in"
     [


### PR DESCRIPTION
Works perfectly fine without glibc.

```bash
$ apropos mandb
mandb (8)            - create or update the manual page index caches
$ whatis apropos
apropos (1)          - search the manual page names and descriptions
$ manpath
manpath: warning: $MANPATH set, ignoring /usr/local/etc/man_db.conf
/usr/local/pkg/man:/usr/local/share/man:/usr/share/man:/usr/local/share/texlive/2020/bin/texmf-dist/doc/man
```