### PR TITLE
Fix ant

### DIFF
--- a/packages/ant.rb
+++ b/packages/ant.rb
@@ -3,7 +3,7 @@ require 'package'
 class Ant < Package
   description 'Apache Ant is a Java library and command-line tool whose mission is to drive processes described in build files as targets and extension points dependent upon each other.'
   homepage 'http://ant.apache.org/'
-  version '1.10.9'
+  version '1.10.9-1'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://downloads.apache.org/ant/source/apache-ant-1.10.9-src.tar.xz'
@@ -41,7 +41,7 @@ class Ant < Package
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d/"
     @antenv = <<~ANTEOF
       # Apache Ant configuration
-      export JAVA_HOME=#{CREW_PREFIX}/share/jdk8'
+      export JAVA_HOME=#{CREW_PREFIX}/share/jdk8
       export ANT_HOME=\$JAVA_HOME
     ANTEOF
     IO.write("#{CREW_DEST_PREFIX}/etc/env.d/ant", @antenv)


### PR DESCRIPTION
Fixes this error with ant installed and sourcing ~/.bashrc

```
bash: /usr/local/etc/env.d/ant: line 2: unexpected EOF while looking for matching `''
bash: /usr/local/etc/env.d/ant: line 4: syntax error: unexpected end of file
```