### PR TITLE
Fix dep inside crew_launcher

### DIFF
--- a/packages/crew_launcher.rb
+++ b/packages/crew_launcher.rb
@@ -9,7 +9,7 @@ class Crew_launcher < Package
   source_url 'https://github.com/chromebrew/crew-launcher.git'
   git_hashtag '1.1'
   
-  depends_on 'libomp'
+  depends_on 'llvm'
   depends_on 'graphicsmagick'
 
   def self.install


### PR DESCRIPTION
Crew Launcher has a broken dependency. This fixes it.

![image](https://user-images.githubusercontent.com/1096701/136832392-f3cbc63d-443f-4f56-9a2d-fe3f11b8b507.png)
