### PR TITLE
libinput -> 1.19.0

### DIFF
--- a/packages/libinput.rb
+++ b/packages/libinput.rb
@@ -13,11 +13,13 @@ class Libinput < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_armv7l/libinput-1.19.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_armv7l/libinput-1.19.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_i686/libinput-1.19.0-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_x86_64/libinput-1.19.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '92d7106871145a7b83c4fcf91603563473de4da33c4b3368b4a795a7e51629e1',
      armv7l: '92d7106871145a7b83c4fcf91603563473de4da33c4b3368b4a795a7e51629e1',
+       i686: 'f33badf3a7bed9a0ba5c343663be77c32d773c943a886d1307a9ec05d58abd80',
      x86_64: '46bdc13b4d3e214591300759ec62d14d76e20faa9d8f05f887f88e1cd70cac62'
   })
 

--- a/packages/libinput.rb
+++ b/packages/libinput.rb
@@ -3,24 +3,22 @@ require 'package'
 class Libinput < Package
   description 'libinput is a library to handle input devices in Wayland compositors and to provide a generic X.Org input driver.'
   homepage 'https://www.freedesktop.org/wiki/Software/libinput'
-  @_ver = '1.17.0'
+  @_ver = '1.19.0'
   version @_ver
   license 'MIT'
   compatibility 'all'
   source_url "https://www.freedesktop.org/software/libinput/libinput-#{@_ver}.tar.xz"
-  source_sha256 'c560cfca14cb5c50d2a1b7551df06bc5d4306e32c128f3e3d37e137285dedbad'
+  source_sha256 '3d3a2f12b4a65cd82684121ae4b33cdc3ad541c761a55e8eb73a8e5e443cccbb'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.17.0_armv7l/libinput-1.17.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.17.0_armv7l/libinput-1.17.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.17.0_i686/libinput-1.17.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.17.0_x86_64/libinput-1.17.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_armv7l/libinput-1.19.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_armv7l/libinput-1.19.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_x86_64/libinput-1.19.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'a449ec4b3a457cf1222606c053bd90d6ff857434f06fdce33689d2bc198f2280',
-     armv7l: 'a449ec4b3a457cf1222606c053bd90d6ff857434f06fdce33689d2bc198f2280',
-       i686: '3b5cd49e73d1351369a4afd268a5bb84dc1a6ac00a0381fc9d94b89e753ca7c1',
-     x86_64: '7f4ed0a79f83c740aa1c708accf6f483b00345507df91a4d164117cd5bbb498e'
+    aarch64: '92d7106871145a7b83c4fcf91603563473de4da33c4b3368b4a795a7e51629e1',
+     armv7l: '92d7106871145a7b83c4fcf91603563473de4da33c4b3368b4a795a7e51629e1',
+     x86_64: '46bdc13b4d3e214591300759ec62d14d76e20faa9d8f05f887f88e1cd70cac62'
   })
 
   depends_on 'mtdev'


### PR DESCRIPTION


Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686