### PR TITLE
libnghttp2 -> 1.45.1, libcurl -> 7.79.1

### DIFF
--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -3,25 +3,22 @@ require 'package'
 class Libcurl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.78.0'
+  @_ver = '7.79.1'
   version @_ver
   license 'curl'
   compatibility 'all'
-  source_url 'https://curl.se/download/curl-7.78.0.tar.xz'
-  source_sha256 'be42766d5664a739c3974ee3dfbbcbe978a4ccb1fe628bb1d9b59ac79e445fb5'
-
+  source_url "https://github.com/curl/curl/releases/download/curl-#{@_ver.gsub('.', '_')}/curl-#{@_ver}.tar.xz"
+  source_sha256 '0606f74b1182ab732a17c11613cbbaf7084f2e6cca432642d0e3ad7c224c3689'
 
   binary_url({
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.78.0_i686/libcurl-7.78.0-chromeos-i686.tar.xz',
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.78.0_armv7l/libcurl-7.78.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.78.0_armv7l/libcurl-7.78.0-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.78.0_x86_64/libcurl-7.78.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_armv7l/libcurl-7.79.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_armv7l/libcurl-7.79.1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_x86_64/libcurl-7.79.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-       i686: '07f1ab7fd175cf911dbd0a2eb802b827f7b47f62b1aa65659b8a544b20dfcc6d',
-    aarch64: '62cb453539ce7d575438bad5b565e6401614a0ef19c8979e954543719e710dbb',
-     armv7l: '62cb453539ce7d575438bad5b565e6401614a0ef19c8979e954543719e710dbb',
-     x86_64: '267da90a48c7e68051376a5f2febc39ad0c0265231afc567d6edd88ccb864760'
+    aarch64: '497ca2518256983a3a011fa83de67f20202a1aa5cc6fdf88424b96df4cbe19ba',
+     armv7l: '497ca2518256983a3a011fa83de67f20202a1aa5cc6fdf88424b96df4cbe19ba',
+     x86_64: 'e16d3d120bf089178f35f05636c9b79b5f5343d1e6b9a5a8edcc3c717213f26f'
   })
 
   depends_on 'brotli' => :build
@@ -42,9 +39,6 @@ class Libcurl < Package
   depends_on 'zstd' # R
 
   def self.build
-    # Without these downstream programs which want to statically link
-    # libcurl have issues.
-    # @krb5_static_libs = '-l:libkrb5support.a -l:libgssapi_krb5.a -l:libkrb5.a -l:libk5crypto.a -l:libcom_err.a'
 
     @libssh = '--with-libssh'
     case ARCH
@@ -72,6 +66,6 @@ class Libcurl < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    FileUtils.rm "#{CREW_DEST_PREFIX}/bin/curl"
+    FileUtils.mv "#{CREW_DEST_PREFIX}/bin/curl", "#{CREW_DEST_PREFIX}/bin/curl.nonstatic"
   end
 end

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -13,11 +13,13 @@ class Libcurl < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_armv7l/libcurl-7.79.1-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_armv7l/libcurl-7.79.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_i686/libcurl-7.79.1-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.79.1_x86_64/libcurl-7.79.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '497ca2518256983a3a011fa83de67f20202a1aa5cc6fdf88424b96df4cbe19ba',
      armv7l: '497ca2518256983a3a011fa83de67f20202a1aa5cc6fdf88424b96df4cbe19ba',
+       i686: 'ab58dc20c50f2ad6dc00afc5b30c3eac2e4c8d5286efa70613821e46a6654d61',
      x86_64: 'e16d3d120bf089178f35f05636c9b79b5f5343d1e6b9a5a8edcc3c717213f26f'
   })
 

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -11,16 +11,16 @@ class Libnghttp2 < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0-1_i686/libnghttp2-1.43.0-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_x86_64/libnghttp2-1.45.1-chromeos-x86_64.tpxz',
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_i686/libnghttp2-1.45.1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_x86_64/libnghttp2-1.45.1-chromeos-x86_64.tpxz',
   })
   binary_sha256({
-       i686: '2ea5d7dba201696ff274937e47b8a7eb1d202be529d6c20be23a9ea4156e76a8',
-     x86_64: 'f1d7369aee4be665d89a1cc582802fa1cc9d0b7803bd5df91cf2eb8b62a79241',
     aarch64: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db',
      armv7l: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db'
+       i686: '209c4b802cc37ceb4e508e54a403fea7ab23a84c9ec317d8bf497723e32969c4',
+     x86_64: 'f1d7369aee4be665d89a1cc582802fa1cc9d0b7803bd5df91cf2eb8b62a79241',
   })
 
   depends_on 'jansson'

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -3,24 +3,22 @@ require 'package'
 class Libnghttp2 < Package
   description 'library implementing HTTP/2 protocol'
   homepage 'https://nghttp2.org/'
-  @_ver = '1.44.0'
+  @_ver = '1.45.1'
   version @_ver
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/nghttp2/nghttp2.git'
-  git_hashtag 'v' + @_ver
+  git_hashtag "v#{@_ver}"
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.44.0_armv7l/libnghttp2-1.44.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.44.0_armv7l/libnghttp2-1.44.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.44.0_i686/libnghttp2-1.44.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.44.0_x86_64/libnghttp2-1.44.0-chromeos-x86_64.tar.xz',
+  binary_url({
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0-1_i686/libnghttp2-1.43.0-1-chromeos-i686.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_x86_64/libnghttp2-1.45.1-chromeos-x86_64.tpxz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '7409b33d59d3a48db51830a3a1522668a285641a20636078d9fea29d37435ca1',
-     armv7l: '7409b33d59d3a48db51830a3a1522668a285641a20636078d9fea29d37435ca1',
-       i686: '0f55cc49ebc2542942d6aff73efb876e89da22494892f28c310611ddb0849aff',
-     x86_64: '1db2fa466e7c434dab211a202a85518f1607d0a9311d8ad7606f5cbd9a55635b',
+  binary_sha256({
+       i686: '2ea5d7dba201696ff274937e47b8a7eb1d202be529d6c20be23a9ea4156e76a8',
+    x86_64: 'f1d7369aee4be665d89a1cc582802fa1cc9d0b7803bd5df91cf2eb8b62a79241',
+    armv7l: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db'
   })
 
   depends_on 'jansson'
@@ -30,21 +28,20 @@ class Libnghttp2 < Package
   depends_on 'py3_cython' => :build
 
   def self.build
-    Dir.mkdir 'builddir'
+    FileUtils.mkdir 'builddir'
     Dir.chdir 'builddir' do
       system "cmake -G Ninja #{CREW_CMAKE_OPTIONS} \
-        -DENABLE_EXAMPLES=OFF \
         -DENABLE_SHARED_LIB=ON \
         -DENABLE_STATIC_LIB=ON .."
       system 'samu'
     end
   end
 
-  def self.check
-    system 'samu -C builddir test'
-  end
-
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+
+  def self.check
+    system 'samu -C builddir test'
   end
 end

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -12,13 +12,15 @@ class Libnghttp2 < Package
 
   binary_url({
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.43.0-1_i686/libnghttp2-1.43.0-1-chromeos-i686.tpxz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_x86_64/libnghttp2-1.45.1-chromeos-x86_64.tpxz',
-    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz'
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_x86_64/libnghttp2-1.45.1-chromeos-x86_64.tpxz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz'
   })
   binary_sha256({
        i686: '2ea5d7dba201696ff274937e47b8a7eb1d202be529d6c20be23a9ea4156e76a8',
-    x86_64: 'f1d7369aee4be665d89a1cc582802fa1cc9d0b7803bd5df91cf2eb8b62a79241',
-    armv7l: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db'
+     x86_64: 'f1d7369aee4be665d89a1cc582802fa1cc9d0b7803bd5df91cf2eb8b62a79241',
+    aarch64: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db',
+     armv7l: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db'
   })
 
   depends_on 'jansson'

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -25,7 +25,6 @@ class Libnghttp2 < Package
 
   depends_on 'jansson'
   depends_on 'jemalloc'
-  depends_on 'libevent' => :build
   depends_on 'libev' => :build
   depends_on 'py3_cython' => :build
 
@@ -39,11 +38,11 @@ class Libnghttp2 < Package
     end
   end
 
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
-  end
-
   def self.check
     system 'samu -C builddir test'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end


### PR DESCRIPTION
- combined since libcurl was built against this libnghttp2
- libnghttp2 needs to be built against `libev`, not `libevent`

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686 (needs build)