### PR TITLE
fix perl usage in non-self section of package

### DIFF
--- a/packages/info2man.rb
+++ b/packages/info2man.rb
@@ -4,7 +4,6 @@ class Info2man < Package
   description 'Convert GNU info files to POD or man pages.'
   homepage 'https://www.cskk.ezoshosting.com/cs/css/info2pod.html'
   @_ver = '1.1-10'
-  @_perl_version = %x[echo "printf '%vd', $^V;" | perl].to_s
   version @_ver
   license 'unknown'
   compatibility 'all'
@@ -17,6 +16,7 @@ class Info2man < Package
   end
 
   def self.install
+    @_perl_version = %x[echo "printf '%vd', $^V;" | perl].to_s
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin/"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/lib/perl5/site_perl/#{@_perl_version}/"
     FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man1/"


### PR DESCRIPTION
Fixes #6550 

- Don't use `perl` (and minimize invoking programs) in non-self sections of packages, as such gets invoked on every `crew update` and `crew update compatible`, including during installs.
Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=perl_fix CREW_TESTING=1 crew update
```
