### PR TITLE
Switch upx to just use lzma to speed up builds

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1028,7 +1028,7 @@ def shrink_dir(dir)
             pool.post do
               begin
                 puts "Attempting to compress #{execfile.chomp} ...".lightblue
-                system "upx --best -k --overlay=skip #{execfile}"
+                system "upx --lzma -k --overlay=skip #{execfile}"
                 system "upx -t #{execfile}" and FileUtils.rm "#{execfile}.~"
               rescue
                 FileUtils.mv "#{execfile}.~", execfile

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.17.4'
+CREW_VERSION = '1.17.5'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- upx is very slow testing all compression formats, but lzma tends to be give some of the best compression anyway, so just stick to that, which should speed up builds with large executable binaries.

Works properly:
- [x] x86_64
