### PR TITLE
License notice

### DIFF
--- a/crew
+++ b/crew
@@ -47,7 +47,7 @@ Usage:
 version #{CREW_VERSION}
 DOCOPT
 
-LICENSE = <<~LICENSESTRING
+CREW_LICENSE = <<~LICENSESTRING
   Copyright (C) 2021 Chromebrew Authors
 
   This program is free software: you can redistribute it and/or modify
@@ -82,7 +82,7 @@ rescue Docopt::Exit => e
       puts CREW_VERSION
       exit 0
     when '-L', '--license'
-      puts LICENSE
+      puts CREW_LICENSE
       exit 0
     end
     if ARGV[0] != '-h' and ARGV[0] != '--help' then

--- a/crew
+++ b/crew
@@ -77,10 +77,11 @@ begin
   args['<name>'] = args['<name>'].map { |arg| arg.gsub('-','_') } if args['<name>']
 rescue Docopt::Exit => e
   if ARGV[0] then
-    if ARGV[0] == '-V' or ARGV[0] == '--version' then
+    case ARGV[0]
+    when '-V', '--version'
       puts CREW_VERSION
       exit 0
-    elsif ARGV[0] == '-L' or ARGV[0] == '--license' then
+    when '-L', '--license'
       puts LICENSE
       exit 0
     end

--- a/crew
+++ b/crew
@@ -47,6 +47,22 @@ Usage:
 version #{CREW_VERSION}
 DOCOPT
 
+LICENSE = <<~LICENSESTRING
+  Copyright (C) 2021 Chromebrew Authors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html.
+LICENSESTRING
+
 # Set XZ_OPT environment variable for build command.
 # If CREW_XZ_OPT is defined, use it by default.  Use `-7e`, otherwise.
 ENV["XZ_OPT"] = ENV['CREW_XZ_OPT'] || "-7e -T #{CREW_NPROC}"
@@ -63,6 +79,9 @@ rescue Docopt::Exit => e
   if ARGV[0] then
     if ARGV[0] == '-V' or ARGV[0] == '--version' then
       puts CREW_VERSION
+      exit 0
+    elsif ARGV[0] == '-L' or ARGV[0] == '--license' then
+      puts LICENSE
       exit 0
     end
     if ARGV[0] != '-h' and ARGV[0] != '--help' then

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.20'
+CREW_VERSION = '1.7.21'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
If one reads near the bottom of the GPL license, they'll notice some recommendations of implementing license notices. This adds an implementation of a license notice to chromebrew. Works on x86_64.