### PR TITLE
Add git_fetchtags, simplify (.nil? or .empty?) to .to_s.empty?

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -729,7 +729,7 @@ def download
           cachefile = CREW_CACHE_DIR + filename + @pkg.git_hashtag.gsub('/', '_') + '.tar.xz'
           puts "cachefile is #{cachefile}".orange if @opt_verbose
         # Git branch and git commit specified
-        elsif ! @pkg.git_hashtag.to_s.empty? and ! @pkg.git_branch.to_s.empty?
+        elsif ! @pkg.git_hashtag.to_s.empty?
           cachefile = CREW_CACHE_DIR + filename + @pkg.git_branch.gsub(/[^0-9A-Za-z.\-]/, '_') + '_' + @pkg.git_hashtag.gsub('/', '_') + '.tar.xz'
           puts "cachefile is #{cachefile}".orange if @opt_verbose
         # Git branch specified, without a specific git commit.

--- a/bin/crew
+++ b/bin/crew
@@ -724,12 +724,12 @@ def download
       # Recall repository from cache if requested
       if CREW_CACHE_ENABLED
         # No git branch specified, just a git commit or tag
-        if @pkg.git_branch.nil? || @pkg.git_branch.empty?
-          abort("No Git branch, commit, or tag specified!").lightred if @pkg.git_hashtag.nil? || @pkg.git_hashtag.empty?
+        if @pkg.git_branch.to_s.empty?
+          abort("No Git branch, commit, or tag specified!").lightred if @pkg.git_hashtag.to_s.empty?
           cachefile = CREW_CACHE_DIR + filename + @pkg.git_hashtag.gsub('/', '_') + '.tar.xz'
           puts "cachefile is #{cachefile}".orange if @opt_verbose
         # Git branch and git commit specified
-        elsif ( ! @pkg.git_hashtag.nil? || ! @pkg.git_hashtag.empty )  and ( ! @pkg.git_branch.nil? || ! @pkg.git_branch.empty?)
+        elsif ! @pkg.git_hashtag.to_s.empty? and ! @pkg.git_branch.to_s.empty?
           cachefile = CREW_CACHE_DIR + filename + @pkg.git_branch.gsub(/[^0-9A-Za-z.\-]/, '_') + '_' + @pkg.git_hashtag.gsub('/', '_') + '.tar.xz'
           puts "cachefile is #{cachefile}".orange if @opt_verbose
         # Git branch specified, without a specific git commit.
@@ -753,7 +753,7 @@ def download
       # Download via git
       Dir.mkdir @extract_dir
       Dir.chdir @extract_dir do
-        unless @pkg.git_branch.nil? || @pkg.git_branch.empty?
+        unless @pkg.git_branch.to_s.empty?
           # Leave a message because this step can be slow.
           puts "Downloading src from a git branch. This may take a while..."
           system "git clone --branch #{@pkg.git_branch} --single-branch #{@pkg.source_url} tmpdir", exception: true
@@ -768,7 +768,9 @@ def download
           system 'git checkout FETCH_HEAD'
         end
         system 'git submodule update --init --recursive'
-        system 'git fetch --tags', exception: true
+        if @pkg.git_fetchtags?
+          system 'git fetch --tags', exception: true
+        end
         puts 'Repository downloaded.'.lightgreen
       end
       # Stow file in cache if requested and cache is writable.
@@ -1046,7 +1048,7 @@ def shrink_dir(dir)
         # Also disable for sommelier.elf and Xwayland.elf since upx
         # breaks those binaries.
         @execfiles = %x[find . -executable -type f ! \\( -name \"*.so*\" -o -name \"*.a\" -o -name \"Xwayland.elf\" -o -name \"sommelier.elf\" \\) -exec sh -c \"file -i \'{}\' | grep -q \'executable; charset=binary\'\" \\; -exec ls -1i {} \\; | sort -u -n -s -k1,1 | awk '{print $2}'].chomp
-        unless @execfiles.empty? or @execfiles.nil?
+        unless @execfiles.to_s.empty?
           puts "Using upx to shrink binaries."
           # Copying in the ThreadPoolExecutor loop fails non-deterministically
           @execfiles.each_line do |execfilecp|
@@ -1109,7 +1111,7 @@ def install_package(pkgdir)
 
     @brokensymlinks = nil
     @brokensymlinks = %x[find . -type l -exec test ! -e {} \\; -print].chomp
-    unless @brokensymlinks.nil? or @brokensymlinks.empty?
+    unless @brokensymlinks.to_s.empty?
       puts "There are broken symlinks. Will try to fix.".orange if @opt_verbose
       @brokensymlinks.each_line do |fixlink|
         @brokentarget = nil

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.21.6'
+CREW_VERSION = '1.21.7'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/musl.rb
+++ b/lib/musl.rb
@@ -75,7 +75,7 @@ class Musl
       abort('No Patchelf found!').lightred unless File.exist?("#{CREW_PREFIX}/bin/patchelf")
 
       @execfiles = `find . -executable -type f ! \\( -name \"*.a\" \\) -exec sh -c \"file -i \'{}\' | grep -q \'executable; charset=binary\'\" \\; -exec ls -1i {} \\; | sort -u -n -s -k1,1 | awk '{print $2}'`.chomp
-      return if @execfiles.empty? || @execfiles.nil?
+      return if @execfiles.to_s.empty?
 
       puts 'Running patchelf to patch binaries for musl paths'.lightblue
       @execfiles.each_line(chomp: true) do |execfiletopatch|

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -3,7 +3,7 @@ require 'package_helpers'
 class Package
   property :description, :homepage, :version, :license, :compatibility,
            :binary_url, :binary_sha256, :source_url, :source_sha256,
-           :git_branch, :git_hashtag, :is_fake, :is_static
+           :git_branch, :git_fetchtags, :git_hashtag, :is_fake, :is_static
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.
                      :patch,       # Function to perform patch operations prior to build from source.
@@ -84,6 +84,14 @@ class Package
 
   def self.get_extract_dir
     name + '.' + Time.now.utc.strftime("%Y%m%d%H%M%S") + '.dir'
+  end
+
+  def self.git_fetchtags
+    @git_fetchtags = true
+  end
+
+  def self.git_fetchtags?
+    @git_fetchtags
   end
 
   def self.is_binary? (architecture)

--- a/packages/py3_numpy.rb
+++ b/packages/py3_numpy.rb
@@ -9,6 +9,7 @@ class Py3_numpy < Package
   compatibility 'all'
   source_url 'https://github.com/numpy/numpy.git'
   git_hashtag "v#{@_ver}"
+  git_fetchtags
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_numpy/1.21.4_armv7l/py3_numpy-1.21.4-chromeos-armv7l.tpxz',


### PR DESCRIPTION
- We have been fetching git tags because some packages require git tags to pull version information.
- However, doing this massively increases the size of the download and resultant cached file (if caching is enabled.) (@saltedcoffii pointed this out.)
- Instead, mark packages which need git tags with `git_fetchtags` and only fetch git tags for such packages.
- The `py3_numpy` package requires git tags, and has been so marked.

- ALSO, replaced instances of `.nil? or .empty?` with `.to_s.empty?` which handles this more simply.

Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_cache CREW_TESTING=1 crew update
```
