### PR TITLE
Fix '-j#' regex addition by excluding lines w/ cmake

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.20.5'
+CREW_VERSION = '1.20.6'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -134,7 +134,7 @@ class Package
     cmd_args = args.join(' ')
 
     # Add -j arg to build commands.
-    cmd_args.sub!(/\b(?<=make)(?=\b)/, " -j#{CREW_NPROC}") unless cmd_args =~ /-j\s*\d+/
+    cmd_args.sub!(/\b(?<=make)(?=\b)/, " -j#{CREW_NPROC}") unless cmd_args =~ /-j\s*\d+|cmake/
 
     begin
       Kernel.system(env, cmd_args, **opt_args)


### PR DESCRIPTION

Works properly:
- [x] x86_64
