### PR TITLE
libpng: Rebuild x86_64 binary for older glibc

### DIFF
--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -14,13 +14,13 @@ class Libpng < Package
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_armv7l/libpng-1.6.37-3-chromeos-armv7l.tar.xz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_armv7l/libpng-1.6.37-3-chromeos-armv7l.tar.xz',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_i686/libpng-1.6.37-3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-1_x86_64/libpng-1.6.37-1-chromeos-x86_64.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_x86_64/libpng-1.6.37-3-chromeos-x86_64.tpxz',
   })
   binary_sha256 ({
     aarch64: '267f2ef6f7261612350b576acadbfa258471122365a68c1f81bf5785b65631d0',
      armv7l: '267f2ef6f7261612350b576acadbfa258471122365a68c1f81bf5785b65631d0',
        i686: '39cb6b94600b6fa4619941ddacc42972d176aa9ac8e2372bdaf469644c2caf35',
-     x86_64: 'bd8a6e366fbb60cdb86dcd88660ecb44bbee44c8087802a789b720b59ab43db2',
+     x86_64: '374bdf9e5ff3f15a966990bbc6def09dd45898966a2be1075e1ebd3a52b69402',
   })
 
   depends_on 'shared_mime_info'


### PR DESCRIPTION

Works properly:
- [x] x86_64

```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libpng_glibc227 CREW_TESTING=1 crew update
```
---
