### PR TITLE
package.rb: Use a function to create function placeholders

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.20.3'
+CREW_VERSION = '1.20.5'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -125,20 +125,26 @@ CREW_COMMON_FNO_LTO_FLAGS = '-O2 -pipe -fno-lto -fPIC -fuse-ld=gold'
 CREW_LDFLAGS = '-flto'
 CREW_FNO_LTO_LDFLAGS = '-fno-lto'
 
-CREW_ENV_OPTIONS = <<~OPT.chomp
-  CFLAGS='#{CREW_COMMON_FLAGS}' \
-  CXXFLAGS='#{CREW_COMMON_FLAGS}' \
-  FCFLAGS='#{CREW_COMMON_FLAGS}' \
-  FFLAGS='#{CREW_COMMON_FLAGS}' \
-  LDFLAGS='#{CREW_LDFLAGS}'
-OPT
-CREW_ENV_FNO_LTO_OPTIONS = <<~OPT.chomp
-  CFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
-  CXXFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
-  FCFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
-  FFLAGS='#{CREW_COMMON_FNO_LTO_FLAGS}' \
-  LDFLAGS='#{CREW_FNO_LTO_LDFLAGS}'
-OPT
+CREW_ENV_OPTIONS_HASH = {
+  'CFLAGS'   => CREW_COMMON_FLAGS,
+  'CXXFLAGS' => CREW_COMMON_FLAGS,
+  'FCFLAGS'  => CREW_COMMON_FLAGS,
+  'FFLAGS'   => CREW_COMMON_FLAGS,
+  'LDFLAGS'  => CREW_LDFLAGS
+}
+# parse from hash to shell readable string
+CREW_ENV_OPTIONS = CREW_ENV_OPTIONS_HASH.map {|k, v| "#{k}=\"#{v}\"" } .join(' ')
+
+CREW_ENV_FNO_LTO_OPTIONS_HASH = {
+  'CFLAGS'   => CREW_COMMON_FNO_LTO_FLAGS,
+  'CXXFLAGS' => CREW_COMMON_FNO_LTO_FLAGS,
+  'FCFLAGS'  => CREW_COMMON_FNO_LTO_FLAGS,
+  'FFLAGS'   => CREW_COMMON_FNO_LTO_FLAGS,
+  'LDFLAGS'  => CREW_FNO_LTO_LDFLAGS
+}
+# parse from hash to shell readable string
+CREW_ENV_FNO_LTO_OPTIONS = CREW_ENV_FNO_LTO_OPTIONS_HASH.map {|k, v| "#{k}=\"#{v}\"" } .join(' ')
+
 CREW_OPTIONS = <<~OPT.chomp
   --prefix=#{CREW_PREFIX} \
   --libdir=#{CREW_LIB_PREFIX} \

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -109,52 +109,6 @@ class Package
     @is_fake
   end
 
-  # Function for checks to see if install should occur.
-  def self.preflight
-
-  end
-
-  # Function to perform patch operations prior to build from source.
-  def self.patch
-
-  end
-
-  # Function to perform pre-build operations prior to build from source.
-  def self.prebuild
-
-  end
-
-  # Function to perform build from source.
-  def self.build
-
-  end
-
-  # Function to perform check from source build.
-  # This executes only during `crew build`.
-  def self.check
-
-  end
-
-  # Function to perform pre-install operations prior to install.
-  def self.preinstall
-
-  end
-
-  # Function to perform install from source build.
-  def self.install
-
-  end
-
-  # Function to perform post-install for both source build and binary distribution.
-  def self.postinstall
-
-  end
-
-  # Function to perform after package removal.
-  def self.remove
-
-  end
-
   def self.system(*args)
     # add "-j#" argument to "make" at compile-time, if necessary
 

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -5,6 +5,16 @@ class Package
            :binary_url, :binary_sha256, :source_url, :source_sha256,
            :git_branch, :git_hashtag, :is_fake
 
+  create_placeholder :preflight,   # Function for checks to see if install should occur.
+                     :patch,       # Function to perform patch operations prior to build from source.
+                     :prebuild,    # Function to perform pre-build operations prior to build from source.
+                     :build,       # Function to perform build from source.
+                     :check,       # Function to perform check from source build. (executes only during `crew build`)
+                     :preinstall,  # Function to perform pre-install operations prior to install.
+                     :install,     # Function to perform install from source build.
+                     :postinstall, # Function to perform post-install for both source build and binary distribution.
+                     :remove       # Function to perform after package removal.
+
   class << self
     attr_reader :is_fake
     attr_accessor :name, :is_dep, :in_build, :build_from_source
@@ -167,9 +177,7 @@ class Package
     # Add -j arg to build commands.
     cmd_args.sub(/\b(?<=make)(?=\b)/, " -j#{CREW_NPROC}") unless cmd_args =~ /-j\s*\d+/
     # Escape special bash characters.
-    cmd_args.gsub!('"','\\\\"')
-    cmd_args.gsub!('$','\\\\$')
-    cmd_args.gsub!('`','\\\\`')
+    cmd_args.gsub!(/("|\$|`)/, '\\\\\1')
 
     begin
       # use bash instead of /bin/sh

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -119,6 +119,9 @@ class Package
     # 3. The value of `nproc`.strip
     # See lib/const.rb for more details
 
+    # add exception option to opt_args
+    opt_args.merge!(exception: true)
+
     # extract env hash
     if args[0].is_a?(Hash)
       env = CREW_ENV_OPTIONS_HASH.merge(args[0])
@@ -134,7 +137,7 @@ class Package
     cmd_args.sub!(/\b(?<=make)(?=\b)/, " -j#{CREW_NPROC}") unless cmd_args =~ /-j\s*\d+/
 
     begin
-      Kernel.system(env, cmd_args, opt_args, exception: true)
+      Kernel.system(env, cmd_args, **opt_args)
     rescue => e
       exitstatus = $?.exitstatus
       # print failed line number and error message

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -2,7 +2,7 @@ class InstallError < RuntimeError; end
 
 def create_placeholder (*functions)
   # create_placeholder: create a placeholder for functions that will be used by crew later
-  function.each do |func|
+  functions.each do |func|
     self.class_eval("def self.#{func.to_s}; end")
   end
 end

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -1,7 +1,23 @@
 class InstallError < RuntimeError; end
 
-def property(*properties)
+def create_placeholder (*functions)
+  # create_placeholder: create a placeholder for functions that will be used by crew later
+  function.each |func| do
+    self.class_eval("def self.#{func.to_s}; end")
+  end
+end
+
+def property (*properties)
+  # property: like attr_accessor, but `=` is not needed to define a value
+  # Examples:
+  #   {prop_name}('example') # set {prop_name} to 'example'
+  #   {prop_name}            # return the value of {prop_name}
   properties.each do |prop|
-    self.class_eval("def self.#{prop}(#{prop} = nil); @#{prop} = #{prop} if #{prop}; @#{prop}; end")
+    self.class_eval <<~EOT
+      def self.#{prop} (#{prop} = nil)
+        @#{prop} = #{prop} if #{prop}
+        @#{prop}
+      end
+    EOT
   end
 end

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -2,7 +2,7 @@ class InstallError < RuntimeError; end
 
 def create_placeholder (*functions)
   # create_placeholder: create a placeholder for functions that will be used by crew later
-  function.each |func| do
+  function.each do |func|
     self.class_eval("def self.#{func.to_s}; end")
   end
 end


### PR DESCRIPTION
Tested on `x86_64`

### Changes
- Create a new function in `lib/package_helpers.rb` for creating function placeholders (Line 8-17)
- Put all escape sequences into a regex (Line 180)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken666/chromebrew.git CREW_TESTING_BRANCH=crew_buildessential CREW_TESTING=1 crew update
crew reinstall -s screen
```
