### PR TITLE
ledger => 3.2.1

### DIFF
--- a/packages/ledger.rb
+++ b/packages/ledger.rb
@@ -9,19 +9,6 @@ class Ledger < Package
   source_url 'https://github.com/ledger/ledger/archive/v3.1.3.tar.gz'
   source_sha256 'b248c91d65c7a101b9d6226025f2b4bf3dabe94c0c49ab6d51ce84a22a39622b'
 
-  binary_url ({
-    aarch64: '',
-     armv7l: '',
-       i686: '',
-     x86_64: '',
-  })
-  binary_sha256 ({
-    aarch64: '',
-     armv7l: '',
-       i686: '',
-     x86_64: '',
-  })
-
   depends_on 'boost' => :build
 
   def self.build

--- a/packages/ledger.rb
+++ b/packages/ledger.rb
@@ -3,11 +3,11 @@ require 'package'
 class Ledger < Package
   description 'A double-entry accounting system with a command-line reporting interface'
   homepage 'https://www.ledger-cli.org/'
-  version '3.1.3'
+  version '3.2.1'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://github.com/ledger/ledger/archive/v3.1.3.tar.gz'
-  source_sha256 'b248c91d65c7a101b9d6226025f2b4bf3dabe94c0c49ab6d51ce84a22a39622b'
+  source_url 'https://github.com/ledger/ledger.git'
+  git_hashtag "v#{version}"
 
   depends_on 'boost' => :build
 


### PR DESCRIPTION
**build failed:**
```shell
/usr/local/tmp/crew/ledger.20211105161548.dir/src/format.h:154:35: error: ‘elements’ was not declared in this scope; did you mean ‘element_t’?
  154 |     for (const element_t * elem = elements.get();
      |                                   ^~~~~~~~
      |                                   element_t
/usr/local/tmp/crew/ledger.20211105161548.dir/src/format.
```