### PR TITLE
Proper fix for gdk_pixbuf / libpng circular dependency

### DIFF
--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -25,9 +25,9 @@ class Gdk_pixbuf < Package
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build
   depends_on 'jasper' => :build
-  depends_on 'libjpeg' => :build #Actually runtime
-  depends_on 'libpng' => :build #Actually runtime
-  depends_on 'libtiff' => :build #Actually runtime
+  depends_on 'libjpeg'
+  depends_on 'libpng'
+  depends_on 'libtiff'
   depends_on 'libwebp' => :build
   depends_on 'pango' => :build
   depends_on 'six' => :build
@@ -53,9 +53,9 @@ class Gdk_pixbuf < Package
   end
 
   def self.postinstall
-    ENV['GDK_PIXBUF_MODULEDIR'] = "#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders"
-    ENV['GDK_PIXBUF_MODULE_FILE'] = "#{ENV['GDK_PIXBUF_MODULEDIR']}.cache"
-    system 'gdk-pixbuf-query-loaders --update-cache'
+    system 'env GDK_PIXBUF_MODULEDIR=#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders \
+      GDK_PIXBUF_MODULE_FILE=#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache \
+      gdk-pixbuf-query-loaders --update-cache'
     gdk_pixbuf_in_bashrc = `grep -c "GDK_PIXBUF_MODULEDIR" ~/.bashrc || true`
     unless gdk_pixbuf_in_bashrc.to_i.positive?
       puts 'Putting GDK_PIXBUF code in ~/.bashrc'.lightblue

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -45,11 +45,6 @@ class Libpng < Package
   end
 
   def self.postinstall
-    # *.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
     system 'update-mime-database', "#{CREW_PREFIX}/share/mime"
-    if File.exist?("#{CREW_PREFIX}/bin/gdk-pixbuf-query-loaders")
-      system 'gdk-pixbuf-query-loaders',
-             '--update-cache'
-    end
   end
 end

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -66,7 +66,8 @@ class Librsvg < Package
   end
 
   def self.postinstall
-    # gdk_pixbuf should be setting the correct env variables
-    system 'gdk-pixbuf-query-loaders'
-  end
+    if File.exist?("#{CREW_PREFIX}/bin/gdk-pixbuf-query-loaders")
+      system 'gdk-pixbuf-query-loaders',
+             '--update-cache'
+    end
 end


### PR DESCRIPTION
- `libpng` is a runtime dep of `gdk_pixbuf`, and its info does not go into the gdk pixbuffer loader cache file.
(I don't see any png info in my `/usr/local/lib64/gdk-pixbuf-2.0/2.10.0/loaders.cache`)
- So don't invoke `gdk_pixbuf` programs from the `libpng` postinstall script.
- revert temporary workaround involving deps listed in `gdk_pixbuf` package file.
- Just to be safe, don't run `gdk-pixbuf-query-loaders` from postinstall unless it is there.

Works properly:
- [x] x86_64
