### PR TITLE
add missing binaries to _1394 packages.

### DIFF
--- a/packages/libavc1394.rb
+++ b/packages/libavc1394.rb
@@ -4,22 +4,22 @@ class Libavc1394 < Package
   description 'libavc1394 is a programming interface for the 1394 Trade Association AV/C (Audio/Video Control) Digital Interface Command Set.'
   homepage 'https://sourceforge.net/projects/libavc1394/'
   version '0.5.4-1'
-  compatibility 'all'
   license 'LGPL-2.1'
+  compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/libavc1394/libavc1394/libavc1394-0.5.4.tar.gz'
   source_sha256 '7cb1ff09506ae911ca9860bef4af08c2403f3e131f6c913a2cbd6ddca4215b53'
 
-  binary_url ({
-     aarch64: 'file:///usr/local/tmp/packages/libavc1394-0.5.4-1-chromeos-armv7l.tpxz',
-      armv7l: 'file:///usr/local/tmp/packages/libavc1394-0.5.4-1-chromeos-armv7l.tpxz',
-        i686: 'file:///usr/local/tmp/packages/libavc1394-0.5.4-1-chromeos-i686.tpxz',
-      x86_64: 'file:///usr/local/tmp/packages/libavc1394-0.5.4-1-chromeos-x86_64.tpxz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavc1394/0.5.4-1_armv7l/libavc1394-0.5.4-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavc1394/0.5.4-1_armv7l/libavc1394-0.5.4-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavc1394/0.5.4-1_i686/libavc1394-0.5.4-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavc1394/0.5.4-1_x86_64/libavc1394-0.5.4-1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '58d8363b74e0bedfd11ae22835f0032a8f91f5bef61d0c06b146cc5bd13d51bd',
-      armv7l: '58d8363b74e0bedfd11ae22835f0032a8f91f5bef61d0c06b146cc5bd13d51bd',
-        i686: '0c18c2d74748e2cbb0c08f85741a71220909c0ffff020066cc307cf8878c0dad',
-      x86_64: '7c875d65b15e5cd43f51965743a7f79453982399aed94bcd0ed93e9104314ad1',
+  binary_sha256({
+    aarch64: '23401f9493493c0368a6fcc3039df80bfb840661b3f6846a45acc991856b149a',
+     armv7l: '23401f9493493c0368a6fcc3039df80bfb840661b3f6846a45acc991856b149a',
+       i686: '0097f563822dfbeb71df4d74d06a53df9a68e15bea70bfd677a22c3a71e0fb82',
+     x86_64: '844ced6d6835b915bc7882ce5503e893c52426c9a789bc2aeb274bbf82dbc219'
   })
 
   depends_on 'libraw1394'

--- a/packages/libraw1394.rb
+++ b/packages/libraw1394.rb
@@ -4,22 +4,22 @@ class Libraw1394 < Package
   description 'libraw1394 provides direct access to the IEEE 1394 bus through the Linux 1394 subsystem\'s raw1394 user space interface.'
   homepage 'https://sourceforge.net/projects/libraw1394/'
   version '2.0.5-1'
-  compatibility 'all'
   license 'LGPL-2.1'
+  compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/libraw1394/libraw1394/libraw1394-2.0.5.tar.gz'
   source_sha256 '50e7b812f09ec8181fc060e7e25e260017c16c1b41a04c51e23446f26fa109d4'
 
-  binary_url ({
-     aarch64: 'file:///usr/local/tmp/packages/libraw1394-2.0.5-1-chromeos-armv7l.tpxz',
-      armv7l: 'file:///usr/local/tmp/packages/libraw1394-2.0.5-1-chromeos-armv7l.tpxz',
-        i686: 'file:///usr/local/tmp/packages/libraw1394-2.0.5-1-chromeos-i686.tpxz',
-      x86_64: 'file:///usr/local/tmp/packages/libraw1394-2.0.5-1-chromeos-x86_64.tpxz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libraw1394/2.0.5-1_armv7l/libraw1394-2.0.5-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libraw1394/2.0.5-1_armv7l/libraw1394-2.0.5-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libraw1394/2.0.5-1_i686/libraw1394-2.0.5-1-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libraw1394/2.0.5-1_x86_64/libraw1394-2.0.5-1-chromeos-x86_64.tpxz'
   })
-  binary_sha256 ({
-     aarch64: '89c4930bdff2cf21ee6c7b89221da7fb7140b414769f3ba387d435bf0d9e39c4',
-      armv7l: '89c4930bdff2cf21ee6c7b89221da7fb7140b414769f3ba387d435bf0d9e39c4',
-        i686: '4ba228574aef58ffecf52343fe0775458222e5228fc7e38ba65a70554c49af6f',
-      x86_64: 'b7cc279e24024fcc74df606f7fe33518902ab67531838caf165f2ed3cd23f12d',
+  binary_sha256({
+    aarch64: 'f98d25737550b990177048ca94b6bfbc262c1029bece77c27885053070e9bcae',
+     armv7l: 'f98d25737550b990177048ca94b6bfbc262c1029bece77c27885053070e9bcae',
+       i686: '53af9bb5729d454481705f5d7f8b4f1cb69178cb1955da7392f52e334cf6cd4c',
+     x86_64: '874f0550d05403d7b90c448430c82fab2490a61d826c7b9d1c49aeb7441f1476'
   })
 
   def self.build


### PR DESCRIPTION


Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686
