### PR TITLE
rebuild ruby w/o dependence on gcc10 libssp

### DIFF
--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -3,23 +3,23 @@ require 'package'
 class Ruby < Package
   description 'Ruby is a dynamic, open source programming language with a focus on simplicity and productivity.'
   homepage 'https://www.ruby-lang.org/en/'
-  version '3.0.1'
+  version '3.0.1-1'
   license 'Ruby-BSD and BSD-2'
   compatibility 'all'
   source_url 'https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.1.tar.gz'
   source_sha256 '369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727'
 
   binary_url({
-    aarch64: 'https://downloads.sourceforge.net/project/chromebrew/armv7l/ruby-3.0.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://downloads.sourceforge.net/project/chromebrew/armv7l/ruby-3.0.1-chromeos-armv7l.tar.xz',
-       i686: 'https://downloads.sourceforge.net/project/chromebrew/i686/ruby-3.0.1-chromeos-i686.tar.xz',
-     x86_64: 'https://downloads.sourceforge.net/project/chromebrew/x86_64/ruby-3.0.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://downloads.sourceforge.net/project/chromebrew/armv7l/ruby-3.0.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://downloads.sourceforge.net/project/chromebrew/armv7l/ruby-3.0.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://downloads.sourceforge.net/project/chromebrew/i686/ruby-3.0.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://downloads.sourceforge.net/project/chromebrew/x86_64/ruby-3.0.1-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '210eb6582d1a06e7fbdbbfeb6658abed7633437de3e7faa4ebf16875e3687e28',
-     armv7l: '210eb6582d1a06e7fbdbbfeb6658abed7633437de3e7faa4ebf16875e3687e28',
-       i686: 'a7b5531d7d331bdaa2b822eed85dd66ecf3a9f7f04ed9227c154f9657a4d53cd',
-     x86_64: '78bba3bf15210fd85ece6a0551fc0a1097c55a39f92b334a204ac97edfa2e1a5'
+    aarch64: '03f443d63cca0fb640ec4d11f3b1306a9719e775f8c706c732f9231e41e66afd',
+     armv7l: '03f443d63cca0fb640ec4d11f3b1306a9719e775f8c706c732f9231e41e66afd',
+       i686: 'dc388589df39c39e9c494e761ae2ca950a9b4f0573aa0d96508959787c050dcd',
+     x86_64: '4f86c98eaae1e708bf66f1c939a5cd07d5764b9b64ca827e6f7d5f61021bcb7e'
   })
 
   depends_on 'ca_certificates'
@@ -29,8 +29,9 @@ class Ruby < Package
   def self.build
     # The download from ruby-lang.org doesn't need autoconf run,
     # but the download from github does.
-    # system 'autoreconf -fiv'
-    system "env CFLAGS='-ltinfo -flto=auto' CXXFLAGS='-flto=auto' \
+    system '[ -x configure ] || autoreconf -fiv'
+    system "env RUBY_CONF_ENV='stack_protector=no' \
+    CFLAGS='-ltinfow -flto=auto' CXXFLAGS='-flto=auto' \
     LDFLAGS='-flto=auto' \
     optflags='-flto=auto' \
     ./configure #{CREW_OPTIONS} \
@@ -39,9 +40,9 @@ class Ruby < Package
     system 'make'
   end
 
-  def self.check
-    system "make check || true"
-  end
+  # def self.check
+  #  system 'make check || true'
+  # end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'


### PR DESCRIPTION
- This works for me with `gcc10` 10.3.0 built w/o libssp.
- This removes the `gcc10` dependence for `ruby` at install time,

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l