### PR TITLE
groff is a runtime dependency for mandb

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -25,7 +25,7 @@ class Mandb < Package
 
   depends_on 'gdbm'
   depends_on 'glibc'
-  depends_on 'groff' => :build
+  depends_on 'groff'
   depends_on 'libpipeline'
   depends_on 'libseccomp'
   depends_on 'zlibpkg'


### PR DESCRIPTION
Fixes #5693.