### PR TITLE
Libnghttp2 -> 1.45.1, libcurl -> 7.79.1

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,249 +3,216 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.77.0'
-  version "#{@_ver}-1"
+  @_ver = '7.78.0'
+  version @_ver
   license 'curl'
   compatibility 'all'
-  source_url 'https://github.com/curl/curl.git'
-  git_hashtag 'curl-7_77_0'
+  source_url "https://github.com/curl/curl/releases/download/curl-#{@_ver.gsub('.', '_')}/curl-#{@_ver}.tar.xz"
+  source_sha256 'be42766d5664a739c3974ee3dfbbcbe978a4ccb1fe628bb1d9b59ac79e445fb5'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-1_armv7l/curl-7.77.0-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-1_armv7l/curl-7.77.0-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-1_i686/curl-7.77.0-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.77.0-1_x86_64/curl-7.77.0-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.78.0_armv7l/curl-7.78.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.78.0_armv7l/curl-7.78.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.78.0_i686/curl-7.78.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.78.0_x86_64/curl-7.78.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '439fb6468782be5842b4f7a3c2854e5026d3eaf3a99023dd3d82b540458ec110',
-     armv7l: '439fb6468782be5842b4f7a3c2854e5026d3eaf3a99023dd3d82b540458ec110',
-       i686: '98479b4d6c3d9deee57fb261b58c2a327ebdfaa15a14eead2d979a26e2f2c74d',
-     x86_64: '07d49c2d5ad27ccaeba9f50b73b5c0078a1d0c57902797e0b5cc2e98d4c1f2b9'
+    aarch64: '4a8737953581f3277af58f45e7ce43381e5d8d0601018f668106f01ea35bc098',
+     armv7l: '4a8737953581f3277af58f45e7ce43381e5d8d0601018f668106f01ea35bc098',
+       i686: 'e908c912a425cb71e071238b2260d90c513f7bb5a19ffa7ab877adc81f617ba8',
+     x86_64: 'a03326367b15ad2e46a78be0d31ffe0276d302c8e8f37bc51fd3b9fe7dec5be9'
   })
 
   depends_on 'ca_certificates' => :build
-  depends_on 'hashpipe' => :build
   depends_on 'libunbound' => :build
-  depends_on 'musl' => :build
-  depends_on 'py3_pip' => :build
+  depends_on 'musl_brotli' => :build
+  depends_on 'musl_c_ares' => :build
+  depends_on 'musl_cyrus_sasl' => :build
+  depends_on 'musl_krb5' => :build
+  depends_on 'musl_libidn2' => :build
+  depends_on 'musl_libnghttp2' => :build
+  depends_on 'musl_libssh' => :build
+  depends_on 'musl_libunistring' => :build
+  depends_on 'musl_native_toolchain' => :build
+  depends_on 'musl_ncurses' => :build
+  depends_on 'musl_openssl' => :build
+  depends_on 'musl_zlib' => :build
+  depends_on 'musl_zstd' => :build
   depends_on 'rust' => :build
   depends_on 'valgrind' => :build
 
+  def self.patch
+    # Curl 7.78.0 needs a patch to enable static builds.
+    # See https://github.com/moparisthebest/static-curl/commit/0ab82474d449b7f2ea0d43451fd3951ebd49ddc3
+    @curl_778_static_patch = <<~CURL_HEREDOC
+            diff --git a/src/Makefile.am b/src/Makefile.am
+            index 734373187..37e3a1564 100644
+            --- a/src/Makefile.am
+            +++ b/src/Makefile.am
+            @@ -66,6 +66,9 @@ else
+             curl_LDADD = \$(top_builddir)/lib/libcurl.la @NSS_LIBS@ @SSL_LIBS@ @ZLIB_LIBS@ @CURL_NETWORK_AND_TIME_LIBS@
+             endif
+      #{'       '}
+            +curl_LDFLAGS = \$(curl_LDFLAGS)
+            +curl_CPPFLAGS = \$(AM_CPPFLAGS)
+            +
+             # if unit tests are enabled, build a static library to link them with
+             if BUILD_UNITTESTS
+             noinst_LTLIBRARIES = libcurltool.la
+    CURL_HEREDOC
+    IO.write('curl_778_static.patch', @curl_778_static_patch)
+    system 'patch -Np1 -i curl_778_static.patch'
+  end
+
   def self.build
-    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
-
-    FileUtils.mkdir_p 'build'
-    FileUtils.mkdir_p 'deproot/include'
-    FileUtils.mkdir_p 'deproot/lib'
-    Dir.chdir 'deproot' do
-      FileUtils.ln_s 'lib', 'lib64'
-    end
-    @deppath = "#{`pwd`.chomp}/deproot"
-    FileUtils.ln_s "#{CREW_PREFIX}/include/linux", "#{@deppath}/include/"
-    FileUtils.ln_s "#{CREW_PREFIX}/include/asm", "#{@deppath}/include/"
-    FileUtils.ln_s "#{CREW_PREFIX}/include/asm-generic", "#{@deppath}/include/"
-
+    @abi = ''
     @arch_ssp_cflags = ''
+    @arch_c_flags = ''
+    @arch_cxx_flags = ''
     case ARCH
+    when 'aarch64', 'armv7l'
+      @abi = 'eabihf'
+      @openssl_configure_target = 'linux-generic32'
     when 'i686'
       @arch_ssp_cflags = '-fno-stack-protector'
+      @openssl_configure_target = 'linux-x86'
+    when 'x86_64'
+      @openssl_configure_target = 'linux-x86_64'
     end
 
-    @curldep_cmake_options = "CC=musl-gcc \
-          CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-          CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-          CPPFLAGS='-I#{@deppath}/include' \
-          LDFLAGS='-L#{@deppath}/#{ARCH_LIB}' \
+    @cflags = "-B#{CREW_PREFIX}/musl/include -flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_c_flags} #{@arch_ssp_cflags} -fcommon"
+    @cxxflags = "-B#{CREW_PREFIX}/musl/include -flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_cxx_flags} #{@arch_ssp_cflags} -fcommon"
+    @ldflags = "-L#{CREW_PREFIX}/musl/lib -flto -static"
+    @cmake_ldflags = '-flto'
+    @curldep_cmake_options = "PATH=#{CREW_PREFIX}/musl/bin:#{CREW_PREFIX}/musl/#{ARCH}-linux-musl#{@abi}/bin:#{ENV['PATH']} \
+          CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
+          CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
+          LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
+          AR=#{CREW_PREFIX}/bin/ar \
+          CFLAGS='#{@cflags}' \
+          CXXFLAGS='#{@cxxflags}' \
+          CPPFLAGS='-I#{CREW_PREFIX}/musl/include -fcommon' \
+          LDFLAGS='#{@cmake_ldflags}' \
           cmake \
-          -DCMAKE_INSTALL_PREFIX='#{@deppath}' \
-          -DCMAKE_LIBRARY_PATH='#{@deppath}/#{ARCH_LIB}' \
-          -DCMAKE_C_COMPILER=`which musl-gcc` \
+          -DCMAKE_INSTALL_PREFIX='#{CREW_PREFIX}/musl' \
+          -DCMAKE_INSTALL_LIBDIR='#{CREW_PREFIX}/musl/lib' \
+          -DCMAKE_LIBRARY_PATH='#{CREW_PREFIX}/musl/lib' \
+          -DCMAKE_C_COMPILER=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc \
+          -DCMAKE_CXX_COMPILER=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++ \
           -DCMAKE_INCLUDE_DIRECTORIES_BEFORE=ON \
-          -DINCLUDE_DIRECTORIES=#{@deppath}/include \
-          -DCMAKE_C_FLAGS='-O3 -fPIC -pipe -flto -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-          -DCMAKE_EXE_LINKER_FLAGS='-flto' \
-          -DCMAKE_SHARED_LINKER_FLAGS='-flto' \
-          -DCMAKE_STATIC_LINKER_FLAGS='-flto' \
-          -DCMAKE_MODULE_LINKER_FLAGS='-flto' \
+          -DINCLUDE_DIRECTORIES=#{CREW_PREFIX}/musl/include \
+          -DCMAKE_C_FLAGS='#{@cflags}' \
+          -DCMAKE_CXX_FLAGS='#{@cxxflags}' \
+          -DCMAKE_EXE_LINKER_FLAGS='#{@cmake_ldflags}' \
+          -DCMAKE_SHARED_LINKER_FLAGS='#{@cmake_ldflags}' \
+          -DCMAKE_STATIC_LINKER_FLAGS='#{@cmake_ldflags}' \
+          -DCMAKE_MODULE_LINKER_FLAGS='#{@cmake_ldflags}' \
           -DPROPERTY_INTERPROCEDURAL_OPTIMIZATION=TRUE \
           -DCMAKE_BUILD_TYPE=Release"
 
-    @curldep_env_options = "CC=musl-gcc \
-        CFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-        CXXFLAGS='-flto -pipe -O3 -fPIC -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans#{@arch_ssp_cflags}' \
-        CPPFLAGS='-I#{@deppath}/include' \
-        LDFLAGS='-L#{@deppath}/#{ARCH_LIB}'"
+    @curldep_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+        CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
+        CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
+        LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
+        PKG_CONFIG_LIBDIR=#{CREW_PREFIX}/musl/lib \
+        CFLAGS='#{@cflags}' \
+        CXXFLAGS='#{@cxxflags}' \
+        CPPFLAGS='-I#{CREW_PREFIX}/musl/include -DCURL_STATICLIB -DNGHTTP2_STATICLIB -fcommon' \
+        LDFLAGS='#{@ldflags}'"
 
-    FileUtils.mkdir_p 'build/zlib'
-    Dir.chdir 'build/zlib' do
-      puts 'Building Zlib.'.yellow
-      system 'curl -Ls http://zlib.net/zlib-1.2.11.tar.gz | \
-        hashpipe sha256 c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1 | \
-        tar --strip-components=1 -zxf -'
-      system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
-        --static"
-      system 'make'
-      system 'make install'
-    end
-    FileUtils.mkdir_p 'build/zstd'
-    Dir.chdir 'build/zstd' do
-      puts 'Building Zstd.'.yellow
-      system 'curl -Ls https://github.com/facebook/zstd/archive/v1.5.0.tar.gz | \
-        hashpipe sha256 0d9ade222c64e912d6957b11c923e214e2e010a18f39bec102f572e693ba2867 | \
-        tar --strip-components=1 -zxf -'
-      FileUtils.mkdir('build/cmake/builddir')
-      Dir.chdir('build/cmake/builddir') do
-        system "#{@curldep_cmake_options} \
-        -DZSTD_BUILD_STATIC=ON \
-        -DZSTD_BUILD_SHARED=OFF \
-        ../ -G Ninja"
-      end
-      system 'ninja -C build/cmake/builddir'
-      system 'ninja -C build/cmake/builddir install'
-    end
-    FileUtils.mkdir_p 'build/brotli'
-    Dir.chdir 'build/brotli' do
-      puts 'Building Brotli.'.yellow
-      system 'curl -Ls https://github.com/google/brotli/archive/v1.0.9.tar.gz | \
-        hashpipe sha256 f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46 | \
-        tar --strip-components=1 -zxf -'
-      FileUtils.mkdir('builddir')
-      Dir.chdir('builddir') do
-        system "#{@curldep_cmake_options} \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DWITH_STATIC_LIB=ON \
-        ../ -G Ninja"
-      end
-      system 'ninja -C builddir'
-      system 'ninja -C builddir install'
-      Dir.chdir "#{@deppath}/#{ARCH_LIB}" do
-        @brotlilibs = %w[libbrotlidec libbrotlienc libbrotlicommon]
-        @brotlilibs.each do |lib|
-          FileUtils.ln_s "#{lib}-static.a", "#{lib}.a"
-        end
-      end
-    end
-    FileUtils.mkdir_p 'build/idn2'
-    Dir.chdir 'build/idn2' do
-      puts 'Building IDN2.'.yellow
-      system 'curl -Ls http://ftp.gnu.org/gnu/libidn/libidn2-2.3.1.tar.gz | \
-        hashipe sha256 8af684943836b8b53965d5f5b6714ef13c26c91eaa36ce7d242e3d21f5d40f2d | \
-        tar --strip-components=1 -zxf -'
-      system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
-        --disable-shared"
-      system 'make'
-      system 'make install'
-    end
-    FileUtils.mkdir_p 'build/ssl'
-    case ARCH
-    when 'aarch64', 'armv7l'
-      @arch_c_flags = '-march=armv7-a -mfloat-abi=hard'
-      @arch_cxx_flags = '-march=armv7-a -mfloat-abi=hard'
-      @openssl_configure_target = 'linux-generic32'
-    when 'i686'
-      @arch_c_flags = ''
-      @arch_cxx_flags = ''
-      @openssl_configure_target = 'linux-x86'
-    when 'x86_64'
-      @arch_c_flags = ''
-      @arch_cxx_flags = ''
-      @openssl_configure_target = 'linux-x86_64'
-    end
-    Dir.chdir 'build/ssl' do
-      puts 'Building OpenSSL.'.yellow
-      system 'curl -Ls https://www.openssl.org/source/openssl-1.1.1k.tar.gz | \
-        hashpipe sha256 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5 | \
-        tar --strip-components=1 -zxf -'
-      system "CC=musl-gcc \
-        CFLAGS='-flto -pipe -O3 -fPIC #{@arch_c_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-        CXXFLAGS='-flto -pipe -O3 -fPIC #{@arch_cxx_flags} -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-        CPPFLAGS='-I#{@deppath}/include' \
-        LDFLAGS='-L#{@deppath}/#{ARCH_LIB} -flto' \
-        ./Configure \
-        --prefix=#{@deppath} \
-        no-tests zlib no-shared \
-        #{@openssl_configure_target}"
-      system 'make'
-      system 'make install_sw'
-    end
+    @krb5_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+        CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
+        CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
+        LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
+        LIBS='-l:libncursesw.a -l:libtinfow.a' \
+        CFLAGS='#{@cflags}' \
+        CXXFLAGS='#{@cxxflags}' \
+        CPPFLAGS='-I#{CREW_PREFIX}/musl/include -DCURL_STATICLIB -DNGHTTP2_STATICLIB -fcommon' \
+        LDFLAGS=' #{@ldflags} -l:libncursesw.a -l:libtinfow.a'"
 
-    # libssh has problems linking with musl statically
-    # FileUtils.mkdir_p 'build/libssh'
-    # Dir.chdir 'build/libssh' do
-    # puts 'Building Libssh.'.yellow
-    # system 'curl -Ls https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz | \
-    #   hashpipe sha256 acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718 | \
-    #   tar --strip-components=1 -Jxf -'
-    # FileUtils.mkdir('builddir')
-    # Dir.chdir('builddir') do
-    # system "#{@curldep_cmake_options} \
-    #-DWITH_EXAMPLES=OFF \
-    #-DBUILD_SHARED_LIBS=OFF \
-    #-DWITH_STATIC_LIB=ON \
-    #-DWITH_GSSAPI=OFF \
-    #-DHAVE_GLOB=0 \
-    # ../ -G Ninja"
-    # end
-    # system 'ninja -C builddir'
-    # system 'ninja -C builddir install'
-    # end
-    FileUtils.mkdir_p 'build/nghttp2'
-    Dir.chdir 'build/nghttp2' do
-      puts 'Building Nghttp2.'.yellow
-      system 'curl -Ls https://github.com/nghttp2/nghttp2/releases/download/v1.43.0/nghttp2-1.43.0.tar.gz | \
-        hashpipe sha256 45cc3ed91966551f92b31958ceca9b3a9f23ce4faf5cbedb78aa3327cd4e5907 | \
-        tar --strip-components=1 -zxf -'
-      system "#{@curldep_env_options} ./configure --prefix=#{@deppath} \
-        --enable-lib-only \
-        --disable-shared \
-        --enable-static"
-      system 'make'
-      system 'make install'
-    end
+    @krb5_static_libs = "#{CREW_PREFIX}/musl/lib/libkrb5support.a  #{CREW_PREFIX}/musl/lib/libgssapi_krb5.a #{CREW_PREFIX}/musl/lib/libkrb5.a  #{CREW_PREFIX}/musl/lib/libk5crypto.a #{CREW_PREFIX}/musl/lib/libcom_err.a"
 
-    puts 'Done building static curl dependencies.'.lightgreen
-    system '[ -x configure ] || autoreconf -fvi'
+    @curl_lib_deps = "#{@krb5_static_libs} \
+      -l:libresolv.a \
+      -l:libm.a \
+      -l:libbrotlicommon-static.a \
+      -l:libbrotlidec-static.a \
+      -l:libzstd.a \
+      -l:libz.a \
+      -l:libssl.a \
+      -l:libcrypto.a \
+      -l:libsasl2.a \
+      -l:libnghttp2.a \
+      -l:libpthread.a \
+      -l:libncursesw.a \
+      -l:libtinfow.a \
+      -l:libcares.a \
+      -l:libunistring.a \
+      -l:libidn2.a \
+      -l:libssh.a"
+
+    @curl_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+        CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
+        CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
+        LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
+        CFLAGS='#{@cflags}' \
+        CXXFLAGS='#{@cxxflags}' \
+        CPPFLAGS='-I#{CREW_PREFIX}/musl/include -DCURL_STATICLIB -DNGHTTP2_STATICLIB' \
+        LDFLAGS='#{@ldflags}'"
+
+    system 'autoreconf -fvi'
     system 'filefix'
-    system "env CC=musl-gcc \
-      PKG_CONFIG='pkg-config --static' \
-      CPPFLAGS='-I#{@deppath}/include' \
-      CFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-      CXXFLAGS='-flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_ssp_cflags}' \
-      LDFLAGS='-L#{@deppath}/#{ARCH_LIB} -flto -static -Wl,--no-as-needed -ldl' \
-      LIBS='#{@deppath}/#{ARCH_LIB}/libssl.a #{@deppath}/#{ARCH_LIB}/libcrypto.a #{@deppath}/#{ARCH_LIB}/libbrotlicommon.a #{@deppath}/#{ARCH_LIB}/libbrotlidec.a #{@deppath}/#{ARCH_LIB}/libidn2.a #{@deppath}/#{ARCH_LIB}/libnghttp2.a  #{@deppath}/#{ARCH_LIB}/libz.a #{@deppath}/#{ARCH_LIB}/libzstd.a -L#{@deppath}/#{ARCH_LIB}' \
-      CURL_LIBRARY_PATH=#{@deppath}/#{ARCH_LIB} \
-      ./configure --prefix=#{@deppath} \
-      --disable-imap \
-      --disable-ldap \
-      --disable-ldaps \
-      --disable-libcurl-option \
-      --disable-maintainer-mode \
-      --disable-rtsp \
-      --disable-shared \
-      --enable-ipv6 \
-      --enable-static \
-      --enable-unix-sockets \
-      --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
-      --with-ca-fallback \
-      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
-      --with-libidn2=#{@deppath} \
-      --with-nghttp2=#{@deppath} \
-      --with-openssl=#{@deppath} \
-      --with-brotli=#{@deppath} \
-      --without-librtmp \
-      --with-openssl=#{@deppath} \
-      --with-zlib=#{@deppath}"
+    system "#{@curl_env_options} \
+    LIBS='#{@curl_lib_deps} \
+    -L#{CREW_PREFIX}/musl/lib' \
+    CURL_LIBRARY_PATH=#{CREW_PREFIX}/musl/lib \
+    ./configure --prefix=#{CREW_PREFIX}/musl \
+    --libdir=#{CREW_PREFIX}/musl \
+    --disable-dependency-tracking \
+    --disable-imap \
+    --disable-ldap \
+    --disable-ldaps \
+    --disable-maintainer-mode \
+    --disable-rtsp \
+    --disable-shared \
+    --enable-ares \
+    --enable-ipv6 \
+    --enable-static \
+    --enable-unix-sockets \
+    --with-brotli=#{CREW_PREFIX}/musl \
+    --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
+    --with-ca-fallback \
+    --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+    --with-gssapi=#{CREW_PREFIX}/musl \
+    --with-libidn2=#{CREW_PREFIX}/musl \
+    --with-libssh=#{CREW_PREFIX}/musl \
+    --with-nghttp2=#{CREW_PREFIX}/musl \
+    --with-openssl=#{CREW_PREFIX}/musl \
+    --without-librtmp \
+    --with-zlib=#{CREW_PREFIX}/musl \
+    "
     system 'make curl_LDFLAGS=-all-static'
-    FileUtils.cp 'src/curl', 'curl.static'
+    # FileUtils.cp 'src/curl', 'curl.static'
   end
 
   def self.check
+    # Fail if curl is not statically built.
+    system 'ldd src/curl && exit 1 || true'
     system 'src/curl -Lf https://github.com/skycocker/chromebrew/raw/master/install.sh -o /tmp/install.sh'
     FileUtils.rm '/tmp/install.sh'
   end
 
   def self.install
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install', 'curl_LDFLAGS=-all-static'
+    # Curl already includes man pages via "curl -M"
+    FileUtils.rm_rf "#{CREW_DEST_PREFIX}/musl/share/man"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.install 'curl.static', "#{CREW_DEST_PREFIX}/bin/curl", mode: 0o755
+    FileUtils.ln_s "#{CREW_DEST_PREFIX}/musl/bin/curl", "#{CREW_DEST_PREFIX}/bin/curl"
+    # FileUtils.install 'curl.static', "#{CREW_DEST_PREFIX}/bin/curl", mode: 0o755
   end
 end

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -17,10 +17,10 @@ class Curl < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.78.0_x86_64/curl-7.78.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '4a8737953581f3277af58f45e7ce43381e5d8d0601018f668106f01ea35bc098',
-     armv7l: '4a8737953581f3277af58f45e7ce43381e5d8d0601018f668106f01ea35bc098',
-       i686: 'e908c912a425cb71e071238b2260d90c513f7bb5a19ffa7ab877adc81f617ba8',
-     x86_64: 'a03326367b15ad2e46a78be0d31ffe0276d302c8e8f37bc51fd3b9fe7dec5be9'
+    aarch64: '9f176fb06b0d039fb59674d4fb8d9fd96f194d4ac7fbcc906f4eacf1d45ca5a8',
+     armv7l: '9f176fb06b0d039fb59674d4fb8d9fd96f194d4ac7fbcc906f4eacf1d45ca5a8',
+       i686: '2286de285438ee9f4885c1f6b759c1ff28ee7cc17c828797081a7cbe167d1287',
+     x86_64: 'b67ca7c670ef0ecb0ab896f3743ff8971246cb947c2339bc096d86613d2b0181'
   })
 
   depends_on 'ca_certificates' => :build
@@ -167,7 +167,7 @@ class Curl < Package
     -L#{CREW_PREFIX}/musl/lib' \
     CURL_LIBRARY_PATH=#{CREW_PREFIX}/musl/lib \
     ./configure --prefix=#{CREW_PREFIX}/musl \
-    --libdir=#{CREW_PREFIX}/musl \
+    --libdir=#{CREW_PREFIX}/musl/lib \
     --disable-dependency-tracking \
     --disable-imap \
     --disable-ldap \

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,13 +3,12 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.78.0'
+  @_ver = '7.79.1'
   version @_ver
   license 'curl'
-  # source_url "https://github.com/curl/curl/releases/download/curl-#{@_ver.gsub('.', '_')}/curl-#{@_ver}.tar.xz"
   compatibility 'all'
-  source_url 'https://curl.se/download/curl-7.78.0.tar.xz'
-  source_sha256 'be42766d5664a739c3974ee3dfbbcbe978a4ccb1fe628bb1d9b59ac79e445fb5'
+  source_url "https://github.com/curl/curl/releases/download/curl-#{@_ver.gsub('.', '_')}/curl-#{@_ver}.tar.xz"
+  source_sha256 '0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689'
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.78.0_armv7l/curl-7.78.0-chromeos-armv7l.tpxz',
@@ -20,7 +19,7 @@ class Curl < Package
   binary_sha256({
     aarch64: 'b1a96f22014ca2b23f7b42cda81fbcdab5710d75b3eef0bf60aef3c5fee8fdb3',
      armv7l: 'b1a96f22014ca2b23f7b42cda81fbcdab5710d75b3eef0bf60aef3c5fee8fdb3',
-       i686: '2286de285438ee9f4885c1f6b759c1ff28ee7cc17c828797081a7cbe167d1287',
+       i686: '6aa7e94a6d3dd8f103a49e8029ee515c19128e35a6af142188cc6d810add48df',
      x86_64: '667d70c2bdebcfcd0e185b5344073a3000a764ed094e76b00471fafcc37f0af2'
   })
 

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -6,8 +6,9 @@ class Curl < Package
   @_ver = '7.78.0'
   version @_ver
   license 'curl'
+  # source_url "https://github.com/curl/curl/releases/download/curl-#{@_ver.gsub('.', '_')}/curl-#{@_ver}.tar.xz"
   compatibility 'all'
-  source_url "https://github.com/curl/curl/releases/download/curl-#{@_ver.gsub('.', '_')}/curl-#{@_ver}.tar.xz"
+  source_url 'https://curl.se/download/curl-7.78.0.tar.xz'
   source_sha256 'be42766d5664a739c3974ee3dfbbcbe978a4ccb1fe628bb1d9b59ac79e445fb5'
 
   binary_url({
@@ -17,10 +18,10 @@ class Curl < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/7.78.0_x86_64/curl-7.78.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '9f176fb06b0d039fb59674d4fb8d9fd96f194d4ac7fbcc906f4eacf1d45ca5a8',
-     armv7l: '9f176fb06b0d039fb59674d4fb8d9fd96f194d4ac7fbcc906f4eacf1d45ca5a8',
+    aarch64: 'b1a96f22014ca2b23f7b42cda81fbcdab5710d75b3eef0bf60aef3c5fee8fdb3',
+     armv7l: 'b1a96f22014ca2b23f7b42cda81fbcdab5710d75b3eef0bf60aef3c5fee8fdb3',
        i686: '2286de285438ee9f4885c1f6b759c1ff28ee7cc17c828797081a7cbe167d1287',
-     x86_64: 'b67ca7c670ef0ecb0ab896f3743ff8971246cb947c2339bc096d86613d2b0181'
+     x86_64: '667d70c2bdebcfcd0e185b5344073a3000a764ed094e76b00471fafcc37f0af2'
   })
 
   depends_on 'ca_certificates' => :build

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -3,25 +3,22 @@ require 'package'
 class Libcurl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.78.0'
+  @_ver = '7.79.1'
   version @_ver
   license 'curl'
   compatibility 'all'
-  source_url 'https://curl.se/download/curl-7.78.0.tar.xz'
-  source_sha256 'be42766d5664a739c3974ee3dfbbcbe978a4ccb1fe628bb1d9b59ac79e445fb5'
-
+  source_url "https://github.com/curl/curl/releases/download/curl-#{@_ver.gsub('.', '_')}/curl-#{@_ver}.tar.xz"
+  source_sha256 '0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689'
 
   binary_url({
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.78.0_i686/libcurl-7.78.0-chromeos-i686.tar.xz',
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.78.0_armv7l/libcurl-7.78.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.78.0_armv7l/libcurl-7.78.0-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.78.0_x86_64/libcurl-7.78.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_armv7l/libcurl-7.79.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_armv7l/libcurl-7.79.1-chromeos-armv7l.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_x86_64/libcurl-7.79.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-       i686: '07f1ab7fd175cf911dbd0a2eb802b827f7b47f62b1aa65659b8a544b20dfcc6d',
-    aarch64: '62cb453539ce7d575438bad5b565e6401614a0ef19c8979e954543719e710dbb',
-     armv7l: '62cb453539ce7d575438bad5b565e6401614a0ef19c8979e954543719e710dbb',
-     x86_64: '267da90a48c7e68051376a5f2febc39ad0c0265231afc567d6edd88ccb864760'
+    aarch64: 'bf352a127695aaa84e77bfe19c0acd0b6f9dab90387ca19d40f0e8af621a0d6d',
+     armv7l: 'bf352a127695aaa84e77bfe19c0acd0b6f9dab90387ca19d40f0e8af621a0d6d',
+    x86_64: '83fed4b64ca34fd6e10c3b1f855ab7b4634a0ca58fb45297d00b74501c8827d1'
   })
 
   depends_on 'brotli' => :build

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -3,24 +3,22 @@ require 'package'
 class Libnghttp2 < Package
   description 'library implementing HTTP/2 protocol'
   homepage 'https://nghttp2.org/'
-  @_ver = '1.44.0'
+  @_ver = '1.45.1'
   version @_ver
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/nghttp2/nghttp2.git'
-  git_hashtag 'v' + @_ver
+  git_hashtag "v#{@_ver}"
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.44.0_armv7l/libnghttp2-1.44.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.44.0_armv7l/libnghttp2-1.44.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.44.0_i686/libnghttp2-1.44.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.44.0_x86_64/libnghttp2-1.44.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_x86_64/libnghttp2-1.45.1-chromeos-x86_64.tpxz',
+   aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz'
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '7409b33d59d3a48db51830a3a1522668a285641a20636078d9fea29d37435ca1',
-     armv7l: '7409b33d59d3a48db51830a3a1522668a285641a20636078d9fea29d37435ca1',
-       i686: '0f55cc49ebc2542942d6aff73efb876e89da22494892f28c310611ddb0849aff',
-     x86_64: '1db2fa466e7c434dab211a202a85518f1607d0a9311d8ad7606f5cbd9a55635b',
+  binary_sha256({
+    x86_64: 'f1d7369aee4be665d89a1cc582802fa1cc9d0b7803bd5df91cf2eb8b62a79241',
+   aarch64: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db'
+    armv7l: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db'
   })
 
   depends_on 'jansson'
@@ -30,21 +28,20 @@ class Libnghttp2 < Package
   depends_on 'py3_cython' => :build
 
   def self.build
-    Dir.mkdir 'builddir'
+    FileUtils.mkdir 'builddir'
     Dir.chdir 'builddir' do
       system "cmake -G Ninja #{CREW_CMAKE_OPTIONS} \
-        -DENABLE_EXAMPLES=OFF \
         -DENABLE_SHARED_LIB=ON \
         -DENABLE_STATIC_LIB=ON .."
       system 'samu'
     end
   end
 
-  def self.check
-    system 'samu -C builddir test'
-  end
-
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+
+  def self.check
+    system 'samu -C builddir test'
   end
 end


### PR DESCRIPTION
- Combined here because libcurl was built with the newer libnghttp2
- Is there anything this `libcurl` breaks?

Builds properly:
- [x] x86_64
- [x] armv7l
- [ ] i686 (@uberhacker builds please? libnghttp2 needs `libev` and not `libevent` installed to build.)
