### PR TITLE
combine nss & nspr (-> 3.69.1, 4.32) as they share source package

### DIFF
--- a/packages/nspr.rb
+++ b/packages/nspr.rb
@@ -3,40 +3,12 @@ require 'package'
 class Nspr < Package
   description 'Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc-like functions.'
   homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR'
-  version '4.29'
+  version '4.32'
   license 'MPL-2.0, GPL-2 or LGPL-2.1'
   compatibility 'all'
-  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_59_RTM/src/nss-3.59-with-nspr-4.29.tar.gz'
-  source_sha256 '2e2c09c17b1c9f43a2f0a5d83a30a712bff3016d2b7cf5a3dd904847292607ae'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nspr/4.29_armv7l/nspr-4.29-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nspr/4.29_armv7l/nspr-4.29-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nspr/4.29_i686/nspr-4.29-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nspr/4.29_x86_64/nspr-4.29-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '7fe5265f56931e762523e9412303ed9ed4befa69ddf9aa54216bbbeb51e75f5a',
-     armv7l: '7fe5265f56931e762523e9412303ed9ed4befa69ddf9aa54216bbbeb51e75f5a',
-       i686: 'b31f337c9e154bf363dd379c8616a453375f9b46dad68a4cebf575a90d394c93',
-     x86_64: '1df12a62f4fbbe0424687e65c1d0f6de54f2e7594cb72d841de6893e4aa99e3c',
-  })
+  is_fake
 
-  def self.build
-    Dir.chdir 'nspr' do
-      case ARCH
-      when 'x86_64'
-        system "./configure #{CREW_OPTIONS} --enable-64bit"
-      else
-        system "./configure #{CREW_OPTIONS}"
-      end
-      system 'make'
-    end
-  end
+  depends_on 'nss'
 
-  def self.install
-    Dir.chdir 'nspr' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
-  end
 end

--- a/packages/nss.rb
+++ b/packages/nss.rb
@@ -25,11 +25,7 @@ class Nss < Package
   depends_on 'gyp_next' => :build
 
   def self.build
-    @build_64 = if ARCH == 'x86_64'
-                  '1'
-                else
-                  '0'
-                end
+    @build_64 = ARCH == 'x86_64' ? '1' : '0'
     @arch_cflags = ''
     @arch_ldflags = @arch_cflags
 

--- a/packages/nss.rb
+++ b/packages/nss.rb
@@ -14,13 +14,13 @@ class Nss < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_armv7l/nss-nss.3.69.1.nspr.4.32-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_armv7l/nss-nss.3.69.1.nspr.4.32-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.3.69.1_i686/nss-nss.3.69.1.nspr.3.69.1-chromeos-i686.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_i686/nss-nss.3.69.1.nspr.4.32-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_x86_64/nss-nss.3.69.1.nspr.4.32-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: 'e68a620a7b7f35289f401561e3c86ff1fceb38d0b0652da7e6c531addc020a14',
      armv7l: 'e68a620a7b7f35289f401561e3c86ff1fceb38d0b0652da7e6c531addc020a14',
-       i686: '88d3a49f76d9fe8722aab3f9553a576609741004c2acdd2773bef28b2cc9e12a',
+       i686: '2b16871a705710c6f772c255b68572013e765658cb5f791b9fdaf697c1bf36ed',
      x86_64: '89f80e57d77168fe58e28f60e245a18256dd3b1c68640a1430fc512f93e01b01'
   })
 

--- a/packages/nss.rb
+++ b/packages/nss.rb
@@ -14,11 +14,13 @@ class Nss < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_armv7l/nss-nss.3.69.1.nspr.4.32-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_armv7l/nss-nss.3.69.1.nspr.4.32-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.3.69.1_i686/nss-nss.3.69.1.nspr.3.69.1-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_x86_64/nss-nss.3.69.1.nspr.4.32-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: 'e68a620a7b7f35289f401561e3c86ff1fceb38d0b0652da7e6c531addc020a14',
      armv7l: 'e68a620a7b7f35289f401561e3c86ff1fceb38d0b0652da7e6c531addc020a14',
+       i686: '88d3a49f76d9fe8722aab3f9553a576609741004c2acdd2773bef28b2cc9e12a',
      x86_64: '89f80e57d77168fe58e28f60e245a18256dd3b1c68640a1430fc512f93e01b01'
   })
 

--- a/packages/nss.rb
+++ b/packages/nss.rb
@@ -3,70 +3,66 @@ require 'package'
 class Nss < Package
   description 'Network Security Services (NSS) is a set of libraries designed to support cross-platform development of security-enabled client and server applications.'
   homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS'
-  @_ver = '3.61'
-  version @_ver
+  @nss_ver = '3.69.1'
+  @nspr_ver = '4.32'
+  version "nss.#{@nss_ver}.nspr.#{@nss_ver}"
   license 'MPL-2.0, GPL-2 or LGPL-2.1'
   compatibility 'all'
-  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_61_RTM/src/nss-3.61-with-nspr-4.29.tar.gz'
-  source_sha256 '812468f3cf22917f9647fec7997f4ab27ae4167811d9cbdc831f41f5ed281c5d'
+  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_69_1_RTM/src/nss-3.69.1-with-nspr-4.32.tar.gz'
+  source_sha256 '976dd57391aa269aa2961ac7ae002dc49935f855263df58b59b1dd4836d47cb7'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/3.61_armv7l/nss-3.61-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/3.61_armv7l/nss-3.61-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/3.61_i686/nss-3.61-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/3.61_x86_64/nss-3.61-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_armv7l/nss-nss.3.69.1.nspr.4.32-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_armv7l/nss-nss.3.69.1.nspr.4.32-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_x86_64/nss-nss.3.69.1.nspr.4.32-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '812f36d5c1875cf8803097265483b8a558194c6f0778977d55637407682ba51c',
-     armv7l: '812f36d5c1875cf8803097265483b8a558194c6f0778977d55637407682ba51c',
-       i686: 'e724b986a9a2edce790a8bef0b89d096ff46cb93815fc2d7bf8beb950af851f5',
-     x86_64: 'ba50721b2e968c49fbd5d4a90112ff27374903d33dbcfc3f1877b2c7074adbcd'
+    aarch64: 'e68a620a7b7f35289f401561e3c86ff1fceb38d0b0652da7e6c531addc020a14',
+     armv7l: 'e68a620a7b7f35289f401561e3c86ff1fceb38d0b0652da7e6c531addc020a14',
+     x86_64: '89f80e57d77168fe58e28f60e245a18256dd3b1c68640a1430fc512f93e01b01'
   })
 
   depends_on 'gyp_next' => :build
-  depends_on 'nspr'
 
   def self.build
-    ENV['opt_build'] = '1'
-    ENV['build_64'] = if ARCH == 'x86_64'
-                        '1'
-                      else
-                        '0'
-                      end
-    @arch_cflags = if ARCH == 'armv7l'
-                     ''
-                   else
-                     '-flto=auto'
-                   end
+    @build_64 = if ARCH == 'x86_64'
+                  '1'
+                else
+                  '0'
+                end
+    @arch_cflags = ''
     @arch_ldflags = @arch_cflags
 
-    ENV['NS_USE_GCC'] = '1'
-    ENV['CPPFLAGS'] = "-I#{CREW_PREFIX}/include/nspr"
-    ENV['USEABSPATH'] = 'NO'
-    ENV['NSS_GYP_PREFIX'] = CREW_PREFIX
     Dir.chdir 'nss' do
-      system "env CFLAGS='-pipe #{@arch_cflags}' \
+      system "env opt_build=1 build_64=#{@build_64} \
+        NSS_ENABLE_WERROR=0 NS_USE_GCC=1 USEABSPATH=NO \
+        NSS_GYP_PREFIX=#{CREW_PREFIX} CFLAGS='-pipe #{@arch_cflags}' \
         CXXFLAGS='-pipe #{@arch_cflags}' LDFLAGS='#{@arch_ldflags}' \
         ./build.sh -v --opt --gcc --gyp \
-        --with-nspr=#{CREW_PREFIX}/include/nspr --system-nspr \
         --system-sqlite --disable-tests"
     end
+    system "sed -i \
+    -e 's,^libdir=.*,libdir=#{CREW_LIB_PREFIX},g' \
+    -e 's,^prefix=.*,prefix=#{CREW_PREFIX},g' \
+    -e 's,\${exec_prefix}/lib,\${exec_prefix}/#{ARCH_LIB},g' \
+    dist/Release/lib/pkgconfig/nspr.pc"
   end
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include/nss"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include/nspr"
     FileUtils.rm Dir.glob('dist/Release/lib/*.so.TOC')
     FileUtils.mv 'dist/Release/lib', "dist/Release/#{ARCH_LIB}" unless ARCH_LIB == 'lib'
     FileUtils.cp_r Dir.glob('dist/Release/*'), CREW_DEST_PREFIX
     FileUtils.cp_r Dir.glob('dist/public/nss/*'), "#{CREW_DEST_PREFIX}/include/nss/"
-
+    FileUtils.cp_r Dir.glob('dist/public/nspr/*'), "#{CREW_DEST_PREFIX}/include/nspr/"
     system "sed nss/pkg/pkg-config/nss.pc.in \
     -e 's,%libdir%,#{CREW_LIB_PREFIX},g' \
     -e 's,%prefix%,#{CREW_PREFIX},g' \
-    -e 's,%exec_prefix%,#{CREW_PREFIX}/bin,g' \
+    -e 's,%exec_prefix%,#{CREW_PREFIX},g' \
     -e 's,%includedir%,#{CREW_PREFIX}/include/nss,g' \
-    -e 's,%NSPR_VERSION%,$(pkg-config --modversion nspr),g' \
-    -e 's,%NSS_VERSION%,#{@_ver},g' | \
+    -e 's,%NSPR_VERSION%,#{@nspr_ver},g' \
+    -e 's,%NSS_VERSION%,#{@nss_ver},g' | \
     install -Dm644 /dev/stdin #{CREW_DEST_LIB_PREFIX}/pkgconfig/nss.pc"
     FileUtils.ln_s "#{CREW_LIB_PREFIX}/pkgconfig/nss.pc",
                    "#{CREW_DEST_LIB_PREFIX}/pkgconfig/mozilla-nss.pc"


### PR DESCRIPTION
- Underlies build for `js78`
- Since they share a source package this combined build also lets us avoid issues with the packages being out of sync.
- fix `exec_prefix` in nss package-config file.

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686