### PR TITLE
crew remove upx backup files not deleted

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -997,6 +997,7 @@ def shrink_dir(dir)
             system "upx --best -k --overlay=skip #{execfile} && \
             \( upx -t #{execfile} && rm #{execfile}.~ || mv #{execfile}.~ #{execfile}\)"
           end
+          system 'find . -executable -type f -name "*.~" -delete'
         end
       end
     end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.11.8'
+CREW_VERSION = '1.11.9'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- the upx shell code was leaving backup files after successful compression instead of deleting them.

Works properly:
- [x] x86_64