### PR TITLE
pygobject -> 3.42.0

### DIFF
--- a/packages/gnome_tweaks.rb
+++ b/packages/gnome_tweaks.rb
@@ -22,7 +22,7 @@ class Gnome_tweaks < Package
 
   depends_on 'gnome_settings_daemon'
   depends_on 'gsettings_desktop_schemas'
-  depends_on 'py3_gobject'
+  depends_on 'pygobject'
   depends_on 'libhandy'
   depends_on 'libnotify'
 

--- a/packages/pygobject.rb
+++ b/packages/pygobject.rb
@@ -13,13 +13,13 @@ class Pygobject < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.42.0_armv7l/pygobject-3.42.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.42.0_armv7l/pygobject-3.42.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.42.0_i686/pygobject-3.42.0-chromeos-i686.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.42.0_i686/pygobject-3.42.0-chromeos-i686.tar.xz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.42.0_x86_64/pygobject-3.42.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '3078465f299ca21b754eddacf8f3d10e5674cb93773288539010803a7024c339',
      armv7l: '3078465f299ca21b754eddacf8f3d10e5674cb93773288539010803a7024c339',
-       i686: '9ddfd5b69486b7af2e07bb455136d60a412764d0e02839ca74baefe81ed55243',
+       i686: 'b4a3f0c1db1c86bcba8f36a213af0031ec749218d7facf8c77f20c76f1cf9fb2',
      x86_64: '119c35a1e20179f9e1010e6b713209539e060d3fbd8c0f560aaa6e8d55499b00'
   })
 

--- a/packages/pygobject.rb
+++ b/packages/pygobject.rb
@@ -3,7 +3,7 @@ require 'package'
 class Pygobject < Package
   description 'PyGObject is a Python package which provides bindings for GObject based libraries such as GTK+, GStreamer, WebKitGTK+, GLib, GIO and many more.'
   homepage 'https://pygobject.readthedocs.io/'
-  @_ver = '3.40.1'
+  @_ver = '3.42.0'
   version @_ver
   license 'LGPL-2.1+'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Pygobject < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.40.1_armv7l/pygobject-3.40.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.40.1_armv7l/pygobject-3.40.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.40.1_i686/pygobject-3.40.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.40.1_x86_64/pygobject-3.40.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.42.0_armv7l/pygobject-3.42.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.42.0_armv7l/pygobject-3.42.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.42.0_i686/pygobject-3.42.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pygobject/3.42.0_x86_64/pygobject-3.42.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '1500e6bc54033b30b095bee58fed4690d614c765671bd3722688e76b78fe454e',
-     armv7l: '1500e6bc54033b30b095bee58fed4690d614c765671bd3722688e76b78fe454e',
-       i686: 'ebe701b39d9ca9fb0b394333c92eab82ff76d3126566bcefc140b800a0356f48',
-     x86_64: '25669c04d58e2f76ea77ef6d7f9235feb608291dbdf8632bb8dd5c1e4cd44fe9'
+    aarch64: '3078465f299ca21b754eddacf8f3d10e5674cb93773288539010803a7024c339',
+     armv7l: '3078465f299ca21b754eddacf8f3d10e5674cb93773288539010803a7024c339',
+       i686: '9ddfd5b69486b7af2e07bb455136d60a412764d0e02839ca74baefe81ed55243',
+     x86_64: '119c35a1e20179f9e1010e6b713209539e060d3fbd8c0f560aaa6e8d55499b00'
   })
 
   depends_on 'glib'


### PR DESCRIPTION
- Also fixed `gnome_tweaks` package having an orphan py3_gobjects dependency
- built using glib 2.70.0 in https://github.com/skycocker/chromebrew/pull/6260

Works properly:
- [x] x86_64
- [x] i686 (@uberhacker This was also built on a newer container... )