### PR TITLE
add make to lsb_release deps

### DIFF
--- a/packages/lsb_release.rb
+++ b/packages/lsb_release.rb
@@ -14,8 +14,8 @@ class Lsb_release < Package
   binary_sha256 ({
   })
 
-  depends_on 'help2man' => :build
-  depends_on 'make' => :build
+  depends_on 'help2man'
+  depends_on 'make'
 
   def self.build
     system "cp /etc/lsb-release /tmp"

--- a/packages/lsb_release.rb
+++ b/packages/lsb_release.rb
@@ -15,6 +15,7 @@ class Lsb_release < Package
   })
 
   depends_on 'help2man'
+  depends_on 'make'
 
   def self.build
     system "cp /etc/lsb-release /tmp"

--- a/packages/lsb_release.rb
+++ b/packages/lsb_release.rb
@@ -14,8 +14,8 @@ class Lsb_release < Package
   binary_sha256 ({
   })
 
-  depends_on 'help2man'
-  depends_on 'make'
+  depends_on 'help2man' => :build
+  depends_on 'make' => :build
 
   def self.build
     system "cp /etc/lsb-release /tmp"


### PR DESCRIPTION
Fixes #5703
- Add `make` to deps for `lsb_release`
- make both `make` and `help2man` build deps

Works properly:
- [x] x86_64
