### PR TITLE
OpenSSH -> 8.8

### DIFF
--- a/packages/openssh.rb
+++ b/packages/openssh.rb
@@ -3,23 +3,23 @@ require 'package'
 class Openssh < Package
   description 'OpenSSH is the premier connectivity tool for remote login with the SSH protocol.'
   homepage 'https://www.openssh.com/'
-  version '8.7'
+  version '8.8'
   license 'BSD and GPL-2'
   compatibility 'all'
-  source_url 'https://github.com/openssh/openssh-portable/archive/refs/tags/V_8_7_P1.tar.gz'
-  source_sha256 '7094e2d9886f07ed7885c4a5d212384259b3b935932920a0eb95eba35a4542a0'
+  source_url 'https://github.com/openssh/openssh-portable/archive/refs/tags/V_8_8_P1.tar.gz'
+  source_sha256 'a944effea9597a36c80a6c71aa520bf6fbef7b6bcefbb648dc39d0ed788c90c8'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/8.7_armv7l/openssh-8.7-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/8.7_armv7l/openssh-8.7-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/8.7_i686/openssh-8.7-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/8.7_x86_64/openssh-8.7-chromeos-x86_64.tpxz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/8.8_i686/openssh-8.8-chromeos-i686.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/8.8_armv7l/openssh-8.8-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/8.8_armv7l/openssh-8.8-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/8.8_x86_64/openssh-8.8-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '773918e9e9fdcbeba4b4240057e0d1946942806e37ae1812c5dbbb37aca8154f',
-     armv7l: '773918e9e9fdcbeba4b4240057e0d1946942806e37ae1812c5dbbb37aca8154f',
-       i686: '3ec04d72c174ede9ff283c5e0a8f994fba40e714ebc21ed647e4964b1ff8c80c',
-     x86_64: '8c04f059c2d1f7683185d795fd87adad1988cd46546ab0c445957c2ed593781c'
+       i686: '7f584f07449817a69d2780cca72aabae6bdf383b18aa724b710fa7043af53161',
+    aarch64: '926ed75ad7a0d374de9f28db3233b34a6e0650cab4e55297858e386286c6df68',
+     armv7l: '926ed75ad7a0d374de9f28db3233b34a6e0650cab4e55297858e386286c6df68',
+     x86_64: 'd734097f18ce48e634a6300574053e2cb4b904a572264ca6d73beb3a5740bfce'
   })
 
   def self.build


### PR DESCRIPTION
- FYI from changelog:

> Potentially-incompatible changes
> ================================
> 
> This release disables RSA signatures using the SHA-1 hash algorithm
> by default. This change has been made as the SHA-1 hash algorithm is
> cryptographically broken, and it is possible to create chosen-prefix
> hash collisions for <USD$50K [1]
> 
> For most users, this change should be invisible and there is
> no need to replace ssh-rsa keys. OpenSSH has supported RFC8332
> RSA/SHA-256/512 signatures since release 7.2 and existing ssh-rsa keys
> will automatically use the stronger algorithm where possible.
> 
> Incompatibility is more likely when connecting to older SSH
> implementations that have not been upgraded or have not closely tracked
> improvements in the SSH protocol. For these cases, it may be necessary
> to selectively re-enable RSA/SHA1 to allow connection and/or user
> authentication via the HostkeyAlgorithms and PubkeyAcceptedAlgorithms
> options. For example, the following stanza in ~/.ssh/config will enable
> RSA/SHA1 for host and user authentication for a single destination host:
> 
>     Host old-host
>         HostkeyAlgorithms +ssh-rsa
> 	PubkeyAcceptedAlgorithms +ssh-rsa
> 
> We recommend enabling RSA/SHA1 only as a stopgap measure until legacy
> implementations can be upgraded or reconfigured with another key type
> (such as ECDSA or Ed25519).
> 
> [1] "SHA-1 is a Shambles: First Chosen-Prefix Collision on SHA-1 and
>     Application to the PGP Web of Trust" Leurent, G and Peyrin, T
>     (2020) https://eprint.iacr.org/2020/014.pdf

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686 (@uberhacker please confirm)
