### PR TITLE
Automatically generate constants list for crew const

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -402,45 +402,15 @@ def const(var)
     value = eval(var)
     puts "#{var}=#{value}"
   else
-    vars = [
-      'ARCH',
-      'ARCH_LIB',
-      'CHROMEOS_RELEASE',
-      'CURL',
-      'CREW_BREW_DIR',
-      'CREW_BUILD',
-      'CREW_CMAKE_LIBSUFFIX_OPTIONS',
-      'CREW_CMAKE_OPTIONS',
-      'CREW_CONFIG_PATH',
-      'CREW_DEST_DIR',
-      'CREW_DEST_HOME',
-      'CREW_DEST_LIB_PREFIX',
-      'CREW_DEST_MAN_PREFIX',
-      'CREW_DEST_PREFIX',
-      'CREW_LIB_PATH',
-      'CREW_LIB_PREFIX',
-      'CREW_LIB_SUFFIX',
-      'CREW_MAN_PREFIX',
-      'CREW_COMMON_FLAGS',
-      'CREW_COMMON_FNO_LTO_FLAGS',
-      'CREW_ENV_OPTIONS',
-      'CREW_MESON_FNO_LTO_OPTIONS',
-      'CREW_MESON_OPTIONS',
-      'CREW_META_PATH',
-      'CREW_NOT_COMPRESS',
-      'CREW_NOT_STRIP',
-      'CREW_NPROC',
-      'CREW_OPTIONS',
-      'CREW_PACKAGES_PATH',
-      'CREW_PREFIX',
-      'CREW_TGT',
-      'CREW_VERSION',
-      'HOME',
-      'LIBC_VERSION',
-      'USER'
-    ]
-    vars.each { |var|
-      value = eval(var)
+   @ruby_default_constants = %w[ENV IO STDIN STDOUT STDERR ARGF  GC RubyVM 
+     TOPLEVEL_BINDING RUBY_VERSION RUBY_RELEASE_DATE RUBY_PLATFORM 
+     RUBY_PATCHLEVEL RUBY_REVISION RUBY_COPYRIGHT RUBY_ENGINE 
+     RUBY_ENGINE_VERSION ARGV RUBY_DESCRIPTION CROSS_COMPILING
+     OpenSSL StringIO URI Q R S DOC JSON]
+    @constants = Module.constants.select {|e| e =~ /[[:upper:]]$/}
+    @constants = @constants.map(&:to_s).reject{ |e| @ruby_default_constants.find{ |f| /\A#{e}\z/ =~ f }}
+    @constants.sort.each { |var|
+      value = eval(var.to_s)
       puts "#{var}=#{value}"
     }
   end

--- a/bin/crew
+++ b/bin/crew
@@ -402,13 +402,42 @@ def const(var)
     value = eval(var)
     puts "#{var}=#{value}"
   else
-   @ruby_default_constants = %w[ENV IO STDIN STDOUT STDERR ARGF  GC RubyVM 
-     TOPLEVEL_BINDING RUBY_VERSION RUBY_RELEASE_DATE RUBY_PLATFORM 
-     RUBY_PATCHLEVEL RUBY_REVISION RUBY_COPYRIGHT RUBY_ENGINE 
-     RUBY_ENGINE_VERSION ARGV RUBY_DESCRIPTION CROSS_COMPILING
-     OpenSSL StringIO URI Q R S DOC JSON]
+    @ruby_default_constants = %w[
+      ARGF
+      ARGV
+      CROSS_COMPILING
+      DOC
+      ENV
+      GC
+      IO
+      JSON
+      OpenSSL
+      Q
+      R
+      RUBY_COPYRIGHT
+      RUBY_DESCRIPTION
+      RUBY_ENGINE
+      RUBY_ENGINE_VERSION
+      RUBYGEMS_ACTIVATION_MONITOR
+      RUBY_PATCHLEVEL
+      RUBY_PLATFORM
+      RUBY_RELEASE_DATE
+      RUBY_REVISION
+      RUBY_VERSION
+      RubyVM
+      S
+      STDERR
+      STDIN
+      STDOUT
+      StringIO
+      TOPLEVEL_BINDING
+      URI
+    ]
+    # Get all constants
     @constants = Module.constants.select {|e| e =~ /[[:upper:]]$/}
+    # Reject all constants which match the default list
     @constants = @constants.map(&:to_s).reject{ |e| @ruby_default_constants.find{ |f| /\A#{e}\z/ =~ f }}
+    # Print a sorted list of the remaining constants used by crew.
     @constants.sort.each { |var|
       value = eval(var.to_s)
       puts "#{var}=#{value}"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.10.3'
+CREW_VERSION = '1.10.4'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- Instead of using a whitelist, just blacklist known ruby default constants and print the rest. This lets us avoid having to add each new variable in `lib/const.rb` to `crew`

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l
