### PR TITLE
fix libunbound for i686

### DIFF
--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -23,6 +23,8 @@ class Libunbound < Package
      x86_64: 'fe16753a6cb9a8c69cf759201f39dec701d29b9de75954c77a2225e32e7a3edc'
   })
 
+  depends_on 'openssl' # On i686 openssl needs to be installed before libunbound.
+
   def self.patch
     system 'filefix'
   end


### PR DESCRIPTION
- `libunbound` requires a newer version of `OpenSSL` than available on i686, so add explicit `OpenSSL` dependency to make sure it gets installed first.

- [x] x86_64
- [x] i686
- [x] armv7l