### PR TITLE
libdsm => 0.3.2

### DIFF
--- a/packages/libdsm.rb
+++ b/packages/libdsm.rb
@@ -1,37 +1,29 @@
 require 'package'
 
 class Libdsm < Package
-  description 'Defective SMb: A minimalist implementation of a client library for SMB using Plain\'Ol C'
+  description 'Defective SMb: A minimalist implementation of a client library for SMB using C.'
   homepage 'https://videolabs.github.io/libdsm/'
-  version '0.3.0'
+  @_ver = '0.3.2'
+  version @_ver
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url 'https://github.com/videolabs/libdsm/releases/download/v0.3.0/libdsm-0.3.0.tar.gz'
-  source_sha256 '96caef854a1f7aa61ab6fdfca9c36a1813b37d23d013db0bc4ec7cd38a570b1c'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdsm/0.3.0_armv7l/libdsm-0.3.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdsm/0.3.0_armv7l/libdsm-0.3.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdsm/0.3.0_i686/libdsm-0.3.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdsm/0.3.0_x86_64/libdsm-0.3.0-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '03273279d98be86b0da0db0eb251c6a8475dcf32816337bef2aaaecf3f02318d',
-     armv7l: '03273279d98be86b0da0db0eb251c6a8475dcf32816337bef2aaaecf3f02318d',
-       i686: 'dd47b71fbc2ec25b1d307a426e14d36af75650aa278754b185c7236db83b7068',
-     x86_64: '7c42e38967b7b4de66544c4d95d17a0c71b7300e7afdbd70584a7c2f15c62122',
-  })
+  source_url 'https://github.com/videolabs/libdsm.git'
+  git_hashtag 'v' + @_ver
 
   depends_on 'libtasn1'
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system './bootstrap'
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+            --with-urandom=/dev/urandom"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/libdsm.rb
+++ b/packages/libdsm.rb
@@ -5,10 +5,23 @@ class Libdsm < Package
   homepage 'https://videolabs.github.io/libdsm/'
   @_ver = '0.3.2'
   version @_ver
-  license 'LGPL-2.1+'
   compatibility 'all'
+  license 'LGPL-2.1+'
   source_url 'https://github.com/videolabs/libdsm.git'
-  git_hashtag 'v' + @_ver
+  git_hashtag "v#{@_ver}"
+
+  binary_url ({
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdsm/0.3.2_armv7l/libdsm-0.3.2-chromeos-armv7l.tpxz',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdsm/0.3.2_armv7l/libdsm-0.3.2-chromeos-armv7l.tpxz',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdsm/0.3.2_i686/libdsm-0.3.2-chromeos-i686.tpxz',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdsm/0.3.2_x86_64/libdsm-0.3.2-chromeos-x86_64.tpxz',
+  })
+  binary_sha256 ({
+     aarch64: '0f1cfa4ecfd15ce2638be2e8bd85538898cada850ed99beea1247f928b22625b',
+      armv7l: '0f1cfa4ecfd15ce2638be2e8bd85538898cada850ed99beea1247f928b22625b',
+        i686: '08f6535b7e4c50f39770b8c113df27c26681f0ee614621ae4d49bb300700d645',
+      x86_64: 'cf1ff783f5cbd3232715b73d0907e39763c5412b75be5907cbb99b970f3deff2',
+  })
 
   depends_on 'libtasn1'
 


### PR DESCRIPTION
Works on x86_64. needs binaries.

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libdsm_0.3.2 CREW_TESTING=1 crew update
```