### PR TITLE
crew: Handle attempted removal of essential files

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1341,13 +1341,23 @@ def remove(pkgName)
   #if the filelist exists, remove the files and directories installed by the package
   if File.file?("#{CREW_META_PATH}#{pkgName}.filelist")
     Dir.chdir CREW_CONFIG_PATH do
-
       #remove all files installed by the package
       File.open("meta/#{pkgName}.filelist").each_line do |line|
-        begin
+        # Do not remove essential files from gcc or libssp which ruby
+        # relies on, especially during package upgrades or reinstalls.
+        # These essential files are enumerated in const.rb as
+        # CREW_ESSENTIAL_FILES.
+        if CREW_ESSENTIAL_FILES.include? line.chomp
+          if @opt_verbose
+            puts "Removing #{line.chomp} will break crew. It was " +
+                 'NOT'.lightred + ' deleted.'
+          end
+        else
           puts 'Removing file ' + line.chomp + ''.lightred if @opt_verbose
-          File.unlink line.chomp
-        rescue => exception #swallow exception
+          begin
+            File.unlink line.chomp
+          rescue => exception #swallow exception
+          end
         end
       end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.16.7'
+CREW_VERSION = '1.16.8'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -127,4 +127,6 @@ PY_SETUP_INSTALL_OPTIONS = "#{PY_SETUP_INSTALL_OPTIONS_NO_SVEM} --single-version
 CREW_FIRST_PACKAGES = %w[libssh curl git pixz shared_mime_info]
 CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
 
+# libssp is in the libssp package
+# libatomic is in the gcc package
 CREW_ESSENTIAL_FILES = %W[#{CREW_LIB_PREFIX}/libssp.so.0.0.0 #{CREW_LIB_PREFIX}/libatomic.so.1]

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -126,3 +126,5 @@ PY_SETUP_INSTALL_OPTIONS = "#{PY_SETUP_INSTALL_OPTIONS_NO_SVEM} --single-version
 
 CREW_FIRST_PACKAGES = %w[libssh curl git pixz shared_mime_info]
 CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
+
+CREW_ESSENTIAL_FILES = %W[#{CREW_LIB_PREFIX}/libssp.so.0.0.0 #{CREW_LIB_PREFIX}/libatomic.so.1]


### PR DESCRIPTION
- Upgrading libssp, gcc10, gcc11, etc breaks crew because removing the old package removes libraries ruby is using.
- This PR allows crew to ignore deletions of those files.
- Reinstalling or upgrading such packages no longer breaks crew.


Works properly:
- [x] x86_64

e.g.
previously:
```
bash-5.1$ crew remove libssp
Libssp removed!
bash-5.1$ crew install libssp
ruby: error while loading shared libraries: libssp.so.0: cannot open shared object file: No such file or directory
bash-5.1$ 
```
Now:
![image](https://user-images.githubusercontent.com/1096701/134576453-592e76ad-ef7e-495e-8d00-48276cf22f2a.png)

