### PR TITLE
Add gcc 11.2.0 and libssp 11.2.0

### DIFF
--- a/packages/gcc11.rb
+++ b/packages/gcc11.rb
@@ -4,28 +4,27 @@ require 'open3'
 class Gcc11 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '11.1.0-2'
+  version '11.2.0'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/gcc/gcc-11.1.0/gcc-11.1.0.tar.xz'
-  source_sha256 '4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf'
+  source_url 'https://ftpmirror.gnu.org/gcc/gcc-11.2.0/gcc-11.2.0.tar.xz'
+  source_sha256 'd08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.1.0-2_armv7l/gcc11-11.1.0-2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.1.0-2_armv7l/gcc11-11.1.0-2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.1.0-2_i686/gcc11-11.1.0-2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.1.0-2_x86_64/gcc11-11.1.0-2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_i686/gcc11-11.2.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_x86_64/gcc11-11.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '5a245c4d158cc0c10fc7468d3fdc09cb5e38dd6a23646ceb658dce887c908dca',
-     armv7l: '5a245c4d158cc0c10fc7468d3fdc09cb5e38dd6a23646ceb658dce887c908dca',
-       i686: '9c1e13720a102c62bd0794e4872e9936d73c6c3bcb2934854c32798090035021',
-     x86_64: '91ed0f513618b8d548928d256e68219046c5dcf6726b79f1d71979e0ae5d64dc'
+    aarch64: '6826e30f422f8e1b702422d9f185953bb1ccdd6e03352b3300ec65b510803d5d',
+     armv7l: '6826e30f422f8e1b702422d9f185953bb1ccdd6e03352b3300ec65b510803d5d',
+       i686: '5490594fe9330c0bf253996693d855e23a619a8e6d27b6a2cab54927fd1c7610',
+     x86_64: '809ceaa5af62954eae0ab65256648506231bd672c13bddc3075e1e023279c466'
   })
 
   depends_on 'ccache' => :build
   depends_on 'dejagnu' => :build # for test
-  # depends_on 'hashpipe' => :build
   depends_on 'glibc' # R
   depends_on 'gmp' # R
   depends_on 'isl' # R
@@ -153,6 +152,7 @@ class Gcc11 < Package
         ../configure #{CREW_OPTIONS} \
         #{@gcc_global_opts} \
         #{@archflags} \
+        --with-native-system-header-dir=#{CREW_PREFIX}/include \
         --enable-languages=#{@languages} \
         --program-suffix=-#{@gcc_version}"
       # LIBRARY_PATH=#{CREW_LIB_PREFIX} needed for x86_64 to avoid:

--- a/packages/gcc11.rb
+++ b/packages/gcc11.rb
@@ -11,15 +11,15 @@ class Gcc11 < Package
   source_sha256 'd08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b'
 
   binary_url({
-    aarch64: 'file:///usr/local/tmp/packages/gcc11-11.2.0-chromeos-armv7l.tpxz',
-     armv7l: 'file:///usr/local/tmp/packages/gcc11-11.2.0-chromeos-armv7l.tpxz',
-       i686: 'file:///usr/local/tmp/packages/gcc11-11.2.0-chromeos-i686.tpxz',
-     x86_64: 'file:///usr/local/tmp/packages/gcc11-11.2.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0-1_i686/gcc11-11.2.0-1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_x86_64/gcc11-11.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '5103c1e80e63ab61e3d62973dbb38a8fbb35ca6eb11be2fc50d43c4e5959fbb6',
      armv7l: '5103c1e80e63ab61e3d62973dbb38a8fbb35ca6eb11be2fc50d43c4e5959fbb6',
-       i686: '5490594fe9330c0bf253996693d855e23a619a8e6d27b6a2cab54927fd1c7610',
+       i686: 'dea5a99091b825b44729d3ed0521a4e0f3f5004f316d39cd0ab74ea3534c3e9e',
      x86_64: '809ceaa5af62954eae0ab65256648506231bd672c13bddc3075e1e023279c466'
   })
 
@@ -35,6 +35,7 @@ class Gcc11 < Package
   @gcc_version = version.split('-')[0].partition('.')[0]
 
   @gcc_global_opts = '--disable-bootstrap \
+  --disable-install-libiberty \
   --disable-libmpx \
   --disable-libssp \
   --disable-multilib \

--- a/packages/gcc11.rb
+++ b/packages/gcc11.rb
@@ -13,7 +13,7 @@ class Gcc11 < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0-1_i686/gcc11-11.2.0-chromeos-i686.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_i686/gcc11-11.2.0-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_x86_64/gcc11-11.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({

--- a/packages/gcc11.rb
+++ b/packages/gcc11.rb
@@ -13,7 +13,7 @@ class Gcc11 < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0-1_i686/gcc11-11.2.0-1-chromeos-i686.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0-1_i686/gcc11-11.2.0-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_x86_64/gcc11-11.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({

--- a/packages/gcc11.rb
+++ b/packages/gcc11.rb
@@ -11,14 +11,14 @@ class Gcc11 < Package
   source_sha256 'd08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_armv7l/gcc11-11.2.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_i686/gcc11-11.2.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.0_x86_64/gcc11-11.2.0-chromeos-x86_64.tpxz'
+    aarch64: 'file:///usr/local/tmp/packages/gcc11-11.2.0-chromeos-armv7l.tpxz',
+     armv7l: 'file:///usr/local/tmp/packages/gcc11-11.2.0-chromeos-armv7l.tpxz',
+       i686: 'file:///usr/local/tmp/packages/gcc11-11.2.0-chromeos-i686.tpxz',
+     x86_64: 'file:///usr/local/tmp/packages/gcc11-11.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '6826e30f422f8e1b702422d9f185953bb1ccdd6e03352b3300ec65b510803d5d',
-     armv7l: '6826e30f422f8e1b702422d9f185953bb1ccdd6e03352b3300ec65b510803d5d',
+    aarch64: '5103c1e80e63ab61e3d62973dbb38a8fbb35ca6eb11be2fc50d43c4e5959fbb6',
+     armv7l: '5103c1e80e63ab61e3d62973dbb38a8fbb35ca6eb11be2fc50d43c4e5959fbb6',
        i686: '5490594fe9330c0bf253996693d855e23a619a8e6d27b6a2cab54927fd1c7610',
      x86_64: '809ceaa5af62954eae0ab65256648506231bd672c13bddc3075e1e023279c466'
   })
@@ -85,9 +85,9 @@ class Gcc11 < Package
              installed_gccver.to_s == 'bash:' ||
              installed_gccver.to_s == @gcc_version.to_s ||
              installed_gccver.partition('.')[0].to_s == @gcc_version.partition('.')[0].to_s
-        $stderr.puts "GCC version #{installed_gccver} is currently installed.".lightred
-        $stderr.puts "To use #{self.to_s.downcase} please run:".lightgreen
-        $stderr.puts "crew remove gcc#{installed_gccver} && crew install #{self.to_s.downcase}".lightgreen
+        warn "GCC version #{installed_gccver} is currently installed.".lightred
+        warn "To use #{to_s.downcase} please run:".lightgreen
+        warn "crew remove gcc#{installed_gccver} && crew install #{to_s.downcase}".lightgreen
         exit 1
       end
     end

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -16,8 +16,8 @@ class Libssp < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_x86_64/libssp-11.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '93a91e18ef336c120b20be75dc776cadda89a6515c6a130824dd882ce5d47011',
-     armv7l: '93a91e18ef336c120b20be75dc776cadda89a6515c6a130824dd882ce5d47011',
+    aarch64: '5ff8842611c3cb8a2d72eb3fa591299354ae2021c2b1927259df407910645f19',
+     armv7l: '5ff8842611c3cb8a2d72eb3fa591299354ae2021c2b1927259df407910645f19',
        i686: '16bc98bbd5048b649bd45ca74a2bfdba92a045839b65c2f5fbfc986fbe8436ce',
      x86_64: 'c753248ee6996448fc14d02fe43f79f41974adff30101856a467be70b2b41b7d'
   })

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -12,13 +12,13 @@ class Libssp < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_armv7l/libssp-11.2.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_armv7l/libssp-11.2.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_i686/libssp-11.2.0-chromeos-i686.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_i686/libssp-11.2.0-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_x86_64/libssp-11.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '5ff8842611c3cb8a2d72eb3fa591299354ae2021c2b1927259df407910645f19',
      armv7l: '5ff8842611c3cb8a2d72eb3fa591299354ae2021c2b1927259df407910645f19',
-       i686: '16bc98bbd5048b649bd45ca74a2bfdba92a045839b65c2f5fbfc986fbe8436ce',
+       i686: 'dcf1f3951a9f44e8a5aba0f4db7c675684b747a8cb66efdc2340e513913e79fe',
      x86_64: 'c753248ee6996448fc14d02fe43f79f41974adff30101856a467be70b2b41b7d'
   })
 
@@ -29,6 +29,7 @@ class Libssp < Package
   @gcc_name = 'libssp'
 
   @gcc_global_opts = '--disable-libmpx \
+  --disable-install-libiberty \
   --disable-libssp \
   --disable-multilib \
   --disable-werror \

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libssp < Package
   description 'Libssp is a part of the GCC toolkit.'
   homepage 'https://gcc.gnu.org/'
-  version '11.1.0'
+  version '11.2.0'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/gcc/gcc-11.1.0/gcc-11.1.0.tar.xz'
-  source_sha256 '4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf'
+  source_url 'https://ftpmirror.gnu.org/gcc/gcc-11.2.0/gcc-11.2.0.tar.xz'
+  source_sha256 'd08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.1.0_armv7l/libssp-11.1.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.1.0_armv7l/libssp-11.1.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.1.0_i686/libssp-11.1.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.1.0_x86_64/libssp-11.1.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_armv7l/libssp-11.2.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_armv7l/libssp-11.2.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_i686/libssp-11.2.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.0_x86_64/libssp-11.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '8befe2e0872e61a61f3c3b557905612e64358d7df0617e8101dec63768087eb8',
-     armv7l: '8befe2e0872e61a61f3c3b557905612e64358d7df0617e8101dec63768087eb8',
-       i686: '5b02bf769ec3754f4b0c937e5420f13bf285bc81bdc9c68fbc6f63c56562682b',
-     x86_64: '356cd568080dd0e724081ec7f020d0b21e091d5552d175746f830c48830bd8b9'
+    aarch64: '93a91e18ef336c120b20be75dc776cadda89a6515c6a130824dd882ce5d47011',
+     armv7l: '93a91e18ef336c120b20be75dc776cadda89a6515c6a130824dd882ce5d47011',
+       i686: '16bc98bbd5048b649bd45ca74a2bfdba92a045839b65c2f5fbfc986fbe8436ce',
+     x86_64: 'c753248ee6996448fc14d02fe43f79f41974adff30101856a467be70b2b41b7d'
   })
 
   depends_on 'ccache' => :build
@@ -66,7 +66,6 @@ class Libssp < Package
   when 'i686'
     @archflags = '--with-arch-32=i686'
   end
-
 
   def self.build
     # Set ccache sloppiness as per


### PR DESCRIPTION
- Bugfix release
- Should be tested on all architectures

Works properly:
- [x] x86_64
- [x] i686 (? Needs testing)
- [x] armv7l (needs testing on actual hardware.) @uberhacker Could you do that?