### PR TITLE
Add wayland_proxy_virtwl (a sommelier alternative)

### DIFF
--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -7,68 +7,65 @@ class Opam < Package
   description 'OCaml package manager'
   homepage 'https://opam.ocaml.org/'
   @_ver = '2.1.1'
-  version @_ver
+  version "#{@_ver}-2"
   compatibility 'all'
   source_url 'https://github.com/ocaml/opam.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1_armv7l/opam-2.1.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1_armv7l/opam-2.1.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1_i686/opam-2.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1_x86_64/opam-2.1.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-2_armv7l/opam-2.1.1-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-2_armv7l/opam-2.1.1-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-2_i686/opam-2.1.1-2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-2_x86_64/opam-2.1.1-2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '53d3b4e436c1a70f5772523f0af5454aa54ad7dfb777d50fe7495d31160b7462',
-     armv7l: '53d3b4e436c1a70f5772523f0af5454aa54ad7dfb777d50fe7495d31160b7462',
-       i686: '4d8e3979729315249b0a9dabf795108c91d16618dd5f38285dc758eabf3896d1',
-     x86_64: 'f0cced8d7504be9b5bbd2f98d346e28b9cd18cd8b02985722643854a5cd5d51f'
+    aarch64: 'ef542a60a56abda5549b9e0a07e76898315dd07149bda008f0498b5244ec79b8',
+     armv7l: 'ef542a60a56abda5549b9e0a07e76898315dd07149bda008f0498b5244ec79b8',
+       i686: '380e81c2ce976bf42ccfc18050598c50bf282b157a269f4dd179d0410ab2dbb9',
+     x86_64: 'cb95bae566579fcf5d1952afe41c89d40932a10458e90c00a0f812ae9ef0f43f'
   })
 
   depends_on 'bubblewrap'
   depends_on 'ocaml'
   depends_on 'rsync'
 
+  @OPAMROOT = "#{CREW_PREFIX}/share/opam"
+
   def self.build
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system "make lib-ext all -j1 \
       OCAMLC='ocamlc -unsafe-string' \
       OCAMLOPT='ocamlopt -unsafe-string'"
-    @bashd_opam = <<~EOF
-      export OPAMROOT=#{CREW_PREFIX}/opam
-      eval \$(opam env --root=#{CREW_PREFIX}/opam --switch=default)
-      test -r #{CREW_PREFIX}/opam/opam-init/init.sh && . #{CREW_PREFIX}/opam/opam-init/init.sh > /dev/null 2> /dev/null || true
-    EOF
+    @bashd_opam = <<~OPAMEOF
+      export OPAMROOT=#{@OPAMROOT}
+      eval \$(opam env --root=#{@OPAMROOT} --switch=default)
+      test -r #{@OPAMROOT}/opam-init/init.sh && . #{@OPAMROOT}/opam-init/init.sh > /dev/null 2> /dev/null || true
+    OPAMEOF
   end
 
   def self.install
-    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
-    warn_level = $VERBOSE
-    $VERBOSE = nil
-    load "#{CREW_LIB_PATH}lib/const.rb"
-    $VERBOSE = warn_level
     system "make DESTDIR=#{CREW_DEST_DIR} install"
     FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/etc/bash.d]
     File.write("#{CREW_DEST_PREFIX}/etc/bash.d/opam", @bashd_opam)
   end
 
   def self.postinstall
-    system "opam init --root=#{CREW_PREFIX}/opam -y \
-            && eval \$(opam env --root=#{CREW_PREFIX}/opam --switch=default) \
-            && opam option --global depext=false --root=#{CREW_PREFIX}/opam -y"
+    system "opam init --root=#{@OPAMROOT} -y \
+            && eval \$(opam env --root=#{@OPAMROOT} --switch=default) \
+            && opam option --global depext=false --root=#{@OPAMROOT} -y"
   end
 
   def self.remove
-    if Dir.exist? "#{CREW_PREFIX}/opam"
+    if Dir.exist? @OPAMROOT.to_s
       puts
-      print "Would you like to remove #{CREW_PREFIX}/opam? [y/N] "
+      print "Would you like to remove #{@OPAMROOT}? [y/N] "
       response = $stdin.getc
       case response
       when 'y', 'Y'
-        FileUtils.rm_rf "#{CREW_PREFIX}/opam"
-        puts "#{CREW_PREFIX}/opam removed.".lightred
+        FileUtils.rm_rf @OPAMROOT.to_s
+        puts "#{@OPAMROOT} removed.".lightred
       else
-        puts "#{CREW_PREFIX}/opam saved.".lightgreen
+        puts "#{@OPAMROOT} saved.".lightgreen
       end
       puts
     end

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -19,10 +19,10 @@ class Opam < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.2_x86_64/opam-2.1.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'dc177f2bb38e12fd6ce7c697117a661edc6ad67ca9b7249c7661c43f8e218a52',
-     armv7l: 'dc177f2bb38e12fd6ce7c697117a661edc6ad67ca9b7249c7661c43f8e218a52',
-       i686: '57f36dfc182d5719229f8ef883be8e878160ab116bb8c004a8ce3bdf5a802dd1',
-     x86_64: '612c10ea82c335d79c6a06e5abf9da93e873f3419574a7a93a17fa284c913daf'
+    aarch64: '596b3928ed6ebf82b865314ff0601f40f6e2bd8d9d2a0296ab6f45da1afc29cf',
+     armv7l: '596b3928ed6ebf82b865314ff0601f40f6e2bd8d9d2a0296ab6f45da1afc29cf',
+       i686: 'e21ee0b4989a8d18cc6ea6a0da59c8e214abe3de96104636b6d323195a69f393',
+     x86_64: 'bb2a382e59f36eb109eaaa0e471f0e9bc8f74823703fa9e9e0b0e11dfed6d9e7'
   })
 
   depends_on 'bubblewrap'
@@ -39,7 +39,7 @@ class Opam < Package
     @bashd_opam = <<~OPAMEOF
       export OPAMROOT=#{@OPAMROOT}
       eval \$(opam env --root=#{@OPAMROOT} --switch=default)
-      test -r #{@OPAMROOT}/opam-init/init.sh && . #{@OPAMROOT}/opam-init/init.sh > /dev/null 2> /dev/null || true
+      test -r #{@OPAMROOT}/opam-init/init.sh && . #{@OPAMROOT}/opam-init/init.sh &> /dev/null || true
     OPAMEOF
   end
 
@@ -56,18 +56,18 @@ class Opam < Package
   end
 
   def self.remove
-    if Dir.exist? @OPAMROOT
-      puts
-      print "Would you like to remove #{@OPAMROOT}? [y/N] "
-      response = $stdin.getc
-      case response
-      when 'y', 'Y'
-        FileUtils.rm_rf @OPAMROOT
-        puts "#{@OPAMROOT} removed.".lightred
-      else
-        puts "#{@OPAMROOT} saved.".lightgreen
-      end
-      puts
+    return unless Dir.exist? @OPAMROOT
+
+    puts
+    print "Would you like to remove #{@OPAMROOT}? [y/N] "
+    response = $stdin.getc
+    case response
+    when 'y', 'Y'
+      FileUtils.rm_rf @OPAMROOT
+      puts "#{@OPAMROOT} removed.".lightred
+    else
+      puts "#{@OPAMROOT} saved.".lightgreen
     end
+    puts
   end
 end

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -6,23 +6,23 @@ require 'package'
 class Opam < Package
   description 'OCaml package manager'
   homepage 'https://opam.ocaml.org/'
-  @_ver = '2.1.1'
-  version "#{@_ver}-2"
+  @_ver = '2.1.2'
+  version @_ver
   compatibility 'all'
   source_url 'https://github.com/ocaml/opam.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-2_armv7l/opam-2.1.1-2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-2_armv7l/opam-2.1.1-2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-2_i686/opam-2.1.1-2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.1-2_x86_64/opam-2.1.1-2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.2_armv7l/opam-2.1.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.2_armv7l/opam-2.1.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.2_i686/opam-2.1.2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.2_x86_64/opam-2.1.2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: 'ef542a60a56abda5549b9e0a07e76898315dd07149bda008f0498b5244ec79b8',
-     armv7l: 'ef542a60a56abda5549b9e0a07e76898315dd07149bda008f0498b5244ec79b8',
-       i686: '380e81c2ce976bf42ccfc18050598c50bf282b157a269f4dd179d0410ab2dbb9',
-     x86_64: 'cb95bae566579fcf5d1952afe41c89d40932a10458e90c00a0f812ae9ef0f43f'
+    aarch64: 'dc177f2bb38e12fd6ce7c697117a661edc6ad67ca9b7249c7661c43f8e218a52',
+     armv7l: 'dc177f2bb38e12fd6ce7c697117a661edc6ad67ca9b7249c7661c43f8e218a52',
+       i686: '57f36dfc182d5719229f8ef883be8e878160ab116bb8c004a8ce3bdf5a802dd1',
+     x86_64: '612c10ea82c335d79c6a06e5abf9da93e873f3419574a7a93a17fa284c913daf'
   })
 
   depends_on 'bubblewrap'

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -56,13 +56,13 @@ class Opam < Package
   end
 
   def self.remove
-    if Dir.exist? @OPAMROOT.to_s
+    if Dir.exist? @OPAMROOT
       puts
       print "Would you like to remove #{@OPAMROOT}? [y/N] "
       response = $stdin.getc
       case response
       when 'y', 'Y'
-        FileUtils.rm_rf @OPAMROOT.to_s
+        FileUtils.rm_rf @OPAMROOT
         puts "#{@OPAMROOT} removed.".lightred
       else
         puts "#{@OPAMROOT} saved.".lightgreen

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -109,9 +109,9 @@ class Wayland_proxy_virtwl < Package
                | Ready | Destroyed -> ()
     PATCH_RELAY_EOF
     IO.write('xwayland.patch', @xwayland_patch)
-    system 'patch -Np1 -i xwayland.patch'
-    IO.write('xwayland.patch', @relay_patch)
-    system 'patch -Np1 -i relay.patch'
+    system 'patch -Np2 -i xwayland.patch'
+    IO.write('relay.patch', @relay_patch)
+    system 'patch -Np2 -i relay.patch'
   end
 
   def self.install

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -10,14 +10,14 @@ class Wayland_proxy_virtwl < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-armv7l.tpxz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_armv7l/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_armv7l/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-armv7l.tpxz',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_i686/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-i686.tpxz',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_x86_64/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '2172ba0d35a4a9eedc95a656de158eb08eea91319d5f2fa026a56c6bbeece71f',
-     armv7l: '2172ba0d35a4a9eedc95a656de158eb08eea91319d5f2fa026a56c6bbeece71f',
+    aarch64: '8bc8e2d9520ad8928f135aefbe04a5099ed15230607fb66cea5c8ecbe796b4e9',
+     armv7l: '8bc8e2d9520ad8928f135aefbe04a5099ed15230607fb66cea5c8ecbe796b4e9',
        i686: 'd936e559d1b9a77fd74d2f00353b80e574f67334ea238e9bd29cbb698cc70417',
      x86_64: 'd6a34fb22a85eba404b45ff9a4ddc7351038104b8ef1719db37f5535eb401bee'
   })
@@ -130,14 +130,14 @@ class Wayland_proxy_virtwl < Package
   end
 
   def self.postinstall
-    puts <<~'EOS'.lightblue
+    puts <<~'EOFSTRING'.lightblue
       Note that there is not yet hardware acceleration in wayland-proxy-virtwl.
       wayland-proxy-virtwl example usage (before running a gui program):
-    EOS
-    puts <<~'EOSCODE'.lightcyan
+    EOFSTRING
+    puts <<~'EOFSHELLCODE'.lightcyan
       wayland-proxy-virtwl --wayland-display wayland-2 --x-display=2 --xrdb Xft.dpi:150 &
       export WAYLAND_DISPLAY=wayland-2
       export DISPLAY=:2
-    EOSCODE
+    EOFSHELLCODE
   end
 end

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -135,7 +135,7 @@ class Wayland_proxy_virtwl < Package
       wayland-proxy-virtwl example usage (before running a gui program):
     EOS
     puts <<~'EOSCODE'.lightcyan
-      wayland-proxy-virtwl --wayland-display wayland-2 --x-display=2 --xrdb Xft.dpi:150
+      wayland-proxy-virtwl --wayland-display wayland-2 --x-display=2 --xrdb Xft.dpi:150 &
       export WAYLAND_DISPLAY=wayland-2
       export DISPLAY=:2
     EOSCODE

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -3,10 +3,11 @@ require 'package'
 class Wayland_proxy_virtwl < Package
   description 'Proxy Wayland connections across the VM boundary'
   homepage 'https://github.com/talex5/wayland-proxy-virtwl'
-  @_ver = '69de5648bad98a0f7ae19bea292420d7fd804205'
+  @_ver = 'd8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2'
   version @_ver
   compatibility 'all'
   source_url 'https://github.com/talex5/wayland-proxy-virtwl.git'
+  git_branch 'chromebrew'
   git_hashtag @_ver
 
   binary_url({

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -1,0 +1,143 @@
+require 'package'
+
+class Wayland_proxy_virtwl < Package
+  description 'Proxy Wayland connections across the VM boundary'
+  homepage 'https://github.com/talex5/wayland-proxy-virtwl'
+  @_ver = '69de5648bad98a0f7ae19bea292420d7fd804205'
+  version @_ver
+  compatibility 'all'
+  source_url 'https://github.com/talex5/wayland-proxy-virtwl.git'
+  git_hashtag @_ver
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_i686/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '2172ba0d35a4a9eedc95a656de158eb08eea91319d5f2fa026a56c6bbeece71f',
+     armv7l: '2172ba0d35a4a9eedc95a656de158eb08eea91319d5f2fa026a56c6bbeece71f',
+       i686: 'a8d9f3080c89d7fffa92b4198d47a49a981938ec974f08b287153e27ab0d545e',
+     x86_64: 'cd041ee4a63ec0f540e3820553d12e9e0d933de103eede6a6a97026bcf12363a'
+  })
+
+  depends_on 'ocaml' => :build
+  depends_on 'opam' => :build
+  depends_on 'xwayland'
+
+  @OPAMROOT = "#{CREW_PREFIX}/share/opam"
+
+  def self.patch
+    @xwayland_patch = <<~'PATCH_XWAYLAND_EOF'
+      --- a/wayland-proxy-virtwl/xwayland.ml     2021-11-18 20:34:27.000000000 +0000
+      +++ b/wayland-proxy-virtwl/xwayland.ml     2021-11-24 19:27:16.940505733 +0000
+      @@ -129,9 +129,7 @@ module Selection = struct
+           x11 : X11.Display.t Lwt.t;
+           wayland_primary_offer : [`V1] Primary_offer.t option ref;
+           wayland_clipboard_offer : [`V1|`V2|`V3] Clipboard_offer.t option ref;
+      -    primary_selection_mgr : [`V1] Primary_mgr.t;
+           clipboard_mgr : [`V1] Clipboard_mgr.t;
+      -    primary_device : [`V1] Primary_device.t;
+           clipboard_device : [`V1] Clipboard_device.t;
+           selection_window : X11.Window.t Lwt.t;
+           set_selection_window : X11.Window.t Lwt.u;
+      @@ -373,23 +371,6 @@ module Selection = struct
+             | None -> Lwt.return []
+           in
+           (* Create a Wayland source offering those targets *)
+      -    let source = Primary_mgr.create_source t.primary_selection_mgr @@ object
+      -        inherit [_] Primary_source.v1
+      -
+      -        method on_send _ ~mime_type ~fd =
+      -          Log.info (fun f -> f "Sending X PRIMARY selection to Wayland (%S)" mime_type);
+      -          send_x_selection t primary ~via:requestor ~mime_type ~dst:fd
+      -
+      -        method on_cancelled self =
+      -          Log.info (fun f -> f "X selection source cancelled by Wayland - X app no longer owns selection");
+      -          Lwt.async (fun () ->
+      -              X11.Selection.set_owner x11 ~owner:(Some requestor) ~timestamp:`CurrentTime primary
+      -            );
+      -          Primary_source.destroy self
+      -      end
+      -    in
+      -    targets |> List.iter (fun mime_type -> Primary_source.offer source ~mime_type);
+      -    Primary_device.set_selection t.primary_device ~source:(Some source) ~serial:(Relay.last_serial t.relay);
+           Lwt.return_unit
+
+         (* Similar to {!set_x_owned_primary}, but for Wayland's clipboard API. *)
+      @@ -478,13 +459,11 @@ module Selection = struct
+             failwith "Expected exactly one X11 root window!"
+
+         let create ~relay ~seat ~x11 ~virtwl ~registry =
+      -    let primary_selection_mgr = Wayland.Registry.bind registry @@ new Primary_mgr.v1 in
+           let clipboard_mgr = Wayland.Registry.bind registry @@ new Clipboard_mgr.v1 in
+           let selection_window, set_selection_window = Lwt.wait () in
+           let clipboard_window, set_clipboard_window = Lwt.wait () in
+           let wayland_primary_offer = ref None in
+           let wayland_clipboard_offer = ref None in
+      -    let primary_device = Primary_mgr.get_device primary_selection_mgr ~seat @@ primary_device ~wayland_primary_offer in
+           let clipboard_device = Clipboard_mgr.get_data_device clipboard_mgr ~seat @@ clipboard_device ~wayland_clipboard_offer in
+           {
+             x11;
+      @@ -495,8 +474,6 @@ module Selection = struct
+             wayland_primary_offer;
+             selection_window;
+             set_selection_window;
+      -      primary_selection_mgr;
+      -      primary_device;
+             (* Clipboard: *)
+             wayland_clipboard_offer;
+             clipboard_window;
+    PATCH_XWAYLAND_EOF
+    @relay_patch = <<~'PATCH_RELAY_EOF'
+      --- a/wayland-proxy-virtwl/relay.ml	2021-11-18 20:34:27.000000000 +0000
+      +++ b/wayland-proxy-virtwl/relay.ml	2021-11-24 23:48:42.805651473 +0000
+      @@ -466,13 +466,6 @@ let make_surface ~xwayland ~host_surface
+             if x#scale <> 1l then
+               H.Wl_surface.set_buffer_scale h ~scale:x#scale;       (* Xwayland will be a new enough version *)
+             let set_configured s =
+      -        if s = `Unmanaged then (
+      -          (* For pointer cursors we want them at the normal size, even if low-res.
+      -             Also, Vim tries to hide the pointer by setting a 1x1 cursor, which confuses things
+      -             when unscaled. Ideally we would stop doing transforms in this case, but it doesn't
+      -             seem to matter. *)
+      -          H.Wl_surface.set_buffer_scale h ~scale:1l;
+      -        );
+               state := s;
+               match data.state with
+               | Ready | Destroyed -> ()
+    PATCH_RELAY_EOF
+    IO.write('xwayland.patch', @xwayland_patch)
+    system 'patch -Np1 -i xwayland.patch'
+    IO.write('xwayland.patch', @relay_patch)
+    system 'patch -Np1 -i relay.patch'
+  end
+
+  def self.install
+    ENV['OPAMROOT'] = @OPAMROOT
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    if (ARCH == 'armv7l') || (ARCH == 'aarch64')
+      # ld.gold breaks logs 0.7.0 builds with ocaml 4.1.2
+      FileUtils.cp "#{CREW_PREFIX}/bin/ld.bfd", "#{CREW_DEST_PREFIX}/bin/ld"
+    end
+    system "PATH=#{CREW_DEST_PREFIX}/bin:$PATH OPAMROOT=#{@OPAMROOT} opam install . --root=#{@OPAMROOT} --destdir=#{CREW_DEST_DIR}#{@OPAMROOT} -y"
+    FileUtils.rm "#{CREW_DEST_PREFIX}/bin/ld" if File.exist?("#{CREW_DEST_PREFIX}/bin/ld")
+    Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
+      FileUtils.ln_s '../share/opam/bin/wayland-proxy-virtwl', 'wayland-proxy-virtwl'
+    end
+  end
+
+  def self.postinstall
+    puts <<~'EOS'.lightblue
+      Note that there is not yet hardware acceleration in wayland-proxy-virtwl.
+      wayland-proxy-virtwl example usage (before running a gui program):
+    EOS
+    puts <<~'EOSCODE'.lightcyan
+      stopsommelier
+      wayland-proxy-virtwl --wayland-display wayland-1 --x-display=1 --xrdb Xft.dpi:150
+      export WAYLAND_DISPLAY=wayland-1
+      export DISPLAY=:1
+    EOSCODE
+  end
+end

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -134,10 +134,9 @@ class Wayland_proxy_virtwl < Package
       wayland-proxy-virtwl example usage (before running a gui program):
     EOS
     puts <<~'EOSCODE'.lightcyan
-      stopsommelier
-      wayland-proxy-virtwl --wayland-display wayland-1 --x-display=1 --xrdb Xft.dpi:150
-      export WAYLAND_DISPLAY=wayland-1
-      export DISPLAY=:1
+      wayland-proxy-virtwl --wayland-display wayland-2 --x-display=2 --xrdb Xft.dpi:150
+      export WAYLAND_DISPLAY=wayland-2
+      export DISPLAY=:2
     EOSCODE
   end
 end

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -10,16 +10,16 @@ class Wayland_proxy_virtwl < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2_armv7l/wayland_proxy_virtwl-d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2_armv7l/wayland_proxy_virtwl-d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2_i686/wayland_proxy_virtwl-d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2-chromeos-i686.tpxz',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2_x86_64/wayland_proxy_virtwl-d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d7f58d405514dd031f2f12e402c8c6a58e62a885_armv7l/wayland_proxy_virtwl-d7f58d405514dd031f2f12e402c8c6a58e62a885-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d7f58d405514dd031f2f12e402c8c6a58e62a885_armv7l/wayland_proxy_virtwl-d7f58d405514dd031f2f12e402c8c6a58e62a885-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d7f58d405514dd031f2f12e402c8c6a58e62a885_i686/wayland_proxy_virtwl-d7f58d405514dd031f2f12e402c8c6a58e62a885-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d7f58d405514dd031f2f12e402c8c6a58e62a885_x86_64/wayland_proxy_virtwl-d7f58d405514dd031f2f12e402c8c6a58e62a885-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '5e22eb523da33a806e6f365a903b019fe1c7721a835a9e9b50d6ac1856c3c166',
-     armv7l: '5e22eb523da33a806e6f365a903b019fe1c7721a835a9e9b50d6ac1856c3c166',
-    i686: '50d9cd08dd362fb47bbbc501315393fd275393fc63cff555f0aa3ed63b6de3a0',
-  x86_64: '90b400156918b68b5617a7441e2ffc65b21fabd7d588e7e12b1157212a7943d3'
+    aarch64: '057575d06814635e9cdf22463641569486d7e2b663c82db3c31939fef0a346e7',
+     armv7l: '057575d06814635e9cdf22463641569486d7e2b663c82db3c31939fef0a346e7',
+       i686: '9258061ba55c3ce7b1a65a07a0d98ec68007118533339fd577e71f6154a8d291',
+     x86_64: '8a4ccc9cca2248d2f729e6ab0d66e97e6f3799a14a5da38d955ff8fb1a41f08d'
   })
 
   depends_on 'ocaml' => :build

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -3,24 +3,23 @@ require 'package'
 class Wayland_proxy_virtwl < Package
   description 'Proxy Wayland connections across the VM boundary'
   homepage 'https://github.com/talex5/wayland-proxy-virtwl'
-  @_ver = 'd8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2'
+  @_ver = 'd7f58d405514dd031f2f12e402c8c6a58e62a885'
   version @_ver
   compatibility 'all'
   source_url 'https://github.com/talex5/wayland-proxy-virtwl.git'
-  git_branch 'chromebrew'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_armv7l/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_armv7l/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_i686/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_x86_64/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2_armv7l/wayland_proxy_virtwl-d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2_armv7l/wayland_proxy_virtwl-d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2_i686/wayland_proxy_virtwl-d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2-chromeos-i686.tpxz',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2_x86_64/wayland_proxy_virtwl-d8596b8ef7b8b7b27e48f3621018e5edd2b3a6f2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '8bc8e2d9520ad8928f135aefbe04a5099ed15230607fb66cea5c8ecbe796b4e9',
-     armv7l: '8bc8e2d9520ad8928f135aefbe04a5099ed15230607fb66cea5c8ecbe796b4e9',
-       i686: 'd936e559d1b9a77fd74d2f00353b80e574f67334ea238e9bd29cbb698cc70417',
-     x86_64: 'd6a34fb22a85eba404b45ff9a4ddc7351038104b8ef1719db37f5535eb401bee'
+    aarch64: '5e22eb523da33a806e6f365a903b019fe1c7721a835a9e9b50d6ac1856c3c166',
+     armv7l: '5e22eb523da33a806e6f365a903b019fe1c7721a835a9e9b50d6ac1856c3c166',
+    i686: '50d9cd08dd362fb47bbbc501315393fd275393fc63cff555f0aa3ed63b6de3a0',
+  x86_64: '90b400156918b68b5617a7441e2ffc65b21fabd7d588e7e12b1157212a7943d3'
   })
 
   depends_on 'ocaml' => :build
@@ -28,93 +27,6 @@ class Wayland_proxy_virtwl < Package
   depends_on 'xwayland'
 
   @OPAMROOT = "#{CREW_PREFIX}/share/opam"
-
-  def self.patch
-    # For more info see https://github.com/talex5/wayland-proxy-virtwl/issues/24
-    @xwayland_patch = <<~'PATCH_XWAYLAND_EOF'
-      --- a/wayland-proxy-virtwl/xwayland.ml     2021-11-18 20:34:27.000000000 +0000
-      +++ b/wayland-proxy-virtwl/xwayland.ml     2021-11-24 19:27:16.940505733 +0000
-      @@ -129,9 +129,7 @@ module Selection = struct
-           x11 : X11.Display.t Lwt.t;
-           wayland_primary_offer : [`V1] Primary_offer.t option ref;
-           wayland_clipboard_offer : [`V1|`V2|`V3] Clipboard_offer.t option ref;
-      -    primary_selection_mgr : [`V1] Primary_mgr.t;
-           clipboard_mgr : [`V1] Clipboard_mgr.t;
-      -    primary_device : [`V1] Primary_device.t;
-           clipboard_device : [`V1] Clipboard_device.t;
-           selection_window : X11.Window.t Lwt.t;
-           set_selection_window : X11.Window.t Lwt.u;
-      @@ -373,23 +371,6 @@ module Selection = struct
-             | None -> Lwt.return []
-           in
-           (* Create a Wayland source offering those targets *)
-      -    let source = Primary_mgr.create_source t.primary_selection_mgr @@ object
-      -        inherit [_] Primary_source.v1
-      -
-      -        method on_send _ ~mime_type ~fd =
-      -          Log.info (fun f -> f "Sending X PRIMARY selection to Wayland (%S)" mime_type);
-      -          send_x_selection t primary ~via:requestor ~mime_type ~dst:fd
-      -
-      -        method on_cancelled self =
-      -          Log.info (fun f -> f "X selection source cancelled by Wayland - X app no longer owns selection");
-      -          Lwt.async (fun () ->
-      -              X11.Selection.set_owner x11 ~owner:(Some requestor) ~timestamp:`CurrentTime primary
-      -            );
-      -          Primary_source.destroy self
-      -      end
-      -    in
-      -    targets |> List.iter (fun mime_type -> Primary_source.offer source ~mime_type);
-      -    Primary_device.set_selection t.primary_device ~source:(Some source) ~serial:(Relay.last_serial t.relay);
-           Lwt.return_unit
-
-         (* Similar to {!set_x_owned_primary}, but for Wayland's clipboard API. *)
-      @@ -478,13 +459,11 @@ module Selection = struct
-             failwith "Expected exactly one X11 root window!"
-
-         let create ~relay ~seat ~x11 ~virtwl ~registry =
-      -    let primary_selection_mgr = Wayland.Registry.bind registry @@ new Primary_mgr.v1 in
-           let clipboard_mgr = Wayland.Registry.bind registry @@ new Clipboard_mgr.v1 in
-           let selection_window, set_selection_window = Lwt.wait () in
-           let clipboard_window, set_clipboard_window = Lwt.wait () in
-           let wayland_primary_offer = ref None in
-           let wayland_clipboard_offer = ref None in
-      -    let primary_device = Primary_mgr.get_device primary_selection_mgr ~seat @@ primary_device ~wayland_primary_offer in
-           let clipboard_device = Clipboard_mgr.get_data_device clipboard_mgr ~seat @@ clipboard_device ~wayland_clipboard_offer in
-           {
-             x11;
-      @@ -495,8 +474,6 @@ module Selection = struct
-             wayland_primary_offer;
-             selection_window;
-             set_selection_window;
-      -      primary_selection_mgr;
-      -      primary_device;
-             (* Clipboard: *)
-             wayland_clipboard_offer;
-             clipboard_window;
-    PATCH_XWAYLAND_EOF
-    @relay_patch = <<~'PATCH_RELAY_EOF'
-      --- a/wayland-proxy-virtwl/relay.ml	2021-11-18 20:34:27.000000000 +0000
-      +++ b/wayland-proxy-virtwl/relay.ml	2021-11-24 23:48:42.805651473 +0000
-      @@ -466,13 +466,6 @@ let make_surface ~xwayland ~host_surface
-             if x#scale <> 1l then
-               H.Wl_surface.set_buffer_scale h ~scale:x#scale;       (* Xwayland will be a new enough version *)
-             let set_configured s =
-      -        if s = `Unmanaged then (
-      -          (* For pointer cursors we want them at the normal size, even if low-res.
-      -             Also, Vim tries to hide the pointer by setting a 1x1 cursor, which confuses things
-      -             when unscaled. Ideally we would stop doing transforms in this case, but it doesn't
-      -             seem to matter. *)
-      -          H.Wl_surface.set_buffer_scale h ~scale:1l;
-      -        );
-               state := s;
-               match data.state with
-               | Ready | Destroyed -> ()
-    PATCH_RELAY_EOF
-    #File.write('xwayland.patch', @xwayland_patch)
-    #system 'patch -Np2 -i xwayland.patch'
-    #File.write('relay.patch', @relay_patch)
-    #system 'patch -Np2 -i relay.patch'
-  end
 
   def self.install
     ENV['OPAMROOT'] = @OPAMROOT

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -110,10 +110,10 @@ class Wayland_proxy_virtwl < Package
                match data.state with
                | Ready | Destroyed -> ()
     PATCH_RELAY_EOF
-    File.write('xwayland.patch', @xwayland_patch)
-    system 'patch -Np2 -i xwayland.patch'
-    File.write('relay.patch', @relay_patch)
-    system 'patch -Np2 -i relay.patch'
+    #File.write('xwayland.patch', @xwayland_patch)
+    #system 'patch -Np2 -i xwayland.patch'
+    #File.write('relay.patch', @relay_patch)
+    #system 'patch -Np2 -i relay.patch'
   end
 
   def self.install

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -12,14 +12,14 @@ class Wayland_proxy_virtwl < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_armv7l/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_i686/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/5b576d5cad76de6ed7513cc85748efd78ca366cf-3_x86_64/wayland_proxy_virtwl-5b576d5cad76de6ed7513cc85748efd78ca366cf-3-chromeos-x86_64.tpxz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_i686/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/69de5648bad98a0f7ae19bea292420d7fd804205_x86_64/wayland_proxy_virtwl-69de5648bad98a0f7ae19bea292420d7fd804205-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '2172ba0d35a4a9eedc95a656de158eb08eea91319d5f2fa026a56c6bbeece71f',
      armv7l: '2172ba0d35a4a9eedc95a656de158eb08eea91319d5f2fa026a56c6bbeece71f',
-       i686: 'a8d9f3080c89d7fffa92b4198d47a49a981938ec974f08b287153e27ab0d545e',
-     x86_64: 'cd041ee4a63ec0f540e3820553d12e9e0d933de103eede6a6a97026bcf12363a'
+       i686: 'd936e559d1b9a77fd74d2f00353b80e574f67334ea238e9bd29cbb698cc70417',
+     x86_64: 'd6a34fb22a85eba404b45ff9a4ddc7351038104b8ef1719db37f5535eb401bee'
   })
 
   depends_on 'ocaml' => :build
@@ -29,6 +29,7 @@ class Wayland_proxy_virtwl < Package
   @OPAMROOT = "#{CREW_PREFIX}/share/opam"
 
   def self.patch
+    # For more info see https://github.com/talex5/wayland-proxy-virtwl/issues/24
     @xwayland_patch = <<~'PATCH_XWAYLAND_EOF'
       --- a/wayland-proxy-virtwl/xwayland.ml     2021-11-18 20:34:27.000000000 +0000
       +++ b/wayland-proxy-virtwl/xwayland.ml     2021-11-24 19:27:16.940505733 +0000
@@ -108,9 +109,9 @@ class Wayland_proxy_virtwl < Package
                match data.state with
                | Ready | Destroyed -> ()
     PATCH_RELAY_EOF
-    IO.write('xwayland.patch', @xwayland_patch)
+    File.write('xwayland.patch', @xwayland_patch)
     system 'patch -Np2 -i xwayland.patch'
-    IO.write('relay.patch', @relay_patch)
+    File.write('relay.patch', @relay_patch)
     system 'patch -Np2 -i relay.patch'
   end
 


### PR DESCRIPTION
- This is an alternative to `sommelier`: https://github.com/talex5/wayland-proxy-virtwl
- Wayland & X11 proxying works, albeit unaccelerated.
- Example usage: `/usr/local/opam/bin/wayland-proxy-virtwl  --wayland-display wayland-2 --x-display=2 --xrdb Xft.dpi:150`  
  - This should create a proxied wayland display at `wayland-2` which can be used by prefixing a wayland command with `WAYLAND_DISPLAY=wayland-2`.
  - e.g. `WAYLAND_DISPLAY=wayland-2 weston-terminal`
  - This also creates a proxied X display at `:2` which can be used by prefixing a x11 command with `DISPLAY=:2`.
  - e.g. `DISPLAY=:2 xterm`

Builds properly:
- [x] x86_64
- [x] armv7l 
- [x] i686 (X11 issues... ah well.)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=wayland_proxy_virtwl_2 CREW_TESTING=1 crew update
```