### PR TITLE
Add missing flex dependency to binutils

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,8 @@ EARLY_PACKAGES="gcc10 brotli c_ares libcyrussasl libidn2 libmetalink libnghttp2 
 libtirpc libunistring openldap rtmpdump zstd ncurses ca_certificates libyaml ruby libffi \
 openssl nettle krb5 p11kit libtasn1 gnutls curl git icu4c"
 
-LATE_PACKAGES="crew_profile_base less most manpages filecmd mawk readline perl pcre pcre2 python27 python3 \
-sed bz2 lz4 lzip unzip xzutils zip"
+LATE_PACKAGES="binutils crew_profile_base less most manpages filecmd mawk readline perl pcre pcre2 \
+python27 python3 py3_pip sed bz2 lz4 lzip unzip xzutils zip"
 
 ARCH="$(uname -m)"
 

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -23,6 +23,8 @@ class Binutils < Package
      x86_64: '784c5e9bfd884c411708ae3c2ee1c852022f411794ff109fb7d37e91f124037b'
   })
 
+  depends_on 'flex'
+
   def self.patch
     system 'filefix'
     system "sed -i 's,scriptdir = \$(tooldir)/lib,scriptdir = \$(tooldir)/#{ARCH_LIB},g' ld/Makefile.am"

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,19 +3,15 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.13'
+  version '1.14'
   license 'GPL-3+'
   compatibility 'all'
 
   is_fake
 
-  # Some package installs won't work without this
-  depends_on 'crew_profile_base'
-
-  #install first to get ldconfig
+  # install first to get ldconfig
   depends_on 'glibc'
   depends_on 'gcc10'
-  depends_on 'binutils'
   depends_on 'gmp'
   depends_on 'mpfr'
   depends_on 'mpc'

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -1,5 +1,6 @@
 acl
 attr
+binutils
 brotli
 bz2
 c_ares
@@ -7,6 +8,7 @@ ca_certificates
 crew_profile_base
 curl
 filecmd
+flex
 gcc10
 gdbm
 gettext
@@ -44,6 +46,7 @@ p11kit
 pcre
 pcre2
 perl
+py3_pip
 python27
 python3
 readline


### PR DESCRIPTION
- Add binutils, flex and py3_pip to core packages
- Remove crew_profile_base and binutils from buildessential

Fixes #5753.