### PR TITLE
#1: Static builds of curl, git, and pixz to prevent update breakage.

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,24 +3,24 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.76.1'
+  @_ver = '7.77.0'
   version @_ver
   license 'curl'
   compatibility 'all'
   source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
-  source_sha256 '64bb5288c39f0840c07d077e30d9052e1cbb9fa6c2dc52523824cc859e679145'
+  source_sha256 '0f64582c54282f31c0de9f0a1a596b182776bd4df9a4c4a2a41bbeb54f62594b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.76.1_armv7l/curl-7.76.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.76.1_armv7l/curl-7.76.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.76.1_i686/curl-7.76.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.76.1_x86_64/curl-7.76.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_armv7l/curl-7.77.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_armv7l/curl-7.77.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_i686/curl-7.77.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_x86_64/curl-7.77.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'ae48ef34d0a91114c532590f7f7c754bd3fa9bc7e6a96223b2864d167ba79c3a',
-     armv7l: 'ae48ef34d0a91114c532590f7f7c754bd3fa9bc7e6a96223b2864d167ba79c3a',
-       i686: '61f65c1c8d892c80d40908beadbd73de14a7c987593d93dad62c7c9555927bdf',
-     x86_64: 'fbe7e0e7192e75ff64b24e71a8861b773c4d47ef668206f85fff6e8840d59f54'
+    aarch64: '0273d3cf0ffb3d18777bb4d5da6a20c00970ad3787687e48c023f406aa42d4bc',
+     armv7l: '0273d3cf0ffb3d18777bb4d5da6a20c00970ad3787687e48c023f406aa42d4bc',
+       i686: 'ead35292354673e20806e70a9359306bd63758a04db3888eb5eca7c99cd1904a',
+     x86_64: '81b8641d60b222248a75f910e2bf82ce7b9d793a84558466e7670215bbd9b8d1'
   })
 
   depends_on 'brotli' # R
@@ -35,41 +35,76 @@ class Curl < Package
   depends_on 'libunbound' # ?
   depends_on 'openldap' # R
   depends_on 'openssl' # R
-  depends_on 'rtmpdump' # R
+  depends_on 'py3_pip' => :build
   depends_on 'rust' => :build
   depends_on 'valgrind' => :build
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 
-
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 
+    @krb5_static_libs = "#{CREW_LIB_PREFIX}/libkrb5support.a " + "#{CREW_LIB_PREFIX}/libgssapi_krb5.a " + "#{CREW_LIB_PREFIX}/libkrb5.a " + "#{CREW_LIB_PREFIX}/libk5crypto.a " + "#{CREW_LIB_PREFIX}/libcom_err.a "
+
+    FileUtils.mkdir 'ssl'
+    FileUtils.ln_s "#{CREW_PREFIX}/include/openssl", 'ssl/include'
+    FileUtils.ln_s CREW_LIB_PREFIX, 'ssl/lib'
+    @sslpath = "#{`pwd`.chomp}/ssl"
     system 'filefix'
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-      LDFLAGS='-flto=auto'\
+    system "env CC=clang CXX=clang++ LD=ld.lld RANLIB=llvm-ranlib \
+      AR=llvm-ar \
+      CFLAGS='-flto -pipe -O3 -lz -fuse-ld=lld' \
+      CXXFLAGS='-flto -pipe -O3' \
+      LDFLAGS='-flto -static -Wl,--no-as-needed -ldl' LIBS='-l:libresolv.a #{@krb5_static_libs} -l:libzstd.a -l:libssh.a -lm -lbrotlicommon -lbrotlidec -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
       ./configure #{CREW_OPTIONS} \
+      --disable-ldap \
+      --disable-libcurl-option \
+      --disable-maintainer-mode \
+      --disable-shared \
+      --enable-ipv6 \
+      --enable-static \
+      --enable-unix-sockets \
+      --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
+      --with-ca-fallback \
+      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+      --with-libssh \
+      --with-openssl \
+      --without-librtmp"
+    system 'make curl_LDFLAGS=-all-static'
+    FileUtils.cp 'src/curl', 'curl.static'
+    system "env  CFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+       CXXFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+       LDFLAGS='-flto=auto' LIBS='#{@krb5_static_libs} -lm -lbrotlicommon -lbrotlidec -lzstd -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
+       ./configure #{CREW_OPTIONS} \
       --disable-maintainer-mode \
       --enable-ares \
-      --with-ldap-lib=ldap \
-      --with-lber-lib=lber \
-      --with-libmetalink \
-      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+      --enable-ipv6 \
+      --enable-ldap \
+      --enable-unix-sockets \
       --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
-      --with-ca-fallback"
+      --with-ca-fallback \
+      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+      --with-lber-lib=lber \
+      --with-ldap-lib=ldap \
+      --with-libmetalink \
+      --with-libssh \
+      --with-openssl=#{@sslpath} \
+      --without-gnutls \
+      --without-librtmp"
     system 'make'
   end
 
-  def self.check
-    # Python package impacket needed for testing.
-    # 1094 tests out of 1097 reported OK: 99% on 10/25/2020
-    # The 3 tests that failed were FTP, SMB and GOPHER.
-    system 'pip3 install impacket'
-    system 'make check || true'
-    system 'pip3 uninstall -y impacket'
-  end
+   def self.check
+     # Python package impacket needed for testing.
+     # 1094 tests out of 1097 reported OK: 99% on 10/25/2020
+     # The 3 tests that failed were FTP, SMB and GOPHER.
+     system 'pip3 install impacket'
+     system 'make check || true'
+     system 'pip3 uninstall -y impacket'
+   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.install 'curl.static', "#{CREW_DEST_PREFIX}/bin/curl", mode: 0o755
   end
 end

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -4,40 +4,61 @@ class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
   @_ver = '2.31.1'
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPL-2'
   compatibility 'all'
   source_url "https://github.com/git/git/archive/v#{@_ver}.tar.gz"
   source_sha256 'b1c0e95e9861b5d1b9ad3d8deaa2d8c7f02304ffc1b5e8869dd9fb98f9a0d436'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1_armv7l/git-2.31.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1_armv7l/git-2.31.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1_i686/git-2.31.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1_x86_64/git-2.31.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_armv7l/git-2.31.1-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_armv7l/git-2.31.1-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_i686/git-2.31.1-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_x86_64/git-2.31.1-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '86c740f001fde7008c59a3f85816d25f59190eb9a7ebd4b1f10ecc74606e4739',
-     armv7l: '86c740f001fde7008c59a3f85816d25f59190eb9a7ebd4b1f10ecc74606e4739',
-       i686: '4c14a8d247b71ab55436d688879e3ff8fa20335a1fe1160351ce51b1c9bb4568',
-     x86_64: '43e134e2978f2fab77d9a46191a7d8efff26306eab2c45509fc3d9bb2274f4b5'
+    aarch64: '364b30aafa845d7950b93fd67e72fcc752008dee08ff571155ffb4239eaba2ac',
+     armv7l: '364b30aafa845d7950b93fd67e72fcc752008dee08ff571155ffb4239eaba2ac',
+       i686: 'b80054bb43df65051d37c0c8e7f83c46f97d084027d7997871be91a7731a642c',
+     x86_64: 'c0bf7de6181f29f73abc75793410441aabcf2b71c3bd7a4321179a59859a47e6'
   })
 
   def self.build
     abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 
+    @curl_static_libs = `curl-config --static-libs`.chomp.gsub('=auto', '')
+    @sasl2_static_libs = "#{CREW_LIB_PREFIX}/libdb.a #{CREW_LIB_PREFIX}/libsasl2.a " + `pkg-config --libs --static libsasl2`.chomp
+    @krb5_static_libs = "#{CREW_LIB_PREFIX}/libkrb5support.a #{CREW_LIB_PREFIX}/libgssapi_krb5.a #{CREW_LIB_PREFIX}/libkrb5.a #{CREW_LIB_PREFIX}/libk5crypto.a #{CREW_LIB_PREFIX}/libcom_err.a"
+    @ldflags = "-flto -static -L#{CREW_LIB_PREFIX} #{@krb5_static_libs} #{@sasl2_static_libs} -lgmp #{@curl_static_libs} -lunistring -Wl,--no-as-needed -ldl"
+
+    FileUtils.mkdir 'curl'
+    FileUtils.ln_s "#{CREW_PREFIX}/include/curl", 'curl/include'
+    FileUtils.ln_s CREW_LIB_PREFIX, "curl/lib#{CREW_LIB_SUFFIX}"
     system 'autoreconf -fiv'
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
-      #{CREW_OPTIONS} \
-      --with-openssl=#{CREW_PREFIX}/etc/ssl \
+    # Build with clang to get truly static binaries.
+    system "./configure \
+      --prefix=#{CREW_PREFIX} \
+      --libdir=#{CREW_LIB_PREFIX} \
+      --mandir=#{CREW_MAN_PREFIX} \
+      CC=clang CXX=clang++ LD='ld.lld -L#{CREW_LIB_PREFIX} -lcurl'  CFLAGS='-flto -pipe -O3 -static -fuse-ld=lld' \
+      CXXFLAGS='-flto -pipe -O3 -static -fuse-ld=lld' \
+      LDFLAGS='#{@ldflags}' \
+      CURL_CONFIG=#{CREW_PREFIX}/bin/curl-config \
+      CURLDIR=`pwd`/curl \
+      CURL_LDFLAGS='-L#{CREW_LIB_PREFIX} #{@curl_static_libs}' \
+      AR=llvm-ar \
+      --with-lib='lib#{CREW_LIB_SUFFIX}' \
+      --with-openssl \
       --without-tcltk \
+      --with-curl \
       --with-perl=#{CREW_PREFIX}/bin/perl \
       --with-python=#{CREW_PREFIX}/bin/python3 \
       --with-gitconfig=#{CREW_PREFIX}/etc/gitconfig \
       --with-gitattributes=#{CREW_PREFIX}/etc/gitattributes"
-    system 'make'
+    # Make seems to need environment variables passed again here.
+    system "make CC='clang -L#{CREW_LIB_PREFIX} -lcurl' CXX=clang++ LD=ld.lld  CFLAGS='-flto -pipe -O3 -static -fuse-ld=lld' \
+      CXXFLAGS='-flto -pipe -O3 -static -fuse-ld=lld' \
+      LDFLAGS='#{@ldflags}'"
   end
 
   def self.install

--- a/packages/pixz.rb
+++ b/packages/pixz.rb
@@ -6,34 +6,38 @@ require 'package'
 class Pixz < Package
   description 'Parallel, indexed xz compressor'
   homepage 'https://github.com/vasi/pixz'
-  version '1.0.7-0829'
+  version '1.0.7-0829-1'
   license 'BSD'
   compatibility 'all'
   source_url 'https://github.com/vasi/pixz.git'
   git_hashtag '0829c7315c804a4e40abd63a9d624194dc1e4f0a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829_armv7l/pixz-1.0.7-0829-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829_armv7l/pixz-1.0.7-0829-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829_i686/pixz-1.0.7-0829-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829_x86_64/pixz-1.0.7-0829-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829-1_armv7l/pixz-1.0.7-0829-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829-1_armv7l/pixz-1.0.7-0829-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829-1_i686/pixz-1.0.7-0829-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixz/1.0.7-0829-1_x86_64/pixz-1.0.7-0829-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'b3775ba946ecd95e87b68c8bd2d0c93c78027677eb4de15fc9df5d2e4d80f7c2',
-     armv7l: 'b3775ba946ecd95e87b68c8bd2d0c93c78027677eb4de15fc9df5d2e4d80f7c2',
-       i686: '8fff1c81a1b0f693a5e6fa592fba32410875e53e754c8b70e9bf5f14f8654627',
-     x86_64: '2112ae37128533e88bd492d0aae688028fe7ea8b8149e50c16866aa69f90034e'
+    aarch64: '2260deb2b1748041fe31c2d2f858837ae0a63d4d7a432e0cc8c926539f9d6b7f',
+     armv7l: '2260deb2b1748041fe31c2d2f858837ae0a63d4d7a432e0cc8c926539f9d6b7f',
+       i686: '47dc38370dc228123e8666b5d1c01c47f13b049b40c8b5492c76104322415e04',
+     x86_64: 'b0ad21a8d1f7a3c3e27deac1977b8d7a1c6d82bc5a9a22c4bc266d390cd76657'
   })
 
-  depends_on 'libarchive'
   depends_on 'asciidoc' => :build
+  depends_on 'libarchive'
   depends_on 'xzutils'
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "#{CREW_ENV_OPTIONS} \
-      manpage=true \
-      ./configure #{CREW_OPTIONS}"
+    system "env manpage=true \
+      ./configure \
+      CC=clang LD=ld.lld \
+      CFLAGS='-flto -pipe -O3 -fuse-ld=lld -static' \
+      CXXFLAGS='-flto -pipe -O3 -static' \
+      LDFLAGS='-flto -static' \
+      #{CREW_OPTIONS}"
     system 'make'
   end
 


### PR DESCRIPTION
- Updates `curl`, `git`, and `pixz` to static builds to prevent breakage on dependency upgrades, which should help avoid crew breaking.

This needs to be merged BEFORE https://github.com/skycocker/chromebrew/pull/5837

Works properly:
- [x] x86_64
