### PR TITLE
packages/nano.rb : fix Missing libmagic.so.1

### DIFF
--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -24,6 +24,7 @@ class Nano < Package
   })
 
   depends_on 'xdg_base'
+  depends_on 'filecmd'
 
   def self.patch
     system "sed -i '/SIGWINCH/d' src/nano.c"


### PR DESCRIPTION
Add filecmd dependency to fix "Missing libmagic.so.1 shared library".

Fixes #

#6027 

## Description
Add filecmd dependency to fix Missing libmagic.so.1

Works properly:
- [x] x86_64