### PR TITLE
webkit2gtk -> 2.32.4

### DIFF
--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -11,10 +11,14 @@ class Webkit2gtk_4 < Package
   source_sha256 '00ce2d3f798d7bc5e9039d9059f0c3c974d51de38c8b716f00e94452a177d3fd'
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.4_x86_64/webkit2gtk_4-2.32.4-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.4_armv7l/webkit2gtk_4-2.32.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.4_armv7l/webkit2gtk_4-2.32.4-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.4_x86_64/webkit2gtk_4-2.32.4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    x86_64: '36c5c54bc95ede8c00fb0b35361c4c20213ab6129a2712c10f91ff9c08128942'
+    aarch64: 'd25a0be821cbf2c710539e685268d47bdcde109ed5a18b2202c132b31b341219',
+     armv7l: 'd25a0be821cbf2c710539e685268d47bdcde109ed5a18b2202c132b31b341219',
+     x86_64: '36c5c54bc95ede8c00fb0b35361c4c20213ab6129a2712c10f91ff9c08128942'
   })
 
   depends_on 'atk'

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -123,10 +123,10 @@ class Webkit2gtk_4 < Package
         .."
       end
     end
-    system 'ninja -C builddir4'
+    system 'samu -C builddir4'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir4 install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir4 install"
   end
 end

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -3,24 +3,18 @@ require 'package'
 class Webkit2gtk_4 < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'
-  @_ver = '2.32.1'
-  version "#{@_ver}-1"
+  @_ver = '2.32.4'
+  version @_ver
   license 'LGPL-2+ and BSD-2'
   compatibility 'all'
   source_url "https://webkitgtk.org/releases/webkitgtk-#{@_ver}.tar.xz"
-  source_sha256 '136117317f70f66486f71b8edf5e46f8776403c5d8a296e914b11a36ef836917'
+  source_sha256 '00ce2d3f798d7bc5e9039d9059f0c3c974d51de38c8b716f00e94452a177d3fd'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.1-1_armv7l/webkit2gtk_4-2.32.1-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.1-1_armv7l/webkit2gtk_4-2.32.1-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.1-1_i686/webkit2gtk_4-2.32.1-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.1-1_x86_64/webkit2gtk_4-2.32.1-1-chromeos-x86_64.tpxz'
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.32.4_x86_64/webkit2gtk_4-2.32.4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '64e118160d7101af91e8ffd1505d7eaf2b03a32f6a6bede1f16402d9e40e265b',
-     armv7l: '64e118160d7101af91e8ffd1505d7eaf2b03a32f6a6bede1f16402d9e40e265b',
-       i686: 'cfa921effe347074bb318eaf9cc00e2940262e2c6da452a799cf54ef9c41f12c',
-     x86_64: '45c58419c27cfa20d74f025cf6778acb79a31d7f0a7de0cf2d403f9afbd2ac9a'
+    x86_64: '36c5c54bc95ede8c00fb0b35361c4c20213ab6129a2712c10f91ff9c08128942'
   })
 
   depends_on 'atk'
@@ -77,7 +71,7 @@ class Webkit2gtk_4 < Package
       # bwrap: Can't make symlink at /var/run: File exists
       case ARCH
       when 'x86_64'
-        system "CC=clang CXX=clang++ LD=lld NM=llvm-nm cmake \
+        system "#{CREW_ENV_OPTIONS} cmake \
           -G Ninja \
           #{CREW_CMAKE_OPTIONS.gsub('-flto', '').gsub('-ffat-lto-objects', '')} \
           -DLTO_MODE=thin \

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -89,7 +89,7 @@ class Webkit2gtk_5 < Package
         -DPYTHON_EXECUTABLE=`which python` \
         .."
     end
-    system 'ninja -C builddir5'
+    system 'samu -C builddir5'
   end
 
   def self.install
@@ -98,6 +98,6 @@ class Webkit2gtk_5 < Package
     $VERBOSE = nil
     load "#{CREW_LIB_PATH}lib/const.rb"
     $VERBOSE = warn_level
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir5 install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir5 install"
   end
 end

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -70,7 +70,7 @@ class Webkit2gtk_5 < Package
       # bwrap: Can't make symlink at /var/run: File exists
       system "cmake \
         -G Ninja \
-        #{CREW_CMAKE_OPTIONS.gsub('-flto', '').gsub('-ffat-lto-objects', '')} \
+        #{CREW_CMAKE_OPTIONS.gsub(/-(flto|ffat-lto-objects)/, '')} \
         -DCMAKE_SKIP_RPATH=ON \
         -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
         -DENABLE_GAMEPAD=OFF \

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -11,10 +11,14 @@ class Webkit2gtk_5 < Package
   source_sha256 '00ce2d3f798d7bc5e9039d9059f0c3c974d51de38c8b716f00e94452a177d3fd'
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.4_x86_64/webkit2gtk_5-2.32.4-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.4_armv7l/webkit2gtk_5-2.32.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.4_armv7l/webkit2gtk_5-2.32.4-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.4_x86_64/webkit2gtk_5-2.32.4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    x86_64: 'f33da6311321d201b334f1b720ac0980497c6c57d0c928464f749d5b99cd8699'
+    aarch64: '5a4da2ee8bc5889ccf768da845a33f94bf988e626c3af16a3c30f6dcb3584a85',
+     armv7l: '5a4da2ee8bc5889ccf768da845a33f94bf988e626c3af16a3c30f6dcb3584a85',
+     x86_64: 'f33da6311321d201b334f1b720ac0980497c6c57d0c928464f749d5b99cd8699'
   })
 
   depends_on 'atk'

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -3,26 +3,16 @@ require 'package'
 class Webkit2gtk_5 < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'
-  @_ver = '2.32.1'
+  @_ver = '2.32.4'
   version @_ver
   license 'LGPL-2+ and BSD-2'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url "https://webkitgtk.org/releases/webkitgtk-#{@_ver}.tar.xz"
-  source_sha256 '136117317f70f66486f71b8edf5e46f8776403c5d8a296e914b11a36ef836917'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.1_armv7l/webkit2gtk_5-2.32.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.1_armv7l/webkit2gtk_5-2.32.1-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.1_x86_64/webkit2gtk_5-2.32.1-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '706890a948d02cb2db17d3f1ef0718710c88ba8900a6bc31cb6905498aa85189',
-     armv7l: '706890a948d02cb2db17d3f1ef0718710c88ba8900a6bc31cb6905498aa85189',
-     x86_64: '5dfa210eecb769b0b301474ee2bd819f68eda3fa27e1e372a0cb046718675a90'
-  })
+  source_sha256 '00ce2d3f798d7bc5e9039d9059f0c3c974d51de38c8b716f00e94452a177d3fd'
 
   depends_on 'atk'
   depends_on 'cairo'
+  depends_on 'ccache' => :build
   depends_on 'dav1d'
   depends_on 'enchant'
   depends_on 'fontconfig'
@@ -68,10 +58,10 @@ class Webkit2gtk_5 < Package
       # system "env #{CREW_ENV_OPTIONS} \
       # Bubblewrap sandbox breaks on epiphany with
       # bwrap: Can't make symlink at /var/run: File exists
-      # ccache currently breaks gcc builds of webkit-gtk
       system "cmake \
         -G Ninja \
-        #{CREW_CMAKE_FNO_LTO_OPTIONS} \
+        #{CREW_CMAKE_OPTIONS.gsub('-flto', '').gsub('-ffat-lto-objects', '')} \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_SKIP_RPATH=ON \
         -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
         -DENABLE_GAMEPAD=OFF \

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -10,9 +10,15 @@ class Webkit2gtk_5 < Package
   source_url "https://webkitgtk.org/releases/webkitgtk-#{@_ver}.tar.xz"
   source_sha256 '00ce2d3f798d7bc5e9039d9059f0c3c974d51de38c8b716f00e94452a177d3fd'
 
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_5/2.32.4_x86_64/webkit2gtk_5-2.32.4-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    x86_64: 'f33da6311321d201b334f1b720ac0980497c6c57d0c928464f749d5b99cd8699'
+  })
+
   depends_on 'atk'
   depends_on 'cairo'
-  depends_on 'ccache' => :build
   depends_on 'dav1d'
   depends_on 'enchant'
   depends_on 'fontconfig'
@@ -61,7 +67,6 @@ class Webkit2gtk_5 < Package
       system "cmake \
         -G Ninja \
         #{CREW_CMAKE_OPTIONS.gsub('-flto', '').gsub('-ffat-lto-objects', '')} \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_SKIP_RPATH=ON \
         -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
         -DENABLE_GAMEPAD=OFF \
@@ -84,6 +89,11 @@ class Webkit2gtk_5 < Package
   end
 
   def self.install
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir5 install"
   end
 end


### PR DESCRIPTION
Fixes #6337

Built off of the python 3.10 PR...

**webkit2gtk_4**
Works properly:
- [x] x86_64
- [x] armv7l

**webkit2gtk_5**
Works properly:
- [x] x86_64
- [x] armv7l

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=webkit2gtk_2.32.4 CREW_TESTING=1 crew update
```
---

## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
