### PR TITLE
package.rb: Escape some bash special characters being passed to bash via system to fix issues with building.

### DIFF
--- a/lib/package.rb
+++ b/lib/package.rb
@@ -164,13 +164,19 @@ class Package
       { exception: true }
     end
 
-    # add -j arg to build commands
+    # Add -j arg to build commands.
     cmd_args.sub(/\b(?<=make)(?=\b)/, " -j#{CREW_NPROC}") unless cmd_args =~ /-j\s*\d+/
+    # Escape special bash characters.
+    cmd_args.gsub!('"','\\\\"')
+    cmd_args.gsub!('$','\\\\$')
+    cmd_args.gsub!('`','\\\\`')
 
     begin
       # use bash instead of /bin/sh
       @system_args = ''
       [@system_args, "bash -e -c \"#{cmd_args}\""].reduce(&:concat)
+      # Uncomment following line for debugging.
+      # puts @system_args.orange
       Kernel.system(@system_args, system_options)
     rescue => e
       exitstatus = $?.exitstatus


### PR DESCRIPTION
Fixes #6539

- Another attempt at this. This escapes some bash special characters.
- Please help test this @uberhacker @supechicken @saltedcoffii by running the code to pull this file below and trying to build packages.
- Have only tested this by building `libcap` so far. 
- It would be helpful to create a corpus of sample packages to test with new `crew` updates, such as a package each for `cmake`, `meson`, and `autotools/configure` based building, but that is out of scope for this PR...

Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=package_fix_2 CREW_TESTING=1 crew update
```
