### PR TITLE
#2. Convert curl, git, pixz to static, and update dependencies...

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1189,11 +1189,11 @@ def archive_package(pwd)
         system 'symlinks -cr .' if File.exist?("#{CREW_PREFIX}/bin/symlinks")
       end
      # Issues with non-x86_64
-     # if File.exist?("#{CREW_PREFIX}/bin/upx")
-     #   puts "Using upx to shrink binaries"
-     #   system "find . -executable -type f | xargs file | \
-     #     grep ELF | cut -d: -f1 | xargs upx -9"
-     # end
+      if File.exist?("#{CREW_PREFIX}/bin/upx")
+        puts "Using upx to shrink binaries"
+        system "find . -executable -type f ! \\( -name \"*.so*\" -o -name \"*.a\" \\)| xargs file | \
+          grep ELF | cut -d: -f1 | xargs upx --exact --best"
+      end
     end
   end
   unless ENV['CREW_USE_PIXZ'] == '0' || !File.exist?("#{CREW_PREFIX}/bin/pixz") 

--- a/bin/crew
+++ b/bin/crew
@@ -1178,6 +1178,24 @@ def build_package(pwd)
 end
 
 def archive_package(pwd)
+  if ENV['CREW_SHRINK_ARCHIVE'] == '1'
+    Dir.chdir CREW_DEST_DIR do
+      if File.exist?("#{CREW_PREFIX}/bin/rdfind")
+        puts "Using rdfind to find duplicate or hard linked files."
+        system "#{CREW_PREFIX}/bin/rdfind -removeidentinode true -makesymlinks true ."
+      end
+      if File.exist?("#{CREW_PREFIX}/bin/symlinks")
+        puts "Using symlinks tool to make absolute symlinks relative"
+        system 'symlinks -cr .' if File.exist?("#{CREW_PREFIX}/bin/symlinks")
+      end
+     # Issues with non-x86_64
+     # if File.exist?("#{CREW_PREFIX}/bin/upx")
+     #   puts "Using upx to shrink binaries"
+     #   system "find . -executable -type f | xargs file | \
+     #     grep ELF | cut -d: -f1 | xargs upx -9"
+     # end
+    end
+  end
   unless ENV['CREW_USE_PIXZ'] == '0' || !File.exist?("#{CREW_PREFIX}/bin/pixz") 
     puts "Using pixz to compress archive."
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tpxz"

--- a/bin/crew
+++ b/bin/crew
@@ -1018,8 +1018,8 @@ def resolve_dependencies
   deps = @dependencies
   begin_packages = []
   end_packages = []
-  first_packages = ["shared_mime_info"]
-  last_packages = ["curl", "ghc", "mandb", "gtk3", "gtk4", "sommelier"]
+  first_packages = %w[curl git pixz shared_mime_info]
+  last_packages = %w[ghc mandb gtk3 gtk4 sommelier]
   @dependencies.each do |dep|
     depends = nil
     File.open("#{CREW_PACKAGES_PATH}#{dep}.rb") do |f|

--- a/bin/crew
+++ b/bin/crew
@@ -903,6 +903,9 @@ def prepare_package(destdir)
 
     strip_dir destdir 
 
+    # make hard linked files symlinks and use upx on executables
+    shrink_dir destdir
+
   end
 end
 
@@ -927,6 +930,37 @@ def strip_dir(dir)
       extensions = [ 'bz2', 'gz', 'lha', 'lz', 'lzh', 'rar', 'tar', 'tbz', 'tgz', 'tpxz', 'txz', 'xz', 'Z', 'zip' ]
       inames = extensions.join(' ! -iname *\.')
       strip_find_files "find . -type f ! -iname *\.#{inames} -perm /111 -print | sed -e '/lib.*\.a$/d' -e '/lib.*\.so/d'"
+    end
+  end
+end
+
+def shrink_dir(dir)
+  # We might also want a package option to avoid using these tools
+  # on specific packages such as sommelier & xwayland.
+  if ENV['CREW_SHRINK_ARCHIVE'] == '1'
+    Dir.chdir dir do
+      if File.exist?("#{CREW_PREFIX}/bin/rdfind")
+        puts "Using rdfind to find duplicate or hard linked files."
+        system "#{CREW_PREFIX}/bin/rdfind -removeidentinode true -makesymlinks true -makeresultsfile false ."
+      end
+      if File.exist?("#{CREW_PREFIX}/bin/symlinks")
+        puts "Using symlinks tool to make absolute symlinks relative"
+        system 'symlinks -cr .' if File.exist?("#{CREW_PREFIX}/bin/symlinks")
+      end
+     # Issues with non-x86_64 in compressing libraries, so just compress
+     # non-libraries. Also note that one needs to use "upx -d" on a 
+     # compressed file to use ldd.
+     # sommelier also isn't happy when sommelier and xwayland are compressed
+     # so don't compress those packages.
+      if File.exist?("#{CREW_PREFIX}/bin/upx")
+        puts "Using upx to shrink binaries."
+        # Logic here is to find executable files, check if they are ELF files,
+        # compress a file while making a backup, expand the file with 
+        # upx, and if the expansion doesn't error then delete the backup.
+        system "find . -executable -type f ! \\( -name \"*.so*\" -o -name \"*.a\" \\)| xargs file | \
+          grep ELF | cut -d: -f1 | xargs -I {} \
+          bash -c 'upx --best -k --overlay=skip {} && \( upx -t {} && rm {}.~ || mv {}.~ {}\)'"
+      end
     end
   end
 end
@@ -1178,24 +1212,6 @@ def build_package(pwd)
 end
 
 def archive_package(pwd)
-  if ENV['CREW_SHRINK_ARCHIVE'] == '1'
-    Dir.chdir CREW_DEST_DIR do
-      if File.exist?("#{CREW_PREFIX}/bin/rdfind")
-        puts "Using rdfind to find duplicate or hard linked files."
-        system "#{CREW_PREFIX}/bin/rdfind -removeidentinode true -makesymlinks true -makeresultsfile false ."
-      end
-      if File.exist?("#{CREW_PREFIX}/bin/symlinks")
-        puts "Using symlinks tool to make absolute symlinks relative"
-        system 'symlinks -cr .' if File.exist?("#{CREW_PREFIX}/bin/symlinks")
-      end
-     # Issues with non-x86_64
-      if File.exist?("#{CREW_PREFIX}/bin/upx")
-        puts "Using upx to shrink binaries"
-        system "find . -executable -type f ! \\( -name \"*.so*\" -o -name \"*.a\" \\)| xargs file | \
-          grep ELF | cut -d: -f1 | xargs upx --exact --best"
-      end
-    end
-  end
   unless ENV['CREW_USE_PIXZ'] == '0' || !File.exist?("#{CREW_PREFIX}/bin/pixz") 
     puts "Using pixz to compress archive."
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tpxz"

--- a/bin/crew
+++ b/bin/crew
@@ -1182,7 +1182,7 @@ def archive_package(pwd)
     Dir.chdir CREW_DEST_DIR do
       if File.exist?("#{CREW_PREFIX}/bin/rdfind")
         puts "Using rdfind to find duplicate or hard linked files."
-        system "#{CREW_PREFIX}/bin/rdfind -removeidentinode true -makesymlinks true ."
+        system "#{CREW_PREFIX}/bin/rdfind -removeidentinode true -makesymlinks true -makeresultsfile false ."
       end
       if File.exist?("#{CREW_PREFIX}/bin/symlinks")
         puts "Using symlinks tool to make absolute symlinks relative"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.10.9'
+CREW_VERSION = '1.11.0'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/packages/acl.rb
+++ b/packages/acl.rb
@@ -3,36 +3,39 @@ require 'package'
 class Acl < Package
   description 'Commands for Manipulating POSIX Access Control Lists.'
   homepage 'http://savannah.nongnu.org/projects/acl'
-  version '2.2.53'
-  compatibility 'all'
+  version '2.3.1'
   license 'LGPL-2.1'
-  source_url 'https://bigsearcher.com/mirrors/nongnu/acl/acl-2.2.53.tar.gz'
-  source_sha256 '06be9865c6f418d851ff4494e12406568353b891ffe1f596b34693c387af26c7'
+  compatibility 'all'
+  source_url 'https://bigsearcher.com/mirrors/nongnu/acl/acl-2.3.1.tar.xz'
+  source_sha256 'c0234042e17f11306c23c038b08e5e070edb7be44bef6697fb8734dcff1c66b1'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.2.53_armv7l/acl-2.2.53-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.2.53_armv7l/acl-2.2.53-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.2.53_i686/acl-2.2.53-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.2.53_x86_64/acl-2.2.53-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1_armv7l/acl-2.3.1-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1_armv7l/acl-2.3.1-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1_i686/acl-2.3.1-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1_x86_64/acl-2.3.1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '63d5600ce26933fc49b5fea4a9ab37f1dac8546c9a2bee6d0525ced6b98c03bb',
-     armv7l: '63d5600ce26933fc49b5fea4a9ab37f1dac8546c9a2bee6d0525ced6b98c03bb',
-       i686: 'a6859cfa0dc95c84304e49e90bbabc19f99a88daf962c58ff83914acd87f151e',
-     x86_64: '3dc686dbda7dd835281a0e9f54fb0740bd4fcb318c273bc78bbe75a402b906d9',
+  binary_sha256({
+    aarch64: '53eddf80135a3265f01a90ffd9b71c9453b95d432260aea6d8331514fe4af2eb',
+    armv7l: '53eddf80135a3265f01a90ffd9b71c9453b95d432260aea6d8331514fe4af2eb',
+    i686: 'e96e13e6cce5e572a12e9aa3b1e0190fb8cb95712492dfe219aa3b7c69c971e8',
+    x86_64: 'ced96737007afe57d6ee741165e8c409ad2ea8bb361b8356197d1bd4f2c782c0'
   })
 
   depends_on 'attr'
 
+  def self.patch
+    system 'filefix'
+  end
+
   def self.build
-    system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--disable-static"
-    system "make"
+    system "env #{CREW_ENV_OPTIONS} \
+      ./configure \
+      #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/attr.rb
+++ b/packages/attr.rb
@@ -3,36 +3,33 @@ require 'package'
 class Attr < Package
   description 'Commands for Manipulating Filesystem Extended Attributes.'
   homepage 'http://savannah.nongnu.org/projects/attr'
-  version '2.4.48-1'
+  version '2.5.1'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url 'http://download.savannah.gnu.org/releases/attr/attr-2.4.48.tar.gz'
-  source_sha256 '5ead72b358ec709ed00bbf7a9eaef1654baad937c001c044fe8b74c57f5324e7'
+  source_url 'https://download.savannah.gnu.org/releases/attr/attr-2.5.1.tar.xz'
+  source_sha256 'db448a626f9313a1a970d636767316a8da32aede70518b8050fa0de7947adc32'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.4.48-1_armv7l/attr-2.4.48-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.4.48-1_armv7l/attr-2.4.48-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.4.48-1_i686/attr-2.4.48-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.4.48-1_x86_64/attr-2.4.48-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1_armv7l/attr-2.5.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1_armv7l/attr-2.5.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1_i686/attr-2.5.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1_x86_64/attr-2.5.1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '28abf6ac96e7cc3a1ba2690781b26d855e2f545a408c5583bda3220a8985cbf1',
-     armv7l: '28abf6ac96e7cc3a1ba2690781b26d855e2f545a408c5583bda3220a8985cbf1',
-       i686: 'cc277ad1091fe6b3c5fcd81dd3894f6b24c021b8fe0daab772577cdd1f473ed5',
-     x86_64: '744f97cd27716fcb2f4cb127971e61744fda9ae499479480aef7f6fa5a3c60af',
+  binary_sha256({
+    aarch64: 'da212fa1e85d525d438aa7c0a63ff094d158f241c8f359bad17e4c0932b1b5fa',
+     armv7l: 'da212fa1e85d525d438aa7c0a63ff094d158f241c8f359bad17e4c0932b1b5fa',
+       i686: '13b8ad2172c3cd53e1670a8c9fe890ce9c72b3291f24392b4690ad656c969e61',
+     x86_64: '8f78f7cede30f6be0035f3c3a51a0323e94c7e74dc907302abaf04bc4d3a5ccd'
   })
-
-  depends_on 'gettext'
 
   def self.build
-    system "./configure",
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--disable-static"
-    system "make"
+    system "env #{CREW_ENV_OPTIONS} \
+      ./configure \
+      #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/brotli.rb
+++ b/packages/brotli.rb
@@ -3,36 +3,41 @@ require 'package'
 class Brotli < Package
   description 'Brotli compression format'
   homepage 'https://github.com/google/brotli'
-  version '1.0.8'
+  version '1.0.9'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/google/brotli/archive/v1.0.8.tar.gz'
-  source_sha256 'a0bfaf49d8d35262ef1d1e617486b061f47c634721c345051bf8d9fb806f3bb9'
+  source_url 'https://github.com/google/brotli/archive/v1.0.9.tar.gz'
+  source_sha256 'f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/brotli/1.0.8_armv7l/brotli-1.0.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/brotli/1.0.8_armv7l/brotli-1.0.8-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/brotli/1.0.8_i686/brotli-1.0.8-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/brotli/1.0.8_x86_64/brotli-1.0.8-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/brotli/1.0.9_armv7l/brotli-1.0.9-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/brotli/1.0.9_armv7l/brotli-1.0.9-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/brotli/1.0.9_i686/brotli-1.0.9-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/brotli/1.0.9_x86_64/brotli-1.0.9-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '636a5bb46059311e280f1828aa032e2d2bad83905b124549159b73e279856688',
-     armv7l: '636a5bb46059311e280f1828aa032e2d2bad83905b124549159b73e279856688',
-       i686: 'c16396d2d9a4a000b360fd6f096e4f0053abafb7bf1f8c84766527ea7a4b074f',
-     x86_64: '921fc1be57c195176d500f82bf96a52566824e62036c329ced629a0177c7c9d1',
+  binary_sha256({
+    aarch64: '5346decd05692836b92056ecddbd530ce4b8c741f4b8903104a0495f0b44b590',
+    armv7l: '5346decd05692836b92056ecddbd530ce4b8c741f4b8903104a0495f0b44b590',
+    i686: '2e0214bd69b04c9deb8af703c21ccca71c98462fcad81c7664608376e926af27',
+    x86_64: '04cabaaf97a633c2ffe1de7ebc74dd4227f60e1dc1e69bd6094fe69e38020cb4'
   })
 
   def self.build
-    Dir.mkdir 'out'
-    Dir.chdir 'out' do
-      system "cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DCMAKE_INSTALL_LIBDIR=#{CREW_DEST_LIB_PREFIX}"
-      system "cmake --build . --config Release --target install"
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+      ../ -G Ninja"
     end
+    system 'ninja -C builddir'
   end
 
   def self.install
-    Dir.chdir 'out' do
-      system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_DEST_PREFIX} -DCMAKE_INSTALL_LIBDIR=#{CREW_DEST_LIB_PREFIX} -P cmake_install.cmake"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    Dir.chdir CREW_DEST_LIB_PREFIX.to_s do
+      @brotlilibs = %w[libbrotlidec libbrotlienc libbrotlicommon]
+      @brotlilibs.each do |lib|
+        FileUtils.ln_s "#{lib}-static.a", "#{lib}.a"
+      end
     end
   end
 end

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -109,4 +109,9 @@ class Buildessential < Package
 
   # xorg protocol headers
   #depends_on 'xorg_proto'
+
+  # Packages needed for shrinking package archives
+  depends_on 'rdfind'
+  depends_on 'symlinks'
+  #depends_on 'upx'
 end

--- a/packages/c_ares.rb
+++ b/packages/c_ares.rb
@@ -3,27 +3,27 @@ require 'package'
 class C_ares < Package
   description 'c-ares is a C library for asynchronous DNS requests (including name resolves).'
   homepage 'https://c-ares.haxx.se/'
-  version '1.15.0'
+  version '1.17.1'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://c-ares.haxx.se/download/c-ares-1.15.0.tar.gz'
-  source_sha256 '6cdb97871f2930530c97deb7cf5c8fa4be5a0b02c7cea6e7c7667672a39d6852'
+  source_url 'https://c-ares.haxx.se/download/c-ares-1.17.1.tar.gz'
+  source_sha256 'd73dd0f6de824afd407ce10750ea081af47eba52b8a6cb307d220131ad93fc40'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/c_ares/1.15.0_armv7l/c_ares-1.15.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/c_ares/1.15.0_armv7l/c_ares-1.15.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/c_ares/1.15.0_i686/c_ares-1.15.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/c_ares/1.15.0_x86_64/c_ares-1.15.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/c_ares/1.17.1_armv7l/c_ares-1.17.1-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/c_ares/1.17.1_armv7l/c_ares-1.17.1-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/c_ares/1.17.1_i686/c_ares-1.17.1-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/c_ares/1.17.1_x86_64/c_ares-1.17.1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: 'fb85ed9ab22dc4ba7533b67365b56d9ee666580472898432adf3d27d2a20fe3e',
-     armv7l: 'fb85ed9ab22dc4ba7533b67365b56d9ee666580472898432adf3d27d2a20fe3e',
-       i686: '00ea353730432d9b86c9ddbe05774c2fdcc13dd3cc820c31871410b6d43178f1',
-     x86_64: '6587740ad61b5d0a74973235d6e6c01a4e6ea1f5510ee8103ff6e1d2ad045b41',
+  binary_sha256({
+    aarch64: '7d3542bd270aa9ebf5f2b08273f547978290f5febc5142ff8f7fed363efc122e',
+    armv7l: '7d3542bd270aa9ebf5f2b08273f547978290f5febc5142ff8f7fed363efc122e',
+    i686: 'bb4a3bd9eaeff1e09b68f83514ca9a2a64414445bd040536cfe48c147a745641',
+    x86_64: '2ab4479e0290444e44b842072c86c75e3a7a68c326d987be18f2cad01c19ea46'
   })
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS}"
     system 'make'
   end
 

--- a/packages/clib.rb
+++ b/packages/clib.rb
@@ -22,7 +22,7 @@ class Clib < Package
      x86_64: '06c1bac595387b7eeb3e2fddd64c94d3ef6394492e4315f4604e4c4f719efeb9',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
 
   def self.build
     system "sed -i 's,PREFIX ?= /usr/local,PREFIX ?= #{CREW_DEST_PREFIX},' Makefile"

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -24,6 +24,7 @@ class Curl < Package
   })
 
   depends_on 'ca_certificates' => :build
+  depends_on 'libcurl' # L (This is only here to make sure upgrades of curl pull in libcurl.)
   depends_on 'libunbound' => :build
   depends_on 'musl' => :build
   depends_on 'py3_pip' => :build

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -229,7 +229,7 @@ class Curl < Package
 
   def self.check
     system 'src/curl -Lf https://github.com/skycocker/chromebrew/raw/master/install.sh -o /tmp/install.sh'
-    FileUtil.rm '/tmp/install.sh'
+    FileUtils.rm '/tmp/install.sh'
   end
 
   def self.install

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,99 +3,236 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.77.0'
+  @_ver = '7.77.0-git'
   version @_ver
   license 'curl'
   compatibility 'all'
-  source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
-  source_sha256 '0f64582c54282f31c0de9f0a1a596b182776bd4df9a4c4a2a41bbeb54f62594b'
+  source_url 'https://github.com/curl/curl.git'
+  git_hashtag 'curl-7_77_0'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_armv7l/curl-7.77.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_armv7l/curl-7.77.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_i686/curl-7.77.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_x86_64/curl-7.77.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_armv7l/curl-7.77.0-git-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_armv7l/curl-7.77.0-git-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_i686/curl-7.77.0-git-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_x86_64/curl-7.77.0-git-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '0273d3cf0ffb3d18777bb4d5da6a20c00970ad3787687e48c023f406aa42d4bc',
-     armv7l: '0273d3cf0ffb3d18777bb4d5da6a20c00970ad3787687e48c023f406aa42d4bc',
-       i686: 'ead35292354673e20806e70a9359306bd63758a04db3888eb5eca7c99cd1904a',
-     x86_64: '81b8641d60b222248a75f910e2bf82ce7b9d793a84558466e7670215bbd9b8d1'
+    aarch64: '268771c547ef80761b937aedafe786ca701524e20b4737263aee9791514189d0',
+     armv7l: '268771c547ef80761b937aedafe786ca701524e20b4737263aee9791514189d0',
+       i686: '45796384ef70732ab7d4df71f09d2860e22bee776f86f7ff60c9863ff5bc28c2',
+     x86_64: 'ee99c0558b9dc9e64e4a2619706224daa3e7a0d4b100af135ac5b0a6a3b68ab4'
   })
 
-  depends_on 'libunbound' # ?
-  depends_on 'openldap' # R
-  depends_on 'openssl' # R
+  depends_on 'ca_certificates' => :build
+  depends_on 'libunbound' => :build
+  depends_on 'musl' => :build
   depends_on 'py3_pip' => :build
   depends_on 'rust' => :build
   depends_on 'valgrind' => :build
-  depends_on 'zlibpkg' # R
-  depends_on 'zstd' # R
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 
-    @krb5_static_libs = "#{CREW_LIB_PREFIX}/libkrb5support.a " + "#{CREW_LIB_PREFIX}/libgssapi_krb5.a " + "#{CREW_LIB_PREFIX}/libkrb5.a " + "#{CREW_LIB_PREFIX}/libk5crypto.a " + "#{CREW_LIB_PREFIX}/libcom_err.a "
+    @krb5_static_libs = '-l:libkrb5support.a -l:libgssapi_krb5.a -l:libkrb5.a -l:libk5crypto.a -l:libcom_err.a'
 
-    FileUtils.mkdir 'ssl'
-    FileUtils.ln_s "#{CREW_PREFIX}/include/openssl", 'ssl/include'
-    FileUtils.ln_s CREW_LIB_PREFIX, 'ssl/lib'
-    @sslpath = "#{`pwd`.chomp}/ssl"
+    FileUtils.mkdir_p 'build'
+    FileUtils.mkdir_p 'deproot/include'
+    FileUtils.mkdir_p 'deproot/lib'
+    Dir.chdir 'deproot' do
+      FileUtils.ln_s 'lib', 'lib64'
+    end
+    @deppath = "#{`pwd`.chomp}/deproot"
+    FileUtils.ln_s "#{CREW_PREFIX}/include/linux", "#{@deppath}/include/"
+    FileUtils.ln_s "#{CREW_PREFIX}/include/asm", "#{@deppath}/include/"
+    FileUtils.ln_s "#{CREW_PREFIX}/include/asm-generic", "#{@deppath}/include/"
+
+    @arch_ssp_cflags = ''
+    case ARCH
+    when 'i686'
+      @arch_ssp_cflags = '-fno-stack-protector'
+    end
+
+    @curldep_cmake_options = "CC=musl-gcc \
+          CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+          CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+          CPPFLAGS='-I#{@deppath}/include' \
+          LDFLAGS='-L#{@deppath}/lib' \
+          cmake \
+          -DCMAKE_INSTALL_PREFIX='#{@deppath}' \
+          -DCMAKE_LIBRARY_PATH='#{@deppath}/lib' \
+          -DCMAKE_C_COMPILER=`which musl-gcc` \
+          -DCMAKE_INCLUDE_DIRECTORIES_BEFORE=ON \
+          -DINCLUDE_DIRECTORIES=#{@deppath}/include \
+          -DCMAKE_C_FLAGS='-O3 -fPIC -pipe -flto -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+          -DCMAKE_EXE_LINKER_FLAGS='-flto' \
+          -DCMAKE_SHARED_LINKER_FLAGS='-flto' \
+          -DCMAKE_STATIC_LINKER_FLAGS='-flto' \
+          -DCMAKE_MODULE_LINKER_FLAGS='-flto' \
+          -DPROPERTY_INTERPROCEDURAL_OPTIMIZATION=TRUE \
+          -DCMAKE_BUILD_TYPE=Release"
+
+    @curldep_env_options = "CC=musl-gcc \
+        CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+        CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans#{@arch_ssp_cflags}' \
+        CPPFLAGS='-I#{@deppath}/include' \
+        LDFLAGS='-L#{@deppath}/lib'"
+
+    FileUtils.mkdir_p 'build/zlib'
+    Dir.chdir 'build/zlib' do
+      puts 'Building Zlib.'.lightgreen
+      system 'curl -Ls http://zlib.net/zlib-1.2.11.tar.gz | tar --strip-components=1 -zxf -'
+      system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
+        --static"
+      system 'make'
+      system 'make install'
+    end
+    FileUtils.mkdir_p 'build/zstd'
+    Dir.chdir 'build/zstd' do
+      puts 'Building Zstd.'.lightgreen
+      system 'curl -Ls https://github.com/facebook/zstd/archive/v1.5.0.tar.gz | tar --strip-components=1 -zxf -'
+      FileUtils.mkdir('build/cmake/builddir')
+      Dir.chdir('build/cmake/builddir') do
+        system "#{@curldep_cmake_options} \
+        -DZSTD_BUILD_STATIC=ON \
+        -DZSTD_BUILD_SHARED=OFF \
+        ../ -G Ninja"
+      end
+      system 'ninja -C build/cmake/builddir'
+      system 'ninja -C build/cmake/builddir install'
+    end
+    FileUtils.mkdir_p 'build/brotli'
+    Dir.chdir 'build/brotli' do
+      puts 'Building Brotli.'.lightgreen
+      system 'curl -Ls https://github.com/google/brotli/archive/v1.0.9.tar.gz | tar --strip-components=1 -zxf -'
+      FileUtils.mkdir('builddir')
+      Dir.chdir('builddir') do
+        system "#{@curldep_cmake_options} \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DWITH_STATIC_LIB=ON \
+        ../ -G Ninja"
+      end
+      system 'ninja -C builddir'
+      system 'ninja -C builddir install'
+      Dir.chdir "#{@deppath}/lib" do
+        @brotlilibs = %w[libbrotlidec libbrotlienc libbrotlicommon]
+        @brotlilibs.each do |lib|
+          FileUtils.ln_s "#{lib}-static.a", "#{lib}.a"
+        end
+      end
+    end
+    FileUtils.mkdir_p 'build/idn2'
+    Dir.chdir 'build/idn2' do
+      puts 'Building IDN2.'.lightgreen
+      system 'curl -Ls http://ftp.gnu.org/gnu/libidn/libidn2-2.3.1.tar.gz | tar --strip-components=1 -zxf -'
+      system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
+        --disable-shared"
+      system 'make'
+      system 'make install'
+    end
+    FileUtils.mkdir_p 'build/ssl'
+    case ARCH
+    when 'aarch64', 'armv7l'
+      @arch_c_flags = '-march=armv7-a -mfloat-abi=hard'
+      @arch_cxx_flags = '-march=armv7-a -mfloat-abi=hard'
+      @openssl_configure_target = 'linux-generic32'
+    when 'i686'
+      @arch_c_flags = ''
+      @arch_cxx_flags = ''
+      @openssl_configure_target = 'linux-x86'
+    when 'x86_64'
+      @arch_c_flags = ''
+      @arch_cxx_flags = ''
+      @openssl_configure_target = 'linux-x86_64'
+    end
+    Dir.chdir 'build/ssl' do
+      puts 'Building OpenSSL.'.lightgreen
+      system 'curl -Ls https://www.openssl.org/source/openssl-1.1.1k.tar.gz | tar --strip-components=1 -zxf -'
+      system "CC=musl-gcc \
+        CFLAGS='-flto -pipe -O3 -fPIC #{@arch_c_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+        CXXFLAGS='-flto -pipe -O3 -fPIC #{@arch_cxx_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+        CPPFLAGS='-I#{@deppath}/include' \
+        LDFLAGS='-L#{@deppath}/lib -flto' \
+        ./Configure \
+        --prefix=#{@deppath} \
+        no-tests zlib no-shared \
+        #{@openssl_configure_target}"
+      system 'make'
+      system 'make install_sw'
+    end
+    
+    # libssh has problems linking with musl statically
+    # FileUtils.mkdir_p 'build/libssh'
+    # Dir.chdir 'build/libssh' do
+      # puts 'Building Libssh.'.lightgreen
+      # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | tar --strip-components=1 -Jxf -'
+      # FileUtils.mkdir('builddir')
+      # Dir.chdir('builddir') do
+      # system "#{@curldep_cmake_options} \
+      #-DWITH_EXAMPLES=OFF \
+      #-DBUILD_SHARED_LIBS=OFF \
+      #-DWITH_STATIC_LIB=ON \
+      #-DWITH_GSSAPI=OFF \
+      #-DHAVE_GLOB=0 \
+      # ../ -G Ninja"
+      # end
+      # system 'ninja -C builddir'
+      # system 'ninja -C builddir install'
+    # end
+    FileUtils.mkdir_p 'build/nghttp2'
+    Dir.chdir 'build/nghttp2' do
+      puts 'Building Nghttp2.'.lightgreen
+      system 'curl -Ls https://github.com/nghttp2/nghttp2/releases/download/v1.43.0/nghttp2-1.43.0.tar.gz | tar --strip-components=1 -zxf -'
+      system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
+        --enable-lib-only \
+        --disable-shared \
+        --enable-static"
+      system 'make'
+      system 'make install'
+    end
+
+    puts 'Done building static curl dependencies.'.lightgreen
+    system '[ -x configure ] || autoreconf -fvi'
     system 'filefix'
-    system "env CC=clang CXX=clang++ LD=ld.lld RANLIB=llvm-ranlib \
-      AR=llvm-ar \
-      CFLAGS='-flto -pipe -O3 -lz -fuse-ld=lld' \
-      CXXFLAGS='-flto -pipe -O3' \
-      LDFLAGS='-flto -static -Wl,--no-as-needed -ldl' LIBS='-l:libresolv.a #{@krb5_static_libs} -l:libzstd.a -l:libssh.a -lm -lbrotlicommon -lbrotlidec -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
-      ./configure #{CREW_OPTIONS} \
+    system "env CC=musl-gcc \
+      PKG_CONFIG='pkg-config --static' \
+      CPPFLAGS='-I#{@deppath}/include' \
+      CFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+      CXXFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+      LDFLAGS='-L#{@deppath}/lib -flto -static -Wl,--no-as-needed -ldl' \
+      LIBS='#{@deppath}/lib/libssl.a #{@deppath}/lib/libcrypto.a #{@deppath}/lib/libbrotlicommon.a #{@deppath}/lib/libbrotlidec.a #{@deppath}/lib/libidn2.a #{@deppath}/lib/libnghttp2.a  #{@deppath}/lib/libz.a #{@deppath}/lib/libzstd.a -L#{@deppath}/lib' \
+      CURL_LIBRARY_PATH=#{@deppath}/lib \
+      ./configure --prefix=#{@deppath} \
+      --disable-imap \
       --disable-ldap \
+      --disable-ldaps \
       --disable-libcurl-option \
       --disable-maintainer-mode \
+      --disable-rtsp \
       --disable-shared \
+      --enable-debug \
       --enable-ipv6 \
       --enable-static \
       --enable-unix-sockets \
       --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
       --with-ca-fallback \
       --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
-      --with-libssh \
-      --with-openssl \
-      --without-librtmp"
+      --with-libidn2=#{@deppath} \
+      --with-nghttp2=#{@deppath} \
+      --with-openssl=#{@deppath} \
+      --with-brotli=#{@deppath} \
+      --without-librtmp \
+      --with-openssl=#{@deppath} \
+      --with-zlib=#{@deppath}"
     system 'make curl_LDFLAGS=-all-static'
     FileUtils.cp 'src/curl', 'curl.static'
-    system "env  CFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
-       CXXFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
-       LDFLAGS='-flto=auto' LIBS='#{@krb5_static_libs} -lm -lbrotlicommon -lbrotlidec -lzstd -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
-       ./configure #{CREW_OPTIONS} \
-      --disable-maintainer-mode \
-      --enable-ares \
-      --enable-ipv6 \
-      --enable-ldap \
-      --enable-unix-sockets \
-      --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
-      --with-ca-fallback \
-      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
-      --with-lber-lib=lber \
-      --with-ldap-lib=ldap \
-      --with-libmetalink \
-      --with-libssh \
-      --with-openssl=#{@sslpath} \
-      --without-gnutls \
-      --without-librtmp"
-    system 'make'
   end
 
-   def self.check
-     # Python package impacket needed for testing.
-     # 1094 tests out of 1097 reported OK: 99% on 10/25/2020
-     # The 3 tests that failed were FTP, SMB and GOPHER.
-     system 'pip3 install impacket'
-     system 'make check || true'
-     system 'pip3 uninstall -y impacket'
-   end
+  def self.check
+    system 'src/curl -Lf https://github.com/skycocker/chromebrew/raw/master/install.sh -o /tmp/install.sh'
+  end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.install 'curl.static', "#{CREW_DEST_PREFIX}/bin/curl", mode: 0o755
   end
 end

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -17,10 +17,10 @@ class Curl < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_x86_64/curl-7.77.0-git-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '268771c547ef80761b937aedafe786ca701524e20b4737263aee9791514189d0',
-     armv7l: '268771c547ef80761b937aedafe786ca701524e20b4737263aee9791514189d0',
-       i686: '45796384ef70732ab7d4df71f09d2860e22bee776f86f7ff60c9863ff5bc28c2',
-     x86_64: 'ee99c0558b9dc9e64e4a2619706224daa3e7a0d4b100af135ac5b0a6a3b68ab4'
+    aarch64: '45597919122d848c3b6b91358b67ade0eaa9fb9bfb887f97c6bdeee55fcc84c2',
+     armv7l: '45597919122d848c3b6b91358b67ade0eaa9fb9bfb887f97c6bdeee55fcc84c2',
+       i686: '02436eb8f258cd050cb7c3836801a16cb3c2f24a011ece6a4f388715b2d3c4a7',
+     x86_64: '7399d70a022d09a421b461454b20528d5a8d4fd1976a8364b32190887e8a5780'
   })
 
   depends_on 'ca_certificates' => :build
@@ -57,10 +57,10 @@ class Curl < Package
           CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
           CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
           CPPFLAGS='-I#{@deppath}/include' \
-          LDFLAGS='-L#{@deppath}/lib' \
+          LDFLAGS='-L#{@deppath}/#{ARCH_LIB}' \
           cmake \
           -DCMAKE_INSTALL_PREFIX='#{@deppath}' \
-          -DCMAKE_LIBRARY_PATH='#{@deppath}/lib' \
+          -DCMAKE_LIBRARY_PATH='#{@deppath}/#{ARCH_LIB}' \
           -DCMAKE_C_COMPILER=`which musl-gcc` \
           -DCMAKE_INCLUDE_DIRECTORIES_BEFORE=ON \
           -DINCLUDE_DIRECTORIES=#{@deppath}/include \
@@ -76,7 +76,7 @@ class Curl < Package
         CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
         CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans#{@arch_ssp_cflags}' \
         CPPFLAGS='-I#{@deppath}/include' \
-        LDFLAGS='-L#{@deppath}/lib'"
+        LDFLAGS='-L#{@deppath}/#{ARCH_LIB}'"
 
     FileUtils.mkdir_p 'build/zlib'
     Dir.chdir 'build/zlib' do
@@ -114,7 +114,7 @@ class Curl < Package
       end
       system 'ninja -C builddir'
       system 'ninja -C builddir install'
-      Dir.chdir "#{@deppath}/lib" do
+      Dir.chdir "#{@deppath}/#{ARCH_LIB}" do
         @brotlilibs = %w[libbrotlidec libbrotlienc libbrotlicommon]
         @brotlilibs.each do |lib|
           FileUtils.ln_s "#{lib}-static.a", "#{lib}.a"
@@ -152,7 +152,7 @@ class Curl < Package
         CFLAGS='-flto -pipe -O3 -fPIC #{@arch_c_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
         CXXFLAGS='-flto -pipe -O3 -fPIC #{@arch_cxx_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
         CPPFLAGS='-I#{@deppath}/include' \
-        LDFLAGS='-L#{@deppath}/lib -flto' \
+        LDFLAGS='-L#{@deppath}/#{ARCH_LIB} -flto' \
         ./Configure \
         --prefix=#{@deppath} \
         no-tests zlib no-shared \
@@ -160,24 +160,24 @@ class Curl < Package
       system 'make'
       system 'make install_sw'
     end
-    
+
     # libssh has problems linking with musl statically
     # FileUtils.mkdir_p 'build/libssh'
     # Dir.chdir 'build/libssh' do
-      # puts 'Building Libssh.'.lightgreen
-      # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | tar --strip-components=1 -Jxf -'
-      # FileUtils.mkdir('builddir')
-      # Dir.chdir('builddir') do
-      # system "#{@curldep_cmake_options} \
-      #-DWITH_EXAMPLES=OFF \
-      #-DBUILD_SHARED_LIBS=OFF \
-      #-DWITH_STATIC_LIB=ON \
-      #-DWITH_GSSAPI=OFF \
-      #-DHAVE_GLOB=0 \
-      # ../ -G Ninja"
-      # end
-      # system 'ninja -C builddir'
-      # system 'ninja -C builddir install'
+    # puts 'Building Libssh.'.lightgreen
+    # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | tar --strip-components=1 -Jxf -'
+    # FileUtils.mkdir('builddir')
+    # Dir.chdir('builddir') do
+    # system "#{@curldep_cmake_options} \
+    #-DWITH_EXAMPLES=OFF \
+    #-DBUILD_SHARED_LIBS=OFF \
+    #-DWITH_STATIC_LIB=ON \
+    #-DWITH_GSSAPI=OFF \
+    #-DHAVE_GLOB=0 \
+    # ../ -G Ninja"
+    # end
+    # system 'ninja -C builddir'
+    # system 'ninja -C builddir install'
     # end
     FileUtils.mkdir_p 'build/nghttp2'
     Dir.chdir 'build/nghttp2' do
@@ -199,9 +199,9 @@ class Curl < Package
       CPPFLAGS='-I#{@deppath}/include' \
       CFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
       CXXFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-      LDFLAGS='-L#{@deppath}/lib -flto -static -Wl,--no-as-needed -ldl' \
-      LIBS='#{@deppath}/lib/libssl.a #{@deppath}/lib/libcrypto.a #{@deppath}/lib/libbrotlicommon.a #{@deppath}/lib/libbrotlidec.a #{@deppath}/lib/libidn2.a #{@deppath}/lib/libnghttp2.a  #{@deppath}/lib/libz.a #{@deppath}/lib/libzstd.a -L#{@deppath}/lib' \
-      CURL_LIBRARY_PATH=#{@deppath}/lib \
+      LDFLAGS='-L#{@deppath}/#{ARCH_LIB} -flto -static -Wl,--no-as-needed -ldl' \
+      LIBS='#{@deppath}/#{ARCH_LIB}/libssl.a #{@deppath}/#{ARCH_LIB}/libcrypto.a #{@deppath}/#{ARCH_LIB}/libbrotlicommon.a #{@deppath}/#{ARCH_LIB}/libbrotlidec.a #{@deppath}/#{ARCH_LIB}/libidn2.a #{@deppath}/#{ARCH_LIB}/libnghttp2.a  #{@deppath}/#{ARCH_LIB}/libz.a #{@deppath}/#{ARCH_LIB}/libzstd.a -L#{@deppath}/#{ARCH_LIB}' \
+      CURL_LIBRARY_PATH=#{@deppath}/#{ARCH_LIB} \
       ./configure --prefix=#{@deppath} \
       --disable-imap \
       --disable-ldap \
@@ -210,7 +210,6 @@ class Curl < Package
       --disable-maintainer-mode \
       --disable-rtsp \
       --disable-shared \
-      --enable-debug \
       --enable-ipv6 \
       --enable-static \
       --enable-unix-sockets \
@@ -230,6 +229,7 @@ class Curl < Package
 
   def self.check
     system 'src/curl -Lf https://github.com/skycocker/chromebrew/raw/master/install.sh -o /tmp/install.sh'
+    FileUtil.rm '/tmp/install.sh'
   end
 
   def self.install

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -24,6 +24,7 @@ class Curl < Package
   })
 
   depends_on 'ca_certificates' => :build
+  depends_on 'hashpipe' => :build
   depends_on 'libcurl' # L (This is only here to make sure upgrades of curl pull in libcurl.)
   depends_on 'libunbound' => :build
   depends_on 'musl' => :build
@@ -33,8 +34,6 @@ class Curl < Package
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
-
-    @krb5_static_libs = '-l:libkrb5support.a -l:libgssapi_krb5.a -l:libkrb5.a -l:libk5crypto.a -l:libcom_err.a'
 
     FileUtils.mkdir_p 'build'
     FileUtils.mkdir_p 'deproot/include'
@@ -80,8 +79,10 @@ class Curl < Package
 
     FileUtils.mkdir_p 'build/zlib'
     Dir.chdir 'build/zlib' do
-      puts 'Building Zlib.'.lightgreen
-      system 'curl -Ls http://zlib.net/zlib-1.2.11.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building Zlib.'.yellow
+      system 'curl -Ls http://zlib.net/zlib-1.2.11.tar.gz | \
+        hashpipe sha256 c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1 | \
+        tar --strip-components=1 -zxf -'
       system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
         --static"
       system 'make'
@@ -89,8 +90,10 @@ class Curl < Package
     end
     FileUtils.mkdir_p 'build/zstd'
     Dir.chdir 'build/zstd' do
-      puts 'Building Zstd.'.lightgreen
-      system 'curl -Ls https://github.com/facebook/zstd/archive/v1.5.0.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building Zstd.'.yellow
+      system 'curl -Ls https://github.com/facebook/zstd/archive/v1.5.0.tar.gz | \
+        hashpipe sha256 0d9ade222c64e912d6957b11c923e214e2e010a18f39bec102f572e693ba2867 | \
+        tar --strip-components=1 -zxf -'
       FileUtils.mkdir('build/cmake/builddir')
       Dir.chdir('build/cmake/builddir') do
         system "#{@curldep_cmake_options} \
@@ -103,8 +106,10 @@ class Curl < Package
     end
     FileUtils.mkdir_p 'build/brotli'
     Dir.chdir 'build/brotli' do
-      puts 'Building Brotli.'.lightgreen
-      system 'curl -Ls https://github.com/google/brotli/archive/v1.0.9.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building Brotli.'.yellow
+      system 'curl -Ls https://github.com/google/brotli/archive/v1.0.9.tar.gz | \
+        hashpipe sha256 f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46 | \
+        tar --strip-components=1 -zxf -'
       FileUtils.mkdir('builddir')
       Dir.chdir('builddir') do
         system "#{@curldep_cmake_options} \
@@ -123,8 +128,10 @@ class Curl < Package
     end
     FileUtils.mkdir_p 'build/idn2'
     Dir.chdir 'build/idn2' do
-      puts 'Building IDN2.'.lightgreen
-      system 'curl -Ls http://ftp.gnu.org/gnu/libidn/libidn2-2.3.1.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building IDN2.'.yellow
+      system 'curl -Ls http://ftp.gnu.org/gnu/libidn/libidn2-2.3.1.tar.gz | \
+        hashipe sha256 8af684943836b8b53965d5f5b6714ef13c26c91eaa36ce7d242e3d21f5d40f2d | \
+        tar --strip-components=1 -zxf -'
       system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
         --disable-shared"
       system 'make'
@@ -146,8 +153,10 @@ class Curl < Package
       @openssl_configure_target = 'linux-x86_64'
     end
     Dir.chdir 'build/ssl' do
-      puts 'Building OpenSSL.'.lightgreen
-      system 'curl -Ls https://www.openssl.org/source/openssl-1.1.1k.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building OpenSSL.'.yellow
+      system 'curl -Ls https://www.openssl.org/source/openssl-1.1.1k.tar.gz | \
+        hashpipe sha256 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5 | \
+        tar --strip-components=1 -zxf -'
       system "CC=musl-gcc \
         CFLAGS='-flto -pipe -O3 -fPIC #{@arch_c_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
         CXXFLAGS='-flto -pipe -O3 -fPIC #{@arch_cxx_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
@@ -164,8 +173,10 @@ class Curl < Package
     # libssh has problems linking with musl statically
     # FileUtils.mkdir_p 'build/libssh'
     # Dir.chdir 'build/libssh' do
-    # puts 'Building Libssh.'.lightgreen
-    # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | tar --strip-components=1 -Jxf -'
+    # puts 'Building Libssh.'.yellow
+    # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | \
+    #   hashpipe sha256 acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718 | \
+    #   tar --strip-components=1 -Jxf -'
     # FileUtils.mkdir('builddir')
     # Dir.chdir('builddir') do
     # system "#{@curldep_cmake_options} \
@@ -181,8 +192,10 @@ class Curl < Package
     # end
     FileUtils.mkdir_p 'build/nghttp2'
     Dir.chdir 'build/nghttp2' do
-      puts 'Building Nghttp2.'.lightgreen
-      system 'curl -Ls https://github.com/nghttp2/nghttp2/releases/download/v1.43.0/nghttp2-1.43.0.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building Nghttp2.'.yellow
+      system 'curl -Ls https://github.com/nghttp2/nghttp2/releases/download/v1.43.0/nghttp2-1.43.0.tar.gz | \
+        hashpipe sha256 45cc3ed91966551f92b31958ceca9b3a9f23ce4faf5cbedb78aa3327cd4e5907 | \
+        tar --strip-components=1 -zxf -'
       system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
         --enable-lib-only \
         --disable-shared \

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,73 +3,94 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.76.1'
+  @_ver = '7.77.0'
   version @_ver
   license 'curl'
   compatibility 'all'
   source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
-  source_sha256 '64bb5288c39f0840c07d077e30d9052e1cbb9fa6c2dc52523824cc859e679145'
+  source_sha256 '0f64582c54282f31c0de9f0a1a596b182776bd4df9a4c4a2a41bbeb54f62594b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.76.1_armv7l/curl-7.76.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.76.1_armv7l/curl-7.76.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.76.1_i686/curl-7.76.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.76.1_x86_64/curl-7.76.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_armv7l/curl-7.77.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_armv7l/curl-7.77.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_i686/curl-7.77.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_x86_64/curl-7.77.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'ae48ef34d0a91114c532590f7f7c754bd3fa9bc7e6a96223b2864d167ba79c3a',
-     armv7l: 'ae48ef34d0a91114c532590f7f7c754bd3fa9bc7e6a96223b2864d167ba79c3a',
-       i686: '61f65c1c8d892c80d40908beadbd73de14a7c987593d93dad62c7c9555927bdf',
-     x86_64: 'fbe7e0e7192e75ff64b24e71a8861b773c4d47ef668206f85fff6e8840d59f54'
+    aarch64: '0273d3cf0ffb3d18777bb4d5da6a20c00970ad3787687e48c023f406aa42d4bc',
+     armv7l: '0273d3cf0ffb3d18777bb4d5da6a20c00970ad3787687e48c023f406aa42d4bc',
+       i686: 'ead35292354673e20806e70a9359306bd63758a04db3888eb5eca7c99cd1904a',
+     x86_64: '81b8641d60b222248a75f910e2bf82ce7b9d793a84558466e7670215bbd9b8d1'
   })
 
-  depends_on 'brotli' # R
-  depends_on 'ca_certificates' # L
-  depends_on 'c_ares' # R
-  depends_on 'groff' => :build
-  depends_on 'libidn2' # R
-  depends_on 'libmetalink' # R
-  depends_on 'libnghttp2' # R
-  depends_on 'libpsl' # R
-  depends_on 'libtirpc' # ?
   depends_on 'libunbound' # ?
-  depends_on 'openldap' # R
-  depends_on 'openssl' # R
-  depends_on 'rtmpdump' # R
   depends_on 'rust' => :build
   depends_on 'valgrind' => :build
-  depends_on 'zlibpkg' # R
-  depends_on 'zstd' # R
-
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 
+    @krb5_static_libs = "#{CREW_LIB_PREFIX}/libkrb5support.a " + "#{CREW_LIB_PREFIX}/libgssapi_krb5.a " + "#{CREW_LIB_PREFIX}/libkrb5.a " + "#{CREW_LIB_PREFIX}/libk5crypto.a " + "#{CREW_LIB_PREFIX}/libcom_err.a "
+
+    FileUtils.mkdir 'ssl'
+    FileUtils.ln_s "#{CREW_PREFIX}/include/openssl", 'ssl/include'
+    FileUtils.ln_s CREW_LIB_PREFIX, 'ssl/lib'
+    @sslpath = "#{`pwd`.chomp}/ssl"
     system 'filefix'
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-      LDFLAGS='-flto=auto'\
+    system "env CC=clang CXX=clang++ LD=ld.lld RANLIB=llvm-ranlib \
+      AR=llvm-ar \
+      CFLAGS='-flto -pipe -O3 -lz -fuse-ld=lld' \
+      CXXFLAGS='-flto -pipe -O3' \
+      LDFLAGS='-flto -static -Wl,--no-as-needed -ldl' LIBS='-l:libresolv.a #{@krb5_static_libs} -l:libzstd.a -l:libssh.a -lm -lbrotlicommon -lbrotlidec -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
       ./configure #{CREW_OPTIONS} \
+      --disable-ldap \
+      --disable-libcurl-option \
+      --disable-maintainer-mode \
+      --disable-shared \
+      --enable-ipv6 \
+      --enable-static \
+      --enable-unix-sockets \
+      --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
+      --with-ca-fallback \
+      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+      --with-libssh \
+      --with-openssl \
+      --without-librtmp"
+    system 'make curl_LDFLAGS=-all-static'
+    FileUtils.cp 'src/curl', 'curl.static'
+    system "env  CFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+       CXXFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+       LDFLAGS='-flto=auto' LIBS='#{@krb5_static_libs} -lm -lbrotlicommon -lbrotlidec -lzstd -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
+       ./configure #{CREW_OPTIONS} \
       --disable-maintainer-mode \
       --enable-ares \
-      --with-ldap-lib=ldap \
-      --with-lber-lib=lber \
-      --with-libmetalink \
-      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+      --enable-ipv6 \
+      --enable-ldap \
+      --enable-unix-sockets \
       --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
-      --with-ca-fallback"
+      --with-ca-fallback \
+      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+      --with-lber-lib=lber \
+      --with-ldap-lib=ldap \
+      --with-libmetalink \
+      --with-libssh \
+      --with-openssl=#{@sslpath} \
+      --without-gnutls \
+      --without-librtmp"
     system 'make'
   end
 
-  def self.check
-    # Python package impacket needed for testing.
-    # 1094 tests out of 1097 reported OK: 99% on 10/25/2020
-    # The 3 tests that failed were FTP, SMB and GOPHER.
-    system 'pip3 install impacket'
-    system 'make check || true'
-    system 'pip3 uninstall -y impacket'
-  end
+   def self.check
+     # Python package impacket needed for testing.
+     # 1094 tests out of 1097 reported OK: 99% on 10/25/2020
+     # The 3 tests that failed were FTP, SMB and GOPHER.
+     system 'pip3 install impacket'
+     system 'make check || true'
+     system 'pip3 uninstall -y impacket'
+   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.install 'curl.static', "#{CREW_DEST_PREFIX}/bin/curl", mode: 0o755
   end
 end

--- a/packages/darktable.rb
+++ b/packages/darktable.rb
@@ -18,7 +18,7 @@ class Darktable < Package
 
   depends_on 'cairo'
   depends_on 'colord'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'dbus_glib'
   depends_on 'fop'
   depends_on 'gexiv2'

--- a/packages/dropbox_uploader.rb
+++ b/packages/dropbox_uploader.rb
@@ -22,7 +22,7 @@ class Dropbox_uploader < Package
      x86_64: 'de141ac2bbc1a53d30776f5a280af3733222a92ca09465f13ea5b9d6000b2731',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
 
   def self.install
     system "sed -i 's,dropbox_uploader.sh,dropbox_uploader,g' dropShell.sh"

--- a/packages/e2fsprogs.rb
+++ b/packages/e2fsprogs.rb
@@ -3,38 +3,44 @@ require 'package'
 class E2fsprogs < Package
   description 'e2fsprogs are ext2/3/4 file system utilities.'
   homepage 'http://e2fsprogs.sourceforge.net/'
-  @_ver = '1.45.7'
+  @_ver = '1.46.2'
   version @_ver
   license 'GPL-2 and BSD'
   compatibility 'all'
   source_url "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v#{@_ver}/e2fsprogs-#{@_ver}.tar.xz"
-  source_sha256 '62d49c86d9d4becf305093edd65464484dc9ea41c6ff9ae4f536e4a341b171a2'
+  source_sha256 '23aa093295c94e71ef1be490c4004871c5b01d216a8cb4d111fa6c0aac354168'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/e2fsprogs/1.45.7_armv7l/e2fsprogs-1.45.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/e2fsprogs/1.45.7_armv7l/e2fsprogs-1.45.7-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/e2fsprogs/1.45.7_i686/e2fsprogs-1.45.7-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/e2fsprogs/1.45.7_x86_64/e2fsprogs-1.45.7-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/e2fsprogs/1.46.2_armv7l/e2fsprogs-1.46.2-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/e2fsprogs/1.46.2_armv7l/e2fsprogs-1.46.2-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/e2fsprogs/1.46.2_i686/e2fsprogs-1.46.2-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/e2fsprogs/1.46.2_x86_64/e2fsprogs-1.46.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '4deb49e04d94878c4a9e4977a5aa01937c379cf332b56b4e93524f6a891bdbc1',
-     armv7l: '4deb49e04d94878c4a9e4977a5aa01937c379cf332b56b4e93524f6a891bdbc1',
-       i686: 'a950f3395704adfc93ec3207cfd5d62ae1c1def8c6e70cfb83e0a113092034c8',
-     x86_64: '37e6c64a587dd9d984194a0d22829a36c93d4fac413675b00bd0d77091e210c6'
+    aarch64: '63e83f7a4d01967863b2c92c09c72d2f0897ec247a82c72daa7d9b54a3740a64',
+    armv7l: '63e83f7a4d01967863b2c92c09c72d2f0897ec247a82c72daa7d9b54a3740a64',
+    i686: '1665ca1ac6d19c2505e5ea1730cc5b0d60d5eaf336b4fa4e3dc7986dfb188b53',
+    x86_64: '28da7a270ca155feaa91b2cba1c15050cb5e91d1b90283f7f973ad083dc86ff2'
   })
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+    system "env #{CREW_ENV_OPTIONS} \
+      ./configure #{CREW_OPTIONS}\
+      --enable-elf-shlibs \
+      --enable-lto \
+      --disable-libblkid \
+      --disable-libuuid \
+      --disable-uuidd \
+      --disable-fsck"
     system 'make'
   end
 
-  def self.check
-    system 'make', 'check'
-  end
+   def self.check
+     system 'make', 'check'
+   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-libs'
   end
 end

--- a/packages/expat.rb
+++ b/packages/expat.rb
@@ -3,40 +3,44 @@ require 'package'
 class Expat < Package
   description 'James Clark\'s Expat XML parser library in C.'
   homepage 'https://sourceforge.net/projects/expat/'
-  version '2.2.9'
+  version '2.4.1'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://prdownloads.sourceforge.net/project/expat/expat/2.2.9/expat-2.2.9.tar.bz2'
-  source_sha256 'f1063084dc4302a427dabcca499c8312b3a32a29b7d2506653ecc8f950a9a237'
+  source_url 'https://prdownloads.sourceforge.net/project/expat/expat/2.4.1/expat-2.4.1.tar.xz'
+  source_sha256 'cf032d0dba9b928636548e32b327a2d66b1aab63c4f4a13dd132c2d1d2f2fb6a'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/expat/2.2.9_armv7l/expat-2.2.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/expat/2.2.9_armv7l/expat-2.2.9-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/expat/2.2.9_i686/expat-2.2.9-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/expat/2.2.9_x86_64/expat-2.2.9-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/expat/2.4.1_armv7l/expat-2.4.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/expat/2.4.1_armv7l/expat-2.4.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/expat/2.4.1_i686/expat-2.4.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/expat/2.4.1_x86_64/expat-2.4.1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '2bac1ab7a27c48690d47e28b5826818095932bb9210ec46b69e173a088ead177',
-     armv7l: '2bac1ab7a27c48690d47e28b5826818095932bb9210ec46b69e173a088ead177',
-       i686: '331b397c748e8bfeef19ac927236b19ea03d841e7e15788850f8a207c3ab473b',
-     x86_64: '1f339732173e08417ae6c9f12ff898020a517c345afd34682971ffa7d982a306',
+  binary_sha256({
+    aarch64: '1f044a7aecace21975cb528e625a1364d485f976eb3c12e53edf85006efe2980',
+     armv7l: '1f044a7aecace21975cb528e625a1364d485f976eb3c12e53edf85006efe2980',
+       i686: '5731a665443b8e029da85c5207352e380d476c6a9bbc4810fff23fa5bb0451e4',
+     x86_64: 'e5f8529e86f68486309d884676fdd72186a6ece1864d72ac97151a2d907690d4'
   })
+
+  def self.patch
+    system 'filefix'
+  end
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--enable-shared',
-           '--disable-static',
-           '--with-pic'
+    system "./configure \
+       #{CREW_OPTIONS} \
+       #{CREW_ENV_OPTIONS} \
+       --enable-shared \
+       --enable-static \
+       --with-pic"
     system 'make'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/gdal.rb
+++ b/packages/gdal.rb
@@ -23,7 +23,7 @@ class Gdal < Package
   })
 
   depends_on 'openjpeg'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'geos'
   depends_on 'hdf5'
   depends_on 'proj4'

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -4,24 +4,26 @@ class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
   @_ver = '2.31.1'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'GPL-2'
   compatibility 'all'
   source_url "https://github.com/git/git/archive/v#{@_ver}.tar.gz"
   source_sha256 'b1c0e95e9861b5d1b9ad3d8deaa2d8c7f02304ffc1b5e8869dd9fb98f9a0d436'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_armv7l/git-2.31.1-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_armv7l/git-2.31.1-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_i686/git-2.31.1-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_x86_64/git-2.31.1-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-2_armv7l/git-2.31.1-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-2_armv7l/git-2.31.1-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-2_i686/git-2.31.1-2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-2_x86_64/git-2.31.1-2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '364b30aafa845d7950b93fd67e72fcc752008dee08ff571155ffb4239eaba2ac',
-     armv7l: '364b30aafa845d7950b93fd67e72fcc752008dee08ff571155ffb4239eaba2ac',
-       i686: 'b80054bb43df65051d37c0c8e7f83c46f97d084027d7997871be91a7731a642c',
-     x86_64: 'c0bf7de6181f29f73abc75793410441aabcf2b71c3bd7a4321179a59859a47e6'
+    aarch64: '497a3e7cc45f4a373a65b7d666484949d99ff4ec489cbfd67560abc8dd2f4560',
+     armv7l: '497a3e7cc45f4a373a65b7d666484949d99ff4ec489cbfd67560abc8dd2f4560',
+       i686: '502549508cbd7372d60a642021b50c73fd79a85b87cad9b332875d00f4c9db5e',
+     x86_64: '8b081c8000ec4fb6f8856c48c1f5eb97cece1d857f4afb7e5051283cddf28c53'
   })
+
+  depends_on 'libcurl' => :build
 
   def self.build
     abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
@@ -29,7 +31,7 @@ class Git < Package
     @curl_static_libs = `curl-config --static-libs`.chomp.gsub('=auto', '')
     @sasl2_static_libs = "#{CREW_LIB_PREFIX}/libdb.a #{CREW_LIB_PREFIX}/libsasl2.a " + `pkg-config --libs --static libsasl2`.chomp
     @krb5_static_libs = "#{CREW_LIB_PREFIX}/libkrb5support.a #{CREW_LIB_PREFIX}/libgssapi_krb5.a #{CREW_LIB_PREFIX}/libkrb5.a #{CREW_LIB_PREFIX}/libk5crypto.a #{CREW_LIB_PREFIX}/libcom_err.a"
-    @ldflags = "-flto -static -L#{CREW_LIB_PREFIX} #{@krb5_static_libs} #{@sasl2_static_libs} -lgmp #{@curl_static_libs} -lunistring -Wl,--no-as-needed -ldl"
+    @ldflags = "-flto -static -L#{CREW_LIB_PREFIX} #{CREW_LIB_PREFIX}/libssl.a #{CREW_LIB_PREFIX}/libcrypto.a #{@krb5_static_libs} #{CREW_LIB_PREFIX}/libcurl.a #{@sasl2_static_libs} -lgmp #{@curl_static_libs} -lunistring -Wl,--no-as-needed -ldl"
 
     FileUtils.mkdir 'curl'
     FileUtils.ln_s "#{CREW_PREFIX}/include/curl", 'curl/include'

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,24 +3,24 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  @_ver = '2.31.1'
-  version "#{@_ver}-2"
+  @_ver = '2.32.0'
+  version @_ver
   license 'GPL-2'
   compatibility 'all'
   source_url "https://github.com/git/git/archive/v#{@_ver}.tar.gz"
-  source_sha256 'b1c0e95e9861b5d1b9ad3d8deaa2d8c7f02304ffc1b5e8869dd9fb98f9a0d436'
+  source_sha256 '004697482b6e3b0ae9147580c32efd35869426227f1526f8eafa7950c31def94'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-2_armv7l/git-2.31.1-2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-2_armv7l/git-2.31.1-2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-2_i686/git-2.31.1-2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-2_x86_64/git-2.31.1-2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.32.0_armv7l/git-2.32.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.32.0_armv7l/git-2.32.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.32.0_i686/git-2.32.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.32.0_x86_64/git-2.32.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '497a3e7cc45f4a373a65b7d666484949d99ff4ec489cbfd67560abc8dd2f4560',
-     armv7l: '497a3e7cc45f4a373a65b7d666484949d99ff4ec489cbfd67560abc8dd2f4560',
-       i686: '502549508cbd7372d60a642021b50c73fd79a85b87cad9b332875d00f4c9db5e',
-     x86_64: '8b081c8000ec4fb6f8856c48c1f5eb97cece1d857f4afb7e5051283cddf28c53'
+    aarch64: 'd72074c725dd003aec3eaacc0523c069f6f1c8462291eba04ad625d1d0b37092',
+     armv7l: 'd72074c725dd003aec3eaacc0523c069f6f1c8462291eba04ad625d1d0b37092',
+       i686: '63a71a159ba30241c984b8bbc918c0e73f10b6a890ecd6e266b67b3e14b4aed5',
+     x86_64: '8d08dd84e5f16a11671bd387d2b5ec33ec2474dcf1d948c5d15474fe6afc7c2c'
   })
 
   depends_on 'libcurl' => :build

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -4,40 +4,61 @@ class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
   @_ver = '2.31.1'
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPL-2'
   compatibility 'all'
   source_url "https://github.com/git/git/archive/v#{@_ver}.tar.gz"
   source_sha256 'b1c0e95e9861b5d1b9ad3d8deaa2d8c7f02304ffc1b5e8869dd9fb98f9a0d436'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1_armv7l/git-2.31.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1_armv7l/git-2.31.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1_i686/git-2.31.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1_x86_64/git-2.31.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_armv7l/git-2.31.1-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_armv7l/git-2.31.1-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_i686/git-2.31.1-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_x86_64/git-2.31.1-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '86c740f001fde7008c59a3f85816d25f59190eb9a7ebd4b1f10ecc74606e4739',
-     armv7l: '86c740f001fde7008c59a3f85816d25f59190eb9a7ebd4b1f10ecc74606e4739',
-       i686: '4c14a8d247b71ab55436d688879e3ff8fa20335a1fe1160351ce51b1c9bb4568',
-     x86_64: '43e134e2978f2fab77d9a46191a7d8efff26306eab2c45509fc3d9bb2274f4b5'
+    aarch64: '364b30aafa845d7950b93fd67e72fcc752008dee08ff571155ffb4239eaba2ac',
+     armv7l: '364b30aafa845d7950b93fd67e72fcc752008dee08ff571155ffb4239eaba2ac',
+       i686: 'b80054bb43df65051d37c0c8e7f83c46f97d084027d7997871be91a7731a642c',
+     x86_64: 'c0bf7de6181f29f73abc75793410441aabcf2b71c3bd7a4321179a59859a47e6'
   })
 
   def self.build
     abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 
+    @curl_static_libs = `curl-config --static-libs`.chomp.gsub('=auto', '')
+    @sasl2_static_libs = "#{CREW_LIB_PREFIX}/libdb.a #{CREW_LIB_PREFIX}/libsasl2.a " + `pkg-config --libs --static libsasl2`.chomp
+    @krb5_static_libs = "#{CREW_LIB_PREFIX}/libkrb5support.a #{CREW_LIB_PREFIX}/libgssapi_krb5.a #{CREW_LIB_PREFIX}/libkrb5.a #{CREW_LIB_PREFIX}/libk5crypto.a #{CREW_LIB_PREFIX}/libcom_err.a"
+    @ldflags = "-flto -static -L#{CREW_LIB_PREFIX} #{@krb5_static_libs} #{@sasl2_static_libs} -lgmp #{@curl_static_libs} -lunistring -Wl,--no-as-needed -ldl"
+
+    FileUtils.mkdir 'curl'
+    FileUtils.ln_s "#{CREW_PREFIX}/include/curl", 'curl/include'
+    FileUtils.ln_s CREW_LIB_PREFIX, "curl/lib#{CREW_LIB_SUFFIX}"
     system 'autoreconf -fiv'
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
-      #{CREW_OPTIONS} \
-      --with-openssl=#{CREW_PREFIX}/etc/ssl \
+    # Build with clang to get truly static binaries.
+    system "./configure \
+      --prefix=#{CREW_PREFIX} \
+      --libdir=#{CREW_LIB_PREFIX} \
+      --mandir=#{CREW_MAN_PREFIX} \
+      CC=clang CXX=clang++ LD='ld.lld -L#{CREW_LIB_PREFIX} -lcurl'  CFLAGS='-flto -pipe -O3 -static -fuse-ld=lld' \
+      CXXFLAGS='-flto -pipe -O3 -static -fuse-ld=lld' \
+      LDFLAGS='#{@ldflags}' \
+      CURL_CONFIG=#{CREW_PREFIX}/bin/curl-config \
+      CURLDIR=`pwd`/curl \
+      CURL_LDFLAGS='-L#{CREW_LIB_PREFIX} #{@curl_static_libs}' \
+      AR=llvm-ar \
+      --with-lib='lib#{CREW_LIB_SUFFIX}' \
+      --with-openssl \
       --without-tcltk \
+      --with-curl \
       --with-perl=#{CREW_PREFIX}/bin/perl \
       --with-python=#{CREW_PREFIX}/bin/python3 \
       --with-gitconfig=#{CREW_PREFIX}/etc/gitconfig \
       --with-gitattributes=#{CREW_PREFIX}/etc/gitattributes"
-    system 'make'
+    # Make seems to need environment variables passed again here.
+    system "make CC='clang -L#{CREW_LIB_PREFIX} -lcurl' CXX=clang++ LD=ld.lld  CFLAGS='-flto -pipe -O3 -static -fuse-ld=lld' \
+      CXXFLAGS='-flto -pipe -O3 -static -fuse-ld=lld' \
+      LDFLAGS='#{@ldflags}'"
   end
 
   def self.install

--- a/packages/glyr.rb
+++ b/packages/glyr.rb
@@ -22,7 +22,7 @@ class Glyr < Package
      x86_64: 'c9ade91fe3da5da7cd53d53ff9e17a072fc60dd540f2e812ebfccdfe041aed50',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'glib'
   depends_on 'sqlite'
 

--- a/packages/grive.rb
+++ b/packages/grive.rb
@@ -23,7 +23,7 @@ class Grive < Package
   })
 
   depends_on 'yajl'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'libgcrypt'
   depends_on 'boost'
   depends_on 'expat'

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -3,24 +3,24 @@ require 'package'
 class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
-  @_ver = '2.7.4'
+  @_ver = '2.8.1'
   version @_ver
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
   source_url "https://github.com/harfbuzz/harfbuzz/archive/#{@_ver}.tar.gz"
-  source_sha256 'daff8a4003ac420a8550760ed303ce33b310c8ea17b7f15b307d1969cabcebcb'
+  source_sha256 'b3f17394c5bccee456172b2b30ddec0bb87e9c5df38b4559a973d14ccd04509d'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.7.4_armv7l/harfbuzz-2.7.4-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.7.4_armv7l/harfbuzz-2.7.4-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.7.4_i686/harfbuzz-2.7.4-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.7.4_x86_64/harfbuzz-2.7.4-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.1_armv7l/harfbuzz-2.8.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.1_armv7l/harfbuzz-2.8.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.1_i686/harfbuzz-2.8.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.1_x86_64/harfbuzz-2.8.1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: 'a2cc6f26453bc9077dde0d549ea92e30a8847d9c9d49ceebc681b090056d69fc',
-      armv7l: 'a2cc6f26453bc9077dde0d549ea92e30a8847d9c9d49ceebc681b090056d69fc',
-        i686: 'a98df51edf04334872597256379d041389fce9bf3b020c5700ee4d0b8771967d',
-      x86_64: 'bdcb5b9ab85752b8f8ce46b919e6739754e369fd807a5f52d85afb43ca815153',
+  binary_sha256({
+    aarch64: 'f39e2aba4445d71c63a6602650590d8c5463a5c093b3ec26933e2963dc354dcc',
+     armv7l: 'f39e2aba4445d71c63a6602650590d8c5463a5c093b3ec26933e2963dc354dcc',
+       i686: '25e7c49b04e81fa61db4385d4033b6b2c633bdfe5ef2a5ab3606c970ad4b307d',
+     x86_64: '801f46cbab0369087004aa3ce7952fc4d7754a85a0cb3c4b0648ce647fc87604'
   })
 
   depends_on 'cairo' => :build
@@ -40,8 +40,8 @@ class Harfbuzz < Package
     -Dgraphite=enabled \
     -Ddocs=disabled \
     builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install

--- a/packages/icu4c.rb
+++ b/packages/icu4c.rb
@@ -41,15 +41,16 @@ class Icu4c < Package
     end
   end
 
+  @icuver = '69'
+  @oldicuver = %w[67 68]
+
   def self.install
     FileUtils.cd('source') do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
-    @icuver = '69'
-    @oldicuver = %w[68 67]
     Dir.chdir CREW_DEST_LIB_PREFIX do
       @oldicuver.each do |oldver|
-        # Backwards compatibility symlinks
+        # Backwards compatibility symlinks (which may not work - see postinstall.)
         FileUtils.ln_sf "libicudata.so.#{@icuver}", "libicudata.so.#{oldver}"
         FileUtils.ln_sf "libicui18n.so.#{@icuver}", "libicui18n.so.#{oldver}"
         FileUtils.ln_sf "libicuio.so.#{@icuver}", "libicuio.so.#{oldver}"
@@ -58,5 +59,27 @@ class Icu4c < Package
         FileUtils.ln_sf "libicuuc.so.#{@icuver}", "libicuuc.so.#{oldver}"
       end
     end
+  end
+
+  def self.postinstall
+    # Check for packages that expect an older icu library.
+    #Dir.chdir CREW_LIB_PREFIX do
+      #@oldicuver.each do |oldver|
+        #puts "Finding Packages expecting icu4c version #{oldver} that may need updating:".lightgreen
+        #@fileArray = []
+        #@libArray = []
+        #@nmresults = %x[nm  -A *.so* 2>/dev/null | grep ucol_open_#{oldver}].chop.split(/$/).map(&:strip)
+        #@nmresults.each { |fileLine| @libArray.push(fileLine.partition(":").first) }
+        #@libArray.each do |f|
+          #@grepresults =  %x[grep "#{f}" #{CREW_META_PATH}*.filelist].chomp.gsub('.filelist','').partition(":").first.gsub(CREW_META_PATH,'').split(/$/).map(&:strip)
+          #@grepresults.each { |fileLine| @fileArray.push(fileLine) }
+        #end
+        #unless @fileArray.empty?
+          #@fileArray.uniq.sort.each do |item|
+            #puts item.lightred
+          #end
+        #end
+      #end
+    #end
   end
 end

--- a/packages/icu4c.rb
+++ b/packages/icu4c.rb
@@ -3,35 +3,40 @@ require 'package'
 class Icu4c < Package
   description 'ICU is a mature, widely used set of C/C++ and Java libraries providing Unicode and Globalization support for software applications.'
   homepage 'http://site.icu-project.org/'
-  version '68.2'
+  version '69.1'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://github.com/unicode-org/icu/releases/download/release-68-2/icu4c-68_2-src.tgz'
-  source_sha256 'c79193dee3907a2199b8296a93b52c5cb74332c26f3d167269487680d479d625'
+  source_url 'https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.tgz'
+  source_sha256 '4cba7b7acd1d3c42c44bb0c14be6637098c7faf2b330ce876bc5f3b915d09745'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/68.2_armv7l/icu4c-68.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/68.2_armv7l/icu4c-68.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/68.2_i686/icu4c-68.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/68.2_x86_64/icu4c-68.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/69.1_armv7l/icu4c-69.1-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/69.1_armv7l/icu4c-69.1-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/69.1_i686/icu4c-69.1-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/69.1_x86_64/icu4c-69.1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '35dfc0e95c0d6c09a323fd6ec393dc48e33940fc7815a4f51adff5a63f99416a',
-     armv7l: '35dfc0e95c0d6c09a323fd6ec393dc48e33940fc7815a4f51adff5a63f99416a',
-       i686: '1c45fb6c19db175fba61dd9925b648955c5081ad7dea31feb7b613b5ca0a97c9',
-     x86_64: '290087e9c03a94eaf5d33a82b76dc3b5bb11be1dff5a6e57aa190ec5439bcfb2',
+  binary_sha256({
+    aarch64: '31aaafa8b65f82f0bd77e403c4cf3819b20ddfd8abd775996bbf740251244aeb',
+    armv7l: '31aaafa8b65f82f0bd77e403c4cf3819b20ddfd8abd775996bbf740251244aeb',
+    i686: 'bbb7320a1aac37f09c7f8eb96ed1fefc5f01bc7a85ed0ad1cc9dac2a781472ea',
+    x86_64: '868a783d335eb13ff06d29b5221448a50e68a728ee1c35f3dc4c16c816716d68'
   })
 
   def self.build
     FileUtils.cd('source') do
-
       case ARCH
       when 'aarch64', 'armv7l'
         # Armhf requires sane ELF headers rather than other architectures as
         # discussed in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=653457
         system "sed -e '/LDFLAGSICUDT=/cLDFLAGSICUDT=' -i config/mh-linux"
       end
-      system "env CFLAGS='-pipe -flto' CXXFLAGS='-pipe -flto' ./configure #{CREW_OPTIONS} --without-samples --without-tests"
+      system "./configure \
+        #{CREW_OPTIONS} \
+        #{CREW_ENV_OPTIONS} \
+        --enable-static \
+        --enable-shared \
+        --without-samples \
+        --without-tests"
       system 'make'
     end
   end
@@ -39,13 +44,19 @@ class Icu4c < Package
   def self.install
     FileUtils.cd('source') do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-      # Backwards compatibility symlinks
-      FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libicudata.so.68", "#{CREW_DEST_LIB_PREFIX}/libicudata.so.67"
-      FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libicui18n.so.68", "#{CREW_DEST_LIB_PREFIX}/libicui18n.so.67"
-      FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libicuio.so.68", "#{CREW_DEST_LIB_PREFIX}/libicuio.so.67"
-      FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libicutest.so.68", "#{CREW_DEST_LIB_PREFIX}/libicutest.so.67"
-      FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libicutu.so.68", "#{CREW_DEST_LIB_PREFIX}/libicutu.so.67"
-      FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libicuuc.so.68", "#{CREW_DEST_LIB_PREFIX}/libicuuc.so.67"
+    end
+    @icuver = '69'
+    @oldicuver = %w[68 67]
+    Dir.chdir CREW_DEST_LIB_PREFIX do
+      @oldicuver.each do |oldver|
+        # Backwards compatibility symlinks
+        FileUtils.ln_sf "libicudata.so.#{@icuver}", "libicudata.so.#{oldver}"
+        FileUtils.ln_sf "libicui18n.so.#{@icuver}", "libicui18n.so.#{oldver}"
+        FileUtils.ln_sf "libicuio.so.#{@icuver}", "libicuio.so.#{oldver}"
+        FileUtils.ln_sf "libicutest.so.#{@icuver}", "libicutest.so.#{oldver}"
+        FileUtils.ln_sf "libicutu.so.#{@icuver}", "libicutu.so.#{oldver}"
+        FileUtils.ln_sf "libicuuc.so.#{@icuver}", "libicuuc.so.#{oldver}"
+      end
     end
   end
 end

--- a/packages/kcov.rb
+++ b/packages/kcov.rb
@@ -22,7 +22,7 @@ class Kcov < Package
      x86_64: '35ccebb9cda52beb4cf13977483fcb4ebc6011fe0c1e52ce9be2cefb5fbd300a',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'elfutils'
   depends_on 'six'
 

--- a/packages/krb5.rb
+++ b/packages/krb5.rb
@@ -3,39 +3,79 @@ require 'package'
 class Krb5 < Package
   description 'Kerberos is a network authentication protocol.'
   homepage 'https://web.mit.edu/kerberos'
-  version '1.19'
+  version '1.19.1'
   license 'openafs-krb5-a, BSD, MIT, OPENLDAP, BSD-2, HPND, BSD-4, ISC, RSA, CC-BY-SA-3.0 and BSD-2 or GPL-2+ )'
   compatibility 'all'
-  source_url 'https://web.mit.edu/kerberos/dist/krb5/1.19/krb5-1.19.tar.gz'
-  source_sha256 'bc7862dd1342c04e1c17c984a268d50f29c0a658a59a22bd308ffa007d532a2e'
+  source_url 'https://web.mit.edu/kerberos/dist/krb5/1.19/krb5-1.19.1.tar.gz'
+  source_sha256 'fa16f87eb7e3ec3586143c800d7eaff98b5e0dcdf0772af7d98612e49dbeb20b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.19_armv7l/krb5-1.19-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.19_armv7l/krb5-1.19-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.19_i686/krb5-1.19-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.19_x86_64/krb5-1.19-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.19.1_armv7l/krb5-1.19.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.19.1_armv7l/krb5-1.19.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.19.1_i686/krb5-1.19.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.19.1_x86_64/krb5-1.19.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '69f5fdec7c6c2c409b2d328c325954fdc8f8cf21024f84059968f052437c160a',
-     armv7l: '69f5fdec7c6c2c409b2d328c325954fdc8f8cf21024f84059968f052437c160a',
-       i686: '09f43b2cb5ba53b6699f9db04b7886c4d1a1ffbb6d4510aa3f79b67f77187434',
-     x86_64: '1a3963a507e42b7b2d9faa21724c2945d028b6a1f717a4ba0d48dee206698f33'
+    aarch64: 'ed77e5d8274ca8cd6acf53edca8d86479aaa67be18d69927424fa3b0572e970e',
+     armv7l: 'ed77e5d8274ca8cd6acf53edca8d86479aaa67be18d69927424fa3b0572e970e',
+       i686: 'ab646a5876870bbd762229dbad705f6826eaf34bd2f3838172916ffcc5067a3a',
+     x86_64: 'dde095df31c2a2b8925d0d9323a9e447b07238cec09ae0e5a43191d0a7b2c94d'
   })
 
+  depends_on 'ccache' => :build
+  depends_on 'e2fsprogs'
+
+  @k5libs = %w[libgssapi_krb5.a libgssrpc.a libk5crypto.a
+               libkadm5clnt_mit.a libkadm5clnt.a libkadm5srv_mit.a libkadm5srv.a
+               libkdb5.a libkrad.a libkrb5.a libkrb5support.a libverto.a]
+
   def self.build
+    # First we build static libraries, then rebuild for shared libaries.
     Dir.chdir 'src' do
-      system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
+      # krb5 built with gcc10 or newer needs -fcommon
+      # See https://github.com/ripple/rippled/pull/3813
+      @cppflags = "#{CREW_COMMON_FLAGS} -I#{CREW_PREFIX}/include/et -fcommon"
+      @path = "#{CREW_PREFIX}/bin:" + ENV['PATH']
+      system "env CC='ccache gcc' #{CREW_ENV_OPTIONS} \
+      CPPFLAGS='#{@cppflags}' \
+      PATH=#{@path} \
       ./configure #{CREW_OPTIONS} \
       --localstatedir=#{CREW_PREFIX}/var/krb5kdc \
+      --disable-shared \
+      --enable-static \
+      --with-system-et \
+      --with-system-ss \
       --without-system-verto"
-      system 'make'
+      system "env PATH=#{@path} \
+      make -j#{CREW_NPROC}"
+      # Set aside the static libraries.
+      Dir.chdir 'lib' do
+        @k5libs.each do |lib|
+          FileUtils.cp lib, '../../' if File.exist?(lib)
+        end
+      end
+      system 'make clean'
+      system "env CC='ccache gcc' #{CREW_ENV_OPTIONS} \
+      CPPFLAGS='#{@cppflags}' \
+      PATH=#{@path} \
+      ./configure #{CREW_OPTIONS} \
+      --localstatedir=#{CREW_PREFIX}/var/krb5kdc \
+      --enable-shared \
+      --with-system-et \
+      --with-system-ss \
+      --without-system-verto"
+      system "env PATH=#{@path} \
+      make -j#{CREW_NPROC}"
     end
   end
 
   def self.install
     Dir.chdir 'src' do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
+    # Now install the static libraries.
+    @k5libs.each do |lib|
+      FileUtils.cp lib, CREW_DEST_LIB_PREFIX if File.exist?(lib)
     end
   end
 end

--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -23,7 +23,7 @@ class Ldc < Package                 # The first character of the class name must
   })
 
   depends_on 'llvm'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'ncurses'
   depends_on 'zlibpkg'
   depends_on 'libconfig' => :build

--- a/packages/libarchive.rb
+++ b/packages/libarchive.rb
@@ -4,23 +4,23 @@ class Libarchive < Package
   description 'Multi-format archive and compression library.'
   homepage 'https://www.libarchive.org/'
   @_ver = '3.5.1'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'BSD, BSD-2, BSD-4 and public-domain'
   compatibility 'all'
   source_url "https://www.libarchive.org/downloads/libarchive-#{@_ver}.tar.xz"
   source_sha256 '0e17d3a8d0b206018693b27f08029b598f6ef03600c2b5d10c94ce58692e299b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.5.1-1_armv7l/libarchive-3.5.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.5.1-1_armv7l/libarchive-3.5.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.5.1-1_i686/libarchive-3.5.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.5.1-1_x86_64/libarchive-3.5.1-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.5.1-2_armv7l/libarchive-3.5.1-2-chromeos-armv7l.tar.xz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.5.1-2_armv7l/libarchive-3.5.1-2-chromeos-armv7l.tar.xz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.5.1-2_i686/libarchive-3.5.1-2-chromeos-i686.tar.xz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.5.1-2_x86_64/libarchive-3.5.1-2-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'd58404d09d291373169e80b4012ffb5c51f30760503769808b7a9e98111cfb68',
-     armv7l: 'd58404d09d291373169e80b4012ffb5c51f30760503769808b7a9e98111cfb68',
-       i686: 'b7634129d40fe7beed9185ce73ed78730c8255485d59d4316d67267a0b56c206',
-     x86_64: '53a2d351d07063157a3ed33a8cf711af401b7adee4c72f4fa5772637e4823fa3'
+    aarch64: '9c1ee0cdca17abfba167d39f82fb339ca5a51fd3c10cacd55f538ae99d972655',
+    armv7l: '9c1ee0cdca17abfba167d39f82fb339ca5a51fd3c10cacd55f538ae99d972655',
+    i686: '71c9ae6c9722b152a3798eb15d09cc667e9207518a3ce5c75b823fa5610c64b3',
+    x86_64: 'd21778e1bca3015e53dfe253eedae0b0f497c21554563d41eed6233b37a15762'
   })
 
   depends_on 'lz4'
@@ -29,9 +29,7 @@ class Libarchive < Package
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -1,0 +1,79 @@
+require 'package'
+
+class Libcurl < Package
+  description 'Command line tool and library for transferring data with URLs.'
+  homepage 'https://curl.se/'
+  @_ver = '7.77.0'
+  version @_ver
+  license 'curl'
+  compatibility 'all'
+  source_url 'https://github.com/curl/curl.git'
+  git_hashtag 'curl-7_77_0'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.77.0_armv7l/libcurl-7.77.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.77.0_armv7l/libcurl-7.77.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.77.0_i686/libcurl-7.77.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.77.0_x86_64/libcurl-7.77.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '0acfb983b58fbffc1c94480b5b21b22013f8d853a649f3acadb1d6c41e34616c',
+     armv7l: '0acfb983b58fbffc1c94480b5b21b22013f8d853a649f3acadb1d6c41e34616c',
+       i686: '6aa358d2b91b50f758bd9908492d8b200cd3579da37056169f8edb4254d3cdf4',
+     x86_64: '6f94ed40fb2853d5459e6b9513483f3794630ec6e61f64951311c57a4664b85a'
+  })
+
+  depends_on 'brotli' => :build
+  depends_on 'ca_certificates' => :build
+  depends_on 'c_ares' # R
+  depends_on 'libcyrussasl' # R
+  depends_on 'libidn2' # R
+  depends_on 'libnghttp2' # R
+  depends_on 'libpsl' # R
+  depends_on 'libssh' # R
+  depends_on 'libunbound' # ?
+  depends_on 'openldap' # R
+  depends_on 'openssl' # R
+  depends_on 'py3_pip' => :build
+  depends_on 'rust' => :build
+  depends_on 'valgrind' => :build
+  depends_on 'zlibpkg' # R
+  depends_on 'zstd' # R
+
+  def self.build
+    # Without these downstream programs which want to statically link
+    # libcurl have issues.
+    @krb5_static_libs = '-l:libkrb5support.a -l:libgssapi_krb5.a -l:libkrb5.a -l:libk5crypto.a -l:libcom_err.a'
+
+    @libssh = '--with-libssh'
+    case ARCH
+    when 'i686'
+      @libssh = '--without-libssh'
+    end
+
+    system '[ -x configure ] || autoreconf -fvi'
+    system "env  CFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+       CXXFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+       LDFLAGS='-flto=auto' LIBS='#{@krb5_static_libs} -lm -lbrotlicommon -lbrotlidec -lzstd -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
+       ./configure #{CREW_OPTIONS} \
+      --disable-maintainer-mode \
+      --enable-ares \
+      --enable-ipv6 \
+      --enable-ldap \
+      --enable-unix-sockets \
+      --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
+      --with-ca-fallback \
+      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+      --with-libmetalink \
+      #{@libssh} \
+      --with-openssl \
+      --without-gnutls \
+      --without-librtmp"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.rm "#{CREW_DEST_PREFIX}/bin/curl"
+  end
+end

--- a/packages/libcyrussasl.rb
+++ b/packages/libcyrussasl.rb
@@ -3,37 +3,42 @@ require 'package'
 class Libcyrussasl < Package
   description 'Simple Authentication and Security Layer (SASL) is a specification that describes how authentication mechanisms can be plugged into an application protocol on the wire. Cyrus SASL is an implementation of SASL that makes it easy for application developers to integrate authentication mechanisms into their application in a generic way.'
   homepage 'https://www.cyrusimap.org/sasl'
-  version '2.1.27-1'
+  version '2.1.27-2'
   license 'custom'
   compatibility 'all'
   source_url 'https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz'
   source_sha256 '26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.27-1_armv7l/libcyrussasl-2.1.27-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.27-1_armv7l/libcyrussasl-2.1.27-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.27-1_i686/libcyrussasl-2.1.27-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.27-1_x86_64/libcyrussasl-2.1.27-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.27-2_armv7l/libcyrussasl-2.1.27-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.27-2_armv7l/libcyrussasl-2.1.27-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.27-2_i686/libcyrussasl-2.1.27-2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.27-2_x86_64/libcyrussasl-2.1.27-2-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '281ac03fa4841ff2bd2395e960a9803791fac3ccfa0bf70ec7b8f79088c25817',
-     armv7l: '281ac03fa4841ff2bd2395e960a9803791fac3ccfa0bf70ec7b8f79088c25817',
-       i686: 'dbce3fbbf6efedd4c9266c14163022ca9a1da22386f55eeffe6074c341a5bac0',
-     x86_64: '46241ea5cf5e0181649e91edb183128669d5ab5bc13a938493ba1158a5189743',
+  binary_sha256({
+    aarch64: '5271b29ef9e1bbcd92d597ec69750f89b9a62a70b1c4ceb900cae769da7ad27a',
+     armv7l: '5271b29ef9e1bbcd92d597ec69750f89b9a62a70b1c4ceb900cae769da7ad27a',
+       i686: 'd62620954fbd9ba7fd6279c7412dccb56a91318e0ed0150c1fc0efbf23314587',
+     x86_64: 'f1bc40fa4566b8928447b59387a49268e4aa541a3e80d7f059e74e7d62e17a63'
   })
 
   depends_on 'diffutils' => :build
 
+  def self.patch
+    system 'filefix'
+  end
+
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--with-shared',
-           '--with-cxx-shared'
+    system "env #{CREW_ENV_OPTIONS} \
+      ./configure \
+      #{CREW_OPTIONS} \
+      --enable-static \
+      --enable-shared \
+      --with-cxx-shared"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -3,34 +3,42 @@ require 'package'
 class Libgcrypt < Package
   description 'Libgcrypt is a general purpose cryptographic library originally based on code from GnuPG.'
   homepage 'https://www.gnupg.org/related_software/libgcrypt/index.html'
-  version '1.8.6'
+  version '1.9.3'
   license 'LGPL-2.1 and MIT'
   compatibility 'all'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.6.tar.bz2'
-  source_sha256 '0cba2700617b99fc33864a0c16b1fa7fdf9781d9ed3509f5d767178e5fd7b975'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.9.3.tar.bz2'
+  source_sha256 '97ebe4f94e2f7e35b752194ce15a0f3c66324e0ff6af26659bbfb5ff2ec328fd'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.8.6_armv7l/libgcrypt-1.8.6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.8.6_armv7l/libgcrypt-1.8.6-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.8.6_i686/libgcrypt-1.8.6-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.8.6_x86_64/libgcrypt-1.8.6-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.3_armv7l/libgcrypt-1.9.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.3_armv7l/libgcrypt-1.9.3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.3_i686/libgcrypt-1.9.3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.3_x86_64/libgcrypt-1.9.3-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '1536f3b492773f7145d3f68893e4a4b0f0b6f3c64ac1141d563c243146836988',
-     armv7l: '1536f3b492773f7145d3f68893e4a4b0f0b6f3c64ac1141d563c243146836988',
-       i686: 'd569a14b5ecf2b62895a121e7cd271af4d103375a1f086359d7b5ba7b5dff930',
-     x86_64: '50794006ecb92d0e54be1a27a56f0e11be173dee3d98623b46f737541104b1a1',
+  binary_sha256({
+    aarch64: '1e2b42394624c35f94278ee7f9c70aa544c7c40dedd49b396e3e2a72d2e6e6bc',
+     armv7l: '1e2b42394624c35f94278ee7f9c70aa544c7c40dedd49b396e3e2a72d2e6e6bc',
+       i686: 'c072efaef5595c6f3ef7c57ce9573a8c9d79f2e7fa937425f4bb3a4098e12cd5',
+     x86_64: '3945f3464bd06d41db1be4ad4f59242490bfa897856c9e395f25b5d9f1f1bc75'
   })
 
   depends_on 'libgpgerror'
 
+  def self.patch
+    system 'filefix'
+  end
+
   def self.build
     case ARCH
     when 'aarch64'
-      ENV['gcry_cv_gcc_arm_platform_as_ok'] = 'no'
-      system "./configure #{CREW_OPTIONS} --disable-asm"
+      system "gcry_cv_gcc_arm_platform_as_ok=no ./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS} \
+      --enable-static \
+      --enable-shared \
+      --disable-asm"
     else
-      system "./configure #{CREW_OPTIONS}"
+      system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS} \
+        --enable-static \
+        --enable-shared"
     end
     system 'make'
   end

--- a/packages/libgpgerror.rb
+++ b/packages/libgpgerror.rb
@@ -3,31 +3,35 @@ require 'package'
 class Libgpgerror < Package
   description 'Libgpg-error is a small library that defines common error values for all GnuPG components.'
   homepage 'https://www.gnupg.org/related_software/libgpg-error/index.html'
-  version '1.42'
+  @_ver = '1.42'
+  version "#{@_ver}-1"
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
-  source_url "https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-#{version}.tar.bz2"
+  source_url "https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-#{@_ver}.tar.bz2"
   source_sha256 'fc07e70f6c615f8c4f590a8e37a9b8dd2e2ca1e9408f8e60459c67452b925e23'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42_armv7l/libgpgerror-1.42-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42_armv7l/libgpgerror-1.42-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42_i686/libgpgerror-1.42-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42_x86_64/libgpgerror-1.42-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42-1_armv7l/libgpgerror-1.42-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42-1_armv7l/libgpgerror-1.42-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42-1_i686/libgpgerror-1.42-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42-1_x86_64/libgpgerror-1.42-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '9864ed50574b3830c7e613392e6bdccf1be8857d5e40263b8d31f535481db547',
-     armv7l: '9864ed50574b3830c7e613392e6bdccf1be8857d5e40263b8d31f535481db547',
-       i686: 'fe6ff6e681c9d7730ef69f696d759528b67fa5a5e2f5be584c1277b0ee0498a0',
-     x86_64: '041069951d95c281c22e1f50e06d8402d35c6682d16483da1881e4c20691e6b9'
+    aarch64: '46ca55616094f55ad7a071f06ea9b028d58ab8883407155ef472cf6b8bc105a7',
+     armv7l: '46ca55616094f55ad7a071f06ea9b028d58ab8883407155ef472cf6b8bc105a7',
+       i686: 'ef29d332a020b339c83492adf00b2aae6173d2a86b4b11922c48338dd73b9138',
+     x86_64: '87bdb815ac35effdf3a42e8dad56f947dcd51280590db3e64b59fc744908ce2d'
   })
+
+  def self.patch
+    system 'filefix'
+  end
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "env CFLAGS='-flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS} \
+      --enable-static \
+      --enable-shared \
       --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/libidn2.rb
+++ b/packages/libidn2.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libidn2 < Package
   description 'GNU Libidn is a fully documented implementation of the Stringprep, Punycode and IDNA 2003 specifications.'
   homepage 'https://www.gnu.org/software/libidn/'
-  version '2.3.1'
+  version '2.3.1-1'
   license 'GPL-2+ and LGPL-3+'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/libidn/libidn2-2.3.1.tar.gz'
   source_sha256 '8af684943836b8b53965d5f5b6714ef13c26c91eaa36ce7d242e3d21f5d40f2d'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1_armv7l/libidn2-2.3.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1_armv7l/libidn2-2.3.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1_i686/libidn2-2.3.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1_x86_64/libidn2-2.3.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1-1_armv7l/libidn2-2.3.1-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1-1_armv7l/libidn2-2.3.1-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1-1_i686/libidn2-2.3.1-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1-1_x86_64/libidn2-2.3.1-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'd5451f73189a53bbdd500b23c781750d688d9b8ee4763eecca8323eace221566',
-     armv7l: 'd5451f73189a53bbdd500b23c781750d688d9b8ee4763eecca8323eace221566',
-       i686: '03df0cdc3848415a7e08e2026eab5a3a50c6943c1980223dac8d0579cdbdc3be',
-     x86_64: '2ade8b8171841b7a911b1802d2dbee0f890537687131e16515a4155c9167187a'
+    aarch64: 'b9c6d94688c48b1eae57d2c62e41c15bb4c7942eae4683bc39699f09865d0ad7',
+     armv7l: 'b9c6d94688c48b1eae57d2c62e41c15bb4c7942eae4683bc39699f09865d0ad7',
+       i686: '985b7de2215322d8b7becb9a7673e26d70db39e497b9a2d3af1f6304f6bb2d15',
+     x86_64: '4fd2287da572b21f87a2d63c5c6c933169fa69735075447d8aa83c244a236c37'
   })
 
   def self.build

--- a/packages/libidn2.rb
+++ b/packages/libidn2.rb
@@ -9,17 +9,17 @@ class Libidn2 < Package
   source_url 'https://ftpmirror.gnu.org/libidn/libidn2-2.3.1.tar.gz'
   source_sha256 '8af684943836b8b53965d5f5b6714ef13c26c91eaa36ce7d242e3d21f5d40f2d'
 
-  binary_url ({
+  binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1_armv7l/libidn2-2.3.1-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1_armv7l/libidn2-2.3.1-chromeos-armv7l.tpxz',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1_i686/libidn2-2.3.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1_x86_64/libidn2-2.3.1-chromeos-x86_64.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.1_x86_64/libidn2-2.3.1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '9533e091572a2fb3aff874794327ffb752967b9952608cbccbd06321a1098323',
-     armv7l: '9533e091572a2fb3aff874794327ffb752967b9952608cbccbd06321a1098323',
-       i686: 'f65ae2734d93e883e32a7602bee7e494d396406addd38d675346d41c5eb34943',
-     x86_64: '3a54e6d6c60865885257e3f1383a1b1d957483a97ef5c0ff400611f58908f28e',
+  binary_sha256({
+    aarch64: 'd5451f73189a53bbdd500b23c781750d688d9b8ee4763eecca8323eace221566',
+     armv7l: 'd5451f73189a53bbdd500b23c781750d688d9b8ee4763eecca8323eace221566',
+       i686: '03df0cdc3848415a7e08e2026eab5a3a50c6943c1980223dac8d0579cdbdc3be',
+     x86_64: '2ade8b8171841b7a911b1802d2dbee0f890537687131e16515a4155c9167187a'
   })
 
   def self.build

--- a/packages/libmetalink.rb
+++ b/packages/libmetalink.rb
@@ -3,42 +3,38 @@ require 'package'
 class Libmetalink < Package
   description 'libmetalink is a Metalink library written in C language.'
   homepage 'https://launchpad.net/libmetalink/'
-  version '0.1.3-2'
+  version '0.1.3-3'
   license 'MIT'
   compatibility 'all'
   source_url 'https://launchpad.net/libmetalink/trunk/libmetalink-0.1.3/+download/libmetalink-0.1.3.tar.xz'
   source_sha256 '86312620c5b64c694b91f9cc355eabbd358fa92195b3e99517504076bf9fe33a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmetalink/0.1.3-2_armv7l/libmetalink-0.1.3-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmetalink/0.1.3-2_armv7l/libmetalink-0.1.3-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmetalink/0.1.3-2_i686/libmetalink-0.1.3-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmetalink/0.1.3-2_x86_64/libmetalink-0.1.3-2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmetalink/0.1.3-3_armv7l/libmetalink-0.1.3-3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmetalink/0.1.3-3_armv7l/libmetalink-0.1.3-3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmetalink/0.1.3-3_i686/libmetalink-0.1.3-3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmetalink/0.1.3-3_x86_64/libmetalink-0.1.3-3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'b47564f58da6ce1215010fd9ad152a568f5cae15a466b43b59b871d1469efb25',
-     armv7l: 'b47564f58da6ce1215010fd9ad152a568f5cae15a466b43b59b871d1469efb25',
-       i686: 'f216916b8b89a717f923adb72f446c45c97c057347a71c1b7326224c49d25257',
-     x86_64: '01d87388e27c2d918fa29e885d2818956a7c42297df9d08da772f52f12ff5249'
+    aarch64: '0018a9cfa5c2a896b210b89f11112c8071ce470007c77c922085726ef82634ea',
+     armv7l: '0018a9cfa5c2a896b210b89f11112c8071ce470007c77c922085726ef82634ea',
+       i686: 'e2a61502581e8b39f621b0893bed87df8b2f108cb63b5396973d8b6c3f75aa60',
+     x86_64: '62986bd07f7fd2ade3114e8600e1a920b8614447acdd34164b77181ceb3a6687'
   })
 
+  depends_on 'hashpipe' => :build
+
   def self.patch
-    puts 'Downloading patch...'
-    system 'curl', '--progress-bar', '-LO', 'https://launchpadlibrarian.net/380798344/0001-fix-covscan-issues.patch'
-    unless Digest::SHA256.hexdigest(File.read('0001-fix-covscan-issues.patch')) == 'd236dfa0d4a1938a40ff2ce4dd348c42b74ad68807df0f1b6ea69c11725fd9cf'
-      abort 'Checksum mismatch. :/ Try again.'.lightred
-    end
-    puts 'Done!'.lightgreen
-    puts 'Applying patch...'
-    system 'patch', '-Np1', '-i', '0001-fix-covscan-issues.patch'
-    puts 'Done!'.lightgreen
+    system 'curl -Ls https://launchpadlibrarian.net/380798344/0001-fix-covscan-issues.patch | \
+      hashpipe sha256 d236dfa0d4a1938a40ff2ce4dd348c42b74ad68807df0f1b6ea69c11725fd9cf | \
+      patch -Np1 --binary'
+    system 'filefix'
   end
 
   def self.build
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} \
-      --with-libxml2\
+    system "./configure #{CREW_OPTIONS} \
+      #{CREW_ENV_OPTIONS} \
+      --with-libxml2 \
       --without-libexpat"
     system 'make'
   end

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -3,35 +3,33 @@ require 'package'
 class Libnghttp2 < Package
   description 'library implementing HTTP/2 protocol'
   homepage 'https://nghttp2.org/'
-  version '1.43.0'
+  @_ver = '1.43.0'
+  version "#{@_ver}-1"
   license 'MIT'
   compatibility 'all'
-  source_url "https://github.com/nghttp2/nghttp2/releases/download/v#{version}/nghttp2-#{version}.tar.bz2"
+  source_url "https://github.com/nghttp2/nghttp2/releases/download/v#{@_ver}/nghttp2-#{@_ver}.tar.bz2"
   source_sha256 '556f24653397c71ebb8270b3c5e5507f0893e6eac2c6eeda6be2ecf6e1f50f62'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0_armv7l/libnghttp2-1.43.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0_armv7l/libnghttp2-1.43.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0_i686/libnghttp2-1.43.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0_x86_64/libnghttp2-1.43.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0-1_armv7l/libnghttp2-1.43.0-1-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0-1_armv7l/libnghttp2-1.43.0-1-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0-1_i686/libnghttp2-1.43.0-1-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0-1_x86_64/libnghttp2-1.43.0-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '3a760af4f8f0e4bec998be98b6f942d3baa2bc270a40780922d3bb69b36052af',
-     armv7l: '3a760af4f8f0e4bec998be98b6f942d3baa2bc270a40780922d3bb69b36052af',
-       i686: 'ae37feacc654b4f97090ac642003ec9bd1edc2447f19679ba2d03b1c6ec7f6cb',
-     x86_64: 'af383eeeaaa588726efbd85d883d2eee1f3799a9687d2c16904d229c5662d3db'
+    aarch64: '022e8875b50308e626209a76df03a67e57a904c6932e1bb1c52018c3eb763cbc',
+    armv7l: '022e8875b50308e626209a76df03a67e57a904c6932e1bb1c52018c3eb763cbc',
+    i686: '2ea5d7dba201696ff274937e47b8a7eb1d202be529d6c20be23a9ea4156e76a8',
+    x86_64: '497555f7091679fb5993479a48aabf18704e098269b2d91ba34ef0d592e65b7f'
   })
 
   def self.build
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      cmake \
-        -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        .."
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+      -DENABLE_SHARED_LIB=ON \
+      -DENABLE_STATIC_LIB=ON \
+      ../ -G Ninja"
     end
     system 'ninja -C builddir'
   end

--- a/packages/libpsl.rb
+++ b/packages/libpsl.rb
@@ -4,34 +4,32 @@ class Libpsl < Package
   description 'C library for the Public Suffix List'
   homepage 'https://github.com/rockdaboot/libpsl'
   @_ver = '0.21.1'
-  version @_ver
+  version "#{@_ver}-1"
   license 'MIT'
   compatibility 'all'
   source_url "https://github.com/rockdaboot/libpsl/releases/download/#{@_ver}/libpsl-#{@_ver}.tar.lz"
   source_sha256 '644375d557bb3b84c485df2dae98ee388fe1e11fb75230004e4b8623b3b833a9'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1_armv7l/libpsl-0.21.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1_armv7l/libpsl-0.21.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1_i686/libpsl-0.21.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1_x86_64/libpsl-0.21.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-1_armv7l/libpsl-0.21.1-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-1_armv7l/libpsl-0.21.1-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-1_i686/libpsl-0.21.1-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-1_x86_64/libpsl-0.21.1-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '9b8376e9c1b5e65363e0c4a7ad61721930e07dbaa032c76455723186d6268d47',
-     armv7l: '9b8376e9c1b5e65363e0c4a7ad61721930e07dbaa032c76455723186d6268d47',
-       i686: 'c5d298373d73a26ecd8559254f00286f14e129a09dbe13f94252356a332fc172',
-     x86_64: 'e8c7a5c5f46be4ff1158d5d643a3efa14fcf008f4f6af906703612b907c9e725'
+    aarch64: '820d6bd20a1981c33a9d3a998d6d10660dda64124405ea0ca04f3cc485d35e00',
+     armv7l: '820d6bd20a1981c33a9d3a998d6d10660dda64124405ea0ca04f3cc485d35e00',
+       i686: '38032e35bd8c942a88ee0f911627b41b2e13f5cbc349827127582830fe4d21c8',
+     x86_64: 'e0e147b462d7a1d8a585ca205d6386263fdf7aa59b3b36aaaa3ee528fabf99c2'
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
-    -Ddocs=disabled \
-    builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
+    system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
+    system "./configure #{CREW_ENV_OPTIONS} #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -5,8 +5,8 @@ class Libssh < Package
   homepage 'https://www.libssh.org/'
   @_ver = '0.9.5'
   version "#{@_ver}-2"
-  license 'LGPL-2.1'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
+  license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://www.libssh.org/files/#{@_ver_prelastdot}/libssh-#{@_ver}.tar.xz"
   source_sha256 'acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718'

--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -4,46 +4,51 @@ class Libssh < Package
   description 'libssh is a multiplatform C library implementing the SSHv2 and SSHv1 protocol on client and server side.'
   homepage 'https://www.libssh.org/'
   @_ver = '0.9.5'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'LGPL-2.1'
-  compatibility 'all'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
+  compatibility 'all'
   source_url "https://www.libssh.org/files/#{@_ver_prelastdot}/libssh-#{@_ver}.tar.xz"
   source_sha256 'acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-1_armv7l/libssh-0.9.5-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-1_armv7l/libssh-0.9.5-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-1_i686/libssh-0.9.5-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-1_x86_64/libssh-0.9.5-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-2_armv7l/libssh-0.9.5-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-2_armv7l/libssh-0.9.5-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-2_i686/libssh-0.9.5-2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-2_x86_64/libssh-0.9.5-2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '7823ea3948867ed6b44ff1d62334aa011db8d3e07452c5a6312f5873a26d681c',
-     armv7l: '7823ea3948867ed6b44ff1d62334aa011db8d3e07452c5a6312f5873a26d681c',
-       i686: '07e75554e44aaef4210d9bf6a17b098953d03054ff5f2614dc4c4719d6936d8b',
-     x86_64: 'a3f1c7727f88271291316d186698e2c94afd275493f3b27e93f2eb152679970e'
+    aarch64: 'fe56c352d678f004866c27bf5b4dc1d05114387f65bc07968834ddbd5ec9bb79',
+     armv7l: 'fe56c352d678f004866c27bf5b4dc1d05114387f65bc07968834ddbd5ec9bb79',
+       i686: 'd524f5485303306cb39720c09e9379a3e636a1f18ba68a547dd6534c762c5c12',
+     x86_64: 'abb34682d2e053ff8a7ca1f2d64d45402127a3460314a0b330641715dff21704'
   })
 
   depends_on 'libgcrypt'
 
   def self.build
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-        CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-        LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-        cmake -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        -DWITH_STACK_PROTECTOR_STRONG=NO \
-        -DWITH_STACK_CLASH_PROTECTION=NO \
-        -DWITH_STACK_PROTECTOR=NO \
-        -DWITH_GCRYPT=ON \
-        .."
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+      -DWITH_EXAMPLES=OFF \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DWITH_STATIC_LIB=ON \
+      ../ -G Ninja"
+    end
+    system 'ninja -C builddir'
+    Dir.chdir('builddir') do
+      FileUtils.cp 'src/libssh.a', '../' if File.exist?('src/libssh.a')
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+      -DWITH_EXAMPLES=OFF \
+      -DBUILD_SHARED_LIBS=ON \
+      -DWITH_STATIC_LIB=OFF \
+      ../ -G Ninja"
     end
     system 'ninja -C builddir'
   end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    FileUtils.cp 'libssh.a', CREW_DEST_LIB_PREFIX if File.exist?('libssh.a')
   end
 end

--- a/packages/libtasn1.rb
+++ b/packages/libtasn1.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libtasn1 < Package
   description 'Libtasn1 is the ASN.1 library used by GnuTLS, GNU Shishi and some other packages.'
   homepage 'https://www.gnu.org/software/libtasn1/'
-  version '4.16'
+  version '4.17'
   license 'GPL-3 and LGPL-2.1'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/libtasn1/libtasn1-4.16.0.tar.gz'
-  source_sha256 '0e0fb0903839117cb6e3b56e68222771bebf22ad7fc2295a0ed7d576e8d4329d'
+  source_url 'https://ftpmirror.gnu.org/libtasn1/libtasn1-4.17.0.tar.gz'
+  source_sha256 'ece7551cea7922b8e10d7ebc70bc2248d1fdd73351646a2d6a8d68a9421c45a5'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtasn1/4.16_armv7l/libtasn1-4.16-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtasn1/4.16_armv7l/libtasn1-4.16-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtasn1/4.16_i686/libtasn1-4.16-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtasn1/4.16_x86_64/libtasn1-4.16-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtasn1/4.17_armv7l/libtasn1-4.17-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtasn1/4.17_armv7l/libtasn1-4.17-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtasn1/4.17_i686/libtasn1-4.17-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtasn1/4.17_x86_64/libtasn1-4.17-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '5e4512b5de236f36519662658481c9021956ea210030efe67447fd2e345c296d',
-     armv7l: '5e4512b5de236f36519662658481c9021956ea210030efe67447fd2e345c296d',
-       i686: 'e1960601090933f7b0d25d173dad0d056f9465810959261438da3672cfd008d7',
-     x86_64: 'd6c37f27c28eed8720445a9dba40780230f7a3b824bf0787e67739714a2bf34a',
+  binary_sha256({
+    aarch64: '4705282fadb02d1220ce050cf3236f537daf1925de0c0d8b1b781f9512bd564c',
+     armv7l: '4705282fadb02d1220ce050cf3236f537daf1925de0c0d8b1b781f9512bd564c',
+       i686: 'b11e71ef0e5972523eb9b3a940607603c7eb248f6e2b40b8cf25f9dc634a4020',
+     x86_64: '45bb14fceafe35899eb7d379a6c61347428f7acaca451dc24798eb463939e898'
   })
 
   # bison, diff, cmp are required at compile-time
@@ -28,16 +28,18 @@ class Libtasn1 < Package
 
   def self.build
     system "./configure #{CREW_OPTIONS} \
+      #{CREW_ENV_OPTIONS} \
       --enable-shared \
+      --enable-static \
       --with-pic"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
 end

--- a/packages/libtirpc.rb
+++ b/packages/libtirpc.rb
@@ -3,35 +3,35 @@ require 'package'
 class Libtirpc < Package
   description 'Libtirpc is a port of Suns Transport-Independent RPC library to Linux.'
   homepage 'https://sourceforge.net/projects/libtirpc'
-  @_ver = '1.3.1'
+  @_ver = '1.3.2'
   version @_ver
   license 'GPL-2'
   compatibility 'all'
   source_url "http://downloads.sourceforge.net/project/libtirpc/libtirpc/#{@_ver}/libtirpc-#{@_ver}.tar.bz2"
-  source_sha256 '245895caf066bec5e3d4375942c8cb4366adad184c29c618d97f724ea309ee17'
+  source_sha256 'e24eb88b8ce7db3b7ca6eb80115dd1284abc5ec32a8deccfed2224fc2532b9fd'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtirpc/1.3.1_armv7l/libtirpc-1.3.1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtirpc/1.3.1_armv7l/libtirpc-1.3.1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtirpc/1.3.1_i686/libtirpc-1.3.1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtirpc/1.3.1_x86_64/libtirpc-1.3.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtirpc/1.3.2_armv7l/libtirpc-1.3.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtirpc/1.3.2_armv7l/libtirpc-1.3.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtirpc/1.3.2_i686/libtirpc-1.3.2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtirpc/1.3.2_x86_64/libtirpc-1.3.2-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '489870e43cd86ca9aa252f3639f54e8af9bc6b33e16ef96aa66f0114bef8ee90',
-      armv7l: '489870e43cd86ca9aa252f3639f54e8af9bc6b33e16ef96aa66f0114bef8ee90',
-        i686: '987de099b04760d251425554071d505ec001818a152a782cd51b92ae6edf9dc5',
-      x86_64: '982db8c305a1c2859ab9954a18e03e5500a277fa00717e7646bf69b95a744213',
+  binary_sha256({
+    aarch64: '3b96e0f200153be8e35a289d323d5465d4b11289d7e38bcc098a9c621e9ccf5d',
+     armv7l: '3b96e0f200153be8e35a289d323d5465d4b11289d7e38bcc098a9c621e9ccf5d',
+       i686: '19bf96ac7b5892c12237ee4bd57c8cb5e0bb6c68adaf2059d6a60ab143758241',
+     x86_64: '8fffa00840f66ff4b6bb9c8d66a36d15208829fe2ff00dd0c46b435fcbc2201b'
   })
 
-  depends_on 'krb5'
+  depends_on 'e2fsprogs'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
-    system "make"
+    system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     system "mkdir #{CREW_DEST_PREFIX}/include/rpc"
     system "mv #{CREW_DEST_PREFIX}/include/tirpc/rpc/* #{CREW_DEST_PREFIX}/include/rpc/"
     system "curl -Lo #{CREW_DEST_PREFIX}/include/netconfig.h https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/include/netconfig.h"

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -3,33 +3,38 @@ require 'package'
 class Libunbound < Package
   description 'Unbound is a validating, recursive, and caching DNS resolver.'
   homepage 'https://nlnetlabs.nl/projects/unbound/about/'
-  @_ver = '1.13.0'
+  @_ver = '1.13.1'
   version @_ver
   license 'BSD and GPL-2'
   compatibility 'all'
   source_url "https://nlnetlabs.nl/downloads/unbound/unbound-#{@_ver}.tar.gz"
-  source_sha256 'a954043a95b0326ca4037e50dace1f3a207a0a19e9a4a22f4c6718fc623db2a1'
+  source_sha256 '8504d97b8fc5bd897345c95d116e0ee0ddf8c8ff99590ab2b4bd13278c9f50b8'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.0_armv7l/libunbound-1.13.0-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.0_armv7l/libunbound-1.13.0-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.0_i686/libunbound-1.13.0-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.0_x86_64/libunbound-1.13.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.1_armv7l/libunbound-1.13.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.1_armv7l/libunbound-1.13.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.1_i686/libunbound-1.13.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.1_x86_64/libunbound-1.13.1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '6a233948f7d41046dc23d1cc500cf87b604b6d99861d0806b12393e090bd034a',
-      armv7l: '6a233948f7d41046dc23d1cc500cf87b604b6d99861d0806b12393e090bd034a',
-        i686: '93afb3cb2cbdd9e3fa293b6f04475a7f5cf4e0f713d7eba3538f2547c4547d1a',
-      x86_64: 'b270594cf7ac23a675280e20807730ae437f155a41c4f015b17db51c4bb360de',
+  binary_sha256({
+    aarch64: '1e6999af00f48993d63ff36bff111796a1a79894808499ff0afafcf12a6e5c32',
+     armv7l: '1e6999af00f48993d63ff36bff111796a1a79894808499ff0afafcf12a6e5c32',
+       i686: 'eb5e0d99f4a98ed55e6842d01782e3326045c7a9e3e99e4a3867113d2113a30f',
+     x86_64: 'fe16753a6cb9a8c69cf759201f39dec701d29b9de75954c77a2225e32e7a3edc'
   })
+
+  def self.patch
+    system 'filefix'
+  end
 
   def self.build
-  system "env #{CREW_ENV_OPTIONS} \
-    ./configure \
+    system "./configure \
     #{CREW_OPTIONS} \
+    #{CREW_ENV_OPTIONS} \
     --enable-shared \
+    --enable-static \
     --with-pic"
-    system "make"
+    system 'make'
   end
 
   def self.install
@@ -38,5 +43,10 @@ class Libunbound < Package
 
   def self.check
     system 'make', 'test'
+  end
+
+  def self.postinstall
+    # Use IPv4 if default fails.
+    system "#{CREW_PREFIX}/sbin/unbound-anchor -a '#{CREW_PREFIX}/etc/unbound/root.key' || #{CREW_PREFIX}/sbin/unbound-anchor -4 -a '#{CREW_PREFIX}/etc/unbound/root.key'"
   end
 end

--- a/packages/libunistring.rb
+++ b/packages/libunistring.rb
@@ -3,41 +3,39 @@ require 'package'
 class Libunistring < Package
   description 'A library that provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.'
   homepage 'https://www.gnu.org/software/libunistring/'
-  version '0.9.10'
+  version '0.9.10-1'
   license 'LGPL-3+ or GPL-2+ and FDL-1.2 or GPL-3+'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.xz'
   source_sha256 'eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunistring/0.9.10_armv7l/libunistring-0.9.10-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunistring/0.9.10_armv7l/libunistring-0.9.10-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunistring/0.9.10_i686/libunistring-0.9.10-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunistring/0.9.10_x86_64/libunistring-0.9.10-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunistring/0.9.10-1_armv7l/libunistring-0.9.10-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunistring/0.9.10-1_armv7l/libunistring-0.9.10-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunistring/0.9.10-1_i686/libunistring-0.9.10-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunistring/0.9.10-1_x86_64/libunistring-0.9.10-1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: 'bd3254d74558de91f176d933d0e4c71eb34b82e245abfbbce9fbee675e89e6fc',
-     armv7l: 'bd3254d74558de91f176d933d0e4c71eb34b82e245abfbbce9fbee675e89e6fc',
-       i686: '88cb3cbfdf6c108045cf63d5aa70b2d036fceacc93f0ead76858381db4268c76',
-     x86_64: 'd0fccb9b680e38517ce95483fcbac289ba835aa79e5c106bc21ec8de7872a13b',
+  binary_sha256({
+    aarch64: '1987a956d1d5faf7f1364cd56c61536ca7727782c199d910bbef609109095a32',
+     armv7l: '1987a956d1d5faf7f1364cd56c61536ca7727782c199d910bbef609109095a32',
+       i686: 'd9d4a7741d8ae40b02593d6b4e89f3c4c0da8a0be709a1275045f024853f4c21',
+     x86_64: '3073ee4151dd8c96b87c21cb1f1e183c29c0da7c5a8e51f45641387c237b316c'
   })
 
   depends_on 'glibc'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-static',
-           '--enable-shared'
+    system "./configure #{CREW_ENV_OPTIONS} #{CREW_OPTIONS} \
+      --enable-static \
+      --enable-shared"
     system 'make'
   end
 
-  def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-  end
+  # def self.check
+  # system "make", "check"
+  # end
 
-  def self.check
-    system "make", "check"
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.10-1'
+  version '2.9.12'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.10/libxml2-v2.9.10.tar.bz2'
-  source_sha256 '5f1cc19c849cccabb983881cf1ebf833f42db5d7b8afba7a7763a2ac3101715c'
+  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.12/libxml2-v2.9.12.tar.bz2'
+  source_sha256 'bb5ea084617e2bc706cd1f0c9b36328950c9d802a16ff52795e5f13bae900ca8'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.10-1_armv7l/libxml2-2.9.10-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.10-1_armv7l/libxml2-2.9.10-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.10-1_i686/libxml2-2.9.10-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.10-1_x86_64/libxml2-2.9.10-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12_armv7l/libxml2-2.9.12-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12_armv7l/libxml2-2.9.12-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12_i686/libxml2-2.9.12-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12_x86_64/libxml2-2.9.12-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '5ee3b6147dfce492b631c53893d1cc06e809e204498241710296035e49aa9d57',
-     armv7l: '5ee3b6147dfce492b631c53893d1cc06e809e204498241710296035e49aa9d57',
-       i686: 'd498f4cf27a067bf3d8257f67c6e1a405908460246a15af995991ec1f3c64c74',
-     x86_64: '2082401a85b8e61263556f9fa0612d1d74064db0145a2fac0756c121bc0f11c4',
+  binary_sha256({
+    aarch64: 'a6315954148a4ec7f7867031c282c967b198ea494f81d28f1eef8cd2e3c65e36',
+    armv7l: 'a6315954148a4ec7f7867031c282c967b198ea494f81d28f1eef8cd2e3c65e36',
+    i686: '52be8e1e0497dafbb0f92847342353ce22e104a388a30d075b1de32129089686',
+    x86_64: 'ebb3b81155231be702617246a78945a3698142f63b3138c5763b9813d57dbe19'
   })
 
   depends_on 'zlibpkg'
@@ -32,8 +32,18 @@ class Libxml2 < Package
 
   def self.build
     # libxml2-python built in another package (libxml2_python)
-    system "./autogen.sh #{CREW_OPTIONS} --enable-shared --disable-static --with-pic \
---without-python --without-lzma --with-zlib --with-icu --with-threads --with-history"
+    system "./autogen.sh \
+      #{CREW_OPTIONS} \
+      #{CREW_ENV_OPTIONS} \
+      --enable-shared \
+      --enable-static \
+      --with-pic \
+      --without-python \
+      --without-lzma \
+      --with-zlib \
+      --with-icu \
+      --with-threads \
+      --with-history"
     system 'make'
   end
 

--- a/packages/mapserver.rb
+++ b/packages/mapserver.rb
@@ -24,7 +24,7 @@ class Mapserver < Package
 
   depends_on 'cmake'
   depends_on 'cairo'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'fribidi'
   depends_on 'gdal'
   depends_on 'geos'

--- a/packages/minerd.rb
+++ b/packages/minerd.rb
@@ -22,7 +22,7 @@ class Minerd < Package
      x86_64: 'a4101c3804f18fa55f93ea0516c5deca35093064f47146ef1f398b8b1e10f343',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'jansson'
 
   def self.build

--- a/packages/netcdf.rb
+++ b/packages/netcdf.rb
@@ -22,7 +22,7 @@ class Netcdf < Package
      x86_64: 'ff3aaee614a276bcbde78d0afb4339ca7312b76e16f9811bb97a621cb6f8874c',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'hdf5'
 
   def self.build

--- a/packages/netsurf.rb
+++ b/packages/netsurf.rb
@@ -26,7 +26,7 @@ class Netsurf < Package
   depends_on 'libidn2'
   depends_on 'libmng'
   depends_on 'libxml2'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'lcms'
   depends_on 'libwebp'
   depends_on 'libcss'

--- a/packages/nettle.rb
+++ b/packages/nettle.rb
@@ -3,31 +3,31 @@ require 'package'
 class Nettle < Package
   description 'Nettle is a cryptographic library that is designed to fit easily in more or less any context: In crypto toolkits for object-oriented languages (C++, Python, Pike, ...), in applications like LSH or GNUPG, or even in kernel space.'
   homepage 'http://www.lysator.liu.se/~nisse/nettle/'
-  @_ver = '3.7'
-  version @_ver + '-1'
+  @_ver = '3.7.2'
+  version @_ver
   license 'LGPL-3 or LGPL-2.1'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/nettle/nettle-#{@_ver}.tar.gz"
-  source_sha256 'f001f64eb444bf13dd91bceccbc20acbc60c4311d6e2b20878452eb9a9cec75a'
+  source_sha256 '8d2a604ef1cde4cd5fb77e422531ea25ad064679ff0adf956e78b3352e0ef162'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nettle/3.7-1_armv7l/nettle-3.7-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nettle/3.7-1_armv7l/nettle-3.7-1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nettle/3.7-1_i686/nettle-3.7-1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nettle/3.7-1_x86_64/nettle-3.7-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nettle/3.7.2_armv7l/nettle-3.7.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nettle/3.7.2_armv7l/nettle-3.7.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nettle/3.7.2_i686/nettle-3.7.2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nettle/3.7.2_x86_64/nettle-3.7.2-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '5b39e94078c6b414dbab4bc39d3930cea06cda4fae8ac00ae8070d398cc66427',
-      armv7l: '5b39e94078c6b414dbab4bc39d3930cea06cda4fae8ac00ae8070d398cc66427',
-        i686: '22cc6881f5df8c0e0a6d77154156ab74efb3ec9866208cde5c71a5935bad839b',
-      x86_64: '713dbccd1a267bac1cd71856ab6f68dd897ae32a005d2c9439f9d31d31597481',
+  binary_sha256({
+    aarch64: 'd8aa510c56d8e768789bfc85d7d48f4a82929fc09c63dc13164e56b5cd3944ff',
+     armv7l: 'd8aa510c56d8e768789bfc85d7d48f4a82929fc09c63dc13164e56b5cd3944ff',
+       i686: '0cf3d6e72bfb27525f21a8222361637f8899f3dd97abd2ba5eeb970c74835346',
+     x86_64: '8f3f8f16263b2a1ccef1c078ee9443bcbe4f7a08fc9bb66ab1e5cf0715e7df0f'
   })
 
   depends_on 'm4'
   depends_on 'openssl'
 
   def self.build
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS}"
     system 'make'
   end
 

--- a/packages/obs.rb
+++ b/packages/obs.rb
@@ -18,7 +18,7 @@ class Obs < Package
     x86_64: '854492244415cea4b4874cf3cd2302649d5b538d89366f2fd1ccceda7ff1f3ea',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'ffmpeg'
   depends_on 'jack'
   depends_on 'jansson'

--- a/packages/od1n.rb
+++ b/packages/od1n.rb
@@ -22,7 +22,7 @@ class Od1n < Package
      x86_64: '38b19eb0cb14694e30040105ac05fd0e250ced2bbac6c0e7428b8adbd495dd2c',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
 
   def self.build
     system 'make'

--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -3,24 +3,24 @@ require 'package'
 class Openldap < Package
   description 'OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.'
   homepage 'https://www.openldap.org/'
-  @_ver = '2.5.4'
-  version @_ver
+  @_ver = '2.5.5'
+  version "#{@_ver}-1"
   license 'OpenLDAP and GPL-2'
   compatibility 'all'
   source_url "https://openldap.org/software/download/OpenLDAP/openldap-release/openldap-#{@_ver}.tgz"
-  source_sha256 '61c03c078d70cd859e504fa9555d7d52426eed4b29e6a39e828afc213e4fb356'
+  source_sha256 '74ecefda2afc0e054d2c7dc29166be6587fa9de7a4087a80183bc9c719dbf6b3'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.4_armv7l/openldap-2.5.4-chromeos-armv7l.tpxz',
-    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.4_armv7l/openldap-2.5.4-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.4_i686/openldap-2.5.4-chromeos-i686.tpxz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.4_x86_64/openldap-2.5.4-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5-1_armv7l/openldap-2.5.5-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5-1_armv7l/openldap-2.5.5-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5-1_i686/openldap-2.5.5-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5-1_x86_64/openldap-2.5.5-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'f4f36cd3dd5cd5a2056ce11ab0ff8cd750308102f7f7b39eb273c402062e822d',
-    armv7l: 'f4f36cd3dd5cd5a2056ce11ab0ff8cd750308102f7f7b39eb273c402062e822d',
-    i686: 'd4afb85b12d85a1883b339691f2fa9c29631621094dec2b5a9dc58b3f892761b',
-    x86_64: 'e9bbc0ecbc9972b523150ad6c48fffdee3ee9c6e39ce4d154d5d42c43c178e1a'
+    aarch64: 'fb6fd0f0690103b39b71bce3a71426feb41ac8f0de03466a2a5985dcd82a4fdd',
+     armv7l: 'fb6fd0f0690103b39b71bce3a71426feb41ac8f0de03466a2a5985dcd82a4fdd',
+       i686: '409d75a7523e4de951285a5f9daf0d14166467242ce37cf85b5718a85e63cc88',
+     x86_64: 'a79aa7779fe182d0e529099f704a7c3d9e590b103d33e2f35779e59c4b582e06'
   })
 
   depends_on 'libcyrussasl'

--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -3,31 +3,34 @@ require 'package'
 class Openldap < Package
   description 'OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.'
   homepage 'https://www.openldap.org/'
-  @_ver = '2.4.57'
+  @_ver = '2.5.4'
   version @_ver
   license 'OpenLDAP and GPL-2'
   compatibility 'all'
   source_url "https://openldap.org/software/download/OpenLDAP/openldap-release/openldap-#{@_ver}.tgz"
-  source_sha256 'c7ba47e1e6ecb5b436f3d43281df57abeffa99262141aec822628bc220f6b45a'
+  source_sha256 '61c03c078d70cd859e504fa9555d7d52426eed4b29e6a39e828afc213e4fb356'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.4.57_armv7l/openldap-2.4.57-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.4.57_armv7l/openldap-2.4.57-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.4.57_i686/openldap-2.4.57-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.4.57_x86_64/openldap-2.4.57-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.4_armv7l/openldap-2.5.4-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.4_armv7l/openldap-2.5.4-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.4_i686/openldap-2.5.4-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.4_x86_64/openldap-2.5.4-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: 'eafc72703f61b96747a8d37e6fcdac7d5d400832da9f9205936188dda6e57a46',
-      armv7l: 'eafc72703f61b96747a8d37e6fcdac7d5d400832da9f9205936188dda6e57a46',
-        i686: 'e981259b1c30688d15c3b8ca83ea87fe83bd41f1923322b274df04e6e10611f0',
-      x86_64: 'e0ca5de88bd9808f8e30beb0861bec2da9c3686b538f4563603b19fbd50b6278',
+  binary_sha256({
+    aarch64: 'f4f36cd3dd5cd5a2056ce11ab0ff8cd750308102f7f7b39eb273c402062e822d',
+    armv7l: 'f4f36cd3dd5cd5a2056ce11ab0ff8cd750308102f7f7b39eb273c402062e822d',
+    i686: 'd4afb85b12d85a1883b339691f2fa9c29631621094dec2b5a9dc58b3f892761b',
+    x86_64: 'e9bbc0ecbc9972b523150ad6c48fffdee3ee9c6e39ce4d154d5d42c43c178e1a'
   })
 
   depends_on 'libcyrussasl'
 
+  def self.patch
+    system 'filefix'
+  end
+
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-    ./configure #{CREW_OPTIONS} --disable-slapd"
+    system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS} --disable-slapd"
     system 'make'
     system 'make depend'
   end

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -4,31 +4,33 @@ class Openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
   @_ver = '1.1.1k'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
   source_sha256 '892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-1_armv7l/openssl-1.1.1k-1-chromeos-armv7l.tpxz',
-    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-1_armv7l/openssl-1.1.1k-1-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-1_i686/openssl-1.1.1k-1-chromeos-i686.tpxz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-1_x86_64/openssl-1.1.1k-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-2_armv7l/openssl-1.1.1k-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-2_armv7l/openssl-1.1.1k-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-2_i686/openssl-1.1.1k-2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-2_x86_64/openssl-1.1.1k-2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '0f5d3fa673b9df81c9a1aa26d5315cd74e70322d7a88d97aaf12361e757b3e0d',
-    armv7l: '0f5d3fa673b9df81c9a1aa26d5315cd74e70322d7a88d97aaf12361e757b3e0d',
-    i686: '8eba22bcb2a3cb5aaf68137a28eb6b319c89e0c71020c8a1f55973aca24e5116',
-    x86_64: 'ae64526253eae95b6ef825639c37078872a1ed454bde4a2b40a245c16922060e'
+    aarch64: 'a71bfc9649794f16e03d2aafe43fdd4090e3679078d4c54c18f2de00c2d5ae61',
+     armv7l: 'a71bfc9649794f16e03d2aafe43fdd4090e3679078d4c54c18f2de00c2d5ae61',
+       i686: '5a55581745e62d8e3697b7dfa7b91624c0aeda94cf925c1feb079163e3923b0b',
+     x86_64: 'd095621c44c8607c93b3881cbdc71d8bb219f1d48f93abf0c626d3f7f2eddba7'
   })
 
   depends_on 'ccache' => :build
 
   case ARCH
   when 'aarch64', 'armv7l'
-    @arch_c_flags = '-fPIC -march=armv7-a -mfloat-abi=hard'
-    @arch_cxx_flags = '-fPIC -march=armv7-a -mfloat-abi=hard'
+    # See https://sourceware.org/bugzilla/show_bug.cgi?id=27659
+    # BFD (GNU Binutils) 2.36.1 internal error, aborting at ../../bfd/elfcode.h:224 in bfd_elf32_swap_symbol_out
+    @arch_c_flags = '-fPIC -march=armv7-a -mfloat-abi=hard -fuse-ld=lld'
+    @arch_cxx_flags = '-fPIC -march=armv7-a -mfloat-abi=hard -fuse-ld=lld'
     @openssl_configure_target = 'linux-generic32'
   when 'i686'
     @arch_c_flags = '-fPIC'
@@ -39,14 +41,18 @@ class Openssl < Package
     @arch_cxx_flags = '-fPIC'
     @openssl_configure_target = 'linux-x86_64'
   end
-  @ARCH_LDFLAGS = '-flto=auto'
-  @ARCH_C_LTO_FLAGS = "#{@arch_c_flags}  -ffat-lto-objects -flto=auto"
-  @ARCH_CXX_LTO_FLAGS = "#{@arch_cxx_flags}  -ffat-lto-objects -flto=auto"
+  @ARCH_LDFLAGS = '-flto'
+  # @ARCH_LDFLAGS = '-flto=auto'
+  @ARCH_C_LTO_FLAGS = "#{@arch_c_flags} -flto"
+  @ARCH_CXX_LTO_FLAGS = "#{@arch_cxx_flags} -flto"
+  # @ARCH_C_LTO_FLAGS = "#{@arch_c_flags}  -ffat-lto-objects -flto=auto"
+  # @ARCH_CXX_LTO_FLAGS = "#{@arch_cxx_flags}  -ffat-lto-objects -flto=auto"
 
   def self.build
     # This gives you the list of OpenSSL configure targets
     system './Configure LIST'
-    system "env PATH=#{CREW_LIB_PREFIX}/ccache/bin:#{CREW_PREFIX}/bin:/usr/bin:/bin \
+    system "env CC=clang CXX=clang++ LD=ld.lld AR=llvm-ar RANLIB=llvm-ranlib \
+    PATH=#{CREW_LIB_PREFIX}/ccache/bin:#{CREW_PREFIX}/bin:/usr/bin:/bin \
       CFLAGS=\"#{@ARCH_C_LTO_FLAGS}\" CXXFLAGS=\"#{@ARCH_CXX_LTO_FLAGS}\" \
       LDFLAGS=\"#{@ARCH_LDFLAGS}\" \
       ./Configure --prefix=#{CREW_PREFIX} \

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -4,23 +4,23 @@ class Openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
   @_ver = '1.1.1k'
-  version @_ver
+  version "#{@_ver}-1"
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
   source_sha256 '892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k_armv7l/openssl-1.1.1k-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k_armv7l/openssl-1.1.1k-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k_i686/openssl-1.1.1k-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k_x86_64/openssl-1.1.1k-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-1_armv7l/openssl-1.1.1k-1-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-1_armv7l/openssl-1.1.1k-1-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-1_i686/openssl-1.1.1k-1-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1k-1_x86_64/openssl-1.1.1k-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '4b5a6ff1bbd03a7adf09acebe3b7a928de9a8520e260360f9f4fac8e7c83e903',
-     armv7l: '4b5a6ff1bbd03a7adf09acebe3b7a928de9a8520e260360f9f4fac8e7c83e903',
-       i686: '84d388677881fa56ccfa2dd7bd05ff8ef8ddcccebf30d60e7d13194e18c64e51',
-     x86_64: 'fbcbe9955bd9b8cb9de3f7b2d5c77a4fcd9d8e5704afd192ad597871162a690d'
+    aarch64: '0f5d3fa673b9df81c9a1aa26d5315cd74e70322d7a88d97aaf12361e757b3e0d',
+    armv7l: '0f5d3fa673b9df81c9a1aa26d5315cd74e70322d7a88d97aaf12361e757b3e0d',
+    i686: '8eba22bcb2a3cb5aaf68137a28eb6b319c89e0c71020c8a1f55973aca24e5116',
+    x86_64: 'ae64526253eae95b6ef825639c37078872a1ed454bde4a2b40a245c16922060e'
   })
 
   depends_on 'ccache' => :build
@@ -40,8 +40,8 @@ class Openssl < Package
     @openssl_configure_target = 'linux-x86_64'
   end
   @ARCH_LDFLAGS = '-flto=auto'
-  @ARCH_C_LTO_FLAGS = "#{@arch_c_flags} -flto=auto"
-  @ARCH_CXX_LTO_FLAGS = "#{@arch_cxx_flags} -flto=auto"
+  @ARCH_C_LTO_FLAGS = "#{@arch_c_flags}  -ffat-lto-objects -flto=auto"
+  @ARCH_CXX_LTO_FLAGS = "#{@arch_cxx_flags}  -ffat-lto-objects -flto=auto"
 
   def self.build
     # This gives you the list of OpenSSL configure targets

--- a/packages/p11kit.rb
+++ b/packages/p11kit.rb
@@ -3,37 +3,36 @@ require 'package'
 class P11kit < Package
   description "Provides a standard configuration setup for installing PKCS#11 modules in such a way that they're discoverable."
   homepage 'https://p11-glue.freedesktop.org/p11-kit.html'
-  version '0.23.22'
+  version '0.24.0'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://github.com/p11-glue/p11-kit/archive/0.23.22.tar.gz'
-  source_sha256 'e4bf1e374b3c0950a724cf367bd52201519f4b7025c8e9902a274123cc232560'
+  source_url 'https://github.com/p11-glue/p11-kit/archive/0.24.0.tar.gz'
+  source_sha256 '284d209e045ebc7e30ccb479c7b559edfcb5433d665b497386dd35291826e39c'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/p11kit/0.23.22_armv7l/p11kit-0.23.22-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/p11kit/0.23.22_armv7l/p11kit-0.23.22-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/p11kit/0.23.22_i686/p11kit-0.23.22-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/p11kit/0.23.22_x86_64/p11kit-0.23.22-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/p11kit/0.24.0_armv7l/p11kit-0.24.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/p11kit/0.24.0_armv7l/p11kit-0.24.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/p11kit/0.24.0_i686/p11kit-0.24.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/p11kit/0.24.0_x86_64/p11kit-0.24.0-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: 'd62b5c7216b9b271584147ec0b5c432ef1f993c0985be2c77ec7b681981eb2a8',
-      armv7l: 'd62b5c7216b9b271584147ec0b5c432ef1f993c0985be2c77ec7b681981eb2a8',
-        i686: 'e7a2a1566f4219929789357682f26a6a3f2582f030d1a29fa75bfe53d1010472',
-      x86_64: 'fbbf0478445e54d17f6db35d79ae9c5b7fdf5fcfe88e2fb429eb7e5c1c933035',
+  binary_sha256({
+    aarch64: '2ca3f06bf7057b4ddddb2fd0338e995fce6bf7c609120698a6218687cebd4bb1',
+     armv7l: '2ca3f06bf7057b4ddddb2fd0338e995fce6bf7c609120698a6218687cebd4bb1',
+       i686: '600b55f9167934b5b838e6bff7df938c075467ea59dd7b044fb83392b16166a3',
+     x86_64: '6d4c5565dcd978a0bab78300a512bc2decbb01cb66149f0502ecc4a7d0b0a94e'
   })
 
   depends_on 'libffi'
   depends_on 'libtasn1'
 
   def self.build
-    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       build"
-    system "meson configure build"
-    system "ninja -C build"
+    system 'meson configure build'
+    system 'ninja -C build'
   end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
   end
-
 end

--- a/packages/php5.rb
+++ b/packages/php5.rb
@@ -26,7 +26,7 @@ class Php5 < Package
   depends_on 'libpng'
   depends_on 'libxslt'
   depends_on 'libzip'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'exif'
   depends_on 'freetype'
   depends_on 'pcre'

--- a/packages/php71.rb
+++ b/packages/php71.rb
@@ -26,7 +26,7 @@ class Php71 < Package
   depends_on 'libwebp'
   depends_on 'libxslt'
   depends_on 'libzip'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'exif'
   depends_on 'freetype'
   depends_on 'pcre'

--- a/packages/php72.rb
+++ b/packages/php72.rb
@@ -26,7 +26,7 @@ class Php72 < Package
   depends_on 'libjpeg_turbo'
   depends_on 'libxslt'
   depends_on 'libzip'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'exif'
   depends_on 'freetype'
   depends_on 'pcre'

--- a/packages/pixz.rb
+++ b/packages/pixz.rb
@@ -6,34 +6,38 @@ require 'package'
 class Pixz < Package
   description 'Parallel, indexed xz compressor'
   homepage 'https://github.com/vasi/pixz'
-  version '1.0.7-0829'
+  version '1.0.7-0829-1'
   license 'BSD'
   compatibility 'all'
   source_url 'https://github.com/vasi/pixz.git'
   git_hashtag '0829c7315c804a4e40abd63a9d624194dc1e4f0a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829_armv7l/pixz-1.0.7-0829-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829_armv7l/pixz-1.0.7-0829-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829_i686/pixz-1.0.7-0829-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829_x86_64/pixz-1.0.7-0829-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829-1_armv7l/pixz-1.0.7-0829-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829-1_armv7l/pixz-1.0.7-0829-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829-1_i686/pixz-1.0.7-0829-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829-1_x86_64/pixz-1.0.7-0829-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'b3775ba946ecd95e87b68c8bd2d0c93c78027677eb4de15fc9df5d2e4d80f7c2',
-     armv7l: 'b3775ba946ecd95e87b68c8bd2d0c93c78027677eb4de15fc9df5d2e4d80f7c2',
-       i686: '8fff1c81a1b0f693a5e6fa592fba32410875e53e754c8b70e9bf5f14f8654627',
-     x86_64: '2112ae37128533e88bd492d0aae688028fe7ea8b8149e50c16866aa69f90034e'
+    aarch64: '2260deb2b1748041fe31c2d2f858837ae0a63d4d7a432e0cc8c926539f9d6b7f',
+     armv7l: '2260deb2b1748041fe31c2d2f858837ae0a63d4d7a432e0cc8c926539f9d6b7f',
+       i686: '47dc38370dc228123e8666b5d1c01c47f13b049b40c8b5492c76104322415e04',
+     x86_64: 'b0ad21a8d1f7a3c3e27deac1977b8d7a1c6d82bc5a9a22c4bc266d390cd76657'
   })
 
-  depends_on 'libarchive'
   depends_on 'asciidoc' => :build
+  depends_on 'libarchive'
   depends_on 'xzutils'
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "#{CREW_ENV_OPTIONS} \
-      manpage=true \
-      ./configure #{CREW_OPTIONS}"
+    system "env manpage=true \
+      ./configure \
+      CC=clang LD=ld.lld \
+      CFLAGS='-flto -pipe -O3 -fuse-ld=lld -static' \
+      CXXFLAGS='-flto -pipe -O3 -static' \
+      LDFLAGS='-flto -static' \
+      #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/profanity.rb
+++ b/packages/profanity.rb
@@ -22,7 +22,7 @@ class Profanity < Package
      x86_64: 'ead2d0a06e37c622913b76941c292a3b10ad500a1f75ebab45e2b08779f007bd',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'glib'
   depends_on 'gpgme'
   depends_on 'gtk2'

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -17,7 +17,7 @@ class Qemu < Package
   })
 
   depends_on 'bz2'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'glib'
   depends_on 'gtk3'
   depends_on 'jemalloc'

--- a/packages/r.rb
+++ b/packages/r.rb
@@ -30,7 +30,7 @@ class R < Package
   depends_on 'libtiff'
   depends_on 'xzutils'
   depends_on 'bz2'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'tk'
   depends_on 'xdg_utils'
   depends_on 'sommelier'

--- a/packages/rdfind.rb
+++ b/packages/rdfind.rb
@@ -1,0 +1,42 @@
+# Adapted from Arch Linux rdfind PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=rdfind
+
+require 'package'
+
+class Rdfind < Package
+  description 'Redundant data find - a program that finds duplicate files.'
+  homepage 'http://rdfind.pauldreik.se'
+  version '1.4.1-fa77'
+  license 'GPL2'
+  compatibility 'all'
+  source_url 'https://github.com/pauldreik/rdfind.git'
+  git_hashtag 'fa7752d6205e2071a758e7aa2d4e1c541aa96a6e'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rdfind/1.4.1-fa77_armv7l/rdfind-1.4.1-fa77-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rdfind/1.4.1-fa77_armv7l/rdfind-1.4.1-fa77-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rdfind/1.4.1-fa77_i686/rdfind-1.4.1-fa77-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rdfind/1.4.1-fa77_x86_64/rdfind-1.4.1-fa77-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '323a416209cbe8c2e49bc56d2abf61a5c2bb01df8f8ec0fb4935b269dff77b1e',
+     armv7l: '323a416209cbe8c2e49bc56d2abf61a5c2bb01df8f8ec0fb4935b269dff77b1e',
+       i686: 'af95b9800f9eb6c8695cc23e3f2ee761c1fafc461b2e296b7ac39d84ac8c04b6',
+     x86_64: '2b442e00f36840cea9c023a4ffad71aa8952df831769594759726bd5f24372f4'
+  })
+
+  def self.patch
+    system "sed -i '/<vector>/a #include <limits>' rdfind.cc"
+    system "sed -i '/<cstdio>/a #include <stdexcept>' Checksum.cc"
+  end
+
+  def self.build
+    system '[ -x configure ] || autoreconf -fvi'
+    system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS}"
+    system 'make -s'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/rng_tools.rb
+++ b/packages/rng_tools.rb
@@ -22,7 +22,7 @@ class Rng_tools < Package
      x86_64: 'df9504bf42632204e92fb4b97ac0b863c7e8cbb7d5592ec9ab7c4224071b711b',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'libgcrypt'
   depends_on 'sysfsutils'
   depends_on 'psmisc'

--- a/packages/roswell.rb
+++ b/packages/roswell.rb
@@ -23,7 +23,7 @@ class Roswell < Package
   })
 
   depends_on 'brotli'
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'libcyrussasl'
   depends_on 'libnghttp2'
   depends_on 'openldap'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,22 +3,23 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  version '20210109-2'
+  version '20210109-3'
   license 'BSD-Google'
   compatibility 'all'
-  source_url 'SKIP'
+  source_url 'https://chromium.googlesource.com/chromiumos/platform2.git'
+  git_hashtag 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-2_armv7l/sommelier-20210109-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-2_armv7l/sommelier-20210109-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-2_i686/sommelier-20210109-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-2_x86_64/sommelier-20210109-2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_armv7l/sommelier-20210109-3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_armv7l/sommelier-20210109-3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_i686/sommelier-20210109-3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_x86_64/sommelier-20210109-3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'b518f2f3086e611f6bcdd8cd2b8b67d70956b96c5c43174e26685be6bd7aa0c4',
-     armv7l: 'b518f2f3086e611f6bcdd8cd2b8b67d70956b96c5c43174e26685be6bd7aa0c4',
-       i686: '74a2838593c1297e37127335d6e2aad9402caf264960bf05405434cec67eb254',
-     x86_64: '7e9689e28331c1d9be1f30c9deb6a77fae2519ccb753ef0ffb53faac324bf7e8'
+    aarch64: '401181dfb60f062d00166d39259ca60f593c629af9466dbfb6dcc3f4363575be',
+     armv7l: '401181dfb60f062d00166d39259ca60f593c629af9466dbfb6dcc3f4363575be',
+       i686: 'f00ace87c154fa1c4f786656db369004612b51c27236dbdca9c4f0fd230496eb',
+     x86_64: '29b161ee80fbc1f334bfaf7d191ce8b37c0b7cff414d3e639934b10de64280d7'
   })
 
   depends_on 'coreutils' # for readlink in wrapper script
@@ -46,22 +47,8 @@ class Sommelier < Package
     @peer_cmd_prefix = '/lib64/ld-linux-x86-64.so.2'
   end
 
-  def self.prebuild
-    @git_dir = 'platform2_git'
-    @git_hash = 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
-    @git_url = 'https://chromium.googlesource.com/chromiumos/platform2'
-    FileUtils.rm_rf(@git_dir)
-    FileUtils.mkdir_p(@git_dir)
-    Dir.chdir @git_dir do
-      system 'git init'
-      system "git remote add origin #{@git_url}"
-      system "git fetch --depth 1 origin #{@git_hash}"
-      system 'git checkout FETCH_HEAD'
-    end
-  end
-
   def self.build
-    Dir.chdir('platform2_git/vm_tools/sommelier') do
+    Dir.chdir('vm_tools/sommelier') do
       # Patch to avoid error with GCC > 9.x
       # ../sommelier.cc:3238:10: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 108 equals destination size [-Wstringop-truncation]
       system "sed -i 's/sizeof(addr.sun_path))/sizeof(addr.sun_path) - 1)/' sommelier.cc"
@@ -239,7 +226,7 @@ EOF"
   end
 
   def self.install
-    Dir.chdir('platform2_git/vm_tools/sommelier') do
+    Dir.chdir('vm_tools/sommelier') do
       system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
       Dir.chdir('builddir') do
         FileUtils.mv "#{CREW_DEST_PREFIX}/bin/sommelier", "#{CREW_DEST_PREFIX}/bin/sommelier.elf"

--- a/packages/tracker3.rb
+++ b/packages/tracker3.rb
@@ -6,23 +6,23 @@ require 'package'
 class Tracker3 < Package
   description 'Desktop-neutral user information store, search tool and indexer'
   homepage 'https://wiki.gnome.org/Projects/Tracker'
-  version '3.1.0'
+  version '3.1.1'
   license 'GPLv2+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/tracker/-/archive/#{version}/tracker-#{version}.tar.bz2"
-  source_sha256 'd673f7733753bfca965947e56fd66e61de4d9a931f354b0f74bd7d678bda50f3'
+  source_url 'https://gitlab.gnome.org/GNOME/tracker.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tracker3/3.1.0_armv7l/tracker3-3.1.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tracker3/3.1.0_armv7l/tracker3-3.1.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tracker3/3.1.0_i686/tracker3-3.1.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tracker3/3.1.0_x86_64/tracker3-3.1.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tracker3/3.1.1_armv7l/tracker3-3.1.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tracker3/3.1.1_armv7l/tracker3-3.1.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tracker3/3.1.1_i686/tracker3-3.1.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tracker3/3.1.1_x86_64/tracker3-3.1.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'c0dcefb67e57e81357d16a8ea36354968220e3c219afb221793d258d1a21830f',
-     armv7l: 'c0dcefb67e57e81357d16a8ea36354968220e3c219afb221793d258d1a21830f',
-       i686: '31efe2b60354b1c9a014b0108e090ea06c323c332f830288a9228c916c13cae2',
-     x86_64: 'c0d20b9d905e7fc879ef68c4d4bcf52038fe9da308aa29cb5940f0ffb9fe8fc0'
+    aarch64: 'f4ce0e7b77fba49df81c8f3ce91bd1d5cc467c54419f10f5b558a8c49e27860d',
+     armv7l: 'f4ce0e7b77fba49df81c8f3ce91bd1d5cc467c54419f10f5b558a8c49e27860d',
+       i686: '4289748dfa869bd172a7fae1b6cd3b9238116f31492584f5d887e4b80fa75159',
+     x86_64: '09f9d96911095b5e00f4206a62e56b9e9bfb79fe46ac9206fadc213810dbe714'
   })
 
   depends_on 'asciidoc'
@@ -36,7 +36,6 @@ class Tracker3 < Package
   depends_on 'libstemmer'
   depends_on 'util_linux'
   depends_on 'vala' => :build
-
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/uget.rb
+++ b/packages/uget.rb
@@ -22,7 +22,7 @@ class Uget < Package
      x86_64: 'e75eeddfb77a1d22fbe9ff38b20b65a2e85862b22812f78296a4f760f44a0854',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
   depends_on 'gtk3'
   depends_on 'libnotify'
   depends_on 'gstreamer'

--- a/packages/weechat.rb
+++ b/packages/weechat.rb
@@ -24,7 +24,7 @@ class Weechat < Package
 
   depends_on 'libgcrypt'
   depends_on 'aspell' => :build
-  depends_on 'curl' => :build
+  depends_on 'libcurl' => :build
   depends_on 'lua' => :build
   depends_on 'tcl' => :build
 

--- a/packages/xercesc.rb
+++ b/packages/xercesc.rb
@@ -22,7 +22,7 @@ class Xercesc < Package
      x86_64: 'd1a0c7fd791b712963ea851792e8253474ec0ba5683d631ce0b0ac981e90762e',
   })
 
-  depends_on 'curl'
+  depends_on 'libcurl'
 
   def self.build
     system './configure',

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -4,23 +4,23 @@ class Xwayland < Package
   description 'X server configured to work with weston or sommelier'
   homepage 'https://x.org'
   @_ver = '21.1.1'
-  version @_ver
+  version "#{@_ver}-1"
   license 'MIT-with-advertising, ISC, BSD-3, BSD and custom'
   compatibility 'all'
   source_url "https://xorg.freedesktop.org/archive/individual/xserver/xwayland-#{@_ver}.tar.xz"
   source_sha256 '31f261ce51bbee76a6ca3ec02aa367ffa2b5efa2b98412df57ccefd7a19003ce'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/21.1.1_armv7l/xwayland-21.1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/21.1.1_armv7l/xwayland-21.1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/21.1.1_i686/xwayland-21.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/21.1.1_x86_64/xwayland-21.1.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/21.1.1-1_armv7l/xwayland-21.1.1-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/21.1.1-1_armv7l/xwayland-21.1.1-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/21.1.1-1_i686/xwayland-21.1.1-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/21.1.1-1_x86_64/xwayland-21.1.1-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'd8e3068e17a3870691209f2a72babe5b1e0e777851a39656dda132715227e81a',
-     armv7l: 'd8e3068e17a3870691209f2a72babe5b1e0e777851a39656dda132715227e81a',
-       i686: 'f49397108ca18335ee323d4f71a32d1041eb9747742185b361f1fbe7e9336b90',
-     x86_64: '7c7f7d84957e4ab595458e5add13586bab6c45cb8edde948a9750aa02944f105'
+    aarch64: '38b5d8f88eeebfc129228ba922d1e50c9744603fa8ea1d1b140a3f8febeb44b0',
+     armv7l: '38b5d8f88eeebfc129228ba922d1e50c9744603fa8ea1d1b140a3f8febeb44b0',
+       i686: '6013786072753462890a811aa56bd491e459395133f45ac9914bd1f4b6ea07ac',
+     x86_64: 'ff1faf9120fd8b815a14cacac97efeb788a5a834b7527b2fb6300e533c3c611d'
   })
 
   depends_on 'dbus'
@@ -28,20 +28,25 @@ class Xwayland < Package
   depends_on 'font_util'
   depends_on 'glproto'
   depends_on 'graphite'
-  depends_on 'libbsd'
-  depends_on 'libepoxy'
-  depends_on 'libunwind'
-  depends_on 'libxfont'
+  depends_on 'libbsd' # R
+  depends_on 'libdrm' # R
+  depends_on 'libepoxy' # R
+  depends_on 'libtirpc' => :build
+  depends_on 'libunwind'  => :build
+  depends_on 'libxau' # R
+  depends_on 'libxdmcp' # R
+  depends_on 'libxfont2' # R
+  depends_on 'libxfont' # R
   depends_on 'libxkbcommon'
-  depends_on 'libxkbfile'
+  depends_on 'libxkbfile' # R
+  depends_on 'libxshmfence' # R
   depends_on 'libxtrans'
-  depends_on 'libxdmcp'
-  depends_on 'xzutils' => :build
-  depends_on 'mesa'
-  depends_on 'pixman'
-  depends_on 'wayland'
+  depends_on 'mesa' # R
+  depends_on 'pixman' # R
+  depends_on 'wayland' # R
   depends_on 'xkbcomp'
   depends_on 'xorg_lib'
+
 
   case ARCH
   when 'armv7l', 'aarch64'

--- a/packages/xzutils.rb
+++ b/packages/xzutils.rb
@@ -3,24 +3,26 @@ require 'package'
 class Xzutils < Package
   description 'XZ Utils is free general-purpose data compression software with a high compression ratio.'
   homepage 'http://tukaani.org/xz/'
-  version '5.2.5-e7da'
+  version '5.2.5-e7da-1'
   license 'public-domain, LGPL-2.1+ and GPL-2+'
   compatibility 'all'
   source_url 'https://github.com/xz-mirror/xz.git'
   git_hashtag 'e7da44d5151e21f153925781ad29334ae0786101'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xzutils/5.2.5-e7da_armv7l/xzutils-5.2.5-e7da-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xzutils/5.2.5-e7da_armv7l/xzutils-5.2.5-e7da-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xzutils/5.2.5-e7da_i686/xzutils-5.2.5-e7da-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xzutils/5.2.5-e7da_x86_64/xzutils-5.2.5-e7da-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xzutils/5.2.5-e7da-1_armv7l/xzutils-5.2.5-e7da-1-chromeos-armv7l.tar.xz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xzutils/5.2.5-e7da-1_armv7l/xzutils-5.2.5-e7da-1-chromeos-armv7l.tar.xz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xzutils/5.2.5-e7da-1_i686/xzutils-5.2.5-e7da-1-chromeos-i686.tar.xz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xzutils/5.2.5-e7da-1_x86_64/xzutils-5.2.5-e7da-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '3b87b8150061f2f894f9ee69fceb6ab0b010fa9bdf63f79280c683eae28d588f',
-     armv7l: '3b87b8150061f2f894f9ee69fceb6ab0b010fa9bdf63f79280c683eae28d588f',
-       i686: 'a7da9276492788d722a0c853a81d8a5aff164eb16f49882514a1870d3f1397c7',
-     x86_64: 'a3080d777b7f220b35e9c368925e3099796de08c292239c2c5ca117b9beeb859'
+    aarch64: '4caa279bff570ecefe1fa84519dec7ec66d55bec943eee7ec94a8274d7c8e620',
+    armv7l: '4caa279bff570ecefe1fa84519dec7ec66d55bec943eee7ec94a8274d7c8e620',
+    i686: '853236ac1097893128530ab257f59a3e0c430a886be495e3129917da85ac1060',
+    x86_64: '3dc20e0ee9d0a08c43c61ab4cced5c497ffafd9ab1d46f9ec50ff8969e98dfe0'
   })
+
+  depends_on 'autoconf_archive' => :build
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh --no-po4a'

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -4,28 +4,27 @@ class Zlibpkg < Package
   description 'zlib is a massively spiffy yet delicately unobtrusive compression library.'
   homepage 'http://www.zlib.net/'
   @_ver = '1.2.11'
-  version "#{@_ver}-4"
+  version "#{@_ver}-5"
   license 'BSD'
   compatibility 'all'
   source_url "http://www.zlib.net/zlib-#{@_ver}.tar.gz"
   source_sha256 'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-4_armv7l/zlibpkg-1.2.11-4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-4_armv7l/zlibpkg-1.2.11-4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-4_i686/zlibpkg-1.2.11-4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-4_x86_64/zlibpkg-1.2.11-4-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-5_armv7l/zlibpkg-1.2.11-5-chromeos-armv7l.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-5_armv7l/zlibpkg-1.2.11-5-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-5_i686/zlibpkg-1.2.11-5-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-5_x86_64/zlibpkg-1.2.11-5-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '4b9c8b7ae88784f0c2744f268cc31afa1bb467f2ea964a7cb601509f12fceee7',
-     armv7l: '4b9c8b7ae88784f0c2744f268cc31afa1bb467f2ea964a7cb601509f12fceee7',
-       i686: 'fdd119fa2214635decf1a926a762cffc6e76a9ee4986d3a601c2afee05b150b8',
-     x86_64: '16c5a9c26c5ba526ae48dfaf277bb31c471bde9982747035f3e7594f4da710e8'
+    aarch64: 'b80e7c60c1a250f7d64289ab376547ba93f29e12cdaa3ae4a1a3a00b7d4ad450',
+    armv7l: 'b80e7c60c1a250f7d64289ab376547ba93f29e12cdaa3ae4a1a3a00b7d4ad450',
+    i686: '96bc24d5d6651147fcd99e08740bfa71335aa8b51506cbb580f13cad784c2fb2',
+    x86_64: '475af7ff9074abbe8fbb52f686dbf8f43f4c9dc1987a4231ae85c56d15d246c7'
   })
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
+    system "env #{CREW_ENV_OPTIONS} \
       ./configure \
       --prefix=#{CREW_PREFIX} \
       --libdir=#{CREW_LIB_PREFIX}"

--- a/packages/zstd.rb
+++ b/packages/zstd.rb
@@ -4,37 +4,42 @@ class Zstd < Package
   description 'Zstandard - Fast real-time compression algorithm'
   homepage 'http://www.zstd.net'
   @_ver = '1.5.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'BSD or GPL-2'
   compatibility 'all'
   source_url "https://github.com/facebook/zstd/archive/v#{@_ver}.tar.gz"
   source_sha256 '0d9ade222c64e912d6957b11c923e214e2e010a18f39bec102f572e693ba2867'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.0_armv7l/zstd-1.5.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.0_armv7l/zstd-1.5.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.0_i686/zstd-1.5.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.0_x86_64/zstd-1.5.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.0-1_armv7l/zstd-1.5.0-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.0-1_armv7l/zstd-1.5.0-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.0-1_i686/zstd-1.5.0-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.0-1_x86_64/zstd-1.5.0-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'ee8ce213f9209da69ed272c684cf20d1dcf75e24c1d7bfb11e1091b9484793c2',
-     armv7l: 'ee8ce213f9209da69ed272c684cf20d1dcf75e24c1d7bfb11e1091b9484793c2',
-       i686: 'a8d8312f83a0cdf627ceb5f9a6099e5036f20fbedd9a6c53c678b50c3d1a34c9',
-     x86_64: '4da82c8d02a0f8b2a2e2591110708df8e36b9451631420de28a8c2d14f579265'
+    aarch64: 'e63e459052fb415caa074ac053bb35418421b2573abf4fad4dd8f94197715187',
+     armv7l: 'e63e459052fb415caa074ac053bb35418421b2573abf4fad4dd8f94197715187',
+       i686: 'a5260b4a7c9a372571f0d77fc942b3f9f49d16432ed27447f46919cca246c0e2',
+     x86_64: 'af4b54526d9a6cd8b35d07b7e12c257cb46a5042861b83cf4248b63b6a6628eb'
   })
 
   def self.build
-    Dir.chdir 'build/meson' do
-      system "meson \
-        #{CREW_MESON_OPTIONS} \
-        builddir"
-      system 'meson configure builddir'
+    Dir.chdir 'build/cmake' do
+      FileUtils.mkdir('builddir')
+      Dir.chdir('builddir') do
+        system "cmake #{CREW_CMAKE_OPTIONS} \
+        -DZSTD_BUILD_STATIC=ON \
+        -DZSTD_BUILD_SHARED=ON \
+        -DZSTD_LEGACY_SUPPORT=ON \
+        -DZSTD_BUILD_CONTRIB=ON \
+        ../ -G Ninja"
+      end
       system 'ninja -C builddir'
     end
   end
 
   def self.install
-    Dir.chdir 'build/meson' do
+    Dir.chdir 'build/cmake' do
       system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
     end
   end

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -7,6 +7,7 @@ c_ares
 ca_certificates
 crew_profile_base
 curl
+e2fsprogs
 elfutils
 expat
 filecmd


### PR DESCRIPTION
- Change `git`, `curl`, and `pixz` to static apps
  - This should allow for massively streamlining `EARLY_PACKAGES` in `install.sh` as well as keep dependency changes for these packages from screwing up installs. (Getting ruby to have fewer dependencies is next on my list.)
- Add `rdfind` and a crew option to use it (with `symlinks`) to eliminate duplicate files during archiving.
  - Accordingly added `rdfind` and `symlinks` to `buildessential`
- Update dependencies for git, curl, and pixz to enable static library generation.
- Switch `krb5` to use `e2fsprogs` as a dependency. (and thus add `e2fsprogs` to core)
- `curl` and `libcurl` are now two separate packages. Note that there is also a rebuilt `openssl` which you need to properly link to `libcurl`...
- Updated icu to 69. Packages which may need an update (in progress) include js78, evolution_data_server, webkit2gtk_4, webkit2gtk_5).

- Using `upx` to compress application binaries (butnot libraries) at the moment, as there appears to be library compression issues at the moment. (But this saves a LOAD of space for packages like git.)

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686
