### PR TITLE
Vala -> 0.52.4

### DIFF
--- a/packages/vala.rb
+++ b/packages/vala.rb
@@ -3,34 +3,47 @@ require 'package'
 class Vala < Package
   description 'Vala is a programming language that aims to bring modern programming language features to GNOME developers.'
   homepage 'https://wiki.gnome.org/Projects/Vala'
-  version '0.51.2'
+  version '0.52.4'
   license 'LGPL-2.1+'
-  compatibility 'all'
-  source_url 'https://download.gnome.org/core/40/40.beta/sources/vala-0.51.2.tar.xz'
-  source_sha256 'a1db75bfdc7e8ffa08d2c4a8a4b561fb24f3e9516d712531b8d14a74695a37b2'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://gitlab.gnome.org/GNOME/vala.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vala/0.51.2_armv7l/vala-0.51.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vala/0.51.2_armv7l/vala-0.51.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vala/0.51.2_i686/vala-0.51.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vala/0.51.2_x86_64/vala-0.51.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vala/0.52.4_armv7l/vala-0.52.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vala/0.52.4_armv7l/vala-0.52.4-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vala/0.52.4_x86_64/vala-0.52.4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '322bf1ba49dad18e92a07ff0371d1ecf5ef50658cff4854c866484d0636209cd',
-     armv7l: '322bf1ba49dad18e92a07ff0371d1ecf5ef50658cff4854c866484d0636209cd',
-       i686: '5637fb96d07390df272e5d0864b91442bb9aac4b934d69215eafc4e0e81fdca4',
-     x86_64: '977183724a7552da5c055540d01d702c0887ecd1b0cdb05220718ce964037042'
+    aarch64: '99147de6b7b758595d27359d4a6fa137f844b1d67807d8f0a14a5cf5ae201a4f',
+     armv7l: '99147de6b7b758595d27359d4a6fa137f844b1d67807d8f0a14a5cf5ae201a4f',
+     x86_64: '85dd615b1ff6ccb1c6cf9940349624b8f0228c045ce275e2d2b5f304de79279d'
   })
 
+  depends_on 'autoconf_archive' => :build
+  depends_on 'autoconf213' => :build
   depends_on 'graphviz'
   depends_on 'libxslt'
   depends_on 'glib'
   depends_on 'dbus'
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-    LDFLAGS='-pipe -flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+    # Required for building vala from git.
+    system 'git fetch --tags'
+    # Bootstrap vala
+    FileUtils.mkdir_p 'bootstrap_install'
+    system 'git clone https://gitlab.gnome.org/Archive/vala-bootstrap.git'
+    Dir.chdir('vala-bootstrap') do
+      system 'git checkout b2beeaccdf2307ced172646c2ada9765e1747b28'
+      system 'touch */*.stamp'
+      system 'autoreconf -fi'
+      system 'VALAC=/no-valac ./configure --prefix=`pwd`/../bootstrap_install'
+      system 'make'
+      system 'make install'
+    end
+
+    system "#{CREW_ENV_OPTIONS} VALAC=`pwd`/bootstrap_install/bin/valac ./autogen.sh \
+      #{CREW_OPTIONS} \
       --disable-maintainer-mode \
       --disable-valadoc"
     system 'make'


### PR DESCRIPTION
- build now bootstraps without needing a prior vala install.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l