### PR TITLE
Firefox 92.0 => 92.0.1

### DIFF
--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -3,16 +3,16 @@ require 'package'
 class Firefox < Package
   description 'Mozilla Firefox (or simply Firefox) is a free and open-source web browser'
   homepage 'https://www.mozilla.org/en-US/firefox/'
-  version '92.0'
+  version '92.0.1'
   license 'MPL-2.0, GPL-2 and LGPL-2.1'
   compatibility 'i686,x86_64'
   case ARCH
   when 'i686'
     source_url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-i686/en-US/firefox-#{version}.tar.bz2"
-    source_sha256 '3fbb43fa7e8f1636a5c9be13af710dd5b3ef5326803b1fc35634ef68cb8db531'
+    source_sha256 '18859b248cabf07e082ba419bd8e0fb9f19ee0cbb7818de0096afee09191d4e2'
   when 'x86_64'
     source_url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-x86_64/en-US/firefox-#{version}.tar.bz2"
-    source_sha256 '29050d18670a61585b101f8fa4e196fcfc22d0447178143202301836f3c048eb'
+    source_sha256 'a3ba62122a6cde1d7d2ebf96e765ea57ea3e9a312d2161e0ac70923946844689'
   end
 
   depends_on 'atk'
@@ -39,6 +39,29 @@ class Firefox < Package
   depends_on 'pulseaudio'
   depends_on 'sommelier'
 
+  def self.build
+    @firefox_sh = <<~FIREFOX_SH
+      #!/bin/bash
+      GDK_BACKEND=x11 #{CREW_PREFIX}/firefox/firefox "\$@"
+    FIREFOX_SH
+    # For some reason, the binaries do not have a desktop file so add it here.
+    @firefox_desktop = <<~FIREFOX_DESKTOP
+      [Desktop Entry]
+      Version=#{version}
+      Name=Firefox
+      Name[en_US]=firefox
+      GenericName=Mozilla Firefox
+      GenericName[en_US]=Mozilla Firefox
+      Comment=Free and open-source web browser
+      Exec=firefox %U
+      Terminal=false
+      Type=Application
+      Icon=firefox
+      Categories=Network;WebBrowser;
+      MimeType=text/html;text/xml;application/xhtml_xml;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;
+    FIREFOX_DESKTOP
+  end
+
   def self.install
     ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
     warn_level = $VERBOSE
@@ -47,11 +70,41 @@ class Firefox < Package
     $VERBOSE = warn_level
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/firefox"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/applications"
+    icon_base_path = "#{CREW_DEST_PREFIX}/share/icons/hicolor"
+    FileUtils.mkdir_p "#{icon_base_path}/16x16/apps"
+    FileUtils.mkdir_p "#{icon_base_path}/32x32/apps"
+    FileUtils.mkdir_p "#{icon_base_path}/48x48/apps"
+    FileUtils.mkdir_p "#{icon_base_path}/64x64/apps"
+    FileUtils.mkdir_p "#{icon_base_path}/128x128/apps"
+    FileUtils.mkdir_p "#{icon_base_path}/256x256/apps"
     FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/firefox"
-    @firefox_sh = <<~FIREFOX_HEREDOC
-      #!/bin/bash
-      GDK_BACKEND=x11 #{CREW_PREFIX}/firefox/firefox "\$@"
-    FIREFOX_HEREDOC
     IO.write("#{CREW_DEST_PREFIX}/bin/firefox", @firefox_sh, perm: 0o755)
+    IO.write("#{CREW_DEST_PREFIX}/share/applications/firefox.desktop", @firefox_desktop, perm: 0o644)
+    Dir.chdir 'browser/chrome/icons/default' do
+      FileUtils.mv 'default16.png', "#{icon_base_path}/16x16/apps/firefox.png"
+      FileUtils.mv 'default32.png', "#{icon_base_path}/32x32/apps/firefox.png"
+      FileUtils.mv 'default48.png', "#{icon_base_path}/48x48/apps/firefox.png"
+      FileUtils.mv 'default64.png', "#{icon_base_path}/64x64/apps/firefox.png"
+      FileUtils.mv 'default128.png', "#{icon_base_path}/128x128/apps/firefox.png"
+    end
+    # The following image is needed for crew-launcher which requires a minimum icon size of 144x144.
+    system 'curl -L#O https://files.softicons.com/download/application-icons/round-app-icons-by-ampeross/png/256x256/Mozilla.png'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest(File.read('Mozilla.png')) == '994e780ada1456c26b077a9f97186aefbc90be5c57e66366b1bca32df0c14c4e'
+    FileUtils.mv 'Mozilla.png', "#{icon_base_path}/256x256/apps/firefox.png"
+  end
+
+  def self.postinstall
+    print "\nSet Firefox as your default browser? [Y/n]: "
+    case STDIN.getc
+    when "\n", "Y", "y"
+      Dir.chdir("#{CREW_PREFIX}/bin") do
+        FileUtils.ln_sf 'firefox', 'x-www-browser'
+      end
+      puts 'Firefox is now your default browser.'.lightgreen
+    else
+      puts 'No change has been made.'.orange
+    end
+    puts "\nType 'firefox' to get started.\n".lightblue
   end
 end


### PR DESCRIPTION
This update adds desktop and icon files along with the ability to set as the default browser.  Tested on x86_64 with crew-launcher and the icon works!