### PR TITLE
add conflicts_with

### DIFF
--- a/lib/package.rb
+++ b/lib/package.rb
@@ -37,6 +37,14 @@ class Package
     @dependencies
   end
 
+  def self.conflicts_with (conflict = nil)
+    Dir[CREW_META_PATH + '*.directorylist'].sort.map do |f|
+      if File.basename(f, '.directorylist').include? conflict then
+        abort "#{conflict} is installed so #{**FIXME**} cannot be installed!".lightred
+      end
+    end
+  end
+
   def self.get_url (architecture)
     if !@build_from_source && @binary_url && @binary_url.has_key?(architecture)
       return @binary_url[architecture]


### PR DESCRIPTION
For a really long time we've needed the ability to have conflicting packages. Well here it is!!

I need help though, the 
```ruby
abort "#{conflict} is installed so #{**FIXME**} cannot be installed!".lightred
```
line is broken because I can't figure out the variable name of the current package trying to be installed. I tried so much. Other than that one message, it works!