### PR TITLE
Get linux headers patched for Chrome os using git directly from google

### DIFF
--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -14,8 +14,9 @@ class Linux_sources < Package
   end
   # Only check for kernel version if not in container.
   unless File.exist?('/.dockerenv')
-    @KERNEL_VERSION = %x[uname -r].chomp.reverse.split('.',2).collect(&:reverse)[1]
+    @KERNEL_VERSION = `uname -r`.chomp.reverse.split('.', 2).collect(&:reverse)[1]
     @ver = @KERNEL_VERSION.between?(@KERNEL_VERSION, '5.15') ? @ver : @KERNEL_VERSION
+    version @ver
   end
   license 'GPL-2'
   compatibility 'all'

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -27,7 +27,7 @@ class Linux_sources < Package
     $VERBOSE = warn_level
     linux_src_dir = "#{CREW_DEST_PREFIX}/src/linux"
     FileUtils.mkdir_p(linux_src_dir)
-    FileUtils.rm_rf(.git)
+    FileUtils.rm_rf('.git')
     FileUtils.cp_r('.', linux_src_dir)
     Dir.chdir(linux_src_dir) do
       system 'make', 'defconfig'

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -9,7 +9,7 @@ class Linux_sources < Package
     @_ver = '4.14'
     version @_ver
   when 'i686'
-    @_ver '3.8'
+    @_ver = '3.8'
     version @_ver
   end
   license 'GPL-2'

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -12,6 +12,8 @@ class Linux_sources < Package
     @_ver = '3.8'
     version @_ver
   end
+  @KERNEL_VERSION = %x[uname -r].chomp.reverse.split('.',2).collect(&:reverse)[1]
+  @ver = @KERNEL_VERSION.between?(@KERNEL_VERSION, '5.15') ? @ver : @KERNEL_VERSION
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'
@@ -25,6 +27,7 @@ class Linux_sources < Package
     $VERBOSE = warn_level
     linux_src_dir = "#{CREW_DEST_PREFIX}/src/linux"
     FileUtils.mkdir_p(linux_src_dir)
+    FileUtils.rm_rf(.git)
     FileUtils.cp_r('.', linux_src_dir)
     Dir.chdir(linux_src_dir) do
       system 'make', 'defconfig'

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -12,8 +12,11 @@ class Linux_sources < Package
     @_ver = '3.8'
     version @_ver
   end
-  @KERNEL_VERSION = %x[uname -r].chomp.reverse.split('.',2).collect(&:reverse)[1]
-  @ver = @KERNEL_VERSION.between?(@KERNEL_VERSION, '5.15') ? @ver : @KERNEL_VERSION
+  # Only check for kernel version if not in container.
+  unless File.exist?('/.dockerenv')
+    @KERNEL_VERSION = %x[uname -r].chomp.reverse.split('.',2).collect(&:reverse)[1]
+    @ver = @KERNEL_VERSION.between?(@KERNEL_VERSION, '5.15') ? @ver : @KERNEL_VERSION
+  end
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -3,11 +3,10 @@ require 'package'
 class Linux_sources < Package
   description 'Sources for the Linux kernel'
   homepage 'https://kernel.org/'
-  # KERNEL_VERSION = %x[uname -r].chomp.reverse.split('.',2).collect(&:reverse)[1]
   case ARCH
   when 'aarch64', 'armv7l', 'x86_64'
     @_ver = '4.14'
-    version @_ver
+    version "#{@_ver}-1"
   when 'i686'
     @_ver = '3.8'
     version @_ver
@@ -22,6 +21,19 @@ class Linux_sources < Package
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'
   git_hashtag "chromeos-#{@_ver}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_sources/4.14-1_armv7l/linux_sources-4.14-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_sources/4.14-1_armv7l/linux_sources-4.14-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_sources/3.8_i686/linux_sources-3.8-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_sources/4.14-1_x86_64/linux_sources-4.14-1-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'c9b3116f83033215bf7f925a433bcea906067006d8c4c3f9747a279d729d4db0',
+     armv7l: 'c9b3116f83033215bf7f925a433bcea906067006d8c4c3f9747a279d729d4db0',
+       i686: '2e8cf6b96bfb2f1f65809123696799244ac20b3a7a6b516d00d9f09a0b682266',
+     x86_64: '5dc236576f40cbf6926b4b5f9241ed7e9e3e7db8f2b26643316a2ce1f08a4a02'
+  })
 
   def self.install
     ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -14,24 +14,25 @@ class Linuxheaders < Package
   end
   # Only check for kernel version if not in container.
   unless File.exist?('/.dockerenv')
-    @KERNEL_VERSION = %x[uname -r].chomp.reverse.split('.',2).collect(&:reverse)[1]
+    @KERNEL_VERSION = `uname -r`.chomp.reverse.split('.', 2).collect(&:reverse)[1]
     @ver = @KERNEL_VERSION.between?(@KERNEL_VERSION, '5.15') ? @ver : @KERNEL_VERSION
+    version @ver
   end
   license 'GPL-2'
   compatibility 'all'
   source_url 'SKIP'
 
-  binary_url ({
+  binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14_armv7l/linuxheaders-4.14-chromeos-armv7l.tar.xz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14_armv7l/linuxheaders-4.14-chromeos-armv7l.tar.xz',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/3.18_i686/linuxheaders-3.18-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14_x86_64/linuxheaders-4.14-chromeos-x86_64.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14_x86_64/linuxheaders-4.14-chromeos-x86_64.tar.xz'
   })
-  binary_sha256 ({
+  binary_sha256({
     aarch64: '4960ced072202049c4f90350ebfa6b13a3fe6750ae8a1f0d79c63ad976b66391',
      armv7l: '4960ced072202049c4f90350ebfa6b13a3fe6750ae8a1f0d79c63ad976b66391',
        i686: 'df0178926e599e8a6bb54a74c7c7cda734751e007a2bbb2e59f17a8fb3d4489f',
-     x86_64: '1cbc54cf8c1af9996039c5aec487ed3f047c9c870341b08418c0d93fb40233a0',
+     x86_64: '1cbc54cf8c1af9996039c5aec487ed3f047c9c870341b08418c0d93fb40233a0'
   })
 
   depends_on 'linux_sources' => :build
@@ -42,13 +43,13 @@ class Linuxheaders < Package
     $VERBOSE = nil
     load "#{CREW_LIB_PATH}lib/const.rb"
     $VERBOSE = warn_level
-    linux_src_dir = CREW_PREFIX + '/src/linux'
+    linux_src_dir = "#{CREW_PREFIX}/src/linux"
     Dir.chdir(linux_src_dir) do
       system 'make',
              'headers_install',
              "INSTALL_HDR_PATH=#{CREW_DEST_PREFIX}"
     end
-    Dir.chdir(CREW_DEST_PREFIX + '/include') do
+    Dir.chdir("#{CREW_DEST_PREFIX}/include") do
       system "for file in \$(find . -not -type d -name '.*'); do
                 rm \${file};
               done"

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -9,7 +9,7 @@ class Linuxheaders < Package
     @_ver = '4.14'
     version "#{@_ver}-1"
   when 'i686'
-    @_ver '3.8'
+    @_ver = '3.8'
     version @_ver
   end
   license 'GPL-2'

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -3,7 +3,15 @@ require 'package'
 class Linuxheaders < Package
   description 'Linux headers for Chrome OS.'
   homepage 'https://kernel.org/'
-  version '4.14'
+  # KERNEL_VERSION = %x[uname -r].chomp.reverse.split('.',2).collect(&:reverse)[1]
+  case ARCH
+  when 'aarch64', 'armv7l', 'x86_64'
+    @_ver = '4.14'
+    version "#{@_ver}-1"
+  when 'i686'
+    @_ver '3.8'
+    version @_ver
+  end
   license 'GPL-2'
   compatibility 'all'
   source_url 'SKIP'
@@ -24,6 +32,11 @@ class Linuxheaders < Package
   depends_on 'linux_sources' => :build
 
   def self.install
+    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
     linux_src_dir = CREW_PREFIX + '/src/linux'
     Dir.chdir(linux_src_dir) do
       system 'make',

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -23,16 +23,16 @@ class Linuxheaders < Package
   source_url 'SKIP'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14_armv7l/linuxheaders-4.14-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14_armv7l/linuxheaders-4.14-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/3.18_i686/linuxheaders-3.18-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14_x86_64/linuxheaders-4.14-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14-1_armv7l/linuxheaders-4.14-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14-1_armv7l/linuxheaders-4.14-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/3.8_i686/linuxheaders-3.8-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14-1_x86_64/linuxheaders-4.14-1-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '4960ced072202049c4f90350ebfa6b13a3fe6750ae8a1f0d79c63ad976b66391',
-     armv7l: '4960ced072202049c4f90350ebfa6b13a3fe6750ae8a1f0d79c63ad976b66391',
-       i686: 'df0178926e599e8a6bb54a74c7c7cda734751e007a2bbb2e59f17a8fb3d4489f',
-     x86_64: '1cbc54cf8c1af9996039c5aec487ed3f047c9c870341b08418c0d93fb40233a0'
+    aarch64: '75f253ac2cf0dd785ea8d9cdf9430d23d601ccc372e9f7afa95523a28273a340',
+     armv7l: '75f253ac2cf0dd785ea8d9cdf9430d23d601ccc372e9f7afa95523a28273a340',
+       i686: 'c16afcd95ebcffac67a026b724da19f498003ea80c13c87aeb613f09d412bb91',
+     x86_64: '5d58b327ca9bab5630f0df387a3036125e1f367e6c43cd551f4734ee3e634073'
   })
 
   depends_on 'linux_sources' => :build

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -12,6 +12,11 @@ class Linuxheaders < Package
     @_ver = '3.8'
     version @_ver
   end
+  # Only check for kernel version if not in container.
+  unless File.exist?('/.dockerenv')
+    @KERNEL_VERSION = %x[uname -r].chomp.reverse.split('.',2).collect(&:reverse)[1]
+    @ver = @KERNEL_VERSION.between?(@KERNEL_VERSION, '5.15') ? @ver : @KERNEL_VERSION
+  end
   license 'GPL-2'
   compatibility 'all'
   source_url 'SKIP'


### PR DESCRIPTION
- Download headers and kernel source direct from Google git
- Initial steps towards getting headers for specific kernel version being used. 
- Should we move the logic to get`KERNEL_VERSION` to `const.rb`?

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=kernel_headers CREW_TESTING=1 crew update
```
