### PR TITLE
package.rb: Don't involve a shell when the command is passed in multi parameters

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.21.3'
+CREW_VERSION = '1.21.4'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -136,7 +136,7 @@ class Package
     # add -j arg to build commands
     if args.size == 1
       # involve a shell if the command is passed in one single string
-      cmd_args = [ 'bash', '-c', cmd_args[0].sub(/^make\b/, "\\1 -j#{CREW_NPROC}") ]
+      cmd_args = [ 'bash', '-c', cmd_args[0].sub(/^(make)\b/, "\\1 -j#{CREW_NPROC}") ]
     else
       cmd_args.map! do |arg|
         if arg == 'make'
@@ -150,10 +150,9 @@ class Package
     begin
       Kernel.system(env, *cmd_args, **opt_args)
     rescue => e
-      exitstatus = $?.exitstatus
       # print failed line number and error message
       puts "#{e.backtrace[1]}: #{e.message}".orange
-      raise InstallError, "`#{env.map {|k, v| "#{k}=\"#{v}\"" } .join(' ')} #{cmd_args.join(' ')}` exited with #{exitstatus}"
+      raise InstallError, "`#{env.map {|k, v| "#{k}=\"#{v}\"" } .join(' ')} #{cmd_args.join(' ')}` exited with #{$?.exitstatus}"
     end
   end
 end

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -137,14 +137,8 @@ class Package
     if args.size == 1
       # involve a shell if the command is passed in one single string
       cmd_args = [ 'bash', '-c', cmd_args[0].sub(/^(make)\b/, "\\1 -j#{CREW_NPROC}") ]
-    else
-      cmd_args.map! do |arg|
-        if arg == 'make'
-          [ arg, "-j#{CREW_NPROC}" ]
-        else
-          arg
-        end
-      end.flatten
+    elsif cmd_args[0] == 'make'
+      cmd_args.insert(1, "-j#{CREW_NPROC}")
     end
 
     begin

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -133,21 +133,20 @@ class Package
     # after removing the env hash, all remaining args must be command args
     cmd_args = args
 
-    if args.size == 1
-      # split cmdline to multi arguments if the command is passed in one single string
-      cmd_args = args[0].scan(/(?:\w|["'].*?["'])+/) if need_shell
-      # invlove a shell if the command is passed in one single string
-      cmd_args.unshift('bash', '-c')
-    end
+    # split cmdline to multi arguments if the command is passed in one single string
+    cmd_args = args[0].scan(/(?:\w|["'].*?["'])+/) if args.size == 1
 
     # add -j arg to build commands
-    cmd_args.flat_map do |arg|
-      if args == 'make' and cmd_args != 'cmake'
+    cmd_args.map! do |arg|
+      if arg == 'make'
         [ arg, "-j#{CREW_NPROC}" ]
       else
         arg
       end
-    end
+    end.flatten
+
+    # involve a shell if the command is passed in one single string
+    cmd_args = [ 'bash', '-c', cmd_args.join(' ') ] if args.size == 1
 
     begin
       Kernel.system(env, cmd_args, **opt_args)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -136,7 +136,7 @@ class Package
     # add -j arg to build commands
     if args.size == 1
       # involve a shell if the command is passed in one single string
-      cmd_args = [ 'bash', '-c', cmd_args.sub(/\bmake\b/, "\\1 -j#{CREW_NPROC}") ]
+      cmd_args = [ 'bash', '-c', cmd_args[0].sub(/\bmake\b/, "\\1 -j#{CREW_NPROC}") ]
     else
       cmd_args.map! do |arg|
         if arg == 'make'

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -132,6 +132,8 @@ class Package
 
     # after removing the env hash, all remaining args must be command args
     cmd_args = args.join(' ')
+    # escape all characters if cmd and cmd_args is passed separately
+    cmd_args.gsub(/(.)/, '\\\\\1')
 
     # Add -j arg to build commands.
     cmd_args.sub!(/\b(?<=make)(?=\b)/, " -j#{CREW_NPROC}") unless cmd_args =~ /-j\s*\d+|cmake/

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -153,7 +153,7 @@ class Package
       exitstatus = $?.exitstatus
       # print failed line number and error message
       puts "#{e.backtrace[1]}: #{e.message}".orange
-      raise InstallError, "`#{env.map {|k, v| "#{k}=\"#{v}\"" } .join(' ')} #{*cmd_args}` exited with #{exitstatus}"
+      raise InstallError, "`#{env.map {|k, v| "#{k}=\"#{v}\"" } .join(' ')} #{cmd_args.join(' ')}` exited with #{exitstatus}"
     end
   end
 end

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -149,7 +149,7 @@ class Package
     cmd_args = [ 'bash', '-c', cmd_args.join(' ') ] if args.size == 1
 
     begin
-      Kernel.system(env, cmd_args, **opt_args)
+      Kernel.system(env, *cmd_args, **opt_args)
     rescue => e
       exitstatus = $?.exitstatus
       # print failed line number and error message

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -136,7 +136,7 @@ class Package
     # add -j arg to build commands
     if args.size == 1
       # involve a shell if the command is passed in one single string
-      cmd_args = [ 'bash', '-c', cmd_args[0].sub(/\bmake\b/, "\\1 -j#{CREW_NPROC}") ]
+      cmd_args = [ 'bash', '-c', cmd_args[0].sub(/^make\b/, "\\1 -j#{CREW_NPROC}") ]
     else
       cmd_args.map! do |arg|
         if arg == 'make'


### PR DESCRIPTION
Fixes #6632

### Changes
- Pass command parameters directly if the command is passed in one single string
- Split command to multi parameters if the command is passed in one single string

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken666/chromebrew.git CREW_TESTING_BRANCH=system_fix CREW_TESTING=1 crew update
```