### PR TITLE
allow verbose crew list installed

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -300,7 +300,7 @@ def help (pkgName)
     puts "If `-v` or `--verbose` is present, extra information will be displayed."
   when "list"
     puts "List packages"
-    puts "Usage: crew list available|installed|compatible|incompatible"
+    puts "Usage: crew list [-v|--verbose] available|installed|compatible|incompatible"
   when "postinstall"
     puts "Display postinstall messages of package(s)."
     puts "Usage: crew postinstall <package1> [<package2> ...]"

--- a/bin/crew
+++ b/bin/crew
@@ -188,8 +188,24 @@ def list_available
 end
 
 def list_installed
-  Dir[CREW_META_PATH + '*.directorylist'].sort.map do |f|
-    File.basename(f, '.directorylist').lightgreen
+  unless @opt_verbose
+    Dir[CREW_META_PATH + '*.directorylist'].sort.map do |f|
+      File.basename(f, '.directorylist').lightgreen
+    end
+  else
+    @installed_packages = []
+    @device[:installed_packages].each do |package|
+      search package[:name], true
+      @installed_packages.append(package[:name] + ' ' + package[:version].to_s)
+    end
+    @sorted_installed_packages = @installed_packages.sort
+    @sorted_installed_packages.unshift('======= =======')
+    @sorted_installed_packages.unshift('Package Version')
+    @first_col_width = @sorted_installed_packages.map(&:split).map(&:first).max_by(&:size).size + 2
+    @sorted_installed_packages.map(&:strip).each do |line|
+        puts "%-#{@first_col_width}s%s".lightgreen % line.split
+    end
+    puts
   end
 end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.9.1'
+CREW_VERSION = '1.9.2'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- Adds option to list packages with versions.
- `crew list -v installed`
- The big advantage here is the ability to grep to get the version of an installed package quickly, e.g. 
```
crew list -v installed | grep meson
######################################################################## 100.0%
######################################################################## 100.0%
meson                      0.58.0
```

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686