### PR TITLE
pipdeptree

### DIFF
--- a/packages/py3_pipdeptree.rb
+++ b/packages/py3_pipdeptree.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Py3_pipdeptree < Package
+  description 'Displays a dependency tree of the installed Python packages.'
+  homepage 'https://github.com/naiquevin/pipdeptree/'
+  @_ver = '2.1.0'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/naiquevin/pipdeptree.git'
+  git_hashtag @_ver
+
+  depends_on 'py3_pip'
+  depends_on 'py3_setuptools' => :build
+
+  def self.build
+    system "python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS}"
+  end
+
+  def self.install
+    system "python3 setup.py install #{PY_SETUP_INSTALL_OPTIONS}"
+  end
+end


### PR DESCRIPTION
Pipdeptree is a program that displays the depdency tree of installed pip packages much better than `pip freeze`. I used this so much during #5717 