### PR TITLE
libsigsegv -> 2.1.4

### DIFF
--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -3,29 +3,37 @@ require 'package'
 class Libsigsegv < Package
   description 'GNU libsigsegv is a library for handling page faults in user mode.'
   homepage 'https://www.gnu.org/software/libsigsegv/'
-  version '2.13'
+  version '2.14'
   license 'GPL-2+'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.13.tar.gz'
-  source_sha256 'be78ee4176b05f7c75ff03298d84874db90f4b6c9d5503f0da1226b3a3c48119'
+  source_url 'https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.14.tar.gz'
+  source_sha256 'cdac3941803364cf81a908499beb79c200ead60b6b5b40cad124fd1e06caa295'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.13_armv7l/libsigsegv-2.13-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.13_armv7l/libsigsegv-2.13-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.13_i686/libsigsegv-2.13-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.13_x86_64/libsigsegv-2.13-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.14_armv7l/libsigsegv-2.14-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.14_armv7l/libsigsegv-2.14-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.14_i686/libsigsegv-2.14-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsigsegv/2.14_x86_64/libsigsegv-2.14-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '1c521a9fcee6ae4108bd1177dfa053157f06a5b5931af65bfb5a1d0e52a27e75',
-     armv7l: '1c521a9fcee6ae4108bd1177dfa053157f06a5b5931af65bfb5a1d0e52a27e75',
-       i686: '964dc5402cb5106bd19f2a6a8ede6120d472313ce8998a1233bd2cbb97be3d07',
-     x86_64: '68bad24a4b85d56bd45ca4f1af74ceb94829dd714be6622ac0c564f56030433f'
+    aarch64: '72d6d5f467bfeb47fac29f664344385021932108ca3c72de2719181e1744ec7c',
+     armv7l: '72d6d5f467bfeb47fac29f664344385021932108ca3c72de2719181e1744ec7c',
+       i686: '08efedeb5ea7af99b35ed1073b20feed5bb1a89dfc5f6a1e3f5e0159f254e22f',
+     x86_64: 'efc24c18a85c611994d3e516994ab71a0a1f79780d47af8267940d68ae7f8716'
   })
 
   def self.build
     system 'autoreconf -fiv'
     # libsigsegv fails to build with LTO.
-    system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS}"
+    ENV['CREW_DISABLE_ENV_OPTIONS'] = '1'
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    load "#{CREW_LIB_PATH}lib/const.rb"
+    $VERBOSE = warn_level
+    system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS} \
+    --enable-shared \
+    --enable-static \
+    --enable-relocatable"
     system 'make'
   end
 


### PR DESCRIPTION
- Fixes `libsigsegv`missing shared libraries, which breaks gawk on `i686`.

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=sigsegv_2.1.4 CREW_TESTING=1 crew update
```
