### PR TITLE
libnfs => 4.0.0-1

### DIFF
--- a/packages/libnfs.rb
+++ b/packages/libnfs.rb
@@ -1,40 +1,27 @@
-# Adapted from Arch Linux libnfs PKGBUILD at:
-# https://github.com/archlinux/svntogit-community/raw/packages/libnfs/trunk/PKGBUILD
-
 require 'package'
 
 class Libnfs < Package
   description 'client library for accessing NFS shares'
   homepage 'https://github.com/sahlberg/libnfs'
-  version '4.0.0'
-  license 'GPLv2 & BSD'
+  @_ver = '4.0.0'
+  version @_ver + '-1'
+  license 'GPL-3, LGPL-2.1 and BSD'
   compatibility 'all'
-  source_url "https://github.com/sahlberg/libnfs/archive/refs/tags/libnfs-#{version}.tar.gz"
-  source_sha256 '6ee77e9fe220e2d3e3b1f53cfea04fb319828cc7dbb97dd9df09e46e901d797d'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnfs/4.0.0_armv7l/libnfs-4.0.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnfs/4.0.0_armv7l/libnfs-4.0.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnfs/4.0.0_i686/libnfs-4.0.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnfs/4.0.0_x86_64/libnfs-4.0.0-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'c8aca50954bfbdf85d749655c98d940592cb0f0059375b0142974196a4eb1066',
-     armv7l: 'c8aca50954bfbdf85d749655c98d940592cb0f0059375b0142974196a4eb1066',
-       i686: 'a0efe68bbed97a19e0708c412b6ffc1ae2aa2d3e34b006e59b432218659d6e33',
-     x86_64: '5d51982578b523c791aa1cd4a6903603a41c75d7abfcfbc96aabab0c6fb8adf0'
-  })
+  source_url "https://github.com/sahlberg/libnfs.git"
+  git_hashtag 'libnfs-' + @_ver
 
   def self.build
-    system 'autoreconf -vif'
-    system "env CFLAGS='-flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+    system 'autoreconf -fiv'
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+            --enable-utils"
     system 'make'
   end
 
   def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/libnfs.rb
+++ b/packages/libnfs.rb
@@ -4,11 +4,24 @@ class Libnfs < Package
   description 'client library for accessing NFS shares'
   homepage 'https://github.com/sahlberg/libnfs'
   @_ver = '4.0.0'
-  version @_ver + '-1'
-  license 'GPL-3, LGPL-2.1 and BSD'
+  version "#{@_ver}-1"
   compatibility 'all'
-  source_url "https://github.com/sahlberg/libnfs.git"
-  git_hashtag 'libnfs-' + @_ver
+  license 'GPL-3, LGPL-2.1 and BSD'
+  source_url 'https://github.com/sahlberg/libnfs.git'
+  git_hashtag "libnfs-#{@_ver}"
+
+  binary_url ({
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnfs/4.0.0-1_armv7l/libnfs-4.0.0-1-chromeos-armv7l.tpxz',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnfs/4.0.0-1_armv7l/libnfs-4.0.0-1-chromeos-armv7l.tpxz',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnfs/4.0.0-1_i686/libnfs-4.0.0-1-chromeos-i686.tpxz',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnfs/4.0.0-1_x86_64/libnfs-4.0.0-1-chromeos-x86_64.tpxz',
+  })
+  binary_sha256 ({
+     aarch64: '93c8332ed7a11e62196a451206a1bb01f5c8d1bba0c860fdf08a6ee52638748f',
+      armv7l: '93c8332ed7a11e62196a451206a1bb01f5c8d1bba0c860fdf08a6ee52638748f',
+        i686: 'd838e8f83938d1621884496bcc226b33c61b5d20a1c45496d98733cde4c2505c',
+      x86_64: '8ff8bdbe19ee2c2bafe7ca410729eb30fc1195de1c3cab48867375752ad59299',
+  })
 
   def self.build
     system 'autoreconf -fiv'


### PR DESCRIPTION
Works on x86_64. needs binaries.

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libnfs_4.0.0-1 CREW_TESTING=1 crew update
```