### PR TITLE
crew: rescue downloads in non-interactive terminals (such as in container installs)

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.20.8'
+CREW_VERSION = '1.20.9'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -9,7 +9,15 @@ require_relative 'convert_size'
 def setTermSize
   # setTermSize: set progress bar size based on terminal width
   # get terminal window size
-  @termH, @termW = IO.console.winsize
+  begin
+    @termH, @termW = IO.console.winsize
+  rescue => e
+    puts "Non-interactive terminals may not be able to be queried for size."
+    # @termW = %x[tput cols].chomp.to_i
+    # @termH = %x[tput lines].chomp.to_i
+    @termW = '80'
+    @termH = '25'
+  end
   # space for progress bar after minus the reserved space for showing
   # the file size and progress percentage
   @progBarW = @termW - 17


### PR DESCRIPTION
Fixes #6564
- Issue occurs when building a container image from a non-interactive dockerfile.

Works properly:
- [x] x86_64


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fix_install CREW_TESTING=1 crew update
```
