### PR TITLE
crew: improve 'Attempting to compress' output

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1026,9 +1026,9 @@ def shrink_dir(dir)
             fallback_policy: :caller_runs
           )
           @execfiles.each_line do |execfile|
-            puts "Attempting to compress #{execfile} ...".lightblue
             pool.post do
               begin
+                puts "Attempting to compress #{execfile.chomp} ...".lightblue
                 system "upx --best -k --overlay=skip #{execfile}"
                 system "upx -t #{execfile}" and FileUtils.rm "#{execfile}.~"
               rescue

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.16.5'
+CREW_VERSION = '1.16.6'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- This puts the filename being compressed on the same line as the `...` and also only shows the filename just before trying to compress it.

Works properly:
- [x] x86_64
