### PR TITLE
Crew Package Dev workaround

### DIFF
--- a/crew
+++ b/crew
@@ -682,6 +682,14 @@ end
 
 def prepare_package (destdir)
   Dir.chdir destdir do
+    # Avoid /usr/local/share/info/dir{.gz} file conflict:
+    # The install-info program maintains a directory of installed 
+    # info documents in /usr/share/info/dir for the use of info 
+    # readers. This file must not be included in packages other 
+    # than install-info.
+    # https://www.debian.org/doc/debian-policy/ch-docs.html#info-documents
+    FileUtils.rm "#{CREW_DEST_PREFIX}/share/info/dir" if File.exist?("#{CREW_DEST_PREFIX}/share/info/dir")
+
     # compress manual files
     compress_doc "#{CREW_DEST_PREFIX}/man"
     compress_doc "#{CREW_DEST_PREFIX}/info"
@@ -713,7 +721,7 @@ def prepare_package (destdir)
         puts f.lightred
         pp = p
       end
-      abort
+      abort unless ENV['CREW_CONFLICTS_ONLY_ADVISORY'] == '1'
     end
 
     # create directory list

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.8.1'
+CREW_VERSION = '1.8.2'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- Allow for overriding package conflicts when developing packages which are meant to replace other packages.
- Stop packaging "#{CREW_DEST_PREFIX}/share/info/dir" with a global exclusion during package building

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686