### PR TITLE
libx264 => 5db6aa6

### DIFF
--- a/packages/libx264.rb
+++ b/packages/libx264.rb
@@ -2,25 +2,13 @@ require 'package'
 
 class Libx264 < Package
   description 'x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format.'
-  homepage 'http://www.videolan.org/developers/x264.html'
-  version 'b86a'
+  homepage 'https://www.videolan.org/developers/x264.html'
+  @_commit = '5db6aa6cab1b146e07b60cc1736a01f21da01154'
+  version @_commit[0,7]
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://code.videolan.org/videolan/x264/-/archive/b86ae3c66f51ac9eab5ab7ad09a9d62e67961b8a/x264-b86ae3c66f51ac9eab5ab7ad09a9d62e67961b8a.tar.bz2'
-  source_sha256 '6d4eacd1e735f1670a84f56802023fce9a68f19a6186440281fff7757810297d'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx264/b86a_armv7l/libx264-b86a-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx264/b86a_armv7l/libx264-b86a-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx264/b86a_i686/libx264-b86a-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx264/b86a_x86_64/libx264-b86a-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'e212794830955a9f109c01000eae365580dc61568db24a4ae412f9f518932f3a',
-     armv7l: 'e212794830955a9f109c01000eae365580dc61568db24a4ae412f9f518932f3a',
-       i686: '57005b8eb98bbc08ddca26fcecce43ea58e7f489f493d89367512bdc0ffbbb30',
-     x86_64: '280d34bcb68b0ddf87e747b7f21bb63c9a881f3de6bb91ab6fca6a9d191a16a5'
-  })
+  source_url 'https://code.videolan.org/videolan/x264.git'
+  git_hashtag @_commit
 
   depends_on 'nasm' => :build
   depends_on 'l_smash'
@@ -28,20 +16,15 @@ class Libx264 < Package
   @archflags = ARCH == 'aarch64' || ARCH == 'armv7l' ? '-march=armv7-a -mfpu=neon' : ''
 
   def self.build
-    system '[ -x configure ] || ./autogen.sh'
-    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto #{@archflags}' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS} \
-      --enable-shared \
-      --enable-static \
-      --enable-pic \
-      --enable-lto \
-      --disable-avs"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+              --disable-avs \
+              --enable-lto \
+              --enable-shared \
+              --enable-static"
     system 'make'
   end
 
   def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libx264.rb
+++ b/packages/libx264.rb
@@ -10,6 +10,19 @@ class Libx264 < Package
   source_url 'https://code.videolan.org/videolan/x264.git'
   git_hashtag @_commit
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx264/5db6aa6_armv7l/libx264-5db6aa6-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx264/5db6aa6_armv7l/libx264-5db6aa6-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx264/5db6aa6_i686/libx264-5db6aa6-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx264/5db6aa6_x86_64/libx264-5db6aa6-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '05d471e5ae3d77c4746155c0b1b74200b5f0c1965368e3157a38d5f5b6617be8',
+     armv7l: '05d471e5ae3d77c4746155c0b1b74200b5f0c1965368e3157a38d5f5b6617be8',
+       i686: '50210bd8a64823d520299be85cf6edc6d8aec790427ebcfefa1a017ba9f8a779',
+     x86_64: '77501d484979b7417e97cfa07b60d5251ab959872820d6b4d68149c25af209ae'
+  })
+
   depends_on 'nasm' => :build
   depends_on 'l_smash'
 


### PR DESCRIPTION
This might not work as well on aarch64 and armv7l devices, if someone needs to add the archflags back in, feel free to do so.
Works on x86_64. needs binaries.

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libx264_5db6aa6 CREW_TESTING=1 crew update
```