### PR TITLE
add deps to mpc, mpfr

### DIFF
--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -22,7 +22,8 @@ class Mpc < Package
      x86_64: '57276bec912dabfed4d65d5edb3e18788c168056727057ee0c91aa8484eebdba'
   })
 
-  depends_on 'mpfr' => :build
+  depends_on 'gmp' # R
+  depends_on 'mpfr' # R
 
   def self.build
     system "./configure \

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -23,6 +23,8 @@ class Mpfr < Package
   })
 
   depends_on 'autoconf_archive' => :build
+  depends_on 'hashpipe' => :build
+  depends_on 'gmp' # R
 
   def self.patch
     puts 'Applying current rolling patchset. See https://www.mpfr.org/mpfr-current/#bugs'


### PR DESCRIPTION
- hashpipe is needed for building mpfr

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l