### PR TITLE
Don't break using llvm with meson; flto flags in ldflags unnecessary.

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -80,11 +80,10 @@ end
 CREW_COMMON_FLAGS = "'-Os -pipe -flto=auto -fuse-ld=gold'"
 CREW_COMMON_FNO_LTO_FLAGS = "'-Os -pipe -fno-lto -fuse-ld=gold'"
 
-
 CREW_ENV_OPTIONS = "CFLAGS=#{CREW_COMMON_FLAGS} CXXFLAGS=#{CREW_COMMON_FLAGS} FCFLAGS=#{CREW_COMMON_FLAGS} FFLAGS=#{CREW_COMMON_FLAGS}"
 CREW_OPTIONS = "--prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --mandir=#{CREW_MAN_PREFIX} --build=#{CREW_BUILD} --host=#{CREW_TGT} --target=#{CREW_TGT} --program-prefix='' --program-suffix=''"
-CREW_MESON_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=true -Dstrip=true -Db_pie=true -Dcpp_args=#{CREW_COMMON_FLAGS.sub(/-flto=auto/, '').sub(/-fuse-ld=gold/, '')} -Dc_args=#{CREW_COMMON_FLAGS.sub(/-flto=auto/, '').sub(/-fuse-ld=gold/, '')}"
-CREW_MESON_FNO_LTO_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=false -Dstrip=true -Db_pie=true -Dcpp_args=#{CREW_COMMON_FNO_LTO_FLAGS.sub(/-fno-lto/, '').sub(/-fuse-ld=gold/, '')}} -Dc_args=#{CREW_COMMON_FNO_LTO_FLAGS.sub(/-fno-lto/, '').sub(/-fuse-ld=gold/, '')}"
+CREW_MESON_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=true -Dstrip=true -Db_pie=true -Dcpp_args='-Os -pipe' -Dc_args='-Os -pipe'"
+CREW_MESON_FNO_LTO_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=false -Dstrip=true -Db_pie=true -Dcpp_args='-Os -pipe' -Dc_args='-Os -pipe'"
 
 # Cmake sometimes wants to use LIB_SUFFIX to install libs in LIB64, so specify such for x86_64
 # This is often considered deprecated. See discussio at https://gitlab.kitware.com/cmake/cmake/-/issues/18640

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.10.0'
+CREW_VERSION = '1.10.1'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines
@@ -79,13 +79,12 @@ end
 
 CREW_COMMON_FLAGS = "'-Os -pipe -flto=auto -fuse-ld=gold'"
 CREW_COMMON_FNO_LTO_FLAGS = "'-Os -pipe -fno-lto -fuse-ld=gold'"
-CREW_FNO_LTO_LDFLAGS = "'-fno-lto'"
-CREW_LDFLAGS = "'-flto=auto'"
 
-CREW_ENV_OPTIONS = "CFLAGS=#{CREW_COMMON_FLAGS} CXXFLAGS=#{CREW_COMMON_FLAGS} FCFLAGS=#{CREW_COMMON_FLAGS} FFLAGS=#{CREW_COMMON_FLAGS} LDFLAGS=#{CREW_LDFLAGS}"
+
+CREW_ENV_OPTIONS = "CFLAGS=#{CREW_COMMON_FLAGS} CXXFLAGS=#{CREW_COMMON_FLAGS} FCFLAGS=#{CREW_COMMON_FLAGS} FFLAGS=#{CREW_COMMON_FLAGS}"
 CREW_OPTIONS = "--prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --mandir=#{CREW_MAN_PREFIX} --build=#{CREW_BUILD} --host=#{CREW_TGT} --target=#{CREW_TGT} --program-prefix='' --program-suffix=''"
-CREW_MESON_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=true -Dcpp_args=#{CREW_COMMON_FLAGS} -Dc_args=#{CREW_COMMON_FLAGS}"
-CREW_MESON_FNO_LTO_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=false -Dcpp_args=#{CREW_COMMON_FNO_LTO_FLAGS} -Dc_args=#{CREW_COMMON_FNO_LTO_FLAGS}"
+CREW_MESON_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=true -Dstrip=true -Db_pie=true -Dcpp_args=#{CREW_COMMON_FLAGS.sub(/-flto=auto/, '').sub(/-fuse-ld=gold/, '')} -Dc_args=#{CREW_COMMON_FLAGS.sub(/-flto=auto/, '').sub(/-fuse-ld=gold/, '')}"
+CREW_MESON_FNO_LTO_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=false -Dstrip=true -Db_pie=true -Dcpp_args=#{CREW_COMMON_FNO_LTO_FLAGS.sub(/-fno-lto/, '').sub(/-fuse-ld=gold/, '')}} -Dc_args=#{CREW_COMMON_FNO_LTO_FLAGS.sub(/-fno-lto/, '').sub(/-fuse-ld=gold/, '')}"
 
 # Cmake sometimes wants to use LIB_SUFFIX to install libs in LIB64, so specify such for x86_64
 # This is often considered deprecated. See discussio at https://gitlab.kitware.com/cmake/cmake/-/issues/18640


### PR DESCRIPTION
- `-flto` does not need to be passed via LDFLAGS, so don't set that as the only LDFLAGS option, as that may overwrite other LDFLAGS options which are being set.
- using `llvm` with meson is currently broken because `llvm` doesn't support `-flto=auto`. Since we already use `b_lto=true` this shouldn't be an issue anyways, so don't pass that to meson
- `-fuse-ld=gold` for some reason is breaking `llvm` with libatomics issues. So disable that for meson too.
- Also added option to meson to strip binaries and use `b_pie`
- To use `llvm` with meson just change the first line of the meson command to this: 
```
system "env CC=clang CXX=clang++ C_LD=lld CC_LD=lld \
      meson #{CREW_MESON_OPTIONS} \
      builddir"
```

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l 