### PR TITLE
libbsd => 0.11.3

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.20.0'
+CREW_VERSION = '1.20.1'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -122,8 +122,8 @@ end
 
 CREW_COMMON_FLAGS = '-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=gold'
 CREW_COMMON_FNO_LTO_FLAGS = '-O2 -pipe -fno-lto -fPIC -fuse-ld=gold'
-CREW_FNO_LTO_LDFLAGS = '-fno-lto'
 CREW_LDFLAGS = '-flto'
+CREW_FNO_LTO_LDFLAGS = '-fno-lto'
 
 CREW_ENV_OPTIONS = <<~OPT.chomp
   CFLAGS='#{CREW_COMMON_FLAGS}' \
@@ -131,6 +131,13 @@ CREW_ENV_OPTIONS = <<~OPT.chomp
   FCFLAGS='#{CREW_COMMON_FLAGS}' \
   FFLAGS='#{CREW_COMMON_FLAGS}' \
   LDFLAGS='#{CREW_LDFLAGS}'
+OPT
+CREW_ENV_FNO_LTO_OPTIONS = <<~OPT.chomp
+  CFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
+  CXXFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
+  FCFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
+  FFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
+  LDFLAGS='#{CREW_FNO_LTO_LDFLAGS}'
 OPT
 CREW_OPTIONS = <<~OPT.chomp
   --prefix=#{CREW_PREFIX} \

--- a/packages/libbsd.rb
+++ b/packages/libbsd.rb
@@ -10,6 +10,19 @@ class Libbsd < Package
   source_url 'https://git.hadrons.org/git/libbsd.git'
   git_hashtag @_ver
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbsd/0.11.3_armv7l/libbsd-0.11.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbsd/0.11.3_armv7l/libbsd-0.11.3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbsd/0.11.3_i686/libbsd-0.11.3-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbsd/0.11.3_x86_64/libbsd-0.11.3-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '391cf3f07f66a315e7da44504dc3e713c93a541b92e94e87a0383382f674113d',
+     armv7l: '391cf3f07f66a315e7da44504dc3e713c93a541b92e94e87a0383382f674113d',
+       i686: 'ae08dd18ad0d73e21166745bf5736f4248a42b224d3f0a94736c3172cbfb7712',
+     x86_64: '55da730b6d52c086cb934546543475e298851c1060c5838bede71826631c566f'
+  })
+
   depends_on 'libmd'
 
   def self.build
@@ -17,14 +30,14 @@ class Libbsd < Package
     system 'autoupdate'
     system 'autoreconf -fiv'
     system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS}"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
 end

--- a/packages/libbsd.rb
+++ b/packages/libbsd.rb
@@ -3,31 +3,28 @@ require 'package'
 class Libbsd < Package
   description 'This library provides useful functions commonly found on BSD systems, and lacking on others like GNU systems, thus making it easier to port projects with strong BSD origins, without needing to embed the same code over and over again on each project.'
   homepage 'https://libbsd.freedesktop.org/wiki'
-  version '0.10.0'
+  @_ver = '0.11.3'
+  version @_ver
   license 'BSD, BSD-2, BSD-4, ISC'
   compatibility 'all'
-  source_url 'https://libbsd.freedesktop.org/releases/libbsd-0.10.0.tar.xz'
-  source_sha256 '34b8adc726883d0e85b3118fa13605e179a62b31ba51f676136ecb2d0bc1a887'
+  source_url 'https://git.hadrons.org/git/libbsd.git'
+  git_hashtag @_ver
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbsd/0.10.0_armv7l/libbsd-0.10.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbsd/0.10.0_armv7l/libbsd-0.10.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbsd/0.10.0_i686/libbsd-0.10.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbsd/0.10.0_x86_64/libbsd-0.10.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '37a763df2252323db210cdb3ea216adaa5e04702975de7b3e13164d7b89f7b85',
-     armv7l: '37a763df2252323db210cdb3ea216adaa5e04702975de7b3e13164d7b89f7b85',
-       i686: '0cc3fad8e96ddf9cd0c501a48043f76c8e2d25a8ce2114912cefe0f39633a14c',
-     x86_64: '1eaed035917e2d3656a3e708777cc18f3f350ec495185bae77c3a8f7e254da52',
-  })
+  depends_on 'libmd'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    FileUtils.mkdir_p 'm4'
+    system 'autoupdate'
+    system 'autoreconf -fiv'
+    system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS}"
     system "make"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
   end
 end

--- a/packages/libmd.rb
+++ b/packages/libmd.rb
@@ -10,18 +10,31 @@ class Libmd < Package
   source_url 'https://git.hadrons.org/git/libmd.git'
   git_hashtag @_ver
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmd/1.0.4_armv7l/libmd-1.0.4-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmd/1.0.4_armv7l/libmd-1.0.4-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmd/1.0.4_i686/libmd-1.0.4-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmd/1.0.4_x86_64/libmd-1.0.4-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'd7f7fb355eeffac5bed6e547812810e56b722663262e8059048e3e66da1610b4',
+     armv7l: 'd7f7fb355eeffac5bed6e547812810e56b722663262e8059048e3e66da1610b4',
+       i686: 'd07ff3785775f604b95d0bfec9e3fefe054dc8b9131da983c93033ae4b5042c1',
+     x86_64: '672b5ccf0a9b2188476b6c00940f93c2f8615c55694871e399076a6b7527cdba'
+  })
+
   def self.build
     system 'autoupdate'
     system 'autoreconf -fiv'
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
 end

--- a/packages/libmd.rb
+++ b/packages/libmd.rb
@@ -1,0 +1,27 @@
+require 'package'
+
+class Libmd < Package
+  description 'libmd provides message digest functions found on BSD systems.'
+  homepage 'https://www.hadrons.org/software/libmd/'
+  @_ver = '1.0.4'
+  version @_ver
+  license 'BSD-3, BSD-2, ISC, Beerware, public-domain'
+  compatibility 'all'
+  source_url 'https://git.hadrons.org/git/libmd.git'
+  git_hashtag @_ver
+
+  def self.build
+    system 'autoupdate'
+    system 'autoreconf -fiv'
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "make"
+  end
+
+  def self.install
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system "make", "check"
+  end
+end


### PR DESCRIPTION
upgrade libbsd to 0.11.3 and add dependency for libmd. also add the FNO_LTO to `lib/const.rb` already seen in #6524 as libbsd doesn't build with LTO. needs binaries. works on x86_64.

#### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libbsd_0.11.3 CREW_TESTING=1 crew update
```
Updated packages (in order of building if there is an order): `libmd libbsd`