### PR TITLE
Add package foot and dependencies

### DIFF
--- a/packages/fcft.rb
+++ b/packages/fcft.rb
@@ -14,14 +14,14 @@ class Fcft < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_armv7l/fcft-2.5.1-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_armv7l/fcft-2.5.1-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_i686/fcft-2.5.1-chromeos-i686.tpxz',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_x86_64/fcft-2.5.1-chromeos-x86_64.tpxz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_i686/fcft-2.5.1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_x86_64/fcft-2.5.1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '28f1176a8cece2b6e7464020871a1f543a01b387b107f7ff8eaec0bb525a2745',
      armv7l: '28f1176a8cece2b6e7464020871a1f543a01b387b107f7ff8eaec0bb525a2745',
-    i686: '4cfd8382c087dba1f6fa1c1a1eb4f9c1afb925be0176b648f1dec512dc130f79',
-  x86_64: '4d5d098327ea62f4f4c9ea534e8f79346602f54acca4af2dc18e03be3b64c224'
+       i686: '4cfd8382c087dba1f6fa1c1a1eb4f9c1afb925be0176b648f1dec512dc130f79',
+     x86_64: '4d5d098327ea62f4f4c9ea534e8f79346602f54acca4af2dc18e03be3b64c224'
   })
 
   depends_on 'freetype'
@@ -37,7 +37,9 @@ class Fcft < Package
     return unless LIBC_VERSION < '2.28'
 
     system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('threads.h') ) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
+    unless Digest::SHA256.hexdigest(File.read('threads.h')) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
+      abort 'Checksum mismatch. :/ Try again.'.lightred
+    end
   end
 
   def self.build

--- a/packages/fcft.rb
+++ b/packages/fcft.rb
@@ -37,6 +37,7 @@ class Fcft < Package
     return unless LIBC_VERSION < '2.28'
 
     system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('threads.h') ) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
   end
 
   def self.build

--- a/packages/fcft.rb
+++ b/packages/fcft.rb
@@ -1,0 +1,58 @@
+# Adapted from Arch Linux fcft PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=fcft
+
+require 'package'
+
+class Fcft < Package
+  description 'Simple library for font loading and glyph rasterization using FontConfig, FreeType and pixman.'
+  homepage 'https://codeberg.org/dnkl/fcft'
+  version '2.5.1'
+  compatibility 'all'
+  source_url 'https://codeberg.org/dnkl/fcft.git'
+  git_hashtag version
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_armv7l/fcft-2.5.1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_armv7l/fcft-2.5.1-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_i686/fcft-2.5.1-chromeos-i686.tpxz',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fcft/2.5.1_x86_64/fcft-2.5.1-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '28f1176a8cece2b6e7464020871a1f543a01b387b107f7ff8eaec0bb525a2745',
+     armv7l: '28f1176a8cece2b6e7464020871a1f543a01b387b107f7ff8eaec0bb525a2745',
+    i686: '4cfd8382c087dba1f6fa1c1a1eb4f9c1afb925be0176b648f1dec512dc130f79',
+  x86_64: '4d5d098327ea62f4f4c9ea534e8f79346602f54acca4af2dc18e03be3b64c224'
+  })
+
+  depends_on 'freetype'
+  depends_on 'fontconfig'
+  depends_on 'harfbuzz'
+  depends_on 'utf8proc'
+  depends_on 'pixman'
+  depends_on 'tllist' => ':build'
+
+  def self.patch
+    # threads.h was introduced in glibc 2.28. This is a workaround for
+    # pre-M92 systems.
+    return unless LIBC_VERSION < '2.28'
+
+    system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/master/c11threads.h -o threads.h'
+  end
+
+  def self.build
+    system "meson #{CREW_MESON_OPTIONS} \
+      -Dgrapheme-shaping=enabled \
+      -Drun-shaping=enabled \
+      builddir"
+    system 'meson configure builddir'
+    system 'samu -C builddir'
+  end
+
+  def self.check
+    system 'samu -C builddir test'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+end

--- a/packages/fcft.rb
+++ b/packages/fcft.rb
@@ -36,7 +36,7 @@ class Fcft < Package
     # pre-M92 systems.
     return unless LIBC_VERSION < '2.28'
 
-    system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/master/c11threads.h -o threads.h'
+    system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
   end
 
   def self.build

--- a/packages/foot.rb
+++ b/packages/foot.rb
@@ -40,7 +40,9 @@ class Foot < Package
     return unless LIBC_VERSION < '2.28'
 
     system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('threads.h') ) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
+    unless Digest::SHA256.hexdigest(File.read('threads.h')) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
+      abort 'Checksum mismatch. :/ Try again.'.lightred
+    end
     # Older kernel versions do not have linux header input-event-codes.h Use libc version as a proxy for linux header version.
     return unless LIBC_VERSION < '2.27'
 

--- a/packages/foot.rb
+++ b/packages/foot.rb
@@ -39,7 +39,7 @@ class Foot < Package
     # pre-M92 systems.
     return unless LIBC_VERSION < '2.28'
 
-    system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/master/c11threads.h -o threads.h'
+    system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
     # Older kernel versions do not have linux header input-event-codes.h Use libc version as a proxy for linux header version.
     return unless LIBC_VERSION < '2.27'
 

--- a/packages/foot.rb
+++ b/packages/foot.rb
@@ -40,6 +40,7 @@ class Foot < Package
     return unless LIBC_VERSION < '2.28'
 
     system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
+    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('threads.h') ) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
     # Older kernel versions do not have linux header input-event-codes.h Use libc version as a proxy for linux header version.
     return unless LIBC_VERSION < '2.27'
 

--- a/packages/foot.rb
+++ b/packages/foot.rb
@@ -1,0 +1,62 @@
+# Adapted from Arch Linux foot PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=foot
+
+require 'package'
+
+class Foot < Package
+  description 'Wayland terminal emulator - fast, lightweight and minimalistic'
+  homepage 'https://codeberg.org/dnkl/foot'
+  version '1.10.3'
+  compatibility 'all'
+  source_url 'https://codeberg.org/dnkl/foot.git'
+  git_hashtag version
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.10.3_armv7l/foot-1.10.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.10.3_armv7l/foot-1.10.3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.10.3_i686/foot-1.10.3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.10.3_x86_64/foot-1.10.3-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '3d452085480e5439a082ef18e3c98fe334db9baed0d361d09fb4c658073e3f2e',
+     armv7l: '3d452085480e5439a082ef18e3c98fe334db9baed0d361d09fb4c658073e3f2e',
+       i686: '5785c65916a60a59fb8afa793a867baed0f24c64860f88a525870610a3fada0f',
+     x86_64: '73cb08a9df0cc25858a2cad4a2b2d5d299dc3f5a430c4d82771af2385447c9ea'
+  })
+
+  depends_on 'libxkbcommon'
+  depends_on 'wayland'
+  depends_on 'pixman'
+  depends_on 'fontconfig'
+  depends_on 'utf8proc'
+  depends_on 'ncurses'
+  depends_on 'fcft'
+  depends_on 'wayland_protocols' => ':build'
+  depends_on 'tllist' => ':build'
+
+  def self.patch
+    # threads.h was introduced in glibc 2.28. This is a workaround for
+    # pre-M92 systems.
+    return unless LIBC_VERSION < '2.28'
+
+    system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/master/c11threads.h -o threads.h'
+    # Older kernel versions do not have linux header input-event-codes.h Use libc version as a proxy for linux header version.
+    return unless LIBC_VERSION < '2.27'
+
+    FileUtils.mkdir 'linux'
+    FileUtils.ln_s "#{CREW_PREFIX}/include/linux/input.h", 'linux/input-event-codes.h'
+  end
+
+  def self.build
+    system "meson #{CREW_MESON_OPTIONS} \
+      -Dterminfo=disabled \
+      -Dthemes=false \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/tllist.rb
+++ b/packages/tllist.rb
@@ -14,14 +14,14 @@ class Tllist < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_armv7l/tllist-1.0.5-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_armv7l/tllist-1.0.5-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_i686/tllist-1.0.5-chromeos-i686.tpxz',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_x86_64/tllist-1.0.5-chromeos-x86_64.tpxz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_i686/tllist-1.0.5-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_x86_64/tllist-1.0.5-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: '6eefb42195190f840d23f07dbfb76963abd124babf09d5253b1e08ac9bdba5de',
      armv7l: '6eefb42195190f840d23f07dbfb76963abd124babf09d5253b1e08ac9bdba5de',
-    i686: '36cb299932fcebce6c373980fc427196334fbc8b6cb5a69b7880945f35ea1475',
-  x86_64: '7b46ee399514bd499c3a82f8c10916ed76f2c9c88a49cf75e348f683952dfd96'
+       i686: '36cb299932fcebce6c373980fc427196334fbc8b6cb5a69b7880945f35ea1475',
+     x86_64: '7b46ee399514bd499c3a82f8c10916ed76f2c9c88a49cf75e348f683952dfd96'
   })
 
   def self.build

--- a/packages/tllist.rb
+++ b/packages/tllist.rb
@@ -1,0 +1,37 @@
+# Adapted from Arch Linux tllist PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=tllist
+
+require 'package'
+
+class Tllist < Package
+  description 'A typed linked list C header file only library'
+  homepage 'https://codeberg.org/dnkl/tllist'
+  version '1.0.5'
+  compatibility 'all'
+  source_url 'https://codeberg.org/dnkl/tllist.git'
+  git_hashtag version
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_armv7l/tllist-1.0.5-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_armv7l/tllist-1.0.5-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_i686/tllist-1.0.5-chromeos-i686.tpxz',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tllist/1.0.5_x86_64/tllist-1.0.5-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '6eefb42195190f840d23f07dbfb76963abd124babf09d5253b1e08ac9bdba5de',
+     armv7l: '6eefb42195190f840d23f07dbfb76963abd124babf09d5253b1e08ac9bdba5de',
+    i686: '36cb299932fcebce6c373980fc427196334fbc8b6cb5a69b7880945f35ea1475',
+  x86_64: '7b46ee399514bd499c3a82f8c10916ed76f2c9c88a49cf75e348f683952dfd96'
+  })
+
+  def self.build
+    system "meson #{CREW_MESON_OPTIONS} \
+      builddir"
+    system 'meson configure builddir'
+    system 'samu -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+end

--- a/packages/utf8proc.rb
+++ b/packages/utf8proc.rb
@@ -12,14 +12,14 @@ class Utf8proc < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_armv7l/utf8proc-2.7.0-chromeos-armv7l.tpxz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_armv7l/utf8proc-2.7.0-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_i686/utf8proc-2.7.0-chromeos-i686.tpxz',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_x86_64/utf8proc-2.7.0-chromeos-x86_64.tpxz'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_i686/utf8proc-2.7.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_x86_64/utf8proc-2.7.0-chromeos-x86_64.tpxz'
   })
   binary_sha256({
     aarch64: 'e39494e5757c24266a70ce9ed250f586e7fe1e6afc57986073cc783f70fe5780',
      armv7l: 'e39494e5757c24266a70ce9ed250f586e7fe1e6afc57986073cc783f70fe5780',
-    i686: '23750d9ea1dee537670e2b5d81a59fa972d30286a2402703af0850510011dfb1',
-  x86_64: '7a3c31040fb2dcdafdd1de5e7b3c61a4aeb77c38dc59ecb10138fe205da858d3'
+       i686: '23750d9ea1dee537670e2b5d81a59fa972d30286a2402703af0850510011dfb1',
+     x86_64: '7a3c31040fb2dcdafdd1de5e7b3c61a4aeb77c38dc59ecb10138fe205da858d3'
   })
 
   def self.build

--- a/packages/utf8proc.rb
+++ b/packages/utf8proc.rb
@@ -3,36 +3,40 @@ require 'package'
 class Utf8proc < Package
   description 'a clean C library for processing UTF-8 Unicode data: normalization, case-folding, graphemes, and more'
   homepage 'https://julialang.org/utf8proc/'
-  version '2.5.0'
+  version '2.7.0'
   license 'MIT and custom'
   compatibility 'all'
-  source_url 'https://github.com/JuliaStrings/utf8proc/archive/v2.5.0.tar.gz'
-  source_sha256 'd4e8dfc898cfd062493cb7f42d95d70ccdd3a4cd4d90bec0c71b47cca688f1be'
+  source_url 'https://github.com/JuliaStrings/utf8proc.git'
+  git_hashtag "v#{version}"
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.5.0_armv7l/utf8proc-2.5.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.5.0_armv7l/utf8proc-2.5.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.5.0_i686/utf8proc-2.5.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.5.0_x86_64/utf8proc-2.5.0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_armv7l/utf8proc-2.7.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_armv7l/utf8proc-2.7.0-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_i686/utf8proc-2.7.0-chromeos-i686.tpxz',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/utf8proc/2.7.0_x86_64/utf8proc-2.7.0-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-    aarch64: '9ebbd94d6221173beb34f0c80f62d38d557d87ceceac29d9ee7cfd96f6ccbfb2',
-     armv7l: '9ebbd94d6221173beb34f0c80f62d38d557d87ceceac29d9ee7cfd96f6ccbfb2',
-       i686: '5a8ba1b61b76ce238665c679c00ea25d35815e0bc66cdce0d506227314d90cb9',
-     x86_64: '93e528e8c0e6dbce7a76f0120ceca9de33ad168718893a3a1e16d28514617813',
+  binary_sha256({
+    aarch64: 'e39494e5757c24266a70ce9ed250f586e7fe1e6afc57986073cc783f70fe5780',
+     armv7l: 'e39494e5757c24266a70ce9ed250f586e7fe1e6afc57986073cc783f70fe5780',
+    i686: '23750d9ea1dee537670e2b5d81a59fa972d30286a2402703af0850510011dfb1',
+  x86_64: '7a3c31040fb2dcdafdd1de5e7b3c61a4aeb77c38dc59ecb10138fe205da858d3'
   })
 
   def self.build
-    system 'make'
+    FileUtils.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "cmake -G Ninja #{CREW_CMAKE_OPTIONS} \
+        -DBUILD_SHARED_LIBS=ON \
+        -DUTF8PROC_ENABLE_TESTING=ON .."
+      system 'samu'
+    end
   end
 
   def self.install
-    system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    case ARCH
-    when 'x86_64'
-      Dir.chdir "#{CREW_DEST_PREFIX}" do
-        FileUtils.mv 'lib/', 'lib64/'
-      end
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+
+  def self.check
+    system 'samu -C builddir test'
   end
 end


### PR DESCRIPTION
- Foot is a wayland terminal emulator.
- It does NOT work with the ChromeOS exo wayland compositor, since it needs a v4 compositor.
- But it does work inside weston.
- Also updates `utf8proc` package to current version

Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=foot CREW_TESTING=1 crew update
```
