### PR TITLE
packages/nano.rb: add filecmd to dependencies

### DIFF
--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -24,6 +24,7 @@ class Nano < Package
   })
 
   depends_on 'xdg_base'
+  depends_on 'filecmd'
 
   def self.patch
     system "sed -i '/SIGWINCH/d' src/nano.c"


### PR DESCRIPTION
Fixes
```
nano: error while loading shared libraries: libmagic.so.1: cannot open shared object file: no such file or directory
```