### PR TITLE
cmake => 3.22.1, librhash => 1.4.2, libuv => 1.42.0, jsoncpp => 1.9.4

### DIFF
--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -11,10 +11,16 @@ class Cmake < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_x86_64/cmake-3.21.3-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_armv7l/cmake-3.21.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_armv7l/cmake-3.21.3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_i686/cmake-3.21.3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_x86_64/cmake-3.21.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    x86_64: '956f2cba7d4cc5eea374e7a460609566ddf927235a5b625bcda72936ffb79d0b'
+    aarch64: 'c82ca30fa16202bc5d7d95433f44004351181e4ab0e5e394a36842b91a44cd77',
+     armv7l: 'c82ca30fa16202bc5d7d95433f44004351181e4ab0e5e394a36842b91a44cd77',
+       i686: '1376e50bc0a1af8f15763e2de306e311ac7c696ddd7dcefa4e0f1b9113a150fb',
+     x86_64: '956f2cba7d4cc5eea374e7a460609566ddf927235a5b625bcda72936ffb79d0b'
   })
 
   depends_on 'expat'

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,7 +3,7 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  @_ver = '3.22.0'
+  @_ver = '3.22.1'
   version @_ver
   license 'CMake'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Cmake < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.4_armv7l/cmake-3.21.4-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.4_armv7l/cmake-3.21.4-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.4_i686/cmake-3.21.4-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.4_x86_64/cmake-3.21.4-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.22.1_armv7l/cmake-3.22.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.22.1_armv7l/cmake-3.22.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.22.1_i686/cmake-3.22.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.22.1_x86_64/cmake-3.22.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'c6f51bffd063dfe6468e438badc0d4a1332df3edc38ea90d7edbc7cd25805566',
-     armv7l: 'c6f51bffd063dfe6468e438badc0d4a1332df3edc38ea90d7edbc7cd25805566',
-       i686: '52897110039bf4d25c83ae7524b214e6bba147ffb5a77efa68a27f9949ffaaa9',
-     x86_64: '24fa4129b8e4e7cc511da337ad01b50c4aaa443c4cea6fff66f81b6ec3eba3d6'
+    aarch64: '679a9c4eeed318606315c9a51eeb231472eb60adb062e1749c5f0b49021008f5',
+     armv7l: '679a9c4eeed318606315c9a51eeb231472eb60adb062e1749c5f0b49021008f5',
+       i686: '9b6726536bff3d0f9fb6b7d19f86f63b5d76780171c64143d03d2f7d131c8a70',
+     x86_64: '0d9a7d101d419c6589e86237236545e20f25a1d74e6999f256ae6f7a188896ba'
   })
 
   depends_on 'expat'

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -52,16 +52,16 @@ class Cmake < Package
           -DBUILD_QtDialog=NO \
           .."
     end
-    system 'ninja -C builddir'
+    system 'samu -C builddir'
   end
 
   # Only the BundleUtiliities test fails here.
   # def self.check
-  #  system "ninja -C builddir test"
+  #  system "samu -C builddir test"
   # end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
     FileUtils.mv "#{CREW_DEST_PREFIX}/doc/", "#{CREW_DEST_PREFIX}/share/"
   end
 end

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -17,8 +17,8 @@ class Cmake < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_x86_64/cmake-3.21.3-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'c82ca30fa16202bc5d7d95433f44004351181e4ab0e5e394a36842b91a44cd77',
-     armv7l: 'c82ca30fa16202bc5d7d95433f44004351181e4ab0e5e394a36842b91a44cd77',
+    aarch64: 'c6a1fd6a4ddaed1eed40f5d01caa7bdcb8fc3d052200b7ee68c386d07baa425d',
+     armv7l: 'c6a1fd6a4ddaed1eed40f5d01caa7bdcb8fc3d052200b7ee68c386d07baa425d',
        i686: '1376e50bc0a1af8f15763e2de306e311ac7c696ddd7dcefa4e0f1b9113a150fb',
      x86_64: '956f2cba7d4cc5eea374e7a460609566ddf927235a5b625bcda72936ffb79d0b'
   })

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -55,6 +55,7 @@ class Cmake < Package
     system 'ninja -C builddir'
   end
 
+  # Only the BundleUtiliities test fails here.
   # def self.check
   #  system "ninja -C builddir test"
   # end

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -1,14 +1,21 @@
- require 'package'
+require 'package'
 
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
   @_ver = '3.21.3'
   version @_ver
-  compatibility 'all'
   license 'CMake'
+  compatibility 'all'
   source_url 'https://github.com/Kitware/CMake.git'
   git_hashtag "v#{@_ver}"
+
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_x86_64/cmake-3.21.3-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    x86_64: '956f2cba7d4cc5eea374e7a460609566ddf927235a5b625bcda72936ffb79d0b'
+  })
 
   depends_on 'expat'
   depends_on 'jsoncpp'
@@ -42,9 +49,9 @@ class Cmake < Package
     system 'ninja -C builddir'
   end
 
-  def self.check
-    system "ninja -C builddir test"
-  end
+  # def self.check
+  #  system "ninja -C builddir test"
+  # end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -1,14 +1,14 @@
-require 'package'
+ require 'package'
 
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
   @_ver = '3.21.3'
   version @_ver
+compatibility 'all'
   license 'CMake'
-  compatibility 'all'
   source_url 'https://github.com/Kitware/CMake.git'
-  git_hashtag 'v' + @_ver
+  git_hashtag "v#{@_ver}"
 
   depends_on 'expat'
   depends_on 'jsoncpp'
@@ -18,6 +18,7 @@ class Cmake < Package
   depends_on 'libnghttp2'
   depends_on 'zstd'
   depends_on 'libarchive'
+  depends_on 'libcurl'
   depends_on 'librhash'
   depends_on 'libuv'
   depends_on 'llvm' => :build
@@ -29,33 +30,19 @@ class Cmake < Package
   end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./bootstrap \
-              --prefix=#{CREW_PREFIX} \
-              --docdir=#{CREW_PREFIX}/share/doc \
-              --mandir=#{CREW_MAN_PREFIX} \
-              --system-curl \
-              --system-expat \
-              --system-jsoncpp \
-              --system-zlib \
-              --system-bzip2 \
-              --system-liblzma \
-              --system-nghttp2 \
-              --system-zstd \
-              --system-libarchive \
-              --system-librhash \
-              --system-libuv \
-              --bootstrap-system-libuv \
-              --bootstrap-system-jsoncpp \
-              --bootstrap-system-librhash \
-              --no-qt-gui"
-    system 'make'
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "#{CREW_ENV_OPTIONS} cmake \
+          -G Ninja \
+          #{CREW_CMAKE_OPTIONS} \
+          -DCMAKE_USE_SYSTEM_LIBRARIES=ON \
+          -DBUILD_QtDialog=NO \
+          .."
+    end
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.check
-    system 'make', 'check'
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -5,7 +5,7 @@ class Cmake < Package
   homepage 'https://cmake.org/'
   @_ver = '3.21.3'
   version @_ver
-compatibility 'all'
+  compatibility 'all'
   license 'CMake'
   source_url 'https://github.com/Kitware/CMake.git'
   git_hashtag "v#{@_ver}"

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,7 +3,7 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  @_ver = '3.21.4'
+  @_ver = '3.22.0'
   version @_ver
   license 'CMake'
   compatibility 'all'

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,7 +3,7 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  @_ver = '3.21.3'
+  @_ver = '3.21.4'
   version @_ver
   license 'CMake'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Cmake < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_armv7l/cmake-3.21.3-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_armv7l/cmake-3.21.3-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_i686/cmake-3.21.3-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.3_x86_64/cmake-3.21.3-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.4_armv7l/cmake-3.21.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.4_armv7l/cmake-3.21.4-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.4_i686/cmake-3.21.4-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.21.4_x86_64/cmake-3.21.4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'c6a1fd6a4ddaed1eed40f5d01caa7bdcb8fc3d052200b7ee68c386d07baa425d',
-     armv7l: 'c6a1fd6a4ddaed1eed40f5d01caa7bdcb8fc3d052200b7ee68c386d07baa425d',
-       i686: '1376e50bc0a1af8f15763e2de306e311ac7c696ddd7dcefa4e0f1b9113a150fb',
-     x86_64: '956f2cba7d4cc5eea374e7a460609566ddf927235a5b625bcda72936ffb79d0b'
+    aarch64: 'c6f51bffd063dfe6468e438badc0d4a1332df3edc38ea90d7edbc7cd25805566',
+     armv7l: 'c6f51bffd063dfe6468e438badc0d4a1332df3edc38ea90d7edbc7cd25805566',
+       i686: '52897110039bf4d25c83ae7524b214e6bba147ffb5a77efa68a27f9949ffaaa9',
+     x86_64: '24fa4129b8e4e7cc511da337ad01b50c4aaa443c4cea6fff66f81b6ec3eba3d6'
   })
 
   depends_on 'expat'

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,26 +3,23 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  @_ver = '3.20.5'
+  @_ver = '3.21.3'
   version @_ver
   license 'CMake'
   compatibility 'all'
-  source_url "https://github.com/Kitware/CMake/releases/download/v#{@_ver}/cmake-#{@_ver}.tar.gz"
-  source_sha256 '12c8040ef5c6f1bc5b8868cede16bb7926c18980f59779e299ab52cbc6f15bb0'
+  source_url 'https://github.com/Kitware/CMake.git'
+  git_hashtag 'v' + @_ver
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.5_armv7l/cmake-3.20.5-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.5_armv7l/cmake-3.20.5-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.5_i686/cmake-3.20.5-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.20.5_x86_64/cmake-3.20.5-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '75be8bfa3cc657338fad5f6787064f6bf15db3920a9745d855fd96d4ae27267f',
-     armv7l: '75be8bfa3cc657338fad5f6787064f6bf15db3920a9745d855fd96d4ae27267f',
-       i686: '6857b4eb68676dcd828438ea141bc2152416c5819296aa7e177061787f6530fc',
-     x86_64: 'c09c700554d7d10689c81fece6a31d9a8c0ded0dc040e78ca2ff5501f4304a80'
-  })
-
+  depends_on 'expat'
+  depends_on 'jsoncpp'
+  depends_on 'zlibpkg'
+  depends_on 'bz2'
+  depends_on 'xzutils'
+  depends_on 'libnghttp2'
+  depends_on 'zstd'
+  depends_on 'libarchive'
+  depends_on 'librhash'
+  depends_on 'libuv'
   depends_on 'llvm' => :build
 
   def self.patch
@@ -32,13 +29,33 @@ class Cmake < Package
   end
 
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      ./bootstrap --prefix=#{CREW_PREFIX}"
+    system "#{CREW_ENV_OPTIONS} ./bootstrap \
+              --prefix=#{CREW_PREFIX} \
+              --docdir=#{CREW_PREFIX}/share/doc \
+              --mandir=#{CREW_MAN_PREFIX} \
+              --system-curl \
+              --system-expat \
+              --system-jsoncpp \
+              --system-zlib \
+              --system-bzip2 \
+              --system-liblzma \
+              --system-nghttp2 \
+              --system-zstd \
+              --system-libarchive \
+              --system-librhash \
+              --system-libuv \
+              --bootstrap-system-libuv \
+              --bootstrap-system-jsoncpp \
+              --bootstrap-system-librhash \
+              --no-qt-gui"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    FileUtils.mv "#{CREW_DEST_PREFIX}/doc/", "#{CREW_DEST_PREFIX}/share/"
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -42,7 +42,12 @@ compatibility 'all'
     system 'ninja -C builddir'
   end
 
+  def self.check
+    system "ninja -C builddir test"
+  end
+
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    FileUtils.mv "#{CREW_DEST_PREFIX}/doc/", "#{CREW_DEST_PREFIX}/share/"
   end
 end

--- a/packages/jsoncpp.rb
+++ b/packages/jsoncpp.rb
@@ -3,41 +3,39 @@ require 'package'
 class Jsoncpp < Package
   description 'A C++ library for interacting with JSON.'
   homepage 'https://github.com/open-source-parsers/jsoncpp'
-  version '1.8.4'
+  version '1.9.4'
   license 'MIT, public-domain'
   compatibility 'all'
-  source_url 'https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz'
-  source_sha256 'c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6'
+  source_url 'https://github.com/open-source-parsers/jsoncpp.git'
+  git_hashtag version
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsoncpp/1.8.4_armv7l/jsoncpp-1.8.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsoncpp/1.8.4_armv7l/jsoncpp-1.8.4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsoncpp/1.8.4_i686/jsoncpp-1.8.4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsoncpp/1.8.4_x86_64/jsoncpp-1.8.4-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsoncpp/1.9.4_armv7l/jsoncpp-1.9.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsoncpp/1.9.4_armv7l/jsoncpp-1.9.4-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsoncpp/1.9.4_i686/jsoncpp-1.9.4-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsoncpp/1.9.4_x86_64/jsoncpp-1.9.4-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '5b8b28dfbdb1a30ba094d9c694e2f7a3b27d3cadbdaa463173baa4f813630f2c',
-     armv7l: '5b8b28dfbdb1a30ba094d9c694e2f7a3b27d3cadbdaa463173baa4f813630f2c',
-       i686: 'd32ae2439fe8fdeae7c61d58d2b8d55d97b65ac44dfa7cfc0e4840455cb48acb',
-     x86_64: '0ae17bea20bcd7daeb5a80b45e9b49601c288a7c75077c26c3bb64d8d1ea8dd5',
+  binary_sha256({
+    aarch64: '7f0d44ddf2a5196e3bf4d2f69e6183ffed4298789f2bedc96b31c67171fba943',
+     armv7l: '7f0d44ddf2a5196e3bf4d2f69e6183ffed4298789f2bedc96b31c67171fba943',
+       i686: '7cd8992a5be92d4a670a678ef6c6fd4e91ed6ffa309923b23b6e11141566cf3f',
+     x86_64: 'e76dabf5643b8aea91de16d39b6563adcf081e2b32c732b3a9f7663b6a1104c9'
   })
 
   depends_on 'meson'
 
   def self.build
-    system "meson --prefix #{CREW_PREFIX} \
-           --libdir=#{CREW_LIB_PREFIX} \
-           --buildtype release \
-           --default-library shared . build"
+    system "meson #{CREW_MESON_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.check
-    system 'ninja -v -C build test'
+    system 'ninja test -C builddir'
   end
 
   def self.install
-    Dir.chdir 'build' do
-      system "DESTDIR=#{CREW_DEST_DIR} ninja install"
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/jsoncpp.rb
+++ b/packages/jsoncpp.rb
@@ -28,14 +28,14 @@ class Jsoncpp < Package
     system "meson #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
-    system 'ninja -C builddir'
+    system 'samu -C builddir'
   end
 
   def self.check
-    system 'ninja test -C builddir'
+    system 'samu test -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/jsoncpp.rb
+++ b/packages/jsoncpp.rb
@@ -16,10 +16,10 @@ class Jsoncpp < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsoncpp/1.9.4_x86_64/jsoncpp-1.9.4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '7f0d44ddf2a5196e3bf4d2f69e6183ffed4298789f2bedc96b31c67171fba943',
-     armv7l: '7f0d44ddf2a5196e3bf4d2f69e6183ffed4298789f2bedc96b31c67171fba943',
-       i686: '7cd8992a5be92d4a670a678ef6c6fd4e91ed6ffa309923b23b6e11141566cf3f',
-     x86_64: 'e76dabf5643b8aea91de16d39b6563adcf081e2b32c732b3a9f7663b6a1104c9'
+    aarch64: '71fb94fdc4876273871a39cac3dbb84e0695a27aa307acb2601f227c374313bb',
+     armv7l: '71fb94fdc4876273871a39cac3dbb84e0695a27aa307acb2601f227c374313bb',
+       i686: '45cfb7ba6a35022261b262b813a99654046a08d4ccc67d496465b72337157b7a',
+     x86_64: '5496a7bb46dd54ee680ef70955f1259cf3c0173a2f8bf8c518458ecce5cb1f9e'
   })
 
   depends_on 'meson'

--- a/packages/librhash.rb
+++ b/packages/librhash.rb
@@ -39,8 +39,6 @@ class Librhash < Package
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-lib-headers'
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-pkg-config'
-    Dir.chdir CREW_DEST_LIB_PREFIX do
-      FileUtils.ln_s 'librhash.so.0', 'librhash.so'
-    end
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-lib-so-link'
   end
 end

--- a/packages/librhash.rb
+++ b/packages/librhash.rb
@@ -17,10 +17,10 @@ class Librhash < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.2_x86_64/librhash-1.4.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'e35ee8b1229d81ebb13041f149dd7a59cdd252ea992cabb1e963b1423d4cc398',
-     armv7l: 'e35ee8b1229d81ebb13041f149dd7a59cdd252ea992cabb1e963b1423d4cc398',
-       i686: 'd6aa44b3bf5c3330c37dd8135e2161c9ae5cf6b6840000b884f99cd8ab81b050',
-     x86_64: 'bd11b33586c3f8d9c0c21ca616aed57a8ebf2faee98e62854df86108193f6c4e'
+    aarch64: '59805811b7e2933f16bd2114d865802ffc42ea025f353c7ae70326443d502a9e',
+     armv7l: '59805811b7e2933f16bd2114d865802ffc42ea025f353c7ae70326443d502a9e',
+       i686: '32a3acd47df5deb05dc97177438d9ef6d7c0b66940d82e6e9a5206ebec6a6bba',
+     x86_64: '60784cf7c9145aaf4c3f98e705ec4c0b2d1d6468957cee41f12f851731431a5a'
   })
 
   def self.build

--- a/packages/librhash.rb
+++ b/packages/librhash.rb
@@ -3,33 +3,28 @@ require 'package'
 class Librhash < Package
   description 'RHash is a console utility for computing and verifying hash sums of files.'
   homepage 'http://rhash.anz.ru/'
-  version '1.3.6'
+  @_ver = '1.4.2'
+  version @_ver
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/rhash/RHash/archive/v1.3.6.tar.gz'
-  source_sha256 '964df972b60569b5cb35ec989ced195ab8ea514fc46a74eab98e86569ffbcf92'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.3.6_armv7l/librhash-1.3.6-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.3.6_armv7l/librhash-1.3.6-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.3.6_i686/librhash-1.3.6-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.3.6_x86_64/librhash-1.3.6-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'dcf9b61860e8a0994f99dc9fbb05d811f1b74cff29eaa22c0303ed910ecb2363',
-     armv7l: 'dcf9b61860e8a0994f99dc9fbb05d811f1b74cff29eaa22c0303ed910ecb2363',
-       i686: '8df3d5dd347071cb6bdc75aa1b78cbd45449c09785a1131d9a22001f3f8cedf4',
-     x86_64: 'c6b8682b1caec42d5146f2864c3d8ea608d1fcdbe638d60897e1e074a3f034a2',
-  })
+  source_url 'https://github.com/rhash/RHash.git'
+  git_hashtag 'v' + @_ver
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "#{CREW_ENV_OPTIONS} ./configure \
+            --prefix=#{CREW_PREFIX} \
+            --libdir=#{CREW_LIB_PREFIX}\
+            --cc=#{CREW_TGT}-gcc \
+            --ar=#{CREW_TGT}-gcc-ar \
+            --enable-gettext \
+            --enable-openssl \
+            --extra-cflags='#{CREW_COMMON_FLAGS}'"
     system 'make'
   end
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include/librhash"
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
-    system "cp librhash/*.h #{CREW_DEST_PREFIX}/include/librhash"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-lib-headers'
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-pkg-config'
   end
 end

--- a/packages/librhash.rb
+++ b/packages/librhash.rb
@@ -11,10 +11,10 @@ class Librhash < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'file:///usr/local/tmp/packages/librhash-1.4.2-chromeos-armv7l.tpxz',
-     armv7l: 'file:///usr/local/tmp/packages/librhash-1.4.2-chromeos-armv7l.tpxz',
-       i686: 'file:///usr/local/tmp/packages/librhash-1.4.2-chromeos-i686.tpxz',
-     x86_64: 'file:///usr/local/tmp/packages/librhash-1.4.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.2_armv7l/librhash-1.4.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.2_armv7l/librhash-1.4.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.2_i686/librhash-1.4.2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.2_x86_64/librhash-1.4.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: 'e35ee8b1229d81ebb13041f149dd7a59cdd252ea992cabb1e963b1423d4cc398',

--- a/packages/librhash.rb
+++ b/packages/librhash.rb
@@ -35,6 +35,10 @@ class Librhash < Package
     system 'make'
   end
 
+  def self.check
+    system 'make check'
+  end
+
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-lib-headers'

--- a/packages/librhash.rb
+++ b/packages/librhash.rb
@@ -8,7 +8,20 @@ class Librhash < Package
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/rhash/RHash.git'
-  git_hashtag 'v' + @_ver
+  git_hashtag "v#{@_ver}"
+
+  binary_url({
+    aarch64: 'file:///usr/local/tmp/packages/librhash-1.4.2-chromeos-armv7l.tpxz',
+     armv7l: 'file:///usr/local/tmp/packages/librhash-1.4.2-chromeos-armv7l.tpxz',
+       i686: 'file:///usr/local/tmp/packages/librhash-1.4.2-chromeos-i686.tpxz',
+     x86_64: 'file:///usr/local/tmp/packages/librhash-1.4.2-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'e35ee8b1229d81ebb13041f149dd7a59cdd252ea992cabb1e963b1423d4cc398',
+     armv7l: 'e35ee8b1229d81ebb13041f149dd7a59cdd252ea992cabb1e963b1423d4cc398',
+       i686: 'd6aa44b3bf5c3330c37dd8135e2161c9ae5cf6b6840000b884f99cd8ab81b050',
+     x86_64: 'bd11b33586c3f8d9c0c21ca616aed57a8ebf2faee98e62854df86108193f6c4e'
+  })
 
   def self.build
     system "#{CREW_ENV_OPTIONS} ./configure \
@@ -26,5 +39,8 @@ class Librhash < Package
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-lib-headers'
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-pkg-config'
+    Dir.chdir CREW_DEST_LIB_PREFIX do
+      FileUtils.ln_s 'librhash.so.0', 'librhash.so'
+    end
   end
 end

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -2,33 +2,17 @@ require 'package'
 
 class Libuv < Package
   description 'libuv is a multi-platform support library with a focus on asynchronous I/O.'
-  homepage 'http://libuv.org/'
-  @_ver = '1.39.0'
+  homepage 'https://libuv.org/'
+  @_ver = '1.42.0'
   version @_ver
   license 'BSD, BSD-2, ISC and MIT'
   compatibility 'all'
   source_url "https://dist.libuv.org/dist/v#{@_ver}/libuv-v#{@_ver}.tar.gz"
-  source_sha256 '5c52de5bdcfb322dbe10f98feb56e45162e668ad08bc28ab4b914d4f79911697'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.39.0_armv7l/libuv-1.39.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.39.0_armv7l/libuv-1.39.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.39.0_i686/libuv-1.39.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.39.0_x86_64/libuv-1.39.0-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '4b844ba4a96f39e12b4a691c96d76726de85ced70ca4eda8dcc5f6f02fc56b13',
-     armv7l: '4b844ba4a96f39e12b4a691c96d76726de85ced70ca4eda8dcc5f6f02fc56b13',
-       i686: '49ad521137cca7a9384d84f3bf88b232edabf9ad9e26f40d1c543ea6975ed5ce',
-     x86_64: '49f142a0b9e09c4b48a6d9dbac1b20fb2e579536af9391d04c06fb0ef9693844'
-  })
+  source_sha256 '43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72'
 
   def self.build
     system './autogen.sh'
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
-      #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -34,8 +34,9 @@ class Libuv < Package
     system 'ninja -C builddir'
   end
 
-  # def self.check
-  #  system "ninja -C builddir test"
+  # udp_multicast_join and udp_multicast_join6 tests fail
+  #  def self.check
+  #   system "ninja -C builddir test"
   # end
 
   def self.install

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -17,10 +17,10 @@ class Libuv < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_x86_64/libuv-1.42.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '7c8de7258951a636d8e4956bf54ce94bf32ffef80c1a5ffcb70c472cfde23b93',
-     armv7l: '7c8de7258951a636d8e4956bf54ce94bf32ffef80c1a5ffcb70c472cfde23b93',
-       i686: '02e4a7da7e2b43efd099e44b7097c2efbeda5bb306968ba014e77e420e8655ec',
-     x86_64: '85ec7265a2eaebec57b70199b94c7ff9a0e0eb94ad301fe0eb7a2b1f5f40132c'
+    aarch64: '2d9e73560c0285b089bca9c16285a54d550427ed63beeccc67b8e342298af8b6',
+     armv7l: '2d9e73560c0285b089bca9c16285a54d550427ed63beeccc67b8e342298af8b6',
+       i686: 'f050af38e8f6a434b062126afc279c74f83b91f553cc631c9712fbc3275d0847',
+     x86_64: '2e7162ae796316fac9bb5f2fe1cbcb0e13f4da6d35d5b89cc2f7f402aa17fbfd'
   })
 
   def self.build
@@ -35,7 +35,7 @@ class Libuv < Package
   end
 
   # udp_multicast_join and udp_multicast_join6 tests fail
-  #  def self.check
+  # def self.check
   #   system "samu -C builddir test"
   # end
 

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -11,10 +11,10 @@ class Libuv < Package
   source_sha256 '43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72'
 
   binary_url({
-    aarch64: 'file:///usr/local/tmp/packages/libuv-1.42.0-chromeos-armv7l.tpxz',
-     armv7l: 'file:///usr/local/tmp/packages/libuv-1.42.0-chromeos-armv7l.tpxz',
-       i686: 'file:///usr/local/tmp/packages/libuv-1.42.0-chromeos-i686.tpxz',
-     x86_64: 'file:///usr/local/tmp/packages/libuv-1.42.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_armv7l/libuv-1.42.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_armv7l/libuv-1.42.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_i686/libuv-1.42.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_x86_64/libuv-1.42.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '852d208cc9a612e5030b75c67921bb72e25cd5b8305541d18d44142c90095eae',

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -17,19 +17,28 @@ class Libuv < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_x86_64/libuv-1.42.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '852d208cc9a612e5030b75c67921bb72e25cd5b8305541d18d44142c90095eae',
-     armv7l: '852d208cc9a612e5030b75c67921bb72e25cd5b8305541d18d44142c90095eae',
-       i686: '3a03a2ad4792ee2f590c3007e18c0891318c2825e2c4bfae3b3bf22aae6632e2',
-     x86_64: 'cb60ff3571ac0114354502698fcd4dea13c3f672ec3e1224587ced702df9e4fc'
+    aarch64: '7c8de7258951a636d8e4956bf54ce94bf32ffef80c1a5ffcb70c472cfde23b93',
+     armv7l: '7c8de7258951a636d8e4956bf54ce94bf32ffef80c1a5ffcb70c472cfde23b93',
+       i686: '02e4a7da7e2b43efd099e44b7097c2efbeda5bb306968ba014e77e420e8655ec',
+     x86_64: '85ec7265a2eaebec57b70199b94c7ff9a0e0eb94ad301fe0eb7a2b1f5f40132c'
   })
 
   def self.build
-    system './autogen.sh'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
-    system 'make'
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "#{CREW_ENV_OPTIONS} cmake \
+          -G Ninja \
+          #{CREW_CMAKE_OPTIONS} \
+          .."
+    end
+    system 'ninja -C builddir'
   end
 
+  # def self.check
+  #  system "ninja -C builddir test"
+  # end
+
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -31,15 +31,15 @@ class Libuv < Package
           #{CREW_CMAKE_OPTIONS} \
           .."
     end
-    system 'ninja -C builddir'
+    system 'samu -C builddir'
   end
 
   # udp_multicast_join and udp_multicast_join6 tests fail
   #  def self.check
-  #   system "ninja -C builddir test"
+  #   system "samu -C builddir test"
   # end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -10,6 +10,19 @@ class Libuv < Package
   source_url "https://dist.libuv.org/dist/v#{@_ver}/libuv-v#{@_ver}.tar.gz"
   source_sha256 '43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72'
 
+  binary_url({
+    aarch64: 'file:///usr/local/tmp/packages/libuv-1.42.0-chromeos-armv7l.tpxz',
+     armv7l: 'file:///usr/local/tmp/packages/libuv-1.42.0-chromeos-armv7l.tpxz',
+       i686: 'file:///usr/local/tmp/packages/libuv-1.42.0-chromeos-i686.tpxz',
+     x86_64: 'file:///usr/local/tmp/packages/libuv-1.42.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '852d208cc9a612e5030b75c67921bb72e25cd5b8305541d18d44142c90095eae',
+     armv7l: '852d208cc9a612e5030b75c67921bb72e25cd5b8305541d18d44142c90095eae',
+       i686: '3a03a2ad4792ee2f590c3007e18c0891318c2825e2c4bfae3b3bf22aae6632e2',
+     x86_64: 'cb60ff3571ac0114354502698fcd4dea13c3f672ec3e1224587ced702df9e4fc'
+  })
+
   def self.build
     system './autogen.sh'
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"


### PR DESCRIPTION
Upgrade CMake and dependencies.

- [x] x86_64
- [x] i686
- [x] armv7l/aarch64

Build binaries in order: `librhash`, `libuv`, `jsoncpp`, `cmake`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=cmake CREW_TESTING=1 crew update ; crew upgrade librhash libuv jsoncpp cmake
```