### PR TITLE
Mesa 21.2.1

### DIFF
--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -13,11 +13,13 @@ class Mesa < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_armv7l/mesa-21.2.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_armv7l/mesa-21.2.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_i686/mesa-21.2.0-chromeos-i686.tpxz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_x86_64/mesa-21.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: 'd80e1bde346c0460a377a11ead1f5b30c34369c84e124060f9a025a985bb37b3',
      armv7l: 'd80e1bde346c0460a377a11ead1f5b30c34369c84e124060f9a025a985bb37b3',
+       i686: 'fd43dd3879c980efc701804535b9422e5e41d31b85d2de498c5049c2fced8935',
      x86_64: 'e25ae34492f5da8da9fdcb39b159f0be43b72f9b6420ec03df04cedba7493a23'
   })
 
@@ -37,7 +39,7 @@ class Mesa < Package
   depends_on 'libxvmc' # R
   depends_on 'libxv' # R
   depends_on 'libxxf86vm' # R
-  #depends_on 'libva' => :build # Enable only during build to avoid circular dep.
+  # depends_on 'libva' => :build # Enable only during build to avoid circular dep.
   depends_on 'llvm' => :build
   depends_on 'lm_sensors' # R
   depends_on 'py3_mako'
@@ -73,7 +75,6 @@ class Mesa < Package
       PATCHEOF
       IO.write('freedreno.patch', @freedrenopatch)
       system 'patch -Np1 -i freedreno.patch'
-      # system "sed -i 's/-Werror=implicit-function-declaration/-Wno-error=implicit-function-declaration/g' meson.build"
     end
   end
 
@@ -82,14 +83,17 @@ class Mesa < Package
     when 'i686'
       @vk = 'intel,swrast'
       @galliumdrivers = 'swrast,svga,virgl,swr,lima,zink'
+      @lto = CREW_MESON_FNO_LTO_OPTIONS
     when 'aarch64', 'armv7l'
       @vk = 'auto'
       @galliumdrivers = 'auto'
+      @lto = CREW_MESON_OPTIONS
     when 'x86_64'
       @vk = 'auto'
       @galliumdrivers = 'r300,r600,radeonsi,nouveau,virgl,svga,swrast,iris,crocus'
+      @lto = CREW_MESON_OPTIONS
     end
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson #{@lto} \
     -Db_asneeded=false \
     -Dvulkan-drivers=#{@vk} \
     -Dgallium-drivers=#{@galliumdrivers} \

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -3,7 +3,7 @@ require 'package'
 class Mesa < Package
   description 'Open-source implementation of the OpenGL specification'
   homepage 'https://www.mesa3d.org'
-  @_ver = '21.2.0'
+  @_ver = '21.2.1'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Mesa < Package
   git_hashtag "mesa-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_armv7l/mesa-21.2.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_armv7l/mesa-21.2.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_i686/mesa-21.2.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_x86_64/mesa-21.2.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.1_armv7l/mesa-21.2.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.1_armv7l/mesa-21.2.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.1_i686/mesa-21.2.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.1_x86_64/mesa-21.2.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'd80e1bde346c0460a377a11ead1f5b30c34369c84e124060f9a025a985bb37b3',
-     armv7l: 'd80e1bde346c0460a377a11ead1f5b30c34369c84e124060f9a025a985bb37b3',
-       i686: 'fd43dd3879c980efc701804535b9422e5e41d31b85d2de498c5049c2fced8935',
-     x86_64: 'e25ae34492f5da8da9fdcb39b159f0be43b72f9b6420ec03df04cedba7493a23'
+    aarch64: 'af4f1d97e5404ff136bae551ce9a1dcbc9d1db2990b35fcf71fde37df892caf5',
+     armv7l: 'af4f1d97e5404ff136bae551ce9a1dcbc9d1db2990b35fcf71fde37df892caf5',
+       i686: '41c82db78aad8fb8331ed19bb5698f29bb2a2bbedaae73c192ae1e0333fe4426',
+     x86_64: '5e619405ea17db19a946a690ba98e7def61e0f12077aa4fce844d13f97625660'
   })
 
   depends_on 'glslang' => :build
@@ -104,6 +104,6 @@ class Mesa < Package
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -42,8 +42,8 @@ class Mesa < Package
   depends_on 'lm_sensors' # R
   depends_on 'py3_mako'
   depends_on 'valgrind' => :build
-  depends_on 'vulkan_headers' => :build
-  depends_on 'vulkan_icd_loader' => :build
+  unless ARCH == 'i686' depends_on 'vulkan_headers' => :build
+  unless ARCH == 'i686' depends_on 'vulkan_icd_loader' => :build
   depends_on 'wayland_protocols' => :build
   depends_on 'wayland' # R
 

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -26,7 +26,7 @@ class Mesa < Package
   depends_on 'glslang' => :build
   depends_on 'libdrm' # R
   depends_on 'libomxil_bellagio' => :build
-  depends_on 'libunwind' => :build
+  depends_on 'libunwind'
   depends_on 'libvdpau' => :build
   depends_on 'libx11' # R
   depends_on 'libxcb' # R

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -3,24 +3,22 @@ require 'package'
 class Mesa < Package
   description 'Open-source implementation of the OpenGL specification'
   homepage 'https://www.mesa3d.org'
-  @_ver = '21.1.2'
+  @_ver = '21.2.0'
   version @_ver
   license 'MIT'
   compatibility 'all'
-  source_url "https://mesa.freedesktop.org/archive/mesa-#{@_ver}.tar.xz"
-  source_sha256 '23b4b63760561f3a4f98b5be12c6de621e9a6bdf355e087a83d9184cd4e2825f'
+  source_url 'https://gitlab.freedesktop.org/mesa/mesa.git'
+  git_hashtag "mesa-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.1.2_armv7l/mesa-21.1.2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.1.2_armv7l/mesa-21.1.2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.1.2_i686/mesa-21.1.2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.1.2_x86_64/mesa-21.1.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_armv7l/mesa-21.2.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_armv7l/mesa-21.2.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.0_x86_64/mesa-21.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '55ca672cbbc91981c60cd744bedc34dc1efd26246ebf468f3801c308a8fcd78f',
-     armv7l: '55ca672cbbc91981c60cd744bedc34dc1efd26246ebf468f3801c308a8fcd78f',
-       i686: '8417668f98889fcdae58f783e7b80084d74a69ec5234198f39b4179b68e1d4a9',
-     x86_64: 'a1a297a96645b2c3d63cc4c9411711debb5200d43acea2f3d173b6087cb2e7b8'
+    aarch64: 'd80e1bde346c0460a377a11ead1f5b30c34369c84e124060f9a025a985bb37b3',
+     armv7l: 'd80e1bde346c0460a377a11ead1f5b30c34369c84e124060f9a025a985bb37b3',
+     x86_64: 'e25ae34492f5da8da9fdcb39b159f0be43b72f9b6420ec03df04cedba7493a23'
   })
 
   depends_on 'glslang' => :build
@@ -39,6 +37,7 @@ class Mesa < Package
   depends_on 'libxvmc' # R
   depends_on 'libxv' # R
   depends_on 'libxxf86vm' # R
+  #depends_on 'libva' => :build # Enable only during build to avoid circular dep.
   depends_on 'llvm' => :build
   depends_on 'lm_sensors' # R
   depends_on 'py3_mako'
@@ -48,25 +47,59 @@ class Mesa < Package
   depends_on 'wayland_protocols' => :build
   depends_on 'wayland' # R
 
+  def self.patch
+    case ARCH
+    when 'aarch64', 'armv7l'
+      # See https://gitlab.freedesktop.org/mesa/mesa/-/issues/5067
+      @freedrenopatch = <<~PATCHEOF
+                --- a/src/gallium/drivers/freedreno/freedreno_util.h   2021-08-05 14:40:22.000000000 +0000
+                +++ b/src/gallium/drivers/freedreno/freedreno_util.h   2021-08-05 19:52:53.115410668 +0000
+                @@ -44,6 +44,15 @@
+                 #include "adreno_pm4.xml.h"
+                 #include "disasm.h"
+        #{'         '}
+                +#include <unistd.h>
+                +#include <sys/syscall.h>
+                +
+                +#ifndef SYS_gettid
+                +#error "SYS_gettid unavailable on this system"
+                +#endif
+                +
+                +#define gettid() ((pid_t)syscall(SYS_gettid))
+                +
+                 #ifdef __cplusplus
+                 extern "C" {
+                 #endif
+      PATCHEOF
+      IO.write('freedreno.patch', @freedrenopatch)
+      system 'patch -Np1 -i freedreno.patch'
+      # system "sed -i 's/-Werror=implicit-function-declaration/-Wno-error=implicit-function-declaration/g' meson.build"
+    end
+  end
+
   def self.build
     case ARCH
     when 'i686'
       @vk = 'intel,swrast'
       @galliumdrivers = 'swrast,svga,virgl,swr,lima,zink'
-    when 'x86_64', 'aarch64', 'armv7l'
+    when 'aarch64', 'armv7l'
       @vk = 'auto'
       @galliumdrivers = 'auto'
+    when 'x86_64'
+      @vk = 'auto'
+      @galliumdrivers = 'r300,r600,radeonsi,nouveau,virgl,svga,swrast,iris,crocus'
     end
     system "meson #{CREW_MESON_OPTIONS} \
     -Db_asneeded=false \
     -Dvulkan-drivers=#{@vk} \
     -Dgallium-drivers=#{@galliumdrivers} \
+    -Dprefer-crocus=true \
      builddir"
     system 'meson configure builddir'
     system 'samu -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -42,8 +42,8 @@ class Mesa < Package
   depends_on 'lm_sensors' # R
   depends_on 'py3_mako'
   depends_on 'valgrind' => :build
-  unless ARCH == 'i686' depends_on 'vulkan_headers' => :build
-  unless ARCH == 'i686' depends_on 'vulkan_icd_loader' => :build
+  depends_on 'vulkan_headers' => :build
+  depends_on 'vulkan_icd_loader' => :build
   depends_on 'wayland_protocols' => :build
   depends_on 'wayland' # R
 

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -6,7 +6,7 @@ class Vulkan_headers < Package
   @_ver = '1.2.184'
   version @_ver
   license 'Apache-2.0'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url "https://github.com/KhronosGroup/Vulkan-Headers/archive/v#{@_ver}.tar.gz"
   source_sha256 'de1889ff550c1a78e752fbdf71117ac319fb674b0abe080a4e6e9053da2aea85'
 

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -13,11 +13,13 @@ class Vulkan_headers < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_armv7l/vulkan_headers-1.2.184-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_armv7l/vulkan_headers-1.2.184-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_i686/vulkan_headers-1.2.184-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_x86_64/vulkan_headers-1.2.184-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: 'b17aa592829e1ff8810c92f2cf28bf0b77f198bf0d5d71c5fcc45c12206dc2f8',
      armv7l: 'b17aa592829e1ff8810c92f2cf28bf0b77f198bf0d5d71c5fcc45c12206dc2f8',
+       i686: '45c1f6902b4c42a5a1e29f07e49cfe74de805a8e885492da44f10cfc3787ea44',
      x86_64: '276679a7d8b8061198fe4262e89eca1f745208ea23e26dea99e2510d668795b0'
   })
 

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -3,24 +3,24 @@ require 'package'
 class Vulkan_headers < Package
   description 'Vulkan header files'
   homepage 'https://github.com/KhronosGroup/Vulkan-Headers'
-  @_ver = '1.2.184'
+  @_ver = '1.2.189'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url "https://github.com/KhronosGroup/Vulkan-Headers/archive/v#{@_ver}.tar.gz"
-  source_sha256 'de1889ff550c1a78e752fbdf71117ac319fb674b0abe080a4e6e9053da2aea85'
+  source_sha256 '0939d6cb950746f6f9cab59399c0a99628ed186426a972996599f90d34d8a99a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_armv7l/vulkan_headers-1.2.184-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_armv7l/vulkan_headers-1.2.184-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_i686/vulkan_headers-1.2.184-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.184_x86_64/vulkan_headers-1.2.184-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.189_armv7l/vulkan_headers-1.2.189-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.189_armv7l/vulkan_headers-1.2.189-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.189_i686/vulkan_headers-1.2.189-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.189_x86_64/vulkan_headers-1.2.189-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'b17aa592829e1ff8810c92f2cf28bf0b77f198bf0d5d71c5fcc45c12206dc2f8',
-     armv7l: 'b17aa592829e1ff8810c92f2cf28bf0b77f198bf0d5d71c5fcc45c12206dc2f8',
-       i686: '45c1f6902b4c42a5a1e29f07e49cfe74de805a8e885492da44f10cfc3787ea44',
-     x86_64: '276679a7d8b8061198fe4262e89eca1f745208ea23e26dea99e2510d668795b0'
+    aarch64: '1a219ac7c4cd4f323a63cb39d9aa0141d351be8f333875c201140f2d56f2cfa8',
+     armv7l: '1a219ac7c4cd4f323a63cb39d9aa0141d351be8f333875c201140f2d56f2cfa8',
+       i686: '9c19facd083446993359bac2f5e57ba315cc60c9c5083cd04e01558bc6abff12',
+     x86_64: 'd678eaf1a9f33a28da7c6ad373bc3a0baa2210b058373ab49fd55dd0a9fc6df6'
   })
 
   def self.build

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -3,24 +3,24 @@ require 'package'
 class Vulkan_icd_loader < Package
   description 'Vulkan Installable Client Driver ICD Loader'
   homepage 'https://github.com/KhronosGroup/Vulkan-Loader'
-  @_ver = '1.2.184'
+  @_ver = '1.2.189'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url "https://github.com/KhronosGroup/Vulkan-Loader/archive/v#{@_ver}.tar.gz"
-  source_sha256 '61f2cae1c47f38e17b6a2e578cf247041d733a2db364d6e09f4366cc493aec73'
+  source_sha256 '6e05f54a0c6a35625e8974f88c197b1817b2bddb253c38540ced9d2bc8132d6c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_armv7l/vulkan_icd_loader-1.2.184-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_armv7l/vulkan_icd_loader-1.2.184-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_i686/vulkan_icd_loader-1.2.184-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_x86_64/vulkan_icd_loader-1.2.184-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.189_armv7l/vulkan_icd_loader-1.2.189-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.189_armv7l/vulkan_icd_loader-1.2.189-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.189_i686/vulkan_icd_loader-1.2.189-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.189_x86_64/vulkan_icd_loader-1.2.189-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '34cad6bd4efd3ea9bc603eafdc9bccdbcabbdfb4d84966ea5f04a83bc8e30886',
-     armv7l: '34cad6bd4efd3ea9bc603eafdc9bccdbcabbdfb4d84966ea5f04a83bc8e30886',
-       i686: '2f30b4ec1cca15bb51369cb0de31b876d19ce6d6132ef0d7499c4530c6687df5',
-     x86_64: 'bb7021c88c28ddad6587eb7bc298821cf48181f5570e44ba7eb72c1ff4317068'
+    aarch64: 'e28e70220fc29a11350fa81935620f6c076d1fc70a9cbb02223726bdeac404d3',
+     armv7l: 'e28e70220fc29a11350fa81935620f6c076d1fc70a9cbb02223726bdeac404d3',
+       i686: '58a491339f9fd7ec2fa5e608558d39a94e662acdd23cbc83783cea5a4de17026',
+     x86_64: '1e768311c175fc199f46eaa0c6c2467dd97475983d9cdff2434ca2de858341c2'
   })
 
   depends_on 'libx11'

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -13,11 +13,13 @@ class Vulkan_icd_loader < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_armv7l/vulkan_icd_loader-1.2.184-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_armv7l/vulkan_icd_loader-1.2.184-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_i686/vulkan_icd_loader-1.2.184-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.184_x86_64/vulkan_icd_loader-1.2.184-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '34cad6bd4efd3ea9bc603eafdc9bccdbcabbdfb4d84966ea5f04a83bc8e30886',
      armv7l: '34cad6bd4efd3ea9bc603eafdc9bccdbcabbdfb4d84966ea5f04a83bc8e30886',
+       i686: '2f30b4ec1cca15bb51369cb0de31b876d19ce6d6132ef0d7499c4530c6687df5',
      x86_64: 'bb7021c88c28ddad6587eb7bc298821cf48181f5570e44ba7eb72c1ff4317068'
   })
 

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -6,7 +6,7 @@ class Vulkan_icd_loader < Package
   @_ver = '1.2.184'
   version @_ver
   license 'Apache-2.0'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url "https://github.com/KhronosGroup/Vulkan-Loader/archive/v#{@_ver}.tar.gz"
   source_sha256 '61f2cae1c47f38e17b6a2e578cf247041d733a2db364d6e09f4366cc493aec73'
 


### PR DESCRIPTION
- @uberhacker could you see if this works on armv7l and also generate a `i686` build when you get a chance? (I added a patch to get it to compile, but that doesn't tell me if it is functional.)
- Running `glxinfo -B` from `mesa_utils` after install ought to tell you if it is loading correctly.

Works properly:
- [x] x86_64
- [x] armv7l 
- [ ] i686 (needs build if container build doesn't work)
```
glxinfo -B
name of display: :0
MESA: warning: Kernel 4.1 required to properly query GPU properties.
display: :0  screen: 0
direct rendering: Yes
Extended renderer info (GLX_MESA_query_renderer):
    Vendor: Intel Open Source Technology Center (0x8086)
    Device: Mesa DRI Intel(R) UHD Graphics 615 (AML-KBL) (0x591c)
    Version: 21.2.0
    Accelerated: yes
    Video memory: 3058MB
    Unified memory: yes
    Preferred profile: core (0x1)
    Max core profile version: 4.6
    Max compat profile version: 3.0
    Max GLES1 profile version: 1.1
    Max GLES[23] profile version: 3.2
OpenGL vendor string: Intel Open Source Technology Center
OpenGL renderer string: Mesa DRI Intel(R) UHD Graphics 615 (AML-KBL)
OpenGL core profile version string: 4.6 (Core Profile) Mesa 21.2.0 (git-33595f88d6)
OpenGL core profile shading language version string: 4.60
OpenGL core profile context flags: (none)
OpenGL core profile profile mask: core profile

OpenGL version string: 3.0 Mesa 21.2.0 (git-33595f88d6)
OpenGL shading language version string: 1.30
OpenGL context flags: (none)

OpenGL ES profile version string: OpenGL ES 3.2 Mesa 21.2.0 (git-33595f88d6)
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.20
```
