### PR TITLE
Handle edge case of cachefile already in CREW_BREW_DIR when build restarts

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -653,11 +653,11 @@ def download
           if Digest::SHA256.hexdigest( File.read(cachefile) ) == sha256sum
             begin
               # Hard link cached file if possible.
-              FileUtils.ln cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose
+              FileUtils.ln cachefile, CREW_BREW_DIR, force: true, verbose: @fileutils_verbose unless File.identical?(cachefile,CREW_BREW_DIR + '/' + filename)
               puts "Archive hard linked from cache".green if @opt_verbose
             rescue
               # Copy cached file if hard link fails.
-              FileUtils.cp cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose
+              FileUtils.cp cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose unless File.identical?(cachefile,CREW_BREW_DIR + '/' + filename)
               puts "Archive copied from cache".green if @opt_verbose
             end
             puts "Archive found in cache".lightgreen

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.9.7'
+CREW_VERSION = '1.9.8'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- if a build is interrupted, a cachefile may already be in CREW_BREW_DIR. This avoids an error in that case.

Works properly:
- [x] x86_64
