### PR TITLE
Fix segfault issue in static curl, add libcurl to break out shared libraries, update git (built with libcurl)

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,63 +3,212 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.77.0'
+  @_ver = '7.77.0-git'
   version @_ver
   license 'curl'
   compatibility 'all'
-  source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
-  source_sha256 '0f64582c54282f31c0de9f0a1a596b182776bd4df9a4c4a2a41bbeb54f62594b'
+  source_url 'https://github.com/curl/curl.git'
+  git_hashtag 'curl-7_77_0'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_armv7l/curl-7.77.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_armv7l/curl-7.77.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_i686/curl-7.77.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0_x86_64/curl-7.77.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_armv7l/curl-7.77.0-git-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_armv7l/curl-7.77.0-git-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_i686/curl-7.77.0-git-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_x86_64/curl-7.77.0-git-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '0273d3cf0ffb3d18777bb4d5da6a20c00970ad3787687e48c023f406aa42d4bc',
-     armv7l: '0273d3cf0ffb3d18777bb4d5da6a20c00970ad3787687e48c023f406aa42d4bc',
-       i686: 'ead35292354673e20806e70a9359306bd63758a04db3888eb5eca7c99cd1904a',
-     x86_64: '81b8641d60b222248a75f910e2bf82ce7b9d793a84558466e7670215bbd9b8d1'
+    aarch64: '268771c547ef80761b937aedafe786ca701524e20b4737263aee9791514189d0',
+     armv7l: '268771c547ef80761b937aedafe786ca701524e20b4737263aee9791514189d0',
+       i686: '45796384ef70732ab7d4df71f09d2860e22bee776f86f7ff60c9863ff5bc28c2',
+     x86_64: 'ee99c0558b9dc9e64e4a2619706224daa3e7a0d4b100af135ac5b0a6a3b68ab4'
   })
 
-  depends_on 'brotli' # R
-  depends_on 'ca_certificates' # L
-  depends_on 'c_ares' # R
-  depends_on 'groff' => :build
-  depends_on 'libidn2' # R
-  depends_on 'libmetalink' # R
-  depends_on 'libnghttp2' # R
-  depends_on 'libpsl' # R
-  depends_on 'libtirpc' # ?
-  depends_on 'libunbound' # ?
-  depends_on 'openldap' # R
-  depends_on 'openssl' # R
+  depends_on 'ca_certificates' => :build
+  depends_on 'libcurl' # L (This is only here to make sure upgrades of curl pull in libcurl.)
+  depends_on 'libunbound' => :build
+  depends_on 'musl' => :build
   depends_on 'py3_pip' => :build
   depends_on 'rust' => :build
   depends_on 'valgrind' => :build
-  depends_on 'zlibpkg' # R
-  depends_on 'zstd' # R
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 
-    @krb5_static_libs = "#{CREW_LIB_PREFIX}/libkrb5support.a " + "#{CREW_LIB_PREFIX}/libgssapi_krb5.a " + "#{CREW_LIB_PREFIX}/libkrb5.a " + "#{CREW_LIB_PREFIX}/libk5crypto.a " + "#{CREW_LIB_PREFIX}/libcom_err.a "
+    @krb5_static_libs = '-l:libkrb5support.a -l:libgssapi_krb5.a -l:libkrb5.a -l:libk5crypto.a -l:libcom_err.a'
 
-    FileUtils.mkdir 'ssl'
-    FileUtils.ln_s "#{CREW_PREFIX}/include/openssl", 'ssl/include'
-    FileUtils.ln_s CREW_LIB_PREFIX, 'ssl/lib'
-    @sslpath = "#{`pwd`.chomp}/ssl"
+    FileUtils.mkdir_p 'build'
+    FileUtils.mkdir_p 'deproot/include'
+    FileUtils.mkdir_p 'deproot/lib'
+    Dir.chdir 'deproot' do
+      FileUtils.ln_s 'lib', 'lib64'
+    end
+    @deppath = "#{`pwd`.chomp}/deproot"
+    FileUtils.ln_s "#{CREW_PREFIX}/include/linux", "#{@deppath}/include/"
+    FileUtils.ln_s "#{CREW_PREFIX}/include/asm", "#{@deppath}/include/"
+    FileUtils.ln_s "#{CREW_PREFIX}/include/asm-generic", "#{@deppath}/include/"
+
+    @arch_ssp_cflags = ''
+    case ARCH
+    when 'i686'
+      @arch_ssp_cflags = '-fno-stack-protector'
+    end
+
+    @curldep_cmake_options = "CC=musl-gcc \
+          CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+          CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+          CPPFLAGS='-I#{@deppath}/include' \
+          LDFLAGS='-L#{@deppath}/lib' \
+          cmake \
+          -DCMAKE_INSTALL_PREFIX='#{@deppath}' \
+          -DCMAKE_LIBRARY_PATH='#{@deppath}/lib' \
+          -DCMAKE_C_COMPILER=`which musl-gcc` \
+          -DCMAKE_INCLUDE_DIRECTORIES_BEFORE=ON \
+          -DINCLUDE_DIRECTORIES=#{@deppath}/include \
+          -DCMAKE_C_FLAGS='-O3 -fPIC -pipe -flto -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+          -DCMAKE_EXE_LINKER_FLAGS='-flto' \
+          -DCMAKE_SHARED_LINKER_FLAGS='-flto' \
+          -DCMAKE_STATIC_LINKER_FLAGS='-flto' \
+          -DCMAKE_MODULE_LINKER_FLAGS='-flto' \
+          -DPROPERTY_INTERPROCEDURAL_OPTIMIZATION=TRUE \
+          -DCMAKE_BUILD_TYPE=Release"
+
+    @curldep_env_options = "CC=musl-gcc \
+        CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+        CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans#{@arch_ssp_cflags}' \
+        CPPFLAGS='-I#{@deppath}/include' \
+        LDFLAGS='-L#{@deppath}/lib'"
+
+    FileUtils.mkdir_p 'build/zlib'
+    Dir.chdir 'build/zlib' do
+      puts 'Building Zlib.'.lightgreen
+      system 'curl -Ls http://zlib.net/zlib-1.2.11.tar.gz | tar --strip-components=1 -zxf -'
+      system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
+        --static"
+      system 'make'
+      system 'make install'
+    end
+    FileUtils.mkdir_p 'build/zstd'
+    Dir.chdir 'build/zstd' do
+      puts 'Building Zstd.'.lightgreen
+      system 'curl -Ls https://github.com/facebook/zstd/archive/v1.5.0.tar.gz | tar --strip-components=1 -zxf -'
+      FileUtils.mkdir('build/cmake/builddir')
+      Dir.chdir('build/cmake/builddir') do
+        system "#{@curldep_cmake_options} \
+        -DZSTD_BUILD_STATIC=ON \
+        -DZSTD_BUILD_SHARED=OFF \
+        ../ -G Ninja"
+      end
+      system 'ninja -C build/cmake/builddir'
+      system 'ninja -C build/cmake/builddir install'
+    end
+    FileUtils.mkdir_p 'build/brotli'
+    Dir.chdir 'build/brotli' do
+      puts 'Building Brotli.'.lightgreen
+      system 'curl -Ls https://github.com/google/brotli/archive/v1.0.9.tar.gz | tar --strip-components=1 -zxf -'
+      FileUtils.mkdir('builddir')
+      Dir.chdir('builddir') do
+        system "#{@curldep_cmake_options} \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DWITH_STATIC_LIB=ON \
+        ../ -G Ninja"
+      end
+      system 'ninja -C builddir'
+      system 'ninja -C builddir install'
+      Dir.chdir "#{@deppath}/lib" do
+        @brotlilibs = %w[libbrotlidec libbrotlienc libbrotlicommon]
+        @brotlilibs.each do |lib|
+          FileUtils.ln_s "#{lib}-static.a", "#{lib}.a"
+        end
+      end
+    end
+    FileUtils.mkdir_p 'build/idn2'
+    Dir.chdir 'build/idn2' do
+      puts 'Building IDN2.'.lightgreen
+      system 'curl -Ls http://ftp.gnu.org/gnu/libidn/libidn2-2.3.1.tar.gz | tar --strip-components=1 -zxf -'
+      system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
+        --disable-shared"
+      system 'make'
+      system 'make install'
+    end
+    FileUtils.mkdir_p 'build/ssl'
+    case ARCH
+    when 'aarch64', 'armv7l'
+      @arch_c_flags = '-march=armv7-a -mfloat-abi=hard'
+      @arch_cxx_flags = '-march=armv7-a -mfloat-abi=hard'
+      @openssl_configure_target = 'linux-generic32'
+    when 'i686'
+      @arch_c_flags = ''
+      @arch_cxx_flags = ''
+      @openssl_configure_target = 'linux-x86'
+    when 'x86_64'
+      @arch_c_flags = ''
+      @arch_cxx_flags = ''
+      @openssl_configure_target = 'linux-x86_64'
+    end
+    Dir.chdir 'build/ssl' do
+      puts 'Building OpenSSL.'.lightgreen
+      system 'curl -Ls https://www.openssl.org/source/openssl-1.1.1k.tar.gz | tar --strip-components=1 -zxf -'
+      system "CC=musl-gcc \
+        CFLAGS='-flto -pipe -O3 -fPIC #{@arch_c_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+        CXXFLAGS='-flto -pipe -O3 -fPIC #{@arch_cxx_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+        CPPFLAGS='-I#{@deppath}/include' \
+        LDFLAGS='-L#{@deppath}/lib -flto' \
+        ./Configure \
+        --prefix=#{@deppath} \
+        no-tests zlib no-shared \
+        #{@openssl_configure_target}"
+      system 'make'
+      system 'make install_sw'
+    end
+
+    # libssh has problems linking with musl statically
+    # FileUtils.mkdir_p 'build/libssh'
+    # Dir.chdir 'build/libssh' do
+      # puts 'Building Libssh.'.lightgreen
+      # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | tar --strip-components=1 -Jxf -'
+      # FileUtils.mkdir('builddir')
+      # Dir.chdir('builddir') do
+      # system "#{@curldep_cmake_options} \
+      #-DWITH_EXAMPLES=OFF \
+      #-DBUILD_SHARED_LIBS=OFF \
+      #-DWITH_STATIC_LIB=ON \
+      #-DWITH_GSSAPI=OFF \
+      #-DHAVE_GLOB=0 \
+      # ../ -G Ninja"
+      # end
+      # system 'ninja -C builddir'
+      # system 'ninja -C builddir install'
+    # end
+    FileUtils.mkdir_p 'build/nghttp2'
+    Dir.chdir 'build/nghttp2' do
+      puts 'Building Nghttp2.'.lightgreen
+      system 'curl -Ls https://github.com/nghttp2/nghttp2/releases/download/v1.43.0/nghttp2-1.43.0.tar.gz | tar --strip-components=1 -zxf -'
+      system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
+        --enable-lib-only \
+        --disable-shared \
+        --enable-static"
+      system 'make'
+      system 'make install'
+    end
+
+    puts 'Done building static curl dependencies.'.lightgreen
+    system '[ -x configure ] || autoreconf -fvi'
     system 'filefix'
-    system "env CC=clang CXX=clang++ LD=ld.lld RANLIB=llvm-ranlib \
-      AR=llvm-ar \
-      CFLAGS='-flto -pipe -O3 -lz -fuse-ld=lld' \
-      CXXFLAGS='-flto -pipe -O3' \
-      LDFLAGS='-flto -static -Wl,--no-as-needed -ldl' LIBS='-l:libresolv.a #{@krb5_static_libs} -l:libzstd.a -l:libssh.a -lm -lbrotlicommon -lbrotlidec -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
-      ./configure #{CREW_OPTIONS} \
+    system "env CC=musl-gcc \
+      PKG_CONFIG='pkg-config --static' \
+      CPPFLAGS='-I#{@deppath}/include' \
+      CFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+      CXXFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
+      LDFLAGS='-L#{@deppath}/lib -flto -static -Wl,--no-as-needed -ldl' \
+      LIBS='#{@deppath}/lib/libssl.a #{@deppath}/lib/libcrypto.a #{@deppath}/lib/libbrotlicommon.a #{@deppath}/lib/libbrotlidec.a #{@deppath}/lib/libidn2.a #{@deppath}/lib/libnghttp2.a  #{@deppath}/lib/libz.a #{@deppath}/lib/libzstd.a -L#{@deppath}/lib' \
+      CURL_LIBRARY_PATH=#{@deppath}/lib \
+      ./configure --prefix=#{@deppath} \
+      --disable-imap \
       --disable-ldap \
+      --disable-ldaps \
       --disable-libcurl-option \
       --disable-maintainer-mode \
+      --disable-rtsp \
       --disable-shared \
       --enable-ipv6 \
       --enable-static \
@@ -67,44 +216,24 @@ class Curl < Package
       --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
       --with-ca-fallback \
       --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
-      --with-libssh \
-      --with-openssl \
-      --without-librtmp"
+      --with-libidn2=#{@deppath} \
+      --with-nghttp2=#{@deppath} \
+      --with-openssl=#{@deppath} \
+      --with-brotli=#{@deppath} \
+      --without-librtmp \
+      --with-openssl=#{@deppath} \
+      --with-zlib=#{@deppath}"
     system 'make curl_LDFLAGS=-all-static'
     FileUtils.cp 'src/curl', 'curl.static'
-    system "env  CFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
-       CXXFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
-       LDFLAGS='-flto=auto' LIBS='#{@krb5_static_libs} -lm -lbrotlicommon -lbrotlidec -lzstd -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
-       ./configure #{CREW_OPTIONS} \
-      --disable-maintainer-mode \
-      --enable-ares \
-      --enable-ipv6 \
-      --enable-ldap \
-      --enable-unix-sockets \
-      --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
-      --with-ca-fallback \
-      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
-      --with-lber-lib=lber \
-      --with-ldap-lib=ldap \
-      --with-libmetalink \
-      --with-libssh \
-      --with-openssl=#{@sslpath} \
-      --without-gnutls \
-      --without-librtmp"
-    system 'make'
   end
 
-   def self.check
-     # Python package impacket needed for testing.
-     # 1094 tests out of 1097 reported OK: 99% on 10/25/2020
-     # The 3 tests that failed were FTP, SMB and GOPHER.
-     system 'pip3 install impacket'
-     system 'make check || true'
-     system 'pip3 uninstall -y impacket'
-   end
+  def self.check
+    system 'src/curl -Lf https://github.com/skycocker/chromebrew/raw/master/install.sh -o /tmp/install.sh'
+    FileUtils.rm '/tmp/install.sh'
+  end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.install 'curl.static', "#{CREW_DEST_PREFIX}/bin/curl", mode: 0o755
   end
 end

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -24,6 +24,7 @@ class Curl < Package
   })
 
   depends_on 'ca_certificates' => :build
+  depends_on 'hashpipe' => :build
   depends_on 'libcurl' # L (This is only here to make sure upgrades of curl pull in libcurl.)
   depends_on 'libunbound' => :build
   depends_on 'musl' => :build
@@ -33,8 +34,6 @@ class Curl < Package
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
-
-    @krb5_static_libs = '-l:libkrb5support.a -l:libgssapi_krb5.a -l:libkrb5.a -l:libk5crypto.a -l:libcom_err.a'
 
     FileUtils.mkdir_p 'build'
     FileUtils.mkdir_p 'deproot/include'
@@ -80,8 +79,10 @@ class Curl < Package
 
     FileUtils.mkdir_p 'build/zlib'
     Dir.chdir 'build/zlib' do
-      puts 'Building Zlib.'.lightgreen
-      system 'curl -Ls http://zlib.net/zlib-1.2.11.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building Zlib.'.yellow
+      system 'curl -Ls http://zlib.net/zlib-1.2.11.tar.gz | \
+        hashpipe sha256 c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1 | \
+        tar --strip-components=1 -zxf -'
       system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
         --static"
       system 'make'
@@ -89,8 +90,10 @@ class Curl < Package
     end
     FileUtils.mkdir_p 'build/zstd'
     Dir.chdir 'build/zstd' do
-      puts 'Building Zstd.'.lightgreen
-      system 'curl -Ls https://github.com/facebook/zstd/archive/v1.5.0.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building Zstd.'.yellow
+      system 'curl -Ls https://github.com/facebook/zstd/archive/v1.5.0.tar.gz | \
+        hashpipe sha256 0d9ade222c64e912d6957b11c923e214e2e010a18f39bec102f572e693ba2867 | \
+        tar --strip-components=1 -zxf -'
       FileUtils.mkdir('build/cmake/builddir')
       Dir.chdir('build/cmake/builddir') do
         system "#{@curldep_cmake_options} \
@@ -103,8 +106,10 @@ class Curl < Package
     end
     FileUtils.mkdir_p 'build/brotli'
     Dir.chdir 'build/brotli' do
-      puts 'Building Brotli.'.lightgreen
-      system 'curl -Ls https://github.com/google/brotli/archive/v1.0.9.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building Brotli.'.yellow
+      system 'curl -Ls https://github.com/google/brotli/archive/v1.0.9.tar.gz | \
+        hashpipe sha256 f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46 | \
+        tar --strip-components=1 -zxf -'
       FileUtils.mkdir('builddir')
       Dir.chdir('builddir') do
         system "#{@curldep_cmake_options} \
@@ -123,8 +128,10 @@ class Curl < Package
     end
     FileUtils.mkdir_p 'build/idn2'
     Dir.chdir 'build/idn2' do
-      puts 'Building IDN2.'.lightgreen
-      system 'curl -Ls http://ftp.gnu.org/gnu/libidn/libidn2-2.3.1.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building IDN2.'.yellow
+      system 'curl -Ls http://ftp.gnu.org/gnu/libidn/libidn2-2.3.1.tar.gz | \
+        hashipe sha256 8af684943836b8b53965d5f5b6714ef13c26c91eaa36ce7d242e3d21f5d40f2d | \
+        tar --strip-components=1 -zxf -'
       system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
         --disable-shared"
       system 'make'
@@ -146,8 +153,10 @@ class Curl < Package
       @openssl_configure_target = 'linux-x86_64'
     end
     Dir.chdir 'build/ssl' do
-      puts 'Building OpenSSL.'.lightgreen
-      system 'curl -Ls https://www.openssl.org/source/openssl-1.1.1k.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building OpenSSL.'.yellow
+      system 'curl -Ls https://www.openssl.org/source/openssl-1.1.1k.tar.gz | \
+        hashpipe sha256 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5 | \
+        tar --strip-components=1 -zxf -'
       system "CC=musl-gcc \
         CFLAGS='-flto -pipe -O3 -fPIC #{@arch_c_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
         CXXFLAGS='-flto -pipe -O3 -fPIC #{@arch_cxx_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
@@ -164,8 +173,10 @@ class Curl < Package
     # libssh has problems linking with musl statically
     # FileUtils.mkdir_p 'build/libssh'
     # Dir.chdir 'build/libssh' do
-    # puts 'Building Libssh.'.lightgreen
-    # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | tar --strip-components=1 -Jxf -'
+    # puts 'Building Libssh.'.yellow
+    # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | \
+    #   hashpipe sha256 acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718 | \
+    #   tar --strip-components=1 -Jxf -'
     # FileUtils.mkdir('builddir')
     # Dir.chdir('builddir') do
     # system "#{@curldep_cmake_options} \
@@ -181,8 +192,10 @@ class Curl < Package
     # end
     FileUtils.mkdir_p 'build/nghttp2'
     Dir.chdir 'build/nghttp2' do
-      puts 'Building Nghttp2.'.lightgreen
-      system 'curl -Ls https://github.com/nghttp2/nghttp2/releases/download/v1.43.0/nghttp2-1.43.0.tar.gz | tar --strip-components=1 -zxf -'
+      puts 'Building Nghttp2.'.yellow
+      system 'curl -Ls https://github.com/nghttp2/nghttp2/releases/download/v1.43.0/nghttp2-1.43.0.tar.gz | \
+        hashpipe sha256 45cc3ed91966551f92b31958ceca9b3a9f23ce4faf5cbedb78aa3327cd4e5907 | \
+        tar --strip-components=1 -zxf -'
       system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
         --enable-lib-only \
         --disable-shared \

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -17,10 +17,10 @@ class Curl < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-git_x86_64/curl-7.77.0-git-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '268771c547ef80761b937aedafe786ca701524e20b4737263aee9791514189d0',
-     armv7l: '268771c547ef80761b937aedafe786ca701524e20b4737263aee9791514189d0',
-       i686: '45796384ef70732ab7d4df71f09d2860e22bee776f86f7ff60c9863ff5bc28c2',
-     x86_64: 'ee99c0558b9dc9e64e4a2619706224daa3e7a0d4b100af135ac5b0a6a3b68ab4'
+    aarch64: '45597919122d848c3b6b91358b67ade0eaa9fb9bfb887f97c6bdeee55fcc84c2',
+     armv7l: '45597919122d848c3b6b91358b67ade0eaa9fb9bfb887f97c6bdeee55fcc84c2',
+       i686: '02436eb8f258cd050cb7c3836801a16cb3c2f24a011ece6a4f388715b2d3c4a7',
+     x86_64: '7399d70a022d09a421b461454b20528d5a8d4fd1976a8364b32190887e8a5780'
   })
 
   depends_on 'ca_certificates' => :build
@@ -57,10 +57,10 @@ class Curl < Package
           CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
           CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
           CPPFLAGS='-I#{@deppath}/include' \
-          LDFLAGS='-L#{@deppath}/lib' \
+          LDFLAGS='-L#{@deppath}/#{ARCH_LIB}' \
           cmake \
           -DCMAKE_INSTALL_PREFIX='#{@deppath}' \
-          -DCMAKE_LIBRARY_PATH='#{@deppath}/lib' \
+          -DCMAKE_LIBRARY_PATH='#{@deppath}/#{ARCH_LIB}' \
           -DCMAKE_C_COMPILER=`which musl-gcc` \
           -DCMAKE_INCLUDE_DIRECTORIES_BEFORE=ON \
           -DINCLUDE_DIRECTORIES=#{@deppath}/include \
@@ -76,7 +76,7 @@ class Curl < Package
         CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
         CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans#{@arch_ssp_cflags}' \
         CPPFLAGS='-I#{@deppath}/include' \
-        LDFLAGS='-L#{@deppath}/lib'"
+        LDFLAGS='-L#{@deppath}/#{ARCH_LIB}'"
 
     FileUtils.mkdir_p 'build/zlib'
     Dir.chdir 'build/zlib' do
@@ -114,7 +114,7 @@ class Curl < Package
       end
       system 'ninja -C builddir'
       system 'ninja -C builddir install'
-      Dir.chdir "#{@deppath}/lib" do
+      Dir.chdir "#{@deppath}/#{ARCH_LIB}" do
         @brotlilibs = %w[libbrotlidec libbrotlienc libbrotlicommon]
         @brotlilibs.each do |lib|
           FileUtils.ln_s "#{lib}-static.a", "#{lib}.a"
@@ -152,7 +152,7 @@ class Curl < Package
         CFLAGS='-flto -pipe -O3 -fPIC #{@arch_c_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
         CXXFLAGS='-flto -pipe -O3 -fPIC #{@arch_cxx_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
         CPPFLAGS='-I#{@deppath}/include' \
-        LDFLAGS='-L#{@deppath}/lib -flto' \
+        LDFLAGS='-L#{@deppath}/#{ARCH_LIB} -flto' \
         ./Configure \
         --prefix=#{@deppath} \
         no-tests zlib no-shared \
@@ -164,20 +164,20 @@ class Curl < Package
     # libssh has problems linking with musl statically
     # FileUtils.mkdir_p 'build/libssh'
     # Dir.chdir 'build/libssh' do
-      # puts 'Building Libssh.'.lightgreen
-      # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | tar --strip-components=1 -Jxf -'
-      # FileUtils.mkdir('builddir')
-      # Dir.chdir('builddir') do
-      # system "#{@curldep_cmake_options} \
-      #-DWITH_EXAMPLES=OFF \
-      #-DBUILD_SHARED_LIBS=OFF \
-      #-DWITH_STATIC_LIB=ON \
-      #-DWITH_GSSAPI=OFF \
-      #-DHAVE_GLOB=0 \
-      # ../ -G Ninja"
-      # end
-      # system 'ninja -C builddir'
-      # system 'ninja -C builddir install'
+    # puts 'Building Libssh.'.lightgreen
+    # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | tar --strip-components=1 -Jxf -'
+    # FileUtils.mkdir('builddir')
+    # Dir.chdir('builddir') do
+    # system "#{@curldep_cmake_options} \
+    #-DWITH_EXAMPLES=OFF \
+    #-DBUILD_SHARED_LIBS=OFF \
+    #-DWITH_STATIC_LIB=ON \
+    #-DWITH_GSSAPI=OFF \
+    #-DHAVE_GLOB=0 \
+    # ../ -G Ninja"
+    # end
+    # system 'ninja -C builddir'
+    # system 'ninja -C builddir install'
     # end
     FileUtils.mkdir_p 'build/nghttp2'
     Dir.chdir 'build/nghttp2' do
@@ -199,9 +199,9 @@ class Curl < Package
       CPPFLAGS='-I#{@deppath}/include' \
       CFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
       CXXFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-      LDFLAGS='-L#{@deppath}/lib -flto -static -Wl,--no-as-needed -ldl' \
-      LIBS='#{@deppath}/lib/libssl.a #{@deppath}/lib/libcrypto.a #{@deppath}/lib/libbrotlicommon.a #{@deppath}/lib/libbrotlidec.a #{@deppath}/lib/libidn2.a #{@deppath}/lib/libnghttp2.a  #{@deppath}/lib/libz.a #{@deppath}/lib/libzstd.a -L#{@deppath}/lib' \
-      CURL_LIBRARY_PATH=#{@deppath}/lib \
+      LDFLAGS='-L#{@deppath}/#{ARCH_LIB} -flto -static -Wl,--no-as-needed -ldl' \
+      LIBS='#{@deppath}/#{ARCH_LIB}/libssl.a #{@deppath}/#{ARCH_LIB}/libcrypto.a #{@deppath}/#{ARCH_LIB}/libbrotlicommon.a #{@deppath}/#{ARCH_LIB}/libbrotlidec.a #{@deppath}/#{ARCH_LIB}/libidn2.a #{@deppath}/#{ARCH_LIB}/libnghttp2.a  #{@deppath}/#{ARCH_LIB}/libz.a #{@deppath}/#{ARCH_LIB}/libzstd.a -L#{@deppath}/#{ARCH_LIB}' \
+      CURL_LIBRARY_PATH=#{@deppath}/#{ARCH_LIB} \
       ./configure --prefix=#{@deppath} \
       --disable-imap \
       --disable-ldap \

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,25 +3,27 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  @_ver = '2.31.1'
-  version "#{@_ver}-1"
+  @_ver = '2.32.0'
+  version @_ver
   license 'GPL-2'
   compatibility 'all'
   source_url "https://github.com/git/git/archive/v#{@_ver}.tar.gz"
-  source_sha256 'b1c0e95e9861b5d1b9ad3d8deaa2d8c7f02304ffc1b5e8869dd9fb98f9a0d436'
+  source_sha256 '004697482b6e3b0ae9147580c32efd35869426227f1526f8eafa7950c31def94'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_armv7l/git-2.31.1-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_armv7l/git-2.31.1-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_i686/git-2.31.1-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.31.1-1_x86_64/git-2.31.1-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.32.0_armv7l/git-2.32.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.32.0_armv7l/git-2.32.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.32.0_i686/git-2.32.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.32.0_x86_64/git-2.32.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '364b30aafa845d7950b93fd67e72fcc752008dee08ff571155ffb4239eaba2ac',
-     armv7l: '364b30aafa845d7950b93fd67e72fcc752008dee08ff571155ffb4239eaba2ac',
-       i686: 'b80054bb43df65051d37c0c8e7f83c46f97d084027d7997871be91a7731a642c',
-     x86_64: 'c0bf7de6181f29f73abc75793410441aabcf2b71c3bd7a4321179a59859a47e6'
+    aarch64: 'd72074c725dd003aec3eaacc0523c069f6f1c8462291eba04ad625d1d0b37092',
+     armv7l: 'd72074c725dd003aec3eaacc0523c069f6f1c8462291eba04ad625d1d0b37092',
+       i686: '63a71a159ba30241c984b8bbc918c0e73f10b6a890ecd6e266b67b3e14b4aed5',
+     x86_64: '8d08dd84e5f16a11671bd387d2b5ec33ec2474dcf1d948c5d15474fe6afc7c2c'
   })
+
+  depends_on 'libcurl' => :build
 
   def self.build
     abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
@@ -29,7 +31,7 @@ class Git < Package
     @curl_static_libs = `curl-config --static-libs`.chomp.gsub('=auto', '')
     @sasl2_static_libs = "#{CREW_LIB_PREFIX}/libdb.a #{CREW_LIB_PREFIX}/libsasl2.a " + `pkg-config --libs --static libsasl2`.chomp
     @krb5_static_libs = "#{CREW_LIB_PREFIX}/libkrb5support.a #{CREW_LIB_PREFIX}/libgssapi_krb5.a #{CREW_LIB_PREFIX}/libkrb5.a #{CREW_LIB_PREFIX}/libk5crypto.a #{CREW_LIB_PREFIX}/libcom_err.a"
-    @ldflags = "-flto -static -L#{CREW_LIB_PREFIX} #{@krb5_static_libs} #{@sasl2_static_libs} -lgmp #{@curl_static_libs} -lunistring -Wl,--no-as-needed -ldl"
+    @ldflags = "-flto -static -L#{CREW_LIB_PREFIX} #{CREW_LIB_PREFIX}/libssl.a #{CREW_LIB_PREFIX}/libcrypto.a #{@krb5_static_libs} #{CREW_LIB_PREFIX}/libcurl.a #{@sasl2_static_libs} -lgmp #{@curl_static_libs} -lunistring -Wl,--no-as-needed -ldl"
 
     FileUtils.mkdir 'curl'
     FileUtils.ln_s "#{CREW_PREFIX}/include/curl", 'curl/include'

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -1,0 +1,79 @@
+require 'package'
+
+class Libcurl < Package
+  description 'Command line tool and library for transferring data with URLs.'
+  homepage 'https://curl.se/'
+  @_ver = '7.77.0'
+  version @_ver
+  license 'curl'
+  compatibility 'all'
+  source_url 'https://github.com/curl/curl.git'
+  git_hashtag 'curl-7_77_0'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.77.0_armv7l/libcurl-7.77.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.77.0_armv7l/libcurl-7.77.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.77.0_i686/libcurl-7.77.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.77.0_x86_64/libcurl-7.77.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '0acfb983b58fbffc1c94480b5b21b22013f8d853a649f3acadb1d6c41e34616c',
+     armv7l: '0acfb983b58fbffc1c94480b5b21b22013f8d853a649f3acadb1d6c41e34616c',
+       i686: '6aa358d2b91b50f758bd9908492d8b200cd3579da37056169f8edb4254d3cdf4',
+     x86_64: '6f94ed40fb2853d5459e6b9513483f3794630ec6e61f64951311c57a4664b85a'
+  })
+
+  depends_on 'brotli' => :build
+  depends_on 'ca_certificates' => :build
+  depends_on 'c_ares' # R
+  depends_on 'libcyrussasl' # R
+  depends_on 'libidn2' # R
+  depends_on 'libnghttp2' # R
+  depends_on 'libpsl' # R
+  depends_on 'libssh' # R
+  depends_on 'libunbound' # ?
+  depends_on 'openldap' # R
+  depends_on 'openssl' # R
+  depends_on 'py3_pip' => :build
+  depends_on 'rust' => :build
+  depends_on 'valgrind' => :build
+  depends_on 'zlibpkg' # R
+  depends_on 'zstd' # R
+
+  def self.build
+    # Without these downstream programs which want to statically link
+    # libcurl have issues.
+    @krb5_static_libs = '-l:libkrb5support.a -l:libgssapi_krb5.a -l:libkrb5.a -l:libk5crypto.a -l:libcom_err.a'
+
+    @libssh = '--with-libssh'
+    case ARCH
+    when 'i686'
+      @libssh = '--without-libssh'
+    end
+
+    system '[ -x configure ] || autoreconf -fvi'
+    system "env  CFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+       CXXFLAGS='-flto=auto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans' \
+       LDFLAGS='-flto=auto' LIBS='#{@krb5_static_libs} -lm -lbrotlicommon -lbrotlidec -lzstd -lz -lssl -lcrypto -lsasl2 -lxml2 -lpthread' \
+       ./configure #{CREW_OPTIONS} \
+      --disable-maintainer-mode \
+      --enable-ares \
+      --enable-ipv6 \
+      --enable-ldap \
+      --enable-unix-sockets \
+      --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
+      --with-ca-fallback \
+      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+      --with-libmetalink \
+      #{@libssh} \
+      --with-openssl \
+      --without-gnutls \
+      --without-librtmp"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.rm "#{CREW_DEST_PREFIX}/bin/curl"
+  end
+end


### PR DESCRIPTION
- Dramatically lowers the size of the curl package for install.
- Also used upx to further shrink the binary.
- Also updated git and built with this libcurl.
- Git is now shrunk with upx too, reducing the file size to ~ 300Mb when extracted.)

(These are the same versions as in https://github.com/skycocker/chromebrew/pull/5837 )

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l