### PR TITLE
oniguruma, lua, jq, nmap updates

### DIFF
--- a/packages/jq.rb
+++ b/packages/jq.rb
@@ -3,32 +3,33 @@ require 'package'
 class Jq < Package
   description 'jq is a lightweight and flexible command-line JSON processor.'
   homepage 'https://stedolan.github.io/jq/'
-  version '1.6'
+  version '1.6-1'
   license 'MIT and CC-BY-3.0'
   compatibility 'all'
   source_url 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz'
   source_sha256 '5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6_armv7l/jq-1.6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6_armv7l/jq-1.6-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6_i686/jq-1.6-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6_x86_64/jq-1.6-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-1_armv7l/jq-1.6-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-1_armv7l/jq-1.6-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-1_i686/jq-1.6-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-1_x86_64/jq-1.6-1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: 'c230cb2046a0c1b40fe531a3480ee028cbe4db89cd7631eab48b3e4a38fac679',
-     armv7l: 'c230cb2046a0c1b40fe531a3480ee028cbe4db89cd7631eab48b3e4a38fac679',
-       i686: '135d38a61e055595485694711f8f47ab614d260b910ec73acd963333f1fe655e',
-     x86_64: 'c4c04bfd6860fe7b7072e253ee4a4a1d6e37895cf859bc7caebb8df44a164327',
+  binary_sha256({
+    aarch64: '6540447d8276d2485a2fe2d6f2a9837ab5fcf11609d55f64756af205e88e74b7',
+     armv7l: '6540447d8276d2485a2fe2d6f2a9837ab5fcf11609d55f64756af205e88e74b7',
+       i686: '68b25442f0f72f363365d3f436892a012aabadb1cc46ce91a0b10ed83468600c',
+     x86_64: 'ca1c96623283110b69acedbde1e8cab9f01525e4a11f33249687f23f8e6b1959'
   })
 
   depends_on 'oniguruma'
 
   def self.build
-    system "./configure",
-      "--prefix=#{CREW_PREFIX}",
-      '--disable-maintainer-mode', # disable make rules and dependencies not useful
-      '--disable-docs'             # there's no support for manpages
+    system 'filefix'
+    system "env #{CREW_ENV_OPTIONS}  \
+      ./configure #{CREW_OPTIONS} \
+      --disable-maintainer-mode \
+      --disable-docs" # there's no support for manpages
     system 'make'
   end
 

--- a/packages/lua.rb
+++ b/packages/lua.rb
@@ -3,27 +3,27 @@ require 'package'
 class Lua < Package
   description 'Lua is a powerful, efficient, lightweight, embeddable scripting language.'
   homepage 'https://www.lua.org/'
-  version '5.4.2'
+  version '5.4.3'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.lua.org/ftp/lua-5.4.2.tar.gz'
-  source_sha256 '11570d97e9d7303c0a59567ed1ac7c648340cd0db10d5fd594c09223ef2f524f'
+  source_url 'https://www.lua.org/ftp/lua-5.4.3.tar.gz'
+  source_sha256 'f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.2_armv7l/lua-5.4.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.2_armv7l/lua-5.4.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.2_i686/lua-5.4.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.2_x86_64/lua-5.4.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.3_armv7l/lua-5.4.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.3_armv7l/lua-5.4.3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.3_i686/lua-5.4.3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.3_x86_64/lua-5.4.3-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '1d9a0982da7b59fa17892c699f2818ee137a1eaba895da3519c67e71b4aabd6d',
-     armv7l: '1d9a0982da7b59fa17892c699f2818ee137a1eaba895da3519c67e71b4aabd6d',
-       i686: '8c04a985efa92609659cb618efd59086c7b57ae7ca3f101ebb6bf68d13a127a9',
-     x86_64: 'a063effc0721cc63a4872338a6d139e2f5b8611e1eb3b9391c111444279d88f0',
+  binary_sha256({
+    aarch64: '2cbf9670bd0a9388537d70d5559ff0505d31b6be36e85ccec0077ddb4f3fd3e3',
+     armv7l: '2cbf9670bd0a9388537d70d5559ff0505d31b6be36e85ccec0077ddb4f3fd3e3',
+       i686: '828d08293bb955aa2daa222fb6295a3c8f002c6ddd147d4d067129bed6b6e706',
+     x86_64: 'a1e7d87857e5ea2be3988975750e4af3cb881643bd751beb316b19f9305f5b88'
   })
 
   def self.build
-    system "make PLAT=linux-readline"
+    system "env #{CREW_ENV_OPTIONS} make PLAT=linux-readline"
   end
 
   def self.install

--- a/packages/nmap.rb
+++ b/packages/nmap.rb
@@ -1,35 +1,62 @@
+# Adapted from Arch Linux nmap PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/nmap/trunk/PKGBUILD
+
 require 'package'
 
 class Nmap < Package
-  description 'Nmap (\'Network Mapper\') is a free and open source (license) utility for network discovery and security auditing.'
+  description 'Utility for network discovery and security auditing'
   homepage 'https://nmap.org/'
-  version '7.80'
-  license 'NPSL'
+  version '7.91'
+  license 'GPL2'
   compatibility 'all'
-  source_url 'https://nmap.org/dist/nmap-7.80.tar.bz2'
-  source_sha256 'fcfa5a0e42099e12e4bf7a68ebe6fde05553383a682e816a7ec9256ab4773faa'
+  source_url 'https://nmap.org/dist/nmap-7.91.tar.bz2'
+  source_sha256 '18cc4b5070511c51eb243cdd2b0b30ff9b2c4dc4544c6312f75ce3a67a593300'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nmap/7.80_armv7l/nmap-7.80-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nmap/7.80_armv7l/nmap-7.80-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nmap/7.80_i686/nmap-7.80-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nmap/7.80_x86_64/nmap-7.80-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nmap/7.91_armv7l/nmap-7.91-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nmap/7.91_armv7l/nmap-7.91-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nmap/7.91_i686/nmap-7.91-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nmap/7.91_x86_64/nmap-7.91-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '05f6f7b8303f7249e0ce26650f13bd051d0d5665d321be0ff59f6ce51cff57fe',
-     armv7l: '05f6f7b8303f7249e0ce26650f13bd051d0d5665d321be0ff59f6ce51cff57fe',
-       i686: 'f40786b4937b7d3a6b6ddc67afb4a004ba577f865d9d922fa0982ebb871b1451',
-     x86_64: '624e3f64733244d3f987b5dfbd72a52acef314fa481857cc1ad4f92d621d2f3a',
+  binary_sha256({
+    aarch64: 'b4a00869eb4406a56b541d6f0acc93ac9ca94aa9e6aa89b9f8dea098abc23447',
+     armv7l: 'b4a00869eb4406a56b541d6f0acc93ac9ca94aa9e6aa89b9f8dea098abc23447',
+       i686: '1d02de32a0e266752fefab260e59d7dbfea5fcd3ac57f2dcc87116fe3e1aef00',
+     x86_64: '047f51c3a169ea6d76b45d18fa86c5f6eada542ceca4c02a9ff6e5fafcfb5201'
   })
+
+  depends_on 'libpcap'
+  depends_on 'libssh2'
 
   def self.build
-    #fixup "/usr/bin/file" -> "#{CREW_PREFIX}/bin/file" in the configure scripts
-    system "sed -i s#/usr/bin/file##{CREW_DEST_PREFIX}/bin/file#g libdnet-stripped/configure"
-    system "./configure --with-pcap=linux --without-zenmap --prefix=#{CREW_PREFIX}"
+    # ensure we build devendored deps"
+    @deps = %w[libpcap libpcre macosx mwin32 libssh2 libz]
+    @deps.each do |dep|
+      FileUtils.rm_rf dep if Dir.exist?(dep)
+    end
+    system 'autoreconf -fiv'
+    system 'filefix'
+    system "env #{CREW_ENV_OPTIONS} \
+    ./configure \
+    #{CREW_OPTIONS} \
+    --with-libpcap=#{CREW_PREFIX} \
+    --with-libpcre=#{CREW_PREFIX} \
+    --with-zlib=#{CREW_PREFIX} \
+    --with-libssh2=#{CREW_PREFIX} \
+    --with-liblua=included \
+    --without-ndiff"
     system 'make'
+    @zenmap_ = <<~'ZENMAP_EOF'
+      #!/bin/sh
+      xhost si:localuser:root
+      sudo -E LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} zenmap.elf
+    ZENMAP_EOF
+    IO.write('zenmap_', @zenmap_)
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+    FileUtils.mv "#{CREW_DEST_PREFIX}/bin/zenmap", "#{CREW_DEST_PREFIX}/bin/zenmap.elf"
+    FileUtils.install 'zenmap_', "#{CREW_DEST_PREFIX}/bin/zenmap", mode: 0o755
   end
 end

--- a/packages/oniguruma.rb
+++ b/packages/oniguruma.rb
@@ -3,30 +3,30 @@ require 'package'
 class Oniguruma < Package
   description 'Oniguruma is a modern and flexible regular expressions library.'
   homepage 'https://github.com/kkos/oniguruma'
-  version '6.9.3'
+  version '6.9.7.1'
   license 'BSD-2'
   compatibility 'all'
-  source_url 'https://github.com/kkos/oniguruma/archive/v6.9.3.tar.gz'
-  source_sha256 'dc6dec742941e24b761cea1b9a2f12e750879107ae69fd80ae1046459d4fb1db'
+  source_url 'https://github.com/kkos/oniguruma.git'
+  git_hashtag "v#{version}"
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oniguruma/6.9.3_armv7l/oniguruma-6.9.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oniguruma/6.9.3_armv7l/oniguruma-6.9.3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oniguruma/6.9.3_i686/oniguruma-6.9.3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oniguruma/6.9.3_x86_64/oniguruma-6.9.3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oniguruma/6.9.7.1_armv7l/oniguruma-6.9.7.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oniguruma/6.9.7.1_armv7l/oniguruma-6.9.7.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oniguruma/6.9.7.1_i686/oniguruma-6.9.7.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oniguruma/6.9.7.1_x86_64/oniguruma-6.9.7.1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: 'b6235fcfb3eb95dddafe8979adca6a4ba1bfc47d2c802a8bc14b73f1f57a30f5',
-     armv7l: 'b6235fcfb3eb95dddafe8979adca6a4ba1bfc47d2c802a8bc14b73f1f57a30f5',
-       i686: '11d6178e2662c45b869e9f3c3335291f60c74623e33f8cb027f1cdc1b81ab686',
-     x86_64: 'ba64baffe8cc1797ac44d7385d6d0c11d9438bfe9f11ece17f80a34740e32753',
+  binary_sha256({
+    aarch64: '61e2b0c0a8096bc2acdb1d311021786c08c0a47298fab2a063e2821c19b95f28',
+     armv7l: '61e2b0c0a8096bc2acdb1d311021786c08c0a47298fab2a063e2821c19b95f28',
+       i686: 'e0c27b9259019fc5c1461d689a47cad568e7636de9480086e3e22aec8854c2e4',
+     x86_64: 'bd6365ccee10f95b6091eecf8b23e96a0b30f87a1b9c71f120dabcaa9f5c6cee'
   })
 
   def self.build
-    system './autogen.sh'
-    system './configure',
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}"
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system 'filefix'
+    system "env #{CREW_ENV_OPTIONS} \
+      ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 


### PR DESCRIPTION
Fixes #5759

- nmap update (this has to be built w/o lua installed on armv7l)
- lua update
- oniguruma update
- jq rebuild
- zenmap in the nmap package needs rebuilds of several python2 packages to work, but I'm just going to wait on updates from @saltedcoffii before messing with that.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l