### PR TITLE
Allow downloading extra files, e.g. patches, extra tarballs

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -750,6 +750,36 @@ def download
   return {source: source, filename: filename}
 end
 
+def download_extra(target_dir)
+  urls = @pkg.get_extra_download
+  puts "Downloading extra files".lightgreen unless urls.empty? or urls.nil?
+
+  Dir.chdir target_dir do
+    urls.each_pair {|key, value|
+      case key
+      when /\.git$/i
+        # Don't let git recognize a subrepository
+        system "echo '#{key.split('/')[-1].gsub('.git','')}' >> .gitignore"
+        Dir.mkdir key.split('/')[-1].gsub('.git','')
+        Dir.chdir key.split('/')[-1].gsub('.git','') do
+          system 'git init'
+          system 'git config advice.detachedHead false'
+          system 'git config init.defaultBranch master'
+          system "git remote add origin #{key}", exception: true
+          system "git fetch --depth 1 origin #{value}", exception: true
+          system 'git checkout FETCH_HEAD'
+          system 'git submodule update --init --recursive'
+        end
+      else
+        system "#{CURL} --retry 3 -#{@verbose}#LC - --insecure \'#{key}\' --output #{key.split('/')[-1]}"
+        abort 'Checksum mismatch. :/ Try again.'.lightred unless
+            Digest::SHA256.hexdigest( File.read("#{key.split('/')[-1]}") ) == "#{value}"
+      end
+    }
+  end
+  puts "Extra files downloaded.".lightgreen unless urls.empty? or urls.nil?
+end
+
 def unpack(meta)
   target_dir = nil
   Dir.chdir CREW_BREW_DIR do
@@ -1185,6 +1215,9 @@ def install
     meta = download
     target_dir = unpack meta
     if meta[:source] == true
+
+      # download extra patch files
+      download_extra target_dir
 
       # build from source and place binaries at CREW_DEST_DIR
       # CREW_DEST_DIR contains usr/local/... hierarchy

--- a/bin/crew
+++ b/bin/crew
@@ -752,7 +752,12 @@ end
 
 def download_extra(target_dir)
   urls = @pkg.get_extra_download
-  puts "Downloading extra files".lightgreen unless urls.empty? or urls.nil?
+
+  if urls.empty? or urls.nil?
+    return
+  else
+    puts "Downloading extra files".lightgreen
+  end
 
   Dir.chdir target_dir do
     urls.each_pair {|key, value|
@@ -778,7 +783,7 @@ def download_extra(target_dir)
       end
     }
   end
-  puts "Extra files downloaded.".lightgreen unless urls.empty? or urls.nil?
+  puts "Extra files downloaded.".lightgreen
 end
 
 def unpack(meta)

--- a/bin/crew
+++ b/bin/crew
@@ -753,7 +753,7 @@ end
 def download_extra(target_dir)
   urls = @pkg.get_extra_download
 
-  if urls.empty? or urls.nil?
+  if urls.to_s.empty? or urls.nil?
     return
   else
     puts "Downloading extra files".lightgreen

--- a/bin/crew
+++ b/bin/crew
@@ -760,6 +760,7 @@ def download_extra(target_dir)
       when /\.git$/i
         # Don't let git recognize a subrepository
         system "echo '#{key.split('/')[-1].gsub('.git','')}' >> .gitignore"
+        # Download repository
         Dir.mkdir key.split('/')[-1].gsub('.git','')
         Dir.chdir key.split('/')[-1].gsub('.git','') do
           system 'git init'

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -57,6 +57,25 @@ class Package
     end
   end
 
+  def self.extra_urls
+    @extra_urls = Hash.new unless @extra_urls
+    @extra_urls
+  end
+
+  def self.extra_url (url = nil)
+    @extra_urls = Hash.new unless @extra_urls
+    if url
+      @extra_urls.merge!(url)
+    end
+    @extra_urls
+    puts url
+    puts @extra_urls
+  end
+
+  def self.get_extra_download
+    @extra_urls
+  end
+
   def self.get_extract_dir
     name + '.' + Time.now.utc.strftime("%Y%m%d%H%M%S") + '.dir'
   end

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -68,8 +68,6 @@ class Package
       @extra_urls.merge!(url)
     end
     @extra_urls
-    puts url
-    puts @extra_urls
   end
 
   def self.get_extra_download

--- a/packages/benchmark.rb
+++ b/packages/benchmark.rb
@@ -3,45 +3,15 @@ require 'package'
 class Benchmark < Package
   description 'A microbenchmark support library from Google'
   homepage 'https://github.com/google/benchmark/'
-  version '1.5.2'
+  @_ver = '1.5.5'
+  version @_ver
   license 'Apache-2.0'
   compatibility 'all'
-  source_url 'https://github.com/google/benchmark/archive/v1.5.2.tar.gz'
-  source_sha256 'dccbdab796baa1043f04982147e67bb6e118fe610da2c65f88912d73987e700c'
+  source_url 'https://github.com/google/benchmark.git'
+  git_hashtag 'v' + @_ver
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/benchmark/1.5.2_armv7l/benchmark-1.5.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/benchmark/1.5.2_armv7l/benchmark-1.5.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/benchmark/1.5.2_i686/benchmark-1.5.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/benchmark/1.5.2_x86_64/benchmark-1.5.2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '9aa663f4068a79d821bc556f6dc60b0e6ee2278505cd747e94a0fd7750258711',
-     armv7l: '9aa663f4068a79d821bc556f6dc60b0e6ee2278505cd747e94a0fd7750258711',
-       i686: 'e8f37ed6c926979e2c13949f3cf8eaeb9e7e9eedbc751d550ead9680e0a87a5c',
-     x86_64: '71f73a3dc296d91b2a5ed685396cbad25ad69e0d231cbed59a5d44391e98aa31',
-  })
-
-  def self.patch
-    @limitsh = <<~EOF
-      --- a/src/benchmark_register.h
-      +++ b/src/benchmark_register.h
-      @@ -1,6 +1,7 @@
-       #ifndef BENCHMARK_REGISTER_H
-       #define BENCHMARK_REGISTER_H
-
-      +#include <limits>
-       #include <vector>
-
-       #include "check.h"
-    EOF
-    IO.write("limitsh.patch", @limitsh)
-    system 'patch -p 1 -i limitsh.patch'
-  end
-
-  def self.prebuild
-    system "git clone git://github.com/google/googletest.git -b release-1.10.0 --depth 1" # Required for build, won't interfere with the gtest package
-  end
+  extra_url 'https://github.com/google/googletest.git' => 'release-1.11.0'
+  extra_url 'https://raw.githubusercontent.com/skycocker/chromebrew/master/install.sh' => '47b36145a617b2a7e2222184cfa92ebb1c13bba4787c1efd7a0a85d54c211632'
 
   def self.build
     Dir.mkdir "builddir"
@@ -52,15 +22,15 @@ class Benchmark < Package
               -DBENCHMARK_ENABLE_GTEST_TESTS=ON \
               -DBENCHMARK_ENABLE_TESTING=ON \
               -DINSTALL_GTEST=OFF .."
-      system "ninja"
+      system 'samu'
     end
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 
   def self.check
-    system "ninja -C builddir test"
+    system 'samu -C builddir test'
   end
 end

--- a/packages/oneko.rb
+++ b/packages/oneko.rb
@@ -22,9 +22,7 @@ class Oneko < Package
   extra_url 'https://bouncer.gentoo.org/fetch/root/all/distfiles/oneko-1.2-dog.png' => '5ca2d41b5538618196cfe9e40dd75856fde77fe35cba99ed9b2eacf1fb0e5502'
 
   def self.patch
-    # Unpack the patches
-    system "tar xf oneko_1.2.sakura.6-15.debian.tar.xz"
-    # Patch the patches
+    system "tar xf oneko_#{@_ver}.debian.tar.xz"
     system "for patch in $(cat debian/patches/series); do patch -p 1 -i debian/patches/${patch}; done"
   end
 

--- a/packages/oneko.rb
+++ b/packages/oneko.rb
@@ -3,45 +3,25 @@ require 'package'
 class Oneko < Package
   description 'A cat chases around your mouse cursor.'
   homepage 'http://www.daidouji.com/oneko/'
-  version '1.2.sakura.6'
+  @_ver = '1.2.sakura.6-15'
+  version @_ver
   license 'public-domain'
   compatibility 'all'
   source_url 'https://httpredir.debian.org/debian/pool/main/o/oneko/oneko_1.2.sakura.6.orig.tar.gz'
   source_sha256 'd89cee8b81cdb40ef23b3457c9a7fe1b0ff130081b21a41ec6c41cda01391d25'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oneko/1.2.sakura.6_armv7l/oneko-1.2.sakura.6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oneko/1.2.sakura.6_armv7l/oneko-1.2.sakura.6-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oneko/1.2.sakura.6_i686/oneko-1.2.sakura.6-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oneko/1.2.sakura.6_x86_64/oneko-1.2.sakura.6-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '18128ddab7d13999c43c4fa2ce24fdd15a9bcd4541a815ad8c19f9154d006db8',
-     armv7l: '18128ddab7d13999c43c4fa2ce24fdd15a9bcd4541a815ad8c19f9154d006db8',
-       i686: '68469cb17415e9088f966a3b6551b52dcfcd15f3cec905e91fa4c7eca16dc3a0',
-     x86_64: 'abcfe89e40fb13c5df22abcbae616892d9f9917ef931520a80dbbd067bb0775d',
-  })
-
   depends_on 'libx11'
   depends_on 'libxext'
-  depends_on 'sommelier'
+  #depends_on 'sommelier'
   depends_on 'imake' => :build
   depends_on 'xorg_cf_files' => :build
   depends_on 'gccmakedep' => :build
 
+  extra_url "https://httpredir.debian.org/debian/pool/main/o/oneko/oneko_#{@_ver}.debian.tar.xz" => '8f12f3e167f100e0fcef5185f6f1faf47cb627d96c7011e580348f5f317e76b4'
+  extra_url 'https://bouncer.gentoo.org/fetch/root/all/distfiles/oneko-1.2-cat.png' => '994dec71c4021f4e228b8c69fcefde5b11244445ff8ff6d43b3790beecef5800'
+  extra_url 'https://bouncer.gentoo.org/fetch/root/all/distfiles/oneko-1.2-dog.png' => '5ca2d41b5538618196cfe9e40dd75856fde77fe35cba99ed9b2eacf1fb0e5502'
+
   def self.patch
-    # Download extra sources
-    system "curl -#LO https://httpredir.debian.org/debian/pool/main/o/oneko/oneko_1.2.sakura.6-15.debian.tar.xz"
-    system "curl -#LO https://bouncer.gentoo.org/fetch/root/all/distfiles/oneko-1.2-cat.png"
-    system "curl -#LO https://bouncer.gentoo.org/fetch/root/all/distfiles/oneko-1.2-dog.png"
-    # Verify the sources
-    @sha256sums = <<~EOF
-      8f12f3e167f100e0fcef5185f6f1faf47cb627d96c7011e580348f5f317e76b4  oneko_1.2.sakura.6-15.debian.tar.xz
-      994dec71c4021f4e228b8c69fcefde5b11244445ff8ff6d43b3790beecef5800  oneko-1.2-cat.png
-      5ca2d41b5538618196cfe9e40dd75856fde77fe35cba99ed9b2eacf1fb0e5502  oneko-1.2-dog.png
-    EOF
-    IO.write("sha256sums", @sha256sums)
-    system "sha256sum -c sha256sums"
     # Unpack the patches
     system "tar xf oneko_1.2.sakura.6-15.debian.tar.xz"
     # Patch the patches

--- a/packages/oneko.rb
+++ b/packages/oneko.rb
@@ -12,7 +12,7 @@ class Oneko < Package
 
   depends_on 'libx11'
   depends_on 'libxext'
-  #depends_on 'sommelier'
+  depends_on 'sommelier'
   depends_on 'imake' => :build
   depends_on 'xorg_cf_files' => :build
   depends_on 'gccmakedep' => :build

--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -34,6 +34,6 @@ class Unzip < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "BINDIR=#{CREW_DEST_PREFIX}/bin", "MANDIR=#{CREW_DEST_PREFIX}/share/man/man1", "-f", "unix/Makefile", "install"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "BINDIR=#{CREW_DEST_PREFIX}/bin", "MANDIR=#{CREW_DEST_MAN_PREFIX}/man1", "-f", "unix/Makefile", "install"
   end
 end

--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -2,41 +2,29 @@ require 'package'
 
 class Unzip < Package
   description 'UnZip is an extraction utility for archives compressed in .zip format (also called \'zipfiles\').'
-  homepage 'http://www.info-zip.org/UnZip.html'
-  version '6.0-2'
+  homepage 'http://infozip.sourceforge.net/UnZip.html'
+  @_ver = '6.0-26'
+  version @_ver
   license 'Info-ZIP'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip60.tar.gz'
   source_sha256 '036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/unzip/6.0-2_armv7l/unzip-6.0-2-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/unzip/6.0-2_armv7l/unzip-6.0-2-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/unzip/6.0-2_i686/unzip-6.0-2-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/unzip/6.0-2_x86_64/unzip-6.0-2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-     aarch64: '116ed2b03bcaeaa7ccd339e58b67519361933490d1469a72b3c9e12808fc4797',
-      armv7l: '116ed2b03bcaeaa7ccd339e58b67519361933490d1469a72b3c9e12808fc4797',
-        i686: '488891584f8cf53bcd3969140ab0baffeec4cffb4964c6b836d745afd17a86fe',
-      x86_64: 'a58e8a34a46721674ba16198fa943297c6fa80c5933b956bd1ebb6fe91ac6b89',
-  })
-
   depends_on 'compressdoc' => :build
   depends_on 'patch' => :build
 
-  # adapted from the homebrew recipe as seen at: https://github.com/Homebrew/homebrew-dupes/blob/master/unzip.rb
-  # Upstream is unmaintained so we use the Ubuntu unzip_6.0-25ubuntu1 patchset:
-  # https://changelogs.ubuntu.com/changelogs/pool/main/u/unzip/unzip_6.0-25ubuntu1/changelog
+  extra_url "https://httpredir.debian.org/debian/pool/main/u/unzip/unzip_#{@_ver}.debian.tar.xz" => '88cb7c0f1fd13252b662dfd224b64b352f9e75cd86389557fcb23fa6d2638599'
+
   def self.patch
-    patch_url = "http://archive.ubuntu.com/ubuntu/pool/main/u/unzip/unzip_6.0-25ubuntu1.debian.tar.xz"
-    patch_sha256 = '6a22b0d23cf8b9e1a74626d7d9af5efe1257e157f20006272dc68693a13f3b45'
+    system "tar xf unzip_#{@_ver}.debian.tar.xz"
+    system "for patch in $(cat debian/patches/series); do patch -p 1 -i debian/patches/${patch}; done"
 
-    system('curl -#L', patch_url, '-o', 'unzippatches.tar.xz')
-    abort 'Checksum mismatch :/ try again' unless Digest::SHA256.hexdigest( File.read("./unzippatches.tar.xz") ) == patch_sha256
-    system("tar","-xf","unzippatches.tar.xz")
-
-    system("for i in `cat debian/patches/series`; do  patch -p 1 < debian/patches/$i; done")
+    system "sed -i 's:CC = cc:CC = #{CREW_TGT}-gcc #{CREW_COMMON_FLAGS}:' unix/Makefile"
+    system "sed -i 's:CPP = /lib/cpp:CPP = $(which cpp):' unix/Makefile"
+    system "sed -i 's:INSTALL_PROGRAM = cp:INSTALL_PROGRAM = install:' unix/Makefile"
+    system "sed -i 's:INSTALL_D = mkdir -p:INSTALL_D = install -d:' unix/Makefile"
+    system "sed -i 's:prefix = /usr/local:prefix = #{CREW_PREFIX}:' unix/Makefile"
+    system "sed -i 's:CFLAGS = -O:CFLAGS =:' unix/Makefile"
   end
 
   def self.build
@@ -47,7 +35,5 @@ class Unzip < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "BINDIR=#{CREW_DEST_PREFIX}/bin", "MANDIR=#{CREW_DEST_PREFIX}/share/man/man1", "-f", "unix/Makefile", "install"
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man1"
   end
-
 end

--- a/packages/zip.rb
+++ b/packages/zip.rb
@@ -2,38 +2,28 @@ require 'package'
 
 class Zip < Package
   description 'Zip is a compression and file packaging/archive utility for archives compressed in .zip format (also called \'zipfiles\').'
-  homepage 'http://www.info-zip.org/Zip.html'
-  version '3.0-11'
+  homepage 'http://infozip.sourceforge.net/Zip.html'
+  @_ver = '3.0-12'
+  version @_ver
   license 'Info-ZIP'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/infozip/Zip%203.x%20%28latest%29/3.0/zip30.tar.gz'
   source_sha256 'f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zip/3.0-11_armv7l/zip-3.0-11-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zip/3.0-11_armv7l/zip-3.0-11-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zip/3.0-11_i686/zip-3.0-11-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zip/3.0-11_x86_64/zip-3.0-11-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '1905c224b2b73e81c3622c3f440540953bff6516d514addd1f1e09a75573d34b',
-     armv7l: '1905c224b2b73e81c3622c3f440540953bff6516d514addd1f1e09a75573d34b',
-       i686: '58535613e27ac7494cdfbae25d61c4971ee1d670816169a52eec79df3645e21d',
-     x86_64: 'c78a63d3630f3dbf637127e1a5a08942fd1da213cde296d33e77823e8547a56c',
-  })
+  depends_on 'bz2' => :build
 
-  # adapted from the homebrew recipe as seen at: https://github.com/Homebrew/homebrew-core/blob/master/Formula/zip.rb
-  # Upstream is unmaintained so we use the Debian patchset:
-  # https://packages.debian.org/sid/zip
+  extra_url "https://httpredir.debian.org/debian/pool/main/z/zip/zip_#{@_ver}.debian.tar.xz" => '522174080773f72882bd240ca384e698134f61ad6405ce8f995e1d21c9ba41d8'
+
   def self.patch
-    patch_url = "https://mirrors.ocf.berkeley.edu/debian/pool/main/z/zip/zip_3.0-11.debian.tar.xz"
-    patch_sha256 = "c5c0714a88592f9e02146bfe4a8d26cd9bd97e8d33b1efc8b37784997caa40ed"
+    system "tar xf zip_#{@_ver}.debian.tar.xz"
+    system "for patch in $(cat debian/patches/series); do patch -p 1 -i debian/patches/${patch}; done"
 
-    system('curl -#L', patch_url, '-o', 'zippatches.tar.xz')
-    abort 'Checksum mismatch :/ try again' unless Digest::SHA256.hexdigest( File.read("./zippatches.tar.xz") ) == patch_sha256
-    system("tar","-xf","zippatches.tar.xz")
-
-    system("for i in `cat debian/patches/series`; do patch -p 1 < debian/patches/$i; done")
+    system "sed -i 's:CC = cc:CC = #{CREW_TGT}-gcc #{CREW_COMMON_FLAGS}:' unix/Makefile"
+    system "sed -i 's:CPP = /lib/cpp:CPP = $(which cpp):' unix/Makefile"
+    system "sed -i 's:INSTALL_PROGRAM = cp:INSTALL_PROGRAM = install:' unix/Makefile"
+    system "sed -i 's:INSTALL_D = mkdir -p:INSTALL_D = install -d:' unix/Makefile"
+    system "sed -i 's:prefix = /usr/local:prefix = #{CREW_PREFIX}:' unix/Makefile"
+    system "sed -i 's:CFLAGS = -O2:CFLAGS =:' unix/Makefile"
   end
 
   def self.build
@@ -41,6 +31,6 @@ class Zip < Package
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", "BINDIR=#{CREW_DEST_PREFIX}/bin", "MANDIR=#{CREW_DEST_MAN_PREFIX}/man1", '-f', 'unix/Makefile', 'install'
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "BINDIR=#{CREW_DEST_PREFIX}/bin", "MANDIR=#{CREW_DEST_PREFIX}/share/man/man1", "-f", "unix/Makefile", "install"
   end
 end

--- a/packages/zip.rb
+++ b/packages/zip.rb
@@ -31,6 +31,6 @@ class Zip < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "BINDIR=#{CREW_DEST_PREFIX}/bin", "MANDIR=#{CREW_DEST_PREFIX}/share/man/man1", "-f", "unix/Makefile", "install"
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "BINDIR=#{CREW_DEST_PREFIX}/bin", "MANDIR=#{CREW_DEST_MAN_PREFIX}/man1", "-f", "unix/Makefile", "install"
   end
 end


### PR DESCRIPTION
This pull request allows downloading extra files such as patches, without having to download files in `def self.patch`. This also supports git repositories. At the moment, extra files does not support caching, nor does it uncompress compressed archives (that must be done manually).

I updated `benchmark`, `oneko`, `zip`, and `unzip` as proofs of concept.