### PR TITLE
util_linux doesn't depend on libtinfo

### DIFF
--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -23,7 +23,6 @@ class Util_linux < Package
   })
 
   depends_on 'libcap_ng'
-  depends_on 'libtinfo'
   depends_on 'linux_pam'
   depends_on 'pcre2'
   depends_on 'libeconf'


### PR DESCRIPTION
Since we use `--with-ncursesw` on util linux, it no longer depends on libtinfo.