### PR TITLE
Update openldap from 2.4.57 to 2.5.5

### DIFF
--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -3,27 +3,31 @@ require 'package'
 class Openldap < Package
   description 'OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.'
   homepage 'https://www.openldap.org/'
-  @_ver = '2.4.57'
+  @_ver = '2.5.5'
   version @_ver
   license 'OpenLDAP and GPL-2'
   compatibility 'all'
   source_url "https://openldap.org/software/download/OpenLDAP/openldap-release/openldap-#{@_ver}.tgz"
-  source_sha256 'c7ba47e1e6ecb5b436f3d43281df57abeffa99262141aec822628bc220f6b45a'
+  source_sha256 '74ecefda2afc0e054d2c7dc29166be6587fa9de7a4087a80183bc9c719dbf6b3'
 
   binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.4.57_armv7l/openldap-2.4.57-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.4.57_armv7l/openldap-2.4.57-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.4.57_i686/openldap-2.4.57-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.4.57_x86_64/openldap-2.4.57-chromeos-x86_64.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5_armv7l/openldap-2.5.5-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5_armv7l/openldap-2.5.5-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5_i686/openldap-2.5.5-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5_x86_64/openldap-2.5.5-chromeos-x86_64.tpxz',
   })
   binary_sha256 ({
-     aarch64: 'eafc72703f61b96747a8d37e6fcdac7d5d400832da9f9205936188dda6e57a46',
-      armv7l: 'eafc72703f61b96747a8d37e6fcdac7d5d400832da9f9205936188dda6e57a46',
-        i686: 'e981259b1c30688d15c3b8ca83ea87fe83bd41f1923322b274df04e6e10611f0',
-      x86_64: 'e0ca5de88bd9808f8e30beb0861bec2da9c3686b538f4563603b19fbd50b6278',
+    aarch64: '790797260a558e03e4535274f5fa3166c603ef758e51f57d171bcf8580de8e17',
+     armv7l: '790797260a558e03e4535274f5fa3166c603ef758e51f57d171bcf8580de8e17',
+       i686: 'f02b2011b521f10fc363c114e2302812c34f6c55a0cb476dec18eb323f6d8826',
+     x86_64: '04f71709113fd814c9d2c36ec23fdb329c8d2325bc013f13e8044a36b785e289',
   })
 
   depends_on 'libcyrussasl'
+
+  def self.patch
+    system 'filefix'
+  end
 
   def self.build
     system "env #{CREW_ENV_OPTIONS} \


### PR DESCRIPTION
Fixes #5840.  Tested on all architectures.