### PR TITLE
Handle cases when source_url is not a hash

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.16.2'
+CREW_VERSION = '1.16.3'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -41,8 +41,8 @@ class Package
     if !@build_from_source and @binary_url and @binary_url.has_key?(architecture)
       return @binary_url[architecture]
     else
-      if @source_url.has_key?(architecture)
-        return @source_url[architecture]
+      if @source_url.respond_to?(:has_key?)
+        return @source_url.has_key?(architecture) ? @source_url[architecture] : nil
       else
         return @source_url
       end
@@ -61,8 +61,8 @@ class Package
     if !@build_from_source and @binary_sha256 and @binary_sha256.has_key?(architecture)
       return @binary_sha256[architecture]
     else
-      if @source_sha256.has_key?(architecture)
-        return @source_sha256[architecture]
+      if @source_sha256.respond_to?(:has_key?)
+        return @source_sha256.has_key?(architecture) ? @source_sha256[architecture] : nil
       else
         return @source_sha256
       end


### PR DESCRIPTION
Fixes #6061 

- When a `source_url` is not a hash, it doesn't like `@source_sha256.has_key?(architecture)`, so protect that invocation with `@source_url.respond_to?(:has_key?)`
- Same for `source_sha256`

Works properly:
- [x] x86_64 (in container)
- [x] armv7l (in container)

- tested with 
- - package with source hash (build from source)
- - package without source hash (build from source)