### PR TITLE
Update musl toolchain to Nov 2021 build

### DIFF
--- a/packages/musl_native_toolchain.rb
+++ b/packages/musl_native_toolchain.rb
@@ -3,7 +3,7 @@ require 'package'
 class Musl_native_toolchain < Package
   description 'A modern, simple, and fast C library implementation that strives to be lightweight, fast, simple, free, and correct in the sense of standards-conformance and safety.'
   homepage 'https://musl.cc/'
-  version '1.2.2-e5d2823'
+  version '1.2.2-b76f37fd'
   compatibility 'all'
   license 'MIT, LGPL-2 and GPL-2'
   source_url({
@@ -13,23 +13,23 @@ class Musl_native_toolchain < Package
      x86_64: 'https://musl.cc/x86_64-linux-musl-native.tgz'
   })
   source_sha256({
-    aarch64: 'bf54a4762aed1a53be247bd5ead66569145c02d7ec78f405b184a7cda80149d1',
-     armv7l: 'bf54a4762aed1a53be247bd5ead66569145c02d7ec78f405b184a7cda80149d1',
-       i686: 'ae18b6d0fa58a638dba3b6efa1e660433fe9c0a0ef4283955dd934bc09a9898e',
-     x86_64: '6bceb516e51d2eecc65e9670f605692fec419bb7ecca701bb021b720f71d6d86'
+    aarch64: '2b37466f716d28a9ef313a8916543f53f9c8c78509e1c8d57a18ca4b171f2205',
+     armv7l: '2b37466f716d28a9ef313a8916543f53f9c8c78509e1c8d57a18ca4b171f2205',
+       i686: '978471bf7b8111dfd8c5559a23ef18b80bcd85936872f00424f1b7a5300580ee',
+     x86_64: 'eb1db6f0f3c2bdbdbfb993d7ef7e2eeef82ac1259f6a6e1757c33a97dbcef3ad'
   })
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-e5d2823_armv7l/musl_native_toolchain-1.2.2-e5d2823-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-e5d2823_armv7l/musl_native_toolchain-1.2.2-e5d2823-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-e5d2823_i686/musl_native_toolchain-1.2.2-e5d2823-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-e5d2823_x86_64/musl_native_toolchain-1.2.2-e5d2823-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-b76f37fd_armv7l/musl_native_toolchain-1.2.2-b76f37fd-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-b76f37fd_armv7l/musl_native_toolchain-1.2.2-b76f37fd-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-b76f37fd_i686/musl_native_toolchain-1.2.2-b76f37fd-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.2-b76f37fd_x86_64/musl_native_toolchain-1.2.2-b76f37fd-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'd171b09be7381cbde64dc923560b2ec4da61c926f63fc4c2cd2d9778e1b21900',
-     armv7l: 'd171b09be7381cbde64dc923560b2ec4da61c926f63fc4c2cd2d9778e1b21900',
-       i686: 'cded0394407b43ca30e7b07d91e3a35d3c70e43bcb657f12f8510a8677ef0b27',
-     x86_64: 'a99cc10f24baa7cdbf8bdb263c657793606ae8bdacbf8b5a906ddcc1a303547c'
+    aarch64: '740430d7ac599b6ee678943599cf88b31195f695cc00e6c86336a8b687a27804',
+     armv7l: '740430d7ac599b6ee678943599cf88b31195f695cc00e6c86336a8b687a27804',
+       i686: 'eda5d0e5ec72fa553a75377ac27994e9bb3f5466076de60ff1ad503522288b7b',
+     x86_64: 'af4d4c2b4c451a0679c70b4ba39a5b701d6d0df112b89d080c201c6708e27d77'
   })
 
   def self.install


### PR DESCRIPTION
- Updates musl toolchain to a November 2021 build as per https://musl.cc/#binaries
```
musl: git-b76f37f (2021-09-23)
GCC: 11.2.1 (Snapshot 11-20211120)
binutils: 2.37
GMP: 6.2.1
MPFR: 4.1.0
MPC: 1.2.1
```
Reported to be built using https://git.zv.io/toolchains/musl-cross-make 
and this config.mak:
```
STAT = -static --static
FLAG = -g0 -O2 -fno-align-functions -fno-align-jumps -fno-align-loops -fno-align-labels -Wno-error

ifneq ($(NATIVE),)
COMMON_CONFIG += CC="$(HOST)-gcc ${STAT}" CXX="$(HOST)-g++ ${STAT}" FC="$(HOST)-gfortran ${STAT}"
else
COMMON_CONFIG += CC="gcc ${STAT}" CXX="g++ ${STAT}" FC="gfortran ${STAT}"
endif

COMMON_CONFIG += CFLAGS="${FLAG}" CXXFLAGS="${FLAG}" FFLAGS="${FLAG}" LDFLAGS="-s ${STAT}"

BINUTILS_CONFIG += --enable-gold=yes
GCC_CONFIG += --enable-default-pie --enable-static-pie --disable-cet

CONFIG_SUB_REV = 888c8e3d5f7b
GCC_VER = 11-20211120
BINUTILS_VER = 2.37
MUSL_VER = git-b76f37fd5625d038141b52184956fb4b7838e9a5
GMP_VER = 6.2.1
MPC_VER = 1.2.1
MPFR_VER = 4.1.0

LINUX_VER = 5.15.2
```

Works properly:
- [x] x86_64
- [x] armv7l (in _container_)
- [x] i686 (in _container_) (@uberhacker need to see if this segfaults on i686 hardware.)
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=musl_update CREW_TESTING=1 crew update ; /usr/local/musl/bin/gcc --version
```
![image](https://user-images.githubusercontent.com/1096701/143079754-7544dfc9-d0dd-46e2-8ea5-ac93c4d4fc6e.png)

