### PR TITLE
Build firefox from source

### DIFF
--- a/packages/cbindgen.rb
+++ b/packages/cbindgen.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Cbindgen < Package
+  description 'Generates C bindings from Rust code.'
+  homepage 'https://github.com/eqrion/cbindgen/'
+  @_ver = '0.20.0'
+  version @_ver
+  license 'MPL-2'
+  compatibility 'all'
+  source_url 'https://github.com/eqrion/cbindgen.git'
+  git_hashtag "v#{@_ver}"
+
+  depends_on 'rust' => :build
+
+  def self.build
+    system 'cargo build --release -v'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin/"
+    FileUtils.cp 'target/release/cbindgen', "#{CREW_DEST_PREFIX}/bin/cbindgen"
+  end
+end

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -4,38 +4,26 @@ class Libpng < Package
   description 'libpng is the official PNG reference library.'
   homepage 'http://libpng.org/pub/png/libpng.html'
   @_ver = '1.6.37'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'libpng2'
   compatibility 'all'
   source_url "https://downloads.sourceforge.net/project/libpng/libpng16/#{@_ver}/libpng-#{@_ver}.tar.xz"
   source_sha256 '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_armv7l/libpng-1.6.37-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_armv7l/libpng-1.6.37-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_i686/libpng-1.6.37-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_x86_64/libpng-1.6.37-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'addb9158594a38f2d4ecd90c5de111d43586d3cdd9ab1edc25536cfb3dc3b760',
-     armv7l: 'addb9158594a38f2d4ecd90c5de111d43586d3cdd9ab1edc25536cfb3dc3b760',
-       i686: '865eea143c0e553d9aea22f20fb02cdb89d2fb823cbf94b1e79b1f3a1124442f',
-     x86_64: '703cb00f75ecdab4918029aa57ee9ed53f027d0a4be6cd6c29b9e4fbd25f7dfe'
-  })
-
   depends_on 'shared_mime_info'
+  depends_on 'hashpipe' => :build
 
   def self.patch
     system 'filefix'
+    # Patch in APNG support
+    system 'curl -#L https://sourceforge.net/projects/apng/files/libpng/libpng16/libpng-1.6.37-apng.patch.gz | \
+              hashpipe sha256 10d9e0cb60e2b387a79b355eb7527c0bee2ed8cbd12cf04417cabc4d6976683c | \
+              gunzip | \
+              patch -Np0'
   end
 
   def self.build
-    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure \
-      #{CREW_OPTIONS} \
-      --disable-dependency-tracking \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/nss.rb
+++ b/packages/nss.rb
@@ -3,26 +3,13 @@ require 'package'
 class Nss < Package
   description 'Network Security Services (NSS) is a set of libraries designed to support cross-platform development of security-enabled client and server applications.'
   homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS'
-  @nss_ver = '3.69.1'
+  @nss_ver = '3.71'
   @nspr_ver = '4.32'
   version "nss.#{@nss_ver}.nspr.#{@nss_ver}"
   license 'MPL-2.0, GPL-2 or LGPL-2.1'
   compatibility 'all'
-  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_69_1_RTM/src/nss-3.69.1-with-nspr-4.32.tar.gz'
-  source_sha256 '976dd57391aa269aa2961ac7ae002dc49935f855263df58b59b1dd4836d47cb7'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_armv7l/nss-nss.3.69.1.nspr.4.32-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_armv7l/nss-nss.3.69.1.nspr.4.32-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_i686/nss-nss.3.69.1.nspr.4.32-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nss/nss.3.69.1.nspr.4.32_x86_64/nss-nss.3.69.1.nspr.4.32-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: 'e68a620a7b7f35289f401561e3c86ff1fceb38d0b0652da7e6c531addc020a14',
-     armv7l: 'e68a620a7b7f35289f401561e3c86ff1fceb38d0b0652da7e6c531addc020a14',
-       i686: '2b16871a705710c6f772c255b68572013e765658cb5f791b9fdaf697c1bf36ed',
-     x86_64: '89f80e57d77168fe58e28f60e245a18256dd3b1c68640a1430fc512f93e01b01'
-  })
+  source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_71_RTM/src/nss-3.71-with-nspr-4.32.tar.gz'
+  source_sha256 '6a687ce29b54bda554db5740ff0b79a954852835edd3df35f613e6fed157a13e'
 
   depends_on 'gyp_next' => :build
 


### PR DESCRIPTION
This is a big change, I'm aware. Firefox is one of Chromebrew's more used applications, and historically it's only been available to x86 and x86_64 users. Now, if we compile it from the source, it will be available to users on arm32. I only have an x86_64 computer, so when I finish building the `firefox.rb` file, I'd like some help testing the build on non-x86 hardware.
Other changes:
- Add cbindgen package
- Upgrade NSS package
- Patch animated PNG support into libpng