### PR TITLE
Add libcom_err package

### DIFF
--- a/packages/codium.rb
+++ b/packages/codium.rb
@@ -27,6 +27,7 @@ class Codium < Package
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
   depends_on 'gtk3'
+  depends_on 'libcom_err'
   depends_on 'libdrm'
   depends_on 'libx11'
   depends_on 'libxcb'

--- a/packages/libcom_err.rb
+++ b/packages/libcom_err.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Libcom_err < Package
+  description 'Common error description library'
+  homepage 'http://e2fsprogs.sourceforge.net/'
+  version '1.0'
+  license 'GPL-2'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  depends_on 'e2fsprogs'
+
+  def self.install
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
+    Dir.chdir CREW_DEST_LIB_PREFIX do
+      FileUtils.symlink "#{CREW_LIB_PREFIX}/libcom_err.so.2.1", 'libcom_err.so.3'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #5877.  Adds libcom_err.so.3 that is missing from krb5.  Tested codium on aarch64, armv7l and x86_64.