### PR TITLE
crew: fix crew update reporting a potential package upgrade when a different package's package file is missing

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -277,9 +277,9 @@ def search (pkgName, silent = false)
   begin
     return set_package(pkgName, pkgPath) if File.exist?(pkgPath)
   rescue => e
-    puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
+    puts "Error with #{pkgName}.rb: #{e}".lightred unless e.to_s.include?('uninitialized constant')
   end
-  if ! File.exist?(pkgPath) && silent
+  unless File.exist?(pkgPath) && silent
     @pkg = nil
   return
   end

--- a/bin/crew
+++ b/bin/crew
@@ -279,6 +279,10 @@ def search (pkgName, silent = false)
   rescue => e
     puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
   end
+  if ! File.exist?(pkgPath) && silent
+    @pkg = nil
+  return
+  end
   abort "Package #{pkgName} not found. :(".lightred unless silent
 end
 
@@ -520,9 +524,12 @@ def update
   canBeUpdated = 0
   @device[:installed_packages].each do |package|
     search package[:name], true
+    if @pkg.nil?
+      puts "Package file for #{package[:name]} not found. :(".lightred if @opt_verbose
+      next
+    end 
     if package[:version].to_s != @pkg.version
       canBeUpdated += 1
-      puts @pkg_name + 'version is'+ @pkg.version.inspect
       puts @pkg.name + ' could be updated from ' + package[:version].to_s + ' to ' + @pkg.version
     end
   end

--- a/bin/crew
+++ b/bin/crew
@@ -522,7 +522,7 @@ def update
     search package[:name], true
     if package[:version].to_s != @pkg.version
       canBeUpdated += 1
-      @pkg.version.inspect
+      puts @pkg_name + 'version is'+ @pkg.version.inspect
       puts @pkg.name + ' could be updated from ' + package[:version].to_s + ' to ' + @pkg.version
     end
   end

--- a/bin/crew
+++ b/bin/crew
@@ -522,6 +522,7 @@ def update
     search package[:name], true
     if package[:version].to_s != @pkg.version
       canBeUpdated += 1
+      @pkg.version.inspect
       puts @pkg.name + ' could be updated from ' + package[:version].to_s + ' to ' + @pkg.version
     end
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.16.8'
+CREW_VERSION = '1.16.9'
 
 ARCH_ACTUAL = `uname -m`.strip
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Fixes #6254

- During `crew update`, avoid installed packages missing package files.
- This modifies the crew logic to set `@pkg` to nil in `search` if pkgPath can not be found. This avoids leaving @pkg set to the previous package searched if the current search doesn't find a package file. **This may have unintended consequences elsewhere as search is called from multiple places in `crew`.**

Works properly:
- [x] x86_64
