### PR TITLE
Only need qtbase for qt apps

### DIFF
--- a/packages/avahi.rb
+++ b/packages/avahi.rb
@@ -35,7 +35,7 @@ class Avahi < Package
   depends_on 'libjpeg'
   depends_on 'mono' => :build
   depends_on 'pango'
-  depends_on 'qtbase'
+  depends_on 'qtbase' => :build
 
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \


### PR DESCRIPTION
- qtbase is huge. Don't pull it in via avahi.

Works properly:
- [x] x86_64
