### PR TITLE
compressdoc => 20211031

### DIFF
--- a/packages/compressdoc.rb
+++ b/packages/compressdoc.rb
@@ -10,6 +10,19 @@ class Compressdoc < Package
   source_url 'https://github.com/saltedcoffii/compressdoc.git'
   git_hashtag 'v' + @_ver
 
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/compressdoc/20211031_armv7l/compressdoc-20211031-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/compressdoc/20211031_armv7l/compressdoc-20211031-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/compressdoc/20211031_i686/compressdoc-20211031-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/compressdoc/20211031_x86_64/compressdoc-20211031-chromeos-x86_64.tar.xz',
+  })
+  binary_sha256 ({
+    aarch64: '4540356220ea749beb260e45d25dcb3a6874691d723d3ba619213caae2b8c2a8',
+     armv7l: '4540356220ea749beb260e45d25dcb3a6874691d723d3ba619213caae2b8c2a8',
+       i686: 'ad99eb9bd25eaecbdcf2eef77bbe29b3326a31a984de27609c8f4a833c244aec',
+     x86_64: '7ced0fd4fc946a5cfc1ea22821be18e23572228436736b7787cb1e86e9e202a0',
+  })
+
   depends_on 'help2man' => :build
 
   def self.build

--- a/packages/compressdoc.rb
+++ b/packages/compressdoc.rb
@@ -1,28 +1,22 @@
 require 'package'
 
 class Compressdoc < Package
-  description 'Compress (with bzip2 or gzip) all man pages in a hierarchy and update symlinks'
-  homepage 'https://github.com/ojab/BLFS/blob/master/auxfiles/compressdoc'
-  version '20080421.1623'
-  license '' # Can't find license for project
+  description 'Compress all man pages in a hierarchy and update symlinks. Supports a variety of compression algorithms.'
+  homepage 'https://github.com/saltedcoffii/compressdoc/'
+  @_ver = '20211031'
+  version @_ver
+  license 'EUPL-1.2 and MIT'
   compatibility 'all'
-  source_url 'https://raw.githubusercontent.com/ojab/BLFS/af6c11d985fe36c8828abaa9d5124c8725580b15/auxfiles/compressdoc'
-  source_sha256 'f380473baaa8785b1c7a7a30f2dda4b748a9baed3b335655faedad49ebf8246b'
+  source_url 'https://github.com/saltedcoffii/compressdoc.git'
+  git_hashtag 'v' + @_ver
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/compressdoc/20080421.1623_armv7l/compressdoc-20080421.1623-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/compressdoc/20080421.1623_armv7l/compressdoc-20080421.1623-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/compressdoc/20080421.1623_i686/compressdoc-20080421.1623-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/compressdoc/20080421.1623_x86_64/compressdoc-20080421.1623-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '3e63d392982f5ccfd330f927febec36b18a53ad722b26a4beb2f4de3efad6c94',
-     armv7l: '3e63d392982f5ccfd330f927febec36b18a53ad722b26a4beb2f4de3efad6c94',
-       i686: '9ec4c600cdbff22fe39a719b28fda93ffa78b9517ef930091ff05c486b72123f',
-     x86_64: 'ff47516fe18e91d4e1a255b4a78f336a0cba0dd06c8ee6c4aa3b45e1c9ea8ec8',
-  })
+  depends_on 'help2man' => :build
+
+  def self.build
+    system 'make'
+  end
 
   def self.install
-    system "install -Dm755 ../compressdoc #{CREW_DEST_PREFIX}/bin/compressdoc"
+    system "make PREFIX=#{CREW_PREFIX} MANDIR=#{CREW_MAN_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/compressdoc.rb
+++ b/packages/compressdoc.rb
@@ -5,7 +5,7 @@ class Compressdoc < Package
   homepage 'https://github.com/saltedcoffii/compressdoc/'
   @_ver = '20211031'
   version @_ver
-  license 'EUPL-1.2 and MIT'
+  license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/saltedcoffii/compressdoc.git'
   git_hashtag 'v' + @_ver


### PR DESCRIPTION
Update compressdoc.
Given that `help2man` isn't a core package, `compressdoc` should probably have binaries.
Works on x86_64, however isn't architecture specific, so it should work on all architectures.