### PR TITLE
glib -> 2.70.0

### DIFF
--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -14,12 +14,14 @@ class Glib < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_armv7l/glib-2.70.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_armv7l/glib-2.70.0-chromeos-armv7l.tpxz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_x86_64/glib-2.70.0-chromeos-x86_64.tpxz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_i686/glib-2.70.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_x86_64/glib-2.70.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '5a3b66e351b9bdf6ebb4ca0c23383cffb8c65bec2c69ed40361d3a790aa39e4c',
      armv7l: '5a3b66e351b9bdf6ebb4ca0c23383cffb8c65bec2c69ed40361d3a790aa39e4c',
-    x86_64: '9f96829a225c86f284513766e9ea833d9fb78928f572a5bd78e12ff1932b957f'
+       i686: 'f55c3a7ad33a87829202358af587c6fcb3c6848e75d30b3ef44e2175227e659c',
+     x86_64: '9f96829a225c86f284513766e9ea833d9fb78928f572a5bd78e12ff1932b957f'
   })
 
   depends_on 'shared_mime_info' # L
@@ -39,5 +41,9 @@ class Glib < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+
+  def self.postinstall
+    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
   end
 end

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -14,13 +14,13 @@ class Glib < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_armv7l/glib-2.70.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_armv7l/glib-2.70.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_i686/glib-2.70.0-chromeos-i686.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_i686/glib-2.70.0-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_x86_64/glib-2.70.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '5a3b66e351b9bdf6ebb4ca0c23383cffb8c65bec2c69ed40361d3a790aa39e4c',
      armv7l: '5a3b66e351b9bdf6ebb4ca0c23383cffb8c65bec2c69ed40361d3a790aa39e4c',
-       i686: 'f55c3a7ad33a87829202358af587c6fcb3c6848e75d30b3ef44e2175227e659c',
+       i686: 'aa7fb9b8a770208a1653692c4db68616bd35bfd5add16d121e7f63d6dbf40d5d',
      x86_64: '9f96829a225c86f284513766e9ea833d9fb78928f572a5bd78e12ff1932b957f'
   })
 

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.69.3'
+  @_ver = '2.70.0'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
@@ -12,16 +12,14 @@ class Glib < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.69.3_armv7l/glib-2.69.3-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.69.3_armv7l/glib-2.69.3-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.69.3_i686/glib-2.69.3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.69.3_x86_64/glib-2.69.3-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_armv7l/glib-2.70.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_armv7l/glib-2.70.0-chromeos-armv7l.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.70.0_x86_64/glib-2.70.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '0a28298a4b7c7628d227a627b880b04f4cb1eb7eddc1b9bb470394a883cb7e91',
-     armv7l: '0a28298a4b7c7628d227a627b880b04f4cb1eb7eddc1b9bb470394a883cb7e91',
-       i686: 'f4e2e279a0929b56cfe527d5e48abb5d2722e8d8ac923f4937e239f598a2dc5e',
-     x86_64: '484b56feaa32030249f8b5a66728b15b84190b092539012f102d53f0e011a0c6'
+    aarch64: '5a3b66e351b9bdf6ebb4ca0c23383cffb8c65bec2c69ed40361d3a790aa39e4c',
+     armv7l: '5a3b66e351b9bdf6ebb4ca0c23383cffb8c65bec2c69ed40361d3a790aa39e4c',
+    x86_64: '9f96829a225c86f284513766e9ea833d9fb78928f572a5bd78e12ff1932b957f'
   })
 
   depends_on 'shared_mime_info' # L


### PR DESCRIPTION
Works properly:
- [x] x86_64
- [x] armv7l 
- [x] i686 ( @uberhacker this was built on a new container. The postinstall should work on i686... but please check.)