### PR TITLE
Rescue gcc postinstall in install

### DIFF
--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -21,6 +21,9 @@ class Gcc < Package
   end
 
   def self.postinstall
-    puts "Current GCC version: #{@gcc_ver.chomp}.x".lightblue
+    begin
+      puts "Current GCC version: #{@gcc_ver.chomp}.x".lightblue
+    rescue
+    end
   end
 end


### PR DESCRIPTION
Fixes #6326

- I think this addresses the issue.
- There is no need to bump version as the issue is only during install.

Works properly:
- [x] x86_64
