### PR TITLE
gtk3,gtk4,glib,gdk_pixbuf updates, fix to crew & pygments

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -828,6 +828,7 @@ def build_and_preconfigure(target_dir)
 end
 
 def pre_flight(dest_dir)
+  FileUtils.mkdir_p(dest_dir) unless Dir.exist?(dest_dir)
   Dir.chdir dest_dir do
     puts 'Performing pre-flight checks...'
     @pkg.preflight

--- a/bin/crew
+++ b/bin/crew
@@ -827,12 +827,9 @@ def build_and_preconfigure(target_dir)
   end
 end
 
-def pre_flight(dest_dir)
-  FileUtils.mkdir_p(dest_dir) unless Dir.exist?(dest_dir)
-  Dir.chdir dest_dir do
-    puts 'Performing pre-flight checks...'
-    @pkg.preflight
-  end
+def pre_flight
+  puts 'Performing pre-flight checks...'
+  @pkg.preflight
 end
 
 def pre_install(dest_dir)
@@ -963,7 +960,7 @@ def resolve_dependencies_and_install
   unless @pkg.is_fake?
     # Process preflight block to see if package should even
     # be downloaded or installed.
-    pre_flight CREW_DEST_DIR
+    pre_flight
   end
   begin
     origin = @pkg.name

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.9.9'
+CREW_VERSION = '1.10.0'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -3,32 +3,32 @@ require 'package'
 class Gdk_pixbuf < Package
   description 'GdkPixbuf is a library for image loading and manipulation.'
   homepage 'https://developer.gnome.org/gdk-pixbuf'
-  @_ver = '2.42.4'
-  version "#{@_ver}-1"
+  @_ver = '2.42.6'
+  version @_ver
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/archive/#{@_ver}/gdk-pixbuf-#{@_ver}.tar.bz2"
-  source_sha256 'd94d2e67165739559a6323a23eea8ad3560ab1085e2a3356a19548c9cb88e1e9'
+  source_url 'https://gitlab.gnome.org/GNOME/gdk-pixbuf.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.4-1_armv7l/gdk_pixbuf-2.42.4-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.4-1_armv7l/gdk_pixbuf-2.42.4-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.4-1_i686/gdk_pixbuf-2.42.4-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.4-1_x86_64/gdk_pixbuf-2.42.4-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6_armv7l/gdk_pixbuf-2.42.6-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6_armv7l/gdk_pixbuf-2.42.6-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6_i686/gdk_pixbuf-2.42.6-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6_x86_64/gdk_pixbuf-2.42.6-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '62e8a794241bbeb7e4699617aa77dbae0e4ff7498ffac640a0ddeb09c66c0e92',
-     armv7l: '62e8a794241bbeb7e4699617aa77dbae0e4ff7498ffac640a0ddeb09c66c0e92',
-       i686: '2906220e700f765463aa12e2ca7b6500a92cdbae49f752470860fcc432986849',
-     x86_64: '6eefc5ee6bd5d37334e5745bff55eb240933d7751ad7eb0a78bdd965c3c50a90'
+    aarch64: 'e34b1d8685646cfcf999bb84c699e19c749d6cefd9d5346702bf8bc611293234',
+     armv7l: 'e34b1d8685646cfcf999bb84c699e19c749d6cefd9d5346702bf8bc611293234',
+       i686: 'e96ec7db0611cc7701754b3466b4b1d337123a62eefd06be0976254482b50027',
+     x86_64: '275ea5531916a62aa263e2f94c3eeb23af85140dfc4034ed513c044ad2277d6f'
   })
 
-  depends_on 'glib'
+  depends_on 'glib' # R
   depends_on 'gobject_introspection' => :build
   depends_on 'jasper' => :build
-  depends_on 'libjpeg'
-  depends_on 'libpng'
-  depends_on 'libtiff'
+  depends_on 'libjpeg' # R
+  depends_on 'libpng' # R
+  depends_on 'libtiff' # R
   depends_on 'libwebp' => :build
   depends_on 'pango' => :build
   depends_on 'six' => :build
@@ -75,6 +75,6 @@ class Gdk_pixbuf < Package
   def self.postinstall
     system "env GDK_PIXBUF_MODULEDIR=#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders \
       GDK_PIXBUF_MODULE_FILE=#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache \
-      gdk-pixbuf-query-loaders --update-cache"
+      LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} gdk-pixbuf-query-loaders --update-cache"
   end
 end

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,40 +3,34 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.68.0'
+  @_ver = '2.68.2'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url "https://download.gnome.org/sources/glib/#{@_ver_prelastdot}/glib-#{@_ver}.tar.xz"
-  source_sha256 '67734f584f3a05a2872f57e9a8db38f3b06c7087fb531c5a839d9171968103ea'
+  source_url 'https://gitlab.gnome.org/GNOME/glib.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.0_armv7l/glib-2.68.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.0_armv7l/glib-2.68.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.0_i686/glib-2.68.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.0_x86_64/glib-2.68.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.2_armv7l/glib-2.68.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.2_armv7l/glib-2.68.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.2_i686/glib-2.68.2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.2_x86_64/glib-2.68.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '074bbda5881173ce7d9cb01849cd9c1919ff3e111e3d40c4abbe655b1de6aa55',
-     armv7l: '074bbda5881173ce7d9cb01849cd9c1919ff3e111e3d40c4abbe655b1de6aa55',
-       i686: '4b4236243277ef9e2e1671090b9c5eb761fcbc1f4df43cbe54cffe19f838a922',
-     x86_64: '7c2bca7c57a8552eb0be3bac923d984eb01449d329b4d1a061b2dc42aacece82'
+    aarch64: '51cca2bdab9b0d8725010d9627e1af90553bd80627c7c0ca7822eb1d48977d5e',
+     armv7l: '51cca2bdab9b0d8725010d9627e1af90553bd80627c7c0ca7822eb1d48977d5e',
+       i686: '9edb7d402f59d21ed282bfd68b45c3bfe896a6edd0c6d5fed6b284e42532f8d3',
+     x86_64: '3f6a6728ad5b7e8b048665e2258ea22cf9ee5fa5c60c7e57d8172ada16486932'
   })
 
-  depends_on 'pcre'
-  depends_on 'shared_mime_info'
-  depends_on 'util_linux'
-  depends_on 'six'
-  depends_on 'pygments'
+  depends_on 'pygments' => :build
+  depends_on 'shared_mime_info' # L
+  depends_on 'six' => :build
+  depends_on 'util_linux' # R
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
-    -Dc_args='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
-    -Dc_link_args='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
-    -Dcpp_args='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
-    -Dcpp_link_args='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
-    -Das_needed=false \
     -Dselinux=disabled \
     -Dsysprof=disabled \
     -Dman=false \

--- a/packages/pygments.rb
+++ b/packages/pygments.rb
@@ -21,6 +21,8 @@ class Pygments < Package
      x86_64: '955f2f252e98842b63569334ad133908c2c527617b687f632bbfd1f4db8013b6'
   })
 
+  depends_on 'py3_pip'
+
   def self.install
     system 'pip uninstall -y pygments'
     system "pip install --upgrade --no-warn-script-location pygments --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"


### PR DESCRIPTION
Fixes #5773 #5716

- Updates to `gtk3`,`gtk4`,`gdk_pixbuf`,`glib`
- add pip dep to `pygments`
- fix crew not creating dir before chdir to it

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [X] i686
- [x] armv7l