### PR TITLE
fix png/gdk_pixbuf dep loop

### DIFF
--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -25,10 +25,10 @@ class Gdk_pixbuf < Package
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build
   depends_on 'jasper' => :build
-  depends_on 'libjpeg'
-  depends_on 'libpng'
-  depends_on 'libtiff'
-  depends_on 'libwebp'  => :build
+  depends_on 'libjpeg' => :build #Actually runtime
+  depends_on 'libpng' => :build #Actually runtime
+  depends_on 'libtiff' => :build #Actually runtime
+  depends_on 'libwebp' => :build
   depends_on 'pango' => :build
   depends_on 'six' => :build
 

--- a/packages/libavif.rb
+++ b/packages/libavif.rb
@@ -61,6 +61,9 @@ class Libavif < Package
   end
 
   def self.postinstall
-    system 'gdk-pixbuf-query-loaders --update-cache'
+    if File.exist?("#{CREW_PREFIX}/bin/gdk-pixbuf-query-loaders")
+      system 'gdk-pixbuf-query-loaders',
+             '--update-cache'
+    end
   end
 end

--- a/packages/libheif.rb
+++ b/packages/libheif.rb
@@ -50,6 +50,9 @@ class Libheif < Package
   end
 
   def self.postinstall
-    system 'gdk-pixbuf-query-loaders --update-cache'
+    if File.exist?("#{CREW_PREFIX}/bin/gdk-pixbuf-query-loaders")
+      system 'gdk-pixbuf-query-loaders',
+             '--update-cache'
+    end
   end
 end

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -43,10 +43,13 @@ class Libpng < Package
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
-  
+
   def self.postinstall
     # *.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
     system 'update-mime-database', "#{CREW_PREFIX}/share/mime"
-    system 'gdk-pixbuf-query-loaders', '--update-cache'
+    if File.exist?("#{CREW_PREFIX}/bin/gdk-pixbuf-query-loaders")
+      system 'gdk-pixbuf-query-loaders',
+             '--update-cache'
+    end
   end
 end

--- a/packages/libwmf.rb
+++ b/packages/libwmf.rb
@@ -42,6 +42,9 @@ class Libwmf < Package
   end
 
   def self.postinstall
-    system 'gdk-pixbuf-query-loaders --update-cache'
+    if File.exist?("#{CREW_PREFIX}/bin/gdk-pixbuf-query-loaders")
+      system 'gdk-pixbuf-query-loaders',
+             '--update-cache'
+    end
   end
 end


### PR DESCRIPTION
Fixes #5554 
- Don't run `gdk-pixbuf-query-loaders` unless it is there.
- Temporarily make runtime deps build deps in gdk_pixbuf until we find a better way to deal with this.

Works properly:
- [x] x86_64
