### PR TITLE
Update freebasic from 1.07.1-1 to 1.08.1

### DIFF
--- a/packages/freebasic.rb
+++ b/packages/freebasic.rb
@@ -3,16 +3,19 @@ require 'package'
 class Freebasic < Package
   description 'FreeBASIC is a free and open source, BASIC compiler for Microsoft Windows, DOS and Linux.'
   homepage 'https://www.freebasic.net/'
-  version '1.07.1-1'
+  version '1.08.1'
   license 'LGPL-2 and GPL-2'
-  compatibility 'i686,x86_64'
+  compatibility 'all'
   case ARCH
+  when 'aarch64', 'armv7l'
+    source_url 'https://downloads.sourceforge.net/project/fbc/FreeBASIC-1.08.1/Binaries-Linux/FreeBASIC-1.08.1-linux-arm.tar.xz'
+    source_sha256 'e321b8bec63446c9891db4df2d2e4d08552f3ca030def416a208f851367bee8c'
   when 'i686'
-    source_url 'https://downloads.sourceforge.net/project/fbc/Binaries%20-%20Linux/FreeBASIC-1.07.1-linux-x86.tar.gz' # 404 not found
-    source_sha256 'a5b8f31e38a214d63a3d8e0b1ac6608f6a304891e40a3c0755940cba2f8401f1'
+    source_url 'https://downloads.sourceforge.net/project/fbc/FreeBASIC-1.08.1/Binaries-Linux/FreeBASIC-1.08.1-linux-x86.tar.xz'
+    source_sha256 '8f11af664858e29d0798e19aa895c0439f14a9660eba04c7fe4c872c98132524'
   when 'x86_64'
-    source_url 'https://downloads.sourceforge.net/project/fbc/Binaries%20-%20Linux/FreeBASIC-1.07.1-linux-x86_64.tar.gz' # 404 not found
-    source_sha256 'd5034e81201760de7fd7bc563d8c33213a9530da3d15d4907e52d47278a00243'
+    source_url 'https://downloads.sourceforge.net/project/fbc/FreeBASIC-1.08.1/Binaries-Linux/FreeBASIC-1.08.1-linux-x86_64.tar.xz'
+    source_sha256 'f32213b2efb0be2799995cab0de429ce862ae2f9b36af4e236948985c20583c7'
   end
 
   depends_on 'libtinfo'
@@ -21,5 +24,9 @@ class Freebasic < Package
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
     system "./install.sh -i #{CREW_DEST_PREFIX}"
     FileUtils.mv "#{CREW_DEST_PREFIX}/man", "#{CREW_DEST_PREFIX}/share"
+  end
+
+  def self.postinstall
+    puts "\nType 'fbc' to get started.\n".lightblue
   end
 end

--- a/packages/libtinfo.rb
+++ b/packages/libtinfo.rb
@@ -3,22 +3,79 @@ require 'package'
 class Libtinfo < Package
   description 'Missing ncurses library reference.'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '6.2-1'
+  version '5.9'
   license 'MIT' # Ncurses license
   compatibility 'all'
-  source_url 'SKIP'
+  source_url 'https://github.com/mirror/ncurses.git'
+  git_hashtag "v#{version}"
 
   binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9_armv7l/libtinfo-5.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9_armv7l/libtinfo-5.9-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9_i686/libtinfo-5.9-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9_x86_64/libtinfo-5.9-chromeos-x86_64.tar.xz',
   })
   binary_sha256 ({
+    aarch64: '2e94b9a42682306f5c05eae9a9b28fb797a79b7f782ed4e291c66224fb2a09b4',
+     armv7l: '2e94b9a42682306f5c05eae9a9b28fb797a79b7f782ed4e291c66224fb2a09b4',
+       i686: 'c884149bf8c6dea3fc3d16ba1ac316c811d318fbfa18ef35171e2bf2c81f4bd9',
+     x86_64: '6ff14ec1bdcdbf55e145b4a8c450b09526803c1450fb3a06fc233a9e85e4ea3e',
   })
 
-  depends_on 'ncurses'
+  def self.build
+    # Fix ncurses error: expected ')' before 'int'.
+    # See https://lists.gnu.org/archive/html/bug-ncurses/2015-01/msg00016.html.
+    ENV['CPPFLAGS'] = '-P'
+    # build libncurses
+    Dir.mkdir 'ncurses_build'
+    Dir.chdir 'ncurses_build' do
+      #system "#{CREW_ENV_OPTIONS} ../configure #{CREW_OPTIONS} \
+      system "../configure #{CREW_OPTIONS} \
+          --program-prefix='' \
+          --program-suffix='' \
+          --with-shared \
+          --with-cxx-shared \
+          --without-debug \
+          --without-normal \
+          --without-cxx-binding \
+          --disable-widec \
+          --without-tests \
+          --with-termlib \
+          --enable-termcap"
+      system 'make'
+    end
+    # build libncursesw
+    Dir.mkdir 'ncursesw_build'
+    Dir.chdir 'ncursesw_build' do
+      #system "#{CREW_ENV_OPTIONS} ../configure #{CREW_OPTIONS} \
+      system "../configure #{CREW_OPTIONS} \
+          --program-prefix='' \
+          --program-suffix='' \
+          --with-shared \
+          --with-cxx-shared \
+          --without-debug \
+          --without-normal \
+          --without-cxx-binding \
+          --enable-widec \
+          --without-tests \
+          --with-termlib \
+          --enable-termcap"
+      system 'make'
+    end
+  end
 
   def self.install
-    # See https://forums.opensuse.org/showthread.php/446927-missing-library-libtinfo-so-5.
-    # See also http://www.linuxforums.org/forum/installation/6251-libtinfo-so-5-a.html.
+    Dir.chdir 'ncurses_build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install.libs'
+    end
+    Dir.chdir 'ncursesw_build' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install.libs'
+    end
+    # Save only the libtinfo libraries.
+    FileUtils.mv Dir["ncurses_build/#{ARCH_LIB}/libtinfo.so.5*"], CREW_DEST_DIR
+    FileUtils.mv Dir["ncursesw_build/#{ARCH_LIB}/libtinfow.so.5*"], CREW_DEST_DIR
+    FileUtils.rm_rf CREW_DEST_PREFIX
     FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
-    FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libncurses.so.6", "#{CREW_DEST_LIB_PREFIX}/libtinfo.so.5"
+    FileUtils.mv Dir["#{CREW_DEST_DIR}/libtinfo*.so.5*"], CREW_DEST_LIB_PREFIX
   end
 end


### PR DESCRIPTION
- Update libtinfo from 6.2-1 to 5.9
- Add pre-built binaries for libtinfo
- Add postinstall section to freebasic
- Tested on all architectures (this update includes arm support!)