### PR TITLE
New packages: zopfli, gif2apng, apng2gif, patch libpng with APNG support

### DIFF
--- a/packages/apng2gif.rb
+++ b/packages/apng2gif.rb
@@ -24,7 +24,10 @@ class Apng2gif < Package
 
   def self.build
     system 'make'
-    system "help2man -s 1 -N -h '' --version-string='#{@_ver}' ./apng2gif -o apng2gif.1"
+    system "help2man -s 1 -N -h '' \
+            -n '#{self.description.downcase.delete! '.'}' \
+            --version-string='#{@_ver}' \
+            ./apng2gif -o apng2gif.1"
   end
 
   def self.install

--- a/packages/apng2gif.rb
+++ b/packages/apng2gif.rb
@@ -10,6 +10,19 @@ class Apng2gif < Package
   source_url "https://sourceforge.net/projects/apng2gif/files/#{@_ver}/apng2gif-#{@_ver}-src.zip"
   source_sha256 '9a07e386017dc696573cd7bc7b46b2575c06da0bc68c3c4f1c24a4b39cdedd4d'
 
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/apng2gif/1.8_armv7l/apng2gif-1.8-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/apng2gif/1.8_armv7l/apng2gif-1.8-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/apng2gif/1.8_i686/apng2gif-1.8-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/apng2gif/1.8_x86_64/apng2gif-1.8-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'f0d57f404b10ce2dc14a3ce61baa7be9d7bbefc8e0bb77e6b943bf7c07191578',
+     armv7l: 'f0d57f404b10ce2dc14a3ce61baa7be9d7bbefc8e0bb77e6b943bf7c07191578',
+       i686: '851c65719e952dc8b00c74457002f0f905f75b6bbc64e18a23e2b25b55e0d881',
+     x86_64: '921598e9de5c2ac2d22de713bdc4bdeb9d2cd436b4e166f69773c561a2ff53da',
+  })
+
   depends_on 'libpng'
   depends_on 'help2man' => :build
 

--- a/packages/apng2gif.rb
+++ b/packages/apng2gif.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Apng2gif < Package
+  description 'Convert APNG animations into animated GIF format.'
+  homepage 'https://sourceforge.net/projects/apng2gif/'
+  @_ver = '1.8'
+  version @_ver
+  license 'ZLIB'
+  compatibility 'all'
+  source_url "https://sourceforge.net/projects/apng2gif/files/#{@_ver}/apng2gif-#{@_ver}-src.zip"
+  source_sha256 '9a07e386017dc696573cd7bc7b46b2575c06da0bc68c3c4f1c24a4b39cdedd4d'
+
+  depends_on 'libpng'
+  depends_on 'help2man' => :build
+
+  def self.patch
+    system "sed -i 's:CC         = gcc:CC         = #{CREW_TGT}-gcc:' Makefile"
+    system "sed -i 's:CFLAGS     = -Wall -pedantic:CFLAGS     = -Wall -pedantic #{CREW_COMMON_FLAGS}:' Makefile"
+    system "sed -i 's:CFLAGS_OPT = -O2:CFLAGS_OPT =:' Makefile"
+    # zlib is unused, remove the header and library link
+    system "sed -i 's:LIBS       = -lstdc++ -lm -lpng -lz:LIBS       = -lstdc++ -lm -lpng:' Makefile"
+    system "sed -i 's:#include \"zlib.h\"::' Makefile"
+  end
+
+  def self.build
+    system 'make'
+    system "help2man -s 1 -N -h '' --version-string='#{@_ver}' ./apng2gif -o apng2gif.1"
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin/"
+    FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man1/"
+    FileUtils.install 'apng2gif', "#{CREW_DEST_PREFIX}/bin/apng2gif", mode: 0755
+    FileUtils.install 'apng2gif.1', "#{CREW_DEST_MAN_PREFIX}/man1/apng2gif.1", mode: 0644
+  end
+end

--- a/packages/gif2apng.rb
+++ b/packages/gif2apng.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Gif2apng < Package
+  description 'Convert GIF animations into APNG format.'
+  homepage 'https://sourceforge.net/projects/gif2apng/'
+  @_ver = '1.9'
+  version @_ver
+  license 'ZLIB LGPL-2.1'
+  compatibility 'all'
+  source_url "https://sourceforge.net/projects/gif2apng/files/#{@_ver}/gif2apng-#{@_ver}-src.zip"
+  source_sha256 '3b21308e935d799b3ffb4a86c6e00ffa4cb9b3f72f52d58d51c66eb0574ae7d2'
+
+  depends_on 'zopfli'
+  depends_on 'help2man' => :build
+
+  def self.patch
+    system "sed -i 's:CC         = gcc:CC         = #{CREW_TGT}-gcc:' Makefile"
+    system "sed -i 's:CFLAGS     = -Wall -pedantic:CFLAGS     = -Wall -pedantic #{CREW_COMMON_FLAGS}:' Makefile"
+    system "sed -i 's:CFLAGS_OPT = -O2:CFLAGS_OPT =:' Makefile"
+    # use system zopfli
+    system "sed -i 's:SRC_DIRS   = . 7z zopfli:SRC_DIRS   = . 7z:' Makefile"
+    system "sed -i 's:LIBS       = -lstdc++ -lm -lz:LIBS       = -lstdc++ -lm -lz -lzopfli:' Makefile"
+  end
+
+  def self.build
+    system 'make'
+    system "help2man -s 1 -N -h '' --version-string='#{@_ver}' ./gif2apng -o gif2apng.1"
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin/"
+    FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man1/"
+    FileUtils.install 'gif2apng', "#{CREW_DEST_PREFIX}/bin/gif2apng", mode: 0755
+    FileUtils.install 'gif2apng.1', "#{CREW_DEST_MAN_PREFIX}/man1/gif2apng.1", mode: 0644
+  end
+end

--- a/packages/gif2apng.rb
+++ b/packages/gif2apng.rb
@@ -24,7 +24,10 @@ class Gif2apng < Package
 
   def self.build
     system 'make'
-    system "help2man -s 1 -N -h '' --version-string='#{@_ver}' ./gif2apng -o gif2apng.1"
+    system "help2man -s 1 -N -h '' \
+            -n '#{self.description.downcase.delete! '.'}' \
+            --version-string='#{@_ver}' \
+            ./gif2apng -o gif2apng.1"
   end
 
   def self.install

--- a/packages/gif2apng.rb
+++ b/packages/gif2apng.rb
@@ -10,6 +10,19 @@ class Gif2apng < Package
   source_url "https://sourceforge.net/projects/gif2apng/files/#{@_ver}/gif2apng-#{@_ver}-src.zip"
   source_sha256 '3b21308e935d799b3ffb4a86c6e00ffa4cb9b3f72f52d58d51c66eb0574ae7d2'
 
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gif2apng/1.9_armv7l/gif2apng-1.9-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gif2apng/1.9_armv7l/gif2apng-1.9-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gif2apng/1.9_i686/gif2apng-1.9-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gif2apng/1.9_x86_64/gif2apng-1.9-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: 'c0536e15897691a801c59d4b435c9c6a930bed91ba73a23697c85479284095b7',
+     armv7l: 'c0536e15897691a801c59d4b435c9c6a930bed91ba73a23697c85479284095b7',
+       i686: '488ade6bcc9b8e1d537937b929a6fa04a8825937fbb779512fc93883d0bea978',
+     x86_64: '62ba798c0c56f2df6c00c45b1c7c1e23776175dd7d612333c384ea9c9753a4be',
+  })
+
   depends_on 'zopfli'
   depends_on 'help2man' => :build
 

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -1,10 +1,10 @@
 require 'package'
 
 class Libpng < Package
-  description 'libpng is the official PNG reference library.'
+  description 'libpng is the official PNG reference library. Patched with APNG support.'
   homepage 'http://libpng.org/pub/png/libpng.html'
   @_ver = '1.6.37'
-  version "#{@_ver}+apng"
+  version "#{@_ver}-3"
   license 'libpng2'
   compatibility 'all'
   source_url "https://downloads.sourceforge.net/project/libpng/libpng16/#{@_ver}/libpng-#{@_ver}.tar.xz"

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -4,39 +4,25 @@ class Libpng < Package
   description 'libpng is the official PNG reference library.'
   homepage 'http://libpng.org/pub/png/libpng.html'
   @_ver = '1.6.37'
-  version "#{@_ver}-1"
+  version "#{@_ver}+apng"
   license 'libpng2'
   compatibility 'all'
   source_url "https://downloads.sourceforge.net/project/libpng/libpng16/#{@_ver}/libpng-#{@_ver}.tar.xz"
   source_sha256 '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_armv7l/libpng-1.6.37-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_armv7l/libpng-1.6.37-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_i686/libpng-1.6.37-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_x86_64/libpng-1.6.37-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'addb9158594a38f2d4ecd90c5de111d43586d3cdd9ab1edc25536cfb3dc3b760',
-     armv7l: 'addb9158594a38f2d4ecd90c5de111d43586d3cdd9ab1edc25536cfb3dc3b760',
-       i686: '865eea143c0e553d9aea22f20fb02cdb89d2fb823cbf94b1e79b1f3a1124442f',
-     x86_64: '703cb00f75ecdab4918029aa57ee9ed53f027d0a4be6cd6c29b9e4fbd25f7dfe'
-  })
-
   depends_on 'shared_mime_info'
 
   def self.patch
     system 'filefix'
+    # patch in APNG (animated PNG) support
+    system "curl -#LO https://sourceforge.net/projects/apng/files/libpng/libpng16/libpng-#{@_ver}-apng.patch.gz"
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("libpng-#{@_ver}-apng.patch.gz") ) == '10d9e0cb60e2b387a79b355eb7527c0bee2ed8cbd12cf04417cabc4d6976683c'
+    system "gunzip libpng-#{@_ver}-apng.patch.gz"
+    system "patch -Np0 -i libpng-#{@_ver}-apng.patch"
   end
 
   def self.build
-    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure \
-      #{CREW_OPTIONS} \
-      --disable-dependency-tracking \
-      --disable-maintainer-mode"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -10,6 +10,19 @@ class Libpng < Package
   source_url "https://downloads.sourceforge.net/project/libpng/libpng16/#{@_ver}/libpng-#{@_ver}.tar.xz"
   source_sha256 '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
 
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_armv7l/libpng-1.6.37-3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_armv7l/libpng-1.6.37-3-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_i686/libpng-1.6.37-3-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_x86_64/libpng-1.6.37-1-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '267f2ef6f7261612350b576acadbfa258471122365a68c1f81bf5785b65631d0',
+     armv7l: '267f2ef6f7261612350b576acadbfa258471122365a68c1f81bf5785b65631d0',
+       i686: '39cb6b94600b6fa4619941ddacc42972d176aa9ac8e2372bdaf469644c2caf35',
+     x86_64: 'bd8a6e366fbb60cdb86dcd88660ecb44bbee44c8087802a789b720b59ab43db2',
+  })
+
   depends_on 'shared_mime_info'
 
   def self.patch

--- a/packages/zopfli.rb
+++ b/packages/zopfli.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Zopfli < Package
+  description 'A very good, but slow, deflate or zlib compression.'
+  homepage 'https://github.com/google/zopfli/'
+  @_ver = '1.0.3'
+  version @_ver
+  license 'Apache-2.0'
+  compatibility 'all'
+  source_url 'https://github.com/google/zopfli.git'
+  git_hashtag 'zopfli-' + @_ver
+
+  def self.build
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "#{CREW_ENV_OPTIONS} cmake -G Ninja #{CREW_CMAKE_OPTIONS} \
+            -DZOPFLI_BUILD_SHARED=ON .."
+      system 'samu'
+    end
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+end

--- a/packages/zopfli.rb
+++ b/packages/zopfli.rb
@@ -10,6 +10,19 @@ class Zopfli < Package
   source_url 'https://github.com/google/zopfli.git'
   git_hashtag 'zopfli-' + @_ver
 
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zopfli/1.0.3_armv7l/zopfli-1.0.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zopfli/1.0.3_armv7l/zopfli-1.0.3-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zopfli/1.0.3_i686/zopfli-1.0.3-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zopfli/1.0.3_x86_64/zopfli-1.0.3-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '0df215ad8248545623199d63fabc4ca34962fce0c7aa713b3294cef8da824de4',
+     armv7l: '0df215ad8248545623199d63fabc4ca34962fce0c7aa713b3294cef8da824de4',
+       i686: 'd8247dde07c470fa307c5fbb31a8b3d08f4a1d75d42dacd4f1f12540134c6873',
+     x86_64: 'de21437eb8fefa57c8f62928fe1d25e940bc3a9d9d1f57438a4e6628294d6a8a',
+  })
+
   def self.build
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do


### PR DESCRIPTION
Works on x86_64. These packages need binaries.