### PR TITLE
libcap => 2.62

### DIFF
--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -2,25 +2,13 @@ require 'package'
 
 class Libcap < Package
   description 'Libcap implements the user-space interfaces to the POSIX 1003.1e capabilities available in Linux kernels.'
-  homepage 'https://directory.fsf.org/wiki/Libcap'
-  @_ver = '2.49'
+  homepage 'https://directory.fsf.org/wiki/Libcap/'
+  @_ver = '2.62'
   version @_ver
+  license 'GPL-2 or BSD'
   compatibility 'all'
-  source_url "https://mirrors.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-#{@_ver}.tar.xz"
-  source_sha256 'e98bc4d93645082ec787730b0fd1a712b38882465c505777de17c338831ee181'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.49_armv7l/libcap-2.49-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.49_armv7l/libcap-2.49-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.49_i686/libcap-2.49-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.49_x86_64/libcap-2.49-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'a70c7ce2ce27a15a294ce7229c10a1c2227c2705a8b0e0be88cf8bb5eed73e77',
-     armv7l: 'a70c7ce2ce27a15a294ce7229c10a1c2227c2705a8b0e0be88cf8bb5eed73e77',
-       i686: 'ff41b92eeeb4c068086e67322b6a3fa9609b883a84c29f5a10c51dc3d38aa09c',
-     x86_64: 'bc72fba8169275a4e7a78ee90eea47a20b42fa0544eb321d2c1c1549640982b6'
-  })
+  source_url "https://git.kernel.org/pub/scm/libs/libcap/libcap.git"
+  git_hashtag 'libcap-' + @_ver
 
   depends_on 'gperf' => :build
   depends_on 'linux_pam'
@@ -29,21 +17,25 @@ class Libcap < Package
   def self.build
     # add includes option to make it work with gperf-3.1
     system 'sed -e "/gperf --/s/gperf --/gperf --includes --/" -e "/gperf --/s/cap_lookup_name(/cap_dummy(/" -i libcap/Makefile'
-
     # change the path to ld
     system "sed -i 's,/usr/bin/ld,#{CREW_PREFIX}/bin/ld,g' Make.Rules"
     # change prefix
-    system "sed -i 's,prefix=/usr,prefix=#{CREW_PREFIX},' Make.Rules"
+    system "sed -i 's,prefix=/usr,prefix=#{CREW_PREFIX},g' Make.Rules"
     # set exec_prefix
-    system "sed -i 's,^exec_prefix=,exec_prefix=\$(prefix),' Make.Rules"
+    system "sed -i 's,^exec_prefix=,exec_prefix=\$(prefix),g' Make.Rules"
+    # use system libdir
+    system "sed -i 's,^lib_prefix=$(exec_prefix),lib_prefix=#{CREW_LIB_PREFIX},g' Make.Rules"
     # http://git.yoctoproject.org/cgit.cgi/poky/plain/meta/recipes-support/libcap/files/0001-ensure-the-XATTR_NAME_CAPS-is-defined-when-it-is-use.patch
     system 'sed -i "s,^\#ifdef VFS_CAP_U32,\#if defined (VFS_CAP_U32) \&\& defined (XATTR_NAME_CAPS),g" libcap/cap_file.c'
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-        LDFLAGS='-flto=auto' make"
+    system "#{CREW_ENV_OPTIONS} make"
   end
 
   def self.install
     system 'make', 'RAISE_SETFCAP=no', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/sbin/capsh"
+    #system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/sbin/capsh"
+  end
+
+  def self.check
+    system 'make', 'test'
   end
 end

--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -5,10 +5,23 @@ class Libcap < Package
   homepage 'https://directory.fsf.org/wiki/Libcap/'
   @_ver = '2.62'
   version @_ver
-  compatibility 'all'
   license 'GPL-2 or BSD'
+  compatibility 'all'
   source_url 'https://git.kernel.org/pub/scm/libs/libcap/libcap.git'
   git_hashtag "libcap-#{@_ver}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.62_armv7l/libcap-2.62-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.62_armv7l/libcap-2.62-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.62_i686/libcap-2.62-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.62_x86_64/libcap-2.62-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'ad1ba9eeb6311aa50cae4933861e6ef3c6660114f8f59fae8b38ec33cf52f4ba',
+     armv7l: 'ad1ba9eeb6311aa50cae4933861e6ef3c6660114f8f59fae8b38ec33cf52f4ba',
+       i686: 'fde7113445a251b6109911cbd5de39300ec2469091cdaea6bc6a57e726e0ef86',
+     x86_64: '3964a327f72a3323e1a192d5fbe4020f29e83ede75347e0d65582ace36f4f66b'
+  })
 
   depends_on 'gperf' => :build
   depends_on 'linux_pam'
@@ -34,6 +47,10 @@ class Libcap < Package
   end
 
   def self.check
+    @container_check = system 'grep :/docker /proc/self/cgroup &> /dev/null'
+    # Tests do not work in container.
+    return unless @container_check
+
     system 'make', 'test'
   end
 end

--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -5,14 +5,13 @@ class Libcap < Package
   homepage 'https://directory.fsf.org/wiki/Libcap/'
   @_ver = '2.62'
   version @_ver
-  license 'GPL-2 or BSD'
   compatibility 'all'
-  source_url "https://git.kernel.org/pub/scm/libs/libcap/libcap.git"
-  git_hashtag 'libcap-' + @_ver
+  license 'GPL-2 or BSD'
+  source_url 'https://git.kernel.org/pub/scm/libs/libcap/libcap.git'
+  git_hashtag "libcap-#{@_ver}"
 
   depends_on 'gperf' => :build
   depends_on 'linux_pam'
-  depends_on 'patchelf' => :build
 
   def self.build
     # add includes option to make it work with gperf-3.1
@@ -24,7 +23,7 @@ class Libcap < Package
     # set exec_prefix
     system "sed -i 's,^exec_prefix=,exec_prefix=\$(prefix),g' Make.Rules"
     # use system libdir
-    system "sed -i 's,^lib_prefix=$(exec_prefix),lib_prefix=#{CREW_LIB_PREFIX},g' Make.Rules"
+    system "sed -i 's,^lib_prefix=\$(exec_prefix),lib_prefix=#{CREW_LIB_PREFIX},g' Make.Rules"
     # http://git.yoctoproject.org/cgit.cgi/poky/plain/meta/recipes-support/libcap/files/0001-ensure-the-XATTR_NAME_CAPS-is-defined-when-it-is-use.patch
     system 'sed -i "s,^\#ifdef VFS_CAP_U32,\#if defined (VFS_CAP_U32) \&\& defined (XATTR_NAME_CAPS),g" libcap/cap_file.c'
     system "#{CREW_ENV_OPTIONS} make"
@@ -32,7 +31,6 @@ class Libcap < Package
 
   def self.install
     system 'make', 'RAISE_SETFCAP=no', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    #system "patchelf --set-rpath #{CREW_LIB_PREFIX} #{CREW_DEST_PREFIX}/sbin/capsh"
   end
 
   def self.check

--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -47,9 +47,8 @@ class Libcap < Package
   end
 
   def self.check
-    @container_check = system 'grep :/docker /proc/self/cgroup &> /dev/null'
-    # Tests do not work in container.
-    return unless @container_check
+    # Tests do not work in a Docker container.
+    return if File.exist?('/.dockerenv')
 
     system 'make', 'test'
   end


### PR DESCRIPTION
libcap upgrade 2.62. works on x86_64. needs binaries.

##### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libcap_2.62 CREW_TESTING=1 crew update
```