### PR TITLE
crew downloader: set terminal dimensions fallback using integers, fix lto cmake variable

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.21.1'
+CREW_VERSION = '1.21.0'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.21.0'
+CREW_VERSION = '1.21.1'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.20.9'
+CREW_VERSION = '1.21.0'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -195,7 +195,7 @@ CREW_CMAKE_OPTIONS = <<~OPT.chomp
   -DCMAKE_SHARED_LINKER_FLAGS='#{CREW_LDFLAGS}' \
   -DCMAKE_STATIC_LINKER_FLAGS='#{CREW_LDFLAGS}' \
   -DCMAKE_MODULE_LINKER_FLAGS='#{CREW_LDFLAGS}' \
-  -DPROPERTY_INTERPROCEDURAL_OPTIMIZATION=TRUE \
+  -DCMAKE_INTERPROCEDURAL_OPTIMIZATION \
   -DCMAKE_BUILD_TYPE=Release
 OPT
 CREW_CMAKE_FNO_LTO_OPTIONS = <<~OPT.chomp

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -15,8 +15,8 @@ def setTermSize
     puts "Non-interactive terminals may not be able to be queried for size."
     # @termW = %x[tput cols].chomp.to_i
     # @termH = %x[tput lines].chomp.to_i
-    @termW = '80'
-    @termH = '25'
+    @termW = 80
+    @termH = 25
   end
   # space for progress bar after minus the reserved space for showing
   # the file size and progress percentage


### PR DESCRIPTION
- mea culpa
- fix cmake lto option from https://github.com/skycocker/chromebrew/pull/6558

Works properly:
- [x] x86_64
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=install_fix2 CREW_TESTING=1 crew update
```
