### PR TITLE
libva gmmlib intel_media_driver updates

### DIFF
--- a/packages/gmmlib.rb
+++ b/packages/gmmlib.rb
@@ -3,36 +3,26 @@ require 'package'
 class Gmmlib < Package
   description 'The Intel(R) Graphics Memory Management Library provides device specific and buffer management for the Intel(R) Graphics Compute Runtime for OpenCL(TM) and the Intel(R) Media Driver for VAAPI.'
   homepage 'https://github.com/intel/gmmlib/'
-  @_ver = '21.1.1'
+  @_ver = '21.2.1'
   version @_ver
   license 'MIT'
-  compatibility 'i686 x86_64'
-  source_url "https://github.com/intel/gmmlib/archive/intel-gmmlib-#{@_ver}.tar.gz"
-  source_sha256 'b996f09264e05ebca0dc275ea32791ba22769fe04147592371b4a61cdf508763'
+  compatibility 'x86_64'
+  source_url 'https://github.com/intel/gmmlib.git'
+  git_hashtag "intel-gmmlib-#{@_ver}"
 
   binary_url({
-      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gmmlib/21.1.1_i686/gmmlib-21.1.1-chromeos-i686.tar.xz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gmmlib/21.1.1_x86_64/gmmlib-21.1.1-chromeos-x86_64.tar.xz'
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gmmlib/21.2.1_x86_64/gmmlib-21.2.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-      i686: 'c71cb96bf16648e0818daca7913e32a71a67a117ffaf1379f7e4970f075d5454',
-    x86_64: '8cc86525354adbcc15e2e9ba8b59444178ec2037f72f9d29763286ef23dd1973'
+    x86_64: '99d879841a2c3d0d9d02438ae37720bec7b02f68ba177b52992b0fac6092bf1d'
   })
 
   depends_on 'libva'
 
-  def self.patch
-    system "find . -type f -exec sed -e 's,LD_LIBRARY_PATH=,LD_LIBRARY_PATH=#{CREW_LIB_PREFIX}:,g' \
-            -e 's,-fstack-protector,-fno-stack-protector,g' -i {} +"
-  end
-
   def self.build
     FileUtils.mkdir('builddir')
     Dir.chdir('builddir') do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
-            CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
-            LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-            cmake -G Ninja \
+      system "cmake -G Ninja \
             #{CREW_CMAKE_OPTIONS} \
             -DRUN_TEST_SUITE=OFF \
             .."

--- a/packages/intel_media_driver.rb
+++ b/packages/intel_media_driver.rb
@@ -3,18 +3,18 @@ require 'package'
 class Intel_media_driver < Package
   description 'The Intel(R) Media Driver for VAAPI is a new VA-API (Video Acceleration API) user mode driver supporting hardware accelerated decoding, encoding, and video post processing for GEN based graphics hardware.'
   homepage 'https://github.com/intel/media-driver'
-  @_ver = '21.1.3'
+  @_ver = '21.2.3'
   version @_ver
   license 'BSD-3, and MIT'
   compatibility 'x86_64'
-  source_url "https://github.com/intel/media-driver/archive/intel-media-#{@_ver}.tar.gz"
-  source_sha256 '219ce6b08a84bdce311160dc694d866249fd4e390391c2ac7be55f13a2fb928c'
+  source_url 'https://github.com/intel/media-driver.git'
+  git_hashtag "intel-media-#{@_ver}"
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/intel_media_driver/21.1.3_x86_64/intel_media_driver-21.1.3-chromeos-x86_64.tar.xz'
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/intel_media_driver/21.2.3_x86_64/intel_media_driver-21.2.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    x86_64: 'cb0a13759d9694716c928640384ca59c3ac044a3379e0cc4160f156347e4d158'
+    x86_64: '9bf56121437ac94df50cd1e9e6d2ac74802d0b72d901a0019c47d6ef68af353a'
   })
 
   depends_on 'gmmlib'
@@ -27,16 +27,14 @@ class Intel_media_driver < Package
   def self.patch
     system "find . -type f -exec sed -e 's,LD_LIBRARY_PATH=,LD_LIBRARY_PATH=#{CREW_LIB_PREFIX}:,g' \
             -e 's,-fstack-protector-all,-fno-stack-protector,g' \
+            -e 's,-Werror=return-type,-Werror=return-type -Wno-error=maybe-uninitialized,g' \
             -e 's,-fstack-protector,-fno-stack-protector,g' -i {} +"
   end
 
   def self.build
     FileUtils.mkdir('builddir')
     Dir.chdir('builddir') do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
-            CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
-            LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-            cmake #{CREW_CMAKE_OPTIONS} ../ -G Ninja"
+      system "cmake #{CREW_CMAKE_OPTIONS.sub('-pipe', '-pipe -Wno-error')} ../ -G Ninja"
     end
     system 'ninja -C builddir'
   end

--- a/packages/libva.rb
+++ b/packages/libva.rb
@@ -3,24 +3,22 @@ require 'package'
 class Libva < Package
   description 'Libva is an implementation for VA-API (Video Acceleration API)'
   homepage 'https://01.org/linuxmedia'
-  @_ver = '2.11.0'
+  @_ver = '2.12.0'
   version @_ver
   license 'MIT'
-  compatibility 'all'
-  source_url "https://github.com/intel/libva/archive/refs/tags/#{@_ver}.tar.gz"
-  source_sha256 'ee2bd79bad5e2404143f089360685f5da63a32dd551b54ccd61d2d49c041178a'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/intel/libva.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.11.0_armv7l/libva-2.11.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.11.0_armv7l/libva-2.11.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.11.0_i686/libva-2.11.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.11.0_x86_64/libva-2.11.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.12.0_armv7l/libva-2.12.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.12.0_armv7l/libva-2.12.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.12.0_x86_64/libva-2.12.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '4af41d8c10b335f1b00bbfa9c4afcea07bbb0b7d00acd3a18a0c007592302a4a',
-     armv7l: '4af41d8c10b335f1b00bbfa9c4afcea07bbb0b7d00acd3a18a0c007592302a4a',
-       i686: '49938688385785511cca5cdd3d5354a0e1a227538fd7a1dfec4588dbd9af90b5',
-     x86_64: 'fcdd6886cfacef1a4e3e31448bf469f78233993a1376c1c4255314d7355c1eed'
+    aarch64: 'e64a354e9607f5b220a22d33ebe24cf8b933a0cd97bad7efa0376fdd8ef27c52',
+     armv7l: 'e64a354e9607f5b220a22d33ebe24cf8b933a0cd97bad7efa0376fdd8ef27c52',
+     x86_64: '7cdc4741dd68458cdff0fff55ef4600af6fcf3b0fc385acc5649eda4bfcea0be'
   })
 
   depends_on 'libdrm'


### PR DESCRIPTION
- took out i686 since no X/wayland apps work on i686

Works properly:
- [x] x86_64
