### PR TITLE
Keep crew from crashing due to a malformed package file.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -266,9 +266,9 @@ def generate_compatible
         puts "Thread Error: #{e}".orange unless e.to_s.include?('queue empty') if @opt_verbose
       end
     end
-  end; "ok"
+  end
   begin
-    workers.map(&:join); "ok"
+    workers.map(&:join)
   rescue => exception
     puts "Explicitly caught - #{exception.class}: #{exception.message}" if @opt_verbose
   end

--- a/bin/crew
+++ b/bin/crew
@@ -140,7 +140,6 @@ def print_package(pkgPath, extra = false)
 end
 
 def print_current_package(extra = false)
-  pkgName = @pkg.name
   status = ''
   status = 'installed' if @device[:installed_packages].any? do |elem| elem[:name] == @pkg.name end
   status = 'incompatible' unless @device[:compatible_packages].any? do |elem| elem[:name] == @pkg.name end
@@ -229,7 +228,7 @@ def list_compatible(compat = true)
       if ( File.exist? CREW_META_PATH + pkgName + '.filelist' ) && compat
         puts pkgName.lightgreen
       else
-        puts pkgName unless !compat
+        puts pkgName if compat
       end
     else
       puts pkgName.lightred

--- a/bin/crew
+++ b/bin/crew
@@ -217,7 +217,11 @@ end
 def list_compatible(compat = true)
   Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
     pkgName = File.basename filename, '.rb'
-    set_package pkgName, filename
+    begin
+      set_package pkgName, filename
+    rescue => e
+      puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
+    end
     if compat
       if @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH
         if File.exist? CREW_META_PATH + pkgName + '.filelist'

--- a/bin/crew
+++ b/bin/crew
@@ -259,7 +259,7 @@ def generate_compatible
               puts "#{pkgName} is not a compatible package.".lightred if @opt_verbose
             end
           rescue => e
-            puts "Error with #{pkgName}.rb: #{e}".red
+            puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant') 
           end
         end
       rescue => e

--- a/bin/crew
+++ b/bin/crew
@@ -142,8 +142,8 @@ end
 def print_current_package(extra = false)
   pkgName = @pkg.name
   status = ''
-  status = 'installed' if @device[:installed_packages].any? do |elem| elem[:name] == pkgName end
-  status = 'incompatible' unless @pkg.name.in? @device[:compatible_packages]
+  status = 'installed' if @device[:installed_packages].any? do |elem| elem[:name] == @pkg.name end
+  status = 'incompatible' unless @device[:compatible_packages].any? do |elem| elem[:name] == @pkg.name end
   case status
   when 'installed'
     print @pkg.name.lightgreen
@@ -225,7 +225,7 @@ def list_compatible(compat = true)
   generate_compatible
   Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
     pkgName = File.basename filename, '.rb'
-    if pkgName.in? @device[:compatible_packages]
+    if @device[:compatible_packages].any? do |elem| elem[:name] == pkgName end
       @compatibility = true
     else
       @compatibility = false
@@ -999,7 +999,7 @@ def expand_dependencies
 end
 
 def resolve_dependencies
-  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @pkg.name.in? @device[:compatible_packages]
+  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @device[:compatible_packages].any? do |elem| elem[:name] == @pkg.name end
 
   @dependencies = []
   if @pkg.build_from_source

--- a/bin/crew
+++ b/bin/crew
@@ -275,6 +275,7 @@ def generate_compatible
     output = JSON.parse @device.to_json
     file.write JSON.pretty_generate(output)
   end
+  puts 'Generating compatible packages done.'.orange if @opt_verbose
 end
 
 def search (pkgName, silent = false)
@@ -529,7 +530,6 @@ def update
 
   #update compatible packages
   generate_compatible
-  puts 'Generating compatible packages done.'.orange if @opt_verbose
   #check for outdated installed packages
   puts 'Checking for package updates...'
 

--- a/bin/crew
+++ b/bin/crew
@@ -306,7 +306,7 @@ def regexp_search(pkgPat)
       end
     end
   end
-  abort "Package #{pkgPat} not found. :(".lightred unless results.length.positive?
+  abort "Package #{pkgPat} not found. :(".lightred if results.empty?
 end
 
 def help(pkgName)
@@ -594,7 +594,7 @@ def upgrade
       end
     end
 
-    if toBeUpdated.length.positive?
+    unless toBeUpdated.empty?
       puts 'Updating packages...'
       toBeUpdated.each do |package|
         search package

--- a/bin/crew
+++ b/bin/crew
@@ -850,7 +850,7 @@ def prepare_package (destdir)
     FileUtils.rm "#{CREW_DEST_PREFIX}/share/info/dir" if File.exist?("#{CREW_DEST_PREFIX}/share/info/dir")
     
     # Remove all perl module files which will conflict
-    if @pkg.name.include? 'perl_'
+    if @pkg.name ~= /^perl_/
       puts "Removing .packlist and perllocal.pod files to avoid conflicts with other perl packages.".orange
       system "find #{CREW_DEST_DIR} -type f \\( -name '.packlist' -o -name perllocal.pod \\) -delete" 
     end

--- a/bin/crew
+++ b/bin/crew
@@ -246,7 +246,6 @@ def generate_compatible
   puts 'Generating compatible packages...'
   @device[:compatible_packages] = []
   Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
-
     pkgName = File.basename filename, '.rb'
     begin
       set_package pkgName, filename

--- a/bin/crew
+++ b/bin/crew
@@ -777,7 +777,7 @@ def unpack(meta)
       # Check the number of directories in the archive
       entries = Dir["#{@extract_dir}/*"]
       entries = Dir[@extract_dir] if entries.empty?
-      if entries.length.zero?
+      if entries.empty?
         abort "Empty archive: #{meta[:filename]}".lightred
       elsif entries.length == 1 && File.directory?(entries.first)
         # Use `extract_dir/dir_in_archive` if there is only one directory.

--- a/bin/crew
+++ b/bin/crew
@@ -183,7 +183,7 @@ def list_available
     notInstalled = false if File.exists? CREW_META_PATH + pkgName + '.filelist'
     if notInstalled
       set_package pkgName, filename
-      if @pkg.compatibility.include? 'all' or @pkg.compatibility.include? ARCH
+      if @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH
         puts pkgName
       else
         puts pkgName.lightred
@@ -219,7 +219,7 @@ def list_compatible(compat = true)
     pkgName = File.basename filename, '.rb'
     set_package pkgName, filename
     if compat
-      if @pkg.compatibility.include? 'all' or @pkg.compatibility.include? ARCH
+      if @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH
         if File.exist? CREW_META_PATH + pkgName + '.filelist'
           puts pkgName.lightgreen
         else
@@ -227,7 +227,7 @@ def list_compatible(compat = true)
         end
       end
     else
-      unless @pkg.compatibility.include? 'all' or @pkg.compatibility.include? ARCH
+      unless @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH
         puts pkgName.lightred
       end
     end
@@ -249,7 +249,7 @@ def generate_compatible
             pkgName = File.basename filename, '.rb'
             puts "Checking #{pkgName} for compatibility.".orange if @opt_verbose
             set_package pkgName, filename
-            if @pkg.compatibility.include? 'all' or @pkg.compatibility.include? ARCH
+            if @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH
               #add to compatible packages
               puts "Adding #{pkgName} to compatible packages.".lightgreen if @opt_verbose
               @semaphore.synchronize do
@@ -985,7 +985,7 @@ def expand_dependencies
 end
 
 def resolve_dependencies
-  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @pkg.compatibility.include?('all') or @pkg.compatibility.include?(ARCH)
+  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @pkg.compatibility&.include?('all') or @pkg.compatibility&.include?(ARCH)
 
   @dependencies = []
   if @pkg.build_from_source

--- a/bin/crew
+++ b/bin/crew
@@ -4,6 +4,7 @@ require_relative '../lib/color'
 # Disallow sudo
 abort 'Chromebrew should not be run as root.'.lightred if Process.uid == 0
 
+require 'thread'
 require 'find'
 require 'net/http'
 require 'uri'
@@ -159,7 +160,11 @@ def print_current_package (extra = false)
 end
 
 def set_package (pkgName, pkgPath)
-  require pkgPath
+  begin
+    require_relative pkgPath
+  rescue SyntaxError => e
+    puts "#{e.class}: #{e.message}".red
+  end
   @pkg = Object.const_get(pkgName.capitalize)
   @pkg.build_from_source = true if @opt_recursive
   @pkg.name = pkgName
@@ -231,13 +236,41 @@ end
 
 def generate_compatible
   @device[:compatible_packages] = []
-  Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
-    pkgName = File.basename filename, '.rb'
-    set_package pkgName, filename
-    if @pkg.compatibility.include? 'all' or @pkg.compatibility.include? ARCH
-      #add to compatible packages
-      @device[:compatible_packages].push(name: @pkg.name)
+  @work_q = Queue.new
+  @semaphore = Mutex.new
+  Dir[CREW_PACKAGES_PATH + '*.rb'].each{|file| @work_q << file}
+  # This creates a 10 worker thread pool
+  workers = (0...10).map do
+    Thread.new do
+    Thread.abort_on_exception = true
+      begin
+        while filename = @work_q.pop(true)
+          begin
+            pkgName = File.basename filename, '.rb'
+            puts "Checking #{pkgName} for compatibility.".orange if @opt_verbose
+            set_package pkgName, filename
+            if @pkg.compatibility.include? 'all' or @pkg.compatibility.include? ARCH
+              #add to compatible packages
+              puts "Adding #{pkgName} to compatible packages.".lightgreen if @opt_verbose
+              @semaphore.synchronize do
+                @device[:compatible_packages].push(name: @pkg.name)
+              end
+            else
+              puts "#{pkgName} is not a compatible package.".lightred if @opt_verbose
+            end
+          rescue => e
+            puts "Error with #{pkgName}.rb: #{e}".red
+          end
+        end
+      rescue => e
+        puts "Thread Error: #{e}".orange unless e.to_s.include?('queue empty') if @opt_verbose
+      end
     end
+  end; "ok"
+  begin
+    workers.map(&:join); "ok"
+  rescue => exception
+    puts "Explicitly caught - #{exception.class}: #{exception.message}" if @opt_verbose
   end
   File.open(CREW_CONFIG_PATH + 'device.json', 'w') do |file|
     output = JSON.parse @device.to_json
@@ -488,7 +521,7 @@ def update
   #update compatible packages
   puts 'Generating compatible packages...'
   generate_compatible
-
+  puts 'Generating compatible packages done.'.orange if @opt_verbose
   #check for outdated installed packages
   puts 'Checking for package updates...'
 
@@ -595,7 +628,7 @@ def download
 
     case File.basename(filename)
     # Sources that download with curl
-    when /\.zip$/i, /\.(tar(\.(gz|bz2|xz|lz))?|tgz|tbz|txz)$/i, /\.deb$/i, /\.AppImage$/i
+    when /\.zip$/i, /\.(tar(\.(gz|bz2|xz|lz))?|tgz|tbz|tpxz|txz)$/i, /\.deb$/i, /\.AppImage$/i
       # Recall file from cache if requested
       if CREW_CACHE_ENABLED
         puts "Looking for archive in cache".orange if @opt_verbose
@@ -725,6 +758,12 @@ def unpack (meta)
       Dir.chdir @extract_dir do
         system "../#{meta[:filename]} --appimage-extract", exception: true
       end
+    when /\.tpxz$/i
+      unless File.exist?("#{CREW_PREFIX}/bin/pixz")
+        abort 'Pixz is needed for this install. Please install it with \'crew install pixz\''.lightred
+      end
+      puts "Unpacking 'tpxz' archive using 'tar', this may take a while..."
+      system "tar -Ipixz -x#{@verbose}f #{meta[:filename]} -C #{@extract_dir}", exception: true
     end
     if meta[:source] == true
       # Check the number of directories in the archive
@@ -809,6 +848,12 @@ def prepare_package (destdir)
     # than install-info.
     # https://www.debian.org/doc/debian-policy/ch-docs.html#info-documents
     FileUtils.rm "#{CREW_DEST_PREFIX}/share/info/dir" if File.exist?("#{CREW_DEST_PREFIX}/share/info/dir")
+    
+    # Remove all perl module files which will conflict
+    if @pkg.name.include? 'perl_'
+      puts "Removing .packlist and perllocal.pod files to avoid conflicts with other perl packages.".orange
+      system "find #{CREW_DEST_DIR} -type f \\( -name '.packlist' -o -name perllocal.pod \\) -delete" 
+    end
 
     # compress manual files
     compress_doc "#{CREW_DEST_PREFIX}/man"
@@ -871,7 +916,7 @@ def strip_dir (dir)
 
       # Strip binaries but not compressed archives
       puts "Stripping binaries..."
-      extensions = [ 'bz2', 'gz', 'lha', 'lz', 'lzh', 'rar', 'tar', 'tbz', 'tgz', 'txz', 'xz', 'Z', 'zip' ]
+      extensions = [ 'bz2', 'gz', 'lha', 'lz', 'lzh', 'rar', 'tar', 'tbz', 'tgz', 'tpxz', 'txz', 'xz', 'Z', 'zip' ]
       inames = extensions.join(' ! -iname *\.')
       strip_find_files "find . -type f ! -iname *\.#{inames} -perm /111 -print | sed -e '/lib.*\.a$/d' -e '/lib.*\.so/d'"
     end
@@ -1122,9 +1167,18 @@ def build_package (pwd)
 end
 
 def archive_package (pwd)
-  pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
-  Dir.chdir CREW_DEST_DIR do
-    system "tar c#{@verbose}Jf #{pwd}/#{pkg_name} *"
+  unless ENV['CREW_USE_PIXZ'] == '1'
+    pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
+    Dir.chdir CREW_DEST_DIR do
+      system "tar c#{@verbose}Jf #{pwd}/#{pkg_name} *"
+    end
+  else
+    puts "Using pixz to compress archive."
+    pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tpxz"
+    Dir.chdir CREW_DEST_DIR do
+      # Use smaller blocks with "-f0.25" to make random access faster.
+      system "tar c#{@verbose} * | pixz -f0.25 -9 > #{pwd}/#{pkg_name}"
+    end
   end
   system "sha256sum #{pwd}/#{pkg_name} > #{pwd}/#{pkg_name}.sha256"
 end

--- a/bin/crew
+++ b/bin/crew
@@ -139,7 +139,7 @@ def print_package(pkgPath, extra = false)
   print_current_package extra
 end
 
-def print_current_package (extra = false)
+def print_current_package(extra = false)
   pkgName = @pkg.name
   status = ''
   status = 'installed' if @device[:installed_packages].any? do |elem| elem[:name] == pkgName end
@@ -162,7 +162,7 @@ def print_current_package (extra = false)
   puts ""
 end
 
-def set_package (pkgName, pkgPath)
+def set_package(pkgName, pkgPath)
   begin
     require_relative pkgPath
   rescue SyntaxError => e
@@ -183,7 +183,7 @@ def list_available
   Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
     notInstalled = true
     pkgName = File.basename filename, '.rb'
-    notInstalled = false if File.exists? CREW_META_PATH + pkgName + '.filelist'
+    notInstalled = false if File.exist? CREW_META_PATH + pkgName + '.filelist'
     if notInstalled
       begin
         set_package pkgName, filename
@@ -215,7 +215,7 @@ def list_installed
     @sorted_installed_packages.unshift('Package Version')
     @first_col_width = @sorted_installed_packages.map(&:split).map(&:first).max_by(&:size).size + 2
     @sorted_installed_packages.map(&:strip).each do |line|
-        puts "%-#{@first_col_width}s%s".lightgreen % line.split
+      puts "%-#{@first_col_width}s%s".lightgreen % line.split
     end
     puts
   end
@@ -265,8 +265,8 @@ def generate_compatible
         puts "#{pkgName} is missing compatibility information".red
         #puts "url: #{@url}".green
         # If no source package is available, then package is not compatible.
-        @compatibility = false if !@url
-        puts "#{pkgName} compatibility is #{@compatibility.to_s}" if @opt_verbose
+        @compatibility = false unless @url
+        puts "#{pkgName} compatibility is #{@compatibility}" if @opt_verbose
       end
     end
     if ( @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH or @pkg.compatibility.nil? ) and @compatibility
@@ -312,10 +312,10 @@ def regexp_search(pkgPat)
       end
     end
   end
-  abort "Package #{pkgPat} not found. :(".lightred unless results.length > 0
+  abort "Package #{pkgPat} not found. :(".lightred unless results.length.positive?
 end
 
-def help (pkgName)
+def help(pkgName)
   case pkgName
   when "build"
     puts "Build package(s)."
@@ -398,7 +398,7 @@ def help (pkgName)
   end
 end
 
-def const (var)
+def const(var)
   if var
     value = eval(var)
     puts "#{var}=#{value}"
@@ -472,12 +472,12 @@ end
 
 def files (pkgName)
   filelist = "#{CREW_META_PATH}#{pkgName}.filelist"
-  if File.exists? filelist
+  if File.exist? filelist
     system "sort #{filelist}"
     lines = File.readlines(filelist).size
     size = 0
     File.readlines(filelist).each do |filename|
-      size += File.size(filename.chomp) if File.exists? filename.chomp
+      size += File.size(filename.chomp) if File.exist? filename.chomp
     end
     humansize = human_size(size)
     puts "Total found: #{lines}".lightgreen
@@ -496,13 +496,13 @@ def whatprovides (regexPat)
       found = line[/#{needle}/] if line.ascii_only?
       if found
         fileLine = packageName + ': ' + line
-        if not fileArray.include? fileLine
+        unless fileArray.include? fileLine
           fileArray.push(fileLine)
         end
       end
     end
   end
-  if not fileArray.empty?
+  unless fileArray.empty?
     fileArray.sort.each do |item|
       puts item
     end
@@ -600,7 +600,7 @@ def upgrade
       end
     end
 
-    if toBeUpdated.length > 0
+    if toBeUpdated.length.positive?
       puts 'Updating packages...'
       toBeUpdated.each do |package|
         search package
@@ -652,7 +652,7 @@ def download
           cachefile = ''
         else
           puts "Archive file exists in cache".lightgreen if @opt_verbose
-          if Digest::SHA256.hexdigest( File.read(cachefile) ) == sha256sum then
+          if Digest::SHA256.hexdigest( File.read(cachefile) ) == sha256sum
             begin
               # Hard link cached file if possible.
               FileUtils.ln cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose
@@ -662,8 +662,8 @@ def download
               FileUtils.cp cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose
               puts "Archive copied from cache".green if @opt_verbose
             end
-          puts "Archive found in cache".lightgreen
-          return {source: source, filename: filename}
+            puts "Archive found in cache".lightgreen
+            return {source: source, filename: filename}
           else
             puts 'Cached archive checksum mismatch. 😔 Will download.'.lightred
             cachefile = ''
@@ -751,7 +751,7 @@ def download
   return {source: source, filename: filename}
 end
 
-def unpack (meta)
+def unpack(meta)
   target_dir = nil
   Dir.chdir CREW_BREW_DIR do
     FileUtils.mkdir_p @extract_dir, verbose: @fileutils_verbose
@@ -768,7 +768,7 @@ def unpack (meta)
       system "ar -p #{meta[:filename]} data.tar.xz | xz -dc#{@verbose} | tar x#{@verbose} -C #{@extract_dir}", exception: true
     when /\.AppImage$/i
       puts "Unpacking 'AppImage' archive, this may take a while..."
-      FileUtils.chmod 0755, meta[:filename], verbose: @fileutils_verbose
+      FileUtils.chmod 0o755, meta[:filename], verbose: @fileutils_verbose
       Dir.chdir @extract_dir do
         system "../#{meta[:filename]} --appimage-extract", exception: true
       end
@@ -783,7 +783,7 @@ def unpack (meta)
       # Check the number of directories in the archive
       entries = Dir["#{@extract_dir}/*"]
       entries = Dir[@extract_dir] if entries.empty?
-      if entries.length == 0
+      if entries.length.zero?
         abort "Empty archive: #{meta[:filename]}".lightred
       elsif entries.length == 1 && File.directory?(entries.first)
         # Use `extract_dir/dir_in_archive` if there is only one directory.
@@ -800,7 +800,7 @@ def unpack (meta)
   return CREW_BREW_DIR + target_dir
 end
 
-def build_and_preconfigure (target_dir)
+def build_and_preconfigure(target_dir)
   Dir.chdir target_dir do
     puts 'Building from source, this may take a while...'
 
@@ -829,21 +829,21 @@ def build_and_preconfigure (target_dir)
   end
 end
 
-def pre_install (dest_dir)
+def pre_install(dest_dir)
   Dir.chdir dest_dir do
     puts 'Performing pre-install...'
     @pkg.preinstall
   end
 end
 
-def post_install (dest_dir)
+def post_install(dest_dir)
   Dir.chdir dest_dir do
     puts 'Performing post-install...'
     @pkg.postinstall
   end
 end
 
-def compress_doc (dir)
+def compress_doc(dir)
   # check whether crew should compress
   return if CREW_NOT_COMPRESS || ENV['CREW_NOT_COMPRESS'] || !File.exist?("#{CREW_PREFIX}/bin/compressdoc")
 
@@ -853,7 +853,7 @@ def compress_doc (dir)
   end
 end
 
-def prepare_package (destdir)
+def prepare_package(destdir)
   Dir.chdir destdir do
     # Avoid /usr/local/share/info/dir{.gz} file conflict:
     # The install-info program maintains a directory of installed
@@ -912,7 +912,7 @@ def prepare_package (destdir)
   end
 end
 
-def strip_find_files (find_cmd, strip_option = "")
+def strip_find_files(find_cmd, strip_option = "")
   # check whether crew should strip
   return if CREW_NOT_STRIP || ENV['CREW_NOT_STRIP'] || !File.exist?("#{CREW_PREFIX}/bin/llvm-strip")
 
@@ -921,7 +921,7 @@ def strip_find_files (find_cmd, strip_option = "")
   system "#{find_cmd} | xargs -r sh -c 'for i in \"$0\" \"$@\"; do case \"$(head -c 4 $i)\" in ?ELF|\!?ar) echo \"$i\";; esac ; done' | xargs -r llvm-strip #{strip_option}"
 end
 
-def strip_dir (dir)
+def strip_dir(dir)
   unless CREW_NOT_STRIP || ENV['CREW_NOT_STRIP']
     Dir.chdir dir do
       # Strip libraries with -S
@@ -937,7 +937,7 @@ def strip_dir (dir)
   end
 end
 
-def install_package (pkgdir)
+def install_package(pkgdir)
   Dir.chdir pkgdir do
     # install filelist, dlist and binary files
     puts 'Performing install...'
@@ -1152,7 +1152,7 @@ def resolve_dependencies_and_build
   puts "#{@pkg.name} is built!".lightgreen
 end
 
-def build_package (pwd)
+def build_package(pwd)
   abort 'It is not possible to build a fake package'.lightred if @pkg.is_fake?
   abort 'It is not possible to build without source'.lightred if !@pkg.is_source?(@device[:architecture])
 
@@ -1180,7 +1180,7 @@ def build_package (pwd)
   archive_package pwd
 end
 
-def archive_package (pwd)
+def archive_package(pwd)
   unless ENV['CREW_USE_PIXZ'] == '1'
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do
@@ -1197,7 +1197,7 @@ def archive_package (pwd)
   system "sha256sum #{pwd}/#{pkg_name} > #{pwd}/#{pkg_name}.sha256"
 end
 
-def remove (pkgName)
+def remove(pkgName)
 
   #make sure the package is actually installed
   unless @device[:installed_packages].any? { |pkg| pkg[:name] == pkgName } || File.exist?("#{CREW_META_PATH}#{pkgName}.filelist")
@@ -1252,7 +1252,7 @@ def remove (pkgName)
   puts "#{pkgName.capitalize} removed!".lightgreen
 end
 
-def build_command (args)
+def build_command(args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
@@ -1262,7 +1262,7 @@ def build_command (args)
   end
 end
 
-def download_command (args)
+def download_command(args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
@@ -1271,7 +1271,7 @@ def download_command (args)
   end
 end
 
-def const_command (args)
+def const_command(args)
   unless args["<name>"].empty?
     args["<name>"].each do |name|
       const name
@@ -1281,7 +1281,7 @@ def const_command (args)
   end
 end
 
-def files_command (args)
+def files_command(args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
@@ -1290,7 +1290,7 @@ def files_command (args)
   end
 end
 
-def help_command (args)
+def help_command(args)
   if args["<command>"]
     help args["<command>"]
   else
@@ -1299,7 +1299,7 @@ def help_command (args)
   end
 end
 
-def install_command (args)
+def install_command(args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
@@ -1310,7 +1310,7 @@ def install_command (args)
   end
 end
 
-def list_command (args)
+def list_command(args)
   if args['available']
     list_available
   elsif args['installed']
@@ -1322,7 +1322,7 @@ def list_command (args)
   end
 end
 
-def postinstall_command (args)
+def postinstall_command(args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName, true
@@ -1334,7 +1334,7 @@ def postinstall_command (args)
   end
 end
 
-def reinstall_command (args)
+def reinstall_command(args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
@@ -1349,13 +1349,13 @@ def reinstall_command (args)
   end
 end
 
-def remove_command (args)
+def remove_command(args)
   args["<name>"].each do |name|
     remove name
   end
 end
 
-def search_command (args)
+def search_command(args)
   args["<name>"].each do |name|
     regexp_search name
   end.empty? and begin
@@ -1363,7 +1363,7 @@ def search_command (args)
   end
 end
 
-def update_command (args)
+def update_command(args)
   if args['<compatible>']
     generate_compatible
   else
@@ -1371,7 +1371,7 @@ def update_command (args)
   end
 end
 
-def upgrade_command (args)
+def upgrade_command(args)
   args["<name>"].each do |name|
     @pkgName = name
     search @pkgName
@@ -1383,13 +1383,13 @@ def upgrade_command (args)
   end
 end
 
-def whatprovides_command (args)
+def whatprovides_command(args)
   args["<name>"].each do |name|
     whatprovides name
   end
 end
 
-def is_command (name)
+def is_command(name)
   return false if name =~ /^[-<]/
   return true
 end

--- a/bin/crew
+++ b/bin/crew
@@ -226,11 +226,6 @@ def list_compatible(compat = true)
   Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
     pkgName = File.basename filename, '.rb'
     if @device[:compatible_packages].any? do |elem| elem[:name] == pkgName end
-      @compatibility = true
-    else
-      @compatibility = false
-    end
-    if @compatibility
       if ( File.exist? CREW_META_PATH + pkgName + '.filelist' ) && compat
         puts pkgName.lightgreen
       else

--- a/bin/crew
+++ b/bin/crew
@@ -143,7 +143,7 @@ def print_current_package(extra = false)
   pkgName = @pkg.name
   status = ''
   status = 'installed' if @device[:installed_packages].any? do |elem| elem[:name] == pkgName end
-  status = 'incompatible' unless @device[:compatible_packages].any? do |elem| elem[:name] == pkgName end
+  status = 'incompatible' unless @pkg.name.in? @device[:compatible_packages]
   case status
   when 'installed'
     print @pkg.name.lightgreen
@@ -225,7 +225,7 @@ def list_compatible(compat = true)
   generate_compatible
   Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
     pkgName = File.basename filename, '.rb'
-    if @device[:compatible_packages].any? do |elem| elem[:name] == pkgName end
+    if pkgName.in? @device[:compatible_packages]
       @compatibility = true
     else
       @compatibility = false
@@ -999,7 +999,7 @@ def expand_dependencies
 end
 
 def resolve_dependencies
-  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @device[:compatible_packages].any? do |elem| elem[:name] == pkgName end
+  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @pkg.name.in? @device[:compatible_packages]
 
   @dependencies = []
   if @pkg.build_from_source

--- a/bin/crew
+++ b/bin/crew
@@ -237,7 +237,7 @@ def list_compatible(compat = true)
 end
 
 def generate_compatible
-  puts 'Generating compatible packages...'
+  puts 'Generating compatible packages...'.orange if @opt_verbose
   @device[:compatible_packages] = []
   Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
     pkgName = File.basename filename, '.rb'

--- a/bin/crew
+++ b/bin/crew
@@ -850,7 +850,7 @@ def prepare_package (destdir)
     FileUtils.rm "#{CREW_DEST_PREFIX}/share/info/dir" if File.exist?("#{CREW_DEST_PREFIX}/share/info/dir")
     
     # Remove all perl module files which will conflict
-    if @pkg.name ~= /^perl_/
+    if @pkg.name =~ /^perl_/
       puts "Removing .packlist and perllocal.pod files to avoid conflicts with other perl packages.".orange
       system "find #{CREW_DEST_DIR} -type f \\( -name '.packlist' -o -name perllocal.pod \\) -delete" 
     end

--- a/bin/crew
+++ b/bin/crew
@@ -4,7 +4,6 @@ require_relative '../lib/color'
 # Disallow sudo
 abort 'Chromebrew should not be run as root.'.lightred if Process.uid == 0
 
-require 'thread'
 require 'find'
 require 'net/http'
 require 'uri'
@@ -33,7 +32,7 @@ Usage:
   crew reinstall [options] [-k|--keep] [-s|--build-from-source] [-S|--recursive-build] <name> ...
   crew remove [options] <name> ...
   crew search [options] [<name> ...]
-  crew update [options]
+  crew update [options] [<compatible>]
   crew upgrade [options] [-k|--keep] [-s|--build-from-source] [<name> ...]
   crew whatprovides [options] <name> ...
 
@@ -132,7 +131,11 @@ end
 
 def print_package(pkgPath, extra = false)
   pkgName = File.basename pkgPath, '.rb'
-  set_package pkgName, pkgPath
+  begin
+    set_package pkgName, pkgPath
+  rescue => e
+    puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
+  end
   print_current_package extra
 end
 
@@ -182,7 +185,11 @@ def list_available
     pkgName = File.basename filename, '.rb'
     notInstalled = false if File.exists? CREW_META_PATH + pkgName + '.filelist'
     if notInstalled
-      set_package pkgName, filename
+      begin
+        set_package pkgName, filename
+      rescue => e
+        puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
+      end
       if @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH
         puts pkgName
       else
@@ -215,66 +222,61 @@ def list_installed
 end
 
 def list_compatible(compat = true)
+  generate_compatible
   Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
+    pkgName = File.basename filename, '.rb'
+    if @device[:compatible_packages].any? do |elem| elem[:name] == pkgName end
+      @compatibility = true
+    else
+      @compatibility = false
+    end
+    if @compatibility
+      if ( File.exist? CREW_META_PATH + pkgName + '.filelist' ) && compat
+        puts pkgName.lightgreen
+      else
+        puts pkgName unless !compat
+      end
+    else
+      puts pkgName.lightred
+    end
+  end
+end
+
+def generate_compatible
+  puts 'Generating compatible packages...'
+  @device[:compatible_packages] = []
+  Dir[CREW_PACKAGES_PATH + '*.rb'].each do |filename|
+
     pkgName = File.basename filename, '.rb'
     begin
       set_package pkgName, filename
     rescue => e
       puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
     end
-    if compat
-      if @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH
-        if File.exist? CREW_META_PATH + pkgName + '.filelist'
-          puts pkgName.lightgreen
-        else
-          puts pkgName
-        end
+    puts "Checking #{pkgName} for compatibility.".orange if @opt_verbose
+    # If compatibility property does not exist, check if a binary package
+    # exists, and if not, see if at least a source url exists.
+    @compatibility = true
+    @binary_url = ''
+    @url = ''
+    if @pkg.compatibility.nil?
+      @binary_url = @pkg.get_binary_url(@device[:architecture])
+      @url = @pkg.get_url(@device[:architecture])
+      if !@binary_url
+        puts "#{pkgName} is missing compatibility information".red
+        #puts "url: #{@url}".green
+        # If no source package is available, then package is not compatible.
+        @compatibility = false if !@url
+        puts "#{pkgName} compatibility is #{@compatibility.to_s}" if @opt_verbose
       end
+    end
+    if ( @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH or @pkg.compatibility.nil? ) and @compatibility
+      #add to compatible packages
+      puts "Adding #{pkgName} to compatible packages.".lightgreen if @opt_verbose
+      @device[:compatible_packages].push(name: @pkg.name)
     else
-      unless @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH
-        puts pkgName.lightred
-      end
+      puts "#{pkgName} is not a compatible package.".lightred if @opt_verbose
     end
-  end
-end
-
-def generate_compatible
-  @device[:compatible_packages] = []
-  @work_q = Queue.new
-  @semaphore = Mutex.new
-  Dir[CREW_PACKAGES_PATH + '*.rb'].each{|file| @work_q << file}
-  # This creates a 10 worker thread pool
-  workers = (0...10).map do
-    Thread.new do
-    Thread.abort_on_exception = true
-      begin
-        while filename = @work_q.pop(true)
-          begin
-            pkgName = File.basename filename, '.rb'
-            puts "Checking #{pkgName} for compatibility.".orange if @opt_verbose
-            set_package pkgName, filename
-            if @pkg.compatibility&.include? 'all' or @pkg.compatibility&.include? ARCH
-              #add to compatible packages
-              puts "Adding #{pkgName} to compatible packages.".lightgreen if @opt_verbose
-              @semaphore.synchronize do
-                @device[:compatible_packages].push(name: @pkg.name)
-              end
-            else
-              puts "#{pkgName} is not a compatible package.".lightred if @opt_verbose
-            end
-          rescue => e
-            puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant') 
-          end
-        end
-      rescue => e
-        puts "Thread Error: #{e}".orange unless e.to_s.include?('queue empty') if @opt_verbose
-      end
-    end
-  end
-  begin
-    workers.map(&:join)
-  rescue => exception
-    puts "Explicitly caught - #{exception.class}: #{exception.message}" if @opt_verbose
   end
   File.open(CREW_CONFIG_PATH + 'device.json', 'w') do |file|
     output = JSON.parse @device.to_json
@@ -284,7 +286,11 @@ end
 
 def search (pkgName, silent = false)
   pkgPath = CREW_PACKAGES_PATH + pkgName + '.rb'
-  return set_package(pkgName, pkgPath) if File.exist?(pkgPath)
+  begin
+    return set_package(pkgName, pkgPath) if File.exist?(pkgPath)
+  rescue => e
+    puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
+  end
   abort "Package #{pkgName} not found. :(".lightred unless silent
 end
 
@@ -296,7 +302,11 @@ def regexp_search(pkgPat)
   if results.empty?
     Dir[CREW_PACKAGES_PATH + '*.rb'].each do |packagePath|
       packageName = File.basename packagePath, '.rb'
-      set_package packageName, packagePath
+      begin
+        set_package packageName, packagePath
+      rescue => e
+        puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
+      end
       if ( @pkg.description =~ /#{pkgPat}/i )
         print_current_package @opt_verbose
         results.push(packageName)
@@ -371,6 +381,8 @@ def help (pkgName)
     puts "Update crew."
     puts "Usage: crew update"
     puts "This only updates crew itself.  Use `crew upgrade` to update packages."
+    puts "Usage: crew update compatible"
+    puts "This updates the crew package compatibility list."
   when "upgrade"
     puts "Update package(s)."
     puts "Usage: crew upgrade [-v|--verbose] [-s|--build-from-source] <package1> [<package2> ...]"
@@ -523,7 +535,6 @@ def update
   puts 'Package lists, crew, and library updated.'
 
   #update compatible packages
-  puts 'Generating compatible packages...'
   generate_compatible
   puts 'Generating compatible packages done.'.orange if @opt_verbose
   #check for outdated installed packages
@@ -989,7 +1000,7 @@ def expand_dependencies
 end
 
 def resolve_dependencies
-  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @pkg.compatibility&.include?('all') or @pkg.compatibility&.include?(ARCH)
+  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @device[:compatible_packages].any? do |elem| elem[:name] == pkgName end
 
   @dependencies = []
   if @pkg.build_from_source
@@ -1354,7 +1365,11 @@ def search_command (args)
 end
 
 def update_command (args)
-  update
+  if args['<compatible>']
+    generate_compatible
+  else
+    update
+  end
 end
 
 def upgrade_command (args)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.9.2'
+CREW_VERSION = '1.9.4'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -46,11 +46,7 @@ class Package
   end
 
   def self.get_binary_url (architecture)
-    if @binary_url.has_key?(architecture)
-      return @binary_url[architecture]
-    else
-      return nil
-    end
+    return @binary_url.has_key?(architecture) ? @binary_url[architecture] : nil
   end
 
   def self.get_sha256 (architecture)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -45,6 +45,14 @@ class Package
     end
   end
 
+  def self.get_binary_url (architecture)
+    if @binary_url.has_key?(architecture)
+      return @binary_url[architecture]
+    else
+      return nil
+    end
+  end
+
   def self.get_sha256 (architecture)
     if !@build_from_source and @binary_sha256 and @binary_sha256.has_key?(architecture)
       return @binary_sha256[architecture]


### PR DESCRIPTION
- "Thou shalt not let invalid input crash thy program"
- Make `generated_compatible` threaded, letting crew withstand malformed package files during `crew update`
- Try removing a compatible line from a package file and see how crew doesn't crash.
![image](https://user-images.githubusercontent.com/1096701/117058469-a676e080-acec-11eb-930f-bfe189b06fce.png)

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686