### PR TITLE
Handle git branch only source

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -630,9 +630,13 @@ def download
         unless @pkg.git_branch.nil? || @pkg.git_branch.empty?
           # Leave a message because this step can be slow.
           puts "Downloading src from a git branch. This may take a while..."
-          system "git remote set-branches origin #{@pkg.git_branch}", exception: true
-          system "git fetch --progress origin #{@pkg.git_branch}", exception: true
-          system "git checkout #{@pkg.git_hashtag}", exception: true
+          unless @pkg.git_hashtag.nil? || @pkg.git_hashtag.empty?
+            system "git remote set-branches origin #{@pkg.git_branch}", exception: true
+            system "git fetch --progress origin #{@pkg.git_branch}", exception: true
+            system "git checkout #{@pkg.git_hashtag}", exception: true
+          else
+            system "git clone --depth 1 --branch #{@pkg.git_branch} #{@pkg.source_url}", exception: true
+          end
         else
           system "git fetch --depth 1 origin #{@pkg.git_hashtag}", exception: true
           system 'git checkout FETCH_HEAD'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.8.10'
+CREW_VERSION = '1.8.11'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Sometimes you might want to build from source from a git branch without a git_hashtag.