### PR TITLE
Gnome 41 updates

### DIFF
--- a/packages/gnome_text_editor.rb
+++ b/packages/gnome_text_editor.rb
@@ -1,0 +1,53 @@
+require 'package'
+
+class Gnome_text_editor < Package
+  description 'GNOME Text Editor (2021)'
+  version '41.0'
+  compatibility 'all'
+  source_url 'https://gitlab.gnome.org/GNOME/gnome-text-editor.git'
+  git_hashtag version
+
+  binary_url({
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_text_editor/3.39.92-ft42_i686/gnome_text_editor-3.39.92-ft42-chromeos-i686.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_text_editor/41.0_armv7l/gnome_text_editor-41.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_text_editor/41.0_armv7l/gnome_text_editor-41.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_text_editor/41.0_x86_64/gnome_text_editor-41.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+       i686: '0d33f1154b5585761521d53a134b308f8b0791173f1790599f32834b8767c82a',
+    aarch64: '3c6c53b201f156f8be39c6bbfdd6ba5c3a6d35dc3a5402b8da7ea106e533e838',
+     armv7l: '3c6c53b201f156f8be39c6bbfdd6ba5c3a6d35dc3a5402b8da7ea106e533e838',
+     x86_64: '2b1b22e41c7725a7055e150a78062ebba90d515ee39599195e27c006dcac88e9'
+  })
+
+  depends_on 'glib'
+  depends_on 'gspell'
+  depends_on 'gtk3'
+  depends_on 'gtk4'
+  depends_on 'ibus'
+  depends_on 'gtksourceview_5'
+  depends_on 'libadwaita'
+  depends_on 'libpeas'
+  depends_on 'pango'
+  depends_on 'pcre'
+  depends_on 'pygobject'
+  depends_on 'yelp_tools' => ':build'
+  depends_on 'vala' => ':build'
+  depends_on 'gobject_introspection' => ':build'
+  depends_on 'gtk_doc' => ':build'
+
+  def self.build
+    system "meson #{CREW_MESON_OPTIONS} \
+            builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+
+  def self.postinstall
+    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas/"
+  end
+end

--- a/packages/gtksourceview_5.rb
+++ b/packages/gtksourceview_5.rb
@@ -3,22 +3,24 @@ require 'package'
 class Gtksourceview_5 < Package
   description 'Source code editing widget'
   homepage 'https://wiki.gnome.org/Projects/GtkSourceView'
-  @_ver = '5.0.0'
+  @_ver = '5.2.0'
   version @_ver
   license 'LGPL-2.1+'
-  compatibility 'x86_64 aarch64 armv7l'
-  source_url "https://gitlab.gnome.org/GNOME/gtksourceview/-/archive/#{@_ver}/gtksourceview-#{@_ver}.tar.bz2"
-  source_sha256 'b97ee7f2404d00ba607b865a838ee7c90053811c16c633a6359dace4ee1f218c'
+  compatibility 'all'
+  source_url 'https://gitlab.gnome.org/GNOME/gtksourceview.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_5/5.0.0_armv7l/gtksourceview_5-5.0.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_5/5.0.0_armv7l/gtksourceview_5-5.0.0-chromeos-armv7l.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_5/5.0.0_x86_64/gtksourceview_5-5.0.0-chromeos-x86_64.tar.xz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_5/5.0.0_i686/gtksourceview_5-5.0.0-chromeos-i686.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_5/5.2.0_armv7l/gtksourceview_5-5.2.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_5/5.2.0_armv7l/gtksourceview_5-5.2.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_5/5.2.0_x86_64/gtksourceview_5-5.2.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '0e1f4e4d940074837e075f5008dd5178b5e9c6b4bcf2f8eabd16002adf7adb8c',
-     armv7l: '0e1f4e4d940074837e075f5008dd5178b5e9c6b4bcf2f8eabd16002adf7adb8c',
-     x86_64: '455fb554c60675f9c15b77510cab48ed1986caba9f7c9cabe6f6d945bb30962e'
+       i686: 'd27b36e8275ba473c3758ae708eebd1aa80a34a346db5a44593d196f9f2f96a7',
+    aarch64: '96884f9ce28885b53432644059de5acc5bc251b7f6a8d6d5c27d1a1df32c18d8',
+     armv7l: '96884f9ce28885b53432644059de5acc5bc251b7f6a8d6d5c27d1a1df32c18d8',
+     x86_64: '00986e7083640e3771e854efcbeb3ae5f3fbd3393743722ddd417b4604bf25af'
   })
 
   depends_on 'atk'

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libadwaita < Package
   description 'Library of GNOME-specific UI patterns, replacing libhandy for GTK4'
   homepage 'https://gitlab.gnome.org/GNOME/libadwaita/'
-  version '1.1.0-aab6'
+  version '1.0.0-alpha.2'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/libadwaita/-/archive/aab6c89993dbf9231e0aeec9d31ce35c52ea04a2/libadwaita-aab6c89993dbf9231e0aeec9d31ce35c52ea04a2.tar.bz2'
-  source_sha256 'af4e34b811c18f2e42f76764c33f835b63110f8a1d471156befcd500d062daab'
+  source_url 'https://gitlab.gnome.org/GNOME/libadwaita.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.1.0-aab6_armv7l/libadwaita-1.1.0-aab6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.1.0-aab6_armv7l/libadwaita-1.1.0-aab6-chromeos-armv7l.tar.xz',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.1.0-aab6_i686/libadwaita-1.1.0-aab6-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.1.0-aab6_x86_64/libadwaita-1.1.0-aab6-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.0.0-alpha.2_armv7l/libadwaita-1.0.0-alpha.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.0.0-alpha.2_armv7l/libadwaita-1.0.0-alpha.2-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.0.0-alpha.2_x86_64/libadwaita-1.0.0-alpha.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '50e69b5c70875b5d938f9d578fd786eed3ce1de4ca4ab0d788eac24dcf63788c',
-     armv7l: '50e69b5c70875b5d938f9d578fd786eed3ce1de4ca4ab0d788eac24dcf63788c',
        i686: 'd68dd1fb68393dbeed3f7537a81d5812cc3cdff659dc74dfd07592a1cacad297',
-     x86_64: 'c6e0ebffb33a5c57fb9dfcd94e66e9c4c2a7c354427405ab424c9f205a97e4aa'
+    aarch64: '64fa0c4373eb849fbb139e8fd1fcd2f9f6b64f4ccf373ef17c58a0130a77ae54',
+     armv7l: '64fa0c4373eb849fbb139e8fd1fcd2f9f6b64f4ccf373ef17c58a0130a77ae54',
+     x86_64: '39da23ece24e4872fc0519d499e9f6306d6dbb6e5de11a7220f18e8f9b7c95e3'
   })
 
   depends_on 'cairo'
@@ -31,10 +31,6 @@ class Libadwaita < Package
   depends_on 'libjpeg'
   depends_on 'pango'
   depends_on 'vala' => :build
-
-  def self.patch
-    system "sed -i 's/-fstack-protector-strong/-flto/g' meson.build"
-  end
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \


### PR DESCRIPTION
- gnome text editor is supposed to be the gtk4 based gedit replacement in Gnome 41... but it is still buggy. The package is added so it can be easily updated later.
- This needs the updated `gtksourceview_5` and `libadwaita`

Works properly:
- [x] x86_64

Builds properly:
- [x] x86_64
- [x] armv7l