### PR TITLE
Firefox 90.0

### DIFF
--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -3,16 +3,16 @@ require 'package'
 class Firefox < Package
   description 'Mozilla Firefox (or simply Firefox) is a free and open-source web browser'
   homepage 'https://www.mozilla.org/en-US/firefox/'
-  version '89.0.2'
+  version '90.0'
   license 'MPL-2.0, GPL-2 and LGPL-2.1'
   compatibility 'i686,x86_64'
   case ARCH
   when 'i686'
-    source_url "https://archive.mozilla.org/pub/firefox/releases/#{version}/linux-i686/en-US/firefox-#{version}.tar.bz2"
-    source_sha256 '491fd0066a893fdb3a6cc58e3e0b6b02f15096d07563437a79b2727d09256890'
+    source_url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-i686/en-US/firefox-#{version}.tar.bz2"
+    source_sha256 'f983e7537f54131697366c0926b6aad8045c2f1e16c78a0d5edb392d214e535f'
   when 'x86_64'
-    source_url "https://archive.mozilla.org/pub/firefox/releases/#{version}/linux-x86_64/en-US/firefox-#{version}.tar.bz2"
-    source_sha256 '964b6b515151bb9a0f4e90e9902afd09ff64bfaafa231480b9829264d36fd76f'
+    source_url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-x86_64/en-US/firefox-#{version}.tar.bz2"
+    source_sha256 '29fd51b6316d1e589220c2f47e5ff7cdd996cddd450f64ce1dd28ed0e8e4e8fa'
   end
 
   depends_on 'atk'
@@ -43,6 +43,10 @@ class Firefox < Package
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/firefox"
     FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/firefox"
-    FileUtils.ln_s "#{CREW_PREFIX}/firefox/firefox", "#{CREW_DEST_PREFIX}/bin/firefox"
+    @firefox_sh = <<~FIREFOX_HEREDOC
+      #!/bin/bash
+      GDK_BACKEND=x11 #{CREW_PREFIX}/firefox/firefox "\$@"
+    FIREFOX_HEREDOC
+    IO.write("#{CREW_DEST_PREFIX}/bin/firefox", @firefox_sh, perm: 0o755)
   end
 end


### PR DESCRIPTION
- Added wrapper script to set `GDK_BACKEND=x11` so that firefox doesn't try to use wayland, which leads to an error.
- Should we remove i686, since gui apps don't work from i686?

Works properly:
- [x] x86_64
- [?] i686
