### PR TITLE
Crew Cache Cleanup

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -578,26 +578,31 @@ def download
     case File.basename(filename)
     # Sources that download with curl
     when /\.zip$/i, /\.(tar(\.(gz|bz2|xz|lz))?|tgz|tbz|txz)$/i, /\.deb$/i
-      # Recall file from cache if requeseted
+      # Recall file from cache if requested
       if CREW_CACHE_ENABLED
+        puts "Looking for archive in cache".orange if @opt_verbose
         cachefile = CREW_CACHE_DIR + filename
-        if File.file?(cachefile)
+        if ! File.exist?(cachefile)
+          puts 'Cannot find cached archive. 😔 Will download.'.lightred
+          cachefile = ''
+        else
+          puts "Archive file exists in cache".lightgreen if @opt_verbose
           if Digest::SHA256.hexdigest( File.read(cachefile) ) == sha256sum then
             begin
               # Hard link cached file if possible.
               FileUtils.ln cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose
+              puts "Archive hard linked from cache".green if @opt_verbose
             rescue
               # Copy cached file if hard link fails.
               FileUtils.cp cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose
+              puts "Archive copied from cache".green if @opt_verbose
             end
-            puts "Archive found in cache".lightgreen
-            return {source: source, filename: filename}
+          puts "Archive found in cache".lightgreen
+          return {source: source, filename: filename}
           else
             puts 'Cached archive checksum mismatch. :/ Will download.'.lightred
             cachefile = ''
           end
-        puts 'Cannot find cached archive. :/ Will download.'.lightred
-        cachefile = ''
         end
       end
       # Download file if not cached.
@@ -610,12 +615,15 @@ def download
         begin
           # Hard link to cache if possible.
           FileUtils.ln filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
+          puts "Archive hard linked to cache".green if @opt_verbose
         rescue
           # Copy to cache if hard link fails.
           FileUtils.cp filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
+          puts "Archive copied to cache".green if @opt_verbose
         end
-        puts 'Archive cached.'.lightgreen
+        puts 'Archive copied to cache.'.lightgreen
       end
+      return {source: source, filename: filename}
 
     # Sources that download with git
     when /\.git$/i

--- a/bin/crew
+++ b/bin/crew
@@ -606,7 +606,7 @@ def download
         Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum
       puts 'Archive downloaded.'.lightgreen
       # Stow file in cache if requested (and if file is not from cache).
-      if CREW_CACHE_ENABLED and ! cachefile.to_s.empty?
+      if CREW_CACHE_ENABLED and cachefile.to_s.empty?
         begin
           # Hard link to cache if possible.
           FileUtils.ln filename, CREW_CACHE_DIR, verbose: @fileutils_verbose

--- a/bin/crew
+++ b/bin/crew
@@ -583,23 +583,37 @@ def download
         cachefile = CREW_CACHE_DIR + filename
         if File.file?(cachefile)
           if Digest::SHA256.hexdigest( File.read(cachefile) ) == sha256sum then
-            FileUtils.cp cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose
+            begin
+              # Hard link cached file if possible.
+              FileUtils.ln cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose
+            rescue
+              # Copy cached file if hard link fails.
+              FileUtils.cp cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose
+            end
             puts "Archive found in cache".lightgreen
             return {source: source, filename: filename}
           else
             puts 'Cached archive checksum mismatch. :/ Will download.'.lightred
+            cachefile = ''
           end
         puts 'Cannot find cached archive. :/ Will download.'.lightred
+        cachefile = ''
         end
       end
-      # Download file if not cached
+      # Download file if not cached.
       system "#{CURL} --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
       abort 'Checksum mismatch. :/ Try again.'.lightred unless
         Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum
       puts 'Archive downloaded.'.lightgreen
-      # Stow file in cache if requested
-      if CREW_CACHE_ENABLED
-        FileUtils.cp filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
+      # Stow file in cache if requested (and if file is not from cache).
+      if CREW_CACHE_ENABLED and ! cachefile.to_s.empty?
+        begin
+          # Hard link to cache if possible.
+          FileUtils.ln filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
+        rescue
+          # Copy to cache if hard link fails.
+          FileUtils.cp filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
+        end
         puts 'Archive cached.'.lightgreen
       end
 
@@ -607,7 +621,7 @@ def download
     when /\.git$/i
       # Recall repository from cache if requested
       if CREW_CACHE_ENABLED
-        cachefile = CREW_CACHE_DIR + '/' + filename + '.tar.xz'
+        cachefile = CREW_CACHE_DIR + filename + '.tar.xz'
         if File.file?(cachefile)
           if system "sha256sum -c #{cachefile}.sha256"
             FileUtils.mkdir @extract_dir

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.8.10'
+CREW_VERSION = '1.8.11'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines
@@ -35,11 +35,13 @@ else
   HOME = CREW_PREFIX + ENV['HOME']
 end
 
+# File.join ensures a trailing slash if one does not exist.
 if ENV['CREW_CACHE_DIR'].to_s == ''
-  CREW_CACHE_DIR = HOME + '/.cache/crewcache'
+  CREW_CACHE_DIR = File.join(HOME + '/.cache/crewcache', '')
 else
-  CREW_CACHE_DIR = ENV['CREW_CACHE_DIR']
+  CREW_CACHE_DIR = File.join(ENV['CREW_CACHE_DIR'], '')
 end
+
 FileUtils.mkdir_p CREW_CACHE_DIR unless Dir.exist? CREW_CACHE_DIR
 
 CREW_CACHE_ENABLED = ENV['CREW_CACHE_ENABLED']

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -10,7 +10,7 @@ ARCH = if ARCH_ACTUAL == 'armv8l' then 'armv7l' else ARCH_ACTUAL end
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
 LIBC_VERSION = if File.exist? "/#{ARCH_LIB}/libc-2.27.so" then '2.27' else '2.23' end
 
-if ENV['CREW_PREFIX'].to_s == ''
+if ENV['CREW_PREFIX'].to_s.empty
   CREW_PREFIX = '/usr/local'
 else
   CREW_PREFIX = ENV['CREW_PREFIX']
@@ -29,14 +29,14 @@ CREW_DEST_PREFIX = CREW_DEST_DIR + CREW_PREFIX
 CREW_DEST_LIB_PREFIX = CREW_DEST_DIR + CREW_LIB_PREFIX
 CREW_DEST_MAN_PREFIX = CREW_DEST_DIR + CREW_MAN_PREFIX
 
-if ENV['CREW_PREFIX'].to_s == ''
+if ENV['CREW_PREFIX'].to_s.empty
   HOME = ENV['HOME']
 else
   HOME = CREW_PREFIX + ENV['HOME']
 end
 
 # File.join ensures a trailing slash if one does not exist.
-if ENV['CREW_CACHE_DIR'].to_s == ''
+if ENV['CREW_CACHE_DIR'].to_s.empty
   CREW_CACHE_DIR = File.join(HOME + '/.cache/crewcache', '')
 else
   CREW_CACHE_DIR = File.join(ENV['CREW_CACHE_DIR'], '')
@@ -49,7 +49,7 @@ CREW_CACHE_ENABLED = ENV['CREW_CACHE_ENABLED']
 CREW_DEST_HOME = CREW_DEST_DIR + HOME
 
 # Set CREW_NPROC from environment variable or `nproc`
-if ENV["CREW_NPROC"].to_s == ''
+if ENV["CREW_NPROC"].to_s.empty
   CREW_NPROC = `nproc`.strip
 else
   CREW_NPROC = ENV["CREW_NPROC"]

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -10,7 +10,7 @@ ARCH = if ARCH_ACTUAL == 'armv8l' then 'armv7l' else ARCH_ACTUAL end
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
 LIBC_VERSION = if File.exist? "/#{ARCH_LIB}/libc-2.27.so" then '2.27' else '2.23' end
 
-if ENV['CREW_PREFIX'].to_s.empty
+if ENV['CREW_PREFIX'].to_s.empty?
   CREW_PREFIX = '/usr/local'
 else
   CREW_PREFIX = ENV['CREW_PREFIX']
@@ -29,14 +29,14 @@ CREW_DEST_PREFIX = CREW_DEST_DIR + CREW_PREFIX
 CREW_DEST_LIB_PREFIX = CREW_DEST_DIR + CREW_LIB_PREFIX
 CREW_DEST_MAN_PREFIX = CREW_DEST_DIR + CREW_MAN_PREFIX
 
-if ENV['CREW_PREFIX'].to_s.empty
+if ENV['CREW_PREFIX'].to_s.empty?
   HOME = ENV['HOME']
 else
   HOME = CREW_PREFIX + ENV['HOME']
 end
 
 # File.join ensures a trailing slash if one does not exist.
-if ENV['CREW_CACHE_DIR'].to_s.empty
+if ENV['CREW_CACHE_DIR'].to_s.empty?
   CREW_CACHE_DIR = File.join(HOME + '/.cache/crewcache', '')
 else
   CREW_CACHE_DIR = File.join(ENV['CREW_CACHE_DIR'], '')
@@ -49,7 +49,7 @@ CREW_CACHE_ENABLED = ENV['CREW_CACHE_ENABLED']
 CREW_DEST_HOME = CREW_DEST_DIR + HOME
 
 # Set CREW_NPROC from environment variable or `nproc`
-if ENV["CREW_NPROC"].to_s.empty
+if ENV["CREW_NPROC"].to_s.empty?
   CREW_NPROC = `nproc`.strip
 else
   CREW_NPROC = ENV["CREW_NPROC"]


### PR DESCRIPTION
- Adds trailing slash to CREW_CACHE_DIR using technique from https://stackoverflow.com/a/12393692
- Link cached archive to and from CREW_BREW_DIR using hard links if possible, which is much faster than copying.
- Don't copy archive to cache if it is from cache

Works properly:
- [x] x86_64
