### PR TITLE
Add upx and ucl

### DIFF
--- a/packages/ucl.rb
+++ b/packages/ucl.rb
@@ -1,0 +1,38 @@
+# Adapted from Arch Linux ucl PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/ucl/trunk/PKGBUILD
+
+require 'package'
+
+class Ucl < Package
+  description 'Portable lossless data compression library written in ANSI C'
+  homepage 'https://www.oberhumer.com/opensource/ucl/'
+  version '1.03'
+  compatibility 'all'
+  source_url 'https://www.oberhumer.com/opensource/ucl/download/ucl-1.03.tar.gz'
+  source_sha256 'b865299ffd45d73412293369c9754b07637680e5c826915f097577cd27350348'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ucl/1.03_armv7l/ucl-1.03-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ucl/1.03_armv7l/ucl-1.03-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ucl/1.03_i686/ucl-1.03-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ucl/1.03_x86_64/ucl-1.03-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'da7156b3f5c3def28ef1e276d4e24c9ba0bcb5f623c1856d0c4f886233d16676',
+     armv7l: 'da7156b3f5c3def28ef1e276d4e24c9ba0bcb5f623c1856d0c4f886233d16676',
+       i686: 'c69ddc889d2fbecf1b77b646fe0623565da9d11f7a6c71762fbebc5c77b27882',
+     x86_64: '1d0c3cfc926a6e8c119794d253680044bc10d54a18438199409287d42f6f979f'
+  })
+
+  def self.build
+    system "env CFLAGS='-pipe -std=gnu90 -fPIC -flto' \
+      ./configure #{CREW_OPTIONS} \
+      --enable-shared \
+      --enable-static"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/upx.rb
+++ b/packages/upx.rb
@@ -1,0 +1,49 @@
+# Adapted from Arch Linux upx PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/upx/trunk/PKGBUILD
+
+require 'package'
+
+class Upx < Package
+  description 'Extendable, high-performance executable packer for several executable formats'
+  homepage 'https://github.com/upx/upx'
+  version '4.0.0-66fe'
+  license 'custom GPL2'
+  compatibility 'all'
+  source_url 'https://github.com/upx/upx.git'
+  git_hashtag '66fe8a624d1a4945173955b9edd626664708b383'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.0-66fe_armv7l/upx-4.0.0-66fe-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.0-66fe_armv7l/upx-4.0.0-66fe-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.0-66fe_i686/upx-4.0.0-66fe-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.0-66fe_x86_64/upx-4.0.0-66fe-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '412f53e51a9e4cc07d1c5eb43a19afbfca359c045faa0cd821824c56e5e34e95',
+     armv7l: '412f53e51a9e4cc07d1c5eb43a19afbfca359c045faa0cd821824c56e5e34e95',
+       i686: 'c594ec89c0596866ae7d919465615923dd2d5244b926bb6d0b0f1aed10fbb4d6',
+     x86_64: 'cc24e68b8f1ae2212fb375333a64a3bfb3220df3e07811c38687cd87789c1d49'
+  })
+
+  depends_on 'ucl'
+
+  def self.patch
+    # Disable a warning. upx believes this is not a release version if the git revision is set.
+    system "sed -i 's/bool warn = true/bool warn = false/' src/main.cpp"
+  end
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS} make  \
+      CHECK_WHITESPACE=/bin/true \
+      UPX_LZMA_VERSION=0x465 \
+      UPX_LZMADIR=`pwd` \
+      all"
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man1"
+    FileUtils.install 'src/upx.out', "#{CREW_DEST_PREFIX}/bin/upx", mode: 0o755
+    FileUtils.install 'doc/upx.1', "#{CREW_DEST_MAN_PREFIX}/man1/upx.1", mode: 0o644
+  end
+end


### PR DESCRIPTION
- Adds upx (and dependency ucl) 
- This may be one option for reducing binary size @saltedcoffii 
- older git tags and release version had issues with broken generated binaries that this fixes.

Builds properly:
- [x] x86_64
- [x] i686
- [x] armv7l