### PR TITLE
Use grep in crew whatprovides

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -35,7 +35,7 @@ Usage:
   crew search [options] [<name> ...]
   crew update [options] [<compatible>]
   crew upgrade [options] [-k|--keep] [-s|--build-from-source] [<name> ...]
-  crew whatprovides [options] <name> ...
+  crew whatprovides [options] <pattern> ...
 
   -c --color              Use colors even if standard out is not a tty.
   -d --no-color           Disable colors even if standard out is a tty.
@@ -487,19 +487,8 @@ end
 
 def whatprovides (regexPat)
   fileArray = []
-  needle = regexPat.gsub(/-/,',').gsub(/,/,'\-')
-  Dir[CREW_META_PATH + '*.filelist'].each do |packageList|
-    packageName = File.basename packageList, '.filelist'
-    File.readlines(packageList).each do |line|
-      found = line[/#{needle}/] if line.ascii_only?
-      if found
-        fileLine = packageName + ': ' + line
-        unless fileArray.include? fileLine
-          fileArray.push(fileLine)
-        end
-      end
-    end
-  end
+  @grepresults =  %x[grep "#{regexPat}" #{CREW_META_PATH}*.filelist].chomp.gsub('.filelist','').gsub(':',': ').gsub(CREW_META_PATH,'').split(/$/).map(&:strip)
+  @grepresults.each { |fileLine| fileArray.push(fileLine) }
   unless fileArray.empty?
     fileArray.sort.each do |item|
       puts item
@@ -1397,7 +1386,7 @@ def upgrade_command(args)
 end
 
 def whatprovides_command(args)
-  args["<name>"].each do |name|
+  args["<pattern>"].each do |name|
     whatprovides name
   end
 end

--- a/bin/crew
+++ b/bin/crew
@@ -486,6 +486,10 @@ def files (pkgName)
 end
 
 def whatprovides (regexPat)
+  # Use grep version command to ascertain whether we have a working grep.
+  unless system('grep -V > /dev/null 2>&1')
+    abort 'Grep is not working. Please install it with \'crew install grep\''.lightred
+  end
   fileArray = []
   @grepresults =  %x[grep "#{regexPat}" #{CREW_META_PATH}*.filelist].chomp.gsub('.filelist','').gsub(':',': ').gsub(CREW_META_PATH,'').split(/$/).map(&:strip)
   @grepresults.each { |fileLine| fileArray.push(fileLine) }

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.10.4'
+CREW_VERSION = '1.10.5'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- `crew whatprovides` is currently broken.
e.g. 
```
chronos@localhost /usr/local/lib/crew/packages (master %|SPARSE<>)$ crew whatprovides libgstreamer
gstreamer: /usr/local/lib64/libgstreamer-1.0.so
gstreamer: /usr/local/lib64/libgstreamer-1.0.so.0
gstreamer: /usr/local/lib64/libgstreamer-1.0.so.0.1804.0
gstreamer: /usr/local/share/gdb/auto-load/usr/local/lib64/libgstreamer-1.0.so.0.1804.0-gdb.py
jdk8: /usr/local/share/jdk8/jre/lib/amd64/libgstreamer-lite.so
Total found: 5
chronos@localhost /usr/local/lib/crew/packages (master %|SPARSE<>)$ crew whatprovides /usr/local/lib64/libgstreamer-1.0.so.0
chronos@localhost /usr/local/lib/crew/packages (master %|SPARSE<>)$ 
```
- This fixes the issue by just using `grep` which should be available on all Chromebrew systems. (If `grep` isn't working, there is an error message which suggests installing the `grep` package.) (Also using `grep` is MUCH faster than the line by line comparison which ruby grep functions tend to use.) `crew whatprovides` now returns almost instantly on my system.
```
chronos@localhost /usr/local/lib/crew/packages (master *%|SPARSE<>)$ crew whatprovides /usr/local/lib64/libgstreamer-1.0.so.0
gstreamer: /usr/local/lib64/libgstreamer-1.0.so.0
gstreamer: /usr/local/lib64/libgstreamer-1.0.so.0.1804.0
gstreamer: /usr/local/share/gdb/auto-load/usr/local/lib64/libgstreamer-1.0.so.0.1804.0-gdb.py

Total found: 3
```
- regex also works:
```
crew whatprovides "gstreamer-1\.0*[[:print:]]*\.so"
cogl: /usr/local/lib64/gstreamer-1.0/libgstcogl.so
gst_plugins_bad: /usr/local/lib64/gstreamer-1.0/libgstaccurip.so
gst_plugins_bad: /usr/local/lib64/gstreamer-1.0/libgstadpcmdec.so
gst_plugins_bad: /usr/local/lib64/gstreamer-1.0/libgstadpcmenc.so
gst_plugins_bad: /usr/local/lib64/gstreamer-1.0/libgstaiff.so
gst_plugins_bad: /usr/local/lib64/gstreamer-1.0/libgstaom.so
gst_plugins_bad: /usr/local/lib64/gstreamer-1.0/libgstasfmux.so
...
gstreamer: /usr/local/share/gdb/auto-load/usr/local/lib64/libgstreamer-1.0.so.0.1804.0-gdb.py
pipewire: /usr/local/lib64/gstreamer-1.0/libgstpipewire.so

Total found: 220
```

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l
