### PR TITLE
Upgrade some gnu packages

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.20.0'
+CREW_VERSION = '1.20.1'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -122,8 +122,8 @@ end
 
 CREW_COMMON_FLAGS = '-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=gold'
 CREW_COMMON_FNO_LTO_FLAGS = '-O2 -pipe -fno-lto -fPIC -fuse-ld=gold'
-CREW_FNO_LTO_LDFLAGS = '-fno-lto'
 CREW_LDFLAGS = '-flto'
+CREW_FNO_LTO_LDFLAGS = '-fno-lto'
 
 CREW_ENV_OPTIONS = <<~OPT.chomp
   CFLAGS='#{CREW_COMMON_FLAGS}' \
@@ -131,6 +131,13 @@ CREW_ENV_OPTIONS = <<~OPT.chomp
   FCFLAGS='#{CREW_COMMON_FLAGS}' \
   FFLAGS='#{CREW_COMMON_FLAGS}' \
   LDFLAGS='#{CREW_LDFLAGS}'
+OPT
+CREW_ENV_FNO_LTO_OPTIONS = <<~OPT.chomp
+  CFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
+  CXXFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
+  FCFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
+  FFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
+  LDFLAGS='#{CREW_FNO_LTO_LDFLAGS}'
 OPT
 CREW_OPTIONS = <<~OPT.chomp
   --prefix=#{CREW_PREFIX} \

--- a/packages/bison.rb
+++ b/packages/bison.rb
@@ -20,7 +20,7 @@ class Bison < Package
   end
 
   def self.check
-    puts 'Information: Bison checks take a very long time.'.lightblue
+    puts 'Notice: Bison checks take a very long time.'.yellow
     system 'make', 'check'
   end
 end

--- a/packages/bison.rb
+++ b/packages/bison.rb
@@ -10,6 +10,19 @@ class Bison < Package
   source_url "https://ftpmirror.gnu.org/bison/bison-#{@_ver}.tar.lz"
   source_sha256 'fdf98bfe82abb04a34d4356753f7748dbbd2ef1221b1f202852a2b5ce0f78534'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bison/3.8.2_armv7l/bison-3.8.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bison/3.8.2_armv7l/bison-3.8.2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bison/3.8.2_i686/bison-3.8.2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bison/3.8.2_x86_64/bison-3.8.2-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '8f1ac3143e216a054c56a4dcb23d58078c7dbccdc67f86b1d4a8169fb4f0d43b',
+     armv7l: '8f1ac3143e216a054c56a4dcb23d58078c7dbccdc67f86b1d4a8169fb4f0d43b',
+       i686: '026e8c897e6f8c5bc1d30d17f0f5612d5d0b99e8e5cf77e16cecaf646716a755',
+     x86_64: 'e671fd14e25757fd0fc45d65443ff55d13df428e34e80fc2f642d86aa5a9df14'
+  })
+
   def self.build
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'

--- a/packages/bison.rb
+++ b/packages/bison.rb
@@ -3,28 +3,15 @@ require 'package'
 class Bison < Package
   description 'Bison is a general-purpose parser generator that converts an annotated context-free grammar into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables.'
   homepage 'https://www.gnu.org/software/bison/'
-  @_ver = '3.7.4'
+  @_ver = '3.8.2'
   version @_ver
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/gnu/bison/bison-#{@_ver}.tar.xz"
-  source_sha256 'a3b5813f48a11e540ef26f46e4d288c0c25c7907d9879ae50e430ec49f63c010'
-
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bison/3.7.4_armv7l/bison-3.7.4-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bison/3.7.4_armv7l/bison-3.7.4-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bison/3.7.4_i686/bison-3.7.4-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bison/3.7.4_x86_64/bison-3.7.4-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-     aarch64: 'ba8edbb5a88d16aedbd7c37dc247bd4a4fec5390063dc6220b1275a0bdcfb44c',
-      armv7l: 'ba8edbb5a88d16aedbd7c37dc247bd4a4fec5390063dc6220b1275a0bdcfb44c',
-        i686: '5e3db2010be0f04fefe4d4db3c265e4c5c96e7d9b36748fbd221fb71c4405ff5',
-      x86_64: '9ae17d6c8ae82bbf4ff2d6e2cdca52f91c21a8498b972f1012629697e6d8ee5d',
-  })
+  source_url "https://ftpmirror.gnu.org/bison/bison-#{@_ver}.tar.lz"
+  source_sha256 'fdf98bfe82abb04a34d4356753f7748dbbd2ef1221b1f202852a2b5ce0f78534'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 
@@ -33,6 +20,7 @@ class Bison < Package
   end
 
   def self.check
-    system 'make check'
+    puts 'Information: Bison checks take a very long time.'.lightblue
+    system 'make', 'check'
   end
 end

--- a/packages/gnuchess.rb
+++ b/packages/gnuchess.rb
@@ -9,17 +9,30 @@ class Gnuchess < Package
   source_url 'https://ftpmirror.gnu.org/chess/gnuchess-6.2.9.tar.gz'
   source_sha256 'ddfcc20bdd756900a9ab6c42c7daf90a2893bf7f19ce347420ce36baebc41890'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnuchess/6.2.9_armv7l/gnuchess-6.2.9-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnuchess/6.2.9_armv7l/gnuchess-6.2.9-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnuchess/6.2.9_i686/gnuchess-6.2.9-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnuchess/6.2.9_x86_64/gnuchess-6.2.9-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '04cbe6c7a1175da4efec1fbf4e2e804a565910a3d9a858bb5d642ecda39c804f',
+     armv7l: '04cbe6c7a1175da4efec1fbf4e2e804a565910a3d9a858bb5d642ecda39c804f',
+       i686: '8741213f6f4ae25654c7a4df3c5c17566101dffcd8f932eda0048415996b7ef8',
+     x86_64: 'fcf26dedf74b36d4b470b89f6accacafb88675b85db8e76862c179560ef7163d'
+  })
+
   def self.build
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
               --with-readline"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
 end

--- a/packages/gnuchess.rb
+++ b/packages/gnuchess.rb
@@ -3,28 +3,15 @@ require 'package'
 class Gnuchess < Package
   description 'GNU Chess is a chess-playing program.'
   homepage 'https://www.gnu.org/software/chess/'
-  version '6.2.7'
+  version '6.2.9'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/chess/gnuchess-6.2.7.tar.gz'
-  source_sha256 'e536675a61abe82e61b919f6b786755441d9fcd4c21e1c82fb9e5340dd229846'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnuchess/6.2.7_armv7l/gnuchess-6.2.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnuchess/6.2.7_armv7l/gnuchess-6.2.7-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnuchess/6.2.7_i686/gnuchess-6.2.7-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnuchess/6.2.7_x86_64/gnuchess-6.2.7-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'beaa12320b833a03fcf58db484efd22b32e5a51feb50548345a298e316ca0915',
-     armv7l: 'beaa12320b833a03fcf58db484efd22b32e5a51feb50548345a298e316ca0915',
-       i686: 'b26f068d1463c64b5ef92537110e8d6b18896d9b3b3e16e316148fcd2481d307',
-     x86_64: 'd2a753a59caa3072e77a99e604b6adf81f4baccc5002e2ad8742a4e500ac8cd2',
-  })
+  source_url 'https://ftpmirror.gnu.org/chess/gnuchess-6.2.9.tar.gz'
+  source_sha256 'ddfcc20bdd756900a9ab6c42c7daf90a2893bf7f19ce347420ce36baebc41890'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
-            --with-readline"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+              --with-readline"
     system "make"
   end
 

--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -9,6 +9,19 @@ class Libsigsegv < Package
   source_url 'https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.13.tar.gz'
   source_sha256 'be78ee4176b05f7c75ff03298d84874db90f4b6c9d5503f0da1226b3a3c48119'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.13_armv7l/libsigsegv-2.13-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.13_armv7l/libsigsegv-2.13-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.13_i686/libsigsegv-2.13-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.13_x86_64/libsigsegv-2.13-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '1c521a9fcee6ae4108bd1177dfa053157f06a5b5931af65bfb5a1d0e52a27e75',
+     armv7l: '1c521a9fcee6ae4108bd1177dfa053157f06a5b5931af65bfb5a1d0e52a27e75',
+       i686: '964dc5402cb5106bd19f2a6a8ede6120d472313ce8998a1233bd2cbb97be3d07',
+     x86_64: '68bad24a4b85d56bd45ca4f1af74ceb94829dd714be6622ac0c564f56030433f'
+  })
+
   def self.build
     system 'autoreconf -fiv'
     # libsigsegv fails to build with LTO.
@@ -17,10 +30,10 @@ class Libsigsegv < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
 end

--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -3,32 +3,16 @@ require 'package'
 class Libsigsegv < Package
   description 'GNU libsigsegv is a library for handling page faults in user mode.'
   homepage 'https://www.gnu.org/software/libsigsegv/'
-  version '2.12'
+  version '2.13'
   license 'GPL-2+'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.12.tar.gz'
-  source_sha256 '3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.12_armv7l/libsigsegv-2.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.12_armv7l/libsigsegv-2.12-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.12_i686/libsigsegv-2.12-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.12_x86_64/libsigsegv-2.12-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'e95892871d5cfd7164b3056e87461fd852d1a224ca0a23f0dd73a98e71a83217',
-     armv7l: 'e95892871d5cfd7164b3056e87461fd852d1a224ca0a23f0dd73a98e71a83217',
-       i686: '626159d654d90139bfb1301323aea5c28b6ad37f895824323471eb7911a5ce4f',
-     x86_64: '02097e964faa7116a1e4701f322da97375d8df1a0928cadc05e86b838fe9fef3',
-  })
+  source_url 'https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.13.tar.gz'
+  source_sha256 'be78ee4176b05f7c75ff03298d84874db90f4b6c9d5503f0da1226b3a3c48119'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--enable-shared',
-           '--disable-static',
-           '--with-pic'
+    system 'autoreconf -fiv'
+    # libsigsegv fails to build with LTO.
+    system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/mailutils.rb
+++ b/packages/mailutils.rb
@@ -3,35 +3,25 @@ require 'package'
 class Mailutils < Package
   description 'GNU Mailutils is the swiss army knife of electronic mail handling.'
   homepage 'https://mailutils.org'
-  version '3.12'
+  version '3.13'
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/mailutils/mailutils-3.12.tar.xz'
-  source_sha256 '6d43fa217c4ac63f057de87890c562d170bb92bc402368b5fbc579e4c2b3a158'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mailutils/3.12_armv7l/mailutils-3.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mailutils/3.12_armv7l/mailutils-3.12-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mailutils/3.12_i686/mailutils-3.12-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mailutils/3.12_x86_64/mailutils-3.12-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '826c7106823744618d9d070727ce7349845918576442dc00e52643e394792a5a',
-     armv7l: '826c7106823744618d9d070727ce7349845918576442dc00e52643e394792a5a',
-       i686: '19680504fee9c4864c544f674c83ad052af68624cdce0b50fe56e8184da4cc85',
-     x86_64: '80da9e98948aa0a87d062659783a6518669892bc27e65d755ef58aefc1977e96',
-  })
+  source_url 'https://ftpmirror.gnu.org/mailutils/mailutils-3.13.tar.xz'
+  source_sha256 'd920971dcb49878a009911774fd6404f13d27bd101e2d59b664a28659a4094c7'
 
   depends_on 'libdb'
   depends_on 'emacs'
   depends_on 'tcpwrappers'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
             --enable-ipv6 \
+            --with-gnutls \
+            --with-tcpwrappers \
             --with-berkeley-db \
             --without-guile \
             --with-gdbm \
+            --with-fribidi \
             --with-unistring \
             --with-tcp-wrappers \
             --with-readline"

--- a/packages/mailutils.rb
+++ b/packages/mailutils.rb
@@ -17,7 +17,6 @@ class Mailutils < Package
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
             --enable-ipv6 \
             --with-gnutls \
-            --with-tcpwrappers \
             --with-berkeley-db \
             --without-guile \
             --with-gdbm \

--- a/packages/mailutils.rb
+++ b/packages/mailutils.rb
@@ -9,6 +9,19 @@ class Mailutils < Package
   source_url 'https://ftpmirror.gnu.org/mailutils/mailutils-3.13.tar.xz'
   source_sha256 'd920971dcb49878a009911774fd6404f13d27bd101e2d59b664a28659a4094c7'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mailutils/3.13_armv7l/mailutils-3.13-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mailutils/3.13_armv7l/mailutils-3.13-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mailutils/3.13_i686/mailutils-3.13-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mailutils/3.13_x86_64/mailutils-3.13-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'ad6e2116b39db4db712d59caddf7a70bfe0cb1e206d595af4011eaac29d4136a',
+     armv7l: 'ad6e2116b39db4db712d59caddf7a70bfe0cb1e206d595af4011eaac29d4136a',
+       i686: '686e6342e25f5e34c1f84bd75df7fda7b51dca020d485c7d9d0489c57b4e24d7',
+     x86_64: 'b135bb16017bf602bd00b8f5ccd28b2582627c69f9abab8318e2b79e025981b3'
+  })
+
   depends_on 'libdb'
   depends_on 'emacs'
   depends_on 'tcpwrappers'
@@ -24,14 +37,14 @@ class Mailutils < Package
             --with-unistring \
             --with-tcp-wrappers \
             --with-readline"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
-    system "make check || /bin/true" # Check 471 will fail
+    system 'make check || /bin/true' # Check 471 will fail
   end
 end

--- a/packages/sed.rb
+++ b/packages/sed.rb
@@ -3,31 +3,17 @@ require 'package'
 class Sed < Package
   description 'sed (stream editor) is a non-interactive command-line text editor.'
   homepage 'https://www.gnu.org/software/sed/'
-  version '4.8'
+  version '4.8-1'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/sed/sed-4.8.tar.xz'
   source_sha256 'f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sed/4.8_armv7l/sed-4.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sed/4.8_armv7l/sed-4.8-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sed/4.8_i686/sed-4.8-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sed/4.8_x86_64/sed-4.8-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '362e263677dcf8ac059f1bbc27b5193f4ce05e52fff1295f8faae559778e5b50',
-     armv7l: '362e263677dcf8ac059f1bbc27b5193f4ce05e52fff1295f8faae559778e5b50',
-       i686: 'eb6cda5a3cd77cf5a155f6593afefe4417ab8a679f197c9706e4ae3ef16b01dc',
-     x86_64: 'f0179b4feee9f5f130fdd6af0718c91de52c606343d1672e2b229c8581b9914f',
-  })
-
   depends_on 'acl'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           '--without-selinux'
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+            --without-selinux"
     system 'make'
   end
 

--- a/packages/sed.rb
+++ b/packages/sed.rb
@@ -9,6 +9,19 @@ class Sed < Package
   source_url 'https://ftpmirror.gnu.org/sed/sed-4.8.tar.xz'
   source_sha256 'f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sed/4.8-1_armv7l/sed-4.8-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sed/4.8-1_armv7l/sed-4.8-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sed/4.8-1_i686/sed-4.8-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sed/4.8-1_x86_64/sed-4.8-1-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'fd595a2f1e13c1e961e25fc22cc3407d8cb6b294bdae42736ac25678f862ae79',
+     armv7l: 'fd595a2f1e13c1e961e25fc22cc3407d8cb6b294bdae42736ac25678f862ae79',
+       i686: '051be8f498eaefaa5d1abc57e19f3205927fa35fcbf5cdb0c10368a0a89ec760',
+     x86_64: '1d2c3988aa831e795c8a0f0b9c4345cd6e40c1df9a16960015bdef0aaf9e9387'
+  })
+
   depends_on 'acl'
 
   def self.build

--- a/packages/texinfo.rb
+++ b/packages/texinfo.rb
@@ -3,24 +3,11 @@ require 'package'
 class Texinfo < Package
   description 'Texinfo is the official documentation format of the GNU project.'
   homepage 'https://www.gnu.org/software/texinfo/'
-  version '6.7-1'
+  version '6.8'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/texinfo/texinfo-6.7.tar.xz'
-  source_sha256 '988403c1542d15ad044600b909997ba3079b10e03224c61188117f3676b02caa'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.7-1_armv7l/texinfo-6.7-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.7-1_armv7l/texinfo-6.7-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.7-1_i686/texinfo-6.7-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.7-1_x86_64/texinfo-6.7-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '005b37aa4e36dea62555ce6ca36426f37ebc66d9f8ecba23cb8c960b3fc7c092',
-     armv7l: '005b37aa4e36dea62555ce6ca36426f37ebc66d9f8ecba23cb8c960b3fc7c092',
-       i686: '24bf126b3bba3a6dff27bdd869e0c6e3263eb9b04c39003ecc7bc8730230e816',
-     x86_64: '4e7a16cb4f7d93a7c949c7ff10b03fa2e27b9db4372e5c138b0f10561fafa292',
-  })
+  source_url 'https://ftpmirror.gnu.org/texinfo/texinfo-6.8.tar.xz'
+  source_sha256 '8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4'
 
   depends_on 'perl_locale_messages'
   depends_on 'perl_text_unidecode'
@@ -28,8 +15,7 @@ class Texinfo < Package
 
   def self.build
     # configure and make
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
       --with-external-Text-Unidecode \
       --with-external-Unicode-EastAsianWidth"
     system 'make'

--- a/packages/texinfo.rb
+++ b/packages/texinfo.rb
@@ -9,6 +9,19 @@ class Texinfo < Package
   source_url 'https://ftpmirror.gnu.org/texinfo/texinfo-6.8.tar.xz'
   source_sha256 '8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8_armv7l/texinfo-6.8-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8_armv7l/texinfo-6.8-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8_i686/texinfo-6.8-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8_x86_64/texinfo-6.8-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '8ab8c07b8df6060de246818fe5c94d8fb52c1c16789eddc1ecdcf47d77a53e71',
+     armv7l: '8ab8c07b8df6060de246818fe5c94d8fb52c1c16789eddc1ecdcf47d77a53e71',
+       i686: 'd0a9f83f9314f21775cdddf404dfd63117ad55a22bfc2c2134c22e045ed7e1ac',
+     x86_64: '9b3df80fbebafc830f9ad99c73ab8aaaa3ad0d0ca13cf33a6a4ed9fb737e8ed3'
+  })
+
   depends_on 'perl_locale_messages'
   depends_on 'perl_text_unidecode'
   depends_on 'perl_unicode_eastasianwidth'


### PR DESCRIPTION
all need binaries. works on x86_64.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=update-and-fix-gnu CREW_TESTING=1 crew update
```

Updated packages are: `bison gnuchess libsigsegv mailutils sed texinfo`