### PR TITLE
Add postbuild function to crew

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -932,6 +932,9 @@ def prepare_package(destdir)
     compress_doc "#{CREW_DEST_PREFIX}/share/man"
     compress_doc "#{CREW_DEST_PREFIX}/share/info"
 
+    # Allow postbuild to override the filelist contents
+    @pkg.postbuild
+
     # create file list
     system 'find . -type f > ../filelist'
     system 'find . -type l >> ../filelist'
@@ -957,8 +960,8 @@ def prepare_package(destdir)
     # check for conflicts with other installed files
     puts "Checking for conflicts with files from installed packages..."
     conflicts = []
-    @conflictscmd = %x[grep --exclude #{CREW_META_PATH}#{@pkg.name}.filelist -Fxf filelist #{CREW_META_PATH}*.filelist].chomp
-    conflicts << @conflictscmd.gsub(/(:|filelist|#{CREW_META_PATH})/, '').split(' ')
+    conflictscmd = %x[grep --exclude #{CREW_META_PATH}#{@pkg.name}.filelist -Fxf filelist #{CREW_META_PATH}*.filelist]
+    conflicts << conflictscmd.gsub(/(\.filelist|#{CREW_META_PATH})/, '').split("\n")
     conflicts.reject!(&:empty?)
     unless conflicts.empty?
       if CREW_CONFLICTS_ONLY_ADVISORY == '1'
@@ -967,17 +970,7 @@ def prepare_package(destdir)
         puts "Error: There is a conflict with the same file in another package.".lightred
         @_errors = 1
       end
-      pp = ''
-      conflicts.each do |p, f|
-        if CREW_CONFLICTS_ONLY_ADVISORY == '1'
-          puts "\n#{p} package conflicts below:".orange if p != pp
-          puts f.orange
-        else
-          puts "\n#{p} package conflicts below:".lightred if p != pp
-          puts f.lightred
-        end
-        pp = p
-      end
+      conflicts.each do |conflict| puts conflict end
     end
 
     # abort if errors encountered

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.20.3'
+CREW_VERSION = '1.20.4'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -119,6 +119,11 @@ class Package
 
   end
 
+  # Function to perform post-build for both source build and binary distribution.
+  def self.postbuild
+
+  end
+
   # Function to perform check from source build.
   # This executes only during `crew build`.
   def self.check


### PR DESCRIPTION
This PR solves 2 issues.  A postbuild function is added to enable a package build (or install from source) to override the filelist meta data.  For instance, in the cases where you want to remove when there are conflicting files with other installed packages or if you want to touch config files that are generated after the app is executed to track them.  It also solves another problem that has been bugging me for a long time.  Currently, the conflicts check will only return the first instance it finds and exclude all other conflicts.
Before update:
```
Checking for conflicts with files from installed packages...
Warning: There is a conflict with the same file in another package.

py3_numpy./usr/local/lib64/python3.10/site-packages/numpy/lib/twodim_base.pyi package conflicts below:                                                                                    
py3_numpy./usr/local/lib64/python3.10/site-packages/numpy/lib/twodim_base.py
```
After update from this PR:
```
Checking for conflicts with files from installed packages...
Warning: There is a conflict with the same file in another package.
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/twodim_base.pyi
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/twodim_base.py
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/scimath.py
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/function_base.py
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/stride_tricks.pyi
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/recfunctions.py
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/nanfunctions.py
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/_iotools.py
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/format.py
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/arraysetops.py
py3_numpy:/usr/local/lib64/python3.10/site-packages/numpy/lib/arraysetops.pyi
... snip ...
```