### PR TITLE
cmake => 3.20.5

### DIFF
--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,24 +3,24 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  @_ver = '3.20.4'
+  @_ver = '3.20.5'
   version @_ver
   license 'CMake'
   compatibility 'all'
   source_url "https://github.com/Kitware/CMake/releases/download/v#{@_ver}/cmake-#{@_ver}.tar.gz"
-  source_sha256 '87a4060298f2c6bb09d479de1400bc78195a5b55a65622a7dceeb3d1090a1b16'
+  source_sha256 '12c8040ef5c6f1bc5b8868cede16bb7926c18980f59779e299ab52cbc6f15bb0'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.4_armv7l/cmake-3.20.4-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.4_armv7l/cmake-3.20.4-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.4_i686/cmake-3.20.4-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.4_x86_64/cmake-3.20.4-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.5_armv7l/cmake-3.20.5-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.5_armv7l/cmake-3.20.5-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.5_i686/cmake-3.20.5-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.5_x86_64/cmake-3.20.5-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '77018414bfe96cdffc8e7240c1b73cc39759679e0ff239b49ba5a5443f785332',
-     armv7l: '77018414bfe96cdffc8e7240c1b73cc39759679e0ff239b49ba5a5443f785332',
-       i686: 'b0fe910f5b1866a5405587735a971940d7625b359f48d19b530a77c3a5b4c92a',
-     x86_64: '468c6364a9972a7261149784db9357b72a2adf66bb07db0adf4af154f9f12f65'
+    aarch64: '75be8bfa3cc657338fad5f6787064f6bf15db3920a9745d855fd96d4ae27267f',
+     armv7l: '75be8bfa3cc657338fad5f6787064f6bf15db3920a9745d855fd96d4ae27267f',
+       i686: '6857b4eb68676dcd828438ea141bc2152416c5819296aa7e177061787f6530fc',
+     x86_64: 'c09c700554d7d10689c81fece6a31d9a8c0ded0dc040e78ca2ff5501f4304a80'
   })
 
   depends_on 'llvm' => :build


### PR DESCRIPTION
Fixes #5934

Works properly:
- [x] x86_64
- [x] armv7l

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686 @uberhacker 