### PR TITLE
curl: Use dynamic curl on i686

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -219,8 +219,8 @@ class Curl < Package
 
   def self.postinstall
     if ARCH == 'i686'
-      puts 'Static curl is broken on i686, so use dynamic curl from libcurl package.'.orange
-      FileUtils.cp "#{CREW_PREFIX}/bin/curl.nonstatic", "#{CREW_PREFIX}/bin/curl"
+      puts 'Static curl is broken on i686, so using curl from the libcurl package.'.orange
+      FileUtils.cp_r "#{CREW_PREFIX}/bin/curl.nonstatic", "#{CREW_PREFIX}/bin/curl", remove_destination: true
     end
   end
 end


### PR DESCRIPTION
- Current musl-derived build of curl is having issues on `i686`, so copy over the curl.nonstatic from the `libcurl` package for now at install via postinstall.
- Now properly using ruby method for overwriting the file...
- This keeps further package upgrades from breaking on i686 subsequent to install.

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=curl_i686_fix CREW_TESTING=1 crew update
```
