### PR TITLE
remove libcurl dep from curl

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -25,7 +25,6 @@ class Curl < Package
 
   depends_on 'ca_certificates' => :build
   depends_on 'hashpipe' => :build
-  depends_on 'libcurl' # L (This is only here to make sure upgrades of curl pull in libcurl.)
   depends_on 'libunbound' => :build
   depends_on 'musl' => :build
   depends_on 'py3_pip' => :build


### PR DESCRIPTION
- no longer require libcurl for curl

Works properly:
- [x] x86_64
