### PR TITLE
Add fallback during install if rsync is not working

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1149,17 +1149,19 @@ def install_package(pkgdir)
         system "#{CREW_PREFIX}/bin/rdfind -removeidentinode true -makesymlinks false -makehardlinks true -makeresultsfile false ."
     end
     if Dir.exists? "#{pkgdir}/home" then
-      if File.exist?("#{CREW_PREFIX}/bin/rsync")
+      if system("#{CREW_PREFIX}/bin/rsync -V > /dev/null 2>&1")
         system "rsync -ahHAXW --remove-source-files ./#{HOME.delete_prefix('/')}/ #{HOME}"
       else
+        puts 'rsync is not working. Please install it with \'crew install rsync\''.lightred if @opt_verbose
         system "tar -c#{@verbose}f - ./usr/* ./home/* | (cd /; tar xp --keep-directory-symlink -f -)"
       end
     end
     if Dir.exists? "#{pkgdir}/usr/local" then
-      if File.exist?("#{CREW_PREFIX}/bin/rsync")
+      if system("#{CREW_PREFIX}/bin/rsync -V > /dev/null 2>&1")
         # Adjust "./usr/local" if the build CREW_PREFIX ever changes.
         system "rsync -ahHAXWx --remove-source-files ./usr/local/ #{CREW_PREFIX}"
       else
+        puts 'rsync is not working. Please install it with \'crew install rsync\''.lightred if @opt_verbose
         system "tar -c#{@verbose}f - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
       end
     end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.19.4'
+CREW_VERSION = '1.19.5'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- upgrade of rsync dependencies breaks `rsync` during install, so make sure we use `tar` in such a situation.


Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rsync_fallback CREW_TESTING=1 crew update
```