### PR TITLE
Execute preflight only for build, install and reinstall

### DIFF
--- a/crew
+++ b/crew
@@ -757,7 +757,6 @@ end
 
 def resolve_dependencies
   abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @pkg.compatibility.include?('all') or @pkg.compatibility.include?(ARCH)
-  @pkg.preflight
   expand_dependencies
 
   # leave only not installed packages in dependencies
@@ -980,6 +979,7 @@ def build_command (args)
     @pkgName = name
     search @pkgName
     print_current_package @opt_verbose
+    @pkg.preflight
     resolve_dependencies_and_build
   end
 end
@@ -1027,6 +1027,7 @@ def install_command (args)
     search @pkgName
     print_current_package true
     @pkg.build_from_source = true if @opt_src or @opt_recursive
+    @pkg.preflight
     resolve_dependencies_and_install
   end
 end
@@ -1063,6 +1064,7 @@ def reinstall_command (args)
     @pkg.build_from_source = true if @opt_src or @opt_recursive
     if @pkgName
       @pkg.in_upgrade = true
+      @pkg.preflight
       resolve_dependencies_and_install
       @pkg.in_upgrade = false
     end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.18'
+CREW_VERSION = '1.7.19'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
It doesn't make sense to run preflight for updates.