### PR TITLE
Add crew_profile_base to LATE_PACKAGES

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative 'lib/color'
+require_relative '../lib/color'
 
 # Disallow sudo
 abort 'Chromebrew should not be run as root.'.lightred if Process.uid == 0
@@ -10,8 +10,8 @@ require 'uri'
 require 'digest/sha2'
 require 'json'
 require 'fileutils'
-require_relative 'lib/const'
-require_relative 'lib/util'
+require_relative '../lib/const'
+require_relative '../lib/util'
 
 # Add lib to LOAD_PATH
 $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"
@@ -72,7 +72,7 @@ ENV["XZ_OPT"] = ENV['CREW_XZ_OPT'] || "-7e -T #{CREW_NPROC}"
 CURL = ENV['CURL'] || 'curl'
 
 # Parse arguments using docopt
-require_relative 'lib/docopt'
+require_relative '../lib/docopt'
 begin
   args = Docopt::docopt(DOC)
   args['<name>'] = args['<name>'].map { |arg| arg.gsub('-','_') } if args['<name>']

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ EARLY_PACKAGES="gcc10 brotli c_ares libcyrussasl libidn2 libmetalink libnghttp2 
 libtirpc libunistring openldap rtmpdump zstd ncurses ca_certificates ruby libffi openssl \
 nettle krb5 p11kit libtasn1 gnutls curl git icu4c"
 
-LATE_PACKAGES="less most manpages filecmd mawk readline perl pcre pcre2 python27 python3 \
+LATE_PACKAGES="crew_profile_base less most manpages filecmd mawk readline perl pcre pcre2 python27 python3 \
 sed bz2 lz4 lzip unzip xzutils zip"
 
 ARCH="$(uname -m)"

--- a/install.sh
+++ b/install.sh
@@ -188,7 +188,7 @@ sudo ldconfig > /dev/null 2> /dev/null || true
 
 # create symlink to 'crew' in ${CREW_PREFIX}/bin/
 rm -f "${CREW_PREFIX}/bin/crew"
-ln -s "../lib/crew/crew" "${CREW_PREFIX}/bin/"
+ln -s "../lib/crew/bin/crew" "${CREW_PREFIX}/bin/"
 
 # prepare sparse checkout .rb packages directory and do it
 cd "${CREW_LIB_PATH}"

--- a/install.sh
+++ b/install.sh
@@ -184,7 +184,7 @@ for i in $(seq 0 $((${#urls[@]} - 1))); do
 done
 
 ## workaround https://github.com/skycocker/chromebrew/issues/3305
-sudo ldconfig > /dev/null 2> /dev/null || true
+sudo ldconfig &> /dev/null || true
 
 # create symlink to 'crew' in ${CREW_PREFIX}/bin/
 rm -f "${CREW_PREFIX}/bin/crew"

--- a/install.sh
+++ b/install.sh
@@ -187,8 +187,7 @@ done
 sudo ldconfig &> /dev/null || true
 
 # create symlink to 'crew' in ${CREW_PREFIX}/bin/
-rm -f "${CREW_PREFIX}/bin/crew"
-ln -s "../lib/crew/bin/crew" "${CREW_PREFIX}/bin/"
+ln -sfv "../lib/crew/bin/crew" "${CREW_PREFIX}/bin/"
 
 # prepare sparse checkout .rb packages directory and do it
 cd "${CREW_LIB_PATH}"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.7.25'
+CREW_VERSION = '1.7.26'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
The revisions to the install script prevent crew_profile_base, an essential package to some functions of chromebrew, like `/usr/local/tmp` and setting locales (for `crew whatprovides`)