### PR TITLE
Add pdfchain package

### DIFF
--- a/packages/libunwind.rb
+++ b/packages/libunwind.rb
@@ -3,23 +3,24 @@ require 'package'
 class Libunwind < Package
   description 'libunwind is a portable and efficient C programming interface (API) to determine the call-chain of a program.'
   homepage 'https://www.nongnu.org/libunwind/'
-  version '1.5.0-1'
+  @_ver = '1.5.0'
+  version @_ver + '-2'
   license 'MIT'
   compatibility 'all'
   source_url 'https://download.savannah.gnu.org/releases/libunwind/libunwind-1.5.0.tar.gz'
   source_sha256 '90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017'
 
   binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunwind/1.5.0-1_armv7l/libunwind-1.5.0-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunwind/1.5.0-1_armv7l/libunwind-1.5.0-1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunwind/1.5.0-1_i686/libunwind-1.5.0-1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunwind/1.5.0-1_x86_64/libunwind-1.5.0-1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunwind/1.5.0-2_armv7l/libunwind-1.5.0-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunwind/1.5.0-2_armv7l/libunwind-1.5.0-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunwind/1.5.0-2_i686/libunwind-1.5.0-2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunwind/1.5.0-2_x86_64/libunwind-1.5.0-2-chromeos-x86_64.tpxz',
   })
   binary_sha256 ({
-     aarch64: 'c1b315c17464f67a1e719a615da0154c661eaf1e6e1584f8a68870a2de8721e8',
-      armv7l: 'c1b315c17464f67a1e719a615da0154c661eaf1e6e1584f8a68870a2de8721e8',
-        i686: 'd697d0a6c015dc8c01593669679c367ca0c9f412e140adb2d4ced0af9fb42fb2',
-      x86_64: 'a759499690b70258e91d8ac7cd32047a3cf3308364b04f062e8fc60a33782ec6',
+    aarch64: '21a4912e68f2310216c3054ada90ab13886a11024402713520ea14c22d4c90a5',
+     armv7l: '21a4912e68f2310216c3054ada90ab13886a11024402713520ea14c22d4c90a5',
+       i686: '3f5e16bb0482bab2d8671b4f386b27c786b844398617ad2cead8f33f304322e3',
+     x86_64: 'b7e31f468ce7114748f09cff66b6e8f04ad843db4c5a835d993b8ca80c0ff256',
   })
 
   def self.build
@@ -30,5 +31,6 @@ class Libunwind < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.ln_s "#{CREW_LIB_PREFIX}/libunwind.so.8.0.1", "#{CREW_DEST_LIB_PREFIX}/libunwind.so.1"
   end
 end

--- a/packages/pdfchain.rb
+++ b/packages/pdfchain.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Pdfchain < Package
+  description 'PDF Chain is a graphical user interface for the PDF Toolkit (PDFtk).'
+  homepage 'https://pdfchain.sourceforge.io/'
+  version '0.4.4.2'
+  license 'GPL-3'
+  compatibility 'all'
+  source_url 'https://downloads.sourceforge.net/project/pdfchain/pdfchain-0.4.4.2/pdfchain-0.4.4.2.tar.gz'
+  source_sha256 '1eee0f93dbe8c9cef9f9fe4ec0a10e0a45ca8cde67cd6ceffa2ce6c843752f3d'
+
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pdfchain/0.4.4.2_armv7l/pdfchain-0.4.4.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pdfchain/0.4.4.2_armv7l/pdfchain-0.4.4.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pdfchain/0.4.4.2_i686/pdfchain-0.4.4.2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pdfchain/0.4.4.2_x86_64/pdfchain-0.4.4.2-chromeos-x86_64.tpxz',
+  })
+  binary_sha256 ({
+    aarch64: 'b052c791dab36fb8a87e9abd77be1695cfe1246093b222a3f83a74f9f3d8ca3a',
+     armv7l: 'b052c791dab36fb8a87e9abd77be1695cfe1246093b222a3f83a74f9f3d8ca3a',
+       i686: 'd983a44e676ee973c5d4f67c597d5ba1ca8419ab4081a89b3823f60052bce2fd',
+     x86_64: 'a3cdadfccb70459207f0bf61b81df07697e33c8fe04c009a5878470e29661008',
+  })
+
+  depends_on 'libunwind'
+  depends_on 'pdftk'
+  depends_on 'gtkmm3'
+  depends_on 'valgrind'
+  depends_on 'sommelier'
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.postinstall
+    puts "\nType 'pdfchain' to get started.\n".lightblue
+  end
+end


### PR DESCRIPTION
PDF Chain is a graphical user interface for the PDF Toolkit (PDFtk).  See https://pdfchain.sourceforge.io/.  Tested on all architectures.  Also updated libunwind to add a shared library symlink.