### PR TITLE
libpng: Load itself after installation

### DIFF
--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -40,4 +40,10 @@ class Libpng < Package
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
+  
+  def self.postinstall
+    # *.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
+    system 'update-mime-database', "#{CREW_PREFIX}/share/mime"
+    system 'gdk-pixbuf-query-loaders', '--update-cache'
+  end
 end


### PR DESCRIPTION
Fix `*.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)`

Tested on `x86_64`