### PR TITLE
libdrm -> 2.4.105

### DIFF
--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -3,30 +3,30 @@ require 'package'
 class Libdrm < Package
   description 'Cross-driver middleware for DRI protocol.'
   homepage 'https://dri.freedesktop.org'
-  @_ver = '2.4.104'
+  @_ver = '2.4.105'
   version @_ver
   license 'MIT'
   compatibility 'all'
   source_url "https://dri.freedesktop.org/libdrm/libdrm-#{@_ver}.tar.xz"
-  source_sha256 'd66ad8b5c2441015ac1333e40137bb803c3bde3612ff040286fcc12158ea1bcb'
+  source_sha256 '1d1d024b7cadc63e2b59cddaca94f78864940ab440843841113fbac6afaf2a46'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.104_armv7l/libdrm-2.4.104-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.104_armv7l/libdrm-2.4.104-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.104_i686/libdrm-2.4.104-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.104_x86_64/libdrm-2.4.104-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.105_armv7l/libdrm-2.4.105-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.105_armv7l/libdrm-2.4.105-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.105_i686/libdrm-2.4.105-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.105_x86_64/libdrm-2.4.105-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: 'd92b2cf767f17517a2e90e610749b38d878f126f237bafa027c5f019bd26ab78',
-      armv7l: 'd92b2cf767f17517a2e90e610749b38d878f126f237bafa027c5f019bd26ab78',
-        i686: 'ffe58ea6bed51afe09957f581c1490643090b8d6b79c6ae0467d0e7d682afa94',
-      x86_64: '74ebadab71db82425c8a823e03f9da0f8f44eb692e448c83f8b7d12b69bb76b6',
+  binary_sha256({
+    aarch64: '457114332298eceb569af56d616ad691090c916c30e4aab132787f231e2b10b1',
+     armv7l: '457114332298eceb569af56d616ad691090c916c30e4aab132787f231e2b10b1',
+       i686: 'e55e2df9df10d55c9f25a1c4c44adf8f400afc076742377a2717bc7062f01bd7',
+     x86_64: '868460097f1ac8928b165655b8effbc265134a1205887e3003ed6ec2c0d6a678'
   })
 
-  depends_on 'libpciaccess'
-  depends_on 'xorg_lib'
-  depends_on 'eudev'
-  depends_on 'libxslt'
+  depends_on 'libpciaccess' # R
+  depends_on 'xorg_lib' => :build
+  depends_on 'eudev' => :build
+  depends_on 'libxslt' => :build
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \


### PR DESCRIPTION
- libdrm -> 2.4.105
- This is the first `tpxz` package.
- This is a requirement for mesa 21.1.0

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l
