### PR TITLE
Add dosbox package

### DIFF
--- a/packages/dosbox.rb
+++ b/packages/dosbox.rb
@@ -1,0 +1,58 @@
+require 'package'
+
+class Dosbox < Package
+  description 'DOSBox is a DOS-emulator that uses the SDL-library'
+  homepage 'https://www.dosbox.com/'
+  version '0.74-3'
+  license 'GPL-2'
+  compatibility 'all'
+  source_url 'https://downloads.sourceforge.net/project/dosbox/dosbox/0.74-3/dosbox-0.74-3.tar.gz'
+  source_sha256 'c0d13dd7ed2ed363b68de615475781e891cd582e8162b5c3669137502222260a'
+
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dosbox/0.74-3_armv7l/dosbox-0.74-3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dosbox/0.74-3_armv7l/dosbox-0.74-3-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dosbox/0.74-3_i686/dosbox-0.74-3-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dosbox/0.74-3_x86_64/dosbox-0.74-3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '4d63eeba4d2e93696ff90cf61f806ea64b86552a7739651a6b717427e9ebe94f',
+     armv7l: '4d63eeba4d2e93696ff90cf61f806ea64b86552a7739651a6b717427e9ebe94f',
+       i686: 'ff371f1229c13dd11e11bf052c22f556373bf3d2c5eac1c12df8116a2b0bbed3',
+     x86_64: '1e45f3a2ef42431b06cc98f4c3769f8f1ce65094d71b0a9ff871eaabb6f22e86',
+  })
+
+  depends_on 'libpng'
+  depends_on 'libsdl'
+  depends_on 'sommelier'
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.postinstall
+    puts
+    puts "Type 'dosbox' to get started.".lightblue
+    puts
+  end
+
+  def self.remove
+    print "Would you like to remove the config directory? [y/N] "
+    response = STDIN.getc
+    config_dir = "#{HOME}/.dosbox"
+    if Dir.exists? config_dir
+      case response
+      when "y", "Y"
+        FileUtils.rm_rf config_dir
+        puts "#{config_dir} removed.".lightred
+      else
+        puts "#{config_dir} saved.".lightgreen
+      end
+    end
+  end
+end


### PR DESCRIPTION
DOSBox is a DOS-emulator that uses the SDL-library.  See https://www.dosbox.com/.  Tested on all architectures.