### PR TITLE
const.rb: readd Db_lto=false to CREW_MESON_FNO_LTO_OPTIONS

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.17.8'
+CREW_VERSION = '1.17.9'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -119,12 +119,24 @@ CREW_OPTIONS = <<~OPT.chomp
   --program-suffix=''
 OPT
 
-CREW_MESON_OPTIONS = CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
+CREW_MESON_OPTIONS = <<~OPT.chomp
   -Dprefix=#{CREW_PREFIX} \
   -Dlibdir=#{CREW_LIB_PREFIX} \
   -Dmandir=#{CREW_MAN_PREFIX} \
   -Dbuildtype=release \
   -Db_lto=true \
+  -Dstrip=true \
+  -Db_pie=true \
+  -Dcpp_args='-O2' \
+  -Dc_args='-O2'
+OPT
+
+CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
+  -Dprefix=#{CREW_PREFIX} \
+  -Dlibdir=#{CREW_LIB_PREFIX} \
+  -Dmandir=#{CREW_MAN_PREFIX} \
+  -Dbuildtype=release \
+  -Db_lto=false \
   -Dstrip=true \
   -Db_pie=true \
   -Dcpp_args='-O2' \


### PR DESCRIPTION
- `CREW_MESON_FNO_LTO_OPTIONS` should NOT be the same as `CREW_MESON_OPTIONS`
- This might explain why I was having some compilation errors on i686. 😅

Works properly:
- [x] x86_64


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fix_meson_nolto CREW_TESTING=1 crew update
```
