### PR TITLE
crew: show env hash expanded when showing Kernel.system errors

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.21.2'
+CREW_VERSION = '1.21.3'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -142,7 +142,7 @@ class Package
       exitstatus = $?.exitstatus
       # print failed line number and error message
       puts "#{e.backtrace[1]}: #{e.message}".orange
-      raise InstallError, "`#{env} #{cmd_args}` exited with #{exitstatus}"
+      raise InstallError, "`#{env.map {|k, v| "#{k}=\"#{v}\"" } .join(' ')} #{cmd_args}` exited with #{exitstatus}"
     end
   end
 end


### PR DESCRIPTION
Test package: `test.rb`
```
require 'package'

class Test < Package
  description 'Test Package.'
  homepage 'http://chromebrew'
  @_ver = '1.0'
  version @_ver
  license 'BSD and GPL-2'
  compatibility 'all'
  source_url 'SKIP'

  def self.build
    system "exit 1"
  end

  def self.check
    system 'make', 'test'
  end

  def self.install
    system "make DESTDIR=#{CREW_DEST_DIR} install"
  end
end
```


Before:
![image](https://user-images.githubusercontent.com/1096701/148781556-60b76036-1b0a-42d7-8537-9ac8bfca1677.png)
After:
![image](https://user-images.githubusercontent.com/1096701/148781817-1bbea4f6-798b-4332-9424-ec355d378151.png)


Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=system_error_tweak CREW_TESTING=1 crew update
```
