### PR TITLE
Chromebrew Launcher

### DIFF
--- a/packages/crew_launcher.rb
+++ b/packages/crew_launcher.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Crew_launcher < Package
+  description 'Add Chromebrew app to launcher'
+  homepage 'https://github.com/skycocker/chromebrew'
+  version '1'
+  license 'GPL-3'
+  compatibility 'all'
+  source_url 'https://github.com/supechicken/crew-launcher.git'
+  git_hashtag 'main'
+  
+  depends_on 'graphicsmagick'
+
+  def self.install
+    FileUtils.mkdir_p [
+      "#{CREW_DEST_PREFIX}/bin/",
+      "#{CREW_DEST_PREFIX}/lib/crew-launcher/",
+      "#{CREW_DEST_PREFIX}/share/crew-launcher/",
+      "#{CREW_DEST_DIR}/tmp/crew-launcher/",
+      "#{CREW_DEST_PREFIX}/etc/env.d/"
+    ]
+
+    FileUtils.cp_r Dir['*'], "#{CREW_DEST_PREFIX}/lib/crew-launcher/"
+    FileUtils.ln_s "#{CREW_LIB_PATH}/lib/color.rb", "#{CREW_DEST_PREFIX}/lib/crew-launcher/lib"
+    FileUtils.ln_s '../lib/crew-launcher/main.rb', "#{CREW_DEST_PREFIX}/bin/crew-launcher"
+
+    File.write "#{CREW_DEST_PREFIX}/etc/env.d/crew_launcher", <<~EOF
+      crew-launcher start-server > /dev/null
+    EOF
+  end
+end


### PR DESCRIPTION
crew_launcher: Add Chromebrew app to launcher

New features from previous pr:
- Add `.svg` icon support
- Add support for [Desktop Actions](https://www.electronjs.org/docs/tutorial/linux-desktop-actions) (requires CrOS v92+)

Tested on CrOS v92

Feel free to suggest code changes in supechicken/crew-launcher :)