### PR TITLE
libcdio => 2.1.0

### DIFF
--- a/packages/libcdio.rb
+++ b/packages/libcdio.rb
@@ -3,38 +3,24 @@ require 'package'
 class Libcdio < Package
   description 'The GNU Compact Disc Input and Control library (libcdio) contains a library for CD-ROM and CD image access.'
   homepage 'http://www.gnu.org/software/libcdio/'
-  version '2.0.0'
+  version '2.1.0'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://ftp.gnu.org/gnu/libcdio/libcdio-2.0.0.tar.gz'
-  source_sha256 '1b481b5da009bea31db875805665974e2fc568e2b2afa516f4036733657cf958'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdio/2.0.0_armv7l/libcdio-2.0.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdio/2.0.0_armv7l/libcdio-2.0.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdio/2.0.0_i686/libcdio-2.0.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdio/2.0.0_x86_64/libcdio-2.0.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '96fe10d82e1165af8ddf59512c0f5e47adbebab38fcdb9741e687fc591075e98',
-     armv7l: '96fe10d82e1165af8ddf59512c0f5e47adbebab38fcdb9741e687fc591075e98',
-       i686: '0f4cd7753e6ba8c5304769fbebdd7c9603ed8841c1085e50d79f1ee9091f2857',
-     x86_64: 'b3e6ab517eaae30320ffbdc3f6874b250f59783dfb35708590e6fd22782e89ac',
-  })
+  source_url 'https://ftpmirror.gnu.org/libcdio/libcdio-2.1.0.tar.bz2'
+  source_sha256 '8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b'
 
   depends_on 'libcddb'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--without-cdda-player',
-           '--disable-maintainer-mode',
-           '--disable-static'
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+              --without-cdda-player \
+              --enable-cxx \
+              --disable-cpp-progs \
+              --disable-example-progs"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libcdio.rb
+++ b/packages/libcdio.rb
@@ -4,10 +4,23 @@ class Libcdio < Package
   description 'The GNU Compact Disc Input and Control library (libcdio) contains a library for CD-ROM and CD image access.'
   homepage 'http://www.gnu.org/software/libcdio/'
   version '2.1.0'
-  license 'GPL-3'
   compatibility 'all'
+  license 'GPL-3'
   source_url 'https://ftpmirror.gnu.org/libcdio/libcdio-2.1.0.tar.bz2'
   source_sha256 '8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b'
+
+  binary_url ({
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdio/2.1.0_armv7l/libcdio-2.1.0-chromeos-armv7l.tpxz',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdio/2.1.0_armv7l/libcdio-2.1.0-chromeos-armv7l.tpxz',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdio/2.1.0_i686/libcdio-2.1.0-chromeos-i686.tpxz',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdio/2.1.0_x86_64/libcdio-2.1.0-chromeos-x86_64.tpxz',
+  })
+  binary_sha256 ({
+     aarch64: 'd501f42889d4d997b535180436445b914dd5646991a24b8bfbce0bab3233a5a0',
+      armv7l: 'd501f42889d4d997b535180436445b914dd5646991a24b8bfbce0bab3233a5a0',
+        i686: '023e53fb398b4c9429ff136aefb6b9c5341e4ff4bb0b7eb78072d1a141141d16',
+      x86_64: 'ba61ed6f31f29fe3d477004d36d2b119f1d67db1d084109a96dff59f98b23bd1',
+  })
 
   depends_on 'libcddb'
 


### PR DESCRIPTION
Works on x86_64. needs binaries. depends on #6599

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libcdio_2.1.0 CREW_TESTING=1 crew update
```