### PR TITLE
Fix sha256 hash for svt_av1 pre-built binary

### DIFF
--- a/packages/svt_av1.rb
+++ b/packages/svt_av1.rb
@@ -16,7 +16,7 @@ class Svt_av1 < Package
     x86_64: 'https://downloads.sourceforge.net/project/chromebrew/x86_64/svt_av1-0.8.6-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    x86_64: 'aae2d184ceaefd583dc310342497e01f334d6abf65bfd123a96ea8d4d535a8e0'
+    x86_64: '930dad392dc9b31153adfbdb01f5c9cc947bf58c29c121aac89039a24c043867'
   })
 
   def self.build


### PR DESCRIPTION
Fixes #5615.