### PR TITLE
new package libinstpatch

### DIFF
--- a/packages/libinstpatch.rb
+++ b/packages/libinstpatch.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Libinstpatch < Package
+  description 'libInstPatch is a library for processing digital sample based MIDI instrument "patch" files.'
+  homepage 'https://github.com/swami/libinstpatch/'
+  @_ver = '1.1.6'
+  version @_ver
+  license 'LGPL-2.1'
+  compatibility 'all'
+  source_url 'https://github.com/swami/libinstpatch.git'
+  git_hashtag 'v' + @_ver
+
+  depends_on 'glib'
+
+  def self.build
+    FileUtils.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "cmake -G 'Ninja' #{CREW_CMAKE_OPTIONS} .."
+    end
+    system 'samu -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+end

--- a/packages/libinstpatch.rb
+++ b/packages/libinstpatch.rb
@@ -5,10 +5,23 @@ class Libinstpatch < Package
   homepage 'https://github.com/swami/libinstpatch/'
   @_ver = '1.1.6'
   version @_ver
-  license 'LGPL-2.1'
   compatibility 'all'
+  license 'LGPL-2.1'
   source_url 'https://github.com/swami/libinstpatch.git'
-  git_hashtag 'v' + @_ver
+  git_hashtag "v#{@_ver}"
+
+  binary_url ({
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinstpatch/1.1.6_armv7l/libinstpatch-1.1.6-chromeos-armv7l.tpxz',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinstpatch/1.1.6_armv7l/libinstpatch-1.1.6-chromeos-armv7l.tpxz',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinstpatch/1.1.6_i686/libinstpatch-1.1.6-chromeos-i686.tpxz',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinstpatch/1.1.6_x86_64/libinstpatch-1.1.6-chromeos-x86_64.tpxz',
+  })
+  binary_sha256 ({
+     aarch64: 'b7a7e8bec56017428e7aa7ebf630b6ca60ccaec4a3675d3d10c5cb9d89e13a9f',
+      armv7l: 'b7a7e8bec56017428e7aa7ebf630b6ca60ccaec4a3675d3d10c5cb9d89e13a9f',
+        i686: '881717a4dac1023bd5819f2af363b5185ef05dda0d6bc8edc9a23ea193fc929f',
+      x86_64: '8a53448ff86a653799bdcf65965e32c726a1fc6ba8aeaefea7a33ee76ef95cfa',
+  })
 
   depends_on 'glib'
   depends_on 'libsndfile'

--- a/packages/libinstpatch.rb
+++ b/packages/libinstpatch.rb
@@ -11,6 +11,7 @@ class Libinstpatch < Package
   git_hashtag 'v' + @_ver
 
   depends_on 'glib'
+  depends_on 'libsndfile'
 
   def self.build
     FileUtils.mkdir 'builddir'


### PR DESCRIPTION
"libInstPatch is a library for processing digital sample based MIDI instrument "patch" files."
I don't have a MIDI device to actually test this, but it builds and other things can link against it!
Works on x86_64. needs binaries.

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libinstpatch CREW_TESTING=1 crew update
```