### PR TITLE
Add check for conflicts with other installed files during a build

### DIFF
--- a/crew
+++ b/crew
@@ -690,6 +690,29 @@ def prepare_package (destdir)
     system 'find . -type l >> ../filelist'
     system 'cut -c2- ../filelist > filelist'
 
+    # check for conflicts with other installed files
+    conflicts = []
+    Dir[CREW_META_PATH + '*.filelist'].each do |packageList|
+      packageName = File.basename packageList, '.filelist'
+      File.readlines(packageList).each do |line|
+        File.readlines('filelist').each do |item|
+          if line == item && packageName != @pkg.name
+            conflicts << [packageName, item.chomp]
+          end
+        end
+      end
+    end
+    unless conflicts.empty?
+      puts "Unable to complete this build since there is a conflict with the same file in another package.".lightred
+      pp = ''
+      conflicts.each do |p, f|
+        puts "\n#{p} package conflicts below:".lightred if p != pp
+        puts f.lightred
+        pp = p
+      end
+      abort
+    end
+
     # create directory list
     system 'find . -type d > ../dlist'
     system 'cut -c2- ../dlist > dlistcut'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.22'
+CREW_VERSION = '1.7.23'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Solves the problem introduced in #5587.  Output from `crew build libiconv` below:
```
Checking...
Unable to complete this build since there is a conflict with the same file in another package.

manpages package conflicts below:
/usr/local/share/man/man3/iconv_close.3.gz
/usr/local/share/man/man3/iconv.3.gz
/usr/local/share/man/man3/iconv_open.3.gz
/usr/local/share/man/man1/iconv.1.gz
```