### PR TITLE
More gnome 40.1 updates, fix speex/speexdsp; webkit2gtk, wpebackend_fdo, waypipe, smbclient updates

### DIFF
--- a/packages/alsa_plugins.rb
+++ b/packages/alsa_plugins.rb
@@ -22,11 +22,12 @@ class Alsa_plugins < Package
      x86_64: '2c0108843697c8711160defebbf6db421a2b6fe1aa582b9567e8cbb9b124bf02',
   })
 
+  depends_on 'alsa_lib' # R
   depends_on 'dbus'
   depends_on 'ffmpeg'
-  depends_on 'speex'
-  depends_on 'alsa_lib'
   depends_on 'pulseaudio'
+  depends_on 'pulseaudio' # R
+  depends_on 'speexdsp' # R
 
   def self.build
     system './configure',

--- a/packages/cras.rb
+++ b/packages/cras.rb
@@ -22,17 +22,16 @@ class Cras < Package
       x86_64: '1f53ed96948e29f71d42f1b437e7e4637f6e08a4e573966ec139bb3437ed0d21',
   })
 
-
-    depends_on 'alsa_lib'
-    depends_on 'ladspa'
-    depends_on 'iniparser'
-    depends_on 'speex'
-    depends_on 'sbc'
-    depends_on 'dbus'
-    depends_on 'rust' => :build
-    depends_on 'llvm' => :build
-    depends_on 'gtest' => :build
-    depends_on 'eudev'
+  depends_on 'alsa_lib' # R
+  depends_on 'dbus' # R
+  depends_on 'eudev' # R
+  depends_on 'gtest' => :build
+  depends_on 'iniparser' # R
+  depends_on 'ladspa'
+  depends_on 'llvm' => :build
+  depends_on 'rust' => :build
+  depends_on 'sbc' # R
+  depends_on 'speexdsp' # R
 
   def self.build
     system 'git', 'clone', 'https://chromium.googlesource.com/chromiumos/third_party/adhd', '-b', version, '.'

--- a/packages/gjs.rb
+++ b/packages/gjs.rb
@@ -2,33 +2,34 @@ require 'package'
 
 class Gjs < Package
   description 'Javascript Bindings for GNOME'
-  @_ver = '1.67.3'
+  @_ver = '1.68.1'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'MIT and MPL-1.1, LGPL-2+ or GPL-2+'
   compatibility 'all'
-  source_url "https://download.gnome.org/sources/gjs/#{@_ver_prelastdot}/gjs-#{@_ver}.tar.xz"
-  source_sha256 '12df0c0ff2dd4c944ad27477ee8053e1363c4ad499542686bba21e06d38c6733'
+  source_url 'https://gitlab.gnome.org/GNOME/gjs.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gjs/1.67.3_armv7l/gjs-1.67.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gjs/1.67.3_armv7l/gjs-1.67.3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gjs/1.67.3_i686/gjs-1.67.3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gjs/1.67.3_x86_64/gjs-1.67.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gjs/1.68.1_armv7l/gjs-1.68.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gjs/1.68.1_armv7l/gjs-1.68.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gjs/1.68.1_i686/gjs-1.68.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gjs/1.68.1_x86_64/gjs-1.68.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '6ee8b11391aee0245536d1d702b765739b20310df841ca4395fce2d9b07eb532',
-     armv7l: '6ee8b11391aee0245536d1d702b765739b20310df841ca4395fce2d9b07eb532',
-       i686: 'f8eeea3dd66b93420d99942db1dc355c8b0f36d0201e77ca239186e8de113051',
-     x86_64: '0bcdfb345b073565735fbd8b3e76a5cd6d9694590cbd10b217619207b91a3f88'
+    aarch64: 'a44d907e21468900d3ac6e0ea326dc051e431dd2eedf3ea8f3fc1603b5b93d70',
+     armv7l: 'a44d907e21468900d3ac6e0ea326dc051e431dd2eedf3ea8f3fc1603b5b93d70',
+       i686: 'd1c8db6ed575dd5f471fc3c91e8c7f5f34e448ba8eca2c3aa8802eaf923f3ff3',
+     x86_64: '0d0b81db80db509870491850ce86bc0b7b0aaca8407eb8d7c09e47797aa908ba'
   })
 
-  depends_on 'cairo'
-  depends_on 'gobject_introspection'
-  depends_on 'js78'
-  depends_on 'dconf'
-  depends_on 'gobject_introspection' => :build
+  depends_on 'cairo' # R
   depends_on 'dbus' => :build
+  depends_on 'dconf' => :build
+  depends_on 'glib' # R
+  depends_on 'gobject_introspection' # R
+  depends_on 'js78' => :build
+  depends_on 'libx11' # R
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/gvfs.rb
+++ b/packages/gvfs.rb
@@ -3,49 +3,48 @@ require 'package'
 class Gvfs < Package
   description 'Virtual filesystem implementation for GIO'
   homepage 'https://wiki.gnome.org/Projects/gvfs'
-  @_ver = '1.48.0'
-  version "#{@_ver}-1"
+  @_ver = '1.48.1'
+  version @_ver
   license 'GPLv2'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gvfs/-/archive/#{@_ver}/gvfs-#{@_ver}.tar.bz2"
-  source_sha256 'acde26bee8a04e8432b0946b0fd36bc831ccc4f58c32fbcee6a3f525a595f5e9'
+  source_url 'https://gitlab.gnome.org/GNOME/gvfs.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvfs/1.48.0-1_armv7l/gvfs-1.48.0-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvfs/1.48.0-1_armv7l/gvfs-1.48.0-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvfs/1.48.0-1_i686/gvfs-1.48.0-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvfs/1.48.0-1_x86_64/gvfs-1.48.0-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvfs/1.48.1_armv7l/gvfs-1.48.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvfs/1.48.1_armv7l/gvfs-1.48.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvfs/1.48.1_i686/gvfs-1.48.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvfs/1.48.1_x86_64/gvfs-1.48.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '97b9379b27f4005491a2737d7f549d750a8c7b7cb4939cf423e610306e888a66',
-     armv7l: '97b9379b27f4005491a2737d7f549d750a8c7b7cb4939cf423e610306e888a66',
-       i686: '7b1c91a1b4004bdee1904e5dda3fb4a57626c953105dc5ca65ba1d1f1604e9bf',
-     x86_64: '58d2e873fcd548ed212466b098f24925abb05e6e3a5fc76e5cbecfe42f3661a6'
+    aarch64: '3585ea23719cf4e3c3da8c84beed3df3f020a91feb3d3af7f05e81514cec1e21',
+     armv7l: '3585ea23719cf4e3c3da8c84beed3df3f020a91feb3d3af7f05e81514cec1e21',
+       i686: 'b617653b15b4c87f2759c36067f638b70e501f4ecf01243b6ae6ef1ced47b314',
+     x86_64: '5094180c75e7e99ac78a191935a6d0af41a50bf4dbcd7764bea96d7114282b19'
   })
 
-  depends_on 'avahi'
+  depends_on 'avahi' # R
   depends_on 'dbus' => :build
   depends_on 'dconf'
   depends_on 'docbook_xsl' => :build
   depends_on 'elogind' => :build
-  depends_on 'fuse3'
-  depends_on 'gcr'
-  depends_on 'glib'
+  depends_on 'fuse3' # R
+  depends_on 'gcr' # R
+  depends_on 'glib' # R
   depends_on 'gtk3' => :build
-  depends_on 'libarchive'
   depends_on 'libcdio'
-  depends_on 'libcdio_paranoia'
-  depends_on 'libgcrypt'
-  depends_on 'libgphoto'
-  depends_on 'libgudev'
-  depends_on 'libimobiledevice'
-  depends_on 'libnfs'
-  depends_on 'libplist'
-  depends_on 'libsecret'
-  depends_on 'libsoup'
-  depends_on 'libsoup2'
-  depends_on 'polkit'
-  depends_on 'smbclient'
+  depends_on 'libcdio_paranoia' # R
+  depends_on 'libcdio' # R
+  depends_on 'libgcrypt' # R
+  depends_on 'libgphoto' # R
+  depends_on 'libgudev' # R
+  depends_on 'libimobiledevice' # R
+  depends_on 'libnfs' # R
+  depends_on 'libplist' # R
+  depends_on 'libsecret' # R
+  depends_on 'libsoup2' # R
+  depends_on 'polkit' # R
+  depends_on 'smbclient' # R
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -51,7 +51,7 @@ class Pulseaudio < Package
   depends_on 'libxtst' # R
   depends_on 'orc' # R
   depends_on 'pipewire' # R
-  depends_on 'speex' # R
+  depends_on 'speexdsp' # R
   depends_on 'tcpwrappers' => :build
   depends_on 'tdb' # R
   depends_on 'valgrind' => :build

--- a/packages/py3_pip.rb
+++ b/packages/py3_pip.rb
@@ -3,7 +3,7 @@ require 'package'
 class Py3_pip < Package
   description 'Pip is the python package manager from the Python Packaging Authority.'
   homepage 'https://pip.pypa.io/'
-  @_ver = '21.0.1'
+  @_ver = '21.1.1'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Py3_pip < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pip/21.0.1_armv7l/py3_pip-21.0.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pip/21.0.1_armv7l/py3_pip-21.0.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pip/21.0.1_i686/py3_pip-21.0.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pip/21.0.1_x86_64/py3_pip-21.0.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pip/21.1.1_armv7l/py3_pip-21.1.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pip/21.1.1_armv7l/py3_pip-21.1.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pip/21.1.1_i686/py3_pip-21.1.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pip/21.1.1_x86_64/py3_pip-21.1.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'ce0f563a1f9a8fdd16c9d44263d42206742d8fbbc705f5a2a11973c234a96ac0',
-     armv7l: 'ce0f563a1f9a8fdd16c9d44263d42206742d8fbbc705f5a2a11973c234a96ac0',
-       i686: 'd782d6d8cf6a857ee31e07a304dd4d07223f30f3e2812e29deb4d1a7962cad51',
-     x86_64: '729a9958cae998936dc3ca300feb7c10eb8d56f74b524913cc84cb1cf6bbe553'
+    aarch64: '9762d97c11d232dda3a0009620793d93f6f073839deb5478178b39131ebc568f',
+     armv7l: '9762d97c11d232dda3a0009620793d93f6f073839deb5478178b39131ebc568f',
+       i686: '167a767129284e150af3953dcfcf35caab2f9552d383ad55041d511d49b72e58',
+     x86_64: '794210d8b23bf7f3ecf2377eee166da6acc3e1cfaa8db7ddbff1b4ec29d60007'
   })
 
   depends_on 'py3_setuptools'

--- a/packages/smbclient.rb
+++ b/packages/smbclient.rb
@@ -6,23 +6,23 @@ require 'package'
 class Smbclient < Package
   description 'Tools to access a servers filespace and printers via SMB'
   homepage 'https://www.samba.org'
-  version '4.14.2'
+  version '4.14.4'
   license 'GPLv3'
   compatibility 'all'
   source_url "https://us1.samba.org/samba/ftp/stable/samba-#{version}.tar.gz"
-  source_sha256 '95651da478743f7cb407aec81287536c096e3e18bb4981dbe47ca70bf6181f96'
+  source_sha256 '89af092a0b00f5354ed287f0aa37b8c2cf9ba2ce67ea6464192e2c18528f89b9'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.14.2_armv7l/smbclient-4.14.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.14.2_armv7l/smbclient-4.14.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.14.2_i686/smbclient-4.14.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.14.2_x86_64/smbclient-4.14.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.14.4_armv7l/smbclient-4.14.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.14.4_armv7l/smbclient-4.14.4-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.14.4_i686/smbclient-4.14.4-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.14.4_x86_64/smbclient-4.14.4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '19d88b0a7b60b5f1002ef071f3aa8c1ecefb00067e89eff653d2c234da2ff428',
-     armv7l: '19d88b0a7b60b5f1002ef071f3aa8c1ecefb00067e89eff653d2c234da2ff428',
-       i686: 'd4952770d1531c5bfc34b1e3527cad7b8b13e2c04d9c2630c9d8bd630d6dbd7a',
-     x86_64: 'f1c215ece0eae7eb36212ccaef962347b31b660403fa8b835a12b797e0786c2b'
+    aarch64: '22d24a7a51efc97853ed1b7b110a84b099efd7b465dbf46194a406fc9af6b8d5',
+     armv7l: '22d24a7a51efc97853ed1b7b110a84b099efd7b465dbf46194a406fc9af6b8d5',
+       i686: '2e50aa2792825d119143bd9cbeae10d167623d2ffee50f4e4b7d64ff69251b7e',
+     x86_64: '8f0f6e9e37d39b8893034af1e019bcf4c1c4fcf0c689edbb37da967658c7c1f4'
   })
 
   depends_on 'avahi'
@@ -32,10 +32,8 @@ class Smbclient < Package
   depends_on 'gpgme' => :build
   depends_on 'jansson'
   depends_on 'ldb'
-  depends_on 'libarchive'
   depends_on 'libbsd'
   depends_on 'libcap'
-  depends_on 'libdb'
   depends_on 'libunwind'
   depends_on 'liburing' => :build
   depends_on 'linux_pam'

--- a/packages/speex.rb
+++ b/packages/speex.rb
@@ -3,23 +3,23 @@ require 'package'
 class Speex < Package
   description 'Speex is an Open Source/Free Software patent-free audio compression format designed for speech.'
   homepage 'https://speex.org/'
-  version '1.2rc3-1'
+  version '1.2-870f'
   license 'BSD'
   compatibility 'all'
-  source_url 'http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz'
-  source_sha256 '4ae688600039f5d224bdf2e222d2fbde65608447e4c2f681585e4dca6df692f1'
+  source_url 'https://gitlab.xiph.org/xiph/speex.git'
+  git_hashtag '870ff845b32f314aec0036641ffe18aba4916887'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2rc3-1_armv7l/speex-1.2rc3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2rc3-1_armv7l/speex-1.2rc3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2rc3_i686/speexdsp-1.2rc3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2rc3-1_x86_64/speex-1.2rc3-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2-870f_armv7l/speex-1.2-870f-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2-870f_armv7l/speex-1.2-870f-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2-870f_i686/speex-1.2-870f-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speex/1.2-870f_x86_64/speex-1.2-870f-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '7583ec635edf411815b3ec3b03941559180d41cb7f1e375ee9d43bb720fc47bb',
-     armv7l: '7583ec635edf411815b3ec3b03941559180d41cb7f1e375ee9d43bb720fc47bb',
-       i686: '5c3d9bd633a11a8da1e8408d6db745f620d759ea2e4f8239a9ab5b34a9fe6b6a',
-     x86_64: '209375ce4d5f48d6449ddb876f3bf94f4f562979a3937ef81fbedffddc7d3898'
+    aarch64: '1f4901f04da81fe723e0c0181ad1ec5066c138c4ecb7f8854983e986108914be',
+     armv7l: '1f4901f04da81fe723e0c0181ad1ec5066c138c4ecb7f8854983e986108914be',
+       i686: 'e69fcd81e05805c964067e130961e9467add67ec50a850b2837ba6df705e6712',
+     x86_64: 'e448b7e79abf3a303d54d3997a9f491b086c55f7c5ae8b3654f61cfb636fd917'
   })
 
   def self.patch
@@ -27,6 +27,7 @@ class Speex < Package
   end
 
   def self.build
+    system 'NOCONFIGURE=1 ./autogen.sh'
     system "env #{CREW_ENV_OPTIONS} \
       ./configure \
       #{CREW_OPTIONS} \

--- a/packages/speexdsp.rb
+++ b/packages/speexdsp.rb
@@ -3,14 +3,43 @@ require 'package'
 class Speexdsp < Package
   description 'Speex is an Open Source/Free Software patent-free audio compression format designed for speech.'
   homepage 'https://speex.org/'
-  version '1.2rc3-1'
+  version '1.2-095f'
   license 'BSD'
   compatibility 'all'
-  source_url 'http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz'
-  source_sha256 '4ae688600039f5d224bdf2e222d2fbde65608447e4c2f681585e4dca6df692f1'
+  source_url 'https://gitlab.xiph.org/xiph/speexdsp.git'
+  git_hashtag '095fd36e189554bbcbfd9884630a53d7792409dc'
 
-  is_fake
-  
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2-095f_armv7l/speexdsp-1.2-095f-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2-095f_armv7l/speexdsp-1.2-095f-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2-095f_i686/speexdsp-1.2-095f-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/speexdsp/1.2-095f_x86_64/speexdsp-1.2-095f-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'fe34514fd4960fd4fe424a054329a56b6c502d85453b679a149129fd57b39cce',
+     armv7l: 'fe34514fd4960fd4fe424a054329a56b6c502d85453b679a149129fd57b39cce',
+       i686: 'd88d59b9f0165918fb0d6f34218209fa9ed3617c5ca5b5a70c3227ecfa328bb7',
+     x86_64: '037c5fbb5c957ef1de46fed752894aec4edb08994343bc88ca1c40584b72e53f'
+  })
+
   depends_on 'speex'
 
+  def self.patch
+    system 'filefix'
+  end
+
+  def self.build
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "env #{CREW_ENV_OPTIONS} \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --disable-dependency-tracking \
+      --disable-maintainer-mode \
+      --disable-examples"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/waypipe.rb
+++ b/packages/waypipe.rb
@@ -3,29 +3,30 @@ require 'package'
 class Waypipe < Package
   description 'A proxy for Wayland protocol applications. WARNING: different versions are incompatible'
   homepage 'https://gitlab.freedesktop.org/mstoeckl/waypipe'
-  version '0.7.2'
+  version '0.8.0'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://gitlab.freedesktop.org/mstoeckl/waypipe/-/archive/v0.7.2/waypipe-v0.7.2.tar.gz'
-  source_sha256 'b280079b05aef9b243be3644fc803e3feaa2fc2952d11a6c02ab33257fb52479'
+  source_url 'https://gitlab.freedesktop.org/mstoeckl/waypipe.git'
+  git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/waypipe/0.7.2_armv7l/waypipe-0.7.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/waypipe/0.7.2_armv7l/waypipe-0.7.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/waypipe/0.7.2_i686/waypipe-0.7.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/waypipe/0.7.2_x86_64/waypipe-0.7.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/waypipe/0.8.0_armv7l/waypipe-0.8.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/waypipe/0.8.0_armv7l/waypipe-0.8.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/waypipe/0.8.0_i686/waypipe-0.8.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/waypipe/0.8.0_x86_64/waypipe-0.8.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '115949938eaf98fd38af6b1b8ffdb90e7976e87910fb5e0288d17c69d3cdb47c',
-     armv7l: '115949938eaf98fd38af6b1b8ffdb90e7976e87910fb5e0288d17c69d3cdb47c',
-       i686: '462f32367698388dd6333d14be082a20d1293102bfbb3ab5dfa9c8f55e42b3ea',
-     x86_64: '3e2bfc20d665b49b6023b2f6d1e703e9bfce519a802ea8c8d8dde33e5a179640'
+    aarch64: '7ed1843341ca708c08c6ec854ece411d0dc4a2e37af472e8c11a75651c5beecc',
+     armv7l: '7ed1843341ca708c08c6ec854ece411d0dc4a2e37af472e8c11a75651c5beecc',
+       i686: '0c994fb5538080d055b0116fa26b65538e9b4f237b7be268b877df1c006ae408',
+     x86_64: '96d33e96782fe12fb707271c66de01d3e5948a7c9d9fc59963bae8f33f19bf9f'
   })
 
-  depends_on 'mesa'
-  depends_on 'ffmpeg'
-  depends_on 'libva'
+  depends_on 'speexdsp' => :build
+  depends_on 'ffmpeg' # R
   depends_on 'libdrm' => :build
+  depends_on 'libva' # R
+  depends_on 'mesa' # R
 
   def self.patch
     system "sed -i '/#include \"util.h\"/a #include  <linux/version.h>' src/dmabuf.c"

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -3,29 +3,29 @@ require 'package'
 class Webkit2gtk_4 < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'
-  @_ver = '2.32.0'
+  @_ver = '2.32.1'
   version @_ver
   license 'LGPL-2+ and BSD-2'
   compatibility 'all'
   source_url "https://webkitgtk.org/releases/webkitgtk-#{@_ver}.tar.xz"
-  source_sha256 '9d7df4dae9ada2394257565acc2a68ace9308c4c61c3fcc00111dc1f11076bf0'
+  source_sha256 '136117317f70f66486f71b8edf5e46f8776403c5d8a296e914b11a36ef836917'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.0_armv7l/webkit2gtk_4-2.32.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.0_armv7l/webkit2gtk_4-2.32.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.0_i686/webkit2gtk_4-2.32.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.0_x86_64/webkit2gtk_4-2.32.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.1_armv7l/webkit2gtk_4-2.32.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.1_armv7l/webkit2gtk_4-2.32.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.1_i686/webkit2gtk_4-2.32.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.1_x86_64/webkit2gtk_4-2.32.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'be723ff23a31c85ad8c5dea8cadbeaac12aa17810f6bf448999b46f008a30034',
-     armv7l: 'be723ff23a31c85ad8c5dea8cadbeaac12aa17810f6bf448999b46f008a30034',
-       i686: 'b0bd0f98543cee946931bd3726a0a7d10d709006d930f28ecb322086876567a2',
-     x86_64: '2bfe6213119d1bbaa98634a99e0390a222ea95c30ef1d329d0b17d6df0aaf89b'
+    aarch64: '6c5cbf8c55706aa5253e2bbe5fccd9478103c35ff9ac7c68056099c2a18fe85f',
+     armv7l: '6c5cbf8c55706aa5253e2bbe5fccd9478103c35ff9ac7c68056099c2a18fe85f',
+       i686: 'ab5cc183f6b51d9bd971c7bac70f617485d66efb0436dfbd941d153d32f5bf8d',
+     x86_64: '34d1284e175e6ebdf078ce0ba7e08b404ebb125849470668a35162d2aa2d1daf'
   })
 
   depends_on 'atk'
   depends_on 'cairo'
-  depends_on 'ccache' => :build
+  depends_on 'dav1d'
   depends_on 'enchant'
   depends_on 'fontconfig'
   depends_on 'freetype'
@@ -68,10 +68,10 @@ class Webkit2gtk_4 < Package
       # system "env #{CREW_ENV_OPTIONS} \
       # Bubblewrap sandbox breaks on epiphany with
       # bwrap: Can't make symlink at /var/run: File exists
+      # ccache currently breaks gcc builds of webkit-gtk
       system "cmake \
         -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        #{CREW_CMAKE_FNO_LTO_OPTIONS} \
         -DCMAKE_SKIP_RPATH=ON \
         -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
         -DENABLE_GAMEPAD=OFF \
@@ -86,6 +86,8 @@ class Webkit2gtk_4 < Package
         -DUSE_GTK4=OFF \
         -DUSE_SOUP2=ON \
         -DUSE_SYSTEMD=OFF \
+        -DUSE_AVIF=ON \
+        -DPYTHON_EXECUTABLE=`which python` \
         .."
     end
     system 'ninja -C builddir4'

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -3,29 +3,29 @@ require 'package'
 class Webkit2gtk_5 < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'
-  @_ver = '2.32.0'
+  @_ver = '2.32.1'
   version @_ver
   license 'LGPL-2+ and BSD-2'
   compatibility 'all'
   source_url "https://webkitgtk.org/releases/webkitgtk-#{@_ver}.tar.xz"
-  source_sha256 '9d7df4dae9ada2394257565acc2a68ace9308c4c61c3fcc00111dc1f11076bf0'
+  source_sha256 '136117317f70f66486f71b8edf5e46f8776403c5d8a296e914b11a36ef836917'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.0_armv7l/webkit2gtk_5-2.32.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.0_armv7l/webkit2gtk_5-2.32.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.0_i686/webkit2gtk_5-2.32.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.0_x86_64/webkit2gtk_5-2.32.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.1_armv7l/webkit2gtk_5-2.32.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.1_armv7l/webkit2gtk_5-2.32.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.1_i686/webkit2gtk_5-2.32.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.1_x86_64/webkit2gtk_5-2.32.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '0d49b1141892ec63b2b43c682aa4feb3c5b64dc04bfea08ec9f9c0d2c6fb583d',
-     armv7l: '0d49b1141892ec63b2b43c682aa4feb3c5b64dc04bfea08ec9f9c0d2c6fb583d',
-       i686: 'f1481e0a9cdf9df4308320777971dc6c168344aa9488169caad6c4c6549c56d4',
-     x86_64: '11d1d701c17bdf1f7de0e4d0df094dd6342195134cf153b22b125ec1dfd58ead'
+    aarch64: '706890a948d02cb2db17d3f1ef0718710c88ba8900a6bc31cb6905498aa85189',
+     armv7l: '706890a948d02cb2db17d3f1ef0718710c88ba8900a6bc31cb6905498aa85189',
+       i686: '74d8d4d4badd3f4484cd098a1828aeb423d05a1dad4b5e1a42f13101c5af123b',
+     x86_64: '5dfa210eecb769b0b301474ee2bd819f68eda3fa27e1e372a0cb046718675a90'
   })
 
   depends_on 'atk'
   depends_on 'cairo'
-  depends_on 'ccache' => :build
+  depends_on 'dav1d'
   depends_on 'enchant'
   depends_on 'fontconfig'
   depends_on 'freetype'
@@ -56,6 +56,7 @@ class Webkit2gtk_5 < Package
   depends_on 'mesa'
   depends_on 'openjpeg'
   depends_on 'pango'
+  depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader'
   depends_on 'wayland'
   depends_on 'woff2'
@@ -69,10 +70,10 @@ class Webkit2gtk_5 < Package
       # system "env #{CREW_ENV_OPTIONS} \
       # Bubblewrap sandbox breaks on epiphany with
       # bwrap: Can't make symlink at /var/run: File exists
+      # ccache currently breaks gcc builds of webkit-gtk
       system "cmake \
         -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        #{CREW_CMAKE_FNO_LTO_OPTIONS} \
         -DCMAKE_SKIP_RPATH=ON \
         -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
         -DENABLE_GAMEPAD=OFF \
@@ -87,6 +88,8 @@ class Webkit2gtk_5 < Package
         -DUSE_GTK4=ON \
         -DUSE_SOUP2=OFF \
         -DUSE_SYSTEMD=OFF \
+        -DUSE_AVIF=ON \
+        -DPYTHON_EXECUTABLE=`which python` \
         .."
     end
     system 'ninja -C builddir5'

--- a/packages/wpebackend_fdo.rb
+++ b/packages/wpebackend_fdo.rb
@@ -3,24 +3,24 @@ require 'package'
 class Wpebackend_fdo < Package
   description 'Freedesktop.org backend for WPE WebKit'
   homepage 'https://wpewebkit.org'
-  @_ver = '1.8.0'
+  @_ver = '1.8.4'
   version @_ver
   license 'BSD-2'
   compatibility 'all'
   source_url "https://github.com/Igalia/WPEBackend-fdo/releases/download/#{@_ver}/wpebackend-fdo-#{@_ver}.tar.xz"
-  source_sha256 '9652a99c75fe1c6eab0585b6395f4e104b2427e4d1f42969f1f77df29920d253'
+  source_sha256 'def59bed5e8cdabb65ffa76ee2eef349fba7b42a75dac80f3da5954b17f4074a'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wpebackend_fdo/1.8.0_armv7l/wpebackend_fdo-1.8.0-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wpebackend_fdo/1.8.0_armv7l/wpebackend_fdo-1.8.0-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wpebackend_fdo/1.8.0_i686/wpebackend_fdo-1.8.0-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wpebackend_fdo/1.8.0_x86_64/wpebackend_fdo-1.8.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wpebackend_fdo/1.8.4_armv7l/wpebackend_fdo-1.8.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wpebackend_fdo/1.8.4_armv7l/wpebackend_fdo-1.8.4-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wpebackend_fdo/1.8.4_i686/wpebackend_fdo-1.8.4-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wpebackend_fdo/1.8.4_x86_64/wpebackend_fdo-1.8.4-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '2eb8dbb4be7ec82b3b48c5396759f447374b206ef3d498d49899a86b066b60d0',
-      armv7l: '2eb8dbb4be7ec82b3b48c5396759f447374b206ef3d498d49899a86b066b60d0',
-        i686: '77e5834339fe892f5f4eca9f642b28a5e7f72e5c1ecaafff8b5acea570543e90',
-      x86_64: 'a6ebf24575dc975a1615508cd259542ea3379529dae274ae800e64b5166cf5f6',
+  binary_sha256({
+    aarch64: 'fe50fe41d14a69954f6df24f77f4a86ed123c62c07cecbd9e20881b22ec8a4b6',
+     armv7l: 'fe50fe41d14a69954f6df24f77f4a86ed123c62c07cecbd9e20881b22ec8a4b6',
+       i686: 'df008b94ea6fc3172ba993d5aab760f92659bbdfe022a012d20837cf35a242ab',
+     x86_64: '8da6d976164abe12aaea42e61d57dfab772639fffa954305c9b9e59889d09f8d'
   })
 
   depends_on 'libwpe'
@@ -32,8 +32,8 @@ class Wpebackend_fdo < Package
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install


### PR DESCRIPTION
- Fixup speex and speexdsp (they are separate packages! :/ and update them plus dependent packages.)
- Add more gnome updates (gvfs, gjs)
- Update webkit2gtk, wpebackend_fdo, waypipe, smbclient
- py3_pip -> 21.1.1

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l
