### PR TITLE
gedit needs schemas built at install

### DIFF
--- a/packages/gedit.rb
+++ b/packages/gedit.rb
@@ -67,4 +67,8 @@ class Gedit < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
+
+  def self.postinstall
+    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
+  end
 end


### PR DESCRIPTION
- Without this gedit complains of schema issues and does not load.
- no binaries need adjusting with this change, as we're only adding a postinstall

Works properly:
- [x] x86_64
