### PR TITLE
Update komodo from 11.1.1 to 12.0.1

### DIFF
--- a/packages/komodo.rb
+++ b/packages/komodo.rb
@@ -1,24 +1,13 @@
 require 'package'
 
 class Komodo < Package
-  description 'Komodo Edit is a great editor if you\'re looking for something powerful, yet simple.'
-  homepage 'https://www.activestate.com/products/komodo-edit/'
-  version '11.1.1'
-  license '' # Can't find license for project
-  compatibility 'all'
-  case ARCH
-  when 'i686'
-    source_url 'https://downloads.activestate.com/Komodo/releases/11.1.1/Komodo-Edit-11.1.1-18206-linux-x86.tar.gz'
-    source_sha256 'b2879342b3fcda0688bd461ad9545b178a3315c6ab7229b350db58b794f7c9a5'
-  when 'x86_64'
-    source_url 'https://downloads.activestate.com/Komodo/releases/11.1.1/Komodo-Edit-11.1.1-18206-linux-x86_64.tar.gz'
-    source_sha256 '649d5375ea963ac9211ca7ae294d61d07292f017a1852a804c8507b836c74fa6'
-  end
-
-  binary_url ({
-  })
-  binary_sha256 ({
-  })
+  description 'Komodo IDE is a great editor if you\'re looking for something powerful, yet simple.'
+  homepage 'https://www.activestate.com/products/komodo-ide/'
+  version '12.0.1'
+  license 'ActiveState® Platform EULA'
+  compatibility 'x86_64'
+  source_url 'https://downloads.activestate.com/Komodo/releases/12.0.1/Komodo-Edit-12.0.1-18441-linux-x86_64.tar.gz'
+  source_sha256 'b51783eb1cb8ce60b26e506ee00cd54ff31b61830622c5e5a8c77405e9c54e48'
 
   depends_on 'gtk2'
   depends_on 'sommelier'
@@ -26,12 +15,27 @@ class Komodo < Package
   def self.build
     system "sed -i 's,\$dname/INSTALLDIR/lib/python/bin/python,#{CREW_PREFIX}/bin/python2,' install.sh"
     system "sed -i 's,INSTALLDIR,#{CREW_DEST_PREFIX},' install.sh"
-    system "sed -i '622,630d' support/_install.py"
-    system "sed -i 's,/usr/bin/env python,#{CREW_PREFIX}/bin/env python,' support/_install.py"
-    system "sed -i '61iinstallDir = \"#{CREW_DEST_PREFIX}\"' support/_install.py"
+    system "sed -i '74d' install.sh"
   end
 
   def self.install
-    system './install.sh'
+    system "./install.sh -I #{CREW_DEST_PREFIX}"
+  end
+
+  def self.remove
+    print "Would you like to remove the config directories? [y/N] "
+    response = STDIN.getc
+    config_dirs = ["#{HOME}/.komodoide", "#{HOME}/.activestate"]
+    config_dirs.each { |config_dir|
+      if Dir.exists? config_dir
+        case response
+        when "y", "Y"
+          FileUtils.rm_rf config_dir
+          puts "#{config_dir} removed.".lightred
+        else
+          puts "#{config_dir} saved.".lightgreen
+        end
+      end
+    }
   end
 end


### PR DESCRIPTION
Komodo IDE is now free.  See https://www.activestate.com/products/komodo-ide/.  Tested on x86_64.