### PR TITLE
Add smallbasic package

### DIFF
--- a/packages/smallbasic.rb
+++ b/packages/smallbasic.rb
@@ -1,0 +1,43 @@
+require 'package'
+
+class Smallbasic < Package
+  description 'SmallBASIC is a fast and easy to learn BASIC language interpreter'
+  homepage 'https://smallbasic.github.io/'
+  version '12.23'
+  license 'GPLv3'
+  compatibility 'all'
+  source_url 'https://github.com/smallbasic/SmallBASIC.git'
+  git_hashtag "v#{version}"
+
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smallbasic/12.23_armv7l/smallbasic-12.23-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smallbasic/12.23_armv7l/smallbasic-12.23-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smallbasic/12.23_i686/smallbasic-12.23-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smallbasic/12.23_x86_64/smallbasic-12.23-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'e86e6eda7034972b3d8cac560fab08c64eb9868105104b8846c8f0c5c4e5e8ec',
+     armv7l: 'e86e6eda7034972b3d8cac560fab08c64eb9868105104b8846c8f0c5c4e5e8ec',
+       i686: 'c3121b950dafdfb351db77cdedaebe15b7c0c7cccb9467c0df2770ca5c3beaac',
+     x86_64: 'b4ab1ab31b5c350340245cded4e39ed3070dc65537c35640091ea721df0475c6',
+  })
+
+  depends_on 'libiconv'
+  depends_on 'libsdl2'
+  depends_on 'msttcorefonts'
+  depends_on 'sommelier'
+
+  def self.build
+    system 'bash ./autogen.sh && filefix'
+    system "./configure #{CREW_OPTIONS} --enable-sdl"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.postinstall
+    puts "\nType 'sbasicg' to get started.\n".lightblue
+  end
+end


### PR DESCRIPTION
SmallBASIC is a fast and easy to learn BASIC language interpreter.  See https://smallbasic.github.io/.  Tested on all architectures.  i686 builds without issue but the binary won't run due to the inability to execute sommelier.