### PR TITLE
Rebase qtbase to maintained kde/5.15 tree

### DIFF
--- a/packages/qtbase.rb
+++ b/packages/qtbase.rb
@@ -13,12 +13,12 @@ class Qtbase < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_armv7l/qtbase-kde-5.15-830a-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_armv7l/qtbase-kde-5.15-830a-chromeos-armv7l.tpxz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_x86_64/qtbase-kde-5.15-830a-chromeos-x86_64.tpxz'
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_x86_64/qtbase-kde-5.15-830a-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '19eb54d1fe54d4bf1c49afadbaeeb5a7adcec584624ab88938c3ea7827bc56a2',
-     armv7l: '19eb54d1fe54d4bf1c49afadbaeeb5a7adcec584624ab88938c3ea7827bc56a2',
-    x86_64: '9b58c01ad6d16498b1cd8a35ac97026f75dc5d19b586a0a3759362757ddd8bf7'
+    aarch64: '8554431fc8f552380aa8822d440559c9fd2bbe00314d96ed5939637ef3a329e6',
+     armv7l: '8554431fc8f552380aa8822d440559c9fd2bbe00314d96ed5939637ef3a329e6',
+     x86_64: '9b58c01ad6d16498b1cd8a35ac97026f75dc5d19b586a0a3759362757ddd8bf7'
   })
 
   depends_on 'alsa_plugins'

--- a/packages/qtbase.rb
+++ b/packages/qtbase.rb
@@ -3,17 +3,17 @@ require 'package'
 class Qtbase < Package
   description 'Qt Base (Core, Gui, Widgets, Network, ...)'
   homepage 'https://code.qt.io/cgit/qt/qtbase'
-  @_ver = 'kde-5.15'
-  version "#{@_ver}-830a"
+  @_ver = '5.15'
+  version @_ver
   license 'FDL, GPL-2, GPL-3, GPL-3-with-qt-exception and LGPL-3'
   compatibility 'all'
   source_url 'https://invent.kde.org/qt/qt/qtbase.git'
-  git_hashtag '830a461a89e1272e811f6cb85754f06128cd2efb'
+  git_hashtag "kde/#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_armv7l/qtbase-kde-5.15-830a-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_armv7l/qtbase-kde-5.15-830a-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_x86_64/qtbase-kde-5.15-830a-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15_armv7l/qtbase-5.15-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15_armv7l/qtbase-5.15-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15_x86_64/qtbase-5.15-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '8554431fc8f552380aa8822d440559c9fd2bbe00314d96ed5939637ef3a329e6',

--- a/packages/qtbase.rb
+++ b/packages/qtbase.rb
@@ -3,23 +3,22 @@ require 'package'
 class Qtbase < Package
   description 'Qt Base (Core, Gui, Widgets, Network, ...)'
   homepage 'https://code.qt.io/cgit/qt/qtbase'
-  @_ver = '5.15.2'
-  version @_ver + '-1'
+  @_ver = 'kde-5.15'
+  version "#{@_ver}-830a"
   license 'FDL, GPL-2, GPL-3, GPL-3-with-qt-exception and LGPL-3'
   compatibility 'all'
-  source_url 'SKIP'
+  source_url 'https://invent.kde.org/qt/qt/qtbase.git'
+  git_hashtag '830a461a89e1272e811f6cb85754f06128cd2efb'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.2-1_armv7l/qtbase-5.15.2-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.2-1_armv7l/qtbase-5.15.2-1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.2-1_i686/qtbase-5.15.2-1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.2-1_x86_64/qtbase-5.15.2-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_armv7l/qtbase-kde-5.15-830a-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_armv7l/qtbase-kde-5.15-830a-chromeos-armv7l.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/kde-5.15-830a_x86_64/qtbase-kde-5.15-830a-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: 'a3e863cc19101742af4d808cb552b954d0c8581febd8015865087ea36da0fa56',
-      armv7l: 'a3e863cc19101742af4d808cb552b954d0c8581febd8015865087ea36da0fa56',
-        i686: '34eedd58aac9f5a803af9e2641a645badbf6b96e501eae1aa495a271bb53037a',
-      x86_64: '0d26af5842faa70ad3f1c7aa822c8e4f7c4c6f42535f1f24042f1f6e1e73df4d',
+  binary_sha256({
+    aarch64: '19eb54d1fe54d4bf1c49afadbaeeb5a7adcec584624ab88938c3ea7827bc56a2',
+     armv7l: '19eb54d1fe54d4bf1c49afadbaeeb5a7adcec584624ab88938c3ea7827bc56a2',
+    x86_64: '9b58c01ad6d16498b1cd8a35ac97026f75dc5d19b586a0a3759362757ddd8bf7'
   })
 
   depends_on 'alsa_plugins'
@@ -39,34 +38,29 @@ class Qtbase < Package
   depends_on 'protobuf'
 
   def self.build
-    system "git clone --branch v#{@_ver} --depth 1 git://code.qt.io/qt/qtbase.git"
-    Dir.chdir 'qtbase' do
-      system './configure',
-        "--prefix=#{CREW_PREFIX}/share/Qt-5",
-        "--libdir=#{CREW_LIB_PREFIX}",
-        '-nomake', 'examples',
-        '-nomake', 'tests',
-        '-verbose',
-        '-release',
-        '-opensource',
-        '-confirm-license',
-        '-inotify',
-        '-system-pcre',
-        '-system-zlib',
-        '-system-libpng',
-        '-system-libjpeg',
-        '-system-freetype'
-      system 'make'
-    end
+    system './configure',
+           "--prefix=#{CREW_PREFIX}/share/Qt-5",
+           "--libdir=#{CREW_LIB_PREFIX}",
+           '-nomake', 'examples',
+           '-nomake', 'tests',
+           '-verbose',
+           '-release',
+           '-opensource',
+           '-confirm-license',
+           '-inotify',
+           '-system-pcre',
+           '-system-zlib',
+           '-system-libpng',
+           '-system-libjpeg',
+           '-system-freetype'
+    system 'make'
   end
 
   def self.install
-    Dir.chdir 'qtbase' do
-      system 'make', "INSTALL_ROOT=#{CREW_DEST_DIR}", 'install'
-      FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-      Dir.chdir "#{CREW_DEST_PREFIX}/share/Qt-5/bin" do
-        system "find . -type f -exec ln -s #{CREW_PREFIX}/share/Qt-5/bin/{} #{CREW_DEST_PREFIX}/bin/{} \\;"
-      end
+    system 'make', "INSTALL_ROOT=#{CREW_DEST_DIR}", 'install'
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    Dir.chdir "#{CREW_DEST_PREFIX}/share/Qt-5/bin" do
+      system "find . -type f -exec ln -s #{CREW_PREFIX}/share/Qt-5/bin/{} #{CREW_DEST_PREFIX}/bin/{} \\;"
     end
   end
 end

--- a/packages/qtbase.rb
+++ b/packages/qtbase.rb
@@ -10,9 +10,9 @@ class Qtbase < Package
   git_hashtag "kde/5.15"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15_armv7l/qtbase-5.15-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15_armv7l/qtbase-5.15-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15_x86_64/qtbase-5.15-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.3_armv7l/qtbase-5.15.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.3_armv7l/qtbase-5.15.3-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.3_x86_64/qtbase-5.15.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '8554431fc8f552380aa8822d440559c9fd2bbe00314d96ed5939637ef3a329e6',

--- a/packages/qtbase.rb
+++ b/packages/qtbase.rb
@@ -3,12 +3,11 @@ require 'package'
 class Qtbase < Package
   description 'Qt Base (Core, Gui, Widgets, Network, ...)'
   homepage 'https://code.qt.io/cgit/qt/qtbase'
-  @_ver = '5.15'
-  version @_ver
+  version '5.15.3'
   license 'FDL, GPL-2, GPL-3, GPL-3-with-qt-exception and LGPL-3'
   compatibility 'all'
   source_url 'https://invent.kde.org/qt/qt/qtbase.git'
-  git_hashtag "kde/#{@_ver}"
+  git_hashtag "kde/5.15"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15_armv7l/qtbase-5.15-chromeos-armv7l.tpxz',

--- a/packages/qtbase.rb
+++ b/packages/qtbase.rb
@@ -12,11 +12,13 @@ class Qtbase < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.3_armv7l/qtbase-5.15.3-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.3_armv7l/qtbase-5.15.3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.3_i686/qtbase-5.15.3-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qtbase/5.15.3_x86_64/qtbase-5.15.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '8554431fc8f552380aa8822d440559c9fd2bbe00314d96ed5939637ef3a329e6',
      armv7l: '8554431fc8f552380aa8822d440559c9fd2bbe00314d96ed5939637ef3a329e6',
+       i686: 'ae0ecf607b4f2742b7a6bde14f77c9aace3ad28511cfdec4e4db5e2a5ad54b6d',
      x86_64: '9b58c01ad6d16498b1cd8a35ac97026f75dc5d19b586a0a3759362757ddd8bf7'
   })
 


### PR DESCRIPTION
Fixes #6053 

- qtbase needed a rebuild to work with newer dependencies
- qtbase 5.15.2 is no longer maintained as open source, and no longer compiles, but luckily[ kde has taken on the task](https://community.kde.org/Qt5PatchCollection), and they have a working, [patched fork of kde 5.15 at https://invent.kde.org/qt/qt/qtbase/-/tree/kde/5.15](https://invent.kde.org/qt/qt/qtbase/-/tree/kde/5.15) .

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686

Works properly:
- [x] x86_64 (needs testing on actual hardware)
- [x] armv7l (needs testing on actual hardware)
- [x] i686 (needs testing on actual hardware)

**Reviewers please test on hardware before merging!**
