### PR TITLE
ncurses wide 20210403

### DIFF
--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -1,66 +1,43 @@
 require 'package'
 
 class Ncurses < Package
-  description 'The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0 (SVr4), and more.'
+  description 'The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0 (SVr4), and more. — Wide character'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '6.2-20210206-1'
+  version "6.2-20210403"
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/mirror/ncurses/archive/b724cdc89cf31757ab43262ecefe5242b0edc450.zip'
-  source_sha256 'e5e83965329c85d8d28f9a35a71ab785fce015f42f491e7dcafbb9f36ad1eaea'
+  source_url 'https://github.com/mirror/ncurses.git'
+  git_hashtag 'd30f99439fcc8d4bb4c38e5c4afb4f6555fc6ad4'
 
   binary_url({
-    aarch64: 'https://downloads.sourceforge.net/project/chromebrew/armv7l/ncurses-6.2-20210206-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://downloads.sourceforge.net/project/chromebrew/armv7l/ncurses-6.2-20210206-1-chromeos-armv7l.tar.xz',
-       i686: 'https://downloads.sourceforge.net/project/chromebrew/i686/ncurses-6.2-20210206-1-chromeos-i686.tar.xz',
-     x86_64: 'https://downloads.sourceforge.net/project/chromebrew/x86_64/ncurses-6.2-20210206-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://downloads.sourceforge.net/project/chromebrew/armv7l/ncurses-6.2-20210403-chromeos-armv7l.tar.xz',
+     armv7l: 'https://downloads.sourceforge.net/project/chromebrew/armv7l/ncurses-6.2-20210403-chromeos-armv7l.tar.xz',
+       i686: 'https://downloads.sourceforge.net/project/chromebrew/i686/ncurses-6.2-20210403-chromeos-i686.tar.xz',
+     x86_64: 'https://downloads.sourceforge.net/project/chromebrew/x86_64/ncurses-6.2-20210403-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'f87816a803fdbb6403ecb03ea4faec04da8c3a829a1455a2c9e0a0686818ebb6',
-     armv7l: 'f87816a803fdbb6403ecb03ea4faec04da8c3a829a1455a2c9e0a0686818ebb6',
-       i686: 'ad1fb3a7d832d4fcf4e695cd5f5f7e023581c2d0529a2bf9729acd2cd96e44cd',
-     x86_64: 'd81416072e4e4454b585495db8b7e0767867c851e512afd4655fa8174d244c02'
+    aarch64: '4244d294b65d47c744f3991616af8a8c4e01e2620a5e612a94477fd42742b2f8',
+     armv7l: '4244d294b65d47c744f3991616af8a8c4e01e2620a5e612a94477fd42742b2f8',
+       i686: '27c1aff7631cc628de5f210395015698c8de6ffef287b14e01a06f64a822086b',
+     x86_64: 'f356d8d2b2637faf2d16b5f483439bbaca168c7b89ab052c369dcdd62caa6fcd'
   })
-
+  
   def self.build
     # build libncursesw
     FileUtils.mkdir 'ncursesw_build'
     Dir.chdir 'ncursesw_build' do
-      system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-        LDFLAGS='-flto=auto' ../configure \
-        #{CREW_OPTIONS} \
-        --program-prefix='' \
-        --program-suffix='' \
-        --with-shared \
-        --with-cxx-shared \
-        --without-debug \
-        --enable-pc-files \
-        --with-pkg-config-libdir=#{CREW_LIB_PREFIX}/pkgconfig \
-        --enable-widec \
-        --without-tests \
-        --with-termlib"
-      system 'make'
-    end
-
-    # build libncurses
-    FileUtils.mkdir 'ncurses_build'
-    Dir.chdir 'ncurses_build' do
-      system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-        LDFLAGS='-flto=auto' ../configure \
-         #{CREW_OPTIONS} \
-         --program-prefix='' \
-         --program-suffix='' \
-         --with-shared \
-         --with-cxx-shared \
-         --without-debug \
-         --enable-pc-files \
-         --with-pkg-config-libdir=#{CREW_LIB_PREFIX}/pkgconfig \
-         --disable-db-install \
-         --without-manpages \
-         --without-progs \
-         --without-tack \
-         --without-tests \
-         --with-termlib"
+      system "env #{CREW_ENV_OPTIONS} \
+        ../configure #{CREW_OPTIONS} \
+          --program-prefix='' \
+          --program-suffix='' \
+          --with-shared \
+          --with-cxx-shared \
+          --without-debug \
+          --enable-pc-files \
+          --with-pkg-config-libdir=#{CREW_LIB_PREFIX}/pkgconfig \
+          --enable-widec \
+          --without-tests \
+          --with-termlib"
       system 'make'
     end
   end
@@ -69,8 +46,13 @@ class Ncurses < Package
     Dir.chdir 'ncursesw_build' do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
-    Dir.chdir 'ncurses_build' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    # Make symlinks for non-wide software
+    Dir.chdir CREW_DEST_LIB_PREFIX.to_s do
+      Dir.glob('*w.so*').each do |f|
+        @basefile_nowide = f.gsub('w.so', '.so')
+        puts "Symlinking #{f} to #{@basefile_nowide}"
+        FileUtils.ln_sf f, @basefile_nowide
+      end
     end
   end
 end


### PR DESCRIPTION
- This is ncurses updated to use wide.
- This needs testing.

How to test:
```
crew update
export CREW_TESTING_BRANCH=ncursesw
export CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git
CREW_TESTING=1 crew update
CREW_TESTING=1 crew upgrade ncurses
# Now test apps.
# Now revert to normal:
crew update 
crew upgrade ncurses
```

Works properly:
- [?] x86_64
- [?] armv7l
- [?] i686
