### PR TITLE
libraw1394 => 2.0.5-1

### DIFF
--- a/packages/libraw1394.rb
+++ b/packages/libraw1394.rb
@@ -3,33 +3,22 @@ require 'package'
 class Libraw1394 < Package
   description 'libraw1394 provides direct access to the IEEE 1394 bus through the Linux 1394 subsystem\'s raw1394 user space interface.'
   homepage 'https://sourceforge.net/projects/libraw1394/'
-  version '2.0.5'
+  version '2.0.5-1'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/libraw1394/libraw1394/libraw1394-2.0.5.tar.gz'
   source_sha256 '50e7b812f09ec8181fc060e7e25e260017c16c1b41a04c51e23446f26fa109d4'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libraw1394/2.0.5_armv7l/libraw1394-2.0.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libraw1394/2.0.5_armv7l/libraw1394-2.0.5-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libraw1394/2.0.5_i686/libraw1394-2.0.5-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libraw1394/2.0.5_x86_64/libraw1394-2.0.5-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '80d9eaa85a6bdca66142ccc091e94a1e049d24fb50be4adcaf0656bf136560a2',
-     armv7l: '80d9eaa85a6bdca66142ccc091e94a1e049d24fb50be4adcaf0656bf136560a2',
-       i686: 'd5701722d2fbb3a2bb7fb4bded4b2635f95a3332cd39a9f5896cd139091e5dcc',
-     x86_64: '4c0fd94617c2f7c9cd5c3468b562aa208c6a34812bc05ca63f7c490d298cab84',
-  })
-
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/libraw1394.rb
+++ b/packages/libraw1394.rb
@@ -4,10 +4,23 @@ class Libraw1394 < Package
   description 'libraw1394 provides direct access to the IEEE 1394 bus through the Linux 1394 subsystem\'s raw1394 user space interface.'
   homepage 'https://sourceforge.net/projects/libraw1394/'
   version '2.0.5-1'
-  license 'LGPL-2.1'
   compatibility 'all'
+  license 'LGPL-2.1'
   source_url 'https://downloads.sourceforge.net/project/libraw1394/libraw1394/libraw1394-2.0.5.tar.gz'
   source_sha256 '50e7b812f09ec8181fc060e7e25e260017c16c1b41a04c51e23446f26fa109d4'
+
+  binary_url ({
+     aarch64: 'file:///usr/local/tmp/packages/libraw1394-2.0.5-1-chromeos-armv7l.tpxz',
+      armv7l: 'file:///usr/local/tmp/packages/libraw1394-2.0.5-1-chromeos-armv7l.tpxz',
+        i686: 'file:///usr/local/tmp/packages/libraw1394-2.0.5-1-chromeos-i686.tpxz',
+      x86_64: 'file:///usr/local/tmp/packages/libraw1394-2.0.5-1-chromeos-x86_64.tpxz',
+  })
+  binary_sha256 ({
+     aarch64: '89c4930bdff2cf21ee6c7b89221da7fb7140b414769f3ba387d435bf0d9e39c4',
+      armv7l: '89c4930bdff2cf21ee6c7b89221da7fb7140b414769f3ba387d435bf0d9e39c4',
+        i686: '4ba228574aef58ffecf52343fe0775458222e5228fc7e38ba65a70554c49af6f',
+      x86_64: 'b7cc279e24024fcc74df606f7fe33518902ab67531838caf165f2ed3cd23f12d',
+  })
 
   def self.build
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"


### PR DESCRIPTION
Works on x86_64. needs binaries.

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libraw1934_2.0.5-1 CREW_TESTING=1 crew update
```

Ignore the commit name, it's 1394, not 1934. My bad.