### PR TITLE
Add core to buildessential

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,11 +3,14 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.17'
+  version '1.18'
   license 'GPL-3+'
   compatibility 'all'
 
   is_fake
+
+  # Makre sure core is installed
+  depends_on 'core'
 
   # install first to get ldconfig
   depends_on 'glibc'

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -9,7 +9,7 @@ class Buildessential < Package
 
   is_fake
 
-  # Makre sure core is installed
+  # Make sure core is installed
   depends_on 'core'
 
   # install first to get ldconfig


### PR DESCRIPTION
Older installs may not have installed core, so make sure at least `buildessential` has a core dependency.

Works properly:
- [x] x86_64
