### PR TITLE
Fix crew whatprovides for files with underscores

### DIFF
--- a/crew
+++ b/crew
@@ -419,7 +419,7 @@ end
 
 def whatprovides (regexPat)
   fileArray = []
-  needle = regexPat.gsub(/-/,'_').gsub(/_/,'\-')
+  needle = regexPat.gsub(/-/,',').gsub(/,/,'\-')
   Dir[CREW_META_PATH + '*.filelist'].each do |packageList|
     packageName = File.basename packageList, '.filelist'
     File.readlines(packageList).each do |line|

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.23'
+CREW_VERSION = '1.7.24'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Fixes #5589.  It makes sense to replace the underscores with commas for substitutions since filenames cannot have that character.