### PR TITLE
Allow arch specific sources in crew

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.16.1'
+CREW_VERSION = '1.16.2'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -41,7 +41,11 @@ class Package
     if !@build_from_source and @binary_url and @binary_url.has_key?(architecture)
       return @binary_url[architecture]
     else
-      return @source_url
+      if @source_url.has_key?(architecture)
+        return @source_url[architecture]
+      else
+        return @source_url
+      end
     end
   end
 
@@ -49,11 +53,19 @@ class Package
     return @binary_url.has_key?(architecture) ? @binary_url[architecture] : nil
   end
 
+  def self.get_source_url (architecture)
+    return @source_url.has_key?(architecture) ? @source_url[architecture] : nil
+  end
+
   def self.get_sha256 (architecture)
     if !@build_from_source and @binary_sha256 and @binary_sha256.has_key?(architecture)
       return @binary_sha256[architecture]
     else
-      return @source_sha256
+      if @source_sha256.has_key?(architecture)
+        return @source_sha256[architecture]
+      else
+        return @source_sha256
+      end
     end
   end
 


### PR DESCRIPTION
Allows for packages to have sources like this:

```
  source_url({
    aarch64: 'https://musl.cc/armv7l-linux-musleabihf-native.tgz',
     armv7l: 'https://musl.cc/armv7l-linux-musleabihf-native.tgz',
       i686: 'https://musl.cc/i686-linux-musl-native.tgz',
     x86_64: 'https://musl.cc/x86_64-linux-musl-native.tgz'
  })
  source_sha256({
    aarch64: 'bf54a4762aed1a53be247bd5ead66569145c02d7ec78f405b184a7cda80149d1',
     armv7l: 'bf54a4762aed1a53be247bd5ead66569145c02d7ec78f405b184a7cda80149d1',
       i686: 'ae18b6d0fa58a638dba3b6efa1e660433fe9c0a0ef4283955dd934bc09a9898e',
     x86_64: '6bceb516e51d2eecc65e9670f605692fec419bb7ecca701bb021b720f71d6d86'
  })
```

Works properly:
- [x] x86_64 (in a container)
