### PR TITLE
[New Package] flatseal

### DIFF
--- a/packages/flatseal.rb
+++ b/packages/flatseal.rb
@@ -13,6 +13,7 @@ class Flatseal < Package
   depends_on 'desktop_file_utils'
   depends_on 'gjs'
   depends_on 'gtk3'
+  depends_on 'sommelier'
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} builddir"

--- a/packages/flatseal.rb
+++ b/packages/flatseal.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Flatseal < Package
+  description 'Flatseal is a graphical utility to review and modify permissions from your Flatpak applications.'
+  homepage 'https://github.com/tchx84/Flatseal'
+  version '1.6.8'
+  license 'GPL-3+'
+  compatibility 'all'
+  source_url 'https://github.com/tchx84/Flatseal/archive/v1.6.8.tar.gz'
+  source_sha256 '28d05995effa2858483283cbc9fb54c55bf4dcb6267e4d7d495a32ff724806b1'
+
+  depends_on 'libhandy'
+  depends_on 'desktop_file_utils'
+  depends_on 'gjs'
+  depends_on 'gtk3'
+
+  def self.build
+    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "samu -C builddir"
+  end
+
+  def self.check
+    system "samu -C builddir test"
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+    FileUtils.symlink 'com.github.tchx84.Flatseal', "#{CREW_DEST_PREFIX}/bin/flatseal"
+  end
+end

--- a/packages/meson.rb
+++ b/packages/meson.rb
@@ -22,8 +22,9 @@ class Meson < Package
        i686: 'f8a173fefc3b188208fbd6da61f3f9b0e94db62b8bbdb18573b8d740547ade82',
      x86_64: '4f6668f8cf6463fbe20e9d7de20d818548ab53ec69c7dae1e5700f57e6d6b816'
   })
-  
+
   depends_on 'ninja'
+  depends_on 'samurai'
 
   def self.install
     system "python3 setup.py install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"


### PR DESCRIPTION
Flatseal is a flatpak permissions manager. Although its original intention was to be installed as a flatpak, the AUR offers a non-sandboxed version. Alpine followed suit recently as well, and I thought, why not? It's smaller than a sandboxed version anyway.

Flatpak isn't a dependency because flatseal doesn't require it to run, however it's kinda useless without flatpak? (may be considered a logical dependency, but the dependency is weak enough I left it out.)

Works on x86_64, theoretically works on all arches we support.