### PR TITLE
binutils: add deps

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -23,7 +23,10 @@ class Binutils < Package
      x86_64: '784c5e9bfd884c411708ae3c2ee1c852022f411794ff109fb7d37e91f124037b'
   })
 
-  depends_on 'flex'
+  depends_on 'zlibpkg' # R
+  depends_on 'glibc' # R
+  depends_on 'elfutils' # R
+  depends_on 'flex' # R
 
   def self.patch
     system 'filefix'

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -7,6 +7,7 @@ c_ares
 ca_certificates
 crew_profile_base
 curl
+elfutils
 expat
 filecmd
 flex


### PR DESCRIPTION
Fixes #5768

- Add runtime deps to binutils

Works properly:
- [x] x86_64
