### PR TITLE
crew: add CREW_DISABLE_ENV_OPTION option

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -127,13 +127,18 @@ CREW_COMMON_FNO_LTO_FLAGS = '-O2 -pipe -fno-lto -fPIC -fuse-ld=gold'
 CREW_LDFLAGS = '-flto'
 CREW_FNO_LTO_LDFLAGS = '-fno-lto'
 
-CREW_ENV_OPTIONS_HASH = {
-  'CFLAGS'   => CREW_COMMON_FLAGS,
-  'CXXFLAGS' => CREW_COMMON_FLAGS,
-  'FCFLAGS'  => CREW_COMMON_FLAGS,
-  'FFLAGS'   => CREW_COMMON_FLAGS,
-  'LDFLAGS'  => CREW_LDFLAGS
-}
+CREW_DISABLE_ENV_OPTIONS = ENV['CREW_DISABLE_ENV_OPTIONS']
+unless CREW_DISABLE_ENV_OPTIONS
+  CREW_ENV_OPTIONS_HASH = {
+    'CFLAGS'   => CREW_COMMON_FLAGS,
+    'CXXFLAGS' => CREW_COMMON_FLAGS,
+    'FCFLAGS'  => CREW_COMMON_FLAGS,
+    'FFLAGS'   => CREW_COMMON_FLAGS,
+    'LDFLAGS'  => CREW_LDFLAGS
+  }
+else
+  CREW_ENV_OPTIONS_HASH = { "CREW_DISABLE_ENV_OPTIONS" => '1' }
+end
 # parse from hash to shell readable string
 CREW_ENV_OPTIONS = CREW_ENV_OPTIONS_HASH.map {|k, v| "#{k}=\"#{v}\"" } .join(' ')
 
@@ -224,5 +229,3 @@ CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
 # libssp is in the libssp package
 # libatomic is in the gcc package
 CREW_ESSENTIAL_FILES = %x[LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby].scan(/\t([^ ]+)/).flatten
-
-CREW_DISABLE_ENV_OPTION = ENV['CREW_DISABLE_ENV_OPTION']

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.21.1'
+CREW_VERSION = '1.21.2'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -195,7 +195,7 @@ CREW_CMAKE_OPTIONS = <<~OPT.chomp
   -DCMAKE_SHARED_LINKER_FLAGS='#{CREW_LDFLAGS}' \
   -DCMAKE_STATIC_LINKER_FLAGS='#{CREW_LDFLAGS}' \
   -DCMAKE_MODULE_LINKER_FLAGS='#{CREW_LDFLAGS}' \
-  -DCMAKE_INTERPROCEDURAL_OPTIMIZATION \
+  -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE \
   -DCMAKE_BUILD_TYPE=Release
 OPT
 CREW_CMAKE_FNO_LTO_OPTIONS = <<~OPT.chomp
@@ -224,3 +224,5 @@ CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
 # libssp is in the libssp package
 # libatomic is in the gcc package
 CREW_ESSENTIAL_FILES = %x[LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby].scan(/\t([^ ]+)/).flatten
+
+CREW_NO_ADD_ENV_TO_MAKE = ENV['CREW_NO_ADD_ENV_TO_MAKE']

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -225,4 +225,4 @@ CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
 # libatomic is in the gcc package
 CREW_ESSENTIAL_FILES = %x[LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby].scan(/\t([^ ]+)/).flatten
 
-CREW_NO_ADD_ENV_TO_MAKE = ENV['CREW_NO_ADD_ENV_TO_MAKE']
+CREW_DISABLE_ENV_OPTION = ENV['CREW_DISABLE_ENV_OPTION']

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -129,7 +129,6 @@ class Package
     else
       env = CREW_ENV_OPTIONS_HASH
     end
-    if CREW_DISABLE_ENV_OPTION then env = { "CREW_DISABLE_ENV_OPTION" => '1' } end
 
     # after removing the env hash, all remaining args must be command args
     cmd_args = args.join(' ')

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -129,6 +129,7 @@ class Package
     else
       env = CREW_ENV_OPTIONS_HASH
     end
+    if CREW_NO_ADD_ENV_TO_MAKE then env = { "CREW_NO_ADD_ENV_TO_MAKE " => '1' } end
 
     # after removing the env hash, all remaining args must be command args
     cmd_args = args.join(' ')
@@ -142,7 +143,7 @@ class Package
       exitstatus = $?.exitstatus
       # print failed line number and error message
       puts "#{e.backtrace[1]}: #{e.message}".orange
-      raise InstallError, "`#{cmd_args}` exited with #{exitstatus}"
+      raise InstallError, "`#{env} #{cmd_args}` exited with #{exitstatus}"
     end
   end
 end

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -129,7 +129,7 @@ class Package
     else
       env = CREW_ENV_OPTIONS_HASH
     end
-    if CREW_NO_ADD_ENV_TO_MAKE then env = { "CREW_NO_ADD_ENV_TO_MAKE " => '1' } end
+    if CREW_DISABLE_ENV_OPTION then env = { "CREW_DISABLE_ENV_OPTION" => '1' } end
 
     # after removing the env hash, all remaining args must be command args
     cmd_args = args.join(' ')


### PR DESCRIPTION
- `package.rb` currently automatically adds `CREW_ENV_OPTIONS` whereas we previously added it manually.
- With this modification we can set an env variable which sets the env variables passed with `make` to be just `CREW_DISABLE_ENV_OPTION=1`
- This also modifies the error message to include `CREW_ENV_OPTIONS` since that may have been involved in causing the error.

Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=CREW_NO_ADD_ENV_TO_MAKE CREW_TESTING=1 crew update
```
