### PR TITLE
Crew: add git hash for caching git dirs

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -631,12 +631,14 @@ def download
       if CREW_CACHE_ENABLED
         if @pkg.git_branch.nil? || @pkg.git_branch.empty?
           cachefile = CREW_CACHE_DIR + filename + @pkg.git_hashtag + '.tar.xz'
+          puts "cachefile is #{cachefile}".orange if @opt_verbose
         else
           # Use to the day granularity for a branch timestamp.
-          cachefile = CREW_CACHE_DIR + filename + @pkg.git_branch + Time.now.strftime("%m%d%Y") + '.tar.xz'
+          cachefile = CREW_CACHE_DIR + filename + @pkg.git_branch.gsub(/[^0-9A-Za-z.\-]/, '_') + Time.now.strftime("%m%d%Y") + '.tar.xz'
+          puts "cachefile is #{cachefile}".orange if @opt_verbose
         end
         if File.file?(cachefile)
-          if system "sha256sum -c #{cachefile}.sha256"
+          if system "cd #{CREW_CACHE_DIR} && sha256sum -c #{cachefile}.sha256"
             FileUtils.mkdir @extract_dir
             system "tar x#{@verbose}f #{cachefile} -C #{@extract_dir}"
             return {source: source, filename: filename}
@@ -674,8 +676,7 @@ def download
             system "tar c#{@verbose}Jf #{cachefile} \
               $(find -mindepth 1 -maxdepth 1 -printf '%P\n')"
           end
-            system "sha256sum #{cachefile} > #{cachefile}.sha256"
-        end
+          system "sha256sum #{cachefile} > #{cachefile}.sha256"
         puts 'Git repo cached.'.lightgreen
       end
     end

--- a/bin/crew
+++ b/bin/crew
@@ -670,15 +670,13 @@ def download
       # Stow file in cache if requested
       if CREW_CACHE_ENABLED
         puts 'Caching downloaded git repo...'
-        archivegitjob = fork do
           Dir.chdir "#{@extract_dir}" do
-            exec "tar c#{@verbose}Jf #{cachefile} \
-              $(find -mindepth 1 -maxdepth 1 -printf '%P\n'); \
-              sha256sum #{cachefile} > #{cachefile}.sha256"
+            system "tar c#{@verbose}Jf #{cachefile} \
+              $(find -mindepth 1 -maxdepth 1 -printf '%P\n')"
           end
+            system "sha256sum #{cachefile} > #{cachefile}.sha256"
         end
-        Process.detach(archivegitjob)
-        puts 'Git archive caching job backgrounded.'.lightgreen
+        puts 'Git repo cached.'.lightgreen
       end
     end
   end

--- a/bin/crew
+++ b/bin/crew
@@ -600,14 +600,14 @@ def download
           puts "Archive found in cache".lightgreen
           return {source: source, filename: filename}
           else
-            puts 'Cached archive checksum mismatch. :/ Will download.'.lightred
+            puts 'Cached archive checksum mismatch. 😔 Will download.'.lightred
             cachefile = ''
           end
         end
       end
       # Download file if not cached.
       system "#{CURL} --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
-      abort 'Checksum mismatch. :/ Try again.'.lightred unless
+      abort 'Checksum mismatch. 😔 Try again.'.lightred unless
         Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum
       puts 'Archive downloaded.'.lightgreen
       # Stow file in cache if requested (and if file is not from cache).
@@ -629,17 +629,22 @@ def download
     when /\.git$/i
       # Recall repository from cache if requested
       if CREW_CACHE_ENABLED
-        cachefile = CREW_CACHE_DIR + filename + '.tar.xz'
+        if @pkg.git_branch.nil? || @pkg.git_branch.empty?
+          cachefile = CREW_CACHE_DIR + filename + @pkg.git_hashtag + '.tar.xz'
+        else
+          # Use to the day granularity for a branch timestamp.
+          cachefile = CREW_CACHE_DIR + filename + @pkg.git_branch + Time.now.strftime("%m%d%Y") + '.tar.xz'
+        end
         if File.file?(cachefile)
           if system "sha256sum -c #{cachefile}.sha256"
             FileUtils.mkdir @extract_dir
             system "tar x#{@verbose}f #{cachefile} -C #{@extract_dir}"
             return {source: source, filename: filename}
           else
-            puts 'Cached repository checksum mismatch. :/ Will download.'.lightred
+            puts 'Cached git repository checksum mismatch. 😔 Will download.'.lightred
           end
         else
-          puts 'Cannot find cached repository. :/ Will download.'.lightred
+          puts 'Cannot find cached git repository. 😔 Will download.'.lightred
         end
       end
       # Download via git
@@ -664,13 +669,16 @@ def download
       end
       # Stow file in cache if requested
       if CREW_CACHE_ENABLED
-        puts 'Caching downloaded archive...'
+        puts 'Caching downloaded git repo...'
+        archivegitjob = fork do
           Dir.chdir "#{@extract_dir}" do
-            system "tar c#{@verbose}Jf #{CREW_CACHE_DIR}/#{filename}.tar.xz \
-              $(find -mindepth 1 -maxdepth 1 -printf '%P\n')"
+            exec "tar c#{@verbose}Jf #{cachefile} \
+              $(find -mindepth 1 -maxdepth 1 -printf '%P\n'); \
+              sha256sum #{cachefile} > #{cachefile}.sha256"
           end
-        system "sha256sum #{CREW_CACHE_DIR}/#{filename}.tar.xz > #{CREW_CACHE_DIR}/#{filename}.tar.xz.sha256"
-        puts 'Archive cached.'.lightgreen
+        end
+        Process.detach(archivegitjob)
+        puts 'Git archive caching job backgrounded.'.lightgreen
       end
     end
   end

--- a/bin/crew
+++ b/bin/crew
@@ -672,11 +672,11 @@ def download
       # Stow file in cache if requested
       if CREW_CACHE_ENABLED
         puts 'Caching downloaded git repo...'
-          Dir.chdir "#{@extract_dir}" do
-            system "tar c#{@verbose}Jf #{cachefile} \
-              $(find -mindepth 1 -maxdepth 1 -printf '%P\n')"
-          end
-          system "sha256sum #{cachefile} > #{cachefile}.sha256"
+        Dir.chdir "#{@extract_dir}" do
+          system "tar c#{@verbose}Jf #{cachefile} \
+            $(find -mindepth 1 -maxdepth 1 -printf '%P\n')"
+        end
+        system "sha256sum #{cachefile} > #{cachefile}.sha256"
         puts 'Git repo cached.'.lightgreen
       end
     end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.8.12'
+CREW_VERSION = '1.8.13'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- use git hash for git cache filename
- use git branch plus day datestamp for git cache filename
- Otherwise builds with changing git hashes use the same git cache archive.

Works properly:
- [x] x86_64
