### PR TITLE
Add testing instructions to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Works properly:
 
 ## Run the following to get this pull request's changes locally for testing.
 ```
-CREW_TESTING_REPO=https://github.com/<Please_enter_your_repo>/chromebrew.git CREW_TESTING_BRANCH=<Please_enter_the_branch_name_for_this_PR> CREW_TESTING=1 crew update
+CREW_TESTING_REPO=https://github.com/<Please_enter_the_name_of_your_repo>/chromebrew.git CREW_TESTING_BRANCH=<Please_enter_the_branch_name_for_this_PR> CREW_TESTING=1 crew update
 ```
 ---
 


### PR DESCRIPTION
- I think this should work?  It would be nice to have the repo and branch name for a PR automatically added, but unfortunately that doesn't seem to be possible at the moment.