### PR TITLE
sommelier => 20211110

### DIFF
--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,23 +3,15 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  version '20210109-5'
+  version '20211110'
   license 'BSD-Google'
-  compatibility 'all'
+  compatibility 'aarch64, armv7l, x86_64'
   source_url 'https://chromium.googlesource.com/chromiumos/platform2.git'
-  git_hashtag 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
+  git_hashtag '1f1be4598c9de7e3865666176a33cf2223c17944'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-5_armv7l/sommelier-20210109-5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-5_armv7l/sommelier-20210109-5-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-5_i686/sommelier-20210109-5-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-5_x86_64/sommelier-20210109-5-chromeos-x86_64.tar.xz',
   })
   binary_sha256({
-    aarch64: '2b270ec19410594ba6969f20e168cc91739f090315a8046a95e303cac71d723e',
-     armv7l: '2b270ec19410594ba6969f20e168cc91739f090315a8046a95e303cac71d723e',
-       i686: '0b8f8ee99968f1cd3c429c9a1a7ffb6577b8ec430b91c83d1f7fa1c3856e7a3b',
-     x86_64: 'b652d65be2330108b4232dbf79991cc27c755a4fed958480b62696f4499b036d',
   })
 
   depends_on 'libdrm'
@@ -27,55 +19,78 @@ class Sommelier < Package
   depends_on 'libxcomposite' => :build
   depends_on 'libxfixes' => :build
   depends_on 'libxkbcommon'
+  depends_on 'llvm'
   depends_on 'mesa'
   depends_on 'pixman'
-  depends_on 'procps' # for pgrep in wrapper script
   depends_on 'psmisc'
   depends_on 'wayland'
   depends_on 'xauth'
   depends_on 'xdpyinfo' # for xdpyinfo in wrapper script
   depends_on 'xsetroot' # for xsetroot in sommelierrc script
   depends_on 'xhost' # for xhost in sommelierd script
+  depends_on 'xrdb' # for xrdb in sommelierrc script
   depends_on 'xwayland'
-  depends_on 'xxd_standalone' # for xxd in wrapper script
 
   case ARCH
   when 'armv7l', 'aarch64'
     @peer_cmd_prefix = '/lib/ld-linux-armhf.so.3'
-  when 'i686'
-    @peer_cmd_prefix = '/lib/ld-linux-i686.so.2'
   when 'x86_64'
     @peer_cmd_prefix = '/lib64/ld-linux-x86-64.so.2'
   end
 
   def self.preflight
-    @container_check = `grep :/docker /proc/self/cgroup | wc -l`
-    unless File.socket?('/var/run/chrome/wayland-0') || !@container_check.to_i.zero?
+    @container_check = system 'grep :/docker /proc/self/cgroup &> /dev/null'
+    if @container_check and ENV['SKIP_SOMM_CHECK'].to_s != '1' and !File.socket?('/var/run/chrome/wayland-0')
       abort 'This package is not compatible with your device :/'.lightred
     end
   end
 
   def self.patch
-    # Patch to avoid error with GCC > 9.x
-    # ../sommelier.cc:3238:10: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 108 equals destination size [-Wstringop-truncation]
-    Kernel.system "sed -i 's/sizeof(addr.sun_path))/sizeof(addr.sun_path) - 1)/' sommelier.cc",
-                  chdir: 'vm_tools/sommelier'
+    Dir.chdir('vm_tools/sommelier') do
+      @_drm_device = Dir['/dev/dri/renderD*'][0]
+
+      system <<~SED
+        # open the drm device without calling the new open_virtgpu logic (since it only accept virgl gpu)
+        sed -i -e 's#char\\* drm_device = NULL#char const \\*drm_device = "#{@_drm_device}"#' \
+               -e 's#int drm_fd = open_virtgpu(&drm_device)#int drm_fd = open(drm_device, O_RDWR | O_CLOEXEC)#' sommelier.cc
+
+        # point virtwl path to /dev/null (virtwl path is hardcoded now)
+        sed -i -e 's:#define VIRTWL_DEVICE "/dev/wl0":#define VIRTWL_DEVICE "/dev/null":' virtualization/virtwl_channel.cc
+      SED
+      
+      # replace the virtwl shm driver to noop shm driver (removed in commit 180e42d)
+      @sommelier_shm_patch = { /^[[:blank:]]+struct sl_host_buffer\*.+?host_buffer->resource;$/m => <<~P1.chomp, /^[[:blank:]]+host_shm_pool->fd = fd;$/ => <<~P2.chomp }
+        assert(host->proxy);
+        sl_create_host_buffer(host->shm->ctx, client, id,
+            wl_shm_pool_create_buffer(host->proxy, offset, width, height, stride, format), width, height);
+      P1
+        host_shm_pool->proxy = wl_shm_create_pool(host->shm_proxy, fd, size);
+        wl_shm_pool_set_user_data(host_shm_pool->proxy, host_shm_pool);
+        close(fd);
+      P2
+
+      @sommelier_shm = File.read('sommelier-shm.cc')
+      @sommelier_shm_patch.each_pair do |k, v|
+        @sommelier_shm.sub!(k, v)
+      end
+
+      File.write('sommelier-shm.cc', @sommelier_shm)
+    end
   end
 
   def self.build
     Dir.chdir('vm_tools/sommelier') do
       # lld is needed so libraries linked to system libraries (e.g. libgbm.so) can be linked against, since those are required for graphics acceleration.
-
       system <<~BUILD
-        env CC=clang CXX=clang++ \
+        #{CREW_ENV_OPTIONS.gsub('gold', 'lld')} CC=clang CXX=clang++ \
           meson #{CREW_MESON_OPTIONS} \
           -Db_asneeded=false \
           -Db_lto=true \
           -Db_lto_mode=thin \
           -Dxwayland_path=#{CREW_PREFIX}/bin/Xwayland \
-          -Dxwayland_gl_driver_path=/usr/#{ARCH_LIB}/dri -Ddefault_library=both \
-          -Dxwayland_shm_driver=noop -Dshm_driver=noop -Dvirtwl_device=/dev/null \
-          -Dpeer_cmd_prefix="#{CREW_PREFIX}#{@peer_cmd_prefix}" \
+          -Dxwayland_gl_driver_path=/usr/#{ARCH_LIB}/dri \
+          -Ddefault_library=both \
+          -Dwith_tests=false \
           builddir
       BUILD
 
@@ -83,32 +98,77 @@ class Sommelier < Package
       system 'samu -C builddir'
 
       Dir.chdir('builddir') do
-        system 'curl -L "https://chromium.googlesource.com/chromiumos/containers/sommelier/+/fbdefff6230026ac333eac0924d71cf824e6ecd8/sommelierrc?format=TEXT" | base64 --decode > sommelierrc'
+        @help = <<~EOF
+          To start the sommelier daemon, run 'startsommelier'
+          To stop the sommelier daemon, run 'stopsommelier'
+          To restart the sommelier daemon, run 'restartsommelier'
+        EOF
 
         @sommelierenv = <<~EOF
           set -a
-          CLUTTER_BACKEND=wayland
+
           DISPLAY=:0
-          GDK_BACKEND=x11
-          SCALE=1
           SOMMELIER_ACCELERATORS='Super_L,<Alt>bracketleft,<Alt>bracketright'
-          WAYLAND_DISPLAY=wayland-0
-          XDG_RUNTIME_DIR=/var/run/chrome
+          WAYLAND_DISPLAY=wayland-1
+
+          : "${CLUTTER_BACKEND:=x11}"
+          : "${GDK_BACKEND:=x11}"
+          : "${SOMMELIER_LOG:=#{CREW_PREFIX}/var/log/sommelier.log}"
+          : "${SOMMELIER_SCALE:=1.0}"
+          : "${XCURSOR_SIZE:=30}"
+          : "${XDG_RUNTIME_DIR:=/var/run/chrome}"
 
           case "$(uname -m)" in
           x86_64|i686)
-            sort_result="$(sort -V <<< "$(uname -r)"$'\\n'"4.16.0" | tail -n1)"
-            if [[ "${sort_result}" == "4.16.0" ]]; then
+            if [[ "$(sort -V <<< "$(uname -r)"$'\\n'"4.16.0" | tail -n1)" == "4.16.0" ]]; then
               MESA_LOADER_DRIVER_OVERRIDE=i965
             fi
           ;;
           esac
 
-          if [ -f "~/.sommelier.env" ]; then
-            source ~/.sommelier.env
+          [ -f "~/.sommelier.env" ] && source ~/.sommelier.env
+        EOF
+
+        # sommelierrc
+        # This file via:
+        # crostini: /etc/sommelierrc
+        # https://chromium.googlesource.com/chromiumos/containers/cros-container-guest-tools/+/4329a11adc890173f2385848e7b1bcc89fbd150d/cros-sommelier/sommelierrc
+        @sommelierrc = <<~EOF
+          #!/usr/bin/env bash
+          # Copyright 2019 The Chromium OS Authors. All rights reserved.
+          # Use of this source code is governed by a BSD-style license that can be
+          # found in the LICENSE file.
+          # Startup hook for the sommelier service.  You should not need to modify this
+          # file as customizations may be placed in ~/.sommelierrc instead.
+          #
+          # For documentation, see:
+          # https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/
+
+          set -e
+
+          if { command -v xdpyinfo && command -v xrdb; } > /dev/null; then
+            # Set Xft.dpi. Some applications (e.g. Chrome) use this to detect HiDPI.
+            # 1.25x of the DPI reported by xdpyinfo = the DPI reported by xdpyinfo in Crostini
+            DPI="$(( $(xdpyinfo | sed -n -E "/dots per inch/{s|^.* ([0-9]+)x.*$|\\1|g; p}") / 4 * 5 ))"
+            xrdb -merge <<< "Xft.dpi: ${DPI}"
+
+            # Set cursor theme
+            if [[ ! "$(xrdb -get Xcursor.theme)" ]]; then
+              xrdb -merge <<< 'Xcursor.theme: Adwaita'
+            fi
           fi
 
-          set +a
+          if command -v xsetroot > /dev/null; then
+            xsetroot -cursor_name left_ptr
+          fi
+
+          if command -v xhost > /dev/null; then
+            xhost +si:localuser:root
+          fi
+
+          if [ -f ~/.sommelierrc ]; then
+            source ~/.sommelierrc
+          fi
         EOF
 
         # Create local startup and shutdown scripts
@@ -117,8 +177,9 @@ class Sommelier < Package
         # This file via:
         # crostini: /opt/google/cros-containers/bin/sommelier
         # https://source.chromium.org/chromium/chromium/src/+/master:third_party/chromite/third_party/lddtree.py;drc=46da9a8dfce28c96765dc7d061f0c6d7a52e7352;l=146
-        IO.write 'sommelier_sh', <<~EOF
-          #!/bin/bash
+        @sommelier_sh = <<~EOF
+          #!/usr/bin/env bash
+
           function readlink(){
             coreutils --coreutils-prog=readlink "$@"
           }
@@ -131,7 +192,7 @@ class Sommelier < Package
           else
             case $0 in
             /*) base=$0;;
-            *)  base=${PWD:-`pwd`}/$0;;
+            *)  base=${PWD:-$(pwd)}/$0;;
             esac
           fi
           basedir=${base%/*}
@@ -145,134 +206,125 @@ class Sommelier < Package
         EOF
 
         # sommelierd
-        IO.write 'sommelierd', <<~EOF
-          #!/bin/bash -a
+        @sommelierd = <<~EOF
+          #!/usr/bin/env bash
 
-          source ${CREW_PREFIX}/etc/env.d/sommelier.env &>/dev/null
-          set +a
-          mkdir -p #{CREW_PREFIX}/var/{log,run}
-          checksommelierwayland () {
-            [[ -f "#{CREW_PREFIX}/var/run/sommelier-wayland.pid" ]] || return 1
-            /sbin/ss --unix -a -p | grep "\b$(cat #{CREW_PREFIX}/var/run/sommelier-wayland.pid)" | grep wayland &>/dev/null
-          }
-          checksommelierxwayland () {
-            xdpyinfo -display "${DISPLAY}" &>/dev/null
+          function log () {
+            echo -e "[log]: ${@}" >> ${SOMMELIER_LOG}
           }
 
-          ## As per https://www.reddit.com/r/chromeos/comments/8r5pvh/crouton_sommelier_openjdk_and_oracle_sql/e0pfknx/
-          ## One needs a second sommelier instance for wayland clients since at some point wl-drm was not implemented
-          ## in ChromeOS's wayland compositor.
-          #if ! checksommelierwayland ; then
-          #  pkill -F #{CREW_PREFIX}/var/run/sommelier-wayland.pid &>/dev/null
-          #  rm ${XDG_RUNTIME_DIR}/wayland-1*
-          #  sommelier --parent \
-          #    --peer-cmd-prefix="#{CREW_PREFIX}#{@peer_cmd_prefix}" \
-          #    --drm-device=/dev/dri/renderD128 --shm-driver=noop \
-          #    --data-driver=noop --display=wayland-0 --socket=wayland-1 \
-          #    --virtwl-device=/dev/null &> #{CREW_PREFIX}/var/log/sommelier.log &
-          #  echo "$!" > #{CREW_PREFIX}/var/run/sommelier-wayland.pid
-          #fi
-
-          if ! checksommelierxwayland; then
-            pkill -F #{CREW_PREFIX}/var/run/sommelier-xwayland.pid &>/dev/null
-            DISPLAY="${DISPLAY:0:3}"
-
-            sommelier -X \
-              --x-display=${DISPLAY}  \
-              --scale=${SCALE} --glamor \
-              --drm-device=/dev/dri/renderD128 \
-              --virtwl-device=/dev/null \
-              --shm-driver=noop --data-driver=noop \
-              --display=wayland-0 \
-              --xwayland-path=/usr/local/bin/Xwayland \
-              --xwayland-gl-driver-path=#{CREW_LIB_PREFIX}/dri \
-              --peer-cmd-prefix="#{CREW_PREFIX}#{@peer_cmd_prefix}" \
-              --no-exit-with-child \
-              /bin/sh -c "touch ~/.Xauthority
-                xauth -f ~/.Xauthority add ${DISPLAY} . $(xxd -l 16 -p /dev/urandom)
-                source #{CREW_PREFIX}/etc/sommelierrc" \
-            &>> #{CREW_PREFIX}/var/log/sommelier.log
-
-            echo "${!}" > #{CREW_PREFIX}/var/run/sommelier-xwayland.pid
-            xhost +si:localuser:root &>/dev/null
-          fi
-        EOF
-
-        # startsommelier
-        IO.write 'startsommelier', <<~EOF
-          #!/bin/bash -a
-
-          source ~/.sommelier-default.env &>/dev/null
-          source ~/.sommelier.env &>/dev/null
-          set +a
-
-          checksommelierwayland () {
-            #if [ -f "#{CREW_PREFIX}/var/run/sommelier-wayland.pid" ]; then
-            #  /sbin/ss --unix -a -p |\
-            #    grep "\b$(cat #{CREW_PREFIX}/var/run/sommelier-wayland.pid)" |\
-            #    grep wayland &>/dev/null
-            #else
-            #  return 1
-            #fi
-            return 0
+          function err () {
+            echo -e "[err]: ${@}"
           }
-          checksommelierxwayland () {
-            xdpyinfo -display "${DISPLAY}" &>/dev/null
+
+          function checksommelierwayland () {
+            if [[ "$(/sbin/ss -lxp)" =~ ${WAYLAND_DISPLAY} ]]; then
+              log "vaild wayland display (${WAYLAND_DISPLAY})"
+            else
+              err "sommelier-wayland failed to start"
+              return 1
+            fi
           }
-          if ! checksommelierwayland || ! checksommelierxwayland ; then
-            [ -f  #{CREW_PREFIX}/bin/stopbroadway ] && stopbroadway
-            #{CREW_PREFIX}/sbin/sommelierd &> /dev/null &
-          fi
-          wait=3
-          until checksommelierwayland && checksommelierxwayland; do
-            [ "${wait}" -le "0" ] && break
-            (( wait = wait - 1 ))
-            sleep 3
-          done
 
-          SOMMWPIDS="$(pgrep -f "sommelier.elf --parent" 2> /dev/null)"
-          SOMMWPROCS="$(pgrep -fa "sommelier.elf --parent" 2> /dev/null)"
-          SOMMXPIDS="$(pgrep -f "sommelier.elf -X" 2> /dev/null)"
-          SOMMXPROCS="$(pgrep -fa "sommelier.elf -X" 2> /dev/null)"
+          function checksommelierxwayland () {
+            if [[ "$(/sbin/ss -lxp)" =~ ${DISPLAY/:/X} ]]; then
+              log "sommelier running on display ${DISPLAY}"
+            else
+              err "sommelier-x11 failed to start"
+              return 1
+            fi
+          }
 
-          if checksommelierwayland && checksommelierxwayland ; then
-            echo -e "sommelier processes running: ${SOMMWPIDS} ${SOMMXPIDS}"
+          function start () {
+            if ! checksommelierwayland &> /dev/null; then
+              # start a nested (hardware accelerated) wayland compositor on top of exo
+              nohup sommelier --parent \
+                --peer-cmd-prefix='#{CREW_PREFIX}#{@peer_cmd_prefix}' \
+                --display=wayland-0 \
+                --socket=wayland-1 \
+              &> ${SOMMELIER_LOG} &
+              echo -n "${!}" > #{CREW_PREFIX}/var/run/sommelier-wayland.pid
+            fi
+
+            if ! checksommelierxwayland &> /dev/null; then
+              nohup sommelier -X \
+                --x-display=${DISPLAY}  \
+                --glamor \
+                --display=wayland-0 \
+                --xwayland-path=#{CREW_PREFIX}/bin/Xwayland \
+                --xwayland-gl-driver-path=#{CREW_LIB_PREFIX}/dri \
+                --peer-cmd-prefix='#{CREW_PREFIX}#{@peer_cmd_prefix}' \
+                --no-exit-with-child \
+                  /usr/bin/env bash -c "touch ~/.Xauthority
+                  xauth -f ~/.Xauthority add '${DISPLAY}' . '$(openssl rand -hex 16)'
+                  source #{CREW_PREFIX}/etc/sommelierrc" \
+              &>> ${SOMMELIER_LOG} &
+              echo -n "${!}" > #{CREW_PREFIX}/var/run/sommelier-xwayland.pid
+            fi
+          }
+          
+          function stop () {
+            {
+              pkill -f sommelier.elf
+              pkill -F #{CREW_PREFIX}/var/run/sommelier-wayland.pid &>/dev/null
+              pkill -F #{CREW_PREFIX}/var/run/sommelier-xwayland.pid &>/dev/null
+            } &> /dev/null
+
+            # remove wayland socket after sommelier gone
+            if [[ ! "$(/sbin/ss -lxp)" =~ ${WAYLAND_DISPLAY} ]]; then
+              rm -f ${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}*
+            fi
+
+            if [[ "$(ps -Ao args)" =~ sommelier.elf ]]; then
+              echo "#{'sommelier failed to stop'.yellow}"
+              exit 1
+            else
+              echo "sommelier stopped"
+            fi
+          }
+
+          if [[ "${0}" == */startsommelier || "${1}" == '--start' ]]; then
+            # reload env variables when started via startsommelier symlink
+            [[ "${0}" == */startsommelier ]] && source #{CREW_PREFIX}/etc/env.d/sommelier
+
+            if [ -z "${SOMMELIER_LOG}" ]; then
+              err "SOMMELIER_LOG not set, exiting..."
+              exit 1
+            fi
+
+            # clear log file
+            echo -n > ${SOMMELIER_LOG}
+
+            start
+
+            # wait for sommelier start
+            RETRY=20
+            i=0
+            until { checksommelierwayland && checksommelierxwayland; } &> /dev/null; do
+              (( ${i} > ${RETRY} )) && break
+              sleep 0.3
+              ((i++))
+            done
+
+            if ! { checksommelierwayland && checksommelierxwayland; }; then
+              echo -e "#{'some sommelier processes failed to start'.yellow}"
+              echo "check ${SOMMELIER_LOG} for more info"
+              exit 1
+            fi
+
+            echo -e "sommelier processes running: $(< #{CREW_PREFIX}/var/run/sommelier-wayland.pid) $(< #{CREW_PREFIX}/var/run/sommelier-xwayland.pid)"
+          elif [[ "${0}" == */stopsommelier || "${1}" == '--stop' ]]; then
+            stop
+          elif [[ "${0}" == */restartsommelier || "${1}" == '--restart' ]]; then
+            stop && exec startsommelier
           else
-            echo "some sommelier processes failed to start"
-            echo -e "sommelier processes running: ${SOMMWPROCS} \\n ${SOMMXPROCS}"
+            echo -en "#{@help}"
             exit 1
           fi
-        EOF
-
-        # stopsommelier
-        IO.write 'stopsommelier', <<~EOF
-          #!/bin/bash
-          SOMM="$(pgrep -fc sommelier.elf 2> /dev/null)"
-          if [[ "${SOMM}" -gt "0" ]]; then
-            pkill -f sommelier.elf &>/dev/null
-            pkill -F #{CREW_PREFIX}/var/run/sommelier-wayland.pid &>/dev/null
-            pkill -F #{CREW_PREFIX}/var/run/sommelier-xwayland.pid &>/dev/null
-          else
-            exit 0
-          fi
-          if [[ "$(pgrep -fc sommelier.elf 2> /dev/null)" -gt "0" ]]; then
-            echo "sommelier failed to stop"
-            exit 1
-          else
-            echo "sommelier stopped"
-          fi
-        EOF
-
-        # restartsommelier
-        IO.write 'restartsommelier', <<~EOF
-          #!/bin/bash
-          stopsommelier && startsommelier
         EOF
 
         # start sommelier from bash.d, which loads after all of env.d via #{CREW_PREFIX}/etc/profile
-        @bashd_sommelier = <<~EOF
-          startsommelier
-        EOF
+        @bashd_sommelier = 'sommelierd --start'
       end
     end
   end
@@ -282,39 +334,43 @@ class Sommelier < Package
                          #{CREW_DEST_PREFIX}/etc/env.d CREW_DEST_HOME]
     Dir.chdir('vm_tools/sommelier') do
       system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
-      Dir.chdir('builddir') do
-        FileUtils.mv "#{CREW_DEST_PREFIX}/bin/sommelier", "#{CREW_DEST_PREFIX}/bin/sommelier.elf"
-        FileUtils.install 'sommelier_sh', "#{CREW_DEST_PREFIX}/bin/sommelier", mode: 0o755
-        FileUtils.install 'sommelierd', "#{CREW_DEST_PREFIX}/sbin/sommelierd", mode: 0o755
-        FileUtils.install 'startsommelier', "#{CREW_DEST_PREFIX}/bin/startsommelier", mode: 0o755
-        FileUtils.ln_sf 'startsommelier', "#{CREW_DEST_PREFIX}/bin/initsommelier"
-        FileUtils.install 'stopsommelier', "#{CREW_DEST_PREFIX}/bin/stopsommelier", mode: 0o755
-        FileUtils.install 'restartsommelier', "#{CREW_DEST_PREFIX}/bin/restartsommelier", mode: 0o755
-        FileUtils.install 'sommelierrc', "#{CREW_DEST_PREFIX}/etc/sommelierrc", mode: 0o644
+      FileUtils.mv "#{CREW_DEST_PREFIX}/bin/sommelier", "#{CREW_DEST_PREFIX}/bin/sommelier.elf"
+
+      {
+        "#{CREW_DEST_PREFIX}/bin/sommelier" => @sommelier_sh,
+        "#{CREW_DEST_PREFIX}/bin/sommelierd" => @sommelierd,
+        "#{CREW_DEST_PREFIX}/etc/sommelierrc" => @sommelierrc
+      } .each_pair do |filename, v|
+        File.write filename, v
+        File.chmod 0755, filename
+      end
+
+      {
+        "#{CREW_DEST_PREFIX}/bin/startsommelier" => 'sommelierd',
+        "#{CREW_DEST_PREFIX}/bin/stopsommelier" => 'sommelierd',
+        "#{CREW_DEST_PREFIX}/bin/restartsommelier" => 'sommelierd'
+      } .each_pair do |link, target|
+        FileUtils.ln_s target, link
       end
     end
 
-    IO.write("#{CREW_DEST_PREFIX}/etc/bash.d/sommelier", @bashd_sommelier)
-    IO.write("#{CREW_DEST_PREFIX}/etc/env.d/sommelier", @sommelierenv)
+    File.write("#{CREW_DEST_PREFIX}/etc/bash.d/sommelier", @bashd_sommelier)
+    File.write("#{CREW_DEST_PREFIX}/etc/env.d/sommelier", @sommelierenv)
   end
 
   def self.postinstall
     # all tasks are done by sommelier.env now
     puts
-    puts 'Removing old sommelier env variable loading code in ~/.bashrc'.lightblue
-    system 'sed -i "/[sS]ommelier/d" -i.backup ~/.bashrc'
     puts 'To complete the installation, execute the following:'.orange
     puts 'source ~/.bashrc'.orange
-
     puts
-    FileUtils.touch "#{HOME}/.sommelier.env" unless File.exist? "#{HOME}/.sommelier.env"
+
+    FileUtils.touch "#{HOME}/.sommelier.env"
     puts <<~EOT.lightblue
       To adjust sommelier environment variables, edit #{CREW_PREFIX}/etc/env.d/sommelier
       Default values are in #{CREW_PREFIX}/etc/env.d/sommelier
 
-      To start the sommelier daemon, run 'startsommelier'
-      To stop the sommelier daemon, run 'stopsommelier'
-      To restart the sommelier daemon, run 'restartsommelier'
+      #{@help}
 
     EOT
     puts <<~EOT.orange

--- a/packages/xrdb.rb
+++ b/packages/xrdb.rb
@@ -1,0 +1,22 @@
+require 'package'
+
+class Xrdb < Package
+  description 'xrdb - X server resource database utility'
+  homepage 'https://x.org'
+  @_ver = '1.2.1'
+  version @_ver
+  license 'custom'
+  compatibility 'all'
+  source_url 'https://gitlab.freedesktop.org/xorg/app/xrdb.git'
+  git_hashtag "xrdb-#{@_ver}"
+
+  def self.build
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end


### PR DESCRIPTION
Get it working finally :)

## New patches
- Change hardcoded virtwl path to `/dev/null`
- Open `/dev/dri/renderD128` directly without calling the newly added function (that function is broken with non-virgl GPU devices)
- Replace the virtwl driver the removed noop shm driver (run into errors when using the default virtwl driver)

## Changes
- Add `SKIP_SOMM_CHECK` env variable
- Re-enable nested Wayland compositor
- Set xcursor theme and size at sommelier start
- Correct DPI
- Add missing `llvm` (need by `sommelier.elf`) and `xrdb` dependency (needed by `sommelierd`)
- Remove gcc patch
- Use `lld`
- Remove deprecated build options
- Remove `procps` dependency, use `ps` + `grep`

## Working
- [x] Acceleration
- [x] Wayland
- [x] X

Tested on `x86_64`

## Run the following to test this pull request
```shell
CREW_TESTING_REPO=https://github.com/supechicken666/chromebrew.git \
CREW_TESTING_BRANCH=update_sommelier \
CREW_TESTING=1 \
crew update
crew reinstall sommelier
```
