### PR TITLE
Update gtk2 from 2.24.33-1 to 2.24.33-2

### DIFF
--- a/packages/gtk2.rb
+++ b/packages/gtk2.rb
@@ -3,23 +3,23 @@ require 'package'
 class Gtk2 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://www.gtk.org/'
-  version '2.24.33-1'
+  version '2.24.33-2'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.33.tar.xz'
   source_sha256 'ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk2/2.24.33-1_armv7l/gtk2-2.24.33-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk2/2.24.33-1_armv7l/gtk2-2.24.33-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk2/2.24.33-1_i686/gtk2-2.24.33-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk2/2.24.33-1_x86_64/gtk2-2.24.33-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk2/2.24.33-2_armv7l/gtk2-2.24.33-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk2/2.24.33-2_armv7l/gtk2-2.24.33-2-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk2/2.24.33-2_i686/gtk2-2.24.33-2-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk2/2.24.33-2_x86_64/gtk2-2.24.33-2-chromeos-x86_64.tar.xz',
   })
   binary_sha256({
-    aarch64: '973cb7478861aa2821870c07e1ab3570b3d66afd51b3b065e1fd7598d4a666a2',
-     armv7l: '973cb7478861aa2821870c07e1ab3570b3d66afd51b3b065e1fd7598d4a666a2',
-       i686: '425d69586e1f990a1ef2eac1ecbafee226183bc2266a65a7df5fc6eb3e14b803',
-     x86_64: '0e39307d3bb40f03a24d676404a8d5359f61a6d4b1219ab0aa4fb35be0b5806a'
+    aarch64: '3e4c4c44a9713a5e37770718e7951062ea9b986bb1a9a99d45f4fd79a9fdf747',
+     armv7l: '3e4c4c44a9713a5e37770718e7951062ea9b986bb1a9a99d45f4fd79a9fdf747',
+       i686: 'aaa52bb7041e4d459314b8a27d1564a9aac73a6464c055ce78a6860bc169de0a',
+     x86_64: 'c2696e86d1b93611ff3f0d6c5931cdb2666afb0f90324a25214db3e6c2a51df3',
   })
 
   depends_on 'atk'
@@ -46,14 +46,29 @@ class Gtk2 < Package
   depends_on 'py3_six' => :build
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto' \
+    system "#{CREW_ENV_OPTIONS} \
       ./configure #{CREW_OPTIONS} --with-gdktarget=x11"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
+      FileUtils.mv 'gtk-update-icon-cache', 'gtk2-update-icon-cache'
+    end
+  end
+
+  def self.postinstall
+    unless File.exists? "#{CREW_PREFIX}/bin/gtk-update-icon-cache"
+      Dir.chdir "#{CREW_PREFIX}/bin" do
+        FileUtils.ln_s 'gtk2-update-icon-cache', 'gtk-update-icon-cache'
+      end
+    end
+  end
+
+  def self.remove
+    if File.symlink? "#{CREW_PREFIX}/bin/gtk-update-icon-cache"
+      FileUtils.rm "#{CREW_PREFIX}/bin/gtk-update-icon-cache"
+    end
   end
 end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -7,18 +7,20 @@ class Gtk3 < Package
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gtk.git'
   git_hashtag @_ver
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.30_armv7l/gtk3-3.24.30-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.30_armv7l/gtk3-3.24.30-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.30_i686/gtk3-3.24.30-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.30_x86_64/gtk3-3.24.30-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '53ac51ba579ca1845428d1fbc05563066ecc3f6ee66461b444eb3ded928ae4ef',
      armv7l: '53ac51ba579ca1845428d1fbc05563066ecc3f6ee66461b444eb3ded928ae4ef',
+       i686: '3d2c917a0c7bd975a726220f3f4d99b246b650c16609b258566d84c1416202cb',
      x86_64: '29ca5524c6b7e39d778db9c65cfa606ddac87f9af8ec2f4cb238f94435827d63'
   })
 

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -7,18 +7,20 @@ class Gtk4 < Package
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gtk.git'
   git_hashtag @_ver
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.3.1_armv7l/gtk4-4.3.1-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.3.1_armv7l/gtk4-4.3.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.3.1_i686/gtk4-4.3.1-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.3.1_x86_64/gtk4-4.3.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: 'd714a0b5c0318ee50ad3e7bd581e4d69435aafcf3800b640030f940e5accb1cd',
      armv7l: 'd714a0b5c0318ee50ad3e7bd581e4d69435aafcf3800b640030f940e5accb1cd',
+       i686: 'b9fc6152bf910f95f9d7823d47b592a689a9ccb7279955d1f25731a15d6dd000',
      x86_64: '986e9290a4ba1e216db1f7d6c89ce4d86cf9ecae1af3b90c1ad43fd385237c75'
   })
 

--- a/packages/gtkmm4.rb
+++ b/packages/gtkmm4.rb
@@ -1,22 +1,24 @@
 require 'package'
 
 class Gtkmm4 < Package
-  description 'The Gtkmm3 package provides a C++ interface to GTK+ 3.'
+  description 'The Gtkmm4 package provides a C++ interface to GTK+ 4.'
   homepage 'https://www.gtkmm.org/'
   version '4.0.1'
   license 'LGPL-2.1+'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url 'https://download.gnome.org/sources/gtkmm/4.0/gtkmm-4.0.1.tar.xz'
   source_sha256 '8973d9bc7848e02cb2051e05f3ee3a4baffe2feb4af4a5487f0e3132eec03884'
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.1_armv7l/gtkmm4-4.0.1-chromeos-armv7l.tar.xz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.1_armv7l/gtkmm4-4.0.1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.1_i686/gtkmm4-4.0.1-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.1_x86_64/gtkmm4-4.0.1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
     aarch64: '1d2640f81201631586b082735b8ad82a229ff9502233acc4ed628ba88dd46278',
      armv7l: '1d2640f81201631586b082735b8ad82a229ff9502233acc4ed628ba88dd46278',
+       i686: '1be63d921a1b6013e1a36ef9be69d904ed7b6234c75dc24880598d290681914c',
      x86_64: 'd6b5659e5e00d16442c9368db8c7baf610fb62f43111ed6f6cd93dfb0417fbf1'
   })
 


### PR DESCRIPTION
- Add binaries for gtk2
- Add i686 binaries for gtk3 and gtk4
- Add i686 binary for gtkmm4

Fixes #6070.