### PR TITLE
Fix crew buildessential dependency resolution

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -511,7 +511,7 @@ def upgrade
       puts "#{@pkg.name} is already up to date.".lightgreen
     end
   else
-    # Make a installed packages list belong to the dependency order
+    # Make an installed packages list belong to the dependency order
     dependencies = []
     @device[:installed_packages].each do |package|
       # skip package if it is dependent other packages previously checked
@@ -520,6 +520,7 @@ def upgrade
       dependencies = [ package[:name] ].concat(dependencies)
       # expand dependencies and add it to the dependencies list
       search package[:name], true
+      @dependencies = []
       exp_dep = expand_dependencies
       dependencies = exp_dep.concat(dependencies)
     end
@@ -849,17 +850,6 @@ def resolve_dependencies_and_install
 end
 
 def expand_dependencies
-  @dependencies = []
-  if @pkg.build_from_source
-    # make sure all buildessential packages are installed
-    pkgname = @pkg.name
-    search 'buildessential', true
-    check_deps = @pkg.dependencies.map {|k, v| k}
-    check_deps.each do |dep|
-      @dependencies << dep unless @device[:installed_packages].include?(dep)
-    end
-    search pkgname, true
-  end
   def push_dependencies
     if @pkg.is_binary?(@device[:architecture]) ||
       (!@pkg.in_upgrade && !@pkg.build_from_source && @device[:installed_packages].any? { |pkg| pkg[:name] == @pkg.name })
@@ -884,6 +874,15 @@ end
 
 def resolve_dependencies
   abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @pkg.compatibility.include?('all') or @pkg.compatibility.include?(ARCH)
+
+  @dependencies = []
+  if @pkg.build_from_source
+    # make sure all buildessential packages are installed
+    pkgname = @pkg.name
+    search 'buildessential', true
+    expand_dependencies
+    search pkgname, true
+  end
   expand_dependencies
 
   # leave only not installed packages in dependencies

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.8.9'
+CREW_VERSION = '1.8.10'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
The current buildessential dependency resolver code block has the parent dependencies only and does not include the inherited dependencies.  This can be confirmed by attempting a build of bmon which requires autoconf.  This PR solves that issue.