### PR TITLE
Install gcc10 dependencies in buildessential

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,8 @@ CURL="${CURL:-curl}"
 
 # EARLY_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
 EARLY_PACKAGES="gcc10 brotli c_ares libcyrussasl libidn2 libmetalink libnghttp2 libpsl \
-libtirpc libunistring openldap rtmpdump zstd ncurses ca_certificates ruby libffi openssl \
-nettle krb5 p11kit libtasn1 gnutls curl git icu4c"
+libtirpc libunistring openldap rtmpdump zstd ncurses ca_certificates libyaml ruby libffi \
+openssl nettle krb5 p11kit libtasn1 gnutls curl git icu4c"
 
 LATE_PACKAGES="crew_profile_base less most manpages filecmd mawk readline perl pcre pcre2 python27 python3 \
 sed bz2 lz4 lzip unzip xzutils zip"

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.12'
+  version '1.13'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -15,6 +15,12 @@ class Buildessential < Package
   #install first to get ldconfig
   depends_on 'glibc'
   depends_on 'gcc10'
+  depends_on 'binutils'
+  depends_on 'gmp'
+  depends_on 'mpfr'
+  depends_on 'mpc'
+  depends_on 'isl'
+  depends_on 'libyaml'
   depends_on 'gcc_tools'
   depends_on 'linuxheaders'
   depends_on 'make'


### PR DESCRIPTION
Because gcc10 is an early package in install.sh and dependencies are not resolved at that point, we need to include them in buildessential to get the gcc compiler working.