### PR TITLE
Display conflicts detection progress

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -759,10 +759,14 @@ def prepare_package (destdir)
     conflicts = []
     Dir[CREW_META_PATH + '*.filelist'].each do |packageList|
       packageName = File.basename packageList, '.filelist'
-      File.readlines(packageList).each do |line|
-        File.readlines('filelist').each do |item|
-          if line == item && packageName != @pkg.name
-            conflicts << [packageName, item.chomp]
+      if packageName != @pkg.name
+        puts "Checking for conflicts in #{packageName}..."
+        File.readlines(packageList).each do |line|
+          File.readlines('filelist').each do |item|
+            if line == item
+              conflicts << [packageName, item.chomp]
+              puts item.chomp
+            end
           end
         end
       end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.8.7'
+CREW_VERSION = '1.8.8'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -12,7 +12,6 @@ gdbm
 gettext
 git
 gnutls
-groff
 icu4c
 krb5
 less
@@ -52,7 +51,6 @@ ruby
 sed
 slang
 sqlite
-uchardet
 unzip
 xzutils
 zip


### PR DESCRIPTION
Should help alleviate confusion for long delays with `Checking...`.  This does nothing to help speed up the painfully long process of detecting conflicts, however.