### PR TITLE
Mesa -> 21.2.2

### DIFF
--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -13,11 +13,13 @@ class Mesa < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.2_armv7l/mesa-21.2.2-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.2_armv7l/mesa-21.2.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.2_i686/mesa-21.2.2-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.2_x86_64/mesa-21.2.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '0cbce907c2515100c624643c1243876c3c0cc47c6c531ca253e6d97b3d13f438',
      armv7l: '0cbce907c2515100c624643c1243876c3c0cc47c6c531ca253e6d97b3d13f438',
+       i686: '7d28e75839baed8ceb15e677eba566b6501819c03cbe9f8067857d79a0bb9a7e',
      x86_64: '82f5de3eb10852a5fdd40ac38b85ed3c4c17c9f7a67199417a9ebe8021552d2e'
   })
 

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -3,7 +3,7 @@ require 'package'
 class Mesa < Package
   description 'Open-source implementation of the OpenGL specification'
   homepage 'https://www.mesa3d.org'
-  @_ver = '21.2.1'
+  @_ver = '21.2.2'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,16 +11,14 @@ class Mesa < Package
   git_hashtag "mesa-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.1_armv7l/mesa-21.2.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.1_armv7l/mesa-21.2.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.1_i686/mesa-21.2.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.1_x86_64/mesa-21.2.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.2_armv7l/mesa-21.2.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.2_armv7l/mesa-21.2.2-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.2.2_x86_64/mesa-21.2.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'af4f1d97e5404ff136bae551ce9a1dcbc9d1db2990b35fcf71fde37df892caf5',
-     armv7l: 'af4f1d97e5404ff136bae551ce9a1dcbc9d1db2990b35fcf71fde37df892caf5',
-       i686: '41c82db78aad8fb8331ed19bb5698f29bb2a2bbedaae73c192ae1e0333fe4426',
-     x86_64: '5e619405ea17db19a946a690ba98e7def61e0f12077aa4fce844d13f97625660'
+    aarch64: '0cbce907c2515100c624643c1243876c3c0cc47c6c531ca253e6d97b3d13f438',
+     armv7l: '0cbce907c2515100c624643c1243876c3c0cc47c6c531ca253e6d97b3d13f438',
+     x86_64: '82f5de3eb10852a5fdd40ac38b85ed3c4c17c9f7a67199417a9ebe8021552d2e'
   })
 
   depends_on 'glslang' => :build
@@ -53,7 +51,7 @@ class Mesa < Package
     case ARCH
     when 'aarch64', 'armv7l'
       # See https://gitlab.freedesktop.org/mesa/mesa/-/issues/5067
-      @freedrenopatch = <<~PATCHEOF
+      @freedrenopatch = <<~FREEDRENOPATCHEOF
                 --- a/src/gallium/drivers/freedreno/freedreno_util.h   2021-08-05 14:40:22.000000000 +0000
                 +++ b/src/gallium/drivers/freedreno/freedreno_util.h   2021-08-05 19:52:53.115410668 +0000
                 @@ -44,6 +44,15 @@
@@ -72,9 +70,28 @@ class Mesa < Package
                  #ifdef __cplusplus
                  extern "C" {
                  #endif
-      PATCHEOF
+      FREEDRENOPATCHEOF
       IO.write('freedreno.patch', @freedrenopatch)
       system 'patch -Np1 -i freedreno.patch'
+      # See https://gitlab.freedesktop.org/mesa/mesa/-/issues/3505
+      @tegrapatch = <<~TEGRAPATCHEOF
+                diff --git a/src/gallium/drivers/nouveau/nvc0/nvc0_state_validate.c b/src/gallium/drivers/nouveau/nvc0/nvc0_state_validate.c
+                index 48d81f197db..f9b7bd57b27 100644
+                --- a/src/gallium/drivers/nouveau/nvc0/nvc0_state_validate.c
+                +++ b/src/gallium/drivers/nouveau/nvc0/nvc0_state_validate.c
+                @@ -255,6 +255,10 @@ nvc0_validate_fb(struct nvc0_context *nvc0)
+        #{'         '}
+                          nvc0_resource_fence(res, NOUVEAU_BO_WR);
+        #{'         '}
+                +         // hack to make opengl at least halfway working on a tegra k1
+                +         // see: https://gitlab.freedesktop.org/mesa/mesa/-/issues/3505#note_627006
+                +         fb->zsbuf=NULL;
+                +
+                          assert(!fb->zsbuf);
+                       }
+      TEGRAPATCHEOF
+      IO.write('tegra.patch', @tegrapatch)
+      system 'patch -Np1 -i tegra.patch'
     end
   end
 


### PR DESCRIPTION
Fixes #6218 

- Update and suggested patch for armv7l

Works properly:
- [x] x86_64
- [x] armv7l? (Can you check this @ThatGeekyWeeb )
- [x] i686 (needs build)

Testing:
```
export CREW_TESTING_BRANCH=mesa_21.2.2
export CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git
CREW_TESTING=1 crew update
yes | crew install mesa_utils
crew upgrade mesa
glxinfo -B
crew update
```