### PR TITLE
Ocaml -> 4.13.1, Add wayland_proxy_virtwl

### DIFF
--- a/packages/ocaml.rb
+++ b/packages/ocaml.rb
@@ -15,8 +15,8 @@ class Ocaml < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ocaml/4.13.1_x86_64/ocaml-4.13.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '6e52264c7ae4739404b8791fb12561ec03e506b4f27cd203887366557db41038',
-     armv7l: '6e52264c7ae4739404b8791fb12561ec03e506b4f27cd203887366557db41038',
+    aarch64: 'c7a6fbbfe966ed1396cbf9b9222fa1b11cffa294c11d86f3a4e45ae16f99f062',
+     armv7l: 'c7a6fbbfe966ed1396cbf9b9222fa1b11cffa294c11d86f3a4e45ae16f99f062',
      x86_64: 'a641c92dc3f56eaa29c5abf31bda397bb0c5cd35319a3d56f0fda30808d5bbc5'
   })
 

--- a/packages/ocaml.rb
+++ b/packages/ocaml.rb
@@ -21,10 +21,12 @@ class Ocaml < Package
   })
 
   @crew_env_options = CREW_ENV_OPTIONS
+  @cc = ''
   case ARCH
   when 'aarch64', 'armv7l'
     # the ocaml log module fails to build when ld.gold is used.
     @crew_env_options = CREW_ENV_OPTIONS.gsub('-fuse-ld=gold', '-fuse-ld=bfd')
+    @cc = "CC='gcc -fuse-ld=bfd'"
   end
 
   def self.patch
@@ -55,10 +57,10 @@ class Ocaml < Package
   def self.prebuild; end
 
   def self.build
-    system "#{@crew_env_options} \
+    system "#{@cc} #{@crew_env_options} \
       ./configure #{CREW_OPTIONS}"
     FileUtils.ln_s "#{CREW_PREFIX}/bin/as", "#{CREW_BUILD}-as"
-    system "PATH=$PATH:$(pwd) make -j#{CREW_NPROC}"
+    system "#{@cc} PATH=$PATH:$(pwd) make -j#{CREW_NPROC}"
   end
 
   def self.install

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -1,0 +1,72 @@
+# Adapted from Arch Linux opam PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/opam/trunk/PKGBUILD
+
+require 'package'
+
+class Opam < Package
+  description 'OCaml package manager'
+  homepage 'https://opam.ocaml.org/'
+  @_ver = '2.1.1'
+  version "#{@_ver}-1"
+  compatibility 'all'
+  source_url 'https://github.com/ocaml/opam.git'
+  git_hashtag @_ver
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-1_armv7l/opam-2.1.1-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-1_armv7l/opam-2.1.1-1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-1_x86_64/opam-2.1.1-1-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'ec54d9008a122e6e4050c43357de070086aa2d1cf4b1b770eacb2ff5e2753ca4',
+     armv7l: 'ec54d9008a122e6e4050c43357de070086aa2d1cf4b1b770eacb2ff5e2753ca4',
+     x86_64: 'c09d490e44d8e4ac4c723b7421f7b9203d8a7b3a8810f6505b1e3d1344505509'
+  })
+
+  depends_on 'bubblewrap'
+  depends_on 'ocaml'
+  depends_on 'rsync'
+
+  @OPAMROOT = "#{CREW_PREFIX}/share/opam"
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "make lib-ext all -j1 \
+      OCAMLC='ocamlc -unsafe-string' \
+      OCAMLOPT='ocamlopt -unsafe-string'"
+    @bashd_opam = <<~OPAMEOF
+      export OPAMROOT=#{@OPAMROOT}
+      eval \$(opam env --root=#{@OPAMROOT} --switch=default)
+      test -r #{@OPAMROOT}/opam-init/init.sh && . #{@OPAMROOT}/opam-init/init.sh > /dev/null 2> /dev/null || true
+    OPAMEOF
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+    FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/etc/bash.d]
+    File.write("#{CREW_DEST_PREFIX}/etc/bash.d/opam", @bashd_opam)
+  end
+
+  def self.postinstall
+    system "opam init --root=#{@OPAMROOT} -y \
+            && eval \$(opam env --root=#{@OPAMROOT} --switch=default) \
+            && opam option --global depext=false --root=#{@OPAMROOT} -y"
+  end
+
+  def self.remove
+    # Leave this in until the next revision
+    if Dir.exist? "#{CREW_PREFIX}/opam"
+      puts
+      print "Would you like to remove #{CREW_PREFIX}/opam? [y/N] "
+      response = $stdin.getc
+      case response
+      when 'y', 'Y'
+        FileUtils.rm_rf "#{CREW_PREFIX}/opam"
+        puts "#{CREW_PREFIX}/opam removed.".lightred
+      else
+        puts "#{CREW_PREFIX}/opam saved.".lightgreen
+      end
+      puts
+    end
+  end
+end

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -18,8 +18,8 @@ class Opam < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-1_x86_64/opam-2.1.1-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '72cab77dbbca98b2b46deb3568c66ea4745286c2596c4ffa9d053c81abbf65dc',
-     armv7l: '72cab77dbbca98b2b46deb3568c66ea4745286c2596c4ffa9d053c81abbf65dc',
+    aarch64: '02de504f0585aded75d222df3c5fbd27be99d380611171cba57a4f210949ab45',
+     armv7l: '02de504f0585aded75d222df3c5fbd27be99d380611171cba57a4f210949ab45',
      x86_64: 'ca9f60990edc0784f650fec6744f3e4de6166997851bb85d550268171db22836'
   })
 

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -18,9 +18,9 @@ class Opam < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-1_x86_64/opam-2.1.1-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'ec54d9008a122e6e4050c43357de070086aa2d1cf4b1b770eacb2ff5e2753ca4',
-     armv7l: 'ec54d9008a122e6e4050c43357de070086aa2d1cf4b1b770eacb2ff5e2753ca4',
-     x86_64: 'c09d490e44d8e4ac4c723b7421f7b9203d8a7b3a8810f6505b1e3d1344505509'
+    aarch64: '72cab77dbbca98b2b46deb3568c66ea4745286c2596c4ffa9d053c81abbf65dc',
+     armv7l: '72cab77dbbca98b2b46deb3568c66ea4745286c2596c4ffa9d053c81abbf65dc',
+     x86_64: 'ca9f60990edc0784f650fec6744f3e4de6166997851bb85d550268171db22836'
   })
 
   depends_on 'bubblewrap'
@@ -54,17 +54,16 @@ class Opam < Package
   end
 
   def self.remove
-    # Leave this in until the next revision
-    if Dir.exist? "#{CREW_PREFIX}/opam"
+    if Dir.exist? "#{@OPAMROOT}"
       puts
-      print "Would you like to remove #{CREW_PREFIX}/opam? [y/N] "
+      print "Would you like to remove #{@OPAMROOT}? [y/N] "
       response = $stdin.getc
       case response
       when 'y', 'Y'
-        FileUtils.rm_rf "#{CREW_PREFIX}/opam"
-        puts "#{CREW_PREFIX}/opam removed.".lightred
+        FileUtils.rm_rf "#{@OPAMROOT}"
+        puts "#{@OPAMROOT} removed.".lightred
       else
-        puts "#{CREW_PREFIX}/opam saved.".lightgreen
+        puts "#{@OPAMROOT} saved.".lightgreen
       end
       puts
     end

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -15,21 +15,20 @@ class Wayland_proxy_virtwl < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_i686/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-i686.tpxz',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-x86_64.tpxz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_i686/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '9cd15da6fb9278ec06a85e8db9192691cb9785e07806a3e02aa1d2e64056aef2',
      armv7l: '9cd15da6fb9278ec06a85e8db9192691cb9785e07806a3e02aa1d2e64056aef2',
-    i686: 'eeaae9cf7237f0941ea8810089d71f75c0fa79388f45762be33d1bcde60c7ab8',
-  x86_64: 'dc6ec360d6f58b84f41cb2b97ba0c7355307d3f1b1d249e82cc0467b70cd54bf'
+       i686: 'eeaae9cf7237f0941ea8810089d71f75c0fa79388f45762be33d1bcde60c7ab8',
+     x86_64: 'dc6ec360d6f58b84f41cb2b97ba0c7355307d3f1b1d249e82cc0467b70cd54bf'
   })
 
   depends_on 'ocaml' => :build
   depends_on 'opam' => :build
 
-  def self.build
-  end
+  def self.build; end
 
   def self.install
     ENV['OPAMROOT'] = "#{CREW_PREFIX}/opam"

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -13,10 +13,14 @@ class Wayland_proxy_virtwl < Package
   git_hashtag @_ver
 
   binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-armv7l.tpxz',
     i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_i686/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-i686.tpxz',
   x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-x86_64.tpxz'
   })
   binary_sha256({
+    aarch64: '9cd15da6fb9278ec06a85e8db9192691cb9785e07806a3e02aa1d2e64056aef2',
+     armv7l: '9cd15da6fb9278ec06a85e8db9192691cb9785e07806a3e02aa1d2e64056aef2',
     i686: 'eeaae9cf7237f0941ea8810089d71f75c0fa79388f45762be33d1bcde60c7ab8',
   x86_64: 'dc6ec360d6f58b84f41cb2b97ba0c7355307d3f1b1d249e82cc0467b70cd54bf'
   })

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -1,6 +1,3 @@
-# Adapted from Arch Linux opam PKGBUILD at:
-# https://github.com/archlinux/svntogit-community/raw/packages/opam/trunk/PKGBUILD
-
 require 'package'
 
 class Wayland_proxy_virtwl < Package

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -21,7 +21,7 @@ class Wayland_proxy_virtwl < Package
   x86_64: 'dc6ec360d6f58b84f41cb2b97ba0c7355307d3f1b1d249e82cc0467b70cd54bf'
   })
 
-  depends_on 'ocaml'=> :build
+  depends_on 'ocaml' => :build
   depends_on 'opam' => :build
 
   def self.build

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -1,0 +1,39 @@
+# Adapted from Arch Linux opam PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/opam/trunk/PKGBUILD
+
+require 'package'
+
+class Wayland_proxy_virtwl < Package
+  description 'Proxy Wayland connections across the VM boundary'
+  homepage 'https://github.com/talex5/wayland-proxy-virtwl'
+  @_ver = '5b576d5cad76de6ed7513cc85748efd78ca366cf'
+  version @_ver
+  compatibility 'all'
+  source_url 'https://github.com/talex5/wayland-proxy-virtwl.git'
+  git_hashtag @_ver
+
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_i686/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-i686.tpxz',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    i686: 'eeaae9cf7237f0941ea8810089d71f75c0fa79388f45762be33d1bcde60c7ab8',
+  x86_64: 'dc6ec360d6f58b84f41cb2b97ba0c7355307d3f1b1d249e82cc0467b70cd54bf'
+  })
+
+  depends_on 'ocaml'
+  depends_on 'opam'
+
+  def self.build
+  end
+
+  def self.install
+    ENV['OPAMROOT'] = "#{CREW_PREFIX}/opam"
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
+    system "OPAMROOT=#{CREW_PREFIX}/opam opam install . --root=#{CREW_PREFIX}/opam --destdir=#{CREW_DEST_PREFIX}/opam -y"
+  end
+end

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -21,8 +21,8 @@ class Wayland_proxy_virtwl < Package
   x86_64: 'dc6ec360d6f58b84f41cb2b97ba0c7355307d3f1b1d249e82cc0467b70cd54bf'
   })
 
-  depends_on 'ocaml'
-  depends_on 'opam'
+  depends_on 'ocaml'=> :build
+  depends_on 'opam' => :build
 
   def self.build
   end

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -4,36 +4,35 @@ class Wayland_proxy_virtwl < Package
   description 'Proxy Wayland connections across the VM boundary'
   homepage 'https://github.com/talex5/wayland-proxy-virtwl'
   @_ver = '5b576d5cad76de6ed7513cc85748efd78ca366cf'
-  version @_ver
+  version "#{@_ver}-1"
   compatibility 'all'
   source_url 'https://github.com/talex5/wayland-proxy-virtwl.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_i686/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-1_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-1_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-1-chromeos-armv7l.tpxz',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-1_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '9cd15da6fb9278ec06a85e8db9192691cb9785e07806a3e02aa1d2e64056aef2',
-     armv7l: '9cd15da6fb9278ec06a85e8db9192691cb9785e07806a3e02aa1d2e64056aef2',
-       i686: 'eeaae9cf7237f0941ea8810089d71f75c0fa79388f45762be33d1bcde60c7ab8',
-     x86_64: 'dc6ec360d6f58b84f41cb2b97ba0c7355307d3f1b1d249e82cc0467b70cd54bf'
+    aarch64: 'dbc7832b84f64fe292f77cc74e9ee809acb69098072f10d7cab4bf61c3a47070',
+     armv7l: 'dbc7832b84f64fe292f77cc74e9ee809acb69098072f10d7cab4bf61c3a47070',
+    x86_64: '9d5e0b7ca63b3ec2949f66da4e594741c729a7aa9e488ba16f4a7e6e237d4671'
   })
 
   depends_on 'ocaml' => :build
   depends_on 'opam' => :build
 
+  @OPAMROOT = "#{CREW_PREFIX}/share/opam"
+
   def self.build; end
 
   def self.install
-    ENV['OPAMROOT'] = "#{CREW_PREFIX}/opam"
-    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
-    warn_level = $VERBOSE
-    $VERBOSE = nil
-    load "#{CREW_LIB_PATH}lib/const.rb"
-    $VERBOSE = warn_level
-    system "OPAMROOT=#{CREW_PREFIX}/opam opam install . --root=#{CREW_PREFIX}/opam --destdir=#{CREW_DEST_PREFIX}/opam -y"
+    ENV['OPAMROOT'] = @OPAMROOT
+    system "LINKFLAGS='-fuse-ld=bfd' LDFLAGS='-fuse-ld=bfd' OPAMROOT=#{@OPAMROOT} opam install . --root=#{@OPAMROOT} --destdir=#{CREW_DEST_DIR}#{@OPAMROOT} -y"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
+      FileUtils.ln_s '../share/opam/bin/wayland-proxy-virtwl', 'wayland-proxy-virtwl'
+    end
   end
 end

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -12,12 +12,12 @@ class Wayland_proxy_virtwl < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-1_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-1-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-1_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-1-chromeos-armv7l.tpxz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-1_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-1-chromeos-x86_64.tpxz'
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-1_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'dbc7832b84f64fe292f77cc74e9ee809acb69098072f10d7cab4bf61c3a47070',
-     armv7l: 'dbc7832b84f64fe292f77cc74e9ee809acb69098072f10d7cab4bf61c3a47070',
-    x86_64: '9d5e0b7ca63b3ec2949f66da4e594741c729a7aa9e488ba16f4a7e6e237d4671'
+    aarch64: '2fb0aae6ab88066b9756405dde7af9664786ceffa4eb6e5e2a844dd8bbfb60c5',
+     armv7l: '2fb0aae6ab88066b9756405dde7af9664786ceffa4eb6e5e2a844dd8bbfb60c5',
+     x86_64: '9fa325befbcc08134de3be19d5362a4621c3b2288518fd5b49293c8fff0f17b6'
   })
 
   depends_on 'ocaml' => :build
@@ -29,7 +29,7 @@ class Wayland_proxy_virtwl < Package
 
   def self.install
     ENV['OPAMROOT'] = @OPAMROOT
-    system "LINKFLAGS='-fuse-ld=bfd' LDFLAGS='-fuse-ld=bfd' OPAMROOT=#{@OPAMROOT} opam install . --root=#{@OPAMROOT} --destdir=#{CREW_DEST_DIR}#{@OPAMROOT} -y"
+    system "CHECK_IF_PREINSTALLED=false OPAMROOT=#{@OPAMROOT} opam install . --root=#{@OPAMROOT} --destdir=#{CREW_DEST_DIR}#{@OPAMROOT} -y"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
       FileUtils.ln_s '../share/opam/bin/wayland-proxy-virtwl', 'wayland-proxy-virtwl'


### PR DESCRIPTION
- This is an alternative to `sommelier`: https://github.com/talex5/wayland-proxy-virtwl
- Wayland proxying works, but X11 proxying is currently not working, [as far as I can tell](https://github.com/talex5/wayland-proxy-virtwl/issues/24).
- Example usage: `stopsommelier ; /usr/local/opam/bin/wayland-proxy-virtwl --tag="test" --wayland-display wayland-1 --x-display=0 --xrdb Xft.dpi:150`  
  - This should create a wayland display at `wayland-1` which can be used by prefixing a wayland command with `WAYLAND_DISPLAY=wayland-1`.
  - e.g. `WAYLAND_DISPLAY=wayland-1 weston-terminal`
  - This requires https://github.com/skycocker/chromebrew/pull/6396 to build
  - Yes the directory structure is wacky, which is why I just pointed it to /usr/local/opam...

Works properly:
- [x] x86_64
- [x] armv7l (Need someone to verify that the binary works... but it builds... if I replace ld with ld.bfd for the build.)
- [ ] i686 (it does build...)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=wayland_proxy_virtwl CREW_TESTING=1 crew update
```
