### PR TITLE
Make sure crew update-ca-certificates is called from postinstall

### DIFF
--- a/packages/ca_certificates.rb
+++ b/packages/ca_certificates.rb
@@ -124,6 +124,7 @@ class Ca_certificates < Package
 
   # This isn't run from install.sh, but that's ok. This is for cleanup if updated after an install.
   def self.postinstall
-    system "update-ca-certificates --fresh --certsconf #{CREW_PREFIX}/etc/ca-certificates.conf"
+    # Do not call system update-ca-certificates as that tries to update certs in /etc .
+    system "#{CREW_PREFIX}/bin/update-ca-certificates --fresh --certsconf #{CREW_PREFIX}/etc/ca-certificates.conf"
   end
 end


### PR DESCRIPTION
- If PATH still has /usr/bin before /usr/local/bin (as possible during an install) the system `update-ca-certificates` will be called, which will fail since /etc is not writable.

Works properly:
- [x] x86_64
