### PR TITLE
Fix minecraft installs

### DIFF
--- a/packages/minecraft.rb
+++ b/packages/minecraft.rb
@@ -15,9 +15,15 @@ class Minecraft < Package
   depends_on 'jdk8'
   depends_on 'gtk3'
   depends_on 'libcom_err'
+  depends_on 'libsecret'
   depends_on 'sommelier'
 
   def self.install
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}"
     FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/"
     FileUtils.mv "#{CREW_DEST_PREFIX}/bin/minecraft-launcher", "#{CREW_DEST_PREFIX}/bin/minecraft-launcher.elf"


### PR DESCRIPTION
Fixes #6387 

- Add missing dependency, and add note that this drops files in a non-FHS-compliant manner.

Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=minecraft CREW_TESTING=1 crew update
```
