### PR TITLE
Only install llvm as a runtime dependency when necessary

### DIFF
--- a/packages/inkscape.rb
+++ b/packages/inkscape.rb
@@ -29,7 +29,7 @@ class Inkscape < Package
   depends_on 'hicolor_icon_theme'
   depends_on 'imagemagick6'
   depends_on 'imagemagick7'
-  depends_on 'llvm'
+  depends_on 'llvm' => :build
   depends_on 'popt'
   depends_on 'xdg_base'
   depends_on 'sommelier'

--- a/packages/js78.rb
+++ b/packages/js78.rb
@@ -24,7 +24,7 @@ class Js78 < Package
 
   depends_on 'autoconf213' => :build
   depends_on 'rust' => :build
-  depends_on 'llvm'
+  depends_on 'llvm' => :build
   depends_on 'nspr'
 
   case ARCH

--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -22,13 +22,13 @@ class Ldc < Package                 # The first character of the class name must
      x86_64: '6730100e809fc14d8b42f6d39fce4699917d24b971438eceb819e9c9264fbeaa',
   })
 
-  depends_on 'llvm'
   depends_on 'libcurl'
   depends_on 'ncurses'
   depends_on 'zlibpkg'
   depends_on 'libconfig' => :build
   depends_on 'cmake' => :build
   depends_on 'libedit' => :build
+  depends_on 'llvm' => :build
 
   def self.build                   # the steps required to build the package
     system "mkdir", "build"

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -39,7 +39,7 @@ class Mesa < Package
   depends_on 'libxvmc' # R
   depends_on 'libxv' # R
   depends_on 'libxxf86vm' # R
-  depends_on 'llvm' # R
+  depends_on 'llvm' => :build
   depends_on 'lm_sensors' # R
   depends_on 'valgrind' => :build
   depends_on 'vulkan_headers' => :build


### PR DESCRIPTION
No need to install this massive app unless needed for builds.