### PR TITLE
fixed checksum mismatch for tar-1.34.tar.xz

### DIFF
--- a/packages/tar.rb
+++ b/packages/tar.rb
@@ -7,7 +7,7 @@ class Tar < Package
   license 'BSD'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/gnu/tar/tar-1.34.tar.xz'
-  source_sha256 '03d908cf5768cfe6b7ad588c921c6ed21acabfb2b79b788d1330453507647aed'
+  source_sha256 '63bebd26879c5e1eea4352f0d03c991f966aeb3ddeb3c7445c902568d5411d28'
 
   
 


### PR DESCRIPTION
Fixes #

(let GitHub automatically close an issue when this pull request gets merged)

## Before you submit a pull request
This template is not necessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.

## Description
Provide a description, what your changes do and why they are important

Please link issues and other pull requests connected to this one.

## Additional information
Mention things we might need to know. Like:

Works properly:
- [x] x86_64
- [x] aarch64 (reasons why it doesn't)

---

## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
