### PR TITLE
Connected updates & rebuilds of chafa, graphite, freetype, freetype_sub

### DIFF
--- a/packages/chafa.rb
+++ b/packages/chafa.rb
@@ -15,11 +15,13 @@ class Chafa < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_armv7l/chafa-1.8.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_armv7l/chafa-1.8.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_i686/chafa-1.8.0-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_x86_64/chafa-1.8.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '8e4a30680cb863f3735e8e21f33332dae55aa894648719ac8f26028d99cc178e',
      armv7l: '8e4a30680cb863f3735e8e21f33332dae55aa894648719ac8f26028d99cc178e',
+       i686: '7a5d976bd6c4790a9bf3612ce18ff2160103d1fac5fbda282f8655ae9e443715',
      x86_64: '0a7c5213a65a6058a766022ec58867f6c435a0759ee27d69727c43f2f9db2c9b'
   })
 

--- a/packages/chafa.rb
+++ b/packages/chafa.rb
@@ -6,23 +6,21 @@ require 'package'
 class Chafa < Package
   description 'Image-to-text converter supporting a wide range of symbols and palettes, transparency, animations, etc.'
   homepage 'https://hpjansson.org/chafa/'
-  version '1.6.1'
+  version '1.8.0'
   license 'LGPL'
   compatibility 'all'
-  source_url 'https://github.com/hpjansson/chafa/releases/download/1.6.1/chafa-1.6.1.tar.xz'
-  source_sha256 '76c98930e99b3e5fadb986148b99d65636e9e9619124e568ff13d364ede89fa5'
+  source_url 'https://github.com/hpjansson/chafa/releases/download/1.8.0/chafa-1.8.0.tar.xz'
+  source_sha256 '21ff652d836ba207098c40c459652b2f1de6c8a64fbffc62e7c6319ced32286b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.6.1_armv7l/chafa-1.6.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.6.1_armv7l/chafa-1.6.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.6.1_i686/chafa-1.6.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.6.1_x86_64/chafa-1.6.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_armv7l/chafa-1.8.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_armv7l/chafa-1.8.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_x86_64/chafa-1.8.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '3b1070f6bb7c4e3756fec41b9241b7823d34c09cbedf59fb7a700921e06cb561',
-     armv7l: '3b1070f6bb7c4e3756fec41b9241b7823d34c09cbedf59fb7a700921e06cb561',
-       i686: 'a2d4ff382d205c1522b8155b999b5499fea83815b9f71f8697256f93174cc288',
-     x86_64: '4b3fd102523ce0458a897bcd0ce1bbe8c60e30eb830e4aa98cedb782576795e6'
+    aarch64: '8e4a30680cb863f3735e8e21f33332dae55aa894648719ac8f26028d99cc178e',
+     armv7l: '8e4a30680cb863f3735e8e21f33332dae55aa894648719ac8f26028d99cc178e',
+     x86_64: '0a7c5213a65a6058a766022ec58867f6c435a0759ee27d69727c43f2f9db2c9b'
   })
 
   depends_on 'imagemagick7' => :build

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -12,11 +12,13 @@ class Freetype < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_armv7l/freetype-2.11.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_armv7l/freetype-2.11.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_i686/freetype-2.11.0-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_x86_64/freetype-2.11.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '24c9fee8ddd769952dd1eb0927020892b61677f8097e8d70fccf7ee4902680e4',
      armv7l: '24c9fee8ddd769952dd1eb0927020892b61677f8097e8d70fccf7ee4902680e4',
+       i686: 'c4d4948ff5f63714de352e88f2b8ddcc167a30e2ae6af7979d3dc4815d123d64',
      x86_64: '8a173447f2471d35512e6ea75cda0f53f18ae930e990881f94c7dbea9011b402'
   })
 

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -3,23 +3,21 @@ require 'package'
 class Freetype < Package
   description 'FreeType is a freely available software library to render fonts.'
   homepage 'https://www.freetype.org/'
-  version '2.10.4'
+  version '2.11.0'
   license 'FTL or GPL-2+'
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.xz'
-  source_sha256 '86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784'
+  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.xz'
+  source_sha256 '8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.10.4_armv7l/freetype-2.10.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.10.4_armv7l/freetype-2.10.4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.10.4_i686/freetype-2.10.4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.10.4_x86_64/freetype-2.10.4-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_armv7l/freetype-2.11.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_armv7l/freetype-2.11.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_x86_64/freetype-2.11.0-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: 'c3063feb7034883e248ac4d62a82409df69577ccc4abe38ca7bd7e39c5ed3576',
-     armv7l: 'c3063feb7034883e248ac4d62a82409df69577ccc4abe38ca7bd7e39c5ed3576',
-       i686: 'a53b10cf19f25922aa6cc0f09fe846e5ee7221c73f2288ca04f83529191a94f5',
-     x86_64: '4622df673ffd07fdcec9591f039ad6e89c4687517678adb6f964dbfdff6a39cf',
+  binary_sha256({
+    aarch64: '24c9fee8ddd769952dd1eb0927020892b61677f8097e8d70fccf7ee4902680e4',
+     armv7l: '24c9fee8ddd769952dd1eb0927020892b61677f8097e8d70fccf7ee4902680e4',
+     x86_64: '8a173447f2471d35512e6ea75cda0f53f18ae930e990881f94c7dbea9011b402'
   })
 
   depends_on 'expat'

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -12,11 +12,13 @@ class Freetype_sub < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_armv7l/freetype_sub-2.11.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_armv7l/freetype_sub-2.11.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_i686/freetype_sub-2.11.0-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_x86_64/freetype_sub-2.11.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '7cb416b93f2b41dcef3f7fa9cc5624467e5cc89a720a2850b0edde19f48999b7',
      armv7l: '7cb416b93f2b41dcef3f7fa9cc5624467e5cc89a720a2850b0edde19f48999b7',
+       i686: '1f83220dee2819353ce9fdf268397b969b9c368b6d4088d8e0a92772170eb0f3',
      x86_64: '5abc6e6e8c4b68d6e1e860f4a9b421578ed2b3a21180a3f2ac880af629ee2afd'
   })
 
@@ -26,13 +28,18 @@ class Freetype_sub < Package
 
   def self.build
     system 'pip3 install docwriter'
-    system "./configure CFLAGS=' -fPIC' #{CREW_OPTIONS} --enable-freetype-config --without-harfbuzz"
+    system "./configure CFLAGS=' -fPIC' #{CREW_OPTIONS} --disable-freetype-config --without-harfbuzz"
     system 'make'
     system 'pip3 uninstall docwriter -y'
     system "pip3 install docwriter --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
   end
 
   def self.install
+    ENV['CREW_CONFLICTS_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -3,23 +3,21 @@ require 'package'
 class Freetype_sub < Package
   description 'Freetype_sub is a version without harfbuzz. It is intended to handle circular dependency betwwen freetype and harfbuzz.'
   homepage 'https://www.freetype.org/'
-  version '2.10.4'
+  version '2.11.0'
   license 'FTL or GPL-2+'
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.xz'
-  source_sha256 '86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784'
+  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.xz'
+  source_sha256 '8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.10.4_armv7l/freetype_sub-2.10.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.10.4_armv7l/freetype_sub-2.10.4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.10.4_i686/freetype_sub-2.10.4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.10.4_x86_64/freetype_sub-2.10.4-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_armv7l/freetype_sub-2.11.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_armv7l/freetype_sub-2.11.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_x86_64/freetype_sub-2.11.0-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '7c8620a0cad19fbcd7ff0d96a7304323648b97c93d86352cfbb8216c768aeb1b',
-     armv7l: '7c8620a0cad19fbcd7ff0d96a7304323648b97c93d86352cfbb8216c768aeb1b',
-       i686: '4e6ab3e8a7dacab4380099315c2d547b89ce490f33d7e677744034d4e44ccabe',
-     x86_64: 'a5c364bdee4a22ca72bbaba4162dc2d75730f15b4340bddf038ee3698751c116',
+  binary_sha256({
+    aarch64: '7cb416b93f2b41dcef3f7fa9cc5624467e5cc89a720a2850b0edde19f48999b7',
+     armv7l: '7cb416b93f2b41dcef3f7fa9cc5624467e5cc89a720a2850b0edde19f48999b7',
+     x86_64: '5abc6e6e8c4b68d6e1e860f4a9b421578ed2b3a21180a3f2ac880af629ee2afd'
   })
 
   depends_on 'expat'

--- a/packages/graphite.rb
+++ b/packages/graphite.rb
@@ -3,23 +3,21 @@ require 'package'
 class Graphite < Package
   description 'Reimplementation of the SIL Graphite text processing engine'
   homepage 'https://github.com/silnrsi/graphite'
-  version '1.3.14-1'
+  version '1.3.14-2'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://github.com/silnrsi/graphite/releases/download/1.3.14/graphite2-1.3.14.tgz'
   source_sha256 'f99d1c13aa5fa296898a181dff9b82fb25f6cc0933dbaa7a475d8109bd54209d'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-1_armv7l/graphite-1.3.14-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-1_armv7l/graphite-1.3.14-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-1_i686/graphite-1.3.14-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-1_x86_64/graphite-1.3.14-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_armv7l/graphite-1.3.14-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_armv7l/graphite-1.3.14-2-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_x86_64/graphite-1.3.14-2-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '3ee1594a2f5a0349dd12ef28fb60dffe254c8ca3ac4444da7be90741057c63b5',
-     armv7l: '3ee1594a2f5a0349dd12ef28fb60dffe254c8ca3ac4444da7be90741057c63b5',
-       i686: '772269f953a7ddb6a40d164bf405f2e0219a0d6dc805efe8a0df5b9840769fb2',
-     x86_64: '1eac00455f2ff39b9ed26689054a5794e62fa7c4b8eacf1c5cb4a839c3d01ac5',
+  binary_sha256({
+    aarch64: '4b7ccb98e54afb311014eedeaee7a262cc8d46c0ee9ca4102cc5aee8a38660e0',
+     armv7l: '4b7ccb98e54afb311014eedeaee7a262cc8d46c0ee9ca4102cc5aee8a38660e0',
+     x86_64: '298e03f04acb71d5b8fdfb340b0bc6387fe4ecf2ac2b0ebad7ecb21101c85e66'
   })
 
   depends_on 'freetype_sub'

--- a/packages/graphite.rb
+++ b/packages/graphite.rb
@@ -12,11 +12,13 @@ class Graphite < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_armv7l/graphite-1.3.14-2-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_armv7l/graphite-1.3.14-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_i686/graphite-1.3.14-2-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_x86_64/graphite-1.3.14-2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '4b7ccb98e54afb311014eedeaee7a262cc8d46c0ee9ca4102cc5aee8a38660e0',
      armv7l: '4b7ccb98e54afb311014eedeaee7a262cc8d46c0ee9ca4102cc5aee8a38660e0',
+       i686: '457ed635172c5ba7f61b95cfa2036efdfa1183ae2a77e4e9f06b9d33f9dbe763',
      x86_64: '298e03f04acb71d5b8fdfb340b0bc6387fe4ecf2ac2b0ebad7ecb21101c85e66'
   })
 

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -13,11 +13,13 @@ class Harfbuzz < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0-1_armv7l/harfbuzz-3.0.0-1-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0-1_armv7l/harfbuzz-3.0.0-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0-1_i686/harfbuzz-3.0.0-1-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0-1_x86_64/harfbuzz-3.0.0-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '1b8e95215f5147d297389f81831f27d33eb10d3bc8ef31e6efa4588b477d9d04',
      armv7l: '1b8e95215f5147d297389f81831f27d33eb10d3bc8ef31e6efa4588b477d9d04',
+       i686: 'f60099106878fd712bb16cba741509333f67bab1761c23ace579a37cb7feb1fc',
      x86_64: 'cd44acac570c86213ccb02a4da7ff4c2f60c26e12ca7e531e8210334a08166c2'
   })
 

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -4,23 +4,21 @@ class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
   @_ver = '3.0.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0_armv7l/harfbuzz-3.0.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0_armv7l/harfbuzz-3.0.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0_i686/harfbuzz-3.0.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0_x86_64/harfbuzz-3.0.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0-1_armv7l/harfbuzz-3.0.0-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0-1_armv7l/harfbuzz-3.0.0-1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.0.0-1_x86_64/harfbuzz-3.0.0-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '51af46f21b3d0e280c5ffcb036e1917094278f79ad39cd4038d057a33302c1ac',
-     armv7l: '51af46f21b3d0e280c5ffcb036e1917094278f79ad39cd4038d057a33302c1ac',
-       i686: '860d5987343de26476cac29fc3de30e8cbcf336fb718433ca6b0770689d82759',
-     x86_64: '3e087664cdf7d74ffcccff126c8b37f922168f2d25a5807bd8ac2e809028965d'
+    aarch64: '1b8e95215f5147d297389f81831f27d33eb10d3bc8ef31e6efa4588b477d9d04',
+     armv7l: '1b8e95215f5147d297389f81831f27d33eb10d3bc8ef31e6efa4588b477d9d04',
+     x86_64: 'cd44acac570c86213ccb02a4da7ff4c2f60c26e12ca7e531e8210334a08166c2'
   })
 
   depends_on 'cairo' => :build
@@ -39,6 +37,8 @@ class Harfbuzz < Package
     -Dbenchmark=disabled \
     -Dtests=disabled \
     -Dgraphite=enabled \
+    -Dfreetype=enabled \
+    -Dragel_subproject=true \
     -Ddocs=disabled \
     builddir"
     system 'meson configure builddir'


### PR DESCRIPTION
- `vuze`, `gedit`, `audacious` all start properly on x86_64 with this set of updates.

Works properly:
- [x] x86_64
- [x] armv7l (needs testing)
- [x] i686 (needs builds)
