### PR TITLE
musl libunwind test

### DIFF
--- a/packages/lzip.rb
+++ b/packages/lzip.rb
@@ -3,32 +3,73 @@ require 'package'
 class Lzip < Package
   description 'Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2.'
   homepage 'https://www.nongnu.org/lzip/lzip.html'
-  version '1.22'
-  license 'GPL-2+'
+  version '1.22-2'
   compatibility 'all'
+  license 'GPL-2+'
   source_url 'https://download.savannah.gnu.org/releases/lzip/lzip-1.22.tar.gz'
   source_sha256 'c3342d42e67139c165b8b128d033b5c96893a13ac5f25933190315214e87a948'
 
   binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22_armv7l/lzip-1.22-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22_armv7l/lzip-1.22-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22_i686/lzip-1.22-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22_x86_64/lzip-1.22-chromeos-x86_64.tar.xz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-1_armv7l/lzip-1.22-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-1_armv7l/lzip-1.22-1-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-1_x86_64/lzip-1.22-1-chromeos-x86_64.tpxz',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-2_i686/lzip-1.22-2-chromeos-i686.tar.xz',
   })
   binary_sha256 ({
-    aarch64: '34905a03071ba31b215c5aa5f769d2d835063cc3959df47dfdbd38654c1785a0',
-     armv7l: '34905a03071ba31b215c5aa5f769d2d835063cc3959df47dfdbd38654c1785a0',
-       i686: 'cb4110131bdd571ae4ef73c32548e53a792f833da399597a29e89daea454e29a',
-     x86_64: '77c7eb34fe9a72694f1c9fe10f8c27e3205526f90b7bd55c6e659dd34e7b60f8',
+    aarch64: '1af4e5160612003a2dcf992da1e250f69e94e0541afbc362ef08c64f03fd804b',
+     armv7l: '1af4e5160612003a2dcf992da1e250f69e94e0541afbc362ef08c64f03fd804b',
+     x86_64: '2238d47dee1af70ab2f3cce80208c73e0f8f1dec325d48ae92d80641ac09cd12',
+        i686: 'fd3836f7370bc538deeab5b080e7f9e0177b1933eeb4071eef366e0107ad057a',
   })
 
+
+  depends_on 'musl_native_toolchain' => :build
+  depends_on 'musl_libunwind' => :build if ARCH == 'i686'
+
+  @abi = ''
+  @arch_c_flags = ''
+  @arch_cxx_flags = ''
+  @libunwind = ''
+  case ARCH
+  when 'aarch64', 'armv7l'
+    @abi = 'eabihf'
+  when 'i686'
+    @libunwind = '-lunwind'
+  end
+
+  @cflags = "-B#{CREW_PREFIX}/musl/include -pipe -O2 -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_c_flags} -fcommon"
+  @cxxflags = "-B#{CREW_PREFIX}/musl/include -pipe -O2 -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_cxx_flags} -fcommon -static"
+  @ldflags = "-L#{CREW_PREFIX}/musl/lib -static #{@libunwind}"
+  @cmake_ldflags = ''
+
+  @musldep_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+      CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
+      CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
+      LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
+      PKG_CONFIG_LIBDIR=#{CREW_PREFIX}/musl/lib/pkgconfig \
+      CFLAGS='#{@cflags}' \
+      CXXFLAGS='#{@cxxflags}' \
+      CPPFLAGS='-I#{CREW_PREFIX}/musl/include -fcommon' \
+      LDFLAGS='#{@ldflags}'"
+
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure --prefix=#{CREW_PREFIX}"
-    system 'make'
+    system "./configure --prefix=#{CREW_PREFIX}/musl \
+      --datarootdir=#{CREW_PREFIX}/share \
+      #{@musldep_env_options}"
+    system 'make -j1'
   end
 
   def self.install
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
+      FileUtils.ln_s '../musl/bin/lzip', 'lzip'
+    end
   end
 
   def self.check

--- a/packages/lzip.rb
+++ b/packages/lzip.rb
@@ -4,24 +4,23 @@ class Lzip < Package
   description 'Lzip is a lossless data compressor with a user interface similar to the one of gzip or bzip2.'
   homepage 'https://www.nongnu.org/lzip/lzip.html'
   version '1.22-2'
-  compatibility 'all'
   license 'GPL-2+'
+  compatibility 'all'
   source_url 'https://download.savannah.gnu.org/releases/lzip/lzip-1.22.tar.gz'
   source_sha256 'c3342d42e67139c165b8b128d033b5c96893a13ac5f25933190315214e87a948'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-1_armv7l/lzip-1.22-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-1_armv7l/lzip-1.22-1-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-1_x86_64/lzip-1.22-1-chromeos-x86_64.tpxz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-2_i686/lzip-1.22-2-chromeos-i686.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-2_armv7l/lzip-1.22-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-2_armv7l/lzip-1.22-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-2_i686/lzip-1.22-2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lzip/1.22-2_x86_64/lzip-1.22-2-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '1af4e5160612003a2dcf992da1e250f69e94e0541afbc362ef08c64f03fd804b',
-     armv7l: '1af4e5160612003a2dcf992da1e250f69e94e0541afbc362ef08c64f03fd804b',
-     x86_64: '2238d47dee1af70ab2f3cce80208c73e0f8f1dec325d48ae92d80641ac09cd12',
-        i686: 'fd3836f7370bc538deeab5b080e7f9e0177b1933eeb4071eef366e0107ad057a',
+  binary_sha256({
+    aarch64: 'c2845ab07bbaf3ece8c9fbe6ebc877b9ab2028d20f125d15dac95c6a805feab4',
+     armv7l: 'c2845ab07bbaf3ece8c9fbe6ebc877b9ab2028d20f125d15dac95c6a805feab4',
+       i686: 'c06db451f1f55bd962826bdb95ecf236e8be2e32d740ce485edbf3986cff3943',
+     x86_64: '03d91cc0ed167a0e1cc6a294123b138542ee6a4689461813cd21d058ff590487'
   })
-
 
   depends_on 'musl_native_toolchain' => :build
   depends_on 'musl_libunwind' => :build if ARCH == 'i686'
@@ -43,6 +42,7 @@ class Lzip < Package
   @cmake_ldflags = ''
 
   @musldep_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+      LIBRARY_PATH='#{CREW_PREFIX}/musl/lib:$LIBRARY_PATH' \
       CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
       CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
       LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \

--- a/packages/musl_libbacktrace.rb
+++ b/packages/musl_libbacktrace.rb
@@ -11,6 +11,19 @@ class Musl_libbacktrace < Package
   source_url 'https://github.com/ianlancetaylor/libbacktrace.git'
   git_hashtag version
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libbacktrace/d0f5e95a87a4d3e0a1ed6c069b5dae7cbab3ed2a_armv7l/musl_libbacktrace-d0f5e95a87a4d3e0a1ed6c069b5dae7cbab3ed2a-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libbacktrace/d0f5e95a87a4d3e0a1ed6c069b5dae7cbab3ed2a_armv7l/musl_libbacktrace-d0f5e95a87a4d3e0a1ed6c069b5dae7cbab3ed2a-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libbacktrace/d0f5e95a87a4d3e0a1ed6c069b5dae7cbab3ed2a_i686/musl_libbacktrace-d0f5e95a87a4d3e0a1ed6c069b5dae7cbab3ed2a-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libbacktrace/d0f5e95a87a4d3e0a1ed6c069b5dae7cbab3ed2a_x86_64/musl_libbacktrace-d0f5e95a87a4d3e0a1ed6c069b5dae7cbab3ed2a-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '19bc88daa2ee3de04167a159d2a52d1f35e3f54e531847de9b441517cfef7d4b',
+     armv7l: '19bc88daa2ee3de04167a159d2a52d1f35e3f54e531847de9b441517cfef7d4b',
+       i686: '1dc24f90bd5cb0c86518f6843906fa28647f8e3c4c4c44ce33e41707e22cf967',
+     x86_64: '24b85b73f26b55343485cca8938aebfcd09c586ffba6cef5a7430b4a0336c82b'
+  })
+
   depends_on 'musl_native_toolchain' => :build
 
   @abi = ''
@@ -27,6 +40,7 @@ class Musl_libbacktrace < Package
   @cmake_ldflags = '-flto'
 
   @musldep_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+      LIBRARY_PATH='#{CREW_PREFIX}/musl/lib:$LIBRARY_PATH' \
       CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
       CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
       LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \

--- a/packages/musl_libbacktrace.rb
+++ b/packages/musl_libbacktrace.rb
@@ -1,0 +1,55 @@
+# Adapted from Arch Linux libbacktrace-git PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=libbacktrace-git
+
+require 'package'
+
+class Musl_libbacktrace < Package
+  description 'Library to produce symbolic backtraces'
+  homepage 'https://github.com/ianlancetaylor/libbacktrace'
+  version 'd0f5e95a87a4d3e0a1ed6c069b5dae7cbab3ed2a'
+  compatibility 'all'
+  source_url 'https://github.com/ianlancetaylor/libbacktrace.git'
+  git_hashtag version
+
+  depends_on 'musl_native_toolchain' => :build
+
+  @abi = ''
+  @arch_c_flags = ''
+  @arch_cxx_flags = ''
+  case ARCH
+  when 'aarch64', 'armv7l'
+    @abi = 'eabihf'
+  end
+
+  @cflags = "-B#{CREW_PREFIX}/musl/include -flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_c_flags} -fcommon"
+  @cxxflags = "-B#{CREW_PREFIX}/musl/include -flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_cxx_flags} -fcommon -static"
+  @ldflags = "-L#{CREW_PREFIX}/musl/lib -flto -static"
+  @cmake_ldflags = '-flto'
+
+  @musldep_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+      CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
+      CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
+      LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
+      PKG_CONFIG_LIBDIR=#{CREW_PREFIX}/musl/lib/pkgconfig \
+      CFLAGS='#{@cflags}' \
+      CXXFLAGS='#{@cxxflags}' \
+      CPPFLAGS='-I#{CREW_PREFIX}/musl/include -fcommon' \
+      LDFLAGS='#{@ldflags}'"
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX}/musl \
+      #{@musldep_env_options} \
+      --enable-shared \
+      --enable-static"
+    system 'make'
+  end
+
+  def self.install
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/musl_libucontext.rb
+++ b/packages/musl_libucontext.rb
@@ -1,0 +1,66 @@
+require 'package'
+
+class Musl_libucontext < Package
+  description 'Library which provides the ucontext.h C API'
+  homepage 'https://github.com/kaniini/libucontext'
+  @_ver = '1.1'
+  version @_ver
+  compatibility 'all'
+  source_url 'https://github.com/kaniini/libucontext.git'
+  git_hashtag "libucontext-#{@_ver}"
+
+  depends_on 'musl_native_toolchain' => :build
+
+  @abi = ''
+  @arch_c_flags = ''
+  @arch_cxx_flags = ''
+  case ARCH
+  when 'aarch64', 'armv7l'
+    @abi = 'eabihf'
+    @arch = 'arm'
+  when 'i686'
+    @arch = 'X86'
+  when 'x86_64'
+    @arch = 'X86_64'
+  end
+
+  @cflags = "-B#{CREW_PREFIX}/musl/include -flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_c_flags} -fcommon"
+  @cxxflags = "-B#{CREW_PREFIX}/musl/include -flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_cxx_flags} -fcommon -static"
+  @ldflags = "-L#{CREW_PREFIX}/musl/lib -flto -static"
+  @cmake_ldflags = '-flto'
+
+  @musldep_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+      CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
+      CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
+      LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
+      LIBDIR=#{CREW_PREFIX}/musl/lib \
+      INCLUDEDIR=#{CREW_PREFIX}/musl/include \
+      PKG_CONFIG_LIBDIR=#{CREW_PREFIX}/musl/lib/pkgconfig \
+      PKGCONFIGDIR=#{CREW_PREFIX}/musl/lib/pkgconfig \
+      CFLAGS='#{@cflags}' \
+      CXXFLAGS='#{@cxxflags}' \
+      CPPFLAGS='-I#{CREW_PREFIX}/musl/include -fcommon' \
+      LDFLAGS='#{@ldflags}'"
+
+  def self.patch
+    system "sed -i 's,LIBDIR := /lib,LIBDIR := #{CREW_PREFIX}/musl/lib,g' Makefile"
+    system "sed -i 's,INCLUDEDIR := /usr/include,INCLUDEDIR := #{CREW_PREFIX}/musl/include,g' Makefile"
+    system "sed -i 's,PKGCONFIGDIR := /usr/lib/pkgconfig,PKGCONFIGDIR := #{CREW_PREFIX}/musl/lib/pkgconfig,g' Makefile"
+  end
+  def self.build
+    #system "./configure --prefix=#{CREW_PREFIX}/musl \
+      ##{@musldep_env_options} \
+      #--enable-shared \
+      #--enable-static"
+    system "#{@musldep_env_options} make ARCH=#{@arch}"
+  end
+
+  def self.install
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
+    system "make ARCH=#{@arch} DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/musl_libucontext.rb
+++ b/packages/musl_libucontext.rb
@@ -9,6 +9,19 @@ class Musl_libucontext < Package
   source_url 'https://github.com/kaniini/libucontext.git'
   git_hashtag "libucontext-#{@_ver}"
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libucontext/1.1_armv7l/musl_libucontext-1.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libucontext/1.1_armv7l/musl_libucontext-1.1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libucontext/1.1_i686/musl_libucontext-1.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libucontext/1.1_x86_64/musl_libucontext-1.1-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'ecb4f59b8669ea34f61cb5889e46f5de6be4241f8730c570d2f180d30782370f',
+     armv7l: 'ecb4f59b8669ea34f61cb5889e46f5de6be4241f8730c570d2f180d30782370f',
+       i686: '6bc511905bc917b2cd3ecf708760e18fd3b2c1f59560b1f5796bdeb2e3c4ffaf',
+     x86_64: 'cc3d984411b2353fe19cb3796cbe0d8a590b48d7e7998dc6a42d22703201c325'
+  })
+
   depends_on 'musl_native_toolchain' => :build
 
   @abi = ''
@@ -30,6 +43,7 @@ class Musl_libucontext < Package
   @cmake_ldflags = '-flto'
 
   @musldep_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+      LIBRARY_PATH='#{CREW_PREFIX}/musl/lib:$LIBRARY_PATH' \
       CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
       CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
       LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
@@ -47,11 +61,8 @@ class Musl_libucontext < Package
     system "sed -i 's,INCLUDEDIR := /usr/include,INCLUDEDIR := #{CREW_PREFIX}/musl/include,g' Makefile"
     system "sed -i 's,PKGCONFIGDIR := /usr/lib/pkgconfig,PKGCONFIGDIR := #{CREW_PREFIX}/musl/lib/pkgconfig,g' Makefile"
   end
+
   def self.build
-    #system "./configure --prefix=#{CREW_PREFIX}/musl \
-      ##{@musldep_env_options} \
-      #--enable-shared \
-      #--enable-static"
     system "#{@musldep_env_options} make ARCH=#{@arch}"
   end
 

--- a/packages/musl_libunwind.rb
+++ b/packages/musl_libunwind.rb
@@ -1,0 +1,72 @@
+require 'package'
+
+class Musl_libunwind < Package
+  description 'libunwind is a portable and efficient C programming interface (API) to determine the call-chain of a program.'
+  homepage 'https://www.nongnu.org/libunwind/'
+  @_ver = '1.5.0'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://download.savannah.gnu.org/releases/libunwind/libunwind-1.5.0.tar.gz'
+  source_sha256 '90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017'
+
+  depends_on 'musl_native_toolchain' => :build
+  depends_on 'musl_libbacktrace' => :build
+  depends_on 'musl_libucontext' => :build
+
+  @abi = ''
+  @arch_c_flags = ''
+  @arch_cxx_flags = ''
+  case ARCH
+  when 'aarch64', 'armv7l'
+    @abi = 'eabihf'
+    @arch = 'arm'
+  when 'i686'
+    @arch = 'x86'
+  when 'x86_64'
+    @arch = 'x86_64'
+  end
+
+  @cflags = "-B#{CREW_PREFIX}/musl/include -flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_c_flags} -fcommon"
+  @cxxflags = "-B#{CREW_PREFIX}/musl/include -flto -pipe -O3 -ffat-lto-objects -fipa-pta -fno-semantic-interposition -fdevirtualize-at-ltrans #{@arch_cxx_flags} -fcommon -static"
+  @ldflags = "-L#{CREW_PREFIX}/musl/lib -flto -static"
+  @cmake_ldflags = '-flto'
+
+  @musldep_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+      CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
+      CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
+      LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
+      LIBDIR=#{CREW_PREFIX}/musl/lib \
+      INCLUDEDIR=#{CREW_PREFIX}/musl/include \
+      PKG_CONFIG_LIBDIR=#{CREW_PREFIX}/musl/lib/pkgconfig \
+      PKGCONFIGDIR=#{CREW_PREFIX}/musl/lib/pkgconfig \
+      CFLAGS='#{@cflags}' \
+      CXXFLAGS='#{@cxxflags}' \
+      CPPFLAGS='-I#{CREW_PREFIX}/musl/include -fcommon' \
+      LDFLAGS='#{@ldflags}'"
+
+  def self.patch
+    # As per https://www.linuxquestions.org/questions/linux-software-2/building-libunwind-on-x86-musl-libc-against-libucontext-4175692781/#post6235105
+    # https://archive.md/gaEbN
+    system "sed -i '1i#include <ucontext.h>\' src/#{@arch}/Gos-linux.c"
+  end
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX}/musl \
+      #{@musldep_env_options} \
+      --enable-shared \
+      --enable-static \
+      --enable-ptrace \
+      --disable-tests"
+    system 'make'
+  end
+
+  def self.install
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/musl_libunwind.rb
+++ b/packages/musl_libunwind.rb
@@ -10,6 +10,19 @@ class Musl_libunwind < Package
   source_url 'https://download.savannah.gnu.org/releases/libunwind/libunwind-1.5.0.tar.gz'
   source_sha256 '90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunwind/1.5.0_armv7l/musl_libunwind-1.5.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunwind/1.5.0_armv7l/musl_libunwind-1.5.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunwind/1.5.0_i686/musl_libunwind-1.5.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunwind/1.5.0_x86_64/musl_libunwind-1.5.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '8325ff524aa0259dfd76a96fe43a12d16f8cc7e7c0d1a69f2db5bd68eb0f5879',
+     armv7l: '8325ff524aa0259dfd76a96fe43a12d16f8cc7e7c0d1a69f2db5bd68eb0f5879',
+       i686: 'c87940a7e9ea4963fce675445c4276cf8baae2506fb4260adbb1b8baf78cc9d2',
+     x86_64: '77172a1ee1ee561db6c95c1dffd8553b094214afbd8860a5dcdf00b0d288ec23'
+  })
+
   depends_on 'musl_native_toolchain' => :build
   depends_on 'musl_libbacktrace' => :build
   depends_on 'musl_libucontext' => :build
@@ -33,6 +46,7 @@ class Musl_libunwind < Package
   @cmake_ldflags = '-flto'
 
   @musldep_env_options = "PATH=#{CREW_PREFIX}/musl/bin:#{ENV['PATH']} \
+      LIBRARY_PATH='#{CREW_PREFIX}/musl/lib:$LIBRARY_PATH' \
       CC='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-gcc' \
       CXX='#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-g++' \
       LD=#{CREW_PREFIX}/musl/bin/#{ARCH}-linux-musl#{@abi}-ld.gold \
@@ -49,11 +63,11 @@ class Musl_libunwind < Package
     # As per https://www.linuxquestions.org/questions/linux-software-2/building-libunwind-on-x86-musl-libc-against-libucontext-4175692781/#post6235105
     # https://archive.md/gaEbN
     system "sed -i '1i#include <ucontext.h>\' src/#{@arch}/Gos-linux.c"
+    system 'filefix'
   end
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX}/musl \
-      #{@musldep_env_options} \
+    system "#{@musldep_env_options} ./configure --prefix=#{CREW_PREFIX}/musl \
       --enable-shared \
       --enable-static \
       --enable-ptrace \

--- a/packages/musl_native_toolchain.rb
+++ b/packages/musl_native_toolchain.rb
@@ -3,7 +3,7 @@ require 'package'
 class Musl_native_toolchain < Package
   description 'A modern, simple, and fast C library implementation that strives to be lightweight, fast, simple, free, and correct in the sense of standards-conformance and safety.'
   homepage 'https://musl.cc/'
-  version '1.2.2-e5d2823'
+  version '1.2.2-b76f37fd'
   compatibility 'all'
   license 'MIT, LGPL-2 and GPL-2'
   source_url({
@@ -13,23 +13,23 @@ class Musl_native_toolchain < Package
      x86_64: 'https://musl.cc/x86_64-linux-musl-native.tgz'
   })
   source_sha256({
-    aarch64: 'bf54a4762aed1a53be247bd5ead66569145c02d7ec78f405b184a7cda80149d1',
-     armv7l: 'bf54a4762aed1a53be247bd5ead66569145c02d7ec78f405b184a7cda80149d1',
-       i686: 'ae18b6d0fa58a638dba3b6efa1e660433fe9c0a0ef4283955dd934bc09a9898e',
-     x86_64: '6bceb516e51d2eecc65e9670f605692fec419bb7ecca701bb021b720f71d6d86'
+    aarch64: '2b37466f716d28a9ef313a8916543f53f9c8c78509e1c8d57a18ca4b171f2205',
+     armv7l: '2b37466f716d28a9ef313a8916543f53f9c8c78509e1c8d57a18ca4b171f2205',
+       i686: '978471bf7b8111dfd8c5559a23ef18b80bcd85936872f00424f1b7a5300580ee',
+     x86_64: 'eb1db6f0f3c2bdbdbfb993d7ef7e2eeef82ac1259f6a6e1757c33a97dbcef3ad'
   })
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-e5d2823_armv7l/musl_native_toolchain-1.2.2-e5d2823-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-e5d2823_armv7l/musl_native_toolchain-1.2.2-e5d2823-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-e5d2823_i686/musl_native_toolchain-1.2.2-e5d2823-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-e5d2823_x86_64/musl_native_toolchain-1.2.2-e5d2823-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-b76f37fd_armv7l/musl_native_toolchain-1.2.2-b76f37fd-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-b76f37fd_armv7l/musl_native_toolchain-1.2.2-b76f37fd-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-b76f37fd_i686/musl_native_toolchain-1.2.2-b76f37fd-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-b76f37fd_x86_64/musl_native_toolchain-1.2.2-b76f37fd-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'd171b09be7381cbde64dc923560b2ec4da61c926f63fc4c2cd2d9778e1b21900',
-     armv7l: 'd171b09be7381cbde64dc923560b2ec4da61c926f63fc4c2cd2d9778e1b21900',
-       i686: 'cded0394407b43ca30e7b07d91e3a35d3c70e43bcb657f12f8510a8677ef0b27',
-     x86_64: 'a99cc10f24baa7cdbf8bdb263c657793606ae8bdacbf8b5a906ddcc1a303547c'
+    aarch64: '740430d7ac599b6ee678943599cf88b31195f695cc00e6c86336a8b687a27804',
+     armv7l: '740430d7ac599b6ee678943599cf88b31195f695cc00e6c86336a8b687a27804',
+       i686: 'eda5d0e5ec72fa553a75377ac27994e9bb3f5466076de60ff1ad503522288b7b',
+     x86_64: 'af4d4c2b4c451a0679c70b4ba39a5b701d6d0df112b89d080c201c6708e27d77'
   })
 
   def self.install


### PR DESCRIPTION
- Attempt to work around musl i686 issues by adding libunwind to linking.
- Only enabled for `i686`

Works properly:
- [x] x86_64
- [x] i686 ???

### Run the following to test this pull request locally on i686.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=musl_lzip CREW_TESTING=1 crew update && \
crew install -s musl_libunwind ; \
crew upgrade lzip ; \
lzip --version || (crew remove lzip && crew install -s lzip)
```
