### PR TITLE
pango -> 1.49.1

### DIFF
--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -12,11 +12,13 @@ class Pango < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1_armv7l/pango-1.49.1-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1_armv7l/pango-1.49.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1_i686/pango-1.49.1-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1_x86_64/pango-1.49.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '34371224fc5fa1134e9ede5b2c8851edcd21234117fa82debdede86ad60ee8a7',
      armv7l: '34371224fc5fa1134e9ede5b2c8851edcd21234117fa82debdede86ad60ee8a7',
+       i686: '38283172c022958a30c410963f4ee3808f418e6a819f4067ab698b03065cc639',
      x86_64: '164ad6211444cfd9938a761617d1fc65770574026af6c3024111ae53ca8fde85'
   })
 

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -3,23 +3,21 @@ require 'package'
 class Pango < Package
   description 'Pango is a library for laying out and rendering of text, with an emphasis on internationalization.'
   homepage 'http://www.pango.org/'
-  version '1.48.3'
+  version '1.49.1'
   license 'LGPL-2+ and FTL'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/pango/1.48/pango-1.48.2.tar.xz'
-  source_sha256 'd21f8b30dc8abdfc55de25656ecb88dc1105eeeb315e5e2a980dcef8010c2c80'
+  source_url 'https://gitlab.gnome.org/GNOME/pango.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.48.3_armv7l/pango-1.48.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.48.3_armv7l/pango-1.48.3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.48.3_i686/pango-1.48.3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.48.3_x86_64/pango-1.48.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1_armv7l/pango-1.49.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1_armv7l/pango-1.49.1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1_x86_64/pango-1.49.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'c4bc39bde5db09cb6762d6fda0e9d454302f9484c71a3df677562b2db1407716',
-     armv7l: 'c4bc39bde5db09cb6762d6fda0e9d454302f9484c71a3df677562b2db1407716',
-       i686: '09b5c60ba73ebea3a95c0b7d2676e4ae5a7647825ffacebf6b0195c944680f36',
-     x86_64: '0e334cadaaa118649dec9a8a35a6982f349338bed3c974fa3992786bf329b906'
+    aarch64: '34371224fc5fa1134e9ede5b2c8851edcd21234117fa82debdede86ad60ee8a7',
+     armv7l: '34371224fc5fa1134e9ede5b2c8851edcd21234117fa82debdede86ad60ee8a7',
+     x86_64: '164ad6211444cfd9938a761617d1fc65770574026af6c3024111ae53ca8fde85'
   })
 
   depends_on 'cairo'


### PR DESCRIPTION

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686