### PR TITLE
libxfce4util => 4.17.1

### DIFF
--- a/packages/libxfce4util.rb
+++ b/packages/libxfce4util.rb
@@ -9,6 +9,19 @@ class Libxfce4util < Package
   source_url 'https://archive.xfce.org/src/xfce/libxfce4util/4.17/libxfce4util-4.17.1.tar.bz2'
   source_sha256 '1942151f3c1f3732bc53dd9fd3b936f62067796dc47a33c60a0ad05d933d90f2'
 
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxfce4util/4.17.1_armv7l/libxfce4util-4.17.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxfce4util/4.17.1_armv7l/libxfce4util-4.17.1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxfce4util/4.17.1_i686/libxfce4util-4.17.1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxfce4util/4.17.1_x86_64/libxfce4util-4.17.1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '60931162f4dd81641a84a84c840426d9d188a960a9cc222bcbd15591e718af57',
+     armv7l: '60931162f4dd81641a84a84c840426d9d188a960a9cc222bcbd15591e718af57',
+       i686: '597083d2e0a9b254580295236747903e0c032e0bf05537c6c6576c416450e4f2',
+     x86_64: 'bec77f6226c7fb69e215acc98c50da5c44189d089724672e607e9590c3ebc7b9',
+  })
+
   depends_on 'gobject_introspection'
 
   def self.patch

--- a/packages/libxfce4util.rb
+++ b/packages/libxfce4util.rb
@@ -6,30 +6,20 @@ class Libxfce4util < Package
   version '4.16.0'
   license 'LGPL-2+ and GPL-2+'
   compatibility 'all'
-  source_url 'https://archive.xfce.org/src/xfce/libxfce4util/4.16/libxfce4util-4.16.0.tar.bz2'
-  source_sha256 '60598d745d1fc81ff5ad3cecc3a8d1b85990dd22023e7743f55abd87d8b55b83'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxfce4util/4.16.0_armv7l/libxfce4util-4.16.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxfce4util/4.16.0_armv7l/libxfce4util-4.16.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxfce4util/4.16.0_i686/libxfce4util-4.16.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxfce4util/4.16.0_x86_64/libxfce4util-4.16.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'ceca4f8f984045af5c7d945c679884e034ccbe005b778ad51bb957cf59c00cc8',
-     armv7l: 'ceca4f8f984045af5c7d945c679884e034ccbe005b778ad51bb957cf59c00cc8',
-       i686: '6bd36fee5ba039cfd4eeba7d35dd8518d077c8ff7ab3655592a47c2d3b1f6f4a',
-     x86_64: '077a6ddd98402bced4c6269ce7374452ef3709a4c821565c643108ccb8c3cd8e',
-  })
+  source_url 'https://gitlab.xfce.org/xfce/libxfce4util.git'
+  git_hashtag '546a8404050459a7b4d5bd264d11d1748f71d940'
 
   depends_on 'gobject_introspection'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
-    system "make -j#{CREW_NPROC}"
+    system <<~BUILD
+      [ -x autogen.sh ] && env NOCONFIGURE='1' ./autogen.sh
+      env #{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}
+      make
+    BUILD
   end
 
   def self.install
-    system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libxfce4util.rb
+++ b/packages/libxfce4util.rb
@@ -11,6 +11,10 @@ class Libxfce4util < Package
 
   depends_on 'gobject_introspection'
 
+  def self.patch
+    system 'filefix'
+  end
+
   def self.build
     system <<~BUILD
       [ -x autogen.sh ] && env NOCONFIGURE='1' ./autogen.sh

--- a/packages/libxfce4util.rb
+++ b/packages/libxfce4util.rb
@@ -3,11 +3,11 @@ require 'package'
 class Libxfce4util < Package
   description 'Utility library for the Xfce4 desktop environment'
   homepage 'https://xfce.org/'
-  version '4.16.0'
+  version '4.17.1'
   license 'LGPL-2+ and GPL-2+'
   compatibility 'all'
-  source_url 'https://gitlab.xfce.org/xfce/libxfce4util.git'
-  git_hashtag '546a8404050459a7b4d5bd264d11d1748f71d940'
+  source_url 'https://archive.xfce.org/src/xfce/libxfce4util/4.17/libxfce4util-4.17.1.tar.bz2'
+  source_sha256 '1942151f3c1f3732bc53dd9fd3b936f62067796dc47a33c60a0ad05d933d90f2'
 
   depends_on 'gobject_introspection'
 


### PR DESCRIPTION
Built successfully on `x86_64`.  Also builds on armv7l and i686.  All pre-built binaries added.