### PR TITLE
rsync: fix missing runtime dependency

### DIFF
--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -25,6 +25,7 @@ class Rsync < Package
 
   depends_on 'xxhash'
   depends_on 'lz4'
+  depends_on 'popt'
 
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \


### PR DESCRIPTION
- on `armv7l` `rsync` tries to use the built-in libpopt... and then throws an error.

Works properly:
- [x] x86_64
- [x] armv7l

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rsync_fix CREW_TESTING=1 crew update
```
