### PR TITLE
Fix librsvg, missing an end in postinstall

### DIFF
--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -70,4 +70,5 @@ class Librsvg < Package
       system 'gdk-pixbuf-query-loaders',
              '--update-cache'
     end
+  end
 end


### PR DESCRIPTION
librsvg causes the following issue, due to a missing `end`:
```
Generating compatible packages...
<internal:/usr/local/lib64/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': /usr/local/lib/crew/packages/librsvg.rb:73: syntax error, unexpected end-of-input, expecting `end' (SyntaxError)
        from <internal:/usr/local/lib64/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /usr/local/bin/crew:138:in `set_package'
        from /usr/local/bin/crew:196:in `block in generate_compatible'
        from /usr/local/bin/crew:194:in `each'
        from /usr/local/bin/crew:194:in `generate_compatible'
        from /usr/local/bin/crew:434:in `update'
        from /usr/local/bin/crew:1089:in `update_command'
        from /usr/local/bin/crew:1117:in `<main>'
```
This issue was brought to my attention by "MrMiles" in the Chromebrew discord.
