### PR TITLE
libogg => 1.3.5

### DIFF
--- a/packages/libogg.rb
+++ b/packages/libogg.rb
@@ -3,31 +3,22 @@ require 'package'
 class Libogg < Package
   description 'Ogg is a multimedia container format, and the native file and stream format for the Xiph.org multimedia codecs.'
   homepage 'https://xiph.org/ogg/'
-  version '1.3.3'
+  version '1.3.5'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.3.tar.xz'
-  source_sha256 '4f3fc6178a533d392064f14776b23c397ed4b9f48f5de297aba73b643f955c08'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libogg/1.3.3_armv7l/libogg-1.3.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libogg/1.3.3_armv7l/libogg-1.3.3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libogg/1.3.3_i686/libogg-1.3.3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libogg/1.3.3_x86_64/libogg-1.3.3-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '19cedaf925df92be0217fdd752e3c78ca0e864c8b7aca395835fe80b30bd9ef8',
-     armv7l: '19cedaf925df92be0217fdd752e3c78ca0e864c8b7aca395835fe80b30bd9ef8',
-       i686: 'bfbbec754131107ad9e5909546c0719cfcc6c79d790944119f375e0612f7bd79',
-     x86_64: '44358f6cdd5cfec18571bdbcd83208b7a94f5ca726dc60830ba6eb484b469248',
-  })
+  source_url 'https://downloads.xiph.org/releases/ogg/libogg-1.3.5.tar.xz'
+  source_sha256 'c4d91be36fc8e54deae7575241e03f4211eb102afb3fc0775fbbc1b740016705'
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/libogg.rb
+++ b/packages/libogg.rb
@@ -4,10 +4,23 @@ class Libogg < Package
   description 'Ogg is a multimedia container format, and the native file and stream format for the Xiph.org multimedia codecs.'
   homepage 'https://xiph.org/ogg/'
   version '1.3.5'
+compatibility 'all'
   license 'BSD'
-  compatibility 'all'
   source_url 'https://downloads.xiph.org/releases/ogg/libogg-1.3.5.tar.xz'
   source_sha256 'c4d91be36fc8e54deae7575241e03f4211eb102afb3fc0775fbbc1b740016705'
+
+  binary_url ({
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libogg/1.3.5_armv7l/libogg-1.3.5-chromeos-armv7l.tpxz',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libogg/1.3.5_armv7l/libogg-1.3.5-chromeos-armv7l.tpxz',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libogg/1.3.5_i686/libogg-1.3.5-chromeos-i686.tpxz',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libogg/1.3.5_x86_64/libogg-1.3.5-chromeos-x86_64.tpxz',
+  })
+  binary_sha256 ({
+     aarch64: '9daa22080ed04c1b0eeae000e3c13fbbb773e6ee2b1031227f9d8fa7c184c62f',
+      armv7l: '9daa22080ed04c1b0eeae000e3c13fbbb773e6ee2b1031227f9d8fa7c184c62f',
+        i686: '7a4ee216f26bd4bf3710a52fac2860a21b97dec94f7ab86889f1a277167f9f13',
+      x86_64: '548abef188ab0f91d9affc901f4709d0019d06d4726edc8093d88ffc52a3be31',
+  })
 
   def self.build
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"


### PR DESCRIPTION
Works on x86_64. needs binaries.

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libogg_1.3.5 CREW_TESTING=1 crew update
```