### PR TITLE
Package updates, mostly gnome to 40.1

### DIFF
--- a/packages/dav1d.rb
+++ b/packages/dav1d.rb
@@ -3,30 +3,31 @@ require 'package'
 class Dav1d < Package
   description '**dav1d** is a new **AV1** cross-platform **d**ecoder, open-source, and focused on speed and correctness.'
   homepage 'https://code.videolan.org/videolan/dav1d'
-  @_ver = '0.8.2'
+  @_ver = '0.9.0'
   version @_ver
   license 'BSD-2'
   compatibility 'all'
   source_url "https://get.videolan.org/dav1d/#{@_ver}/dav1d-#{@_ver}.tar.xz"
-  source_sha256 '3dd91d96b44e9d8ba7e82ad9e730d6c579ab5e19edca0db857a60f5ae6a0eb13'
+  source_sha256 'cfae88e8067c9b2e5b96d95a7a00155c353376fe9b992a96b4336e0eab19f9f6'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dav1d/0.8.2_armv7l/dav1d-0.8.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dav1d/0.8.2_armv7l/dav1d-0.8.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dav1d/0.8.2_i686/dav1d-0.8.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dav1d/0.8.2_x86_64/dav1d-0.8.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dav1d/0.9.0_armv7l/dav1d-0.9.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dav1d/0.9.0_armv7l/dav1d-0.9.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dav1d/0.9.0_i686/dav1d-0.9.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dav1d/0.9.0_x86_64/dav1d-0.9.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '1e55f2fb0514c8a5fb6b991a2280495b0706ff95f5ae4013e67e70de2e8b5bfe',
-     armv7l: '1e55f2fb0514c8a5fb6b991a2280495b0706ff95f5ae4013e67e70de2e8b5bfe',
-       i686: 'a2115b3d09915b60f6fdffff5ad624df55bbfb3207b55eea08277b77680c34c9',
-     x86_64: '86edb8b9bcd8d7ae8e5062da704f8c223a7c3745340108d13325100c96aafb2e'
+    aarch64: '54fa3dba94781b03e2e8c59ac24f29b3d085490a36a8cc18e438febd18509c24',
+     armv7l: '54fa3dba94781b03e2e8c59ac24f29b3d085490a36a8cc18e438febd18509c24',
+       i686: '72577ec0e01a901a1c8d1f7c0d8b673f556a3bed9d70570755ebe9b726659ec2',
+     x86_64: '3f3f2a3756402e37bbde7d5d9f6374d2e183f2d9ce6ca49288718dc6a3746cb3'
   })
 
   depends_on 'nasm' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "env CC=clang CXX=clang++ C_LD=lld CC_LD=lld \
+      meson #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -6,44 +6,45 @@ require 'package'
 class Epiphany < Package
   description 'A GNOME web browser based on the WebKit rendering engine'
   homepage 'https://wiki.gnome.org/Apps/Web'
-  version '40.0'
+  version '40.1'
   license 'GPL'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url "https://gitlab.gnome.org/GNOME/epiphany/-/archive/#{version}/epiphany-#{version}.tar.bz2"
-  source_sha256 '2603fcc30ea8c2ba1343eda845c70825af0749db1c5e1ef252240e30dd855c06'
+  source_url 'https://gitlab.gnome.org/GNOME/epiphany.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/epiphany/40.0_armv7l/epiphany-40.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/epiphany/40.0_armv7l/epiphany-40.0-chromeos-armv7l.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/epiphany/40.0_x86_64/epiphany-40.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/epiphany/40.1_armv7l/epiphany-40.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/epiphany/40.1_armv7l/epiphany-40.1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/epiphany/40.1_x86_64/epiphany-40.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '8985d22d9a78b08b3a8419acb4e9b808e2a1b4295c8d718a48cc9425025b6ca2',
-     armv7l: '8985d22d9a78b08b3a8419acb4e9b808e2a1b4295c8d718a48cc9425025b6ca2',
-     x86_64: '16990d7104da6872cfeb93f5fcbbc184d2d22f476dd544af848b22196f9facd0'
+    aarch64: '141150e042132087d7e1dc8738fae0d35c26f2a337fa969c414eb912c698b13d',
+     armv7l: '141150e042132087d7e1dc8738fae0d35c26f2a337fa969c414eb912c698b13d',
+     x86_64: 'e0e48fab65f7b75bd9dfb07243a4d14ced036376da71be28eb9491c363b640dd'
   })
 
-  depends_on 'atk'
-  depends_on 'cairo' => :build
+  depends_on 'atk' # R
+  depends_on 'cairo' # R
   depends_on 'docbook_xml' => :build
   depends_on 'freetype' => :build
-  depends_on 'gcr'
-  depends_on 'gdk_pixbuf'
-  depends_on 'glib'
+  depends_on 'gcr' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
+  depends_on 'gmp' # R
   depends_on 'gobject_introspection' => :build
-  depends_on 'gtk3'
+  depends_on 'gtk3' # R
   depends_on 'help2man' => :build
-  depends_on 'json_glib'
-  depends_on 'libarchive'
-  depends_on 'libdazzle'
-  depends_on 'libhandy'
-  depends_on 'libportal'
-  depends_on 'libsecret'
-  depends_on 'libsoup2'
+  depends_on 'json_glib' # R
+  depends_on 'libdazzle' # R
+  depends_on 'libhandy' # R
+  depends_on 'libportal' # R
+  depends_on 'libsecret' # R
+  depends_on 'libsoup2' # R
   depends_on 'lsb_release' => :build
-  depends_on 'pango'
+  depends_on 'pango' # R
   depends_on 'startup_notification' => :build
-  depends_on 'webkit2gtk_4'
+  depends_on 'valgrind' => :build
+  depends_on 'webkit2gtk_4' # R
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -9,43 +9,43 @@ class Evince < Package
   version '40.1'
   license 'GPL'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/evince/-/archive/#{version}/evince-#{version}.tar.bz2"
-  source_sha256 '1c438051423334a49311c941f44924195c4823f64c2fcc55285eb529ef9bff06'
+  source_url 'https://gitlab.gnome.org/GNOME/evince.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_armv7l/evince-40.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_armv7l/evince-40.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_i686/evince-40.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_x86_64/evince-40.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_armv7l/evince-40.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_armv7l/evince-40.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_i686/evince-40.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_x86_64/evince-40.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'ff53c6f065e9d3efe0db2528ced3cf03124201fbe072ad3e113ee4dcc348c1d3',
-     armv7l: 'ff53c6f065e9d3efe0db2528ced3cf03124201fbe072ad3e113ee4dcc348c1d3',
-       i686: 'b3fa8f819fae5d173de436bf2ca2886763e04777c5a05fe81ce27a6e7e98dd57',
-     x86_64: 'e9a5508adad335debaef3105f753fb3e2b821d554edcd8fcecf2da8c5a9bf5c5'
+    aarch64: '62b72ae5cb06f66f219254ca9538c1cb28f91d869689f70f1551d89d5acbd336',
+     armv7l: '62b72ae5cb06f66f219254ca9538c1cb28f91d869689f70f1551d89d5acbd336',
+       i686: '35fddcde12a82b65876ef8ddc6f4dee8b42f74b1c746a5f51a84e2b686bcce8b',
+     x86_64: '66c5249315ae4e4f348ea5c2d732323623f8eb834ffc7cd353a53de966a7672a'
   })
 
-  depends_on 'atk'
-  depends_on 'cairo'
-  depends_on 'djvulibre'
+  depends_on 'atk' # R
+  depends_on 'cairo' # R
+  depends_on 'djvulibre' # R
   depends_on 'docbook_xsl' => :build
-  depends_on 'gdk_pixbuf'
-  depends_on 'glib'
-  depends_on 'gnome_desktop'
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
+  depends_on 'gnome_desktop' # R
   depends_on 'gobject_introspection' => :build
-  depends_on 'gst_plugins_base'
-  depends_on 'gstreamer'
-  depends_on 'gtk3'
+  depends_on 'gst_plugins_base' # R
+  depends_on 'gstreamer' # R
+  depends_on 'gtk3' # R
   depends_on 'gtk_doc' => :build
-  depends_on 'libarchive'
-  depends_on 'libgxps'
-  depends_on 'libhandy'
-  depends_on 'libsecret'
-  depends_on 'libspectre'
-  depends_on 'libtiff'
-  depends_on 'nautilus'
-  depends_on 'pango'
-  depends_on 'poppler'
+  depends_on 'libgxps' # R
+  depends_on 'libhandy' # R
+  depends_on 'libsecret' # R
+  depends_on 'libspectre' # R
+  depends_on 'libtiff' # R
+  depends_on 'nautilus' # R
+  depends_on 'pango' # R
+  depends_on 'poppler' # R
+  depends_on 'valgrind' => :build
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/gedit.rb
+++ b/packages/gedit.rb
@@ -3,41 +3,40 @@ require 'package'
 class Gedit < Package
   description 'GNOME Text Editor'
   homepage 'https://wiki.gnome.org/Apps/Gedit'
-  version '40.0'
+  version '40.1'
   license 'GPL-2+ CC-BY-SA-3.0'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gedit/-/archive/#{version}/gedit-#{version}.tar.bz2"
-  source_sha256 'b7ac78774fe2eadd09a9d91d19b2596ebd3388f2d3d1cf3cbac81cba649c399a'
+  source_url 'https://gitlab.gnome.org/GNOME/gedit.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gedit/40.0_armv7l/gedit-40.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gedit/40.0_armv7l/gedit-40.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gedit/40.0_i686/gedit-40.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gedit/40.0_x86_64/gedit-40.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gedit/40.1_armv7l/gedit-40.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gedit/40.1_armv7l/gedit-40.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gedit/40.1_i686/gedit-40.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gedit/40.1_x86_64/gedit-40.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '7f976a406dd8e8137d0aa7217c1d75fbee756a028c8315c386c41dfb4c3b57f6',
-     armv7l: '7f976a406dd8e8137d0aa7217c1d75fbee756a028c8315c386c41dfb4c3b57f6',
-       i686: '4c495f8e7e307103ded815bc217b8bc021e7957a760f0e820a587e59f53d9569',
-     x86_64: 'd908a24c2ba3085980ad3ff0afbdd3c3996bbffb21bc1c538cb3d21364a8acd5'
+    aarch64: 'd00004e8fe0b7f2f9c1884f4f7657b208ac504cf9b19ef033f58559b4683588f',
+     armv7l: 'd00004e8fe0b7f2f9c1884f4f7657b208ac504cf9b19ef033f58559b4683588f',
+       i686: '415aa41a13957b20b7d420df9337e6344ce0668b29a43ae8913000fdbc5b5ed5',
+     x86_64: 'dc1aee9657dfa305d79fd9f4c582515886aeb6254d06794271997385d5f3060d'
   })
 
-  depends_on 'amtk'
-  depends_on 'atk'
-  depends_on 'cairo'
-  depends_on 'gdk_pixbuf'
-  depends_on 'glib'
-  depends_on 'gobject_introspection'
-  depends_on 'gsettings_desktop_schemas'
-  depends_on 'gspell'
-  depends_on 'gtk3'
-  depends_on 'gtksourceview'
-  depends_on 'libpeas'
-  depends_on 'pango'
-  depends_on 'pygobject'
-  depends_on 'tepl_6'
-  depends_on 'gobject_introspection' => :build
+  depends_on 'amtk' # R
+  depends_on 'atk' # R
+  depends_on 'cairo' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
+  depends_on 'gobject_introspection' # R
+  depends_on 'gsettings_desktop_schemas' # L
+  depends_on 'gspell' # R
+  depends_on 'gtk3' # R
   depends_on 'gtk_doc' => :build
+  depends_on 'gtksourceview_4' # R
+  depends_on 'libpeas' # R
+  depends_on 'pango' # R
+  depends_on 'pygobject'
+  depends_on 'tepl_6' # R
   depends_on 'vala' => :build
   depends_on 'yelp_tools' => :build
 

--- a/packages/libsoup.rb
+++ b/packages/libsoup.rb
@@ -3,25 +3,25 @@ require 'package'
 class Libsoup < Package
   description 'libsoup is an HTTP client/server library for GNOME.'
   homepage 'https://wiki.gnome.org/Projects/libsoup'
-  @_ver = '2.99.2'
+  @_ver = '2.99.5'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://download.gnome.org/sources/libsoup/#{@_ver_prelastdot}/libsoup-#{@_ver}.tar.xz"
-  source_sha256 '664fa1b78a15cc0aa1fa65efb3b281a888417530f9f56a219571c0630f942ba5'
+  source_url 'https://gitlab.gnome.org/GNOME/libsoup.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsoup/2.99.2_armv7l/libsoup-2.99.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsoup/2.99.2_armv7l/libsoup-2.99.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsoup/2.99.2_i686/libsoup-2.99.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsoup/2.99.2_x86_64/libsoup-2.99.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsoup/2.99.5_armv7l/libsoup-2.99.5-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsoup/2.99.5_armv7l/libsoup-2.99.5-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsoup/2.99.5_i686/libsoup-2.99.5-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsoup/2.99.5_x86_64/libsoup-2.99.5-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '7b0fd36b36395b4949af7915af3eab02ab1842ba085f7c1858c977aca4af0534',
-     armv7l: '7b0fd36b36395b4949af7915af3eab02ab1842ba085f7c1858c977aca4af0534',
-       i686: '994478c3f30ed64b0ec04dc13b1383086806c8607f644a541bb4f25de2440a15',
-     x86_64: '2226f557f9d63cf666a17edd10c0831589cd3bdd652774f77b8ae73d0caa6440'
+    aarch64: '4f50b3740fd20061dfe27d08ef6cfb0815fefdd8740e3f5b71e284617c51033b',
+     armv7l: '4f50b3740fd20061dfe27d08ef6cfb0815fefdd8740e3f5b71e284617c51033b',
+       i686: 'f4effaf7fb8acf0262edb3d199bb982e8de90283aee92463005cacd343738a23',
+     x86_64: '28192705371f712fa67d4c6d17a7bd48114f3114882a5a499795bfe1d04c3dda'
   })
 
   depends_on 'glib_networking'

--- a/packages/mutter.rb
+++ b/packages/mutter.rb
@@ -3,34 +3,35 @@ require 'package'
 class Mutter < Package
   description 'A window manager for GNOME'
   homepage 'https://wiki.gnome.org/Projects/Mutter'
-  version '40.0'
+  version '40.1'
   license 'GPL-2+'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url "https://gitlab.gnome.org/GNOME/mutter/-/archive/#{version}/mutter-#{version}.tar.bz2"
-  source_sha256 '3f56768113d536f5842ea6db14d1d9c48f8c87cd240891f9b9305116e425771e'
+  source_url 'https://gitlab.gnome.org/GNOME/mutter.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.0_armv7l/mutter-40.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.0_armv7l/mutter-40.0-chromeos-armv7l.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.0_x86_64/mutter-40.0-chromeos-x86_64.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.1_armv7l/mutter-40.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.1_armv7l/mutter-40.1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.1_x86_64/mutter-40.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'fafa169c22a7aa7595edf43a4c8dc7306210163e6759130f81d338120b92b8bd',
-     armv7l: 'fafa169c22a7aa7595edf43a4c8dc7306210163e6759130f81d338120b92b8bd',
-     x86_64: '1b28b4cd4f91f342bc6bde187f48f58954b7259f0377e679742c9c821b60f668',
+    aarch64: '45b333676e45c13fdeab755581875203cf3f1f23265b86c83db5933e6d80d937',
+     armv7l: '45b333676e45c13fdeab755581875203cf3f1f23265b86c83db5933e6d80d937',
+     x86_64: 'faf3da0f7e8868fdc885b822ce9fb23bb44e0df47a3f0174c19dc7caff9f6c68'
   })
 
+  depends_on 'ccache' => :build
   depends_on 'dconf'
   depends_on 'gnome_settings_daemon'
-  depends_on 'gsettings_desktop_schemas'
   depends_on 'gobject_introspection' => :build
-  depends_on 'xorg_server' => :build
+  depends_on 'gsettings_desktop_schemas'
+  depends_on 'libcanberra'
   depends_on 'libinput'
   depends_on 'libwacom'
-  depends_on 'startup_notification'
   depends_on 'pipewire'
-  depends_on 'libcanberra'
-  depends_on 'ccache' => :build
+  depends_on 'startup_notification'
+  depends_on 'xorg_server' => :build
+  depends_on 'xwayland'
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -6,47 +6,47 @@ require 'package'
 class Nautilus < Package
   description 'Default file manager for GNOME'
   homepage 'https://wiki.gnome.org/Apps/Files'
-  @_ver = '40.0'
-  version "#{@_ver}-1"
+  @_ver = '40.1'
+  version @_ver
   license 'GPLv3'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/nautilus/-/archive/#{@_ver}/nautilus-#{@_ver}.tar.bz2"
-  source_sha256 '9bcb93c5ce56dbe1cd2b2d0808c21a5e37cc1d098ee037b7da75c0a4a59e84e7'
+  source_url 'https://gitlab.gnome.org/GNOME/nautilus.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.0-1_armv7l/nautilus-40.0-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.0-1_armv7l/nautilus-40.0-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.0-1_i686/nautilus-40.0-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.0-1_x86_64/nautilus-40.0-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.1_armv7l/nautilus-40.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.1_armv7l/nautilus-40.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.1_i686/nautilus-40.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.1_x86_64/nautilus-40.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '98663fed405335be9b9e297f641bd7e14edc631f43702e17a6477ba5b43368b3',
-     armv7l: '98663fed405335be9b9e297f641bd7e14edc631f43702e17a6477ba5b43368b3',
-       i686: '41b42d30a12e0e6597d994e8d159828ba68861b8336e46f2288451de08dc2948',
-     x86_64: 'b3412b0b281875a9cd1a9433e25e345246351f9a2eedc2e91e55f4cb4259a40c'
+    aarch64: '5be1b22e7f4c93ea940558f5cfcb7e33c7abbf86d3c2b8cc3ac039c1ca946215',
+     armv7l: '5be1b22e7f4c93ea940558f5cfcb7e33c7abbf86d3c2b8cc3ac039c1ca946215',
+       i686: '66f98e53dd52bd1670d229845b969964fa1be2bbce2419db006defa4919dc5b4',
+     x86_64: '2df5a25aa14395965a8891b3917044537b7faf89dd45b49b46eab331e9379e0f'
   })
 
   depends_on 'appstream_glib' => :build
-  depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'atk' # R
+  depends_on 'cairo' # R
   depends_on 'dconf'
-  depends_on 'gdk_pixbuf'
-  depends_on 'gexiv2'
-  depends_on 'glib'
-  depends_on 'gnome_autoar'
-  depends_on 'gnome_desktop'
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'gexiv2' # R
+  depends_on 'glib' # R
+  depends_on 'gnome_autoar' # R
+  depends_on 'gnome_desktop' # R
   depends_on 'gobject_introspection' => :build
-  depends_on 'gst_plugins_base'
-  depends_on 'gstreamer'
-  depends_on 'gtk3'
+  depends_on 'gst_plugins_base' # R
+  depends_on 'gstreamer' # R
+  depends_on 'gtk3' # R
   depends_on 'gtk_doc' => :build
   depends_on 'gvfs'
-  depends_on 'libhandy'
+  depends_on 'libhandy' # R
   depends_on 'libjpeg'
-  depends_on 'libportal'
-  depends_on 'pango'
-  depends_on 'tracker3'
+  depends_on 'libportal' # R
+  depends_on 'pango' # R
   depends_on 'tracker3_miners'
+  depends_on 'tracker3' # R
 
   def self.patch
     # Source has libgnome-volume-control repo as submodule

--- a/packages/screen.rb
+++ b/packages/screen.rb
@@ -3,30 +3,30 @@ require 'package'
 class Screen < Package
   description 'Screen is a full-screen window manager that multiplexes a physical terminal between several processes, typically interactive shells.'
   homepage 'https://www.gnu.org/software/screen/'
-  version '4.6.2'
+  version '4.8.0'
   license 'public-domain'
   compatibility 'all'
-  source_url 'https://ftp.gnu.org/gnu/screen/screen-4.6.2.tar.gz'
-  source_sha256 '1b6922520e6a0ce5e28768d620b0f640a6631397f95ccb043b70b91bb503fa3a'
+  source_url 'https://ftp.gnu.org/gnu/screen/screen-4.8.0.tar.gz'
+  source_sha256 '6e11b13d8489925fde25dfb0935bf6ed71f9eb47eff233a181e078fde5655aa1'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/screen/4.6.2_armv7l/screen-4.6.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/screen/4.6.2_armv7l/screen-4.6.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/screen/4.6.2_i686/screen-4.6.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/screen/4.6.2_x86_64/screen-4.6.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/screen/4.8.0_armv7l/screen-4.8.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/screen/4.8.0_armv7l/screen-4.8.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/screen/4.8.0_i686/screen-4.8.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/screen/4.8.0_x86_64/screen-4.8.0-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: 'f8d903c06175118730ea3d44ed59f6d6fbd94c7f5c6ed190e8e7ca42bb3cfc76',
-     armv7l: 'f8d903c06175118730ea3d44ed59f6d6fbd94c7f5c6ed190e8e7ca42bb3cfc76',
-       i686: '43e1b9056ee3d67b7b3f45ef52c381a62340bcaf97748a7ebc8b92adfed10026',
-     x86_64: '27ec590cfff20b1429f86baca0d42a6e3819a4978d13155b5ec31db04a374b5b',
+  binary_sha256({
+    aarch64: '9326008594f4e219f65995c8ee60e2aa5053b507d6b03c0561f2090ecae35f4e',
+     armv7l: '9326008594f4e219f65995c8ee60e2aa5053b507d6b03c0561f2090ecae35f4e',
+       i686: 'c7cf733507523e8e57c5b290c9b131a08d0c9a824b5ccc68a578e448afa152ca',
+     x86_64: '4ca4a6c4da3801b368b2cdc924310e304fb378ece773e15e7ca714c7ad0c94b3'
   })
-
-  depends_on 'ncurses'
 
   def self.build
-    system './configure',
-      "--prefix=#{CREW_PREFIX}"
+    system "env #{CREW_ENV_OPTIONS} \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --enable-colors256"
     system 'make'
   end
 

--- a/packages/wayland_protocols.rb
+++ b/packages/wayland_protocols.rb
@@ -3,23 +3,23 @@ require 'package'
 class Wayland_protocols < Package
   description 'Wayland is a protocol for a compositor to talk to its clients.'
   homepage 'https://wayland.freedesktop.org/'
-  version '1.20-1'
+  version '1.21'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://wayland.freedesktop.org/releases/wayland-protocols-1.20.tar.xz'
-  source_sha256 '9782b7a1a863d82d7c92478497d13c758f52e7da4f197aa16443f73de77e4de7'
+  source_url 'https://wayland.freedesktop.org/releases/wayland-protocols-1.21.tar.xz'
+  source_sha256 'b99945842d8be18817c26ee77dafa157883af89268e15f4a5a1a1ff3ffa4cde5'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.20-1_armv7l/wayland_protocols-1.20-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.20-1_armv7l/wayland_protocols-1.20-1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.20-1_i686/wayland_protocols-1.20-1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.20-1_x86_64/wayland_protocols-1.20-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.21_armv7l/wayland_protocols-1.21-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.21_armv7l/wayland_protocols-1.21-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.21_i686/wayland_protocols-1.21-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.21_x86_64/wayland_protocols-1.21-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '1decd76dce195360e3b2879b7a1ee63efefc64b437faa98e9ff5c833758730d2',
-      armv7l: '1decd76dce195360e3b2879b7a1ee63efefc64b437faa98e9ff5c833758730d2',
-        i686: '6ff5c74feef6541c342f7393fb2df70e4ec121f4b94d55f254bfa28c6e3e3dc0',
-      x86_64: 'a88f0f3c10c6108c6b9b584a1c74998d8a49ea70cb022f6350d3df129f120a72',
+  binary_sha256({
+    aarch64: '487266d1e54fd7094f0b75184bbea84044304dbbe4d64c9214069ff6cfee4472',
+     armv7l: '487266d1e54fd7094f0b75184bbea84044304dbbe4d64c9214069ff6cfee4472',
+       i686: '79e0dc6d2724fdc3ca0724a5d04649adf2e88136e3fc1b5a4ee2f4001117cac2',
+     x86_64: 'fd5283cabe38f85f245a5dcbb6b946594fefa64a5d0777a5554ee534f985ee56'
   })
 
   depends_on 'wayland'


### PR DESCRIPTION
- screen -> 4.8.0
- Dav1d -> 0.9.0
- wayland_protocols -> 1.21
- Gnome 40.1 updates
  - epiphany
  - evince
  - gedit
  - libsoup
  - mutter
  - nautilus
  - gvfs

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686 (except epiphany)
- [x] armv7l

![image](https://user-images.githubusercontent.com/1096701/118550043-45a6c980-b72a-11eb-9168-cde723fcf90c.png)
