### PR TITLE
Keep crew from breaking w/ missing package files for installed packages

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -594,6 +594,10 @@ def upgrade
     # Make an installed packages list belong to the dependency order
     dependencies = []
     @device[:installed_packages].each do |package|
+      if not File.exist?(CREW_PACKAGES_PATH + package[:name] + '.rb')
+        puts "Package file for installed package #{package[:name]} is missing.".lightred
+        next
+      end
       # skip package if it is dependent other packages previously checked
       next if dependencies.include? package[:name]
       # add package itself

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.19.2'
+CREW_VERSION = '1.19.3'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- This is a common occurrence when developing packages.

Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_missing_packages_do_not_break CREW_TESTING=1 crew update
```
