### PR TITLE
Don't let crew break if CREW_PREFIX is set.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1402,7 +1402,7 @@ def install_command(args)
     @pkgName = name
     search @pkgName
     print_current_package true
-    @pkg.build_from_source = true if @opt_src or @opt_recursive
+    @pkg.build_from_source = true if @opt_src or @opt_recursive or ENV['CREW_BUILD_FROM_SOURCE'] == '1'
     resolve_dependencies_and_install
   end
 end
@@ -1436,7 +1436,7 @@ def reinstall_command(args)
     @pkgName = name
     search @pkgName
     print_current_package
-    @pkg.build_from_source = true if @opt_src or @opt_recursive
+    @pkg.build_from_source = true if @opt_src or @opt_recursive or ENV['CREW_BUILD_FROM_SOURCE'] == '1'
     if @pkgName
       @pkg.in_upgrade = true
       resolve_dependencies_and_install
@@ -1472,7 +1472,7 @@ def upgrade_command(args)
     @pkgName = name
     search @pkgName
     print_current_package
-    @pkg.build_from_source = true if @opt_src
+    @pkg.build_from_source = true if @opt_src or ENV['CREW_BUILD_FROM_SOURCE'] == '1'
     upgrade
   end.empty? and begin
     upgrade

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.11.9'
+CREW_VERSION = '1.12.0'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines
@@ -13,11 +13,11 @@ ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
 @libcvertokens=  %x[/#{ARCH_LIB}/libc.so.6].lines.first.chomp.split(/[\s]/)
 LIBC_VERSION = @libcvertokens[@libcvertokens.find_index("version") + 1].sub!(/[[:punct:]]?$/,'')
 
-if ENV['CREW_PREFIX'].to_s.empty?
+if ENV['CREW_PREFIX'].to_s.empty? or ENV['CREW_PREFIX'] == '/usr/local'
   CREW_PREFIX = '/usr/local'
 else
   CREW_PREFIX = ENV['CREW_PREFIX']
-  @pkg.build_from_source = true
+  CREW_BUILD_FROM_SOURCE = 1
 end
 
 CREW_LIB_PREFIX = CREW_PREFIX + '/' + ARCH_LIB

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -13,9 +13,8 @@ ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
 @libcvertokens=  %x[/#{ARCH_LIB}/libc.so.6].lines.first.chomp.split(/[\s]/)
 LIBC_VERSION = @libcvertokens[@libcvertokens.find_index("version") + 1].sub!(/[[:punct:]]?$/,'')
 
-if ENV['CREW_PREFIX'].to_s.empty? or ENV['CREW_PREFIX'] == '/usr/local'
-  CREW_PREFIX = '/usr/local'
-else
+CREW_PREFIX = '/usr/local'
+if ENV['CREW_PREFIX'] and ENV['CREW_PREFIX'] != CREW_PREFIX
   CREW_PREFIX = ENV['CREW_PREFIX']
   CREW_BUILD_FROM_SOURCE = 1
 end


### PR DESCRIPTION
If `CREW_PREFIX` is set, `crew` breaks, complaining about `@pkg.build_from_source` being set in `const.rb`, with a `/usr/local/lib/crew/lib/const.rb:20:in `<top (required)>': undefined method `build_from_source=' for nil:NilClass (NoMethodError)
` error.

![image](https://user-images.githubusercontent.com/1096701/125653139-4f0efcbf-14f5-449d-9bbb-3eb27641c95c.png)


Works properly:
- [x] x86_64