### PR TITLE
Add filecmd to core

### DIFF
--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/skycocker/chromebrew'
-  version '1.1'
+  version '1.2'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -18,6 +18,7 @@ class Core < Package
   depends_on 'e2fsprogs'
   depends_on 'elfutils'
   depends_on 'expat'
+  depends_on 'filecmd'
   depends_on 'flex'
   depends_on 'gdbm'
   depends_on 'gettext'


### PR DESCRIPTION
Fixes #6027 

- Adds filecmd to `core`.

Works properly:
- [x] x86_64