### PR TITLE
crew: use rsync for install locally in lieu of tar

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1132,15 +1132,14 @@ def install_package(pkgdir)
       @brokensymlinks.each_line do |fixlink|
         @brokentarget = nil
         @fixedtarget = nil
-        @brokentarget = %x[readlink -n #{fixlink}]
+        @brokentarget = %x[readlink -n #{fixlink}].chomp
         puts "Attempting fix of: #{fixlink.delete_prefix('.')} -> #{@brokentarget}".orange if @opt_verbose
-        @fixedtarget = @brokentarget.delete_prefix(CREW_DEST_DIR)
+        @fixedtarget = @brokentarget.delete_prefix(CREW_DEST_DIR).chomp
+        @fixedlink_loc = pkgdir + fixlink.delete_prefix('.')
+        @fixedlink_loc = @fixedlink_loc.chomp
         # If no changes were made, don't replace symlink
         unless @fixedtarget == @brokentarget
-          # This doesn't work. Why?
-          FileUtils.ln_sf @fixedtarget,pkgdir + fixlink.delete_prefix('.')
-          # This works.
-          system "ln -sf #{@fixedtarget} #{pkgdir + fixlink.delete_prefix('.')}"
+          FileUtils.ln_sf "#{@fixedtarget}","#{@fixedlink_loc}"
           puts "Fixed: #{@fixedtarget} -> #{fixlink.delete_prefix('.')}".orange if @opt_verbose
         end
       end

--- a/bin/crew
+++ b/bin/crew
@@ -1125,10 +1125,44 @@ def install_package(pkgdir)
     FileUtils.mv 'dlist', CREW_META_PATH + @pkg.name + '.directorylist', verbose: @fileutils_verbose
     FileUtils.mv 'filelist', CREW_META_PATH + @pkg.name + '.filelist', verbose: @fileutils_verbose
 
+    @brokensymlinks = nil
+    @brokensymlinks = %x[find . -type l -exec test ! -e {} \\; -print].chomp
+    unless @brokensymlinks.nil? or @brokensymlinks.empty?
+      puts "There are broken symlinks. Will try to fix.".orange if @opt_verbose
+      @brokensymlinks.each_line do |fixlink|
+        @brokentarget = nil
+        @fixedtarget = nil
+        @brokentarget = %x[readlink -n #{fixlink}]
+        puts "Attempting fix of: #{fixlink.delete_prefix('.')} -> #{@brokentarget}".orange if @opt_verbose
+        @fixedtarget = @brokentarget.delete_prefix(CREW_DEST_DIR)
+        # If no changes were made, don't replace symlink
+        unless @fixedtarget == @brokentarget
+          # This doesn't work. Why?
+          FileUtils.ln_sf @fixedtarget,pkgdir + fixlink.delete_prefix('.')
+          # This works.
+          system "ln -sf #{@fixedtarget} #{pkgdir + fixlink.delete_prefix('.')}"
+          puts "Fixed: #{@fixedtarget} -> #{fixlink.delete_prefix('.')}".orange if @opt_verbose
+        end
+      end
+    end
+    if File.exist?("#{CREW_PREFIX}/bin/rdfind")
+        puts "Using rdfind to convert duplicate files to hard links."
+        system "#{CREW_PREFIX}/bin/rdfind -removeidentinode true -makesymlinks false -makehardlinks true -makeresultsfile false ."
+    end
     if Dir.exists? "#{pkgdir}/home" then
-      system "tar -c#{@verbose}f - ./usr/* ./home/* | (cd /; tar xp --keep-directory-symlink -f -)"
-    elsif Dir.exists? "#{pkgdir}/usr" then
-      system "tar -c#{@verbose}f - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
+      if File.exist?("#{CREW_PREFIX}/bin/rsync")
+        system "rsync -ahHAXW --remove-source-files ./#{HOME.delete_prefix('/')}/ #{HOME}"
+      else
+        system "tar -c#{@verbose}f - ./usr/* ./home/* | (cd /; tar xp --keep-directory-symlink -f -)"
+      end
+    end
+    if Dir.exists? "#{pkgdir}/usr/local" then
+      if File.exist?("#{CREW_PREFIX}/bin/rsync")
+        # Adjust "./usr/local" if the build CREW_PREFIX ever changes.
+        system "rsync -ahHAXWx --remove-source-files ./usr/local/ #{CREW_PREFIX}"
+      else
+        system "tar -c#{@verbose}f - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
+      end
     end
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.19.3'
+CREW_VERSION = '1.19.4'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/skycocker/chromebrew'
-  version '1.3'
+  version '1.4'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -71,6 +71,7 @@ class Core < Package
   depends_on 'python2'
   depends_on 'python3'
   depends_on 'readline'
+  depends_on 'rsync'
   depends_on 'rtmpdump'
   depends_on 'ruby'
   depends_on 'slang'


### PR DESCRIPTION
- Using `tar` in `def install_package` effectively requires double the disk space an extracted package will take for the package install to be successful, as it copies everything from the `pkgdir` we have installed to before we delete `pkgdir`. This can be a problem for large packages!
  - rsync allows us to use the `--remove-source-files` option to delete as it copies from `pkgdir`, which might help keep this from being as much of an issue when disk space is tight.
  - This would require adding `rsync` to core. I've added logic to use rsync only if it is available though.
  - Using rsync, I have also set the command to use whatever `CREW_PREFIX` the system has been installed with, in case anyone is using a non-standard CREW_PREFIX. (Not that packages will necessarily work if they can't find libraries in the standard location...)
- I've also added @saltedcoffii 's suggestion of using rdfind during install to save space. Doing a reinstall of a package might save some space with this implemented.
- I also noticed we still have symlinks mangled in packages, so I added logic to try to fix those situations during installs.


Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l


### Run the following to get this pull request's changes locally for testing and to see how this works:
```
yes | crew install rsync
CREW_CACHE_ENABLED=1 \
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git \
CREW_TESTING_BRANCH=rsync_crew_install CREW_TESTING=1 crew update
crew reinstall llvm -v
```
