### PR TITLE
Crew cache git granularity

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -700,11 +700,18 @@ def download
     if @git == true
       # Recall repository from cache if requested
       if CREW_CACHE_ENABLED
+        # No git branch specified, just a git commit or tag
         if @pkg.git_branch.nil? || @pkg.git_branch.empty?
+          abort("No Git branch, commit, or tag specified!").lightred if @pkg.git_hashtag.nil? || @pkg.git_hashtag.empty
           cachefile = CREW_CACHE_DIR + filename + @pkg.git_hashtag + '.tar.xz'
           puts "cachefile is #{cachefile}".orange if @opt_verbose
+        # Git branch and git commit specified
+        elsif ( ! @pkg.git_hashtag.nil? || ! @pkg.git_hashtag.empty )  and ( ! @pkg.git_branch.nil? || ! @pkg.git_branch.empty?)
+          cachefile = CREW_CACHE_DIR + filename + @pkg.git_branch.gsub(/[^0-9A-Za-z.\-]/, '_') + '_' + @pkg.git_hashtag + '.tar.xz'
+          puts "cachefile is #{cachefile}".orange if @opt_verbose
+        # Git branch specified, without a specific git commit.
         else
-          # Use to the day granularity for a branch timestamp.
+          # Use to the day granularity for a branch timestamp with no specific commit specified.
           cachefile = CREW_CACHE_DIR + filename + @pkg.git_branch.gsub(/[^0-9A-Za-z.\-]/, '_') + Time.now.strftime("%m%d%Y") + '.tar.xz'
           puts "cachefile is #{cachefile}".orange if @opt_verbose
         end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.18.0'
+CREW_VERSION = '1.18.1'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- Please check the boolean logic here?
- Adds commit granularity for cached git branch source_url downloads, if a commit was specified. Previously a single cachefile would be used even if a new commit on the branch was specified the same day the cache was created.


Works properly:
- [x] x86_64


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_cache_git_granularity CREW_TESTING=1 crew update
```
