### PR TITLE
libdvdnav => 6.1.1

### DIFF
--- a/packages/libdvdnav.rb
+++ b/packages/libdvdnav.rb
@@ -3,35 +3,24 @@ require 'package'
 class Libdvdnav < Package
   description 'libdvdnav is a library that allows easy use of sophisticated DVD navigation features such as DVD menus, multiangle playback and even interactive DVD games.'
   homepage 'http://dvdnav.mplayerhq.hu/'
-  version '6.0.0'
+  version '6.1.1'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'http://get.videolan.org/libdvdnav/6.0.0/libdvdnav-6.0.0.tar.bz2'
-  source_sha256 'f0a2711b08a021759792f8eb14bb82ff8a3c929bf88c33b64ffcddaa27935618'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdnav/6.0.0_armv7l/libdvdnav-6.0.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdnav/6.0.0_armv7l/libdvdnav-6.0.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdnav/6.0.0_i686/libdvdnav-6.0.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdnav/6.0.0_x86_64/libdvdnav-6.0.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '72938f6813add62c1be036f36cd33e6e3dceeec5255818e8b9c9031ba86cb457',
-     armv7l: '72938f6813add62c1be036f36cd33e6e3dceeec5255818e8b9c9031ba86cb457',
-       i686: '82b4c2028f58bc5064099b4e43a25f32f96f71e0db859613d11c76e18b3f4e1b',
-     x86_64: '6aa51f0f8864f54e106821bdb8aca9466c083b2fde2cb27163e72ef2ed096d70',
-  })
+  source_url 'https://get.videolan.org/libdvdnav/6.1.1/libdvdnav-6.1.1.tar.bz2'
+  source_sha256 'c191a7475947d323ff7680cf92c0fb1be8237701885f37656c64d04e98d18d48'
 
   depends_on 'libdvdread'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/libdvdnav.rb
+++ b/packages/libdvdnav.rb
@@ -4,10 +4,23 @@ class Libdvdnav < Package
   description 'libdvdnav is a library that allows easy use of sophisticated DVD navigation features such as DVD menus, multiangle playback and even interactive DVD games.'
   homepage 'http://dvdnav.mplayerhq.hu/'
   version '6.1.1'
-  license 'GPL-2'
   compatibility 'all'
+  license 'GPL-2'
   source_url 'https://get.videolan.org/libdvdnav/6.1.1/libdvdnav-6.1.1.tar.bz2'
   source_sha256 'c191a7475947d323ff7680cf92c0fb1be8237701885f37656c64d04e98d18d48'
+
+  binary_url ({
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdnav/6.1.1_armv7l/libdvdnav-6.1.1-chromeos-armv7l.tpxz',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdnav/6.1.1_armv7l/libdvdnav-6.1.1-chromeos-armv7l.tpxz',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdnav/6.1.1_i686/libdvdnav-6.1.1-chromeos-i686.tpxz',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdnav/6.1.1_x86_64/libdvdnav-6.1.1-chromeos-x86_64.tpxz',
+  })
+  binary_sha256 ({
+     aarch64: '1663315253bf583fa15d29c094602053baa87927663124821a105e298c325746',
+      armv7l: '1663315253bf583fa15d29c094602053baa87927663124821a105e298c325746',
+        i686: 'f904448267fce9f2cf000d4b542c4eedca15cd26ebca5a75e07698a43c88b8ab',
+      x86_64: 'ac31549a112b165b145668e64688f6cd0f30cd6c8ffe6356c454a1c5bdce1c88',
+  })
 
   depends_on 'libdvdread'
 


### PR DESCRIPTION
Works on x86_64. needs binaries. depends on #6593 .
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libdvdnav_6.1.2 CREW_TESTING=1 crew update
```