### PR TITLE
Fix .deb unarchive algorithm

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -769,7 +769,18 @@ def unpack(meta)
       system "tar x#{@verbose}f #{meta[:filename]} -C #{@extract_dir}", exception: true
     when /\.deb$/i
       puts "Unpacking archive using 'ar', this may take a while..."
-      system "ar -p #{meta[:filename]} data.tar.xz | xz -dc#{@verbose} | tar x#{@verbose} -C #{@extract_dir}", exception: true
+      
+      suffix = `ar -t #{meta[:filename]}`.scan(/data.(.*)/)[0][0]
+      case suffix
+      when 'tar.xz'
+        tar_opt = '--xz'
+      when 'tgz', 'tar.gz'
+        tar_opt = '--gzip'
+      when 'bzip2'
+        tar_opt = '--bzip2'
+      end
+
+      system "ar -p #{meta[:filename]} data.#{suffix} | tar x#{@verbose} #{tar_opt} -C #{@extract_dir}"
     when /\.AppImage$/i
       puts "Unpacking 'AppImage' archive, this may take a while..."
       FileUtils.chmod 0o755, meta[:filename], verbose: @fileutils_verbose

--- a/bin/crew
+++ b/bin/crew
@@ -780,7 +780,7 @@ def unpack(meta)
         tar_opt = '--bzip2'
       end
 
-      system "ar -p #{meta[:filename]} data.#{suffix} | tar x#{@verbose} #{tar_opt} -C #{@extract_dir}"
+      system "ar -p #{meta[:filename]} data.#{suffix} | tar x#{@verbose} #{tar_opt} -C #{@extract_dir}", exception: true
     when /\.AppImage$/i
       puts "Unpacking 'AppImage' archive, this may take a while..."
       FileUtils.chmod 0o755, meta[:filename], verbose: @fileutils_verbose

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.11.5'
+CREW_VERSION = '1.11.6'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Required by #5928 

The `data` archive in a deb file can be different format such as `gzip` and `bzip2`, added a part to help `ar` extracting the data archive with different format

Tested on `x86_64`