### PR TITLE
add package minizip, from zlib

### DIFF
--- a/packages/minizip.rb
+++ b/packages/minizip.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Minizip < Package
+  description 'Minizip is a simple package to zip/unzip files, from zlib.'
+  homepage 'https://www.zlib.net/'
+  @_ver = '1.2.11'
+  # When upgrading minzip, be sure to upgrade zlibpkg in tandem.
+  version @_ver
+  license 'zlib'
+  compatibility 'all'
+  source_url "https://www.zlib.net/zlib-#{@_ver}.tar.gz"
+  source_sha256 'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
+
+  depends_on 'zlibpkg'
+
+  def self.build
+    Dir.chdir 'contrib/minizip' do
+      system 'autoreconf -fiv'
+      system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+              --enable-demos"
+      system 'make'
+    end
+  end
+
+  def self.install
+    Dir.chdir 'contrib/minizip' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    end
+  end
+end

--- a/packages/minizip.rb
+++ b/packages/minizip.rb
@@ -11,6 +11,19 @@ class Minizip < Package
   source_url "https://www.zlib.net/zlib-#{@_ver}.tar.gz"
   source_sha256 'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minizip/1.2.11_armv7l/minizip-1.2.11-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minizip/1.2.11_armv7l/minizip-1.2.11-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minizip/1.2.11_i686/minizip-1.2.11-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minizip/1.2.11_x86_64/minizip-1.2.11-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '9acca61b29f60f66e83e4216290b668f03d756ab59e642a7eca7ef6cedd36c2b',
+     armv7l: '9acca61b29f60f66e83e4216290b668f03d756ab59e642a7eca7ef6cedd36c2b',
+       i686: '27c54c27436820905d315f4d356619897f4beae737fd6ad849339166abb999d3',
+     x86_64: '570539d195bfd82931407cf1e93610159cf8475265d703e9dc91953e5f1bc8da'
+  })
+
   depends_on 'zlibpkg'
 
   def self.build

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -2,40 +2,26 @@ require 'package'
 
 class Zlibpkg < Package
   description 'zlib is a massively spiffy yet delicately unobtrusive compression library.'
-  homepage 'http://www.zlib.net/'
+  homepage 'https://www.zlib.net/'
+  # When upgrading zlibpkg, be sure to upgrade minizip in tandem.
   @_ver = '1.2.11'
-  version "#{@_ver}-5"
+  version "#{@_ver}-6"
   license 'zlib'
   compatibility 'all'
-  source_url "http://www.zlib.net/zlib-#{@_ver}.tar.gz"
+  source_url "https://www.zlib.net/zlib-#{@_ver}.tar.gz"
   source_sha256 'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-5_armv7l/zlibpkg-1.2.11-5-chromeos-armv7l.tpxz',
-    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-5_armv7l/zlibpkg-1.2.11-5-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-5_i686/zlibpkg-1.2.11-5-chromeos-i686.tpxz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-5_x86_64/zlibpkg-1.2.11-5-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: 'b80e7c60c1a250f7d64289ab376547ba93f29e12cdaa3ae4a1a3a00b7d4ad450',
-    armv7l: 'b80e7c60c1a250f7d64289ab376547ba93f29e12cdaa3ae4a1a3a00b7d4ad450',
-    i686: '96bc24d5d6651147fcd99e08740bfa71335aa8b51506cbb580f13cad784c2fb2',
-    x86_64: '475af7ff9074abbe8fbb52f686dbf8f43f4c9dc1987a4231ae85c56d15d246c7'
-  })
-
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure \
-      --prefix=#{CREW_PREFIX} \
-      --libdir=#{CREW_LIB_PREFIX}"
-    system 'make'
-  end
-
-  def self.check
-    system 'make check'
+    # Build zlib proper
+    FileUtils.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "cmake -G Ninja #{CREW_CMAKE_OPTIONS} .."
+    end
+    system 'samu -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    # Install zlib
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -11,6 +11,19 @@ class Zlibpkg < Package
   source_url "https://www.zlib.net/zlib-#{@_ver}.tar.gz"
   source_sha256 'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-6_armv7l/zlibpkg-1.2.11-6-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-6_armv7l/zlibpkg-1.2.11-6-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-6_i686/zlibpkg-1.2.11-6-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-6_x86_64/zlibpkg-1.2.11-6-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: '0012a9c80b2c224cd51556b14cfd52095559a38aaca25a943164e5a1bff04488',
+     armv7l: '0012a9c80b2c224cd51556b14cfd52095559a38aaca25a943164e5a1bff04488',
+       i686: '2c1fbea91e0287064e7a5323b5298af74dc5ae29ee53cb9636e90c7c4842c8d3',
+     x86_64: '6a213888ddd3ff584c8f354a107fdf00f11b8570b5a5dac909a95bc4c165a0cd'
+  })
+
   def self.build
     # Build zlib proper
     FileUtils.mkdir 'builddir'


### PR DESCRIPTION
Minizip is a package from within the zlib sources. I considered just adding it into the zlibpkg file, but it's not an essential part of zlib, and is packaged separately on debian, fedora and arch. needs binaries, in order: `zlibpkg minizip` works on x86_64.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=minizip CREW_TESTING=1 crew update
```