### PR TITLE
Epiphany + webkit2gtk updates

### DIFF
--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -9,11 +9,8 @@ class Epiphany < Package
   version '40.0'
   license 'GPL'
   compatibility 'x86_64 aarch64 armv7l'
-  case ARCH
-  when 'x86_64', 'aarch64', 'armv7l'
-    source_url "https://gitlab.gnome.org/GNOME/epiphany/-/archive/#{version}/epiphany-#{version}.tar.bz2"
-    source_sha256 '2603fcc30ea8c2ba1343eda845c70825af0749db1c5e1ef252240e30dd855c06'
-  end
+  source_url "https://gitlab.gnome.org/GNOME/epiphany/-/archive/#{version}/epiphany-#{version}.tar.bz2"
+  source_sha256 '2603fcc30ea8c2ba1343eda845c70825af0749db1c5e1ef252240e30dd855c06'
 
   binary_url({
     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/epiphany-40.0-chromeos-armv7l.tar.xz',

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -9,8 +9,11 @@ class Epiphany < Package
   version '40.0'
   license 'GPL'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url "https://gitlab.gnome.org/GNOME/epiphany/-/archive/#{version}/epiphany-#{version}.tar.bz2"
-  source_sha256 '2603fcc30ea8c2ba1343eda845c70825af0749db1c5e1ef252240e30dd855c06'
+  case ARCH
+  when 'x86_64', 'aarch64', 'armv7l'
+    source_url "https://gitlab.gnome.org/GNOME/epiphany/-/archive/#{version}/epiphany-#{version}.tar.bz2"
+    source_sha256 '2603fcc30ea8c2ba1343eda845c70825af0749db1c5e1ef252240e30dd855c06'
+  end
 
   binary_url({
     aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/epiphany-40.0-chromeos-armv7l.tar.xz',

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -1,0 +1,62 @@
+# Adapted from Arch Linux epiphany PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/epiphany/trunk/PKGBUILD
+
+require 'package'
+
+class Epiphany < Package
+  description 'A GNOME web browser based on the WebKit rendering engine'
+  homepage 'https://wiki.gnome.org/Apps/Web'
+  version '40.0'
+  license 'GPL'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url "https://gitlab.gnome.org/GNOME/epiphany/-/archive/#{version}/epiphany-#{version}.tar.bz2"
+  source_sha256 '2603fcc30ea8c2ba1343eda845c70825af0749db1c5e1ef252240e30dd855c06'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/epiphany-40.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/epiphany-40.0-chromeos-armv7l.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/epiphany-40.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '8985d22d9a78b08b3a8419acb4e9b808e2a1b4295c8d718a48cc9425025b6ca2',
+     armv7l: '8985d22d9a78b08b3a8419acb4e9b808e2a1b4295c8d718a48cc9425025b6ca2',
+     x86_64: '16990d7104da6872cfeb93f5fcbbc184d2d22f476dd544af848b22196f9facd0'
+  })
+
+  depends_on 'atk'
+  depends_on 'cairo' => :build
+  depends_on 'docbook_xml' => ':build'
+  depends_on 'freetype' => :build
+  depends_on 'gcr'
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk3'
+  depends_on 'help2man' => :build
+  depends_on 'json_glib'
+  depends_on 'libarchive'
+  depends_on 'libdazzle'
+  depends_on 'libhandy'
+  depends_on 'libportal'
+  depends_on 'libsecret'
+  depends_on 'libsoup2'
+  depends_on 'lsb_release' => ':build'
+  depends_on 'pango'
+  depends_on 'startup_notification' => ':build'
+  depends_on 'webkit2gtk_4'
+
+  def self.build
+    system "meson #{CREW_MESON_LTO_OPTIONS} \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+
+  def self.postinstall
+    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas/"
+  end
+end

--- a/packages/webkit2gtk.rb
+++ b/packages/webkit2gtk.rb
@@ -3,72 +3,13 @@ require 'package'
 class Webkit2gtk < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'
-  @_ver = '2.30.5'
+  @_ver = '2.32.0'
   version @_ver
   license 'LGPL-2+ and BSD-2'
   compatibility 'all'
-  source_url "https://webkitgtk.org/releases/webkitgtk-#{@_ver}.tar.xz"
-  source_sha256 '7d0dab08e3c5ae07bec80b2822ef42e952765d5724cac86eb23999bfed5a7f1f'
+  
+  is_fake
 
-  binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.5-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.5-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk-2.30.5-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'b7124c084ab583574893195e4d295d4fd79c2468770d29ca524474c1a5b8bb33',
-     armv7l: 'b7124c084ab583574893195e4d295d4fd79c2468770d29ca524474c1a5b8bb33',
-       i686: 'b6f3fac281c5ddfed66957f210ba226b422b8ffe1935c844d4e9934a32347f78',
-     x86_64: '6c4dd4d6c1625f87950d8d38e99398b670edf1deb758f4efdf53dca7b9b1e57d'
-  })
-
-  depends_on 'cairo'
-  depends_on 'fontconfig'
-  depends_on 'freetype'
-  depends_on 'gtk3'
-  depends_on 'harfbuzz'
-  depends_on 'gtk_doc' => :build
-  depends_on 'gobject_introspection' => :build
-  depends_on 'libsoup'
-  depends_on 'libwpe'
-  depends_on 'wpebackend_fdo'
-  depends_on 'libsecret'
-  depends_on 'enchant'
-  depends_on 'libnotify'
-  depends_on 'hyphen'
-  depends_on 'woff2'
-  depends_on 'bubblewrap'
-  depends_on 'xdg_dbus_proxy'
-  depends_on 'libseccomp'
-  depends_on 'openjpeg'
-  depends_on 'libsoup'
-
-  def self.build
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      # -flto breaks x86_64 builds
-      # system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
-      system "cmake \
-        -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        -DCMAKE_SKIP_RPATH=ON \
-        -DPORT=GTK \
-        -DENABLE_GTKDOC=OFF \
-        -DENABLE_MINIBROWSER=ON \
-        -DUSE_SYSTEMD=OFF \
-        -DENABLE_WAYLAND_TARGET=ON \
-        -DUSE_GTK4=OFF \
-        -DENABLE_VIDEO=OFF \
-        -DENABLE_WEB_AUDIO=OFF \
-        -DENABLE_GLES2=ON \
-        -DENABLE_INTROSPECTION=ON \
-        .."
-    end
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  depends_on 'webkit2gtk_4_0'
+  depends_on 'webkit2gtk_5_0'
 end

--- a/packages/webkit2gtk.rb
+++ b/packages/webkit2gtk.rb
@@ -10,6 +10,6 @@ class Webkit2gtk < Package
   
   is_fake
 
-  depends_on 'webkit2gtk_4_0'
-  depends_on 'webkit2gtk_5_0'
+  depends_on 'webkit2gtk_4'
+  depends_on 'webkit2gtk_5'
 end

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -1,0 +1,82 @@
+require 'package'
+
+class Webkit2gtk_4 < Package
+  description 'Web content engine for GTK'
+  homepage 'https://webkitgtk.org'
+  @_ver = '2.32.0'
+  version @_ver
+  license 'LGPL-2+ and BSD-2'
+  compatibility 'all'
+  source_url "https://webkitgtk.org/releases/webkitgtk-#{@_ver}.tar.xz"
+  source_sha256 '9d7df4dae9ada2394257565acc2a68ace9308c4c61c3fcc00111dc1f11076bf0'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk_4-2.32.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk_4-2.32.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk_4-2.32.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk_4-2.32.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: 'be723ff23a31c85ad8c5dea8cadbeaac12aa17810f6bf448999b46f008a30034',
+     armv7l: 'be723ff23a31c85ad8c5dea8cadbeaac12aa17810f6bf448999b46f008a30034',
+       i686: 'b0bd0f98543cee946931bd3726a0a7d10d709006d930f28ecb322086876567a2',
+     x86_64: '2bfe6213119d1bbaa98634a99e0390a222ea95c30ef1d329d0b17d6df0aaf89b'
+  })
+
+  depends_on 'ccache' => :build
+  depends_on 'cairo'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
+  depends_on 'gtk3'
+  depends_on 'gtk4'
+  depends_on 'harfbuzz'
+  depends_on 'gtk_doc' => :build
+  depends_on 'gobject_introspection' => :build
+  depends_on 'libsoup'
+  depends_on 'libwpe'
+  depends_on 'wpebackend_fdo'
+  depends_on 'libsecret'
+  depends_on 'enchant'
+  depends_on 'libnotify'
+  depends_on 'hyphen'
+  depends_on 'woff2'
+  depends_on 'bubblewrap'
+  depends_on 'xdg_dbus_proxy'
+  depends_on 'openjpeg'
+  depends_on 'libsoup'
+
+  def self.build
+    # This builds webkit2gtk4 (which uses gtk3)
+    Dir.mkdir 'builddir4'
+    Dir.chdir 'builddir4' do
+      # -flto breaks x86_64 builds
+      # system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+      # Bubblewrap sandbox breaks on epiphany with
+      # bwrap: Can't make symlink at /var/run: File exists
+      system "cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_SKIP_RPATH=ON \
+        -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
+        -DENABLE_GAMEPAD=OFF \
+        -DENABLE_GLES2=ON \
+        -DENABLE_GTKDOC=OFF \
+        -DENABLE_INTROSPECTION=ON \
+        -DENABLE_MINIBROWSER=ON \
+        -DENABLE_VIDEO=ON \
+        -DENABLE_WAYLAND_TARGET=ON \
+        -DENABLE_WEB_AUDIO=OFF \
+        -DPORT=GTK \
+        -DUSE_GTK4=OFF \
+        -DUSE_SOUP2=ON \
+        -DUSE_SYSTEMD=OFF \
+        .."
+    end
+    system 'ninja -C builddir4'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir4 install"
+  end
+end

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -23,27 +23,42 @@ class Webkit2gtk_4 < Package
      x86_64: '2bfe6213119d1bbaa98634a99e0390a222ea95c30ef1d329d0b17d6df0aaf89b'
   })
 
-  depends_on 'ccache' => :build
+  depends_on 'atk'
   depends_on 'cairo'
+  depends_on 'ccache' => :build
+  depends_on 'enchant'
   depends_on 'fontconfig'
   depends_on 'freetype'
-  depends_on 'gtk3'
-  depends_on 'gtk4'
-  depends_on 'harfbuzz'
-  depends_on 'gtk_doc' => :build
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
   depends_on 'gobject_introspection' => :build
-  depends_on 'libsoup'
-  depends_on 'libwpe'
-  depends_on 'wpebackend_fdo'
-  depends_on 'libsecret'
-  depends_on 'enchant'
-  depends_on 'libnotify'
+  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
+  depends_on 'gtk3'
+  depends_on 'gtk_doc' => :build
+  depends_on 'harfbuzz'
   depends_on 'hyphen'
-  depends_on 'woff2'
-  depends_on 'bubblewrap'
-  depends_on 'xdg_dbus_proxy'
-  depends_on 'openjpeg'
+  depends_on 'libgcrypt'
+  depends_on 'libjpeg'
+  depends_on 'libnotify'
+  depends_on 'libpng'
+  depends_on 'libsecret'
   depends_on 'libsoup'
+  depends_on 'libsoup2'
+  depends_on 'libwebp'
+  depends_on 'libwpe'
+  depends_on 'libx11'
+  depends_on 'libxcomposite'
+  depends_on 'libxdamage'
+  depends_on 'libxrender'
+  depends_on 'libxslt'
+  depends_on 'libxt'
+  depends_on 'mesa'
+  depends_on 'openjpeg'
+  depends_on 'pango'
+  depends_on 'wayland'
+  depends_on 'woff2'
+  depends_on 'wpebackend_fdo'
 
   def self.build
     # This builds webkit2gtk4 (which uses gtk3)

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -23,27 +23,43 @@ class Webkit2gtk_5 < Package
      x86_64: '11d1d701c17bdf1f7de0e4d0df094dd6342195134cf153b22b125ec1dfd58ead'
   })
 
-  depends_on 'ccache' => :build
+  depends_on 'atk'
   depends_on 'cairo'
+  depends_on 'ccache' => :build
+  depends_on 'enchant'
   depends_on 'fontconfig'
   depends_on 'freetype'
-  depends_on 'gtk3'
-  depends_on 'gtk4'
-  depends_on 'harfbuzz'
-  depends_on 'gtk_doc' => :build
+  depends_on 'gdk_pixbuf'
+  depends_on 'glib'
   depends_on 'gobject_introspection' => :build
-  depends_on 'libsoup'
-  depends_on 'libwpe'
-  depends_on 'wpebackend_fdo'
-  depends_on 'libsecret'
-  depends_on 'enchant'
-  depends_on 'libnotify'
+  depends_on 'graphene'
+  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
+  depends_on 'gtk4'
+  depends_on 'gtk_doc' => :build
+  depends_on 'harfbuzz'
   depends_on 'hyphen'
-  depends_on 'woff2'
-  depends_on 'bubblewrap'
-  depends_on 'xdg_dbus_proxy'
-  depends_on 'openjpeg'
+  depends_on 'libgcrypt'
+  depends_on 'libjpeg'
+  depends_on 'libnotify'
+  depends_on 'libpng'
+  depends_on 'libsecret'
   depends_on 'libsoup'
+  depends_on 'libwebp'
+  depends_on 'libwpe'
+  depends_on 'libx11'
+  depends_on 'libxcomposite'
+  depends_on 'libxdamage'
+  depends_on 'libxrender'
+  depends_on 'libxslt'
+  depends_on 'libxt'
+  depends_on 'mesa'
+  depends_on 'openjpeg'
+  depends_on 'pango'
+  depends_on 'vulkan_icd_loader'
+  depends_on 'wayland'
+  depends_on 'woff2'
+  depends_on 'wpebackend_fdo'
 
   def self.build
     # This builds webkit2gtk5 (which uses gtk4)

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -1,0 +1,82 @@
+require 'package'
+
+class Webkit2gtk_5 < Package
+  description 'Web content engine for GTK'
+  homepage 'https://webkitgtk.org'
+  @_ver = '2.32.0'
+  version @_ver
+  license 'LGPL-2+ and BSD-2'
+  compatibility 'all'
+  source_url "https://webkitgtk.org/releases/webkitgtk-#{@_ver}.tar.xz"
+  source_sha256 '9d7df4dae9ada2394257565acc2a68ace9308c4c61c3fcc00111dc1f11076bf0'
+
+  binary_url({
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk_5-2.32.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk_5-2.32.0-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk_5-2.32.0-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/webkit2gtk_5-2.32.0-chromeos-x86_64.tar.xz'
+  })
+  binary_sha256({
+    aarch64: '0d49b1141892ec63b2b43c682aa4feb3c5b64dc04bfea08ec9f9c0d2c6fb583d',
+     armv7l: '0d49b1141892ec63b2b43c682aa4feb3c5b64dc04bfea08ec9f9c0d2c6fb583d',
+       i686: 'f1481e0a9cdf9df4308320777971dc6c168344aa9488169caad6c4c6549c56d4',
+     x86_64: '11d1d701c17bdf1f7de0e4d0df094dd6342195134cf153b22b125ec1dfd58ead'
+  })
+
+  depends_on 'ccache' => :build
+  depends_on 'cairo'
+  depends_on 'fontconfig'
+  depends_on 'freetype'
+  depends_on 'gtk3'
+  depends_on 'gtk4'
+  depends_on 'harfbuzz'
+  depends_on 'gtk_doc' => :build
+  depends_on 'gobject_introspection' => :build
+  depends_on 'libsoup'
+  depends_on 'libwpe'
+  depends_on 'wpebackend_fdo'
+  depends_on 'libsecret'
+  depends_on 'enchant'
+  depends_on 'libnotify'
+  depends_on 'hyphen'
+  depends_on 'woff2'
+  depends_on 'bubblewrap'
+  depends_on 'xdg_dbus_proxy'
+  depends_on 'openjpeg'
+  depends_on 'libsoup'
+
+  def self.build
+    # This builds webkit2gtk5 (which uses gtk4)
+    Dir.mkdir 'builddir5'
+    Dir.chdir 'builddir5' do
+      # -flto breaks x86_64 builds
+      # system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
+      # Bubblewrap sandbox breaks on epiphany with
+      # bwrap: Can't make symlink at /var/run: File exists
+      system "cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_SKIP_RPATH=ON \
+        -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
+        -DENABLE_GAMEPAD=OFF \
+        -DENABLE_GLES2=ON \
+        -DENABLE_GTKDOC=OFF \
+        -DENABLE_INTROSPECTION=ON \
+        -DENABLE_MINIBROWSER=ON \
+        -DENABLE_VIDEO=ON \
+        -DENABLE_WAYLAND_TARGET=ON \
+        -DENABLE_WEB_AUDIO=OFF \
+        -DPORT=GTK \
+        -DUSE_GTK4=ON \
+        -DUSE_SOUP2=OFF \
+        -DUSE_SYSTEMD=OFF \
+        .."
+    end
+    system 'ninja -C builddir5'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir5 install"
+  end
+end


### PR DESCRIPTION
- Adds epiphany
- breaks out version 4 and version 5 of webkit2gtk, as they are compiled from the same source, but have different dependencies based upon using gtk3 or gtk4.
- webkit2gtk built without bubblewrap, as that is having issues.
- Also depends upon https://github.com/skycocker/chromebrew/pull/5550

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686 (not epiphany but everything else)