### PR TITLE
Gnome updates (& updates for dependencies thereof.)

### DIFF
--- a/packages/evolution_data_server.rb
+++ b/packages/evolution_data_server.rb
@@ -2,24 +2,22 @@ require 'package'
 
 class Evolution_data_server < Package
   description 'Centralized access to appointments and contacts'
-  @_ver = '3.39.3'
+  @_ver = '3.40.3'
   version @_ver
   license 'LGPL-2 or LGPL-3, BSD and Sleepycat'
-  compatibility 'all'
-  source_url "https://github.com/GNOME/evolution-data-server/archive/#{@_ver}.tar.gz"
-  source_sha256 'd789b6dc403d35902b3b6cdcebff31880d2773b1829fbdc561c59a71453eaab9'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://gitlab.gnome.org/GNOME/evolution-data-server.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evolution_data_server/3.39.3_armv7l/evolution_data_server-3.39.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evolution_data_server/3.39.3_armv7l/evolution_data_server-3.39.3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evolution_data_server/3.39.3_i686/evolution_data_server-3.39.3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evolution_data_server/3.39.3_x86_64/evolution_data_server-3.39.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evolution_data_server/3.40.3_armv7l/evolution_data_server-3.40.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evolution_data_server/3.40.3_armv7l/evolution_data_server-3.40.3-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evolution_data_server/3.40.3_x86_64/evolution_data_server-3.40.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'cf89c1f0ee6aaec68cee3dc6d5e9261a715b1e074ea1613f474976f9e8db376e',
-     armv7l: 'cf89c1f0ee6aaec68cee3dc6d5e9261a715b1e074ea1613f474976f9e8db376e',
-       i686: 'afe9ca339c2f242a40754f9a382a7ea07c616bdb50a30d65a4cade0ef641d8f4',
-     x86_64: 'cb36117f9ffaf564b84c0ec60c15c4c08a9e7d07584daa54dc859b5d281a8f17'
+    aarch64: '8ade9630fc18351495084f5e0ae3ad98fbbcd3e50f937d795d8dc2a1c4c36158',
+     armv7l: '8ade9630fc18351495084f5e0ae3ad98fbbcd3e50f937d795d8dc2a1c4c36158',
+     x86_64: '9620cad89b0ed797c84b4d7b85b977883678669963c724a679a09c681ef3934f'
   })
 
   depends_on 'nss'
@@ -34,9 +32,7 @@ class Evolution_data_server < Package
   def self.build
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
-      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} \
-      CFLAGS='-pipe -flto=auto -I#{CREW_PREFIX}/include/gnu-libiconv' CXXFLAGS='-pipe -flto=auto -I#{CREW_PREFIX}/include/gnu-libiconv' \
-      LDFLAGS='-flto=auto -L#{CREW_LIB_PREFIX}' \
+      system "LIBRARY_PATH=#{CREW_LIB_PREFIX} \
       cmake #{CREW_CMAKE_LIBSUFFIX_OPTIONS} .. -G Ninja \
       -DCMAKE_VERBOSE_MAKEFILE=ON \
       -DENABLE_CANBERRA=OFF \
@@ -50,6 +46,7 @@ class Evolution_data_server < Package
       -DENABLE_WEATHER=OFF \
       -DWITH_NSPR_INCLUDES=#{CREW_PREFIX}/include/nspr \
       -DWITH_NSS_INCLUDES=#{CREW_PREFIX}/include/nss \
+      -DWITH_OPENLDAP=OFF \
       -DWITH_PHONENUMBER=OFF"
     end
     system 'ninja -C builddir'

--- a/packages/gnome_desktop.rb
+++ b/packages/gnome_desktop.rb
@@ -3,25 +3,23 @@ require 'package'
 class Gnome_desktop < Package
   description 'Library with common API for various GNOME modules'
   homepage 'https://gitlab.gnome.org/GNOME/gnome-desktop'
-  @_ver = '40.0'
+  @_ver = '40.3'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version "#{@_ver}-1"
+  version @_ver
   license 'GPL-2+, LGPL-2+ and FDL-1.1+'
-  compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gnome-desktop/-/archive/#{@_ver}/gnome-desktop-#{@_ver}.tar.bz2"
-  source_sha256 'b993bb587326e405796ffe15335eba6923cfec4bee454e738a748e98476c320a'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://gitlab.gnome.org/GNOME/gnome-desktop.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_desktop/40.0-1_armv7l/gnome_desktop-40.0-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_desktop/40.0-1_armv7l/gnome_desktop-40.0-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_desktop/40.0-1_i686/gnome_desktop-40.0-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_desktop/40.0-1_x86_64/gnome_desktop-40.0-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_desktop/40.3_armv7l/gnome_desktop-40.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_desktop/40.3_armv7l/gnome_desktop-40.3-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_desktop/40.3_x86_64/gnome_desktop-40.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'aa5626a827b0dc651edc6187b5f9bda067191aaa003961b051d763939488c800',
-     armv7l: 'aa5626a827b0dc651edc6187b5f9bda067191aaa003961b051d763939488c800',
-       i686: '2ec196505f5a9d53833d44af523f7cc1383883ec8de1cc49ee9c0010a0cac8c5',
-     x86_64: '36359861c63f4272417bc9ab23b4eeeba0c301a167268cbca4e7a8c940f53e04'
+    aarch64: '42015f607b49bda566fb307649835336bafafebf182d6a6938bee23489a8c0f9',
+     armv7l: '42015f607b49bda566fb307649835336bafafebf182d6a6938bee23489a8c0f9',
+     x86_64: 'c9dc4e63cc3c1e16a957e37064fd2efed590b96b5bb58b8fe3004ea2dcf825f2'
   })
 
   depends_on 'cairo'

--- a/packages/gnome_settings_daemon.rb
+++ b/packages/gnome_settings_daemon.rb
@@ -3,24 +3,22 @@ require 'package'
 class Gnome_settings_daemon < Package
   description 'GNOME Settings Daemon'
   homepage 'https://gitlab.gnome.org/GNOME/gnome-settings-daemon'
-  @_ver = '40.0'
+  @_ver = '40.0.1'
   version @_ver
   license 'GPL-2+ and LGPL-2+'
-  compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/archive/#{@_ver}/gnome-settings-daemon-#{@_ver}.tar.bz2"
-  source_sha256 'ea6351b9f82c507e431cea15a69e7bb0574b8003618c48ff8c07e04969516e7f'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://gitlab.gnome.org/GNOME/gnome-settings-daemon.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_settings_daemon/40.0_armv7l/gnome_settings_daemon-40.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_settings_daemon/40.0_armv7l/gnome_settings_daemon-40.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_settings_daemon/40.0_i686/gnome_settings_daemon-40.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_settings_daemon/40.0_x86_64/gnome_settings_daemon-40.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_settings_daemon/40.0.1_armv7l/gnome_settings_daemon-40.0.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_settings_daemon/40.0.1_armv7l/gnome_settings_daemon-40.0.1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_settings_daemon/40.0.1_x86_64/gnome_settings_daemon-40.0.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'ae054caa58411bbf1f00729e748aaf0974913bff99ff77d24797f3814e4c5387',
-     armv7l: 'ae054caa58411bbf1f00729e748aaf0974913bff99ff77d24797f3814e4c5387',
-       i686: '90a5725eb84e76c5a23bd80fb670a569e63315a6ae8a599ef92cf8ec499f3aec',
-     x86_64: '294b8c533a037a62c14971e49d909b5a48c62b7717734bdc3b0ab20ee981be11'
+    aarch64: '13be0d7f914c132310b6a5ccd7cfb9584269dac858a3cc61a46fcd63966cf425',
+     armv7l: '13be0d7f914c132310b6a5ccd7cfb9584269dac858a3cc61a46fcd63966cf425',
+     x86_64: '26646a35e2335da43548bcade06a0f1e609ee8eacfe1815c2ac6c07a2187355d'
   })
 
   depends_on 'dconf'
@@ -40,20 +38,20 @@ class Gnome_settings_daemon < Package
   depends_on 'geoclue'
   depends_on 'gcr'
 
-  def self.patch
-    # Source has libgnome-volume-control repo as submodule
-    @git_dir = 'subprojects/gvc'
-    @git_hash = '7a621180b46421e356b33972e3446775a504139c'
-    @git_url = 'https://gitlab.gnome.org/GNOME/libgnome-volume-control.git'
-    FileUtils.rm_rf(@git_dir)
-    FileUtils.mkdir_p(@git_dir)
-    Dir.chdir @git_dir do
-      system 'git init'
-      system "git remote add origin #{@git_url}"
-      system "git fetch --depth 1 origin #{@git_hash}"
-      system 'git checkout FETCH_HEAD'
-    end
-  end
+  # def self.patch
+  ## Source has libgnome-volume-control repo as submodule
+  # @git_dir = 'subprojects/gvc'
+  # @git_hash = '7a621180b46421e356b33972e3446775a504139c'
+  # @git_url = 'https://gitlab.gnome.org/GNOME/libgnome-volume-control.git'
+  # FileUtils.rm_rf(@git_dir)
+  # FileUtils.mkdir_p(@git_dir)
+  # Dir.chdir @git_dir do
+  # system 'git init'
+  # system "git remote add origin #{@git_url}"
+  # system "git fetch --depth 1 origin #{@git_hash}"
+  # system 'git checkout FETCH_HEAD'
+  # end
+  # end
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/gnome_shell.rb
+++ b/packages/gnome_shell.rb
@@ -3,21 +3,21 @@ require 'package'
 class Gnome_shell < Package
   description 'Next generation desktop shell'
   homepage 'https://wiki.gnome.org/Projects/GnomeShell'
-  version '40.0'
+  version '40.3'
   license 'GPL-2+ and LGPL-2+'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url "https://github.com/GNOME/gnome-shell/archive/#{version}.tar.gz"
-  source_sha256 '29567d94787e4b8db2723caeaf230ee1eba6b53072592c9269a24973909aaca3'
+  source_url 'https://gitlab.gnome.org/GNOME/gnome-shell.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_shell/40.0_armv7l/gnome_shell-40.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_shell/40.0_armv7l/gnome_shell-40.0-chromeos-armv7l.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_shell/40.0_x86_64/gnome_shell-40.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_shell/40.3_armv7l/gnome_shell-40.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_shell/40.3_armv7l/gnome_shell-40.3-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_shell/40.3_x86_64/gnome_shell-40.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '31335a6996bc1638c4e63497684b7f3f9b90eb016e10aedaa9c96848190609c0',
-     armv7l: '31335a6996bc1638c4e63497684b7f3f9b90eb016e10aedaa9c96848190609c0',
-     x86_64: '4e933fabbc5cab93e25579de3958cdcde55d7d11c1ef13a6902c5775fb0d925c'
+    aarch64: 'a77bce5ae1cffd7a7a159730565b7308442d44a8ad2fcce5367caa9683d07ff6',
+     armv7l: 'a77bce5ae1cffd7a7a159730565b7308442d44a8ad2fcce5367caa9683d07ff6',
+     x86_64: '26f505c184e1277fba828dd0258845bed34a42d62c0dc19862f0698d1b2113de'
   })
 
   depends_on 'gcr'
@@ -35,21 +35,8 @@ class Gnome_shell < Package
   depends_on 'evolution_data_server' => :build
   depends_on 'gobject_introspection' => :build
   depends_on 'mutter'
-
-  def self.patch
-    # Source has libgnome-volume-control repo as submodule
-    @git_dir = 'subprojects/gvc'
-    @git_hash = 'c5ab6037f460406ac9799b1e5765de3ce0097a8b'
-    @git_url = 'https://gitlab.gnome.org/GNOME/libgnome-volume-control.git'
-    FileUtils.rm_rf(@git_dir)
-    FileUtils.mkdir_p(@git_dir)
-    Dir.chdir @git_dir do
-      system 'git init'
-      system "git remote add origin #{@git_url}"
-      system "git fetch --depth 1 origin #{@git_hash}"
-      system 'git checkout FETCH_HEAD'
-    end
-  end
+  depends_on 'pygments' => :build
+  depends_on 'vulkan_icd_loader' => :build
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -3,24 +3,22 @@ require 'package'
 class Libdrm < Package
   description 'Cross-driver middleware for DRI protocol.'
   homepage 'https://dri.freedesktop.org'
-  @_ver = '2.4.105'
+  @_ver = '2.4.107'
   version @_ver
   license 'MIT'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url "https://dri.freedesktop.org/libdrm/libdrm-#{@_ver}.tar.xz"
-  source_sha256 '1d1d024b7cadc63e2b59cddaca94f78864940ab440843841113fbac6afaf2a46'
+  source_sha256 'c554cef03b033636a975543eab363cc19081cb464595d3da1ec129f87370f888'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.105_armv7l/libdrm-2.4.105-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.105_armv7l/libdrm-2.4.105-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.105_i686/libdrm-2.4.105-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.105_x86_64/libdrm-2.4.105-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.107_armv7l/libdrm-2.4.107-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.107_armv7l/libdrm-2.4.107-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.107_x86_64/libdrm-2.4.107-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '457114332298eceb569af56d616ad691090c916c30e4aab132787f231e2b10b1',
-     armv7l: '457114332298eceb569af56d616ad691090c916c30e4aab132787f231e2b10b1',
-       i686: 'e55e2df9df10d55c9f25a1c4c44adf8f400afc076742377a2717bc7062f01bd7',
-     x86_64: '868460097f1ac8928b165655b8effbc265134a1205887e3003ed6ec2c0d6a678'
+    aarch64: '7610b79d04ea3bd1a74a56fc947fd226bf902d8ff4ca41f62ee61acf95982bcd',
+     armv7l: '7610b79d04ea3bd1a74a56fc947fd226bf902d8ff4ca41f62ee61acf95982bcd',
+     x86_64: 'acad6807fb51761065d53d118f5b6676a9f643af18f87e6ad6dd68c15a734fbe'
   })
 
   depends_on 'libpciaccess' # R

--- a/packages/libical.rb
+++ b/packages/libical.rb
@@ -3,37 +3,33 @@ require 'package'
 class Libical < Package
   description 'An open source reference implementation of the icalendar data type and serialization format'
   homepage 'https://github.com/libical/libical'
-  version '3.0.9'
+  version '3.0.10'
   license 'MPL-2.0 or LGPL-2.1'
-  compatibility 'all'
-  source_url 'https://github.com/libical/libical/releases/download/v3.0.9/libical-3.0.9.tar.gz'
-  source_sha256 'bd26d98b7fcb2eb0cd5461747bbb02024ebe38e293ca53a7dfdcb2505265a728'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/libical/libical/releases/download/v3.0.10/libical-3.0.10.tar.gz'
+  source_sha256 'f933b3e6cf9d56a35bb5625e8e4a9c3a50239a85aea05ed842932c1a1dc336b4'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libical/3.0.9_armv7l/libical-3.0.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libical/3.0.9_armv7l/libical-3.0.9-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libical/3.0.9_i686/libical-3.0.9-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libical/3.0.9_x86_64/libical-3.0.9-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libical/3.0.10_armv7l/libical-3.0.10-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libical/3.0.10_armv7l/libical-3.0.10-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libical/3.0.10_x86_64/libical-3.0.10-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '7db2461fee6be357f39abd270cfad5f20aa2e0d40f65a3310f1d2cc755c50e5e',
-     armv7l: '7db2461fee6be357f39abd270cfad5f20aa2e0d40f65a3310f1d2cc755c50e5e',
-       i686: '15749b91f620d4f108c6c73ce3a23075621a13728348d401ae499b1db047b747',
-     x86_64: 'd3ebd14fbd5b34f1c0347dfb21e6b278a6a7131fb9367a1be0e53d23cac755ac'
+    aarch64: 'eaf30d94276f73f41c57f4c4ef520d90db8dd26c6fabd87ec06eb427d7630c1f',
+     armv7l: 'eaf30d94276f73f41c57f4c4ef520d90db8dd26c6fabd87ec06eb427d7630c1f',
+     x86_64: '4183f8666361ccb3c4c41e41ec1a17a649d1e432836a55a3aeb56ef2d0976f05'
   })
 
   depends_on 'glib'
-  depends_on 'icu4c'
   depends_on 'gtk_doc' => :build
+  depends_on 'icu4c'
   depends_on 'vala' => :build
   depends_on 'gobject_introspection' => :build
 
   def self.build
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
-      system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      cmake #{CREW_CMAKE_OPTIONS} .. -G Ninja \
+      system "cmake #{CREW_CMAKE_OPTIONS} .. -G Ninja \
       -DGOBJECT_INTROSPECTION=true \
       -DICAL_GLIB_VAPI=true \
       -DICAL_BUILD_DOCS=false \

--- a/packages/mutter.rb
+++ b/packages/mutter.rb
@@ -3,21 +3,21 @@ require 'package'
 class Mutter < Package
   description 'A window manager for GNOME'
   homepage 'https://wiki.gnome.org/Projects/Mutter'
-  version '40.1'
+  version '40.3'
   license 'GPL-2+'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/mutter.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.1_armv7l/mutter-40.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.1_armv7l/mutter-40.1-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.1_x86_64/mutter-40.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.3_armv7l/mutter-40.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.3_armv7l/mutter-40.3-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mutter/40.3_x86_64/mutter-40.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '45b333676e45c13fdeab755581875203cf3f1f23265b86c83db5933e6d80d937',
-     armv7l: '45b333676e45c13fdeab755581875203cf3f1f23265b86c83db5933e6d80d937',
-     x86_64: 'faf3da0f7e8868fdc885b822ce9fb23bb44e0df47a3f0174c19dc7caff9f6c68'
+    aarch64: 'ad5d9c51bd569a9a6a06fecf2075eb63ed70817f4c29abf7ececbceeb50fe7d4',
+     armv7l: 'ad5d9c51bd569a9a6a06fecf2075eb63ed70817f4c29abf7ececbceeb50fe7d4',
+     x86_64: 'd1427dea256c51647c61f7e1d8987fe4ce87aee6d98c79993bdaf5657f74b186'
   })
 
   depends_on 'ccache' => :build

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -3,24 +3,22 @@ require 'package'
 class Vulkan_headers < Package
   description 'Vulkan header files'
   homepage 'https://github.com/KhronosGroup/Vulkan-Headers'
-  @_ver = '1.2.171'
+  @_ver = '1.2.184'
   version @_ver
   license 'Apache-2.0'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url "https://github.com/KhronosGroup/Vulkan-Headers/archive/v#{@_ver}.tar.gz"
-  source_sha256 'b86266544ab1d6780c5ee6cdf10f24ba9ec4c97bc83d2229e0fb8142c36e52ac'
+  source_sha256 'de1889ff550c1a78e752fbdf71117ac319fb674b0abe080a4e6e9053da2aea85'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.171_armv7l/vulkan_headers-1.2.171-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.171_armv7l/vulkan_headers-1.2.171-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.171_i686/vulkan_headers-1.2.171-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.171_x86_64/vulkan_headers-1.2.171-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_armv7l/vulkan_headers-1.2.184-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_armv7l/vulkan_headers-1.2.184-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_x86_64/vulkan_headers-1.2.184-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'f0795e78f27c10ab4180743b4f1f46b566007da4fd348b4cdf6e35ee4c3fb72b',
-     armv7l: 'f0795e78f27c10ab4180743b4f1f46b566007da4fd348b4cdf6e35ee4c3fb72b',
-       i686: '285dbac0bfd1e95262b2d60a0b9ff3dc5c300b794777871552d104a4e7f68549',
-     x86_64: 'f054e13240784b5c989d0a046a36dcffed794b1d6cbd3ff3998c2d70d32b0234'
+    aarch64: 'b17aa592829e1ff8810c92f2cf28bf0b77f198bf0d5d71c5fcc45c12206dc2f8',
+     armv7l: 'b17aa592829e1ff8810c92f2cf28bf0b77f198bf0d5d71c5fcc45c12206dc2f8',
+     x86_64: '276679a7d8b8061198fe4262e89eca1f745208ea23e26dea99e2510d668795b0'
   })
 
   def self.build

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -3,24 +3,22 @@ require 'package'
 class Vulkan_icd_loader < Package
   description 'Vulkan Installable Client Driver ICD Loader'
   homepage 'https://github.com/KhronosGroup/Vulkan-Loader'
-  @_ver = '1.2.169'
+  @_ver = '1.2.184'
   version @_ver
-  license 'APache-2.0'
-  compatibility 'all'
+  license 'Apache-2.0'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url "https://github.com/KhronosGroup/Vulkan-Loader/archive/v#{@_ver}.tar.gz"
-  source_sha256 'e8413d6244245e5322a91fa204415115941c5396b892ef28a13152af635c5ca4'
+  source_sha256 '61f2cae1c47f38e17b6a2e578cf247041d733a2db364d6e09f4366cc493aec73'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.169_armv7l/vulkan_icd_loader-1.2.169-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.169_armv7l/vulkan_icd_loader-1.2.169-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.169_i686/vulkan_icd_loader-1.2.169-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.169_x86_64/vulkan_icd_loader-1.2.169-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_armv7l/vulkan_icd_loader-1.2.184-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_armv7l/vulkan_icd_loader-1.2.184-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_x86_64/vulkan_icd_loader-1.2.184-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'b5e441f3f7c9959ae0fc2a9b00bbcc4d5861068687c4174f500b3d1769f08e19',
-     armv7l: 'b5e441f3f7c9959ae0fc2a9b00bbcc4d5861068687c4174f500b3d1769f08e19',
-       i686: '965450506c352b43d05fe88fb2e60ebd9c0080cfd321e59f392a4f32daeddaff',
-     x86_64: 'ba071a6f4a1536b5c5237270c836dd89cd0bb041567f942a71e39adaacd32d87'
+    aarch64: '34cad6bd4efd3ea9bc603eafdc9bccdbcabbdfb4d84966ea5f04a83bc8e30886',
+     armv7l: '34cad6bd4efd3ea9bc603eafdc9bccdbcabbdfb4d84966ea5f04a83bc8e30886',
+     x86_64: 'bb7021c88c28ddad6587eb7bc298821cf48181f5570e44ba7eb72c1ff4317068'
   })
 
   depends_on 'libx11'


### PR DESCRIPTION
- Updates most packages to their Gnome 40.3 versions.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
