### PR TITLE
libxml2 needs gcc11 dep for installs to succeed

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -14,7 +14,7 @@ class Buildessential < Package
 
   # install first to get ldconfig
   depends_on 'glibc'
-  depends_on 'gcc11'
+  # depends_on 'gcc11'
   depends_on 'gmp'
   depends_on 'mpfr'
   depends_on 'mpc'

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -20,6 +20,7 @@ class Core < Package
   depends_on 'expat'
   depends_on 'filecmd'
   depends_on 'flex'
+  depends_on 'gcc11'
   depends_on 'gdbm'
   depends_on 'gettext'
   depends_on 'git'

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -24,6 +24,7 @@ class Libxml2 < Package
 
   depends_on 'zlibpkg'
   depends_on 'readline'
+  depends_on 'gcc11'
 
   def self.patch
     # Fix encoding.c:1961:31: error: ‘TRUE’ undeclared (first use in this function)

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -13,6 +13,7 @@ expat
 filecmd
 flex
 gdbm
+gcc11
 gettext
 git
 glibc


### PR DESCRIPTION
-  xltproc is used by the install process, and it depends upon libxml2. In turn, libxml2 depends upon gcc11's `#{CREW_LIB_PREFIX}/libgcc_s.so.1`
- While this adds gcc11 installs, hopefully, this can be reduced out soon, as this library is small relative to the size of gcc11.

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l