### PR TITLE
crew: Fix error message when executable scripts are found during build archiving

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -961,19 +961,23 @@ def shrink_dir(dir)
         puts "Using symlinks tool to make absolute symlinks relative"
         system 'symlinks -cr .' if File.exist?("#{CREW_PREFIX}/bin/symlinks")
       end
-     # Issues with non-x86_64 in compressing libraries, so just compress
-     # non-libraries. Also note that one needs to use "upx -d" on a 
-     # compressed file to use ldd.
-     # sommelier also isn't happy when sommelier and xwayland are compressed
-     # so don't compress those packages.
+      # Issues with non-x86_64 in compressing libraries, so just compress
+      # non-libraries. Also note that one needs to use "upx -d" on a
+      # compressed file to use ldd.
+      # sommelier also isn't happy when sommelier and xwayland are compressed
+      # so don't compress those packages.
       if File.exist?("#{CREW_PREFIX}/bin/upx")
-        puts "Using upx to shrink binaries."
-        # Logic here is to find executable files, check if they are ELF files,
-        # compress a file while making a backup, expand the file with 
-        # upx, and if the expansion doesn't error then delete the backup.
-        system "find . -executable -type f ! \\( -name \"*.so*\" -o -name \"*.a\" \\)| xargs file | \
-          grep ELF | cut -d: -f1 | xargs -I {} \
-          bash -c 'upx --best -k --overlay=skip {} && \( upx -t {} && rm {}.~ || mv {}.~ {}\)'"
+        # Logic here is to find executable binaries, compress after making
+        # a backup, then expand the compressed file with upx. If the
+        # expansion doesn't error out then it is ok to delete the backup.
+        @execfiles = %x[find . -executable -type f ! \\( -name \"*.so*\" -o -name \"*.a\" \\) -exec sh -c \"file -i \'{}\' | grep -q \'executable; charset=binary\'\" \\; -print].chomp
+        unless @execfiles.empty? or @execfiles.nil?
+          puts "Using upx to shrink binaries."
+          @execfiles.each_line do |execfile|
+            system "upx --best -k --overlay=skip #{execfile} && \
+            \( upx -t #{execfile} && rm #{execfile}.~ || mv #{execfile}.~ #{execfile}\)"
+          end
+        end
       end
     end
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.11.1'
+CREW_VERSION = '1.11.2'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- fixes error messages when `find` discovers executable scripts, which we do not want to pass to `upx`.
- If no executable binaries are found, just don't bother showing the `upx` message.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686