### PR TITLE
Rust -> 1.55.0

### DIFF
--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -10,14 +10,16 @@ class Rust < Package
   source_url 'SKIP'
 
   binary_url({
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.55.0_i686/rust-1.55.0-chromeos-i686.tpxz',
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.55.0_armv7l/rust-1.55.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.55.0_armv7l/rust-1.55.0-chromeos-armv7l.tpxz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.55.0_x86_64/rust-1.55.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'ccd4507777a918c301ed0da5b067e5c0f340843a77ef02d1774cf9067b7c5ef9',
-     armv7l: 'ccd4507777a918c301ed0da5b067e5c0f340843a77ef02d1774cf9067b7c5ef9',
-     x86_64: 'ffc3368e168614ae0f3f6578742b32a96c13d7f057e69c8771b69a835db33bcf'
+       i686: 'bce668e6278d073b9f66d7a1b5980d1a5f350b254aa18af03757ab6e72cc030b',
+    aarch64: 'bb532ba4a0bac36d4321b154bf2b726aa031eaaca2670ca426f544f22cd94cf4',
+     armv7l: 'bb532ba4a0bac36d4321b154bf2b726aa031eaaca2670ca426f544f22cd94cf4',
+     x86_64: 'd25d432ff1294fd0ab95e71951f6271d19e9dbdebede5f47defdb6abe909e96a'
   })
 
   def self.install
@@ -38,12 +40,12 @@ class Rust < Package
     FileUtils.cd("#{CREW_DEST_PREFIX}/share/cargo/bin") do
       system "find -type f -exec ln -s #{CREW_PREFIX}/share/cargo/bin/{} #{CREW_DEST_PREFIX}/bin/{} \\;"
     end
-    system "install -Dm644 #{CREW_DEST_PREFIX}/share/rustup/toolchains/stable-#{default_host}/etc/bash_completion.d/cargo #{CREW_DEST_PREFIX}/share/bash-completion/completions/cargo"
-    FileUtils.rm("#{CREW_DEST_PREFIX}/share/rustup/toolchains/stable-#{default_host}/etc/bash_completion.d/cargo")
+    system "install -Dm644 #{CREW_DEST_PREFIX}/share/rustup/toolchains/#{@_ver}-#{default_host}/etc/bash_completion.d/cargo #{CREW_DEST_PREFIX}/share/bash-completion/completions/cargo"
+    FileUtils.rm("#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{@_ver}-#{default_host}/etc/bash_completion.d/cargo")
     system "touch #{CREW_DEST_PREFIX}/share/bash-completion/completions/rustup"
-    FileUtils.mv("#{CREW_DEST_PREFIX}/share/rustup/toolchains/stable-#{default_host}/share/man/",
+    FileUtils.mv("#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{@_ver}-#{default_host}/share/man/",
                  "#{CREW_DEST_PREFIX}/share/")
-    FileUtils.rm_rf("#{CREW_DEST_PREFIX}/share/rustup/toolchains/stable-#{default_host}/share/doc/")
+    FileUtils.rm_rf("#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{@_ver}-#{default_host}/share/doc/")
     FileUtils.ln_sf("#{CREW_PREFIX}/share/cargo", "#{CREW_DEST_HOME}/.cargo")
     FileUtils.ln_sf("#{CREW_PREFIX}/share/rustup", "#{CREW_DEST_HOME}/.rustup")
 

--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -3,30 +3,28 @@ require 'package'
 class Rust < Package
   description 'Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.'
   homepage 'https://www.rust-lang.org/'
-  @_ver = '1.54.0'
+  @_ver = '1.55.0'
   version @_ver
   license 'Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'SKIP'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.54.0_armv7l/rust-1.54.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.54.0_armv7l/rust-1.54.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.54.0_i686/rust-1.54.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.54.0_x86_64/rust-1.54.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.55.0_armv7l/rust-1.55.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.55.0_armv7l/rust-1.55.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.55.0_x86_64/rust-1.55.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'b0d314f20de04bedd397f29e8f2016be9ef2b4c482c8df7559e5c72bb4e66024',
-     armv7l: 'b0d314f20de04bedd397f29e8f2016be9ef2b4c482c8df7559e5c72bb4e66024',
-       i686: '54b16460b5f8a0b78ae7ef11ab3b31d965c26a7663cc958963c5c35c41a19f54',
-     x86_64: '2287cb7645dcd2c66e7806897095e31ef63cf09fea48c06cb60208cef0d8d0a3'
+    aarch64: 'ccd4507777a918c301ed0da5b067e5c0f340843a77ef02d1774cf9067b7c5ef9',
+     armv7l: 'ccd4507777a918c301ed0da5b067e5c0f340843a77ef02d1774cf9067b7c5ef9',
+     x86_64: 'ffc3368e168614ae0f3f6578742b32a96c13d7f057e69c8771b69a835db33bcf'
   })
 
   def self.install
     ENV['RUST_BACKTRACE'] = 'full'
     ENV['CARGO_HOME'] = "#{CREW_DEST_PREFIX}/share/cargo"
     ENV['RUSTUP_HOME'] = "#{CREW_DEST_PREFIX}/share/rustup"
-    default_host = ARCH == 'aarch64' || ARCH == 'armv7' ? 'armv7-unknown-linux-gnueabihf' : "#{ARCH}-unknown-linux-gnu"
+    default_host = ARCH == 'aarch64' || ARCH == 'armv7l' ? 'armv7-unknown-linux-gnueabihf' : "#{ARCH}-unknown-linux-gnu"
     system 'curl -Lf https://sh.rustup.rs -o rustup.sh'
     unless Digest::SHA256.hexdigest(File.read('rustup.sh')) == 'a3cb081f88a6789d104518b30d4aa410009cd08c3822a1226991d6cf0442a0f8'
       abort 'Checksum mismatch. :/ Try again.'.lightred
@@ -65,8 +63,13 @@ class Rust < Package
     RUSTCOMPLETIONEOF
     IO.write("#{CREW_DEST_PREFIX}/etc/bash.d/rust", @rustcompletionenv)
     system "#{CREW_DEST_PREFIX}/share/cargo/bin/rustup completions bash > #{CREW_DEST_PREFIX}/share/bash-completion/completions/rustup"
+    Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
+      Dir.glob('*').each do |f|
+        FileUtils.ln_sf "../share/cargo/bin/#{f}", f
+      end
+    end
   end
-  
+
   def self.remove
     config_dirs = %W[#{HOME}/.rustup #{CREW_PREFIX}/share/rustup #{HOME}/.cargo #{CREW_PREFIX}/share/cargo]
     system "echo #{config_dirs}"

--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -34,7 +34,7 @@ class Rust < Package
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/bin")
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/cargo")
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/rustup")
-    system "RUSTFLAGS='-Clto=thin' bash ./rustup.sh -y --no-modify-path --default-host #{default_host} --default-toolchain stable --profile minimal"
+    system "RUSTFLAGS='-Clto=thin' bash ./rustup.sh -y --no-modify-path --default-host #{default_host} --default-toolchain #{@_ver} --profile minimal"
     FileUtils.cd("#{CREW_DEST_PREFIX}/share/cargo/bin") do
       system "find -type f -exec ln -s #{CREW_PREFIX}/share/cargo/bin/{} #{CREW_DEST_PREFIX}/bin/{} \\;"
     end

--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -64,7 +64,7 @@ class Rust < Package
     IO.write("#{CREW_DEST_PREFIX}/etc/bash.d/rust", @rustcompletionenv)
     system "#{CREW_DEST_PREFIX}/share/cargo/bin/rustup completions bash > #{CREW_DEST_PREFIX}/share/bash-completion/completions/rustup"
     Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
-      Dir.glob('*').each do |f|
+      Dir['*'] do |f|
         FileUtils.ln_sf "../share/cargo/bin/#{f}", f
       end
     end


### PR DESCRIPTION
Fixes #6190 
- Fixes symlinks issue w/ `symlinks` tool usage

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686