### PR TITLE
intel, texlive, hashpipe, gst_plugins_good , texlive updates

### DIFF
--- a/packages/gmmlib.rb
+++ b/packages/gmmlib.rb
@@ -3,25 +3,23 @@ require 'package'
 class Gmmlib < Package
   description 'The Intel(R) Graphics Memory Management Library provides device specific and buffer management for the Intel(R) Graphics Compute Runtime for OpenCL(TM) and the Intel(R) Media Driver for VAAPI.'
   homepage 'https://github.com/intel/gmmlib/'
-  @_ver = '20.4.1'
+  @_ver = '21.1.1'
   version @_ver
   license 'MIT'
   compatibility 'i686 x86_64'
-  case ARCH
-  when 'i686', 'x86_64'
-    source_url "https://github.com/intel/gmmlib/archive/intel-gmmlib-#{@_ver}.tar.gz"
-    source_sha256 'd54d547f9f9e74196dead6a338923039ea10c859f1f693f33f10be1562b81d6d'
-    depends_on 'libva'
-  end
+  source_url "https://github.com/intel/gmmlib/archive/intel-gmmlib-#{@_ver}.tar.gz"
+  source_sha256 'b996f09264e05ebca0dc275ea32791ba22769fe04147592371b4a61cdf508763'
 
   binary_url({
-    i686: 'https://dl.bintray.com/chromebrew/chromebrew/gmmlib-20.4.1-chromeos-i686.tar.xz',
-  x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gmmlib-20.4.1-chromeos-x86_64.tar.xz'
+    i686: 'https://dl.bintray.com/chromebrew/chromebrew/gmmlib-21.1.1-chromeos-i686.tar.xz',
+  x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gmmlib-21.1.1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    i686: '216f1914cffe386625f78bc930046afa0d04f5254c555bd17fb433e70d161f17',
-  x86_64: '7d846916ab47e45d4d85dc41c08c718d0c4e4e774769886f8b452af8b041de92'
+    i686: 'c71cb96bf16648e0818daca7913e32a71a67a117ffaf1379f7e4970f075d5454',
+  x86_64: '8cc86525354adbcc15e2e9ba8b59444178ec2037f72f9d29763286ef23dd1973'
   })
+  depends_on 'libva'
+
 
   def self.patch
     system "find . -type f -exec sed -e 's,LD_LIBRARY_PATH=,LD_LIBRARY_PATH=#{CREW_LIB_PREFIX}:,g' \
@@ -34,7 +32,10 @@ class Gmmlib < Package
       system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
             CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
             LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-            cmake #{CREW_CMAKE_OPTIONS} ../ -G Ninja"
+            cmake -G Ninja \
+            #{CREW_CMAKE_OPTIONS} \
+            -DRUN_TEST_SUITE=OFF \
+            .."
     end
     system 'ninja -C builddir'
   end

--- a/packages/gst_plugins_good.rb
+++ b/packages/gst_plugins_good.rb
@@ -4,53 +4,59 @@ class Gst_plugins_good < Package
   description 'Multimedia graph framework - good plugins'
   homepage 'https://gstreamer.freedesktop.org/'
   @_ver = '1.18.4'
-  version @_ver
+  version "#{@_ver}-1"
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-#{@_ver}.tar.xz"
   source_sha256 'b6e50e3a9bbcd56ee6ec71c33aa8332cc9c926b0c1fae995aac8b3040ebe39b0'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gst_plugins_good-1.18.4-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'e0fdc371c57de6ec9ce08478f3ed37d11c6c9b732266b2a07e53a5da38a4038e',
-     armv7l: 'e0fdc371c57de6ec9ce08478f3ed37d11c6c9b732266b2a07e53a5da38a4038e',
-       i686: '820d158973841c3e18ef1150b99586787f6fc95f4b18ce9c447a29da75270015',
-     x86_64: 'a4efb5f9552bcd9e6fcc5405f0c41209a9efc8c34404eb043d259d4cf2284cd5'
+    aarch64: 'c6bd8050a3c0f1b314c710a325211955179befb161ad265c6aeea8aec1e4f262',
+     armv7l: 'c6bd8050a3c0f1b314c710a325211955179befb161ad265c6aeea8aec1e4f262',
+       i686: '9d81667abfe65600e5b248de3c2de29ce6eb7f1e352929015c033809423324ea',
+     x86_64: '1ce70592cf499cda3a46f519db2ba479e0e8ca56acf43d44366b884d59b73487'
   })
 
-  depends_on 'aalib'
-  depends_on 'cairo'
-  depends_on 'gdk_pixbuf'
-  depends_on 'glib'
-  depends_on 'gst_plugins_base'
-  depends_on 'gstreamer'
-  depends_on 'gtk3'
-  depends_on 'jack'
-  depends_on 'libdv'
-  depends_on 'libgudev'
-  depends_on 'libjpeg'
-  depends_on 'libmp3lame'
-  depends_on 'libpng'
-  depends_on 'libsoup'
-  depends_on 'libsoup2'
-  depends_on 'libvpx'
-  depends_on 'libx11'
-  depends_on 'libxdamage'
-  depends_on 'libxext'
-  depends_on 'libxfixes'
+  # L = Logical Dependency, R = Runtime Dependency
+  depends_on 'libjpeg' => :build
   depends_on 'nasm' => :build
-  depends_on 'orc'
-  depends_on 'pipewire'
-  depends_on 'pulseaudio'
-  depends_on 'speex'
-  depends_on 'taglib'
-  depends_on 'v4l_utils'
-  depends_on 'wavpack'
+  depends_on 'gst_plugins_base' # L
+  depends_on 'aalib' # R
+  depends_on 'cairo' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
+  depends_on 'gst_plugins_base' # R
+  depends_on 'gstreamer' # R
+  depends_on 'gtk3' # R
+  depends_on 'jack' # R
+  depends_on 'libavc1394' # R
+  depends_on 'libcaca' # R
+  depends_on 'libdv' # R
+  depends_on 'libgudev' # R
+  depends_on 'libiec61883' # R
+  depends_on 'libmp3lame' # R
+  depends_on 'libpng' # R
+  depends_on 'libraw1394' # R
+  depends_on 'libsoup2' # R
+  depends_on 'libvpx' # R
+  depends_on 'libx11' # R
+  depends_on 'libxdamage' # R
+  depends_on 'libxext' # R
+  depends_on 'libxfixes' # R
+  depends_on 'mpg123' # R
+  depends_on 'orc' # R
+  depends_on 'pipewire' # R
+  depends_on 'pulseaudio' # R
+  depends_on 'speex' # R
+  depends_on 'taglib' # R
+  depends_on 'v4l_utils' # R
+  depends_on 'wavpack' # R
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/hashpipe.rb
+++ b/packages/hashpipe.rb
@@ -3,24 +3,202 @@ require 'package'
 class Hashpipe < Package
   description 'Hash in a pipe'
   homepage 'https://git.zx2c4.com/hashpipe/about/#hashpipe'
-  version '1.0'
+  version '1.0-1'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://git.zx2c4.com/hashpipe/snapshot/hashpipe-dc11b6262f4717e61e55760cb2bd637ff1c0f6a9.tar.xz'
   source_sha256 '6b3931d7c46332be2a6c07f94f91924065ba7988edd2e8a471123c77d3c614f6'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/hashpipe-1.0-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '6285f0a271d517f5a945626d9d84378546cd463d3ef2d6bcb6cdc189b8beed25',
-     armv7l: '6285f0a271d517f5a945626d9d84378546cd463d3ef2d6bcb6cdc189b8beed25',
-       i686: 'd03e7e5b7990c41bd8f25e17469db59bf3f1575a00ffb10f5fb441217ddabee9',
-     x86_64: 'fa770efb0a691063e7b2f581abde45d9bacf0822ff9643136d9bf99dd5d42f6b'
+    aarch64: 'c852b3c8c35151b359f94c71505132a865da8bdb710345431b24c46a3ba6931b',
+     armv7l: 'c852b3c8c35151b359f94c71505132a865da8bdb710345431b24c46a3ba6931b',
+       i686: 'fbb73db66ca7a403b566ffc35522d6853e7130a7b73220d3f475235a17a3220c',
+     x86_64: 'e44b2a537d85dfb0667856dd27c14907223767253c95011b1407b606864cb4e4'
   })
+
+  def self.patch
+    @hashpipe_patch = <<~'HASHPIPE_PATCHEOF'
+      diff -Npaur orig/hashpipe.c new/hashpipe.c
+      --- orig/hashpipe.c	2021-04-08 14:56:27.657272292 -0400
+      +++ new/hashpipe.c	2021-04-08 15:11:20.398253126 -0400
+      @@ -1,6 +1,7 @@
+       /* SPDX-License-Identifier: GPL-2.0
+        *
+        * Copyright (C) 2018 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+      + * Code also imported from https://gitlab.gnome.org/GNOME/gtk/-/blob/master/gdk/wayland/cursor/os-compatibility.c
+        */
+       
+       #define _GNU_SOURCE
+      @@ -10,12 +11,59 @@
+       #include <stdbool.h>
+       #include <unistd.h>
+       #include <errno.h>
+      +#if defined (__NR_memfd_create)
+      +#include <sys/mman.h>
+      +#endif
+       #include <sys/types.h>
+       #include <sys/stat.h>
+       #include <sys/sendfile.h>
+       #include <fcntl.h>
+       #include <openssl/evp.h>
+       
+      +#ifndef HAVE_MKOSTEMP
+      +static int
+      +set_cloexec_or_close(int fd)
+      +{
+      +	long flags;
+      +
+      +	if (fd == -1)
+      +		return -1;
+      +
+      +	flags = fcntl(fd, F_GETFD);
+      +	if (flags == -1)
+      +		goto err;
+      +
+      +	if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1)
+      +		goto err;
+      +
+      +	return fd;
+      +
+      +err:
+      +	close(fd);
+      +	return -1;
+      +}
+      +#endif
+      +
+      +static int
+      +create_tmpfile_cloexec(char *tmpname)
+      +{
+      +	int fd;
+      +
+      +#ifdef HAVE_MKOSTEMP
+      +	fd = mkostemp(tmpname, O_CLOEXEC);
+      +	if (fd >= 0)
+      +		unlink(tmpname);
+      +#else
+      +	fd = mkstemp(tmpname);
+      +	if (fd >= 0) {
+      +		fd = set_cloexec_or_close(fd);
+      +		unlink(tmpname);
+      +	}
+      +#endif
+      +
+      +	return fd;
+      +}
+      +
+       /* There's a function in OpenSSL for this too, but it's horrible to use. */
+       static bool hex2bin(unsigned char *bin, const char *hex, size_t hexlen)
+       {
+      @@ -51,11 +99,14 @@ static bool hex2bin(unsigned char *bin,
+       
+       int main(int argc, char *argv[])
+       {
+      +	char *name;
+       	int fd;
+      +	int ret = 0;
+       	off_t pos;
+       	ssize_t len;
+       	size_t hexlen, hashlen, filesize = 0;
+      -	const char *hex, *algo, *home;
+      +	const char *hex, *algo, *path;
+      +	static const char template[] = "/hashpipe-XXXXXX";
+       	unsigned char hash[1024], computed_hash[1024], buffer[1024 * 128];
+       	const EVP_MD *md;
+       	EVP_MD_CTX *mdctx;
+      @@ -65,12 +116,57 @@ int main(int argc, char *argv[])
+       		return 1;
+       	}
+       
+      -	home = getenv("HOME");
+      -	fd = open(home ? home : "/", O_TMPFILE | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+      -	if (fd < 0) {
+      -		perror("Error: unable to create temporary inode");
+      -		return 1;
+      +  #ifdef __NR_memfd_create
+      +    fd = memfd_create("hashpipetmp", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+      +    if (fd >= 0) {
+      +      /* We can add this seal before calling posix_fallocate(), as
+      +       * the file is currently zero-sized anyway.
+      +       *
+      +       * There is also no need to check for the return value, we
+      +       * couldn't do anything with it anyway.
+      +       */
+      +      fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_SEAL);
+      +    } else if (fd < 0) {
+      +      perror("memfd_create error");
+      +      return 1;
+      +    }
+      +  #endif
+      +	{
+      +		path = getenv("TMPDIR");
+      +		if (!path) {
+      +			errno = ENOENT;
+      +			path = "/tmp";
+      +		}
+      +
+      +		name = malloc(strlen(path) + sizeof(template));
+      +		if (!name)
+      +			return -1;
+      +
+      +		strcpy(name, path);
+      +		strcat(name, template);
+      +
+      +		fd = create_tmpfile_cloexec(name);
+      +
+      +		free(name);
+      +
+      +		if (fd < 0)
+      +			return -1;
+      +	}
+      +
+      +#ifdef HAVE_POSIX_FALLOCATE
+      +	ret = posix_fallocate(fd, 0, filesize);
+      +	if (ret != 0) {
+      +		close(fd);
+      +		errno = ret;
+      +		return -1;
+      +	}
+      +#else
+      +	ret = ftruncate(fd, filesize);
+      +	if (ret < 0) {
+      +		close(fd);
+      +		return -1;
+       	}
+      +#endif
+       
+       	algo = argv[1];
+       	hex = argv[2];
+      @@ -99,7 +195,7 @@ int main(int argc, char *argv[])
+       	}
+       	while ((len = read(0, buffer, sizeof(buffer))) > 0) {
+       		if (write(fd, buffer, len) != len) {
+      -			perror("Error: unable to write to temporary inode");
+      +			perror("Error: unable to write to temporary location");
+       			return 1;
+       		}
+       		if (!EVP_DigestUpdate(mdctx, buffer, len)) {
+      diff -Npaur orig/Makefile new/Makefile
+      --- orig/Makefile	2021-04-08 14:57:51.994270482 -0400
+      +++ new/Makefile	2021-04-08 14:59:00.199269017 -0400
+      @@ -4,7 +4,7 @@ BINDIR ?= $(PREFIX)/bin
+       MANDIR ?= $(PREFIX)/share/man
+       
+       LDLIBS := -lcrypto
+      -CFLAGS ?= -O3 -march=native
+      +CFLAGS ?= -O3
+       CFLAGS += -std=gnu11 -Wall -pedantic
+       
+       all: hashpipe
+    HASHPIPE_PATCHEOF
+    IO.write('hashpipe.patch', @hashpipe_patch, perm: 0o644)
+    system 'patch -Np1 -i hashpipe.patch'
+  end
 
   def self.build
     system "make PREFIX=#{CREW_PREFIX}"

--- a/packages/intel_media_driver.rb
+++ b/packages/intel_media_driver.rb
@@ -3,19 +3,18 @@ require 'package'
 class Intel_media_driver < Package
   description 'The Intel(R) Media Driver for VAAPI is a new VA-API (Video Acceleration API) user mode driver supporting hardware accelerated decoding, encoding, and video post processing for GEN based graphics hardware.'
   homepage 'https://github.com/intel/media-driver'
-  @_ver = '20.4.5'
-  version "#{@_ver}-1"
+  @_ver = '21.1.3'
+  version @_ver
   license 'BSD-3, and MIT'
   compatibility 'x86_64'
-
   source_url "https://github.com/intel/media-driver/archive/intel-media-#{@_ver}.tar.gz"
-  source_sha256 '3d856a963127ddd6690fc6dac521d7674947675d5f20452f1e6f45c0fc83f9e6'
+  source_sha256 '219ce6b08a84bdce311160dc694d866249fd4e390391c2ac7be55f13a2fb928c'
 
   binary_url({
-    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/intel_media_driver-20.4.5-1-chromeos-x86_64.tar.xz'
+    x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/intel_media_driver-21.1.3-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    x86_64: '0cc7a352ff10ca44659c49e8ebace37dc8c96a936d66fd28c1c17b7d8c709419'
+    x86_64: 'cb0a13759d9694716c928640384ca59c3ac044a3379e0cc4160f156347e4d158'
   })
 
   depends_on 'gmmlib'

--- a/packages/libva_utils.rb
+++ b/packages/libva_utils.rb
@@ -3,24 +3,24 @@ require 'package'
 class Libva_utils < Package
   description 'Libva-utils is a collection of tests for VA-API (VIdeo Acceleration API)'
   homepage 'https://01.org/linuxmedia'
-  @_ver = '2.10.0'
+  @_ver = '2.11.1'
   version @_ver
   license 'MIT'
   compatibility 'all'
-  source_url "https://github.com/intel/libva-utils/archive/#{@_ver}.tar.gz"
-  source_sha256 'cbb7f9f6eae21d772e31b67bc8c311be6e35fe9c65e63acc57f9b16d72bf8dc0'
+  source_url "https://github.com/intel/libva-utils/archive/refs/tags/#{@_ver}.tar.gz"
+  source_sha256 '0c1eb7f717e391d00da74c53a9fe5caf3d6c510dcd35bac7f71a0e59ad1b8d26'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libva_utils-2.10.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libva_utils-2.10.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libva_utils-2.10.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libva_utils-2.10.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/libva_utils-2.11.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/libva_utils-2.11.1-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/libva_utils-2.11.1-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/libva_utils-2.11.1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '18034e1875d75a811424decae53f36bf84ac1c089cabd9287dc6dce20633b81c',
-     armv7l: '18034e1875d75a811424decae53f36bf84ac1c089cabd9287dc6dce20633b81c',
-       i686: '3d66fe13689f3e46404d87847fc83e216f8f48e1c3c677c2b50ab534324c3472',
-     x86_64: '3a5bec9cc90d365adffa786a0f35d1e211fcec071244046719246d5c7be74084'
+    aarch64: '96b6472a638dc5b6269460b49ff4dab1063b7a9227a07cef8aa2aea5bb7d14f1',
+     armv7l: '96b6472a638dc5b6269460b49ff4dab1063b7a9227a07cef8aa2aea5bb7d14f1',
+       i686: '4e89b693c082deaab2c675597818eafbcec899d2dcaf59d4bf9a8b947c71d9ff',
+     x86_64: '2a2f1a713b00c8a14aeacb73f2cfb599f54cd147d02a001eb99f456fd859e17c'
   })
 
   depends_on 'libva'

--- a/packages/texlive.rb
+++ b/packages/texlive.rb
@@ -3,23 +3,23 @@ require 'package'
 class Texlive < Package
   description 'TeX Live is an easy way to get up and running with the TeX document production system.'
   homepage 'https://www.tug.org/texlive/'
-  version '20200406'
+  version '20210318'
   license 'GPL-2 and GPL-3'
   compatibility 'all'
   source_url 'https://github.com/TeX-Live/texlive-source/archive/refs/tags/svn58528.tar.gz'
   source_sha256 '5c2e53d25d2f85d511bb3fa238e2de718ce27e22db83559284570b5c380f4bed'
 
   binary_url({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/texlive-20200406-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/texlive-20200406-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/texlive-20200406-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/texlive-20200406-chromeos-x86_64.tar.xz'
+    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/texlive-20210318-chromeos-armv7l.tar.xz',
+     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/texlive-20210318-chromeos-armv7l.tar.xz',
+       i686: 'https://dl.bintray.com/chromebrew/chromebrew/texlive-20210318-chromeos-i686.tar.xz',
+     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/texlive-20210318-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'c6f87231b92dd7627ad33bb1038eeb5167b70b52c669a6c87277e8cb8ad7c53a',
-     armv7l: 'c6f87231b92dd7627ad33bb1038eeb5167b70b52c669a6c87277e8cb8ad7c53a',
-       i686: 'c7329f858b8acf873dd2f31be3d5230ac7d2d6e78156d1f919410a9223d493f8',
-     x86_64: '250e8b5a02c440efbcba35c32227537039b1934e97ccc6a83e1fcd57fc42e81c'
+    aarch64: 'ba9b3c7029ede0a12a692ed79125c15d60a00bd2dd17dccbfad4457ef8b264c6',
+     armv7l: 'ba9b3c7029ede0a12a692ed79125c15d60a00bd2dd17dccbfad4457ef8b264c6',
+       i686: '6962944875d9b18fd5f3c491edb25eb0305cce4df6dcd6b7a33dfa30908d06c9',
+     x86_64: 'd8d856b90d628da1cd5a616241eb09c3f695c35cc169645a8a5d5d89f2e71111'
   })
 
   depends_on 'freetype'
@@ -40,21 +40,21 @@ class Texlive < Package
   def self.prebuild
     # This is for people building with limited filespace
     Dir.chdir 'libs' do
-      FileUtils.rm_rf 'cairo'
-      FileUtils.rm_rf 'freetype2'
-      FileUtils.rm_rf 'gd'
-      FileUtils.rm_rf 'gmp'
-      FileUtils.rm_rf 'graphite2'
-      FileUtils.rm_rf 'harfbuzz'
-      FileUtils.rm_rf 'libpaper'
-      FileUtils.rm_rf 'libpng'
+      # FileUtils.rm_rf 'cairo'
+      # FileUtils.rm_rf 'freetype2'
+      # FileUtils.rm_rf 'gd'
+      # FileUtils.rm_rf 'gmp'
+      # FileUtils.rm_rf 'graphite2'
+      # FileUtils.rm_rf 'harfbuzz'
+      # FileUtils.rm_rf 'libpaper'
+      # FileUtils.rm_rf 'libpng'
       # FileUtils.rm_rf 'lua53'
       # FileUtils.rm_rf 'luajit'
-      FileUtils.rm_rf 'mfpr'
-      FileUtils.rm_rf 'pixman'
-      FileUtils.rm_rf 'poppler'
-      FileUtils.rm_rf 'zlib'
-      FileUtils.rm_rf 'zziplib'
+      # FileUtils.rm_rf 'mfpr'
+      # FileUtils.rm_rf 'pixman'
+      # FileUtils.rm_rf 'poppler'
+      # FileUtils.rm_rf 'zlib'
+      # FileUtils.rm_rf 'zziplib'
     end
   end
 


### PR DESCRIPTION
- new gmmlib allows for new intel_media_driver build.
- Hacked up hashpipe to work in docker containers which don't have `O_TMPFILE` functionality in their overlay filesystems by liberally copying code from gtk, which has a workaround.
- rebuilt gst-plugins_good to avoid libjpet_turbo
- updated texlive

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l (where applicable)
- [x] i686 (where applicable)
