### PR TITLE
gedit dependency updates for updated libicu

### DIFF
--- a/packages/gspell.rb
+++ b/packages/gspell.rb
@@ -3,23 +3,21 @@ require 'package'
 class Gspell < Package
   description 'a flexible API to implement the spell checking in a GTK+ application'
   homepage 'https://wiki.gnome.org/Projects/gspell'
-  version '1.9.1-1'
+  version '1.9.1-2'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://download.gnome.org/sources/gspell/1.9/gspell-1.9.1.tar.xz'
   source_sha256 'dcbb769dfdde8e3c0a8ed3102ce7e661abbf7ddf85df08b29915e92cd723abdd'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gspell/1.9.1-1_armv7l/gspell-1.9.1-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gspell/1.9.1-1_armv7l/gspell-1.9.1-1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gspell/1.9.1-1_i686/gspell-1.9.1-1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gspell/1.9.1-1_x86_64/gspell-1.9.1-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gspell/1.9.1-2_armv7l/gspell-1.9.1-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gspell/1.9.1-2_armv7l/gspell-1.9.1-2-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gspell/1.9.1-2_x86_64/gspell-1.9.1-2-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '26c16ee849e3c09cd67f6dd951fd917959d362d195d9e52d3efca4e1b6875328',
-      armv7l: '26c16ee849e3c09cd67f6dd951fd917959d362d195d9e52d3efca4e1b6875328',
-        i686: '6c1dc99a8c02e8e507950149823969c89100c96ca692603d534d4ed5b0a5f7b5',
-      x86_64: 'ed611db95e4986659250615fce945abd25aadb908f819de371182525673b99e2',
+  binary_sha256({
+    aarch64: 'b3d710b9a07b831b1d7b771bd563367e5ebf40adb880238824c4a906ba3118bb',
+     armv7l: 'b3d710b9a07b831b1d7b771bd563367e5ebf40adb880238824c4a906ba3118bb',
+     x86_64: 'e5f3df2f932455279ab3cd4ac3828684644524e39e4a53c6b54de62c30e2ad2b'
   })
 
   depends_on 'gtk3'
@@ -37,16 +35,15 @@ class Gspell < Package
   ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"
 
   def self.patch
-    # Fixes ./configure: /usr/bin/file: No such file or directory
     system 'filefix'
   end
 
   def self.build
-    system "CFLAGS=-fuse-ld=lld \
-    CXXFLAGS=-fuse-ld=lld \
-    ./configure  #{CREW_OPTIONS} --enable-gtk-doc-html=no"
-    system "make"
+    system "#{CREW_ENV_OPTIONS} \
+      ./configure  #{CREW_OPTIONS} --enable-gtk-doc-html=no"
+    system 'make'
   end
+
   def self.install
     system "make DESTDIR=#{CREW_DEST_DIR} install"
   end

--- a/packages/tepl_5.rb
+++ b/packages/tepl_5.rb
@@ -3,23 +3,24 @@ require 'package'
 class Tepl_5 < Package
   description 'Library that eases the development of GtkSourceView-based text editors and IDEs'
   homepage 'https://wiki.gnome.org/Projects/Tepl'
-  version '5.0.1'
+  @_ver = '5.0.1'
+  version "#{@_ver}-1"
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url 'https://github.com/GNOME/tepl/archive/5.0.1.tar.gz'
-  source_sha256 '2dda3ed2bd16742f6d0fc6d602448eaa2e40b9c967b88599add2338d6fa590e7'
+  source_url 'https://gitlab.gnome.org/Archive/tepl.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_5/5.0.1_armv7l/tepl_5-5.0.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_5/5.0.1_armv7l/tepl_5-5.0.1-chromeos-armv7l.tar.xz',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_5/5.0.1_i686/tepl_5-5.0.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_5/5.0.1_x86_64/tepl_5-5.0.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_5/5.0.1-1_armv7l/tepl_5-5.0.1-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_5/5.0.1-1_armv7l/tepl_5-5.0.1-1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_5/5.0.1-1_x86_64/tepl_5-5.0.1-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '1c6bda4f08ad49244dd0e368858e43de9323adf54ab34d387754d0982a8af710',
-     armv7l: '1c6bda4f08ad49244dd0e368858e43de9323adf54ab34d387754d0982a8af710',
        i686: '380fcc1fba9345a966726985dd7232d5bf1326bf62597f43b2bd194a40ce4a91',
-     x86_64: 'd41156324372ef2d95d056a4b58d10f177bd9c1cf176f5c5baafdc81b55d2c1a'
+    aarch64: '720a58a348b85529676c8bd4caa1a1e1566e3afbbcb01017bd91808242c955d0',
+     armv7l: '720a58a348b85529676c8bd4caa1a1e1566e3afbbcb01017bd91808242c955d0',
+     x86_64: '347c0d84339c38b72332b8b91e468f85e72a69e5b13ceb5e689d49332f337c99'
   })
 
   depends_on 'amtk'

--- a/packages/tepl_6.rb
+++ b/packages/tepl_6.rb
@@ -3,23 +3,23 @@ require 'package'
 class Tepl_6 < Package
   description 'Library that eases the development of GtkSourceView-based text editors and IDEs'
   homepage 'https://wiki.gnome.org/Projects/Tepl'
-  version '5.99.0-d61f'
+  version '6.0.0.0'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/tepl/-/archive/d61f4f8c1c17299b75c2dffc67df81a25b9ed243/tepl-d61f4f8c1c17299b75c2dffc67df81a25b9ed243.tar.bz2'
-  source_sha256 '954c9e27d017bddc99788911019ca223222fd1c59e383c4e21be84e62906b662'
+  source_url 'https://gitlab.gnome.org/Archive/tepl.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_6/5.99.0-d61f_armv7l/tepl_6-5.99.0-d61f-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_6/5.99.0-d61f_armv7l/tepl_6-5.99.0-d61f-chromeos-armv7l.tar.xz',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_6/5.99.0-d61f_i686/tepl_6-5.99.0-d61f-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_6/5.99.0-d61f_x86_64/tepl_6-5.99.0-d61f-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_6/6.0.0.0_armv7l/tepl_6-6.0.0.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_6/6.0.0.0_armv7l/tepl_6-6.0.0.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tepl_6/6.0.0.0_x86_64/tepl_6-6.0.0.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '928c126e8c0d2a87a6778dbe9d60fd1a31a0e3160ea384d5c0e36444b4936de9',
-     armv7l: '928c126e8c0d2a87a6778dbe9d60fd1a31a0e3160ea384d5c0e36444b4936de9',
        i686: 'f98b0034642f3433f036107d710f7c466701f94cea809e83908ada8c98305bc2',
-     x86_64: 'f479f11290e064ad429f4708c22cea0ce498dfb440278e98be7bbfcb751ece1b'
+    aarch64: '91d6926ec63368229ac7526d719d15d1e2ae9b5cdb4e6046519792a7ce8f5a8a',
+     armv7l: '91d6926ec63368229ac7526d719d15d1e2ae9b5cdb4e6046519792a7ce8f5a8a',
+     x86_64: 'cb6aa557f538e25b3b9dff15ec7b02699b8efc13e76749d4b262406b541b577d'
   })
 
   depends_on 'amtk'


### PR DESCRIPTION
Fixes #6220

Works properly:
- [x] x86_64
- [ ] i686 (not built... but then these are gui... so it doesn't matter?)

Builds properly:
- [x] x86_64
- [x] armv7l