### PR TITLE
libvorbis => 1.3.7

### DIFF
--- a/packages/libvorbis.rb
+++ b/packages/libvorbis.rb
@@ -4,10 +4,23 @@ class Libvorbis < Package
   description 'Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format.'
   homepage 'https://xiph.org/vorbis/'
   version '1.3.7'
-  license 'BSD'
   compatibility 'all'
+  license 'BSD'
   source_url 'https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz'
   source_sha256 'b33cc4934322bcbf6efcbacf49e3ca01aadbea4114ec9589d1b1e9d20f72954b'
+
+  binary_url ({
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvorbis/1.3.7_armv7l/libvorbis-1.3.7-chromeos-armv7l.tpxz',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvorbis/1.3.7_armv7l/libvorbis-1.3.7-chromeos-armv7l.tpxz',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvorbis/1.3.7_i686/libvorbis-1.3.7-chromeos-i686.tpxz',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvorbis/1.3.7_x86_64/libvorbis-1.3.7-chromeos-x86_64.tpxz',
+  })
+  binary_sha256 ({
+     aarch64: 'd7887b0f9a491d6b9b1e6d0998988c71a398dd0734a8cdc3a9a8973acaa1e5e0',
+      armv7l: 'd7887b0f9a491d6b9b1e6d0998988c71a398dd0734a8cdc3a9a8973acaa1e5e0',
+        i686: '71033a9a6d323bcf3b81376b151bce904ad9e3d16369d4c2e3a5dcda22074b76',
+      x86_64: '155962844a425ab407ce4c38e2a0ee8960059699c4559e3fcedf449b6e5592f0',
+  })
 
   depends_on 'libogg'
 
@@ -21,6 +34,6 @@ class Libvorbis < Package
   end
 
   def self.check
-    #system 'make', 'check'
+    # system 'make', 'check'
   end
 end


### PR DESCRIPTION
Works on x86_64. needs binaries. depends on #6579 .

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libvorbis_1.3.7 CREW_TESTING=1 crew update
```