### PR TITLE
libssh -> 0.9.6

### DIFF
--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -14,11 +14,13 @@ class Libssh < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_armv7l/libssh-0.9.6-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_armv7l/libssh-0.9.6-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_i686/libssh-0.9.6-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_x86_64/libssh-0.9.6-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '5c4a6da32f3b23488dd15e06a5eb77e191143e4d5b5a396331a429e9d5dd5cfd',
      armv7l: '5c4a6da32f3b23488dd15e06a5eb77e191143e4d5b5a396331a429e9d5dd5cfd',
+       i686: '9a3d676f230262a5974fe05e7ea705c9062a5b27364655e29e2abf4158009389',
      x86_64: 'a4a261a53541349d5c9564a74f7a5d5051d33a4cbdbc06885810eb948f0d01a8'
   })
 

--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -3,25 +3,23 @@ require 'package'
 class Libssh < Package
   description 'libssh is a multiplatform C library implementing the SSHv2 and SSHv1 protocol on client and server side.'
   homepage 'https://www.libssh.org/'
-  @_ver = '0.9.5'
-  version "#{@_ver}-2"
+  @_ver = '0.9.6'
+  version @_ver
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://www.libssh.org/files/#{@_ver_prelastdot}/libssh-#{@_ver}.tar.xz"
-  source_sha256 'acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718'
+  source_sha256 '86bcf885bd9b80466fe0e05453c58b877df61afa8ba947a58c356d7f0fab829b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-2_armv7l/libssh-0.9.5-2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-2_armv7l/libssh-0.9.5-2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-2_i686/libssh-0.9.5-2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.5-2_x86_64/libssh-0.9.5-2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_armv7l/libssh-0.9.6-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_armv7l/libssh-0.9.6-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_x86_64/libssh-0.9.6-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'fe56c352d678f004866c27bf5b4dc1d05114387f65bc07968834ddbd5ec9bb79',
-     armv7l: 'fe56c352d678f004866c27bf5b4dc1d05114387f65bc07968834ddbd5ec9bb79',
-       i686: 'd524f5485303306cb39720c09e9379a3e636a1f18ba68a547dd6534c762c5c12',
-     x86_64: 'abb34682d2e053ff8a7ca1f2d64d45402127a3460314a0b330641715dff21704'
+    aarch64: '5c4a6da32f3b23488dd15e06a5eb77e191143e4d5b5a396331a429e9d5dd5cfd',
+     armv7l: '5c4a6da32f3b23488dd15e06a5eb77e191143e4d5b5a396331a429e9d5dd5cfd',
+     x86_64: 'a4a261a53541349d5c9564a74f7a5d5051d33a4cbdbc06885810eb948f0d01a8'
   })
 
   depends_on 'libgcrypt'


### PR DESCRIPTION


Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686 (@uberhacker try a build please?)
