### PR TITLE
Have crew pull the true system Glibc version

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -8,7 +8,10 @@ ARCH_ACTUAL = `uname -m`.strip
 ARCH = if ARCH_ACTUAL == 'armv8l' then 'armv7l' else ARCH_ACTUAL end
 
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
-LIBC_VERSION = %x[/#{ARCH_LIB}/libc.so.6].lines.first.chomp.split.last.delete_suffix!('.')
+
+# Glibc version can be found from the output of libc.so.6
+@libcvertokens=  %x[/#{ARCH_LIB}/libc.so.6].lines.first.chomp.split(/[\s]/)
+LIBC_VERSION = @libcvertokens[@libcvertokens.find_index("version") + 1].sub!(/[[:punct:]]?$/,'')
 
 if ENV['CREW_PREFIX'].to_s.empty?
   CREW_PREFIX = '/usr/local'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.10.6'
+CREW_VERSION = '1.10.7'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines
@@ -8,7 +8,7 @@ ARCH_ACTUAL = `uname -m`.strip
 ARCH = if ARCH_ACTUAL == 'armv8l' then 'armv7l' else ARCH_ACTUAL end
 
 ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
-LIBC_VERSION = if File.exist? "/#{ARCH_LIB}/libc-2.27.so" then '2.27' else '2.23' end
+LIBC_VERSION = %x[/#{ARCH_LIB}/libc.so.6].lines.first.chomp.split.last.delete_suffix!('.')
 
 if ENV['CREW_PREFIX'].to_s.empty?
   CREW_PREFIX = '/usr/local'


### PR DESCRIPTION
- Since we're about to have three versions of glibc, let's just get the actual version, from parsing the output of `libc.so.6`
e.g.

i686:
```
/lib/libc.so.6
GNU C Library (Gentoo 2.23-r4 p6) stable release version 2.23, by Roland McGrath et al.
Copyright (C) 2016 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.
Compiled by GNU CC version 4.9.x 20150123 (prerelease).
Available extensions:
        C stubs add-on version 2.1.2
        crypt add-on version 2.1 by Michael Glad and others
        GNU Libidn by Simon Josefsson
        Native POSIX Threads Library by Ulrich Drepper et al
        BIND-8.2.3-T5B
libc ABIs: UNIQUE IFUNC
For bug reporting instructions, please see:
<http://crbug.com/new>.
```
x86_64:
```
/lib64/libc.so.6
GNU C Library (Gentoo 2.27-r22 p3) stable release version 2.27.
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.
Compiled by GNU CC version 10.2.0.
libc ABIs: UNIQUE IFUNC
For bug reporting instructions, please see:
<http://crbug.com/new>.
```
armv7l:
```
/lib/libc.so.6
GNU C Library (Gentoo 2.27-r21 p3) stable release version 2.27.
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.
Compiled by GNU CC version 10.2.0.
libc ABIs: UNIQUE
For bug reporting instructions, please see:
<http://crbug.com/new>.
```

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l