### PR TITLE
gnupg => 2.3.4

### DIFF
--- a/packages/fig2dev.rb
+++ b/packages/fig2dev.rb
@@ -1,0 +1,49 @@
+# Adapted from Arch Linux fig2dev PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/fig2dev/trunk/PKGBUILD
+
+require 'package'
+
+class Fig2dev < Package
+  description 'Format conversion utility that can be used with xfig'
+  homepage 'http://mcj.sourceforge.net/'
+  version '3.2.8b'
+  license 'custom'
+  compatibility 'all'
+  source_url "https://downloads.sourceforge.net/mcj/fig2dev-#{version}.tar.xz"
+  source_sha256 '418a164aa9fad72d25bb4fec8d7b452fe3a2f12f990cf22e05c0eb16cecb68cb'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fig2dev/3.2.8b_armv7l/fig2dev-3.2.8b-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fig2dev/3.2.8b_armv7l/fig2dev-3.2.8b-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fig2dev/3.2.8b_i686/fig2dev-3.2.8b-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fig2dev/3.2.8b_x86_64/fig2dev-3.2.8b-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '7d58afbf61ec04863fb2c9c1c3f604a5f585ca0e3927e88de1c350497bb5c916',
+     armv7l: '7d58afbf61ec04863fb2c9c1c3f604a5f585ca0e3927e88de1c350497bb5c916',
+       i686: 'ca06980b6095bddc69acfc9f9cc5b1ef42d6d60b3f2c0d4e36c55c57090db2af',
+     x86_64: '4a08b8d9b7a40236308af595d94f08e9043bb7f526fdbc51125768eef21efbba'
+  })
+
+  depends_on 'libpng'
+  depends_on 'libxpm'
+  depends_on 'bc'
+  depends_on 'netpbm'
+  depends_on 'ghostscript'
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS} ./configure \
+      #{CREW_OPTIONS} \
+      --enable-transfig"
+    system "make FIG2DEV_LIBDIR=#{CREW_PREFIX}/share/fig2dev \
+      XFIGLIBDIR=#{CREW_PREFIX}/share/xfig"
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} \
+    XFIGLIBDIR=#{CREW_PREFIX}/share/xfig \
+    FIG2DEV_LIBDIR=#{CREW_PREFIX}/share/fig2dev \
+    MANPATH=#{CREW_MAN_PREFIX} \
+    install"
+  end
+end

--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -4,26 +4,27 @@ class Gettext < Package
   description 'GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages.'
   homepage 'https://www.gnu.org/software/gettext/'
   @_ver = '0.21'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'GPL-3+ and LGPL-2.1+'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/gettext/gettext-#{@_ver}.tar.lz"
   source_sha256 '435b546e3880ab767c967c0731b20629a0cb0ba620e6bac2f590f401c10ebb45'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gettext/0.21-1_armv7l/gettext-0.21-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gettext/0.21-1_armv7l/gettext-0.21-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gettext/0.21-1_i686/gettext-0.21-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gettext/0.21-1_x86_64/gettext-0.21-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gettext/0.21-2_armv7l/gettext-0.21-2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gettext/0.21-2_armv7l/gettext-0.21-2-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gettext/0.21-2_i686/gettext-0.21-2-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gettext/0.21-2_x86_64/gettext-0.21-2-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '6d54ddacd45c8393893173a163b24a0b1ece327fce41b0e37d9353fd203360e7',
-     armv7l: '6d54ddacd45c8393893173a163b24a0b1ece327fce41b0e37d9353fd203360e7',
-       i686: '829a5256d748faaa93b6c5ff7ea142940536b40189222d6d0d4fba888eac0131',
-     x86_64: '25deed7e58cba619b5c9efae12aaec377823b28dcf8d70340c41a8604fd8365f'
+    aarch64: '0c4ba6f36d8c248903ab10ab34859ef7894ed943b5b75f0f7f989cafa3b3396f',
+     armv7l: '0c4ba6f36d8c248903ab10ab34859ef7894ed943b5b75f0f7f989cafa3b3396f',
+       i686: '1b8b246ad1bc3b4fd463e91b93b82e4f69479642f1bf27332d82be2809617f39',
+     x86_64: '4ada2428329f3fc4098b4fab8cc81d816028a7ac283c359c86fdc1d569a52af3'
   })
 
   depends_on 'jdk8' => :build
+  depends_on 'openmp'
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")

--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -3,24 +3,11 @@ require 'package'
 class Gnupg < Package
   description 'GnuPG is a complete and free implementation of the OpenPGP standard as defined by RFC4880 (also known as PGP).'
   homepage 'https://gnupg.org/'
-  version '2.2.7'
+  version '2.3.4'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.7.tar.bz2'
-  source_sha256 'd95b361ee6ef7eff86af40c8c72bf9313736ac9f7010d6604d78bf83818e976e'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnupg/2.2.7_armv7l/gnupg-2.2.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnupg/2.2.7_armv7l/gnupg-2.2.7-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnupg/2.2.7_i686/gnupg-2.2.7-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnupg/2.2.7_x86_64/gnupg-2.2.7-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'e356625feaef9e93d4d0946635db862df13c5f555636b38c5504042fa4ff3c23',
-     armv7l: 'e356625feaef9e93d4d0946635db862df13c5f555636b38c5504042fa4ff3c23',
-       i686: '32060d1d69ac5b44ad7f7fe7e6a2744404f972b26b28ba2999e70c12f9c20dc7',
-     x86_64: 'eaa2a33957ce00de10e0655b326ba1d2d9512b749e1d81cbf205c4c6e064a729',
-  })
+  source_url 'https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.3.4.tar.bz2'
+  source_sha256 'f3468ecafb1d7f9ad7b51fd1db7aebf17ceb89d2efa8a05cf2f39b4d405402ae'
 
   depends_on 'bz2'
   depends_on 'libassuan'
@@ -29,13 +16,20 @@ class Gnupg < Package
   depends_on 'pinentry'
 
   def self.build
-    system './configure',
-      "--prefix=#{CREW_PREFIX}",
-      "--libdir=#{CREW_LIB_PREFIX}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+              --enable-all-tests \
+              --with-capabilities \
+              --with-zlib \
+              --with-bzip2 \
+              --with-readline"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -9,7 +9,21 @@ class Gnupg < Package
   source_url 'https://dev.gnupg.org/source/gnupg.git'
   git_hashtag "gnupg-#{version}"
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnupg/2.3.4_armv7l/gnupg-2.3.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnupg/2.3.4_armv7l/gnupg-2.3.4-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnupg/2.3.4_i686/gnupg-2.3.4-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnupg/2.3.4_x86_64/gnupg-2.3.4-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '4348fdfe6e565163a12fe76ad9c467bc58dcc8811f826343a6bf1bfe203fcca2',
+     armv7l: '4348fdfe6e565163a12fe76ad9c467bc58dcc8811f826343a6bf1bfe203fcca2',
+       i686: 'd3547c621c30cad0ea9eecd9906e86ae041f76ebb8564514bcb98da52da3dc0c',
+     x86_64: '2096de764cf3fd0a77bc390cdfa7bb551a1ec7cb07239221fee6e1f09404f4d9'
+  })
+
   depends_on 'bz2'
+  depends_on 'fig2dev' => :build
   depends_on 'imagemagick7' => :build
   depends_on 'libassuan'
   depends_on 'libgcrypt'
@@ -43,7 +57,7 @@ class Gnupg < Package
                  mycflags="$mycflags -Wno-format-zero-length"
                fi
     GCC10PATCHEOF
-    IO.write('gcc10.patch', @gcc10patch)
+    File.write('gcc10.patch', @gcc10patch)
     system 'patch -Np1 -F 2 -i gcc10.patch'
   end
 

--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -16,10 +16,10 @@ class Gnupg < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnupg/2.3.4_x86_64/gnupg-2.3.4-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '4348fdfe6e565163a12fe76ad9c467bc58dcc8811f826343a6bf1bfe203fcca2',
-     armv7l: '4348fdfe6e565163a12fe76ad9c467bc58dcc8811f826343a6bf1bfe203fcca2',
-       i686: 'd3547c621c30cad0ea9eecd9906e86ae041f76ebb8564514bcb98da52da3dc0c',
-     x86_64: '2096de764cf3fd0a77bc390cdfa7bb551a1ec7cb07239221fee6e1f09404f4d9'
+    aarch64: 'f581a00c668be835091c809538f2ec6be54854daf9a5c413d9919e629881dd8e',
+     armv7l: 'f581a00c668be835091c809538f2ec6be54854daf9a5c413d9919e629881dd8e',
+       i686: '6178b043fd65b6ebfa7ca36a4379ef9fbae8903f2f088cdc7cf2618f8a685305',
+     x86_64: '2d42176822fa0c0b0aa5d32b85296e235c5195747a31b47a4e5f68c62614d639'
   })
 
   depends_on 'bz2'

--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -58,7 +58,7 @@ class Gnupg < Package
                fi
     GCC10PATCHEOF
     File.write('gcc10.patch', @gcc10patch)
-    system 'patch -Np1 -F 2 -i gcc10.patch'
+    system 'patch -Np1 -i gcc10.patch'
   end
 
   def self.build

--- a/packages/imagemagick7.rb
+++ b/packages/imagemagick7.rb
@@ -3,24 +3,24 @@ require 'package'
 class Imagemagick7 < Package
   description 'Use ImageMagick to create, edit, compose, or convert bitmap images.'
   homepage 'http://www.imagemagick.org/script/index.php'
-  @_ver = '7.0.11-2'
+  @_ver = '7.1.0-19'
   version @_ver
   license 'imagemagick'
   compatibility 'all'
-  source_url "https://github.com/ImageMagick/ImageMagick/archive/#{@_ver}.tar.gz"
-  source_sha256 '936959ba77bb9d8fdab4d9c69f90316c02a7e2467dea3790ad36b4d500c31a22'
+  source_url 'https://github.com/ImageMagick/ImageMagick.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.0.11-2_armv7l/imagemagick7-7.0.11-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.0.11-2_armv7l/imagemagick7-7.0.11-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.0.11-2_i686/imagemagick7-7.0.11-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.0.11-2_x86_64/imagemagick7-7.0.11-2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-19_armv7l/imagemagick7-7.1.0-19-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-19_armv7l/imagemagick7-7.1.0-19-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-19_i686/imagemagick7-7.1.0-19-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-19_x86_64/imagemagick7-7.1.0-19-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '04025f5ae6e216cf6e79f2c1a6eccc79ee4a3228eb4d13d9475938a031bb1986',
-     armv7l: '04025f5ae6e216cf6e79f2c1a6eccc79ee4a3228eb4d13d9475938a031bb1986',
-       i686: '2a8cae3b4c308c75078f199e8bb9b005baf0babfdce0ff9f5b5f52b23ca71fa0',
-     x86_64: '8bc32c289e65e5499660cda89afab1dfb68b14de9c70b4f3e82924fa3dafe80a'
+    aarch64: 'e4ab61bc827580630719cdcd95036bff97375f7626deaea8a22e2cb8ffdde9a1',
+     armv7l: 'e4ab61bc827580630719cdcd95036bff97375f7626deaea8a22e2cb8ffdde9a1',
+       i686: 'f112987ecd6c6c5be4632ae7f3b953a30d2a4ad1ebeeb92d51d006a300a887cb',
+     x86_64: 'f3f60b31f682ce39b3fc56bb7a3f44d5fd0fcb87c37e0951080fc57dbc852757'
   })
 
   depends_on 'flif'
@@ -32,6 +32,7 @@ class Imagemagick7 < Package
   depends_on 'jemalloc'
   depends_on 'xzutils'
   depends_on 'libheif'
+  depends_on 'libpng'
   depends_on 'librsvg'
   depends_on 'libwebp'
   depends_on 'libwmf'
@@ -61,11 +62,13 @@ class Imagemagick7 < Package
       --program-prefix='' \
       --with-windows-font-dir=#{CREW_PREFIX}/share/fonts/truetype/msttcorefonts \
       --disable-dependency-tracking \
+      --with-magick-plus-plus \
       --enable-hugepages \
       --with-jemalloc \
       --with-modules \
       --enable-hdri \
       --with-perl \
+      --with-perl-options='INSTALLDIRS=vendor' \
       --with-rsvg \
       --with-x"
     system 'make'

--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -3,24 +3,11 @@ require 'package'
 class Libgcrypt < Package
   description 'Libgcrypt is a general purpose cryptographic library originally based on code from GnuPG.'
   homepage 'https://www.gnupg.org/related_software/libgcrypt/index.html'
-  version '1.9.3'
+  version '1.9.4'
   license 'LGPL-2.1 and MIT'
   compatibility 'all'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.9.3.tar.bz2'
-  source_sha256 '97ebe4f94e2f7e35b752194ce15a0f3c66324e0ff6af26659bbfb5ff2ec328fd'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.3_armv7l/libgcrypt-1.9.3-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.3_armv7l/libgcrypt-1.9.3-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.3_i686/libgcrypt-1.9.3-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.3_x86_64/libgcrypt-1.9.3-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '1e2b42394624c35f94278ee7f9c70aa544c7c40dedd49b396e3e2a72d2e6e6bc',
-     armv7l: '1e2b42394624c35f94278ee7f9c70aa544c7c40dedd49b396e3e2a72d2e6e6bc',
-       i686: 'c072efaef5595c6f3ef7c57ce9573a8c9d79f2e7fa937425f4bb3a4098e12cd5',
-     x86_64: '3945f3464bd06d41db1be4ad4f59242490bfa897856c9e395f25b5d9f1f1bc75'
-  })
+  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.9.4.tar.bz2'
+  source_sha256 'ea849c83a72454e3ed4267697e8ca03390aee972ab421e7df69dfe42b65caaf7'
 
   depends_on 'libgpgerror'
 

--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -6,8 +6,21 @@ class Libgcrypt < Package
   version '1.9.4'
   license 'LGPL-2.1 and MIT'
   compatibility 'all'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.9.4.tar.bz2'
+  source_url "https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-#{version}.tar.bz2"
   source_sha256 'ea849c83a72454e3ed4267697e8ca03390aee972ab421e7df69dfe42b65caaf7'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.4_armv7l/libgcrypt-1.9.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.4_armv7l/libgcrypt-1.9.4-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.4_i686/libgcrypt-1.9.4-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgcrypt/1.9.4_x86_64/libgcrypt-1.9.4-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'c9b2becd32471b6d23c65b513685bf58bd1e5f453b6ab49dd5ebe33959fb2354',
+     armv7l: 'c9b2becd32471b6d23c65b513685bf58bd1e5f453b6ab49dd5ebe33959fb2354',
+       i686: '9d9dea2c93f63e7ab36f6423c873ece51ce2cd3558da61e266e463cda38413c5',
+     x86_64: '83e047dd1591ec41c67d707517f5fd0b31492e15b282345e31ca563689ec8df9'
+  })
 
   depends_on 'libgpgerror'
 
@@ -32,9 +45,5 @@ class Libgcrypt < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.check
-    system 'make', 'check'
   end
 end

--- a/packages/libgcrypt.rb
+++ b/packages/libgcrypt.rb
@@ -33,4 +33,8 @@ class Libgcrypt < Package
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
+
+  def self.check
+    system 'make', 'check'
+  end
 end

--- a/packages/libgpgerror.rb
+++ b/packages/libgpgerror.rb
@@ -3,25 +3,12 @@ require 'package'
 class Libgpgerror < Package
   description 'Libgpg-error is a small library that defines common error values for all GnuPG components.'
   homepage 'https://www.gnupg.org/related_software/libgpg-error/index.html'
-  @_ver = '1.42'
+  @_ver = '1.43'
   version "#{@_ver}-1"
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
   source_url "https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-#{@_ver}.tar.bz2"
-  source_sha256 'fc07e70f6c615f8c4f590a8e37a9b8dd2e2ca1e9408f8e60459c67452b925e23'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42-1_armv7l/libgpgerror-1.42-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42-1_armv7l/libgpgerror-1.42-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42-1_i686/libgpgerror-1.42-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.42-1_x86_64/libgpgerror-1.42-1-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '46ca55616094f55ad7a071f06ea9b028d58ab8883407155ef472cf6b8bc105a7',
-     armv7l: '46ca55616094f55ad7a071f06ea9b028d58ab8883407155ef472cf6b8bc105a7',
-       i686: 'ef29d332a020b339c83492adf00b2aae6173d2a86b4b11922c48338dd73b9138',
-     x86_64: '87bdb815ac35effdf3a42e8dad56f947dcd51280590db3e64b59fc744908ce2d'
-  })
+  source_sha256 'a9ab83ca7acc442a5bd846a75b920285ff79bdb4e3d34aa382be88ed2c3aebaf'
 
   def self.patch
     system 'filefix'

--- a/packages/libgpgerror.rb
+++ b/packages/libgpgerror.rb
@@ -4,11 +4,24 @@ class Libgpgerror < Package
   description 'Libgpg-error is a small library that defines common error values for all GnuPG components.'
   homepage 'https://www.gnupg.org/related_software/libgpg-error/index.html'
   @_ver = '1.43'
-  version "#{@_ver}-1"
+  version @_ver
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
   source_url "https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-#{@_ver}.tar.bz2"
   source_sha256 'a9ab83ca7acc442a5bd846a75b920285ff79bdb4e3d34aa382be88ed2c3aebaf'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.43_armv7l/libgpgerror-1.43-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.43_armv7l/libgpgerror-1.43-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.43_i686/libgpgerror-1.43-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgpgerror/1.43_x86_64/libgpgerror-1.43-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '9b13df6ff89698f3a1f72a56fbd39b26f7f7929f5a0952481485151b4038f39e',
+     armv7l: '9b13df6ff89698f3a1f72a56fbd39b26f7f7929f5a0952481485151b4038f39e',
+       i686: 'a755f774182fd094f1327b4767118f072d6fa39443e37fe139cb88bb9c966aa6',
+     x86_64: '7eaf819b458f2ad35e66b1113fd9fdec0821d93289f41e670234e7137adb90da'
+  })
 
   def self.patch
     system 'filefix'

--- a/packages/libksba.rb
+++ b/packages/libksba.rb
@@ -9,6 +9,19 @@ class Libksba < Package
   source_url 'https://www.gnupg.org/ftp/gcrypt/libksba/libksba-1.6.0.tar.bz2'
   source_sha256 'dad683e6f2d915d880aa4bed5cea9a115690b8935b78a1bbe01669189307a48b'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libksba/1.6.0_armv7l/libksba-1.6.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libksba/1.6.0_armv7l/libksba-1.6.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libksba/1.6.0_i686/libksba-1.6.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libksba/1.6.0_x86_64/libksba-1.6.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'd25ccbccc0a376b5a832167dadf95295117feb63b52020438e301e3f2d6eca66',
+     armv7l: 'd25ccbccc0a376b5a832167dadf95295117feb63b52020438e301e3f2d6eca66',
+       i686: 'db9c4cccfa6452890cfcd2c90155a097cc8c24ff884eacb2377364b437a3d3ce',
+     x86_64: '1306f097b8a500d4bd39442329083fd79cceb8fd62a7b159466b6acef9ad8839'
+  })
+
   depends_on 'libgpgerror'
   depends_on 'npth'
 
@@ -18,7 +31,7 @@ class Libksba < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check

--- a/packages/libksba.rb
+++ b/packages/libksba.rb
@@ -3,34 +3,25 @@ require 'package'
 class Libksba < Package
   description 'Libksba is a library to make the tasks of working with X.509 certificates, CMS data and related objects more easy.'
   homepage 'https://www.gnupg.org/related_software/libksba/index.html'
-  version '1.3.5-0'
+  version '1.6.0'
   license 'LGPL-3+, GPL-2+ and GPL-3+'
   compatibility 'all'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/libksba/libksba-1.3.5.tar.bz2'
-  source_sha256 '41444fd7a6ff73a79ad9728f985e71c9ba8cd3e5e53358e70d5f066d35c1a340'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libksba/1.3.5-0_armv7l/libksba-1.3.5-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libksba/1.3.5-0_armv7l/libksba-1.3.5-0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libksba/1.3.5-0_i686/libksba-1.3.5-0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libksba/1.3.5-0_x86_64/libksba-1.3.5-0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '9992a30c1ec084d843db72b5d183f46e65596ab52925b1807b1c7476dfa0f071',
-     armv7l: '9992a30c1ec084d843db72b5d183f46e65596ab52925b1807b1c7476dfa0f071',
-       i686: 'e69de6e5e76ae483bc8c350eb3ad9ab9cc1f03b1680c05bef2ea2acb4a4dc993',
-     x86_64: '4c0a4853f87105315ae990d0ccc6450bab22dd40666a92d0a22985b301739833',
-  })
+  source_url 'https://www.gnupg.org/ftp/gcrypt/libksba/libksba-1.6.0.tar.bz2'
+  source_sha256 'dad683e6f2d915d880aa4bed5cea9a115690b8935b78a1bbe01669189307a48b'
 
   depends_on 'libgpgerror'
   depends_on 'npth'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/npth.rb
+++ b/packages/npth.rb
@@ -3,31 +3,22 @@ require 'package'
 class Npth < Package
   description 'nPth is a library to provide the GNU Pth API and thus a non-preemptive threads implementation.'
   homepage 'https://www.gnupg.org/related_software/npth/index.html'
-  version '1.5-1'
+  version '1.6'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/npth/npth-1.5.tar.bz2'
-  source_sha256 '294a690c1f537b92ed829d867bee537e46be93fbd60b16c04630fbbfcd9db3c2'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/npth/1.5-1_armv7l/npth-1.5-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/npth/1.5-1_armv7l/npth-1.5-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/npth/1.5-1_i686/npth-1.5-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/npth/1.5-1_x86_64/npth-1.5-1-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '2e1ee46afeb6ab2ed19e3245ba6f3f78d5bfec6594ab64c3f8e94ee1841616e5',
-     armv7l: '2e1ee46afeb6ab2ed19e3245ba6f3f78d5bfec6594ab64c3f8e94ee1841616e5',
-       i686: 'cf3ac9fe003627e7e0577a82e6d128105fa0c5805299bbbd392f1c3f57182088',
-     x86_64: '29fcbdfa008f0e487ceebb1ca221eea79a56bd2937392c29ab01049d0d71699b',
-  })
+  source_url 'https://www.gnupg.org/ftp/gcrypt/npth/npth-1.6.tar.bz2'
+  source_sha256 '1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/npth.rb
+++ b/packages/npth.rb
@@ -9,13 +9,26 @@ class Npth < Package
   source_url 'https://www.gnupg.org/ftp/gcrypt/npth/npth-1.6.tar.bz2'
   source_sha256 '1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/npth/1.6_armv7l/npth-1.6-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/npth/1.6_armv7l/npth-1.6-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/npth/1.6_i686/npth-1.6-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/npth/1.6_x86_64/npth-1.6-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '0b1965d806030039b4ae11b025417bca7c21ad3959eca638e45cd4cd7d55f4ba',
+     armv7l: '0b1965d806030039b4ae11b025417bca7c21ad3959eca638e45cd4cd7d55f4ba',
+       i686: '1681a48ed502d65d3cb9f6ff8979eb009f8b83a94571b5077cd1e0744a75b5d8',
+     x86_64: '1511822e81d1bf23d0c293e602d5cfa55cf4c00718f477e3b9344e4c27241cde'
+  })
+
   def self.build
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check


### PR DESCRIPTION
- Upgrade gnupg and dependencies. works on x86_64. Needs binaries.
- `gettext` rebuild to fix iconv issue with msgmerge complaining that it can't do a conversion.
- Adds `fig2dev`, rebuilds `gettext`, and updates `imagemagick7` as well.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=gnupg_2.3.4 CREW_TESTING=1 crew update
```

Updated packages are: `imagemagick7 libgpgerror npth libksba libgcrypt gnupg`