### PR TITLE
mpv rebuild, and made hw accel default.

### DIFF
--- a/packages/mpv.rb
+++ b/packages/mpv.rb
@@ -48,6 +48,7 @@ class Mpv < Package
   depends_on 'libxrandr' # R
   depends_on 'libxss' # R
   depends_on 'libxv' # R
+  depends_on 'llvm' # R
   depends_on 'luajit' # R
   depends_on 'mesa' # R
   depends_on 'mujs' # R

--- a/packages/mpv.rb
+++ b/packages/mpv.rb
@@ -22,7 +22,6 @@ class Mpv < Package
   })
 
   depends_on 'py3_docutils' => :build
-  depends_on 'libcdio' => :build
   depends_on 'vulkan_headers' => :build
   depends_on 'alsa_lib' # R
   depends_on 'ffmpeg' # R


### PR DESCRIPTION
- Enabled sdl2 in build, and also enabled hw acceleration by default, which makes a dramatic difference in performance on x86_64.
- this is dependent upon https://github.com/skycocker/chromebrew/pull/6120 https://github.com/skycocker/chromebrew/pull/6130 and https://github.com/skycocker/chromebrew/pull/6131

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [ ] i686 (@uberhacker  build please?)