### PR TITLE
Container build tweaks

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -668,8 +668,9 @@ def download
       abort 'Checksum mismatch. 😔 Try again.'.lightred unless
         Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum || sha256sum =~ /^SKIP$/i
       puts "#{@pkg.name.capitalize} archive downloaded.".lightgreen
-      # Stow file in cache if requested (and if file is not from cache).
-      if CREW_CACHE_ENABLED and cachefile.to_s.empty?
+      # Stow file in cache if requested, if file is not from cache,
+      # and cache is writable.
+      if CREW_CACHE_ENABLED and cachefile.to_s.empty? and File.writable?(CREW_CACHE_DIR)
         begin
           # Hard link to cache if possible.
           FileUtils.ln filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
@@ -679,7 +680,6 @@ def download
           FileUtils.cp filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
           puts "Archive copied to cache".green if @opt_verbose
         end
-        puts 'Archive copied to cache.'.lightgreen
       end
       return {source: source, filename: filename}
 
@@ -735,8 +735,8 @@ def download
         system 'git submodule update --init --recursive'
         puts 'Repository downloaded.'.lightgreen
       end
-      # Stow file in cache if requested
-      if CREW_CACHE_ENABLED
+      # Stow file in cache if requested and cache is writable.
+      if CREW_CACHE_ENABLED and File.writable?(CREW_CACHE_DIR)
         puts 'Caching downloaded git repo...'
         Dir.chdir "#{@extract_dir}" do
           system "tar c#{@verbose}Jf #{cachefile} \

--- a/install.sh
+++ b/install.sh
@@ -16,13 +16,15 @@ CREW_DEST_DIR="${CREW_BREW_DIR}/dest"
 CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 CURL="${CURL:-curl}"
 CREW_CACHE_DIR="${CREW_CACHE_DIR:-$CREW_PREFIX/tmp/packages}"
+# For container usage, where we want to specify i686 arch
+# on a x86_64 host by setting ARCH=i686.
+: "${ARCH:=$(uname -m)}"
+# For container usage, when we are emulating armv7l via linux32
+# uname -m reports armv8l.
+ARCH="${ARCH/armv8l/armv7l}"
 
 # BOOTSTRAP_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
 BOOTSTRAP_PACKAGES="pixz jq ca_certificates git gmp ncurses libyaml ruby"
-
-ARCH="$(uname -m)"
-# For container usage, where we are emulating armv7l via linux32
-ARCH="${ARCH/armv8l/armv7l}"
 
 RED='\e[1;91m';    # Use Light Red for errors.
 YELLOW='\e[1;33m'; # Use Yellow for informational messages.
@@ -228,6 +230,9 @@ git reset --hard origin/"${BRANCH}"
 echo -e "${RESET}"
 
 echo -e "${YELLOW}Updating crew package information...${RESET}\n"
+# Without setting LD_LIBRARY_PATH, the mandb postinstall fails
+# from not being able to find the gdbm library.
+export LD_LIBRARY_PATH=$(crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g')
 # Since we just ran git, just update package compatibility information.
 crew update compatible
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,13 +1,15 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.13.0'
+CREW_VERSION = '1.14.0'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines
 # which report armv8l when linux32 is run.
 ARCH = if ARCH_ACTUAL == 'armv8l' then 'armv7l' else ARCH_ACTUAL end
 
-ARCH_LIB = if ARCH == 'x86_64' then 'lib64' else 'lib' end
+# Allow for edge case of i686 install on a x86_64 host before linux32 is
+# downloaded, e.g. in a docker container.
+ARCH_LIB = if ARCH == 'x86_64' and Dir.exist?('/lib64') then 'lib64' else 'lib' end
 
 # Glibc version can be found from the output of libc.so.6
 @libcvertokens=  %x[/#{ARCH_LIB}/libc.so.6].lines.first.chomp.split(/[\s]/)


### PR DESCRIPTION
These are some fixes needed to fix container builds for i686, and for using cached packages on the container host.

- Docker container builds only allow r/o access to the host file system, so allow for the cache directory being read only.
- LD_LIBRARY_PATH can be screwy during running `install.sh`, which breaks mandb's postinstall, so set that to avoid breakage.
- Allow pulling in an ARCH variable at install so that we can tell `install.sh` to for instance install i686 by using `ARCH=i686` when using a x86_64 host on a container build server.
- ARCH_LIB isn't set correctly when ARCH is manually specified and different from the output of `uname -m`, so allow for that edge case so i686 installs in a container work.

Works properly:
- [x] x86_64
- [x] i686