### PR TITLE
Fontconfig -> 2.13.94

### DIFF
--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -3,24 +3,24 @@ require 'package'
 class Fontconfig < Package
   description 'Fontconfig is a library for configuring and customizing font access.'
   homepage 'https://www.freedesktop.org/software/fontconfig/front.html'
-  @_ver = '2.13.93'
-  version "#{@_ver}-2"
+  @_ver = '2.13.94'
+  version @_ver
   license 'MIT'
   compatibility 'all'
   source_url "https://github.com/freedesktop/fontconfig/archive/#{@_ver}.tar.gz"
-  source_sha256 'f8452c78d1a12f6966455b0d584f89553b13e970b40644c3650f690ec0b3b4fe'
+  source_sha256 '4cfaf426a59ad65ea7397182156efdc01835bab9a8e81d15e008f08d38f38d58'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.93-2_armv7l/fontconfig-2.13.93-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.93-2_armv7l/fontconfig-2.13.93-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.93-2_i686/fontconfig-2.13.93-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.93-2_x86_64/fontconfig-2.13.93-2-chromeos-x86_64.tar.xz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.94_i686/fontconfig-2.13.94-chromeos-i686.tpxz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.94_armv7l/fontconfig-2.13.94-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.94_armv7l/fontconfig-2.13.94-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.94_x86_64/fontconfig-2.13.94-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '0047a707a1fc8531fa6bfc6fa45f2aead43ece0e65d1eaad094e4e98f3e43ec0',
-     armv7l: '0047a707a1fc8531fa6bfc6fa45f2aead43ece0e65d1eaad094e4e98f3e43ec0',
-       i686: 'abef1aab53d6880c0f43fc188a6de1ca1bf9b60c20c3f6459cdbcb40b32cb80a',
-     x86_64: '762b2f4a1d0d593f7f4c5000b651e9d03e98b11759a113bac0c260cc45830391'
+       i686: '63bfecf60d42174392ba22d0762f0fb6102540d784eaa86cd098a411e7349d8d',
+    aarch64: '85980c50415f61219e04efc1bb7ae977083756bccb65f7dbe5d6bfc7562698a6',
+     armv7l: '85980c50415f61219e04efc1bb7ae977083756bccb65f7dbe5d6bfc7562698a6',
+     x86_64: '00e921605653191b9b62fadf1437834211e11436c685660782fc1641bd20bfbe'
   })
 
   depends_on 'gperf'
@@ -40,7 +40,7 @@ class Fontconfig < Package
     INSTALLCACHE_HEREDOC
     IO.write('install-cache', @install_cache, perm: 0o666)
     system "meson #{CREW_MESON_OPTIONS} \
-    --localstatedir=#{CREW_PREFIX}/cache \
+    --localstatedir=#{CREW_PREFIX}/var \
     --default-library=both \
     -Ddoc=disabled \
     -Dfreetype2:harfbuzz=enabled \
@@ -53,7 +53,7 @@ class Fontconfig < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/fonts/conf.d"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/cache/fontconfig"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/var/cache/fontconfig"
     @fonts_conf = <<~FONTCONF_HEREDOC
       <?xml version="1.0"?>
       <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
@@ -63,17 +63,17 @@ class Fontconfig < Package
         <dir>/usr/local/share/fonts</dir>
         <dir>~/.fonts</dir>
         <!-- Font cache directory list -->
-        <cachedir>#{CREW_PREFIX}/cache/fontconfig</cachedir>
+        <cachedir>#{CREW_PREFIX}/var/cache/fontconfig</cachedir>
         <cachedir>~/.fontconfig</cachedir>
       </fontconfig>
     FONTCONF_HEREDOC
     IO.write("#{CREW_DEST_PREFIX}/etc/fonts/conf.d/52-chromebrew.conf", @fonts_conf, perm: 0o666)
 
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d/"
-    @env = <<~EOF
+    @env = <<~FONTCONFIG_ENV_HEREDOC
       # Fontconfig configuration
       export FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts
-    EOF
+    FONTCONFIG_ENV_HEREDOC
     IO.write("#{CREW_DEST_PREFIX}/etc/env.d/fontconfig", @env)
   end
 


### PR DESCRIPTION
Fix FHS compliance.
- @uberhacker Can we get a i686 build when you get a chance? (Though since this si graphical...)

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l