### PR TITLE
Meson -> 0.58.1, cmake -> 3.20.4, remove -pipe from meson options

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.11.2'
+CREW_VERSION = '1.11.3'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines
@@ -87,8 +87,8 @@ CREW_LDFLAGS = '-flto'
 
 CREW_ENV_OPTIONS = "CFLAGS='#{CREW_COMMON_FLAGS}' CXXFLAGS='#{CREW_COMMON_FLAGS}' FCFLAGS='#{CREW_COMMON_FLAGS}' FFLAGS='#{CREW_COMMON_FLAGS}' LDFLAGS='#{CREW_LDFLAGS}'"
 CREW_OPTIONS = "--prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --mandir=#{CREW_MAN_PREFIX} --build=#{CREW_BUILD} --host=#{CREW_TGT} --target=#{CREW_TGT} --program-prefix='' --program-suffix=''"
-CREW_MESON_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=true -Dstrip=true -Db_pie=true -Dcpp_args='-Os -pipe' -Dc_args='-Os -pipe'"
-CREW_MESON_FNO_LTO_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=false -Dstrip=true -Db_pie=true -Dcpp_args='-Os -pipe' -Dc_args='-Os -pipe'"
+CREW_MESON_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=true -Dstrip=true -Db_pie=true -Dcpp_args='-Os' -Dc_args='-Os'"
+CREW_MESON_FNO_LTO_OPTIONS = "-Dprefix=#{CREW_PREFIX} -Dlibdir=#{CREW_LIB_PREFIX} -Dmandir=#{CREW_MAN_PREFIX} -Dbuildtype=minsize -Db_lto=false -Dstrip=true -Db_pie=true -Dcpp_args='-Os' -Dc_args='-Os'"
 
 # Cmake sometimes wants to use LIB_SUFFIX to install libs in LIB64, so specify such for x86_64
 # This is often considered deprecated. See discussio at https://gitlab.kitware.com/cmake/cmake/-/issues/18640

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,31 +3,31 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  @_ver = '3.20.1'
+  @_ver = '3.20.4'
   version @_ver
   license 'CMake'
   compatibility 'all'
   source_url "https://github.com/Kitware/CMake/releases/download/v#{@_ver}/cmake-#{@_ver}.tar.gz"
-  source_sha256 '3f1808b9b00281df06c91dd7a021d7f52f724101000da7985a401678dfe035b0'
+  source_sha256 '87a4060298f2c6bb09d479de1400bc78195a5b55a65622a7dceeb3d1090a1b16'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.1_armv7l/cmake-3.20.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.1_armv7l/cmake-3.20.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.1_i686/cmake-3.20.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.1_x86_64/cmake-3.20.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.4_armv7l/cmake-3.20.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.4_armv7l/cmake-3.20.4-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.4_i686/cmake-3.20.4-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.4_x86_64/cmake-3.20.4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '078af3199ebab9ea478b9c162098b1746a91a83a62052017991e6d66ff5e81e2',
-     armv7l: '078af3199ebab9ea478b9c162098b1746a91a83a62052017991e6d66ff5e81e2',
-       i686: '715e5a2d8b097df0f753cac11e6c15fc3b5a47765de4f9be554715c65bbb7a5b',
-     x86_64: '61e754f415704a3feaeb6a0f0bdbd7cbdd958f76f779b32be49c799e351a0852'
+    aarch64: '77018414bfe96cdffc8e7240c1b73cc39759679e0ff239b49ba5a5443f785332',
+     armv7l: '77018414bfe96cdffc8e7240c1b73cc39759679e0ff239b49ba5a5443f785332',
+       i686: 'b0fe910f5b1866a5405587735a971940d7625b359f48d19b530a77c3a5b4c92a',
+     x86_64: '468c6364a9972a7261149784db9357b72a2adf66bb07db0adf4af154f9f12f65'
   })
 
   depends_on 'llvm' => :build
 
   def self.patch
     if Dir.exist? "#{CREW_PREFIX}/include/ncursesw"
-      system 'sed -i "51s,$,\n  set(CURSES_INCLUDE_PATH ' + "#{CREW_PREFIX}/include/ncursesw" + ')," Modules/FindCurses.cmake'
+      system "sed -i \"51s,$,\\n  set(CURSES_INCLUDE_PATH #{CREW_PREFIX}/include/ncursesw),\" Modules/FindCurses.cmake"
     end
   end
 

--- a/packages/meson.rb
+++ b/packages/meson.rb
@@ -3,24 +3,24 @@ require 'package'
 class Meson < Package
   description 'The Meson Build System'
   homepage 'http://mesonbuild.com/'
-  @_ver = '0.57.2'
+  @_ver = '0.58.1'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url "https://github.com/mesonbuild/meson/archive/#{@_ver}.tar.gz"
-  source_sha256 'cd3773625253df4fd1c380faf03ffae3d02198d6301e7c8bc7bba6c66af66096'
+  source_sha256 '78e0f553dd3bc632d5f96ab943b1bbccb599c2c84ff27c5fb7f7fff9c8a3f6b4'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.57.2_armv7l/meson-0.57.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.57.2_armv7l/meson-0.57.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.57.2_i686/meson-0.57.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.57.2_x86_64/meson-0.57.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.58.1_armv7l/meson-0.58.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.58.1_armv7l/meson-0.58.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.58.1_i686/meson-0.58.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.58.1_x86_64/meson-0.58.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '159a2101c1ca6a798baeeee0b95cd10950d7b62e088fa0229270b11983c27ec0',
-     armv7l: '159a2101c1ca6a798baeeee0b95cd10950d7b62e088fa0229270b11983c27ec0',
-       i686: 'f8a173fefc3b188208fbd6da61f3f9b0e94db62b8bbdb18573b8d740547ade82',
-     x86_64: '4f6668f8cf6463fbe20e9d7de20d818548ab53ec69c7dae1e5700f57e6d6b816'
+    aarch64: 'd2a6cacfd9e258918fe0627e117faf27be537c2d7340f0d6ff663e59f0800a3f',
+     armv7l: 'd2a6cacfd9e258918fe0627e117faf27be537c2d7340f0d6ff663e59f0800a3f',
+       i686: '81211605d926df2868241b31726224bfe41f816faa7095a123e9c78dea680a7a',
+     x86_64: 'abe7dfe244c45c3daa4d91938a199c997d81d063a53125117ce218c4a4677aaf'
   })
 
   depends_on 'ninja'


### PR DESCRIPTION
- Meson & Cmake updates, both tested.
- Remove `-pipe` from meson options since it is [added automatically](https://github.com/mesonbuild/meson/issues/8508#issuecomment-794767103).

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l