### PR TITLE
pulseaudio dependency cleanup

### DIFF
--- a/packages/alsa_plugins.rb
+++ b/packages/alsa_plugins.rb
@@ -24,7 +24,7 @@ class Alsa_plugins < Package
 
   depends_on 'dbus'
   depends_on 'ffmpeg'
-  depends_on 'speexdsp'
+  depends_on 'speex'
   depends_on 'alsa_lib'
   depends_on 'pulseaudio'
 

--- a/packages/cras.rb
+++ b/packages/cras.rb
@@ -26,7 +26,7 @@ class Cras < Package
     depends_on 'alsa_lib'
     depends_on 'ladspa'
     depends_on 'iniparser'
-    depends_on 'speexdsp'
+    depends_on 'speex'
     depends_on 'sbc'
     depends_on 'dbus'
     depends_on 'rust' => :build

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -23,33 +23,40 @@ class Pulseaudio < Package
      x86_64: 'cbb4cd934818825e7bc006a82c02e67179d17c25922a04574853374c4760a095'
   })
 
-  depends_on 'gsettings_desktop_schemas'
+  depends_on 'alsa_lib' # R
   depends_on 'alsa_plugins' => :build
-  depends_on 'tcpwrappers'
-  depends_on 'libsndfile'
-  depends_on 'xorg_lib'
-  depends_on 'libgconf'
-  depends_on 'libsoxr'
-  depends_on 'libcap'
-  depends_on 'jsonc'
-  depends_on 'speex'
-  depends_on 'eudev'
-  depends_on 'gtk3'
-  depends_on 'dbus'
-  depends_on 'tdb'
-  depends_on 'cras'
-  depends_on 'orc'
-  depends_on 'jack'
-  depends_on 'avahi'
-  depends_on 'gstreamer'
-  depends_on 'valgrind'
-  depends_on 'elogind'
-  depends_on 'eudev'
-  depends_on 'gst_plugins_base'
-  depends_on 'gst_plugins_good'
-  depends_on 'gst_plugins_bad'
+  depends_on 'avahi' # R
   depends_on 'check' => :build
-  depends_on 'webrtc_audio_processing'
+  depends_on 'cras' # L
+  depends_on 'dbus' # R
+  depends_on 'elogind' => :build
+  depends_on 'eudev' # R
+  depends_on 'gcc10' # R
+  depends_on 'glibc' # R
+  depends_on 'glib' # R
+  depends_on 'gsettings_desktop_schemas' # L
+  depends_on 'gst_plugins_base' # R
+  depends_on 'gstreamer' # R
+  depends_on 'jack' # R
+  depends_on 'jsonc' => :build
+  depends_on 'libcap' # R
+  depends_on 'libgconf' => :build
+  depends_on 'libice' # R
+  depends_on 'libsm' # R
+  depends_on 'libsndfile' # R
+  depends_on 'libsoxr' # R
+  depends_on 'libtool' # R
+  depends_on 'libx11' # R
+  depends_on 'libxcb' # R
+  depends_on 'libxtst' # R
+  depends_on 'orc' # R
+  depends_on 'pipewire' # R
+  depends_on 'speex' # R
+  depends_on 'tcpwrappers' => :build
+  depends_on 'tdb' # R
+  depends_on 'valgrind' => :build
+  depends_on 'webrtc_audio_processing' # R
+  depends_on 'xorg_lib' => :build
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/speex.rb
+++ b/packages/speex.rb
@@ -3,34 +3,38 @@ require 'package'
 class Speex < Package
   description 'Speex is an Open Source/Free Software patent-free audio compression format designed for speech.'
   homepage 'https://speex.org/'
-  version '1.2.0-1'
+  version '1.2rc3-1'
   license 'BSD'
-  compatibility 'all'
-  source_url 'http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz'
-  source_sha256 'eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz'
+  source_sha256 '4ae688600039f5d224bdf2e222d2fbde65608447e4c2f681585e4dca6df692f1'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2.0-1_armv7l/speex-1.2.0-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2.0-1_armv7l/speex-1.2.0-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2.0-1_i686/speex-1.2.0-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2.0-1_x86_64/speex-1.2.0-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2rc3-1_armv7l/speex-1.2rc3-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2rc3-1_armv7l/speex-1.2rc3-1-chromeos-armv7l.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2rc3-1_x86_64/speex-1.2rc3-1-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
-    aarch64: '5e1bba6a53dd827dd342a7e28454080025e8f3f7c8bd4766004a2da3f9842678',
-     armv7l: '5e1bba6a53dd827dd342a7e28454080025e8f3f7c8bd4766004a2da3f9842678',
-       i686: 'dea00b220cacfa50c244dee46977c0827008b7e831ace2abd6a97d2ab7d3cfe1',
-     x86_64: '868c4f618a5a0679ce908774963b73d630b7dddc1b9256fede1aa26c0b09a5d5',
+  binary_sha256({
+    aarch64: '7583ec635edf411815b3ec3b03941559180d41cb7f1e375ee9d43bb720fc47bb',
+     armv7l: '7583ec635edf411815b3ec3b03941559180d41cb7f1e375ee9d43bb720fc47bb',
+     x86_64: '209375ce4d5f48d6449ddb876f3bf94f4f562979a3937ef81fbedffddc7d3898'
   })
+
+  def self.patch
+    system 'filefix'
+  end
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-maintainer-mode'
+    system "env #{CREW_ENV_OPTIONS} \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --disable-dependency-tracking \
+      --disable-maintainer-mode \
+      --disable-examples"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/speex.rb
+++ b/packages/speex.rb
@@ -5,18 +5,20 @@ class Speex < Package
   homepage 'https://speex.org/'
   version '1.2rc3-1'
   license 'BSD'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url 'http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz'
   source_sha256 '4ae688600039f5d224bdf2e222d2fbde65608447e4c2f681585e4dca6df692f1'
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2rc3-1_armv7l/speex-1.2rc3-1-chromeos-armv7l.tar.xz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2rc3-1_armv7l/speex-1.2rc3-1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2rc3_i686/speexdsp-1.2rc3-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2rc3-1_x86_64/speex-1.2rc3-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
     aarch64: '7583ec635edf411815b3ec3b03941559180d41cb7f1e375ee9d43bb720fc47bb',
      armv7l: '7583ec635edf411815b3ec3b03941559180d41cb7f1e375ee9d43bb720fc47bb',
+       i686: '5c3d9bd633a11a8da1e8408d6db745f620d759ea2e4f8239a9ab5b34a9fe6b6a',
      x86_64: '209375ce4d5f48d6449ddb876f3bf94f4f562979a3937ef81fbedffddc7d3898'
   })
 

--- a/packages/speexdsp.rb
+++ b/packages/speexdsp.rb
@@ -3,36 +3,14 @@ require 'package'
 class Speexdsp < Package
   description 'Speex is an Open Source/Free Software patent-free audio compression format designed for speech.'
   homepage 'https://speex.org/'
-  version '1.2rc3'
+  version '1.2rc3-1'
   license 'BSD'
   compatibility 'all'
   source_url 'http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz'
   source_sha256 '4ae688600039f5d224bdf2e222d2fbde65608447e4c2f681585e4dca6df692f1'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2rc3_armv7l/speexdsp-1.2rc3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2rc3_armv7l/speexdsp-1.2rc3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2rc3_i686/speexdsp-1.2rc3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2rc3_x86_64/speexdsp-1.2rc3-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '0aa0fe549eb030ed9e134a39526751817d9e117509ce3dcbae1c7e3b6dfe8602',
-     armv7l: '0aa0fe549eb030ed9e134a39526751817d9e117509ce3dcbae1c7e3b6dfe8602',
-       i686: '5c3d9bd633a11a8da1e8408d6db745f620d759ea2e4f8239a9ab5b34a9fe6b6a',
-     x86_64: '8a83dac7387460d2dbeb3602712cd7b1d0999ba5b6e3f86449e8f215b4a83682',
-  })
+  is_fake
+  
+  depends_on 'speex'
 
-  def self.build
-    system "./configure \
-            --prefix=#{CREW_PREFIX} \
-            --libdir=#{CREW_LIB_PREFIX} \
-            --disable-dependency-tracking \
-            --disable-maintainer-mode \
-            --disable-examples"
-    system "make"
-  end
-
-  def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-  end
 end


### PR DESCRIPTION
Fixes #5709

-make sure all `pulseaudio` runtime deps are in package file
-convert `speexdsp` to `is_fake` and update `speex` and update all dependencies on `speexdsp` in other packages, since those two packages are duplicates of each other.

Works properly:
- [x] x86_64

