### PR TITLE
Wayland protocols -> 1.24

### DIFF
--- a/packages/wayland_protocols.rb
+++ b/packages/wayland_protocols.rb
@@ -3,33 +3,36 @@ require 'package'
 class Wayland_protocols < Package
   description 'Wayland is a protocol for a compositor to talk to its clients.'
   homepage 'https://wayland.freedesktop.org/'
-  version '1.21'
+  version '1.24'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://wayland.freedesktop.org/releases/wayland-protocols-1.21.tar.xz'
-  source_sha256 'b99945842d8be18817c26ee77dafa157883af89268e15f4a5a1a1ff3ffa4cde5'
+  source_url 'https://gitlab.freedesktop.org/wayland/wayland-protocols.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.21_armv7l/wayland_protocols-1.21-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.21_armv7l/wayland_protocols-1.21-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.21_i686/wayland_protocols-1.21-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.21_x86_64/wayland_protocols-1.21-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.24_armv7l/wayland_protocols-1.24-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.24_armv7l/wayland_protocols-1.24-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.24_i686/wayland_protocols-1.24-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.24_x86_64/wayland_protocols-1.24-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '487266d1e54fd7094f0b75184bbea84044304dbbe4d64c9214069ff6cfee4472',
-     armv7l: '487266d1e54fd7094f0b75184bbea84044304dbbe4d64c9214069ff6cfee4472',
-       i686: '79e0dc6d2724fdc3ca0724a5d04649adf2e88136e3fc1b5a4ee2f4001117cac2',
-     x86_64: 'fd5283cabe38f85f245a5dcbb6b946594fefa64a5d0777a5554ee534f985ee56'
+    aarch64: 'c633f35563e10ddb018f0d546f5d3a3414d60981f477fee9e66c638018e4fe2a',
+     armv7l: 'c633f35563e10ddb018f0d546f5d3a3414d60981f477fee9e66c638018e4fe2a',
+       i686: '024424651a90ae99a88c7f7f5fef9b207b1c74e67574f3e86fb09b9d2a051723',
+     x86_64: '985f6edc42f6a1bded7c38563ca45cfa2fa51d9d1128dfa4445998604062db7a'
   })
 
   depends_on 'wayland'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
-    system 'make'
+    system "meson #{CREW_MESON_OPTIONS} \
+    -Dtests=false \
+     builddir"
+    system 'meson configure builddir'
+    system 'samu -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end


### PR DESCRIPTION
- switch to meson, deprecation of autotools setup.

Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=wayland_protocols CREW_TESTING=1 crew update
```
