### PR TITLE
crew: modify upx logic to use concurrent-ruby

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1011,10 +1011,36 @@ def shrink_dir(dir)
         @execfiles = %x[find . -executable -type f ! \\( -name \"*.so*\" -o -name \"*.a\" -o -name \"Xwayland.elf\" -o -name \"sommelier.elf\" \\) -exec sh -c \"file -i \'{}\' | grep -q \'executable; charset=binary\'\" \\; -print].chomp
         unless @execfiles.empty? or @execfiles.nil?
           puts "Using upx to shrink binaries."
-          @execfiles.each_line do |execfile|
-            system "upx --best -k --overlay=skip #{execfile} && \
-            \( upx -t #{execfile} && rm #{execfile}.~ || mv #{execfile}.~ #{execfile}\)"
+          begin
+              gem 'concurrent-ruby'
+          rescue Gem::LoadError
+              puts ' -> install gem ' + 'concurrent-ruby'
+              Gem.install('concurrent-ruby')
+              gem 'concurrent-ruby'
           end
+          require 'concurrent-ruby'
+          pool = Concurrent::ThreadPoolExecutor.new(
+            min_threads: CREW_NPROC,
+            max_threads: CREW_NPROC,
+            max_queue: 0, # unbounded work queue
+            fallback_policy: :caller_runs
+          )
+          @execfiles.each_line do |execfile|
+            puts "Attempting to compress #{execfile}".lightblue
+            pool.post do
+              begin
+                system "upx --best -k --overlay=skip #{execfile}"
+                system "upx -t #{execfile}" and FileUtils.rm "#{execfile}.~"
+              rescue
+                FileUtils.mv "#{execfile}.~", execfile
+              ensure
+                FileUtils.rm_f "#{execfile}.~"
+              end
+            end
+          end
+          pool.shutdown
+          pool.wait_for_termination
+          # This should no longer be needed, but leave for cleanup.
           system 'find . -executable -type f -name "*.~" -delete'
         end
       end

--- a/bin/crew
+++ b/bin/crew
@@ -1020,13 +1020,13 @@ def shrink_dir(dir)
           end
           require 'concurrent-ruby'
           pool = Concurrent::ThreadPoolExecutor.new(
-            min_threads: CREW_NPROC,
+            min_threads: 1,
             max_threads: CREW_NPROC,
             max_queue: 0, # unbounded work queue
             fallback_policy: :caller_runs
           )
           @execfiles.each_line do |execfile|
-            puts "Attempting to compress #{execfile}".lightblue
+            puts "Attempting to compress #{execfile} ...".lightblue
             pool.post do
               begin
                 system "upx --best -k --overlay=skip #{execfile}"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.16.4'
+CREW_VERSION = '1.16.5'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- Using `upx` in crew on multi-core machines is slow when multiple binaries need to be compressed.
- This PR adds the use of `concurrent-ruby` to create a thread pool to spawn multiple simultaneous upx instances, up to `CREW_NPROC`. This way more than one core is used during this process, which should speed up builds.
- This also cleans up the error messages from the long shell code being used in the upx code block.


Works properly:
- [x] x86_64
- [x] armv7l (in container)