### PR TITLE
Some Gnome 40.2 updates

### DIFF
--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -6,23 +6,23 @@ require 'package'
 class Evince < Package
   description 'Document viewer PDF, PostScript, XPS, djvu, dvi, tiff, cbr, cbz, cb7, cbt'
   homepage 'https://wiki.gnome.org/Apps/Evince'
-  version '40.1'
+  version '40.2'
   license 'GPL'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/evince.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_armv7l/evince-40.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_armv7l/evince-40.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_i686/evince-40.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.1_x86_64/evince-40.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.2_armv7l/evince-40.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.2_armv7l/evince-40.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.2_i686/evince-40.2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/40.2_x86_64/evince-40.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '62b72ae5cb06f66f219254ca9538c1cb28f91d869689f70f1551d89d5acbd336',
-     armv7l: '62b72ae5cb06f66f219254ca9538c1cb28f91d869689f70f1551d89d5acbd336',
-       i686: '35fddcde12a82b65876ef8ddc6f4dee8b42f74b1c746a5f51a84e2b686bcce8b',
-     x86_64: '66c5249315ae4e4f348ea5c2d732323623f8eb834ffc7cd353a53de966a7672a'
+    aarch64: '74251f49f4fe22b9a19e4cbd16770d270eb13147df23265e62bb960ec71634e0',
+     armv7l: '74251f49f4fe22b9a19e4cbd16770d270eb13147df23265e62bb960ec71634e0',
+       i686: '30051f33d1c73422b28298ccb9f7a84cc6dbb30a742cc01aef63d7054b090b04',
+     x86_64: '49e164c40f852960136be7660fc38be92d6517d45c073d2b076dcdbf643cffd6'
   })
 
   depends_on 'atk' # R

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.68.2'
+  @_ver = '2.68.3'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
@@ -12,16 +12,16 @@ class Glib < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.2_armv7l/glib-2.68.2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.2_armv7l/glib-2.68.2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.2_i686/glib-2.68.2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.2_x86_64/glib-2.68.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.3_armv7l/glib-2.68.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.3_armv7l/glib-2.68.3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.3_i686/glib-2.68.3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.68.3_x86_64/glib-2.68.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '51cca2bdab9b0d8725010d9627e1af90553bd80627c7c0ca7822eb1d48977d5e',
-     armv7l: '51cca2bdab9b0d8725010d9627e1af90553bd80627c7c0ca7822eb1d48977d5e',
-       i686: '9edb7d402f59d21ed282bfd68b45c3bfe896a6edd0c6d5fed6b284e42532f8d3',
-     x86_64: '3f6a6728ad5b7e8b048665e2258ea22cf9ee5fa5c60c7e57d8172ada16486932'
+    aarch64: '640d0eecf23f8772e38ac490b9c491eb59899d9a1dc50b346e499877363fc629',
+     armv7l: '640d0eecf23f8772e38ac490b9c491eb59899d9a1dc50b346e499877363fc629',
+       i686: '95880703d43a11a6df0d22b7ad1f94272690f1ada158d69506cf9629ac929877',
+     x86_64: 'b0e7d349295d9ba8b01347f0198ab327345f5b8e2c8ad3fab6b6ee584fe03971'
   })
 
   depends_on 'pygments' => :build

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -6,7 +6,7 @@ require 'package'
 class Nautilus < Package
   description 'Default file manager for GNOME'
   homepage 'https://wiki.gnome.org/Apps/Files'
-  @_ver = '40.1'
+  @_ver = '40.2'
   version @_ver
   license 'GPLv3'
   compatibility 'all'
@@ -14,16 +14,16 @@ class Nautilus < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.1_armv7l/nautilus-40.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.1_armv7l/nautilus-40.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.1_i686/nautilus-40.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.1_x86_64/nautilus-40.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.2_armv7l/nautilus-40.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.2_armv7l/nautilus-40.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.2_i686/nautilus-40.2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nautilus/40.2_x86_64/nautilus-40.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '5be1b22e7f4c93ea940558f5cfcb7e33c7abbf86d3c2b8cc3ac039c1ca946215',
-     armv7l: '5be1b22e7f4c93ea940558f5cfcb7e33c7abbf86d3c2b8cc3ac039c1ca946215',
-       i686: '66f98e53dd52bd1670d229845b969964fa1be2bbce2419db006defa4919dc5b4',
-     x86_64: '2df5a25aa14395965a8891b3917044537b7faf89dd45b49b46eab331e9379e0f'
+    aarch64: '8417f762f5857edc7fe0dcfc64fac7a488ec6668f4ed19cf7a4f09b4c7821bbf',
+     armv7l: '8417f762f5857edc7fe0dcfc64fac7a488ec6668f4ed19cf7a4f09b4c7821bbf',
+       i686: '3bc83cc9f2b407584434365c9ac8f95a1b0b691d6cb6f44bc4fadda5a1283ce2',
+     x86_64: 'ddd67ddee30dab06fd42c6b74bbf50a6cee0ab43071a363f283ff4d66b848ba0'
   })
 
   depends_on 'appstream_glib' => :build


### PR DESCRIPTION
- evince, glib, nautilus

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686