### PR TITLE
Update libedit from 20191231-3.1 to 20210522-3.1

### DIFF
--- a/packages/libedit.rb
+++ b/packages/libedit.rb
@@ -3,34 +3,36 @@ require 'package'
 class Libedit < Package
   description 'This is an autotool and libtoolized port of the NetBSD Editline library (libedit).'
   homepage 'http://thrysoee.dk/editline/'
-  version '20191231-3.1'
+  version '20210522-3.1'
   license 'BSD-2'
   compatibility 'all'
-  source_url 'https://thrysoee.dk/editline/libedit-20191231-3.1.tar.gz'
-  source_sha256 'dbb82cb7e116a5f8025d35ef5b4f7d4a3cdd0a3909a146a39112095a2d229071'
+  source_url 'https://thrysoee.dk/editline/libedit-20210522-3.1.tar.gz'
+  source_sha256 '0220bc2047e927c0c1984ef5f7b4eb2a9469a5b7bf12ba573ca3b23ca02bbb6f'
 
   binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libedit/20191231-3.1_armv7l/libedit-20191231-3.1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libedit/20191231-3.1_armv7l/libedit-20191231-3.1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libedit/20191231-3.1_i686/libedit-20191231-3.1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libedit/20191231-3.1_x86_64/libedit-20191231-3.1-chromeos-x86_64.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libedit/20210522-3.1_armv7l/libedit-20210522-3.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libedit/20210522-3.1_armv7l/libedit-20210522-3.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libedit/20210522-3.1_i686/libedit-20210522-3.1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libedit/20210522-3.1_x86_64/libedit-20210522-3.1-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
-     aarch64: '610986dcb014c2079b2b355628ee6f7b867076974cf751b891a926f0a0d9d5b8',
-      armv7l: '610986dcb014c2079b2b355628ee6f7b867076974cf751b891a926f0a0d9d5b8',
-        i686: 'dc3d211fd649803d0dd89c3f82163a8bf67eeebaea9629b14bd9e570ba545933',
-      x86_64: '834915020f3fd98b0e3ca8609ae0b915b47ca77ea5877fa7b758a85571401e8e',
+    aarch64: '21b75fb838a66f7459299bfe2e19905ad51473592d8a3a270b1cec5c7611fa60',
+     armv7l: '21b75fb838a66f7459299bfe2e19905ad51473592d8a3a270b1cec5c7611fa60',
+       i686: '2d42b3a52e8db660b5959f164a436595feada9559cd0635e11ccda26d51ab9e2',
+     x86_64: '5ab911b8abe6d07c2a6c88e5305597001d8de5bd61c799d318db4147a7e52cfa',
   })
 
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto \"-I#{CREW_PREFIX}/include/ncurses\"' LDFLAGS='-flto=auto' \
       ./configure \
       #{CREW_OPTIONS} \
-      CPPFLAGS=\"-I#{CREW_PREFIX}/include/ncurses\""
-    system "make"
+      CPPFLAGS=\"-I#{CREW_PREFIX}/include/ncursesw\""
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    # Remove conflict with readline
+    FileUtils.rm_f "#{CREW_DEST_MAN_PREFIX}/man3/history.3"
   end
 end


### PR DESCRIPTION
I needed to include ncursesw to compile from source so I went ahead and made the change and updated the release.  Tested on all architectures.