### PR TITLE
move core from gcc10 to gcc11

### DIFF
--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -9,7 +9,7 @@ crew_profile_base
 curl
 filecmd
 flex
-gcc10
+gcc11
 gdbm
 gettext
 git


### PR DESCRIPTION
- `core_packages.txt` should have `gcc11`, to match `buildessential` and dependeencies in other packages like `llvm`.

Works properly:
- [x] x86_64
