### PR TITLE
Fix alternate repo/branches in install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -216,11 +216,14 @@ rm -rf "${CREW_LIB_PATH}"
 # Do a minimal clone, which also sets origin to the master/main branch
 # by default. For more on why this setup might be useful see:
 # https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/
-git clone --depth=1 --filter=blob:none --no-checkout "https://github.com/${OWNER}/${REPO}.git" "${CREW_LIB_PATH}"
+# If using alternate branch don't use depth=1
+[[ "$BRANCH" == "master" ]] && GIT_DEPTH="--depth=1" || GIT_DEPTH=
+git clone $GIT_DEPTH --filter=blob:none --no-checkout "https://github.com/${OWNER}/${REPO}.git" "${CREW_LIB_PATH}"
 
 cd "${CREW_LIB_PATH}"
 
 # Checkout, overwriting local files.
+[[ "$BRANCH" != "master" ]] && git fetch --all
 git checkout "${BRANCH}"
 
 # Set sparse-checkout folders and include install.sh for use in reinstalls


### PR DESCRIPTION
- This prevents a early quit when using an alternate BRANCH for the install, which is useful for testing `install.sh` changes.
Works properly:
- [x] x86_64

Example Dockerfile usage (where Dockerfile is being generated in a bash HEREDOC):
```
ENV OWNER=satmandu
ENV BRANCH=altrepoinstall
RUN curl -Ls https://github.com/\$OWNER/chromebrew/raw/\$BRANCH/install.sh -o /home/chronos/user/install.sh
RUN chown chronos /home/chronos/user/install.sh && \
  chmod +x /home/chronos/user/install.sh
SHELL ["/usr/bin/sudo", "-E", "-n", "BASH_ENV=/home/chronos/user/.bashrc", "-u", "chronos", "/bin/bash", "-c"]
RUN --mount=type=bind,target=/input PATH=/usr/local/bin:/usr/local/sbin:\$PATH \
 CREW_CACHE_DIR=/input/pkg_cache \
 CREW_CACHE_ENABLED=1 \
 OWNER=\$OWNER \
 BRANCH=\$BRANCH \
 /bin/bash -x /home/chronos/user/install.sh || true
RUN yes | crew install util_linux bash coreutils psmisc
```
