### PR TITLE
jq static build

### DIFF
--- a/packages/jq.rb
+++ b/packages/jq.rb
@@ -3,33 +3,39 @@ require 'package'
 class Jq < Package
   description 'jq is a lightweight and flexible command-line JSON processor.'
   homepage 'https://stedolan.github.io/jq/'
-  version '1.6-1'
+  @_ver = '1.6'
+  version "#{@_ver}-2"
   license 'MIT and CC-BY-3.0'
   compatibility 'all'
-  source_url 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz'
-  source_sha256 '5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72'
+  source_url 'https://github.com/stedolan/jq.git'
+  git_hashtag "jq-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-1_armv7l/jq-1.6-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-1_armv7l/jq-1.6-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-1_i686/jq-1.6-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-1_x86_64/jq-1.6-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-2_armv7l/jq-1.6-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-2_armv7l/jq-1.6-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-2_i686/jq-1.6-2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jq/1.6-2_x86_64/jq-1.6-2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '6540447d8276d2485a2fe2d6f2a9837ab5fcf11609d55f64756af205e88e74b7',
-     armv7l: '6540447d8276d2485a2fe2d6f2a9837ab5fcf11609d55f64756af205e88e74b7',
-       i686: '68b25442f0f72f363365d3f436892a012aabadb1cc46ce91a0b10ed83468600c',
-     x86_64: 'ca1c96623283110b69acedbde1e8cab9f01525e4a11f33249687f23f8e6b1959'
+    aarch64: '3d7e313a1bdaa9c2d0ab3ede26b93a6932b3a0f21bfebc282f581a8804451767',
+     armv7l: '3d7e313a1bdaa9c2d0ab3ede26b93a6932b3a0f21bfebc282f581a8804451767',
+       i686: 'f11443b8744ce0c38fe9b8430337fd9ba3412fddeb8b343764dc50825c42d806',
+     x86_64: 'c1af7fdb7fee27472773863ca97db802a39363b7a0b9a4866ed93d8fc6cbb528'
   })
 
-  depends_on 'oniguruma'
-
   def self.build
+    system '[ -x configure ] || autoreconf -fvi'
     system 'filefix'
-    system "env #{CREW_ENV_OPTIONS}  \
-      ./configure #{CREW_OPTIONS} \
+    system "CC=clang LD=ld.lld  CFLAGS='-flto -pipe -O3 -fuse-ld=lld -static' \
+      CXXFLAGS='-flto -pipe -O3 -static' \
+      LDFLAGS='-flto -static' \
+      ./configure \
+      --prefix=#{CREW_PREFIX} \
+      --libdir=#{CREW_LIB_PREFIX} \
+      --mandir=#{CREW_MAN_PREFIX} \
+      --enable-all-static \
       --disable-maintainer-mode \
-      --disable-docs" # there's no support for manpages
+      --disable-docs " # there's no support for manpages
     system 'make'
   end
 


### PR DESCRIPTION
- built statically
- no longer needs the oniguruma dependency.

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l