### PR TITLE
sommelier: Add `xhost` and remove `coreutils` dependency

### DIFF
--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -84,7 +84,7 @@ class Sommelier < Package
 
           case "$(uname -m)" in
           x86_64|i686)
-            sort_result = "$(sort -V <<< "$(uname -r)"$'\\n'"4.16.0" | tail -n1)"
+            sort_result="$(sort -V <<< "$(uname -r)"$'\\n'"4.16.0" | tail -n1)"
             if [[ "${sort_result}" == "4.16.0" ]]; then
               MESA_LOADER_DRIVER_OVERRIDE=i965
             fi
@@ -125,7 +125,7 @@ class Sommelier < Package
           basedir=${base%/*}
           LD_ARGV0_REL="../bin/sommelier" \
             exec "${basedir}/..#{@peer_cmd_prefix}" \
-              ../bin/sommelier \
+              --argv0 "$0" \
               --library-path \
               "${basedir}/../#{ARCH_LIB}" \
               --inhibit-rpath '' \
@@ -285,8 +285,7 @@ class Sommelier < Package
     # all tasks are done by sommelier.env now
     puts
     puts 'Removing old sommelier env variable loading code in ~/.bashrc'.lightblue
-    system 'sed -i "s,set -a && source ~/.sommelier.env && set +a,," -i.backup ~/.bashrc'
-    system 'sed -i "s,set -a ; source ~/.sommelier-default.env ; source ~/.sommelier.env ; set +a,," -i.backup ~/.bashrc'
+    system 'sed -i "/[sS]ommelier/d" -i.backup ~/.bashrc'
     puts 'To complete the installation, execute the following:'.orange
     puts 'source ~/.bashrc'.orange
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -296,7 +296,7 @@ class Sommelier < Package
       To restart the sommelier daemon, run 'restartsommelier'
     
     EOT
-    puts <<EOT.orange
+    puts <<~EOT.orange
       Please be aware that gui applications may not work without the
       sommelier daemon running.
     

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -99,7 +99,7 @@ class Sommelier < Package
         # This file via:
         # crostini: /opt/google/cros-containers/bin/sommelier
         # https://source.chromium.org/chromium/chromium/src/+/master:third_party/chromite/third_party/lddtree.py;drc=46da9a8dfce28c96765dc7d061f0c6d7a52e7352;l=146
-        IO.write 'sommelier_sh' <<~EOF
+        IO.write 'sommelier_sh', <<~EOF
           #!/bin/bash
           function readlink(){
             coreutils --coreutils-prog=readlink "$@"
@@ -128,7 +128,7 @@ class Sommelier < Package
         EOF
 
         # sommelierd
-        IO.write 'sommelierd' <<~EOF
+        IO.write 'sommelierd', <<~EOF
           #!/bin/bash -a
 
           source ${CREW_PREFIX}/etc/env.d/sommelier.env &>/dev/null
@@ -182,7 +182,7 @@ class Sommelier < Package
         EOF
         
         # startsommelier
-        IO.write 'startsommelier' <<~EOF
+        IO.write 'startsommelier', <<~EOF
           #!/bin/bash -a
 
           source ~/.sommelier-default.env &>/dev/null
@@ -228,7 +228,7 @@ class Sommelier < Package
         EOF
 
         # stopsommelier
-        IO.write 'stopsommelier' <<~EOF
+        IO.write 'stopsommelier', <<~EOF
           #!/bin/bash
           SOMM="$(pgrep -fc sommelier.elf 2> /dev/null)"
           if [[ "${SOMM}" -gt "0" ]]; then
@@ -247,7 +247,7 @@ class Sommelier < Package
         EOF
         
         # restartsommelier
-        IO.write 'restartsommelier' <<~EOF
+        IO.write 'restartsommelier', <<~EOF
           #!/bin/bash
           stopsommelier && startsommelier
         EOF

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -5,7 +5,7 @@ class Sommelier < Package
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
   version '20210109-4'
   license 'BSD-Google'
-  compatibility 'armv7l aarch64 x86_64'
+  compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/platform2.git'
   git_hashtag 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -12,14 +12,12 @@ class Sommelier < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-4_armv7l/sommelier-20210109-4-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-4_armv7l/sommelier-20210109-4-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-4_i686/sommelier-20210109-4-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-4_x86_64/sommelier-20210109-4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '3698af2c3b77f659d7195f8b7e55d157147d137addeef42790730c9e9cb0bcbc',
-     armv7l: '3698af2c3b77f659d7195f8b7e55d157147d137addeef42790730c9e9cb0bcbc',
-       i686: '423707ace2d90a8ceb0a51287ad9bbdf87c0d8729aa3d8b7e951b20c0d05b28d',
-     x86_64: '7f83d6a5897616b40257dfd4c7bd94e915c4b8a2e8f49158b2c77e77eef8bf73'
+    aarch64: '2fbadad68afa4f712c35874190bac505af989fae8bc8783eaeb8ed5ed7837d93',
+     armv7l: '2fbadad68afa4f712c35874190bac505af989fae8bc8783eaeb8ed5ed7837d93',
+     x86_64: '6204e088afe53b492c470779edeb362023a2797153d424960c6612cd1689ce37'
   })
 
   depends_on 'libdrm'
@@ -281,7 +279,8 @@ class Sommelier < Package
   end
 
   def self.install
-    FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/bin #{CREW_DEST_PREFIX}/sbin #{CREW_DEST_PREFIX}/etc/bash.d #{CREW_DEST_PREFIX}/etc/env.d CREW_DEST_HOME]
+    FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/bin #{CREW_DEST_PREFIX}/sbin #{CREW_DEST_PREFIX}/etc/bash.d
+                         #{CREW_DEST_PREFIX}/etc/env.d CREW_DEST_HOME]
     Dir.chdir('vm_tools/sommelier') do
       system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
       Dir.chdir('builddir') do

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -259,7 +259,7 @@ class Sommelier < Package
     Dir.chdir('vm_tools/sommelier') do
       system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
       Dir.chdir('builddir') do
-        FileUtils.mkdir ["#{CREW_DEST_PREFIX}/bin", "#{CREW_DEST_PREFIX}/sbin", "#{CREW_DEST_PREFIX}/etc", CREW_DEST_HOME]
+        FileUtils.mkdir_p ["#{CREW_DEST_PREFIX}/bin", "#{CREW_DEST_PREFIX}/sbin", "#{CREW_DEST_PREFIX}/etc", CREW_DEST_HOME]
         FileUtils.mv "#{CREW_DEST_PREFIX}/bin/sommelier", "#{CREW_DEST_PREFIX}/bin/sommelier.elf"
         FileUtils.install 'sommelier_sh', "#{CREW_DEST_PREFIX}/bin/sommelier", mode: 0o755
         FileUtils.install 'sommelierd', "#{CREW_DEST_PREFIX}/sbin/sommelierd", mode: 0o755

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,11 +3,11 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  version '20210704'
+  version '20210109-3'
   license 'BSD-Google'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/platform2.git'
-  git_hashtag 'ccee425349c37e50548b0000cc7ce52ebfa62448'
+  git_hashtag 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
 
   depends_on 'libdrm'
   depends_on 'libxcb'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -102,7 +102,7 @@ class Sommelier < Package
         IO.write 'sommelier_sh' <<~EOF
           #!/bin/bash
           function readlink(){
-            coreutils --coreutils-prog=readlink \"$@\"
+            coreutils --coreutils-prog=readlink "$@"
           }
 
           if base=$(readlink "$0" 2>/dev/null); then

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -97,7 +97,7 @@ EOF"
         system "cat <<'EOF'> sommelier_sh
 #!/bin/bash
 function readlink(){
-  coreutils --coreutils-prog=readlink "$@"
+  coreutils --coreutils-prog=readlink \"$@\"
 }
 
 if base=$(readlink \"$0\" 2>/dev/null); then

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -45,7 +45,7 @@ class Sommelier < Package
     end
   end
 
-  def self.prebuild
+  def self.patch
     # Patch to avoid error with GCC > 9.x
     # ../sommelier.cc:3238:10: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 108 equals destination size [-Wstringop-truncation]
     Kernel.system "sed -i 's/sizeof(addr.sun_path))/sizeof(addr.sun_path) - 1)/' sommelier.cc", chdir: 'vm_tools/sommelier'
@@ -270,7 +270,7 @@ class Sommelier < Package
     Dir.chdir('vm_tools/sommelier') do
       system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
       Dir.chdir('builddir') do
-        FileUtils.mkdir_p ["#{CREW_DEST_PREFIX}/bin", "#{CREW_DEST_PREFIX}/sbin", "#{CREW_DEST_PREFIX}/etc", CREW_DEST_HOME]
+        FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/bin #{CREW_DEST_PREFIX}/sbin #{CREW_DEST_PREFIX}/etc CREW_DEST_HOME]
         FileUtils.mv "#{CREW_DEST_PREFIX}/bin/sommelier", "#{CREW_DEST_PREFIX}/bin/sommelier.elf"
         FileUtils.install 'sommelier_sh', "#{CREW_DEST_PREFIX}/bin/sommelier", mode: 0o755
         FileUtils.install 'sommelierd', "#{CREW_DEST_PREFIX}/sbin/sommelierd", mode: 0o755

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,11 +3,11 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  version '20210109-4'
+  version '20210704'
   license 'BSD-Google'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/platform2.git'
-  git_hashtag 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
+  git_hashtag 'ccee425349c37e50548b0000cc7ce52ebfa62448'
 
   depends_on 'libdrm'
   depends_on 'libxcb'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -12,11 +12,13 @@ class Sommelier < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-4_armv7l/sommelier-20210109-4-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-4_armv7l/sommelier-20210109-4-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-4_i686/sommelier-20210109-4-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-4_x86_64/sommelier-20210109-4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '3698af2c3b77f659d7195f8b7e55d157147d137addeef42790730c9e9cb0bcbc',
      armv7l: '3698af2c3b77f659d7195f8b7e55d157147d137addeef42790730c9e9cb0bcbc',
+       i686: '423707ace2d90a8ceb0a51287ad9bbdf87c0d8729aa3d8b7e951b20c0d05b28d',
      x86_64: '7f83d6a5897616b40257dfd4c7bd94e915c4b8a2e8f49158b2c77e77eef8bf73'
   })
 
@@ -40,7 +42,7 @@ class Sommelier < Package
   when 'armv7l', 'aarch64'
     @peer_cmd_prefix = '/lib/ld-linux-armhf.so.3'
   when 'i686'
-    @peer_cmd_prefix = '/lib/ld-linux-i686.so.2'
+    @peer_cmd_prefix = '/lib/ld-linux.so.2'
   when 'x86_64'
     @peer_cmd_prefix = '/lib64/ld-linux-x86-64.so.2'
   end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -39,6 +39,12 @@ class Sommelier < Package
     @peer_cmd_prefix = '/lib64/ld-linux-x86-64.so.2'
   end
 
+  def self.preflight
+    unless File.socket?('/var/run/chrome/wayland-0')
+      abort "This package is not compatible with your device :/".lightred
+    end
+  end
+  
   def self.build
     Dir.chdir('vm_tools/sommelier') do
       # Patch to avoid error with GCC > 9.x
@@ -268,7 +274,6 @@ class Sommelier < Package
         FileUtils.install 'stopsommelier', "#{CREW_DEST_PREFIX}/bin/stopsommelier", mode: 0o755
         FileUtils.install 'restartsommelier', "#{CREW_DEST_PREFIX}/bin/restartsommelier", mode: 0o755
         FileUtils.install 'sommelierrc', "#{CREW_DEST_PREFIX}/etc/sommelierrc", mode: 0o644
-        FileUtils.install '.sommelier-default.env', "#{CREW_DEST_HOME}/.sommelier-default.env", mode: 0o644
       end
     end
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -9,6 +9,19 @@ class Sommelier < Package
   source_url 'https://chromium.googlesource.com/chromiumos/platform2.git'
   git_hashtag 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_armv7l/sommelier-20210109-3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_armv7l/sommelier-20210109-3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_i686/sommelier-20210109-3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_x86_64/sommelier-20210109-3-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '401181dfb60f062d00166d39259ca60f593c629af9466dbfb6dcc3f4363575be',
+     armv7l: '401181dfb60f062d00166d39259ca60f593c629af9466dbfb6dcc3f4363575be',
+       i686: 'f00ace87c154fa1c4f786656db369004612b51c27236dbdca9c4f0fd230496eb',
+     x86_64: '29b161ee80fbc1f334bfaf7d191ce8b37c0b7cff414d3e639934b10de64280d7'
+  })
+  
   depends_on 'libdrm'
   depends_on 'libxcb'
   depends_on 'libxcomposite' => :build

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -220,6 +220,7 @@ EOF"
     Dir.chdir('vm_tools/sommelier') do
       system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
       Dir.chdir('builddir') do
+        FileUtils.mkdir ["#{CREW_DEST_PREFIX}/bin", "#{CREW_DEST_PREFIX}/sbin", "#{CREW_DEST_PREFIX}/etc", CREW_DEST_HOME]
         FileUtils.mv "#{CREW_DEST_PREFIX}/bin/sommelier", "#{CREW_DEST_PREFIX}/bin/sommelier.elf"
         FileUtils.install 'sommelier_sh', "#{CREW_DEST_PREFIX}/bin/sommelier", mode: 0o755
         FileUtils.install 'sommelierd', "#{CREW_DEST_PREFIX}/sbin/sommelierd", mode: 0o755
@@ -227,7 +228,7 @@ EOF"
         FileUtils.ln_sf 'startsommelier', "#{CREW_DEST_PREFIX}/bin/initsommelier"
         FileUtils.install 'stopsommelier', "#{CREW_DEST_PREFIX}/bin/stopsommelier", mode: 0o755
         FileUtils.install 'restartsommelier', "#{CREW_DEST_PREFIX}/bin/restartsommelier", mode: 0o755
-        FileUtils.install 'sommelierrc', "#{CREW_DEST_PREFIX}/etc/sommelierrc", mode: 0o755
+        FileUtils.install 'sommelierrc', "#{CREW_DEST_PREFIX}/etc/sommelierrc", mode: 0o644
         FileUtils.install '.sommelier-default.env', "#{CREW_DEST_HOME}/.sommelier-default.env", mode: 0o644
       end
     end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,24 +3,11 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  version '20210109-3'
+  version '20210109-4'
   license 'BSD-Google'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/platform2.git'
   git_hashtag 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_armv7l/sommelier-20210109-3-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_armv7l/sommelier-20210109-3-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_i686/sommelier-20210109-3-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-3_x86_64/sommelier-20210109-3-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '401181dfb60f062d00166d39259ca60f593c629af9466dbfb6dcc3f4363575be',
-     armv7l: '401181dfb60f062d00166d39259ca60f593c629af9466dbfb6dcc3f4363575be',
-       i686: 'f00ace87c154fa1c4f786656db369004612b51c27236dbdca9c4f0fd230496eb',
-     x86_64: '29b161ee80fbc1f334bfaf7d191ce8b37c0b7cff414d3e639934b10de64280d7'
-  })
 
   depends_on 'libdrm'
   depends_on 'libxcb'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -293,8 +293,8 @@ class Sommelier < Package
     puts
     FileUtils.touch "#{HOME}/.sommelier.env" unless File.exist? "#{HOME}/.sommelier.env"
     puts <<~EOT.lightblue
-      To adjust sommelier environment variables, edit #{CREW_PREFIX}/etc/env.d/sommelier'
-      Default values are in ~/.sommelier-default.env
+      To adjust sommelier environment variables, edit #{CREW_PREFIX}/etc/env.d/sommelier
+      Default values are in #{CREW_PREFIX}/etc/env.d/sommelier
       
       To start the sommelier daemon, run 'startsommelier'
       To stop the sommelier daemon, run 'stopsommelier'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -67,7 +67,7 @@ class Sommelier < Package
 
       system <<~BUILD
         env CC=clang CXX=clang++ \
-          meson #{CREW_MESON_FNO_LTO_OPTIONS} \
+          meson #{CREW_MESON_OPTIONS} \
           -Db_asneeded=false \
           -Db_lto=true \
           -Db_lto_mode=thin \
@@ -273,7 +273,7 @@ class Sommelier < Package
         EOF
 
         # start sommelier from bash.d, which loads after all of env.d via #{CREW_PREFIX}/etc/profile
-        @bash.d_sommelier = <<~EOF
+        @bashd_sommelier = <<~EOF
           startsommelier
         EOF
       end
@@ -296,7 +296,7 @@ class Sommelier < Package
       end
     end
 
-    IO.write("#{CREW_DEST_PREFIX}/etc/bash.d/sommelier", @bash.d_sommelier)
+    IO.write("#{CREW_DEST_PREFIX}/etc/bash.d/sommelier", @bashd_sommelier)
     IO.write("#{CREW_DEST_PREFIX}/etc/env.d/sommelier", @sommelierenv)
   end
 


### PR DESCRIPTION
`xhost` is used to allow root access in `sommelierd`
`readlink` is in system version of `coreutils` already but don’t have a symlink to PATH