### PR TITLE
updates of filecmd and patchelf

### DIFF
--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -3,24 +3,24 @@ require 'package'
 class Filecmd < Package
   description 'file command determines the file type.'
   homepage 'http://ftp.astron.com/'
-  @_ver = '5.39'
+  @_ver = '5.40'
   version @_ver
   license 'BSD-2 and GPL-3+' # Chromebrew's filefix is GPL-3+, file itself is BSD-2
   compatibility 'all'
   source_url "http://ftp.astron.com/pub/file/file-#{@_ver}.tar.gz"
-  source_sha256 'f05d286a76d9556243d0cb05814929c2ecf3a5ba07963f8f70bfaaa70517fad1'
+  source_sha256 '167321f43c148a553f68a0ea7f579821ef3b11c27b8cbe158e4df897e4a5dd57'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/filecmd/5.39_armv7l/filecmd-5.39-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/filecmd/5.39_armv7l/filecmd-5.39-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/filecmd/5.39_i686/filecmd-5.39-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/filecmd/5.39_x86_64/filecmd-5.39-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/filecmd/5.40_armv7l/filecmd-5.40-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/filecmd/5.40_armv7l/filecmd-5.40-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/filecmd/5.40_i686/filecmd-5.40-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/filecmd/5.40_x86_64/filecmd-5.40-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: 'cdd5e95dfa839a179e68822683a0eda74e83b0ec530fdf82665051ced048d3e7',
-      armv7l: 'cdd5e95dfa839a179e68822683a0eda74e83b0ec530fdf82665051ced048d3e7',
-        i686: 'af07c76f343f22825915ffae3ec48a1e2542b1df43555363c5d7c0ccb10e3f95',
-      x86_64: '25591cd681ad7835f0b5033c0a3e10c23a4bb0a8a1d399ead603f80c743643cb',
+  binary_sha256({
+    aarch64: 'fb583470099d4d432aa7bf99b0a84f58c2b3633b79d06a8099002110d02d8fbe',
+    armv7l: 'fb583470099d4d432aa7bf99b0a84f58c2b3633b79d06a8099002110d02d8fbe',
+    i686: '8d772df66fc1901ab427dd4c23866a89543025c3bec0e8f19a43e508f9afddf4',
+    x86_64: '189bb1bbc27d66a4cb0f06cb0f5ad19cea99855add9056e555dccaea6108bd23'
   })
 
   def self.build
@@ -32,21 +32,26 @@ class Filecmd < Package
         sed -i 's,/usr/bin/file,#{CREW_PREFIX}/bin/file,g' ${f}
       done
     EOF
-    IO.write("./filefix", @filefix)
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
+    IO.write('./filefix', @filefix)
+    # Optimization flags from https://github.com/InBetweenNames/gentooLTO
+    # Build static for use in case needed with glibc brokenness.
+    system "env  CFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+      CXXFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+      LDFLAGS='-flto=auto -static' \
       ./configure \
       #{CREW_OPTIONS} \
+      --enable-static \
       --disable-libseccomp"
-    system "make"
+    system 'make'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin/"
-    FileUtils.install 'filefix', "#{CREW_DEST_PREFIX}/bin/filefix", mode: 0755
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install-strip"
+    FileUtils.install 'filefix', "#{CREW_DEST_PREFIX}/bin/filefix", mode: 0o755
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-strip'
   end
 end

--- a/packages/patchelf.rb
+++ b/packages/patchelf.rb
@@ -3,28 +3,43 @@ require 'package'
 class Patchelf < Package
   description 'PatchELF is a small utility to modify the dynamic linker and RPATH of ELF executables.'
   homepage 'http://nixos.org/patchelf.html'
-  version '0.12-f347'
+  version '0.12-PR278'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://github.com/NixOS/patchelf/archive/f34751b88bd07d7f44f5cd3200fb4122bf916c7e.zip'
-  source_sha256 '5ed94d15c44c13c1fa6a78b2f5ca499e465fd9171e4a1daf194e8523c04a9339'
+  source_url 'https://github.com/NixOS/patchelf.git'
+  git_hashtag 'f376fe61bae57e9e50f4622f5a44febb4f5bfd3c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.12-f347_armv7l/patchelf-0.12-f347-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.12-f347_armv7l/patchelf-0.12-f347-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.12-f347_i686/patchelf-0.12-f347-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.12-f347_x86_64/patchelf-0.12-f347-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.12-PR278_armv7l/patchelf-0.12-PR278-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.12-PR278_armv7l/patchelf-0.12-PR278-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.12-PR278_i686/patchelf-0.12-PR278-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.12-PR278_x86_64/patchelf-0.12-PR278-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'e2b7945b1a842076b60347516561d29af99bc450ef66732d41086bb15bc8374d',
-     armv7l: 'e2b7945b1a842076b60347516561d29af99bc450ef66732d41086bb15bc8374d',
-       i686: '9496ae8276c538a798adcbf86816dab573c7ded0e96cd9e678991d7bd5ae54fe',
-     x86_64: 'c234ee6df670e7d1405ff57c607d529a0c9bed6815fd900a51059796620e1fdc'
+    aarch64: '61fc1bd2289cb16b9437c7f2445227d94caee84c7f620311299b48451f6ea9c3',
+     armv7l: '61fc1bd2289cb16b9437c7f2445227d94caee84c7f620311299b48451f6ea9c3',
+       i686: 'f2998b08da471c4a876a3132b87134da6aae53f7dbdcb286e649a389dd7453fb',
+     x86_64: 'ac8031d033df7019916b7fc866b08c1c0c9aeca668946521749ad44c5c0a3d63'
   })
+
+  depends_on 'hashpipe' => :build
+
+  def self.patch
+    # This pulls in a patch from https://github.com/NixOS/patchelf/pull/278
+    # which implements a fix for the program header corruption
+    # addressed in https://github.com/NixOS/patchelf/pull/243
+    system 'curl -Ls https://patch-diff.githubusercontent.com/raw/NixOS/patchelf/pull/278.patch | \
+    hashpipe sha256 0c80997462ab541ea3694a8e988f4f008e40f887b933883e312ff9acb3605fa5 | \
+    patch -Np1 --binary'
+  end
 
   def self.build
     system './bootstrap.sh'
-    system "env CFLAGS='-flto=auto -ltinfo' CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
+    # Optimization flags from https://github.com/InBetweenNames/gentooLTO
+    # Build static for use in case needed with glibc brokenness.
+    system "env  CFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+    CXXFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+    LDFLAGS='-flto=auto -static' \
              ./configure #{CREW_OPTIONS}"
     system 'make'
   end


### PR DESCRIPTION
- File -> 5.40
- Patchelf updated to fix a header corruption bug
- both are compiled (mostly) static to help with glibc debugging with some CFLAG options from gentoo to be brought into `CREW_ENV_OPTIONS` at some poiint.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686
