### PR TITLE
Default Rubocop linter config for Chromebrew Take 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,41 @@
+# The behavior of RuboCop can be controlled via the .rubocop.yml
+# configuration file. It makes it possible to enable/disable
+# certain cops (checks) and to alter their behavior if they accept
+# any parameters. The file can be placed either in your home
+# directory or in some project directory.
+#
+# RuboCop will start looking for the configuration file in the directory
+# where the inspected file is and continue its way up to the root directory.
+#
+# See https://docs.rubocop.org/rubocop/configuration
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.0
+
+Layout/HashAlignment:
+  EnforcedHashRocketStyle:
+    - separator
+  EnforcedColonStyle:
+    - separator
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Naming/VariableNumber:
+  Enabled: false
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Layout/LineLength:
+  IgnoredPatterns: ['description']

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -50,7 +50,7 @@ class Ruby_rubocop < Package
   end
 
   def self.postinstall
-    @gem_name = self.name.sub('ruby_','')
+    @gem_name = name.sub('ruby_', '')
     system "gem install -N #{@gem_name} --conservative"
 
     puts "Installing Chromebrew rubocop config file at #{@xdg_config_home}/rubocop/config.yml".lightblue
@@ -63,9 +63,12 @@ class Ruby_rubocop < Package
   end
 
   def self.remove
-    @gem_name = self.name.sub('ruby_','')
+    @gem_name = name.sub('ruby_', '')
     @gems_deps = `gem dependency ^#{@gem_name}\$ | awk '{print \$1}'`.chomp
-    @gems = @gems_deps.split("\n").drop(1).append("#{@gem_name}")
+    # Delete the first line and convert to an array.
+    @gems = @gems_deps.split("\n").drop(1).append(@gem_name)
+    # bundler never gets uninstalled, though gem dependency lists it for
+    # every package, so delete it from the list.
     @gems.delete('bundler')
     @gems.each do |gem|
       system "gem uninstall -Dx --force --abort-on-dependent #{gem} || true"

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -1,0 +1,49 @@
+# Adapted from Arch Linux ruby-rubocop PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=ruby-rubocop
+
+require 'package'
+
+class Ruby_rubocop < Package
+  description 'A Ruby static code analyzer and formatter'
+  homepage 'https://rubocop.org'
+  version '1.22.0'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  depends_on 'libyaml'
+
+  @xdg_config_home = ENV['XDG_CONFIG_HOME']
+  @xdg_config_home = "#{CREW_PREFIX}/.config" if @xdg_config_home.to_s.empty?
+
+  def self.install
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
+    FileUtils.mkdir_p "#{CREW_DEST_DIR}#{@xdg_config_home}/rubocop"
+  end
+
+  def self.postinstall
+    system 'gem install -N rubocop --conservative'
+    puts "Installing Chromebrew rubocop config file at #{@xdg_config_home}/rubocop/config.yml".lightblue
+    puts "This can be overridden by a ~/.rubocop.yml".lightblue
+    system "curl -Ls https://github.com/chromebrew/chromebrew/raw/master/.rubocop.yml > #{@xdg_config_home}/rubocop/config.yml"
+  end
+
+  def self.remove
+    config_dirs = %W[#{@xdg_config_home}/rubocop]
+    config_dirs.each do |config_dir|
+      next unless Dir.exist? config_dir
+
+      print "\nWould you like to remove #{config_dir}? [y/N] "
+      case $stdin.getc
+      when 'y', 'Y'
+        FileUtils.rm_rf config_dir
+        puts "#{config_dir} removed.".lightred
+      else
+        puts "#{config_dir} saved.".lightgreen
+      end
+    end
+  end
+end

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -6,33 +6,59 @@ require 'package'
 class Ruby_rubocop < Package
   description 'A Ruby static code analyzer and formatter'
   homepage 'https://rubocop.org'
-  version '1.22.0'
+  version '1.26.1'
   compatibility 'all'
-  source_url 'SKIP'
+  source_url 'https://github.com/rubocop/rubocop.git'
+  git_hashtag "v#{version}"
+
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_rubocop/1.26.1_armv7l/ruby_rubocop-1.26.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_rubocop/1.26.1_armv7l/ruby_rubocop-1.26.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_rubocop/1.26.1_i686/ruby_rubocop-1.26.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_rubocop/1.26.1_x86_64/ruby_rubocop-1.26.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'c81b0e5bee7f31d632c5e5a6159331eef36a839aa56d3cd98217161ea1ba1b6e',
+     armv7l: 'c81b0e5bee7f31d632c5e5a6159331eef36a839aa56d3cd98217161ea1ba1b6e',
+       i686: '61e75cfeaa580f4f78e94dfbee12186331b412721244cfc0d7660bd9338040d9',
+     x86_64: '66c9134d10ee390f53449edf863cdc1a58be3af8ed8fda6571aa4228244d45a3'
+  })
+
+  no_fhs
 
   depends_on 'libyaml'
+  depends_on 'ruby'
   depends_on 'xdg_base'
 
   @xdg_config_home = ENV['XDG_CONFIG_HOME']
   @xdg_config_home = "#{CREW_PREFIX}/.config" if @xdg_config_home.to_s.empty?
 
+  def self.build
+    system 'bundle install'
+    system 'rake build'
+  end
+
   def self.install
-    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
-    warn_level = $VERBOSE
-    $VERBOSE = nil
-    load "#{CREW_LIB_PATH}lib/const.rb"
-    $VERBOSE = warn_level
-    FileUtils.mkdir_p "#{CREW_DEST_DIR}#{@xdg_config_home}/rubocop"
+    system "gem install --build=#{CREW_DEST_DIR} pkg/rubocop-#{version}.gem"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/.config/rubocup"
+    system "curl -Ls https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml > #{CREW_DEST_PREFIX}/.config/rubocup/config.yml"
+    # Uncomment after merge
+    # system "curl -Ls https://github.com/chromebrew/chromebrew/raw/master/.rubocop.yml > #{CREW_DEST_PREFIX}/.config/rubocup/config.yml"
   end
 
   def self.postinstall
-    system 'gem install -N rubocop --conservative'
+    # system 'gem install -N rubocop --conservative'
     puts "Installing Chromebrew rubocop config file at #{@xdg_config_home}/rubocop/config.yml".lightblue
-    puts "This can be overridden by a ~/.rubocop.yml".lightblue
-    system "curl -Ls https://github.com/chromebrew/chromebrew/raw/master/.rubocop.yml > #{@xdg_config_home}/rubocop/config.yml"
+    puts 'This can be overridden by a ~/.rubocop.yml'.lightblue
+    FileUtils.mkdir_p "#{@xdg_config_home}/rubocop"
+    system "curl -Ls https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml > #{@xdg_config_home}/rubocop/config.yml"
+    # Uncomment after merge
+    # system "curl -Ls https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml > #{@xdg_config_home}/rubocop/config.yml"
   end
 
   def self.remove
-    system 'gem uninstall -x rubocop'
+    # system 'gem uninstall -x rubocop'
+    FileUtils.rm_f "#{@xdg_config_home}/rubocop/config.yml"
   end
 end

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -8,8 +8,9 @@ class Ruby_rubocop < Package
   homepage 'https://rubocop.org'
   version '1.26.1'
   compatibility 'all'
-  source_url 'https://github.com/rubocop/rubocop.git'
-  git_hashtag "v#{version}"
+  source_url 'SKIP'
+  # source_url 'https://github.com/rubocop/rubocop.git'
+  # git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_rubocop/1.26.1_armv7l/ruby_rubocop-1.26.1-chromeos-armv7l.tar.zst',
@@ -21,7 +22,7 @@ class Ruby_rubocop < Package
     aarch64: '751d173e446bf5e478b5cf75d0d2bcf3ca67e8a0fbb602667c4e3d224e938c5c',
      armv7l: '751d173e446bf5e478b5cf75d0d2bcf3ca67e8a0fbb602667c4e3d224e938c5c',
        i686: '3ba763b890c2bb0a39cd07567bc248b7dc4b12242537e817ef1650b4fb2ce6bc',
-     x86_64: '43962c9f3309ab26545e693ee1bfa04af0198141305a73939428d86e30086397'
+     x86_64: '59942e42753e15dafe07c9e522fa0e01483e5e2ca66b7c54a347bef8e58d4b8c'
   })
 
   no_fhs
@@ -34,30 +35,42 @@ class Ruby_rubocop < Package
   @xdg_config_home = "#{CREW_PREFIX}/.config" if @xdg_config_home.to_s.empty?
 
   def self.build
-    system 'bundle install'
-    system 'rake build'
+    # system 'bundle install'
+    # system 'rake build'
   end
 
   def self.install
-    system "gem install --build=#{CREW_DEST_DIR} pkg/rubocop-#{version}.gem"
+    # system "gem install --build=#{CREW_DEST_DIR} pkg/rubocop-#{version}.gem"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/.config/rubocop"
-    system "curl -Ls https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml > #{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
+
+    # Remove following line after merge of this PR.
+    system "curl -Lsf https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml -o #{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
     # Uncomment after merge
-    # system "curl -Ls https://github.com/chromebrew/chromebrew/raw/master/.rubocop.yml > #{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
+    # system "curl -Lsf https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml -o #{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
   end
 
   def self.postinstall
-    # system 'gem install -N rubocop --conservative'
+    @gem_name = self.name.sub('ruby_','')
+    system "gem install -N #{@gem_name} --conservative"
+
     puts "Installing Chromebrew rubocop config file at #{@xdg_config_home}/rubocop/config.yml".lightblue
     puts 'This can be overridden by a ~/.rubocop.yml'.lightblue
     FileUtils.mkdir_p "#{@xdg_config_home}/rubocop"
-    system "curl -Ls https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml > #{@xdg_config_home}/rubocop/config.yml"
+    # Remove following line after merge of this PR.
+    system "curl -Lsf https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml -o #{@xdg_config_home}/rubocop/config.yml"
     # Uncomment after merge
-    # system "curl -Ls https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml > #{@xdg_config_home}/rubocop/config.yml"
+    # system "curl -Lsf https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml -o #{@xdg_config_home}/rubocop/config.yml"
   end
 
   def self.remove
-    # system 'gem uninstall -x rubocop'
+    @gem_name = self.name.sub('ruby_','')
+    @gems_deps = `gem dependency ^#{@gem_name}\$ | awk '{print \$1}'`.chomp
+    @gems = @gems_deps.split("\n").drop(1).append("#{@gem_name}")
+    @gems.delete('bundler')
+    @gems.each do |gem|
+      system "gem uninstall -Dx --force --abort-on-dependent #{gem} || true"
+    end
+
     FileUtils.rm_f "#{@xdg_config_home}/rubocop/config.yml"
   end
 end

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -44,9 +44,9 @@ class Ruby_rubocop < Package
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/.config/rubocop"
 
     # Remove following line after merge of this PR.
-    system "curl -Lsf https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml -o #{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
+    downloader 'https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml', 'SKIP', "#{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
     # Uncomment after merge
-    # system "curl -Lsf https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml -o #{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
+    # downloader 'https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml', 'SKIP', "#{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
   end
 
   def self.postinstall
@@ -57,9 +57,9 @@ class Ruby_rubocop < Package
     puts 'This can be overridden by a ~/.rubocop.yml'.lightblue
     FileUtils.mkdir_p "#{@xdg_config_home}/rubocop"
     # Remove following line after merge of this PR.
-    system "curl -Lsf https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml -o #{@xdg_config_home}/rubocop/config.yml"
+    downloader 'https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml', 'SKIP', "#{@xdg_config_home}/rubocop/config.yml"
     # Uncomment after merge
-    # system "curl -Lsf https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml -o #{@xdg_config_home}/rubocop/config.yml"
+    # downloader 'https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml', 'SKIP', "#{@xdg_config_home}/rubocop/config.yml"
   end
 
   def self.remove

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -11,7 +11,6 @@ class Ruby_rubocop < Package
   source_url 'https://github.com/rubocop/rubocop.git'
   git_hashtag "v#{version}"
 
-
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_rubocop/1.26.1_armv7l/ruby_rubocop-1.26.1-chromeos-armv7l.tar.zst',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_rubocop/1.26.1_armv7l/ruby_rubocop-1.26.1-chromeos-armv7l.tar.zst',
@@ -19,10 +18,10 @@ class Ruby_rubocop < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_rubocop/1.26.1_x86_64/ruby_rubocop-1.26.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c81b0e5bee7f31d632c5e5a6159331eef36a839aa56d3cd98217161ea1ba1b6e',
-     armv7l: 'c81b0e5bee7f31d632c5e5a6159331eef36a839aa56d3cd98217161ea1ba1b6e',
-       i686: '61e75cfeaa580f4f78e94dfbee12186331b412721244cfc0d7660bd9338040d9',
-     x86_64: '66c9134d10ee390f53449edf863cdc1a58be3af8ed8fda6571aa4228244d45a3'
+    aarch64: '751d173e446bf5e478b5cf75d0d2bcf3ca67e8a0fbb602667c4e3d224e938c5c',
+     armv7l: '751d173e446bf5e478b5cf75d0d2bcf3ca67e8a0fbb602667c4e3d224e938c5c',
+       i686: '3ba763b890c2bb0a39cd07567bc248b7dc4b12242537e817ef1650b4fb2ce6bc',
+     x86_64: '43962c9f3309ab26545e693ee1bfa04af0198141305a73939428d86e30086397'
   })
 
   no_fhs
@@ -41,10 +40,10 @@ class Ruby_rubocop < Package
 
   def self.install
     system "gem install --build=#{CREW_DEST_DIR} pkg/rubocop-#{version}.gem"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/.config/rubocup"
-    system "curl -Ls https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml > #{CREW_DEST_PREFIX}/.config/rubocup/config.yml"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/.config/rubocop"
+    system "curl -Ls https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml > #{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
     # Uncomment after merge
-    # system "curl -Ls https://github.com/chromebrew/chromebrew/raw/master/.rubocop.yml > #{CREW_DEST_PREFIX}/.config/rubocup/config.yml"
+    # system "curl -Ls https://github.com/chromebrew/chromebrew/raw/master/.rubocop.yml > #{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
   end
 
   def self.postinstall

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -11,6 +11,7 @@ class Ruby_rubocop < Package
   source_url 'SKIP'
 
   depends_on 'libyaml'
+  depends_on 'xdg_base'
 
   @xdg_config_home = ENV['XDG_CONFIG_HOME']
   @xdg_config_home = "#{CREW_PREFIX}/.config" if @xdg_config_home.to_s.empty?
@@ -32,18 +33,6 @@ class Ruby_rubocop < Package
   end
 
   def self.remove
-    config_dirs = %W[#{@xdg_config_home}/rubocop]
-    config_dirs.each do |config_dir|
-      next unless Dir.exist? config_dir
-
-      print "\nWould you like to remove #{config_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
-        FileUtils.rm_rf config_dir
-        puts "#{config_dir} removed.".lightred
-      else
-        puts "#{config_dir} saved.".lightgreen
-      end
-    end
+    system 'gem uninstall -x rubocop'
   end
 end


### PR DESCRIPTION
- Add a default Rubocop linter config file people can use.
- This won't change ANYTHING, since we're not running any automated scripts based on this at the moment.
 
Obviously, this is open for additions. I'm not tied to these settings, but I just wanted to start somewhere.

To get this set up on your system do this:
```
crew install libyaml
gem install rubocop
```
Once this file is at ~/.rubocop.yml, you can run ```rubocop package.rb``` to get some suggested changes.

Run ```rubocop -A package.rb``` to try to make those fixes automatically.

Please feel free to add to this PR if there are changes you think should be made.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686