### PR TITLE
Freetype, harfbuzz updates & add chafa

### DIFF
--- a/packages/chafa.rb
+++ b/packages/chafa.rb
@@ -8,15 +8,19 @@ class Chafa < Package
   homepage 'https://hpjansson.org/chafa/'
   version '1.6.1'
   license 'LGPL'
-  compatibility 'x86_64'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/hpjansson/chafa/releases/download/1.6.1/chafa-1.6.1.tar.xz'
   source_sha256 '76c98930e99b3e5fadb986148b99d65636e9e9619124e568ff13d364ede89fa5'
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.6.1_x86_64/chafa-1.6.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.6.1_armv7l/chafa-1.6.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.6.1_armv7l/chafa-1.6.1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.6.1_x86_64/chafa-1.6.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    x86_64: '4b3fd102523ce0458a897bcd0ce1bbe8c60e30eb830e4aa98cedb782576795e6'
+    aarch64: '3b1070f6bb7c4e3756fec41b9241b7823d34c09cbedf59fb7a700921e06cb561',
+     armv7l: '3b1070f6bb7c4e3756fec41b9241b7823d34c09cbedf59fb7a700921e06cb561',
+     x86_64: '4b3fd102523ce0458a897bcd0ce1bbe8c60e30eb830e4aa98cedb782576795e6'
   })
 
   depends_on 'imagemagick7' => :build

--- a/packages/chafa.rb
+++ b/packages/chafa.rb
@@ -1,0 +1,41 @@
+# Adapted from Arch Linux chafa PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/chafa/trunk/PKGBUILD
+
+require 'package'
+
+class Chafa < Package
+  description 'Image-to-text converter supporting a wide range of symbols and palettes, transparency, animations, etc.'
+  homepage 'https://hpjansson.org/chafa/'
+  version '1.6.1'
+  license 'LGPL'
+  compatibility 'x86_64'
+  source_url 'https://github.com/hpjansson/chafa/releases/download/1.6.1/chafa-1.6.1.tar.xz'
+  source_sha256 '76c98930e99b3e5fadb986148b99d65636e9e9619124e568ff13d364ede89fa5'
+
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.6.1_x86_64/chafa-1.6.1-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    x86_64: '4b3fd102523ce0458a897bcd0ce1bbe8c60e30eb830e4aa98cedb782576795e6'
+  })
+
+  depends_on 'imagemagick7' => :build
+  depends_on 'freetype_sub' => :build
+  depends_on 'libxslt'
+  depends_on 'gtk_doc' => ':build'
+
+  def self.patch
+    system 'filefix'
+  end
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS} \
+      ./configure \
+      #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -3,40 +3,44 @@ require 'package'
 class Freetype < Package
   description 'FreeType is a freely available software library to render fonts.'
   homepage 'https://www.freetype.org/'
-  version '2.10.4'
+  version '2.11.0'
   license 'FTL or GPL-2+'
-  compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.xz'
-  source_sha256 '86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784'
+  compatibility 'x86_64'
+  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.xz'
+  source_sha256 '8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.10.4_armv7l/freetype-2.10.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.10.4_armv7l/freetype-2.10.4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.10.4_i686/freetype-2.10.4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.10.4_x86_64/freetype-2.10.4-chromeos-x86_64.tar.xz',
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_x86_64/freetype-2.11.0-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: 'c3063feb7034883e248ac4d62a82409df69577ccc4abe38ca7bd7e39c5ed3576',
-     armv7l: 'c3063feb7034883e248ac4d62a82409df69577ccc4abe38ca7bd7e39c5ed3576',
-       i686: 'a53b10cf19f25922aa6cc0f09fe846e5ee7221c73f2288ca04f83529191a94f5',
-     x86_64: '4622df673ffd07fdcec9591f039ad6e89c4687517678adb6f964dbfdff6a39cf',
+  binary_sha256({
+    x86_64: '395ed9c9be0c260428f1588ddce0a969bdfaab0c664c67f6518278610622a6d1'
   })
 
-  depends_on 'expat'
-  depends_on 'libpng'   # freetype needs zlib optionally. zlib is also the dependency of libpng
-  depends_on 'bz2'
   depends_on 'harfbuzz'
+  depends_on 'libpng'   # freetype needs zlib optionally. zlib is also the dependency of libpng
+
+  def self.patch
+    system 'sed -ri "s:.*(AUX_MODULES.*valid):\1:" modules.cfg'
+    system 'sed -r "s:.*(#.*SUBPIXEL_RENDERING) .*:\1:" \
+    -i include/freetype/config/ftoption.h'
+  end
 
   def self.build
     system 'pip3 install docwriter'
-    system "sed -i 's,/usr/include/freetype2,#{CREW_PREFIX}/include/freetype2,g' configure"
-    system "./configure CFLAGS=' -fPIC' #{CREW_OPTIONS} --enable-freetype-config --with-harfbuzz"
-    system 'make'
+    system "meson #{CREW_MESON_OPTIONS} \
+    --default-library=both \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
     system 'pip3 uninstall docwriter -y'
     system "pip3 install docwriter --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} ninja install -C builddir"
+  end
+
+  def self.postinstall
+    system "find #{CREW_BREW_DIR}/* -name freetype*.tar | xargs rm -rf"  # make sure to delete downloaded files
   end
 end

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -5,15 +5,19 @@ class Freetype < Package
   homepage 'https://www.freetype.org/'
   version '2.11.0'
   license 'FTL or GPL-2+'
-  compatibility 'x86_64'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.xz'
   source_sha256 '8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7'
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_x86_64/freetype-2.11.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_armv7l/freetype-2.11.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_armv7l/freetype-2.11.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_x86_64/freetype-2.11.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    x86_64: '395ed9c9be0c260428f1588ddce0a969bdfaab0c664c67f6518278610622a6d1'
+    aarch64: 'c08cf688f4f1ef885f349da0334de39cecdb20747465687065d95e03465c58d1',
+     armv7l: 'c08cf688f4f1ef885f349da0334de39cecdb20747465687065d95e03465c58d1',
+     x86_64: '395ed9c9be0c260428f1588ddce0a969bdfaab0c664c67f6518278610622a6d1'
   })
 
   depends_on 'harfbuzz'

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -5,15 +5,19 @@ class Freetype_sub < Package
   homepage 'https://www.freetype.org/'
   version '2.11.0'
   license 'FTL or GPL-2+'
-  compatibility 'x86_64'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.xz'
   source_sha256 '8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7'
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_x86_64/freetype_sub-2.11.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_armv7l/freetype_sub-2.11.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_armv7l/freetype_sub-2.11.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_x86_64/freetype_sub-2.11.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    x86_64: '039810744e62693895f366e48f2ff9156b4a02c3784a4b7a851992dc94ded9a6'
+    aarch64: '845ef60abffc0428c99102712323568f17d9a27e5a080df115dd07da25ff110a',
+     armv7l: '845ef60abffc0428c99102712323568f17d9a27e5a080df115dd07da25ff110a',
+     x86_64: '039810744e62693895f366e48f2ff9156b4a02c3784a4b7a851992dc94ded9a6'
   })
 
   depends_on 'libpng'   # freetype needs zlib optionally. zlib is also the dependency of libpng

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -3,39 +3,47 @@ require 'package'
 class Freetype_sub < Package
   description 'Freetype_sub is a version without harfbuzz. It is intended to handle circular dependency betwwen freetype and harfbuzz.'
   homepage 'https://www.freetype.org/'
-  version '2.10.4'
+  version '2.11.0'
   license 'FTL or GPL-2+'
-  compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.xz'
-  source_sha256 '86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784'
+  compatibility 'x86_64'
+  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.xz'
+  source_sha256 '8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.10.4_armv7l/freetype_sub-2.10.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.10.4_armv7l/freetype_sub-2.10.4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.10.4_i686/freetype_sub-2.10.4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.10.4_x86_64/freetype_sub-2.10.4-chromeos-x86_64.tar.xz',
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_x86_64/freetype_sub-2.11.0-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '7c8620a0cad19fbcd7ff0d96a7304323648b97c93d86352cfbb8216c768aeb1b',
-     armv7l: '7c8620a0cad19fbcd7ff0d96a7304323648b97c93d86352cfbb8216c768aeb1b',
-       i686: '4e6ab3e8a7dacab4380099315c2d547b89ce490f33d7e677744034d4e44ccabe',
-     x86_64: 'a5c364bdee4a22ca72bbaba4162dc2d75730f15b4340bddf038ee3698751c116',
+  binary_sha256({
+    x86_64: '039810744e62693895f366e48f2ff9156b4a02c3784a4b7a851992dc94ded9a6'
   })
 
-  depends_on 'expat'
   depends_on 'libpng'   # freetype needs zlib optionally. zlib is also the dependency of libpng
-  depends_on 'bz2'
+
+  def self.preflight
+    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+    if @device[:installed_packages].any? 'harfbuzz'
+      abort 'This harfbuzz prereq needs to be built without harfbuzz installed.'.lightred
+    end
+  end
+
+  def self.patch
+    system 'sed -ri "s:.*(AUX_MODULES.*valid):\1:" modules.cfg'
+    system 'sed -r "s:.*(#.*SUBPIXEL_RENDERING) .*:\1:" \
+    -i include/freetype/config/ftoption.h'
+  end
 
   def self.build
     system 'pip3 install docwriter'
-    system "./configure CFLAGS=' -fPIC' #{CREW_OPTIONS} --enable-freetype-config --without-harfbuzz"
-    system 'make'
+    system "meson #{CREW_MESON_OPTIONS} \
+    --default-library=both \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
     system 'pip3 uninstall docwriter -y'
     system "pip3 install docwriter --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} ninja install -C builddir"
   end
 
   def self.postinstall

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -3,37 +3,33 @@ require 'package'
 class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
-  @_ver = '2.8.1'
+  @_ver = '2.8.2'
   version @_ver
   license 'Old-MIT, ISC and icu'
-  compatibility 'all'
-  source_url "https://github.com/harfbuzz/harfbuzz/archive/#{@_ver}.tar.gz"
-  source_sha256 'b3f17394c5bccee456172b2b30ddec0bb87e9c5df38b4559a973d14ccd04509d'
+  compatibility 'x86_64'
+  source_url 'https://github.com/harfbuzz/harfbuzz.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.1_armv7l/harfbuzz-2.8.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.1_armv7l/harfbuzz-2.8.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.1_i686/harfbuzz-2.8.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.1_x86_64/harfbuzz-2.8.1-chromeos-x86_64.tpxz'
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.2_x86_64/harfbuzz-2.8.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'f39e2aba4445d71c63a6602650590d8c5463a5c093b3ec26933e2963dc354dcc',
-     armv7l: 'f39e2aba4445d71c63a6602650590d8c5463a5c093b3ec26933e2963dc354dcc',
-       i686: '25e7c49b04e81fa61db4385d4033b6b2c633bdfe5ef2a5ab3606c970ad4b307d',
-     x86_64: '801f46cbab0369087004aa3ce7952fc4d7754a85a0cb3c4b0648ce647fc87604'
+    x86_64: 'ab4f370493d031b21c1fbe58575096eb3616c84d824bbed5c7dfe9e3bdfd05f0'
   })
 
   depends_on 'cairo' => :build
+  depends_on 'chafa' => :build
   depends_on 'glib' => :build
   depends_on 'gobject_introspection'
   depends_on 'ragel' => :build
-  depends_on 'freetype_sub'
+  depends_on 'freetype_sub' => :build
   depends_on 'six' => :build
   depends_on 'graphite' => :build
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
     --default-library=both \
+    -Dfreetype=enabled \
     -Dintrospection=enabled \
     -Dbenchmark=disabled \
     -Dtests=disabled \

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -6,15 +6,19 @@ class Harfbuzz < Package
   @_ver = '2.8.2'
   version @_ver
   license 'Old-MIT, ISC and icu'
-  compatibility 'x86_64'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
   git_hashtag @_ver
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.2_x86_64/harfbuzz-2.8.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.2_armv7l/harfbuzz-2.8.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.2_armv7l/harfbuzz-2.8.2-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/2.8.2_x86_64/harfbuzz-2.8.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    x86_64: 'ab4f370493d031b21c1fbe58575096eb3616c84d824bbed5c7dfe9e3bdfd05f0'
+    aarch64: 'b5161044e1976ac2ed7fcc59c7ed1a1539530c6695cb84f1efdd33b1c7b55a97',
+     armv7l: 'b5161044e1976ac2ed7fcc59c7ed1a1539530c6695cb84f1efdd33b1c7b55a97',
+     x86_64: 'ab4f370493d031b21c1fbe58575096eb3616c84d824bbed5c7dfe9e3bdfd05f0'
   })
 
   depends_on 'cairo' => :build


### PR DESCRIPTION
Not to be merged until we get i686 (Do we need that?) and armv7l binaries built.
- Freetype[,_sub] -> 2.11.0
- Harbuzz -> 2.8.2
- chafa 1.6.1 added (as a prereq for harfbuzz)
- Still need to get my arm builder back up...

Build order: chafa, freetype_sub, harfbuzz, freetype

Works properly:
- [x] x86_64