### PR TITLE
Fix `git_hashtag`s with a / character

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -726,11 +726,11 @@ def download
         # No git branch specified, just a git commit or tag
         if @pkg.git_branch.nil? || @pkg.git_branch.empty?
           abort("No Git branch, commit, or tag specified!").lightred if @pkg.git_hashtag.nil? || @pkg.git_hashtag.empty?
-          cachefile = CREW_CACHE_DIR + filename + @pkg.git_hashtag + '.tar.xz'
+          cachefile = CREW_CACHE_DIR + filename + @pkg.git_hashtag.gsub('/', '_') + '.tar.xz'
           puts "cachefile is #{cachefile}".orange if @opt_verbose
         # Git branch and git commit specified
         elsif ( ! @pkg.git_hashtag.nil? || ! @pkg.git_hashtag.empty )  and ( ! @pkg.git_branch.nil? || ! @pkg.git_branch.empty?)
-          cachefile = CREW_CACHE_DIR + filename + @pkg.git_branch.gsub(/[^0-9A-Za-z.\-]/, '_') + '_' + @pkg.git_hashtag + '.tar.xz'
+          cachefile = CREW_CACHE_DIR + filename + @pkg.git_branch.gsub(/[^0-9A-Za-z.\-]/, '_') + '_' + @pkg.git_hashtag.gsub('/', '_') + '.tar.xz'
           puts "cachefile is #{cachefile}".orange if @opt_verbose
         # Git branch specified, without a specific git commit.
         else

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.20.6'
+CREW_VERSION = '1.20.7'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Previously `git_hashtag`s with a slash in them failed to cache because a / in a filename is seen as a directory delineator. Now, the / is changed to a _ before the file is cached, and this now works. This pull request is recommended for pull requests coming up.