### PR TITLE
xorg_server -> 21.1.0 (plus update deps)

### DIFF
--- a/packages/libinput.rb
+++ b/packages/libinput.rb
@@ -3,24 +3,22 @@ require 'package'
 class Libinput < Package
   description 'libinput is a library to handle input devices in Wayland compositors and to provide a generic X.Org input driver.'
   homepage 'https://www.freedesktop.org/wiki/Software/libinput'
-  @_ver = '1.19.0'
+  @_ver = '1.19.2'
   version @_ver
   license 'MIT'
   compatibility 'all'
-  source_url "https://www.freedesktop.org/software/libinput/libinput-#{@_ver}.tar.xz"
-  source_sha256 '3d3a2f12b4a65cd82684121ae4b33cdc3ad541c761a55e8eb73a8e5e443cccbb'
+  source_url 'https://gitlab.freedesktop.org/libinput/libinput.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_armv7l/libinput-1.19.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_armv7l/libinput-1.19.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_i686/libinput-1.19.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.0_x86_64/libinput-1.19.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.2_armv7l/libinput-1.19.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.2_armv7l/libinput-1.19.2-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.19.2_x86_64/libinput-1.19.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '92d7106871145a7b83c4fcf91603563473de4da33c4b3368b4a795a7e51629e1',
-     armv7l: '92d7106871145a7b83c4fcf91603563473de4da33c4b3368b4a795a7e51629e1',
-       i686: 'f33badf3a7bed9a0ba5c343663be77c32d773c943a886d1307a9ec05d58abd80',
-     x86_64: '46bdc13b4d3e214591300759ec62d14d76e20faa9d8f05f887f88e1cd70cac62'
+    aarch64: 'f0bfc3ddddb5d34e874cb9b02bccda660f8600051ffdbdebe60760adfa427f3b',
+     armv7l: 'f0bfc3ddddb5d34e874cb9b02bccda660f8600051ffdbdebe60760adfa427f3b',
+     x86_64: '3d1a343fecb4cedf97f176a3be8ecdb80b8166d45f65fb97142e6fd91f7b3391'
   })
 
   depends_on 'mtdev'

--- a/packages/libxcvt.rb
+++ b/packages/libxcvt.rb
@@ -1,0 +1,35 @@
+# Adapted from Arch Linux libxcvt PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/libxcvt/trunk/PKGBUILD
+
+require 'package'
+
+class Libxcvt < Package
+  description 'library providing a standalone version of the X server implementation of the VESA CVT standard timing modelines generator'
+  homepage 'https://gitlab.freedesktop.org/xorg/lib/libxcvt'
+  version '0.1.1'
+  compatibility 'all'
+  source_url 'https://gitlab.freedesktop.org/xorg/lib/libxcvt.git'
+  git_hashtag "libxcvt-#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxcvt/0.1.1_armv7l/libxcvt-0.1.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxcvt/0.1.1_armv7l/libxcvt-0.1.1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxcvt/0.1.1_x86_64/libxcvt-0.1.1-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '6f230901f2a91504efc7257271c7be5a86a8529da06539c8d7cdf4cd6043a4f9',
+     armv7l: '6f230901f2a91504efc7257271c7be5a86a8529da06539c8d7cdf4cd6043a4f9',
+     x86_64: 'cd3e28274fcc9166d37f26738b9434b86626a48511d9729a7a60ab3ae7d2da6e'
+  })
+
+  def self.build
+    system "meson #{CREW_MESON_OPTIONS} \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/libxdmcp.rb
+++ b/packages/libxdmcp.rb
@@ -3,36 +3,33 @@ require 'package'
 class Libxdmcp < Package
   description 'The libXdmcp package contains a library implementing the X Display Manager Control Protocol.'
   homepage 'http://www.x.org'
-  version '1.1.3-1'
+  @_ver = '1.1.3'
+  version "#{@_ver}-2"
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.x.org/pub/individual/lib/libXdmcp-1.1.3.tar.bz2'
-  source_sha256 '20523b44aaa513e17c009e873ad7bbc301507a3224c232610ce2e099011c6529'
+  source_url 'https://gitlab.freedesktop.org/xorg/lib/libxdmcp.git'
+  git_hashtag "libXdmcp-#{@_ver}"
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-1_armv7l/libxdmcp-1.1.3-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-1_armv7l/libxdmcp-1.1.3-1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-1_i686/libxdmcp-1.1.3-1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-1_x86_64/libxdmcp-1.1.3-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-2_armv7l/libxdmcp-1.1.3-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-2_armv7l/libxdmcp-1.1.3-2-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-2_x86_64/libxdmcp-1.1.3-2-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '8d044dae7bae3290e3189d25216df2dec946bf3214812c3327f44c5d4af908c7',
-      armv7l: '8d044dae7bae3290e3189d25216df2dec946bf3214812c3327f44c5d4af908c7',
-        i686: '0bb28f04ed3c6668febc1f9aad001ff0b39ed1746e0ca808bdfbc795bc36cd83',
-      x86_64: 'e85f069e15080182742ef6a4cc15742c94ea438ccd2ee772feea199a7fad1622',
+  binary_sha256({
+    aarch64: 'a1540e554724bfb3f0eb2525e332c6a5b47d15827596c5d163af7b6efb7c16dd',
+     armv7l: 'a1540e554724bfb3f0eb2525e332c6a5b47d15827596c5d163af7b6efb7c16dd',
+     x86_64: '7567bb45cc60b081c21b72c1526ffb3f9b5bb1016bb3737405bbcd5a4a85a3b7'
   })
 
-  depends_on "xorg_proto"
-  depends_on "llvm" => :build
+  depends_on 'xorg_proto'
 
   def self.build
-    ENV['CXXFLAGS'] = "-fuse-ld=lld"
+    system './autogen.sh'
     system "./configure #{CREW_OPTIONS}"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
-
 end

--- a/packages/xorg_proto.rb
+++ b/packages/xorg_proto.rb
@@ -3,36 +3,31 @@ require 'package'
 class Xorg_proto < Package
   description 'The xorgproto package provides the header files required to build the X Window system, and to allow other applications to build against the installed X Window system.'
   homepage 'https://www.x.org/'
-  version '2020.1-1'
+  version '2021.5'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2020.1.tar.bz2'
-  source_sha256 '54a153f139035a376c075845dd058049177212da94d7a9707cf9468367b699d2'
+  source_url 'https://gitlab.freedesktop.org/xorg/proto/xorgproto.git'
+  git_hashtag "xorgproto-#{version}"
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2020.1-1_armv7l/xorg_proto-2020.1-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2020.1-1_armv7l/xorg_proto-2020.1-1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2020.1-1_i686/xorg_proto-2020.1-1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2020.1-1_x86_64/xorg_proto-2020.1-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2021.5_armv7l/xorg_proto-2021.5-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2021.5_armv7l/xorg_proto-2021.5-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2021.5_x86_64/xorg_proto-2021.5-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '3de61490afe9c9b45ad23abf007109b942e196aed3299f90da7ff6429400b687',
-      armv7l: '3de61490afe9c9b45ad23abf007109b942e196aed3299f90da7ff6429400b687',
-        i686: '521ca4cca07304bf9c18e050a98ad9fde912b1ecc6c5cf13aa223b969c617d09',
-      x86_64: '1ab0f6074972bafa33e78e945958b70c7886c0abff146bc8a020bfc499c7e14f',
+  binary_sha256({
+    aarch64: '1bc453ccee0bc6e0e4709502c09b0e6c86d72c50d9e1b16e00799e7ee7ab2e3d',
+     armv7l: '1bc453ccee0bc6e0e4709502c09b0e6c86d72c50d9e1b16e00799e7ee7ab2e3d',
+     x86_64: '20dd21738b3e2c1521f34a6993071ff797f99d81e4b5c154c560e9cf2f6062a8'
   })
-
-  depends_on 'llvm' => :build
 
   def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} \
-      -Dc_args='-fuse-ld=lld' \
+    system "meson #{CREW_MESON_OPTIONS} \
       builddir"
-    system "meson configure builddir"
-    system "ninja -C builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-   system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -3,24 +3,22 @@ require 'package'
 class Xorg_server < Package
   description 'The Xorg Server is the core of the X Window system.'
   homepage 'https://www.x.org'
-  @_ver = '1.20.11'
+  @_ver = '21.1.0'
   version @_ver
   license 'BSD-3, MIT, BSD-4, MIT-with-advertising, ISC and custom'
   compatibility 'all'
-  source_url "https://gitlab.freedesktop.org/xorg/xserver/-/archive/xorg-server-#{@_ver}/xserver-xorg-server-#{@_ver}.tar.bz2"
-  source_sha256 'c03ef3c2dc44e75bf8caf942135a5aba3638822edb835bd05d2eaf428531a6a2'
+  source_url 'https://gitlab.freedesktop.org/xorg/xserver.git'
+  git_hashtag "xorg-server-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/1.20.11_armv7l/xorg_server-1.20.11-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/1.20.11_armv7l/xorg_server-1.20.11-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/1.20.11_i686/xorg_server-1.20.11-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/1.20.11_x86_64/xorg_server-1.20.11-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.0_armv7l/xorg_server-21.1.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.0_armv7l/xorg_server-21.1.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.0_x86_64/xorg_server-21.1.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '27cb4df4959f2d8e4d379d66daead6fb286bafada5f493d0049fb28227160493',
-     armv7l: '27cb4df4959f2d8e4d379d66daead6fb286bafada5f493d0049fb28227160493',
-       i686: 'f5285506842220eb0690b88a6be7dc921d6be4e51b7db5e25c5d65f75cd1f173',
-     x86_64: '732dd1586499edd926531f56e83f1bf38bdc743203a0041ff2fb1b78e3b2738c'
+    aarch64: 'caf958b2cadb17e6c3f01437bba3549e7c6711afe307c932a69dbbfbf1476c3e',
+     armv7l: 'caf958b2cadb17e6c3f01437bba3549e7c6711afe307c932a69dbbfbf1476c3e',
+     x86_64: '7e2a10031216c8769e637ce8b391ca311d5894d3b538e059a57b7bc3d19bb01f'
   })
 
   depends_on 'libepoxy'
@@ -39,7 +37,7 @@ class Xorg_server < Package
   depends_on 'font_util'
   depends_on 'libbsd'
   depends_on 'dbus'
-  depends_on 'xzutils' => :build
+  depends_on 'lzma' => :build
   depends_on 'xkbcomp'
   depends_on 'glproto'
   depends_on 'xcb_util_renderutil' => :build
@@ -48,6 +46,10 @@ class Xorg_server < Package
   depends_on 'xcb_util_wm' => :build
   depends_on 'xcb_util_xrm' => :build
   depends_on 'xcb_util_cursor' => :build
+  depends_on 'libxcvt'
+  depends_on 'libinput'
+  depends_on 'libxdmcp'
+  depends_on 'xorg_proto'
   depends_on 'mesa'
 
   case ARCH
@@ -61,7 +63,7 @@ class Xorg_server < Package
 
   def self.build
     system 'meson setup build'
-    system "meson configure #{CREW_MESON_OPTIONS} \
+    system "meson configure #{CREW_MESON_OPTIONS.sub("-Dcpp_args='-O2'", '')} \
               -Db_asneeded=false \
               -Dipv6=true \
               -Dxvfb=true \
@@ -69,7 +71,6 @@ class Xorg_server < Package
               -Dxcsecurity=true \
               -Dxorg=true \
               -Dxephyr=true \
-              -Dxwayland=false \
               -Dglamor=true \
               -Dudev=true \
               -Dxwin=false \


### PR DESCRIPTION
- updates xorg_server, libinput, xorg_proto, adds libxcvt, rebuilds libxdmcp
- This removes Xwayland entirely from the xorg build.

Builds properly:
- [x] x86_64
- [x] armv7l
- [ ] i686 (builds please @uberhacker ?)
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=xorg CREW_TESTING=1 crew update
```
