### PR TITLE
Remmina => 1.4.19 w/ new deps

### DIFF
--- a/packages/libappindicator_gtk3.rb
+++ b/packages/libappindicator_gtk3.rb
@@ -1,0 +1,57 @@
+# Adapted from Arch Linux libappindicator PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libappindicator/trunk/PKGBUILD
+
+require 'package'
+
+class Libappindicator_gtk3 < Package
+  description 'Allow applications to extend a menu via Ayatana indicators in Unity, KDE or Systray'
+  homepage 'https://launchpad.net/libappindicator'
+  version '12.10.0'
+  license 'LGPL2.1 LGPL3'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://launchpad.net/libappindicator/12.10/12.10.0/+download/libappindicator-12.10.0.tar.gz'
+  source_sha256 'd5907c1f98084acf28fd19593cb70672caa0ca1cf82d747ba6f4830d4cc3b49f'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libappindicator_gtk3/12.10.0_armv7l/libappindicator_gtk3-12.10.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libappindicator_gtk3/12.10.0_armv7l/libappindicator_gtk3-12.10.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libappindicator_gtk3/12.10.0_x86_64/libappindicator_gtk3-12.10.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'f85c3830820c464e863a0dda0dd9805aece7ba4c5732ef79ef6d520e9bc83f3b',
+     armv7l: 'f85c3830820c464e863a0dda0dd9805aece7ba4c5732ef79ef6d520e9bc83f3b',
+     x86_64: 'ffaa20be62a6af48a4aa709721359a7b1728662b3d1a481e4fbc52d91245d7e1'
+  })
+
+  depends_on 'dbus_glib'
+  depends_on 'gnome_common'
+  depends_on 'gobject_introspection'
+  depends_on 'gtk_doc'
+  depends_on 'libindicator_gtk3'
+  depends_on 'pygtk'
+  depends_on 'vala'
+  depends_on 'libdbusmenu_gtk3'
+
+  def self.patch
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "grep -rl Werror . | xargs sed -i 's,-Wall -Werror,-Wall,g'"
+    system 'filefix'
+  end
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS.sub("CFLAGS='", "CFLAGS='-Wno-deprecated-declarations ")} \
+    ./configure \
+    #{CREW_OPTIONS} \
+    --localstatedir=#{CREW_PREFIX}/var \
+    --sysconfdir=#{CREW_PREFIX}/etc \
+    --with-gtk=3 \
+    --disable-mono-test \
+    --enable-gtk-doc-html=no \
+    --disable-tests"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libdbusmenu_gtk3.rb
+++ b/packages/libdbusmenu_gtk3.rb
@@ -31,7 +31,7 @@ class Libdbusmenu_gtk3 < Package
   depends_on 'vala'
 
   def self.patch
-    system './autogen.sh'
+    system 'NOCONFIGURE=1 ./autogen.sh'
   end
 
   def self.build

--- a/packages/libdbusmenu_gtk3.rb
+++ b/packages/libdbusmenu_gtk3.rb
@@ -1,0 +1,49 @@
+# Adapted from Arch Linux libdbusmenu PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libdbusmenu/trunk/PKGBUILD
+
+require 'package'
+
+class Libdbusmenu_gtk3 < Package
+  description 'Library for passing menus over DBus'
+  homepage 'https://launchpad.net/libdbusmenu'
+  version '16.04.0'
+  license 'GPL3 LGPL2.1 LGPL3'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'git://git.launchpad.net/ubuntu/+source/libdbusmenu'
+  git_hashtag 'a3658f1208c31b1fb03b71af6e49c01119ba52fd'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdbusmenu_gtk3/16.04.0_armv7l/libdbusmenu_gtk3-16.04.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdbusmenu_gtk3/16.04.0_armv7l/libdbusmenu_gtk3-16.04.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdbusmenu_gtk3/16.04.0_x86_64/libdbusmenu_gtk3-16.04.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '1b83ca1cf073b97d68d5f3a69dc587b7bb9019ed85c64c3186a66586f943eb7d',
+     armv7l: '1b83ca1cf073b97d68d5f3a69dc587b7bb9019ed85c64c3186a66586f943eb7d',
+     x86_64: '15883cf528411d88b1ddfed31cc34432ef405fb0ebaedd436861ccc70a3510ec'
+  })
+
+  depends_on 'gnome_common'
+  depends_on 'gobject_introspection'
+  depends_on 'gtk2'
+  depends_on 'gtk3'
+  depends_on 'intltool'
+  depends_on 'vala'
+
+  def self.patch
+    system './autogen.sh'
+  end
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS.sub("CFLAGS='", "CFLAGS='-Wno-deprecated-declarations ")} \
+    ./configure \
+    #{CREW_OPTIONS} \
+    --localstatedir=#{CREW_PREFIX}/var \
+    --sysconfdir=#{CREW_PREFIX}/etc \
+    --with-gtk=3"
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libindicator_gtk3.rb
+++ b/packages/libindicator_gtk3.rb
@@ -1,0 +1,52 @@
+# Adapted from Arch Linux libindicator PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libindicator/trunk/PKGBUILD
+
+require 'package'
+
+class Libindicator_gtk3 < Package
+  description 'Set of symbols and convenience functions for Ayatana indicators'
+  homepage 'https://launchpad.net/libindicator'
+  version '12.10.1'
+  license 'GPL3'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://launchpad.net/libindicator/12.10/12.10.1/+download/libindicator-12.10.1.tar.gz'
+  source_sha256 'b2d2e44c10313d5c9cd60db455d520f80b36dc39562df079a3f29495e8f9447f'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libindicator_gtk3/12.10.1_armv7l/libindicator_gtk3-12.10.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libindicator_gtk3/12.10.1_armv7l/libindicator_gtk3-12.10.1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libindicator_gtk3/12.10.1_x86_64/libindicator_gtk3-12.10.1-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'fcfdbe22d476d4fdef9e740149026e867e049f2c9770c7e332206653d002752d',
+     armv7l: 'fcfdbe22d476d4fdef9e740149026e867e049f2c9770c7e332206653d002752d',
+     x86_64: '854c2183a47a9ab88db302edb47ac155eb275961020a97eeb10aeac556a07936'
+  })
+
+  depends_on 'gtk3'
+
+  def self.patch
+    system 'NOCONFIGURE=1 autoreconf -fi'
+    system 'filefix'
+    system "grep -rl Werror . | xargs sed -i 's,-Wall -Werror,-Wall,g'"
+  end
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS.sub("CFLAGS='", "CFLAGS='-Wno-deprecated-declarations ").sub("LDFLAGS='",
+                                                                                            "LDFLAGS='-lm ")} \
+    ./configure \
+    #{CREW_OPTIONS} \
+    --localstatedir=#{CREW_PREFIX}/var \
+    --libexecdir=#{CREW_LIB_PREFIX}/libindicator \
+    --sysconfdir=#{CREW_PREFIX}/etc \
+    --with-gtk=3 \
+    --disable-tests \
+    --enable-maintainer-flags=no"
+    system "grep -rl lglib-2.0-lm . | xargs sed -i 's,-lglib-2.0-lm,-lglib-2.0 -lm,g'"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/remmina.rb
+++ b/packages/remmina.rb
@@ -3,27 +3,27 @@ require 'package'
 class Remmina < Package
   description 'The GTK Remmina Remote Desktop Client'
   homepage 'https://remmina.org/'
-  version '1.4.13'
+  version '1.4.19'
   license 'GPL-2+-with-openssl-exception'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url "https://gitlab.com/Remmina/Remmina/-/archive/v#{version}/Remmina-v#{version}.tar.bz2"
-  source_sha256 '24531287b85b2500b172cbe125f829c0dcf008c887ffa5e1b19a29c23d902885'
+  source_sha256 'a730d5927232818d55c8e094dba69d504faacabab2288d0c5c0c30ee7e89be46'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.13_armv7l/remmina-1.4.13-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.13_armv7l/remmina-1.4.13-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.13_i686/remmina-1.4.13-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.13_x86_64/remmina-1.4.13-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.19_armv7l/remmina-1.4.19-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.19_armv7l/remmina-1.4.19-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.19_x86_64/remmina-1.4.19-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'e42b0d7595f28712a818d3570274dd3070063c37ec6850da22d8e976a7a77f5d',
-     armv7l: 'e42b0d7595f28712a818d3570274dd3070063c37ec6850da22d8e976a7a77f5d',
-       i686: '31f3bcec48acb1d5acff7ca15a24b8b933f05d176ab8066794b1ceb9c8409f24',
-     x86_64: '6028f81de9c1fb93ed41726884305fa31d706a5cc66f1df7cfdf45ed533b176b'
+    aarch64: 'dab35fcbbc23c18cad70e6410f55add495cdae28056a5f32b135609918f4abf1',
+     armv7l: 'dab35fcbbc23c18cad70e6410f55add495cdae28056a5f32b135609918f4abf1',
+     x86_64: '5c0664d01de495b9e0a8c872d8f510c2523d19bcf9e4c7ae4f0c7c6ad4fcbb6d'
   })
 
   depends_on 'avahi'
   depends_on 'freerdp'
+  depends_on 'hashpipe' => :build
+  depends_on 'libappindicator_gtk3'
   depends_on 'libsecret'
   depends_on 'libsodium'
   depends_on 'libsoup'
@@ -31,15 +31,23 @@ class Remmina < Package
   depends_on 'spice_gtk'
   depends_on 'vte'
   depends_on 'webkit2gtk_4'
+  depends_on 'xdg_utils' => :build
   depends_on 'sommelier'
+
+  def self.patch
+    # https://gitlab.com/Remmina/Remmina/-/issues/2542
+    system "curl -Ls https://gitlab.com/Remmina/Remmina/-/merge_requests/2290.patch | \
+    hashpipe sha256 618b6f759a40293c71cb622bbd16ed673c0474e9238b339095a5957c929e26a9 | \
+    patch -Np1 --binary"
+  end
 
   def self.build
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
       system "cmake \
         -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        -DWITH_APPINDICATOR=OFF \
+        #{CREW_CMAKE_OPTIONS.sub("C_FLAGS='",
+                                 "C_FLAGS='-Wno-unused-function ")} \
         -DWITH_TELEPATHY=OFF \
         .."
     end


### PR DESCRIPTION
- Now uses older libsodium.
- Has new required deps added.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l