### PR TITLE
elfutils update and binutils rebuild

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -18,8 +18,8 @@ class Binutils < Package
   })
   binary_sha256({
        i686: '9bd786abf5e42b06e3ecd51ffdd63348fbf54f18fd6aeec8aafcebc20f231404',
-    aarch64: 'd82b3c0af9587c48a03b531d6869d44ff17282cfd3056238935d015ac92a421c',
-     armv7l: 'd82b3c0af9587c48a03b531d6869d44ff17282cfd3056238935d015ac92a421c',
+    aarch64: '2b0dccac7104572bd7e050ba191fc5eb355019351cba9d07293bb53450b4ff84',
+     armv7l: '2b0dccac7104572bd7e050ba191fc5eb355019351cba9d07293bb53450b4ff84',
      x86_64: 'd9e0347631803d94648495ba9f2b16836f6f637046ac4c757a725c47f57a2c7a'
   })
 
@@ -66,6 +66,13 @@ class Binutils < Package
   end
 
   def self.install
+    if ARCH == 'armv7l'
+      ENV['CREW_SHRINK_ARCHIVE'] = '0'
+      warn_level = $VERBOSE
+      $VERBOSE = nil
+      load "#{CREW_LIB_PATH}lib/const.rb"
+      $VERBOSE = warn_level
+    end
     Dir.chdir 'build' do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", "prefix=#{CREW_PREFIX}",
              "tooldir=#{CREW_PREFIX}", 'install'

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -4,23 +4,23 @@ class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
   @_ver = '2.37'
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/binutils/binutils-#{@_ver}.tar.xz"
   source_sha256 '820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.37_armv7l/binutils-2.37-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.37_armv7l/binutils-2.37-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.37_i686/binutils-2.37-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.37_x86_64/binutils-2.37-chromeos-x86_64.tpxz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.37-1_i686/binutils-2.37-1-chromeos-i686.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.37-1_armv7l/binutils-2.37-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.37-1_armv7l/binutils-2.37-1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.37-1_x86_64/binutils-2.37-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '0acc9160cb2b55fbbd289c25da3b8f0684e02efb6ab16b7aaff2f0fcb6fb8cef',
-     armv7l: '0acc9160cb2b55fbbd289c25da3b8f0684e02efb6ab16b7aaff2f0fcb6fb8cef',
-       i686: '9735a35796db89f36df9ff4cd615e0d030aec2be566b8e3ab4ec8f011a89e1eb',
-     x86_64: '6648a5f4b57cc1b93166920d48ff9ff2318e9eb834984d8511eaa2a4d992da83'
+       i686: '9bd786abf5e42b06e3ecd51ffdd63348fbf54f18fd6aeec8aafcebc20f231404',
+    aarch64: 'd82b3c0af9587c48a03b531d6869d44ff17282cfd3056238935d015ac92a421c',
+     armv7l: 'd82b3c0af9587c48a03b531d6869d44ff17282cfd3056238935d015ac92a421c',
+     x86_64: 'd9e0347631803d94648495ba9f2b16836f6f637046ac4c757a725c47f57a2c7a'
   })
 
   def self.prebuild
@@ -38,8 +38,7 @@ class Binutils < Package
   def self.build
     Dir.mkdir 'build'
     Dir.chdir 'build' do
-      system "#{CREW_ENV_OPTIONS} \
-        ../configure #{CREW_OPTIONS} \
+      system "../configure #{CREW_OPTIONS} \
         --disable-bootstrap \
         --disable-maintainer-mode \
         --enable-64-bit-bfd \

--- a/packages/elfutils.rb
+++ b/packages/elfutils.rb
@@ -3,28 +3,52 @@ require 'package'
 class Elfutils < Package
   description 'elfutils is a collection of utilities and libraries to read, create and modify ELF binary files, find and handle DWARF debug data, symbols, thread state and stacktraces for processes and core files on GNU/Linux.'
   homepage 'https://sourceware.org/elfutils/'
-  @_ver = '0.183'
+  @_ver = '0.185'
   version @_ver
   license 'GPL-2+ or LGPL-3+'
   compatibility 'all'
   source_url "https://sourceware.org/elfutils/ftp/#{@_ver}/elfutils-#{@_ver}.tar.bz2"
-  source_sha256 'c3637c208d309d58714a51e61e63f1958808fead882e9b607506a29e5474f2c5'
+  source_sha256 'dc8d3e74ab209465e7f568e1b3bb9a5a142f8656e2b57d10049a73da2ae6b5a6'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/elfutils/0.183_armv7l/elfutils-0.183-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/elfutils/0.183_armv7l/elfutils-0.183-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/elfutils/0.183_i686/elfutils-0.183-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/elfutils/0.183_x86_64/elfutils-0.183-chromeos-x86_64.tar.xz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/elfutils/0.185_i686/elfutils-0.185-chromeos-i686.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/elfutils/0.185_armv7l/elfutils-0.185-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/elfutils/0.185_armv7l/elfutils-0.185-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/elfutils/0.185_x86_64/elfutils-0.185-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '0780ef4605befe8aa878d7f4997fa4431686f1a40851e513243cabf7d9d31bf8',
-     armv7l: '0780ef4605befe8aa878d7f4997fa4431686f1a40851e513243cabf7d9d31bf8',
-       i686: '894badb331f5d3d092d638b9b2dd2280677e97ffd9c4c37299cb40d529cbb609',
-     x86_64: '73ba6638fd5929c232fc4442de938e25ca34ee66f91232ece874419b0f54cca6'
+       i686: '6bc34ddc832c3b49ee3e0bf887fd64d15537f3641c42c190383ef7f51de7ff49',
+    aarch64: '097278811aa6899156dd5fdf770e9d42b4e20e7214cdd011b1c0d0191b349da1',
+     armv7l: '097278811aa6899156dd5fdf770e9d42b4e20e7214cdd011b1c0d0191b349da1',
+     x86_64: '4a84025108de03a5bcaddf493af476887b37bd2cd8fe7cc28e1ae3aad449ab82'
   })
 
+  def self.patch
+    # See https://www.mail-archive.com/elfutils-devel@sourceware.org/msg03816.html
+    @gccpatch = <<~GCCPATCHEOF
+      diff --git a/src/elflint.c b/src/elflint.c
+      index 85cc7833..35b40500 100644
+      --- a/src/elflint.c
+      +++ b/src/elflint.c
+      @@ -3434,7 +3434,7 @@ buffer_pos (Elf_Data *data, const unsigned char *p)
+         return p - (const unsigned char *) data->d_buf;
+       }
+      #{' '}
+      -inline size_t
+      +static inline size_t
+       buffer_left (Elf_Data *data, const unsigned char *p)
+       {
+         return (const unsigned char *) data->d_buf + data->d_size - p;
+    GCCPATCHEOF
+    IO.write('gcc.patch', @gccpatch)
+    system 'patch -Np1 -i gcc.patch'
+  end
+
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-debuginfod"
+    system "./configure #{CREW_OPTIONS} \
+      --program-prefix='eu-' \
+      --disable-libdebuginfod \
+      --disable-debuginfod"
     system 'make'
   end
 


### PR DESCRIPTION
- `elfutils` update to `.185`, and modified package file to not break everything on rebuild by excluding `CREW_ENV_OPTIONS`
- `binutils` rebuilt, as it depends upon elfutils.
- also did a more minimal build, which will hopefully help `i686`.

Works properly:
- [x] x86_64
- [x] armv7l (need verification)
- [x] i686 (need verification)
