### PR TITLE
Adjust dbus deps & don't require for non-X11 installs

### DIFF
--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -8,7 +8,6 @@ class Crew_profile_base < Package
   compatibility 'all'
   source_url 'SKIP'
 
-  depends_on 'dbus'
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d"
@@ -45,6 +44,10 @@ class Crew_profile_base < Package
       # Remove stale files from the last install
       FileUtils.rm "#{HOME}/.bashrc.bak" if File.exist? "#{HOME}/.bashrc.bak"
       FileUtils.rm "#{HOME}/.zshrc.bak" if File.exist? "#{HOME}/.zshrc.bak"
+
+      # dbus file moved to dbus package, so remove it.
+      FileUtils.rm_f './src/env.d/env.d/03-dbus'
+      FileUtils.rm_f "#{CREW_PREFIX}/etc/env.d/03-dbus"
 
       # Don't overwrite a custom shell rc
       @_str = "source #{CREW_PREFIX}/etc/profile"

--- a/packages/dbus.rb
+++ b/packages/dbus.rb
@@ -3,37 +3,66 @@ require 'package'
 class Dbus < Package
   description 'D-Bus is a message bus system, a simple way for applications to talk to one another.'
   homepage 'https://www.freedesktop.org/wiki/Software/dbus/'
-  version '1.13.18'
+  version '1.13.18-1'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://dbus.freedesktop.org/releases/dbus/dbus-1.13.18.tar.xz'
   source_sha256 '8078f5c25e34ab907ce06905d969dc8ef0ccbec367e1e1707c7ecf8460f4254e'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus/1.13.18_armv7l/dbus-1.13.18-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus/1.13.18_armv7l/dbus-1.13.18-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus/1.13.18_i686/dbus-1.13.18-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus/1.13.18_x86_64/dbus-1.13.18-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus/1.13.18-1_armv7l/dbus-1.13.18-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus/1.13.18-1_armv7l/dbus-1.13.18-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus/1.13.18-1_i686/dbus-1.13.18-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus/1.13.18-1_x86_64/dbus-1.13.18-1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '11c36243a83f99f7a2f44194ed1e8691fc5a4dd98238a067e8fa8caf53364842',
-     armv7l: '11c36243a83f99f7a2f44194ed1e8691fc5a4dd98238a067e8fa8caf53364842',
-       i686: 'cfa8bf8ea807e3b6762a041419ffd39ce6c4888a430debb0b6a4c9aa55a63489',
-     x86_64: 'c777f379f48d88844a5f9eb1f9e38174df8645c6e76845ab0fc8f1ee58034c52',
+  binary_sha256({
+    aarch64: '85709ef07ef65ade2689ecbce629200f349f493247b949817f3272e6cb504327',
+     armv7l: '85709ef07ef65ade2689ecbce629200f349f493247b949817f3272e6cb504327',
+       i686: '0315f3eced7198a0850973289f8af06e9f5bdc7aec29834debfaa56556c29c98',
+     x86_64: '3a459724ba6e7f14eacc089fb5500b20b7857aa3034cfc58edf2450ad8ac1c02'
   })
 
-  depends_on 'expat'
+  depends_on 'expat' # R
+  depends_on 'libice' # R
+  depends_on 'libsm' # R
+  depends_on 'libx11' # R
+
+  def self.patch
+    system 'filefix'
+  end
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-doxygen-docs',
-           '--disable-xml-docs'
+    system "#{CREW_ENV_OPTIONS} \
+              ./configure #{CREW_OPTIONS} \
+              --disable-doxygen-docs \
+              --disable-xml-docs \
+              --disable-apparmor \
+              --disable-libaudit \
+              --enable-x11-autolaunch \
+              --localstatedir=/var \
+              --runstatedir=/var/run \
+              --with-dbus-session-bus-listen-address=unix:tmpdir=/tmp"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d/"
+    @dbusconfigenv = <<~DBUSCONFIGEOF
+      # Dbus settings
+      DBUS_SYSTEM_BUS_ADDRESS='unix:path=/var/run/dbus/system_bus_socket'
+      [[ "\$DBUS_SESSION_BUS_ADDRESS"=="disabled:" ]] && unset DBUS_SESSION_BUS_ADDRESS
+      if [ -z "\${DBUS_SESSION_BUS_ADDRESS}" ]; then
+        # if not found, launch a new one
+        eval `dbus-launch --sh-syntax`
+        # echo "D-Bus per-session daemon address is: \$DBUS_SESSION_BUS_ADDRESS"
+      fi
+      dbus-update-activation-environment --all
+    DBUSCONFIGEOF
+    IO.write("#{CREW_DEST_PREFIX}/etc/env.d/dbus", @dbusconfigenv)
+  end
+
+  def self.postinstall
+    FileUtils.rm_f "#{CREW_PREFIX}/etc/env.d/03-dbus"
   end
 end


### PR DESCRIPTION
Fixes #5976 

- Dbus deps are now appropriately enumerated
- Moves the dbus env.d file to the dbus package.
- This keeps dbus from pulling in a bunch of X11 deps on a non-X11 install of chromebrew
- I am not updating dbus binaries since I don't want to create a broken i686 binary (hence the use of postinstall.)
- https://github.com/chromebrew/crew-profile-base can be updated in a separate PR.
- Thanks to @saltedcoffii for noticing this issue and pointing it out.

Works properly:
- [x] x86_64
