### PR TITLE
Remove firefox dependency from codium

### DIFF
--- a/packages/codium.rb
+++ b/packages/codium.rb
@@ -24,7 +24,6 @@ class Codium < Package
   depends_on 'cairo'
   depends_on 'cups'
   depends_on 'dbus'
-  depends_on 'firefox'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
   depends_on 'gtk3'


### PR DESCRIPTION
Fixes #5747.  Codium works perfectly fine without firefox on arm systems.