### PR TITLE
crew: Adjust logic for branch/tag source_url, don't cache .git folders

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -723,17 +723,17 @@ def download
       # Download via git
       Dir.mkdir @extract_dir
       Dir.chdir @extract_dir do
-        system 'git init'
-        system 'git config advice.detachedHead false'
-        system 'git config init.defaultBranch master'
-        system "git remote add origin #{@pkg.source_url}", exception: true
         unless @pkg.git_branch.nil? || @pkg.git_branch.empty?
           # Leave a message because this step can be slow.
           puts "Downloading src from a git branch. This may take a while..."
-          system "git remote set-branches origin #{@pkg.git_branch}", exception: true
-          system "git fetch --progress origin #{@pkg.git_branch}", exception: true
-          system "git checkout #{@pkg.git_hashtag}", exception: true
+          system "git clone --branch #{@pkg.git_branch} --single-branch #{@pkg.source_url} tmpdir", exception: true
+          system "mv tmpdir/.git . && rm -rf tmpdir"
+          system "git reset --hard #{@pkg.git_hashtag}", exception: true
         else
+          system 'git init'
+          system 'git config advice.detachedHead false'
+          system 'git config init.defaultBranch master'
+          system "git remote add origin #{@pkg.source_url}", exception: true
           system "git fetch --depth 1 origin #{@pkg.git_hashtag}", exception: true
           system 'git checkout FETCH_HEAD'
         end
@@ -744,7 +744,7 @@ def download
       if CREW_CACHE_ENABLED and File.writable?(CREW_CACHE_DIR)
         puts 'Caching downloaded git repo...'
         Dir.chdir "#{@extract_dir}" do
-          system "tar c#{@verbose}Jf #{cachefile} \
+          system "tar c#{@verbose}Jf #{cachefile} --exclude-vcs \
             $(find -mindepth 1 -maxdepth 1 -printf '%P\n')"
         end
         system "sha256sum #{cachefile} > #{cachefile}.sha256"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.17.9'
+CREW_VERSION = '1.18.0'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- Use git's `--single-branch` option when checking out a single branch.
- Don't run `git init` for such situations as `git clone` is needed.
- Don't cache `.git` folders from git checkouts, as they can be huge. This is easy using gnu tar's `--exclude-vcs` option.

Works properly:
- [x] x86_64


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crewcache CREW_TESTING=1 crew update
```
