### PR TITLE
Make sure gtk4 dependencies are installed first

### DIFF
--- a/crew
+++ b/crew
@@ -769,7 +769,7 @@ def resolve_dependencies
 
   i = 0
   last_deps = []
-  last_packages = ["curl", "ghc", "mandb", "gtk3", "sommelier"]
+  last_packages = ["curl", "ghc", "mandb", "gtk3", "gtk4", "sommelier"]
   @dependencies.each do |dep|
     if last_packages.include?(dep)
       @dependencies.delete_at(i)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.19'
+CREW_VERSION = '1.7.20'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
This issue happens when sommelier and all other dependencies are not installed yet.  If gtk4 is installed before some of its dependencies, errors will result.  Until we have a much needed dependency resolver update, this is how we have to fix it.