### PR TITLE
fix ocaml url

### DIFF
--- a/packages/ocaml.rb
+++ b/packages/ocaml.rb
@@ -13,7 +13,7 @@ class Ocaml < Package
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ocaml/4.12.0_armv7l/ocaml-4.12.0-chromeos-armv7l.tar.xz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ocaml/4.12.0_armv7l/ocaml-4.12.0-chromeos-armv7l.tar.xz',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ocaml/4.12.0_i686/ocaml-4.12.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ocaml/4.12.0_x86_64/ocaml-4.10.0-chromeos-x86_64.tar.xz'
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ocaml/4.12.0_x86_64/ocaml-4.12.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
     aarch64: '6da8eaf154e9e5be53d49ba12704cf3ad857fce4b404be44104a2b4417440e9b',


### PR DESCRIPTION
- fix typo in ocaml url.
- The other URLs are correct.

Works properly:
- [x] x86_64
