### PR TITLE
qemu -> 6.2.0

### DIFF
--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -3,21 +3,23 @@ require 'package'
 class Qemu < Package
   description 'QEMU is a generic and open source machine emulator and virtualizer.'
   homepage 'http://www.qemu.org/'
-  version '4.2.0'
-  license 'GPL-2, LGPL-2 and BSD-2'
-  compatibility 'all'
-  source_url 'https://download.qemu.org/qemu-4.2.0.tar.xz'
-  source_sha256 'd3481d4108ce211a053ef15be69af1bdd9dde1510fda80d92be0f6c3e98768f0'
+  @_ver = '6.2.0'
+  version @_ver
+  compatibility 'aarch64,armv7l,x86_64'
+  source_url 'https://github.com/qemu/qemu.git'
+  git_hashtag "v#{@_ver}"
 
-  binary_url ({
-
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/6.2.0_armv7l/qemu-6.2.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/6.2.0_armv7l/qemu-6.2.0-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/6.2.0_x86_64/qemu-6.2.0-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-
+  binary_sha256({
+    aarch64: 'c3446bacc562d8ca3320d20d48922270dfc7300c64d29031a440c19a032c5880',
+     armv7l: 'c3446bacc562d8ca3320d20d48922270dfc7300c64d29031a440c19a032c5880',
+     x86_64: 'b51aab47f59c927803b2c25313a326f7539d2d0a984094389abea78d8366b624'
   })
 
-  depends_on 'bz2'
-  depends_on 'libcurl'
   depends_on 'glib'
   depends_on 'gtk3'
   depends_on 'jemalloc'
@@ -31,14 +33,18 @@ class Qemu < Package
   depends_on 'hicolor_icon_theme'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           "--disable-stack-protector"
-    system 'make'
+    FileUtils.mkdir_p 'build'
+    Dir.chdir 'build' do
+      system "#{CREW_ENV_OPTIONS} ../configure #{CREW_OPTIONS.sub(/--target.*/, '')} \
+        --disable-stack-protector \
+        --enable-lto"
+      system 'make'
+    end
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    Dir.chdir 'build' do
+      system "make DESTDIR=#{CREW_DEST_DIR} install"
+    end
   end
 end


### PR DESCRIPTION
Fixes #6536 


Works properly:
- [x] x86_64
- [x] armv7l
- [ ] i686 (will not build, but that's fine. We don't need qemu for i686.)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=qemu CREW_TESTING=1 crew update
```
