### PR TITLE
Assume binaries are already stripped during install

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -950,8 +950,6 @@ def install_package(pkgdir)
     FileUtils.mv 'dlist', CREW_META_PATH + @pkg.name + '.directorylist', verbose: @fileutils_verbose
     FileUtils.mv 'filelist', CREW_META_PATH + @pkg.name + '.filelist', verbose: @fileutils_verbose
 
-    strip_dir pkgdir if Dir.exists? "#{pkgdir}/usr"
-
     if Dir.exists? "#{pkgdir}/home" then
       system "tar -c#{@verbose}f - ./usr/* ./home/* | (cd /; tar xp --keep-directory-symlink -f -)"
     elsif Dir.exists? "#{pkgdir}/usr" then

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.9.8'
+CREW_VERSION = '1.9.9'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
This speeds up installs significantly.  No reason to strip binaries.