### PR TITLE
Glibc update to support M98

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -7,7 +7,6 @@ class Glibc < Package
   compatibility 'all'
 
   depends_on 'gawk' => :build
-  depends_on 'libgd' => :build
   depends_on 'libidn2' => :build
   depends_on 'texinfo' => :build
   depends_on 'hashpipe' => :build
@@ -27,19 +26,19 @@ class Glibc < Package
       i686: '3ee19cbb907eb219a2c1b02df6de1ca13b09b0d375101657d54a2485aacdc445'
     })
   elsif LIBC_VERSION == '2.27'
-    version '2.27'
+    version '2.27-3'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.27.tar.xz'
     source_sha256 '5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72'
 
     binary_url({
-      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27_armv7l/glibc-2.27-chromeos-armv7l.tar.xz',
-       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27_armv7l/glibc-2.27-chromeos-armv7l.tar.xz',
-       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27_x86_64/glibc-2.27-chromeos-x86_64.tar.xz'
+      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27-3_armv7l/glibc-2.27-3-chromeos-armv7l.tpxz',
+       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27-3_armv7l/glibc-2.27-3-chromeos-armv7l.tpxz',
+       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27-3_x86_64/glibc-2.27-3-chromeos-x86_64.tpxz'
     })
     binary_sha256({
-      aarch64: '64b4b73e2096998fd1a0a0e7d18472ef977aebb2f1cad83d99c77e164cb6a1d6',
-       armv7l: '64b4b73e2096998fd1a0a0e7d18472ef977aebb2f1cad83d99c77e164cb6a1d6',
-       x86_64: '5fe94642dbbf900d22b715021c73ac1a601b81517f0da1e7413f0af8fbea7997'
+      aarch64: '9d71c001feb52fbe7dd201c4ae5a4cadb7b7b3f3020b299ff023624e48aa06db',
+       armv7l: '9d71c001feb52fbe7dd201c4ae5a4cadb7b7b3f3020b299ff023624e48aa06db',
+       x86_64: '1f1bff5247b0e47b7d48e950d24bbce6f9df9f2418ca9aa7b9880cb2c708eef2'
     })
   elsif LIBC_VERSION == '2.32'.freeze # All architectures with updates past M92.
     version '2.32-2'
@@ -72,12 +71,6 @@ class Glibc < Package
        x86_64: '3e3eaa6551492ef0f1bc28600102503b721b19d0ee7396c4301771df402ea355'
     })
   end
-  puts "libc version is #{version}".lightblue
-  depends_on 'gawk' => :build
-  depends_on 'hashpipe' => :build
-  depends_on 'libgd' => :build
-  depends_on 'libidn2' => :build
-  depends_on 'texinfo' => :build
 
   def self.patch
     case LIBC_VERSION
@@ -261,19 +254,19 @@ class Glibc < Package
       when 'i686'
         File.write('glibc_223_i686.patch', @glibc_223_i686_patch)
         system 'patch -Np1 -i glibc_223_i686.patch'
-        # when 'armv7l', 'x86_64'
+      when 'armv7l', 'x86_64'
         # @googlesource_branch = 'release-R91-13904.B'
         # system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
         # Dir.glob("googlesource/sys-libs/glibc/files/local/glibc-2.27/glibc-#{LIBC_VERSION}*.patch").each do |patch|
         # puts patch
         # system "patch -Np1 -i #{patch} || (echo 'Retrying #{patch}' && patch -Np0 -i #{patch})"
         # end
-        ## Fix multiple definitions of __nss_*_database (bug 22918) in Glibc 2.27
-        # system 'curl -Ls "https://sourceware.org/git/?p=glibc.git;a=commitdiff_plain;h=eaf6753f8aac33a36deb98c1031d1bad7b593d2d;hp=4dc23804a220f917f400e2404bc4803cd60491c7" -o glibc_227_nss.patch'
-        # unless Digest::SHA256.hexdigest(File.read('glibc_227_nss.patch')) == '0c40630adf77292abb763362182158a87648e2c45904aebb5758b5ca38653ac9'
-        # abort 'Checksum mismatch :/ try again'
-        # end
-        # system 'patch -Np1 -i glibc_227_nss.patch || true'
+        # Fix multiple definitions of __nss_*_database (bug 22918) in Glibc 2.27
+        system 'curl -Ls "https://sourceware.org/git/?p=glibc.git;a=commitdiff_plain;h=eaf6753f8aac33a36deb98c1031d1bad7b593d2d;hp=4dc23804a220f917f400e2404bc4803cd60491c7" -o glibc_227_nss.patch'
+        unless Digest::SHA256.hexdigest(File.read('glibc_227_nss.patch')) == '0c40630adf77292abb763362182158a87648e2c45904aebb5758b5ca38653ac9'
+        abort 'Checksum mismatch :/ try again'
+        end
+        system 'patch -Np1 -i glibc_227_nss.patch || true'
       end
       # Apply patch due to new version of binutils which causes compilation failure
       # http://lists.busybox.net/pipermail/buildroot/2017-August/199812.html
@@ -323,8 +316,8 @@ class Glibc < Package
       system "sed -i 's,verbose,locale_verbose,g' fedora/build-locale-archive.c"
       system "sed -i 's,be_quiet,locale_be_quiet,g' fedora/build-locale-archive.c"
       FileUtils.mkdir_p 'gentoopatches'
-      system 'curl -Ls https://dev.gentoo.org/~dilfridge/distfiles/glibc-2.32-patches-8.tar.xz | \
-        hashpipe sha256 6653f1d0aadad10bd288f3bae274bd4e0a013d47f09ce78199fb5989b2d8fd9b | \
+      system 'curl -Ls https://dev.gentoo.org/~dilfridge/distfiles/glibc-2.33-patches-6.tar.xz | \
+        hashpipe sha256 29c2e4036c2b33b830a9588055c63fde5dd5255bcfd5fad2fc92f3bbd27456c1 | \
         tar -xJf - -C gentoopatches'
       Dir.glob('gentoopatches/patches/*.patch').each do |patch|
         system "patch -Np1 -i #{patch} || true"
@@ -353,6 +346,7 @@ class Glibc < Package
         system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
                  #{CREW_OPTIONS} \
                  --with-headers=#{CREW_PREFIX}/include \
+                 --without-gd \
                  --disable-werror \
                  --disable-sanity-checks \
                  --enable-shared \
@@ -368,6 +362,7 @@ class Glibc < Package
           system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
                    #{CREW_OPTIONS} \
                    --with-headers=#{CREW_PREFIX}/include \
+                   --without-gd \
                    --disable-werror \
                    --disable-sanity-checks \
                    --enable-shared \
@@ -380,6 +375,7 @@ class Glibc < Package
           system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
                    #{CREW_OPTIONS} \
                    --with-headers=#{CREW_PREFIX}/include \
+                   --without-gd \
                    --disable-werror \
                    --disable-sanity-checks \
                    --enable-shared \
@@ -400,6 +396,7 @@ class Glibc < Package
             --prefix=#{CREW_PREFIX} \
             --libdir=#{CREW_LIB_PREFIX} \
             --with-headers=#{CREW_PREFIX}/include \
+            --without-gd \
             ac_cv_header_cpuid_h=yes \
             ac_cv_lib_audit_audit_log_user_avc_message=no \
             ac_cv_lib_cap_cap_init=no \
@@ -446,6 +443,7 @@ class Glibc < Package
             --prefix=#{CREW_PREFIX} \
             --libdir=#{CREW_LIB_PREFIX} \
             --with-headers=#{CREW_PREFIX}/include \
+            --without-gd \
             ac_cv_header_cpuid_h=yes \
             ac_cv_lib_audit_audit_log_user_avc_message=no \
             ac_cv_lib_cap_cap_init=no \

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -262,7 +262,7 @@ class Glibc < Package
         @googlesource_branch = 'release-R91-13904.B'
         system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
         Dir.glob("googlesource/sys-libs/glibc/files/local/glibc-2.27/glibc-#{@libc_version}*.patch").each do |patch|
-        puts "patch -Np1 -i #{patch}" if @verbose
+        puts "patch -Np1 -i #{patch}" if @opt_verbose
         system "patch -Np1 -i #{patch} || (echo 'Retrying #{patch}' && patch -Np0 -i #{patch} || true)"
         end
         # Fix multiple definitions of __nss_*_database (bug 22918) in Glibc 2.27
@@ -287,13 +287,13 @@ class Glibc < Package
         hashpipe sha256 6653f1d0aadad10bd288f3bae274bd4e0a013d47f09ce78199fb5989b2d8fd9b | \
         tar -xJf - -C gentoopatches'
       Dir.glob('gentoopatches/patches/*.patch').each do |patch|
-        puts "patch -Np1 < #{patch}" if @verbose
+        puts "patch -Np1 < #{patch}" if @opt_verbose
         system "patch -Np1 < #{patch}"
       end
       @googlesource_branch = 'release-R96-14268.B'
       system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
       Dir.glob('googlesource/sys-libs/glibc/files/local/glibc-2.32/*.patch').each do |patch|
-        puts "patch -Np1 < #{patch}" if @verbose
+        puts "patch -Np1 < #{patch}" if @opt_verbose
         system "patch -Np1 < #{patch}"
       end
     when '2.33'
@@ -313,13 +313,13 @@ class Glibc < Package
         hashpipe sha256 29c2e4036c2b33b830a9588055c63fde5dd5255bcfd5fad2fc92f3bbd27456c1 | \
         tar -xJf - -C gentoopatches'
       Dir.glob('gentoopatches/patches/*.patch').each do |patch|
-        puts "patch -Np1 -i #{patch} || true" if @verbose
+        puts "patch -Np1 -i #{patch} || true" if @opt_verbose
         system "patch -Np1 -i #{patch} || true"
       end
       @googlesource_branch = 'release-R99-14469.B'
       system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
       Dir.glob('googlesource/sys-libs/glibc/files/local/glibc-2.33/*.patch').each do |patch|
-        puts "patch -Np1 < #{patch} || true" if @verbose
+        puts "patch -Np1 < #{patch} || true" if @opt_verbose
         system "patch -Np1 < #{patch} || true"
       end
     end

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -11,10 +11,10 @@ class Glibc < Package
   depends_on 'texinfo' => :build
   depends_on 'hashpipe' => :build
 
-  # @LIBC_VERSION = LIBC_VERSION
+  @LIBC_VERSION = LIBC_VERSION
   # Uncomment following line to build a version of glibc different
   # from the one ChromeOS ships with.
-  @LIBC_VERSION = '2.33'
+  # @LIBC_VERSION = '2.33'
   if @LIBC_VERSION == '2.23'.freeze
     version '2.23-3'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.23.tar.xz'
@@ -64,12 +64,12 @@ class Glibc < Package
     binary_url({
       aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_armv7l/glibc-2.32-6-chromeos-armv7l.tpxz',
        armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_armv7l/glibc-2.32-6-chromeos-armv7l.tpxz',
-       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_x86_64/glibc-2.32-6-chromeos-x86_64.tpxz'
+       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.33_x86_64/glibc-2.33-chromeos-x86_64.tpxz'
     })
     binary_sha256({
       aarch64: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
        armv7l: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
-       x86_64: '3e3eaa6551492ef0f1bc28600102503b721b19d0ee7396c4301771df402ea355'
+       x86_64: 'bbdd07d1a4a962aebf365786db48d1da41a84a6bef8b78eef86f051ad01a9980'
     })
   end
 

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -14,11 +14,11 @@ class Glibc < Package
   no_env_options
   conflicts_ok
 
-  @LIBC_VERSION = LIBC_VERSION
+  @libc_version = LIBC_VERSION
   # Uncomment following line to build a version of glibc different
   # from the one ChromeOS ships with.
-  # @LIBC_VERSION = '2.33'
-  if @LIBC_VERSION == '2.23'.freeze
+  # @libc_version = '2.33'
+  if @libc_version == '2.23'.freeze
     version '2.23-3'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.23.tar.xz'
     source_sha256 '94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9'
@@ -29,7 +29,7 @@ class Glibc < Package
     binary_sha256({
       i686: '3ee19cbb907eb219a2c1b02df6de1ca13b09b0d375101657d54a2485aacdc445'
     })
-  elsif @LIBC_VERSION == '2.27'
+  elsif @libc_version == '2.27'
     version '2.27'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.27.tar.xz'
     source_sha256 '5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72'
@@ -44,7 +44,7 @@ class Glibc < Package
        armv7l: '64b4b73e2096998fd1a0a0e7d18472ef977aebb2f1cad83d99c77e164cb6a1d6',
        x86_64: '5fe94642dbbf900d22b715021c73ac1a601b81517f0da1e7413f0af8fbea7997'
     })
-  elsif @LIBC_VERSION == '2.32'.freeze # All architectures with updates past M92.
+  elsif @libc_version == '2.32'.freeze # All architectures with updates past M92.
     version '2.32-2'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.32.tar.xz'
     source_sha256 '1627ea54f5a1a8467032563393e0901077626dc66f37f10ee6363bb722222836'
@@ -59,7 +59,7 @@ class Glibc < Package
        armv7l: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
        x86_64: '3e3eaa6551492ef0f1bc28600102503b721b19d0ee7396c4301771df402ea355'
     })
-  elsif @LIBC_VERSION.to_f >= 2.33 # All architectures with updates past M97.
+  elsif @libc_version.to_f >= 2.33 # All architectures with updates past M97.
     version '2.33'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.33.tar.xz'
     source_sha256 '2e2556000e105dbd57f0b6b2a32ff2cf173bde4f0d85dffccfd8b7e51a0677ff'
@@ -77,7 +77,7 @@ class Glibc < Package
   end
 
   def self.patch
-    case @LIBC_VERSION
+    case @libc_version
     when '2.23', '2.27'
       # Patch to avoid old ld issue on glibc 2.23 by using ld configure
       # portion from https://github.com/bminor/glibc/blob/master/configure
@@ -261,7 +261,7 @@ class Glibc < Package
       when 'armv7l', 'x86_64'
         @googlesource_branch = 'release-R91-13904.B'
         system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
-        Dir.glob("googlesource/sys-libs/glibc/files/local/glibc-2.27/glibc-#{@LIBC_VERSION}*.patch").each do |patch|
+        Dir.glob("googlesource/sys-libs/glibc/files/local/glibc-2.27/glibc-#{@libc_version}*.patch").each do |patch|
         puts patch
         system "patch -Np1 -i #{patch} || (echo 'Retrying #{patch}' && patch -Np0 -i #{patch} || true)"
         end
@@ -333,7 +333,7 @@ class Glibc < Package
         FileUtils.cp bin.chomp, "binutils/#{File.basename(bin.chomp)}" if bin['/bin/']
       end
       FileUtils.cp 'binutils/ld.bfd', 'binutils/ld'
-      case @LIBC_VERSION
+      case @libc_version
       when '2.23' # This is only for glibc 2.23
         system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
                  #{CREW_OPTIONS} \
@@ -391,7 +391,7 @@ class Glibc < Package
                    libc_cv_ssp_strong=no"
         end
       end
-      if @LIBC_VERSION.to_f >= 2.32
+      if @libc_version.to_f >= 2.32
         # Optimization flags from https://github.com/InBetweenNames/gentooLTO
         case ARCH
         when 'armv7l', 'aarch64'
@@ -486,7 +486,7 @@ class Glibc < Package
         end
       end
       system 'make -k'
-      if @LIBC_VERSION.to_f >= 2.32
+      if @libc_version.to_f >= 2.32
         system "gcc -Os -g -static -o build-locale-archive ../fedora/build-locale-archive.c \
           ../glibc_build/locale/locarchive.o \
           ../glibc_build/locale/md5.o \
@@ -510,7 +510,7 @@ class Glibc < Package
       when 'i686', 'x86_64'
         system "make DESTDIR=#{CREW_DEST_DIR} install"
       end
-      case @LIBC_VERSION
+      case @libc_version
       when '2.23', '2.27'
         Dir.chdir 'localedata' do
           system "mkdir -pv #{CREW_DEST_LIB_PREFIX}/locale"
@@ -543,7 +543,7 @@ class Glibc < Package
           system "localedef --prefix=#{CREW_DEST_DIR} -i zh_CN -f GB18030 zh_CN.GB18030"
         end
       end
-      if @LIBC_VERSION.to_f >= 2.32
+      if @libc_version.to_f >= 2.32
         system "install -Dt #{CREW_DEST_PREFIX}/bin -m755 build-locale-archive"
         system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'localedata/install-locales'
       end
@@ -554,7 +554,7 @@ class Glibc < Package
     FileUtils.rm Dir.glob("#{CREW_DEST_LIB_PREFIX}/libmount.so*")
     # threads.h was introduced in glibc 2.28. This is a workaround for
     # pre-M92 systems.
-    return unless @LIBC_VERSION < '2.28'
+    return unless @libc_version < '2.28'
 
     system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
     unless Digest::SHA256.hexdigest(File.read('threads.h')) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
@@ -577,7 +577,7 @@ class Glibc < Package
     return if ARCH == 'i686'
 
     Dir.chdir 'glibc_build' do
-      system "make check"
+      system 'make check'
     end
   end
 
@@ -603,7 +603,7 @@ class Glibc < Package
         end
       end
     end
-    if @LIBC_VERSION.to_f >= 2.32
+    if @libc_version.to_f >= 2.32
       puts 'Paring locales to a minimal set.'.lightblue
       system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive'
       FileUtils.mv "#{CREW_LIB_PREFIX}/locale/locale-archive", "#{CREW_LIB_PREFIX}/locale/locale-archive.tmpl"

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -312,12 +312,12 @@ class Glibc < Package
         hashpipe sha256 29c2e4036c2b33b830a9588055c63fde5dd5255bcfd5fad2fc92f3bbd27456c1 | \
         tar -xJf - -C gentoopatches'
       Dir.glob('gentoopatches/patches/*.patch').each do |patch|
-        system "patch -Np1 -i #{patch} || true"
+        system "patch -Np1 -i #{patch} || true" if @verbose
       end
       @googlesource_branch = 'release-R99-14469.B'
       system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
       Dir.glob('googlesource/sys-libs/glibc/files/local/glibc-2.33/*.patch').each do |patch|
-        puts patch
+        puts patch if @verbose
         system "patch -Np1 < #{patch} || true"
       end
     end
@@ -564,6 +564,7 @@ class Glibc < Package
   end
 
   def self.check
+    # Tests on i686 fail.
     # /usr/local/bin/nm: /usr/local/tmp/crew/glibc.20211222010048.dir/glibc-2.23/glibc_build/elf/../string/rtld-memcpy-sse2-unaligned.os: no symbols
     # /usr/local/bin/nm: /usr/local/tmp/crew/glibc.20211222010048.dir/glibc-2.23/glibc_build/elf/../string/rtld-memmove-sse2-unaligned.os: no symbols
     # make[2]: Target 'tests' not remade because of errors.
@@ -573,11 +574,11 @@ class Glibc < Package
     # make[1]: Target 'check' not remade because of errors.
     # make[1]: Leaving directory '/usr/local/tmp/crew/glibc.20211222010048.dir/glibc-2.23'
     # make: *** [Makefile:9: check] Error 2
-    # return if ARCH == 'i686'
+    return if ARCH == 'i686'
 
-    # Dir.chdir 'glibc_build' do
-    # system "make -k -j#{CREW_NPROC} check || true"
-    # end
+    Dir.chdir 'glibc_build' do
+      system "make check"
+    end
   end
 
   def self.postinstall

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -21,10 +21,10 @@ class Glibc < Package
     source_sha256 '94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9'
 
     binary_url({
-      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.23-2_i686/glibc-2.23-2-chromeos-i686.tpxz'
+      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.23-3_i686/glibc-2.23-3-chromeos-i686.tpxz'
     })
     binary_sha256({
-      i686: 'cb975c4ceee153b89a9a402d4bdd76b233e7ce3ae54f003a2875198039810f55'
+      i686: '3ee19cbb907eb219a2c1b02df6de1ca13b09b0d375101657d54a2485aacdc445'
     })
   elsif LIBC_VERSION == '2.27'
     version '2.27'

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -287,13 +287,13 @@ class Glibc < Package
         hashpipe sha256 6653f1d0aadad10bd288f3bae274bd4e0a013d47f09ce78199fb5989b2d8fd9b | \
         tar -xJf - -C gentoopatches'
       Dir.glob('gentoopatches/patches/*.patch').each do |patch|
-        puts "patch -Np1 < #{patch}" if verbose
+        puts "patch -Np1 < #{patch}" if @verbose
         system "patch -Np1 < #{patch}"
       end
       @googlesource_branch = 'release-R96-14268.B'
       system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
       Dir.glob('googlesource/sys-libs/glibc/files/local/glibc-2.32/*.patch').each do |patch|
-        puts "patch -Np1 < #{patch}" if verbose
+        puts "patch -Np1 < #{patch}" if @verbose
         system "patch -Np1 < #{patch}"
       end
     when '2.33'

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -287,12 +287,13 @@ class Glibc < Package
         hashpipe sha256 6653f1d0aadad10bd288f3bae274bd4e0a013d47f09ce78199fb5989b2d8fd9b | \
         tar -xJf - -C gentoopatches'
       Dir.glob('gentoopatches/patches/*.patch').each do |patch|
-        system "patch -Np1 -i #{patch}"
+        puts "patch -Np1 < #{patch}" if verbose
+        system "patch -Np1 < #{patch}"
       end
       @googlesource_branch = 'release-R96-14268.B'
       system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
       Dir.glob('googlesource/sys-libs/glibc/files/local/glibc-2.32/*.patch').each do |patch|
-        puts patch
+        puts "patch -Np1 < #{patch}" if verbose
         system "patch -Np1 < #{patch}"
       end
     when '2.33'
@@ -312,12 +313,13 @@ class Glibc < Package
         hashpipe sha256 29c2e4036c2b33b830a9588055c63fde5dd5255bcfd5fad2fc92f3bbd27456c1 | \
         tar -xJf - -C gentoopatches'
       Dir.glob('gentoopatches/patches/*.patch').each do |patch|
-        system "patch -Np1 -i #{patch} || true" if @verbose
+        puts "patch -Np1 -i #{patch} || true" if @verbose
+        system "patch -Np1 -i #{patch} || true"
       end
       @googlesource_branch = 'release-R99-14469.B'
       system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
       Dir.glob('googlesource/sys-libs/glibc/files/local/glibc-2.33/*.patch').each do |patch|
-        puts patch if @verbose
+        puts "patch -Np1 < #{patch} || true" if @verbose
         system "patch -Np1 < #{patch} || true"
       end
     end

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -262,7 +262,7 @@ class Glibc < Package
         @googlesource_branch = 'release-R91-13904.B'
         system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
         Dir.glob("googlesource/sys-libs/glibc/files/local/glibc-2.27/glibc-#{@libc_version}*.patch").each do |patch|
-        puts patch
+        puts "patch -Np1 -i #{patch}" if @verbose
         system "patch -Np1 -i #{patch} || (echo 'Retrying #{patch}' && patch -Np0 -i #{patch} || true)"
         end
         # Fix multiple definitions of __nss_*_database (bug 22918) in Glibc 2.27

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -27,19 +27,19 @@ class Glibc < Package
       i686: '3ee19cbb907eb219a2c1b02df6de1ca13b09b0d375101657d54a2485aacdc445'
     })
   elsif @LIBC_VERSION == '2.27'
-    version '2.27-3'
+    version '2.27'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.27.tar.xz'
     source_sha256 '5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72'
 
     binary_url({
-      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27-3_armv7l/glibc-2.27-3-chromeos-armv7l.tpxz',
-       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27-3_armv7l/glibc-2.27-3-chromeos-armv7l.tpxz',
-       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27-3_x86_64/glibc-2.27-3-chromeos-x86_64.tpxz'
+      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27_armv7l/glibc-2.27-chromeos-armv7l.tar.xz',
+       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27_armv7l/glibc-2.27-chromeos-armv7l.tar.xz',
+       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27_x86_64/glibc-2.27-chromeos-x86_64.tar.xz'
     })
     binary_sha256({
-      aarch64: '9d71c001feb52fbe7dd201c4ae5a4cadb7b7b3f3020b299ff023624e48aa06db',
-       armv7l: '9d71c001feb52fbe7dd201c4ae5a4cadb7b7b3f3020b299ff023624e48aa06db',
-       x86_64: '1f1bff5247b0e47b7d48e950d24bbce6f9df9f2418ca9aa7b9880cb2c708eef2'
+      aarch64: '64b4b73e2096998fd1a0a0e7d18472ef977aebb2f1cad83d99c77e164cb6a1d6',
+       armv7l: '64b4b73e2096998fd1a0a0e7d18472ef977aebb2f1cad83d99c77e164cb6a1d6',
+       x86_64: '5fe94642dbbf900d22b715021c73ac1a601b81517f0da1e7413f0af8fbea7997'
     })
   elsif @LIBC_VERSION == '2.32'.freeze # All architectures with updates past M92.
     version '2.32-2'

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -16,12 +16,12 @@ class Glibc < Package
   # this functionality is provided by libtirpc
 
   if LIBC_VERSION == '2.23'.freeze
-    version '2.23-2'
+    version '2.23-3'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.23.tar.xz'
     source_sha256 '94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9'
 
     binary_url({
-      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.23-3_i686/glibc-2.23-3-chromeos-i686.tpxz'
+      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.23-3_i686/glibc-2.23-3-chromeos-i686.tar.xz'
     })
     binary_sha256({
       i686: '3ee19cbb907eb219a2c1b02df6de1ca13b09b0d375101657d54a2485aacdc445'

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -15,20 +15,19 @@ class Glibc < Package
   # enable-obsolete-rpc should NOT be included as a build option as
   # this functionality is provided by libtirpc
 
-  case LIBC_VERSION
-  when '2.23'
-    version LIBC_VERSION
+  if LIBC_VERSION == '2.23'.freeze
+    version '2.23-2'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.23.tar.xz'
     source_sha256 '94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9'
 
     binary_url({
-      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.23_i686/glibc-2.23-chromeos-i686.tar.xz'
+      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.23-2_i686/glibc-2.23-2-chromeos-i686.tpxz'
     })
     binary_sha256({
-      i686: '52145b65cb49c2751f69d4c46636f0685f2abb6685d8a080b71b2f091595a950'
+      i686: 'cb975c4ceee153b89a9a402d4bdd76b233e7ce3ae54f003a2875198039810f55'
     })
-  when '2.27'
-    version LIBC_VERSION
+  elsif LIBC_VERSION == '2.27'
+    version '2.27'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.27.tar.xz'
     source_sha256 '5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72'
 
@@ -42,24 +41,38 @@ class Glibc < Package
        armv7l: '64b4b73e2096998fd1a0a0e7d18472ef977aebb2f1cad83d99c77e164cb6a1d6',
        x86_64: '5fe94642dbbf900d22b715021c73ac1a601b81517f0da1e7413f0af8fbea7997'
     })
-  when '2.32' # All architectures with updates past M92.
-    version '2.32-1'
+  elsif LIBC_VERSION == '2.32'.freeze # All architectures with updates past M92.
+    version '2.32-2'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.32.tar.xz'
     source_sha256 '1627ea54f5a1a8467032563393e0901077626dc66f37f10ee6363bb722222836'
 
     binary_url({
-      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-1_armv7l/glibc-2.32-1-chromeos-armv7l.tpxz',
-       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-1_armv7l/glibc-2.32-1-chromeos-armv7l.tpxz',
-       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-1_x86_64/glibc-2.32-1-chromeos-x86_64.tpxz'
+      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_armv7l/glibc-2.32-2-chromeos-armv7l.tpxz',
+       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_armv7l/glibc-2.32-2-chromeos-armv7l.tpxz',
+       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_x86_64/glibc-2.32-2-chromeos-x86_64.tpxz'
     })
     binary_sha256({
-      aarch64: '9a75b9c77f8a131268f8df3db2066fe0e23513a40cdf45e6093d14e11ee2d394',
-       armv7l: '9a75b9c77f8a131268f8df3db2066fe0e23513a40cdf45e6093d14e11ee2d394',
-       x86_64: '6f27b75e77a2613fff24d36aa176f8a352a26adb8f58fbe7e75e400b84699719'
+      aarch64: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
+       armv7l: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
+       x86_64: '3e3eaa6551492ef0f1bc28600102503b721b19d0ee7396c4301771df402ea355'
     })
+  elsif LIBC_VERSION.to_f >= 2.33 # All architectures with updates past M97.
+    version '2.33'
+    source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.33.tar.xz'
+    source_sha256 '2e2556000e105dbd57f0b6b2a32ff2cf173bde4f0d85dffccfd8b7e51a0677ff'
 
+    binary_url({
+      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_armv7l/glibc-2.32-6-chromeos-armv7l.tpxz',
+       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_armv7l/glibc-2.32-6-chromeos-armv7l.tpxz',
+       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_x86_64/glibc-2.32-6-chromeos-x86_64.tpxz'
+    })
+    binary_sha256({
+      aarch64: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
+       armv7l: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
+       x86_64: '3e3eaa6551492ef0f1bc28600102503b721b19d0ee7396c4301771df402ea355'
+    })
   end
-
+  puts "libc version is #{version}".lightblue
   depends_on 'gawk' => :build
   depends_on 'hashpipe' => :build
   depends_on 'libgd' => :build
@@ -69,6 +82,199 @@ class Glibc < Package
   def self.patch
     case LIBC_VERSION
     when '2.23', '2.27'
+      # Patch to avoid old ld issue on glibc 2.23 by using ld configure
+      # portion from https://github.com/bminor/glibc/blob/master/configure
+      @glibc_223_i686_patch = <<~'GLIBC_223_HEREDOC'
+        --- a/configure	2021-12-22 11:42:36.689574968 -0500
+        +++ b/configure	2021-12-22 11:58:43.052504544 -0500
+        @@ -4434,7 +4434,143 @@ if test $ac_verc_fail = yes; then
+           AS=: critic_missing="$critic_missing as"
+         fi
+
+        -for ac_prog in $LD
+        +libc_cv_with_lld=no
+        +case $($LD --version) in
+        +  "GNU gold"*)
+        +  # Accept gold 1.14 or higher
+        +    for ac_prog in $LD
+        +do
+        +  # Extract the first word of "$ac_prog", so it can be a program name with args.
+        +set dummy $ac_prog; ac_word=$2
+        +{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+        +$as_echo_n "checking for $ac_word... " >&6; }
+        +if ${ac_cv_prog_LD+:} false; then :
+        +  $as_echo_n "(cached) " >&6
+        +else
+        +  if test -n "$LD"; then
+        +  ac_cv_prog_LD="$LD" # Let the user override the test.
+        +else
+        +as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+        +for as_dir in $PATH
+        +do
+        +  IFS=$as_save_IFS
+        +  test -z "$as_dir" && as_dir=.
+        +    for ac_exec_ext in '' $ac_executable_extensions; do
+        +  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+        +    ac_cv_prog_LD="$ac_prog"
+        +    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+        +    break 2
+        +  fi
+        +done
+        +  done
+        +IFS=$as_save_IFS
+        +
+        +fi
+        +fi
+        +LD=$ac_cv_prog_LD
+        +if test -n "$LD"; then
+        +  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LD" >&5
+        +$as_echo "$LD" >&6; }
+        +else
+        +  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+        +$as_echo "no" >&6; }
+        +fi
+        +
+        +
+        +  test -n "$LD" && break
+        +done
+        +
+        +if test -z "$LD"; then
+        +  ac_verc_fail=yes
+        +else
+        +  # Found it, now check the version.
+        +  { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of $LD" >&5
+        +$as_echo_n "checking version of $LD... " >&6; }
+        +  ac_prog_version=`$LD --version 2>&1 | sed -n 's/^.*GNU gold.* \([0-9][0-9]*\.[0-9.]*\).*$/\1/p'`
+        +  case $ac_prog_version in
+        +    '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+        +    1.1[4-9]*|1.[2-9][0-9]*|1.1[0-9][0-9]*|[2-9].*|[1-9][0-9]*)
+        +       ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+        +    *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+        +
+        +  esac
+        +  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_prog_version" >&5
+        +$as_echo "$ac_prog_version" >&6; }
+        +fi
+        +if test $ac_verc_fail = yes; then
+        +  LD=: critic_missing="$critic_missing GNU gold"
+        +fi
+        +
+        +    ;;
+        +  "LLD"*)
+        +  # Accept LLD 13.0.0 or higher
+        +    for ac_prog in $LD
+        +do
+        +  # Extract the first word of "$ac_prog", so it can be a program name with args.
+        +set dummy $ac_prog; ac_word=$2
+        +{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+        +$as_echo_n "checking for $ac_word... " >&6; }
+        +if ${ac_cv_prog_LD+:} false; then :
+        +  $as_echo_n "(cached) " >&6
+        +else
+        +  if test -n "$LD"; then
+        +  ac_cv_prog_LD="$LD" # Let the user override the test.
+        +else
+        +as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+        +for as_dir in $PATH
+        +do
+        +  IFS=$as_save_IFS
+        +  test -z "$as_dir" && as_dir=.
+        +    for ac_exec_ext in '' $ac_executable_extensions; do
+        +  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+        +    ac_cv_prog_LD="$ac_prog"
+        +    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+        +    break 2
+        +  fi
+        +done
+        +  done
+        +IFS=$as_save_IFS
+        +
+        +fi
+        +fi
+        +LD=$ac_cv_prog_LD
+        +if test -n "$LD"; then
+        +  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LD" >&5
+        +$as_echo "$LD" >&6; }
+        +else
+        +  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+        +$as_echo "no" >&6; }
+        +fi
+        +
+        +
+        +  test -n "$LD" && break
+        +done
+        +
+        +if test -z "$LD"; then
+        +  ac_verc_fail=yes
+        +else
+        +  # Found it, now check the version.
+        +  { $as_echo "$as_me:${as_lineno-$LINENO}: checking version of $LD" >&5
+        +$as_echo_n "checking version of $LD... " >&6; }
+        +  ac_prog_version=`$LD --version 2>&1 | sed -n 's/^.*LLD.* \([0-9][0-9]*\.[0-9.]*\).*$/\1/p'`
+        +  case $ac_prog_version in
+        +    '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+        +    1[3-9].*|[2-9][0-9].*)
+        +       ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+        +    *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+        +
+        +  esac
+        +  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_prog_version" >&5
+        +$as_echo "$ac_prog_version" >&6; }
+        +fi
+        +if test $ac_verc_fail = yes; then
+        +  LD=: critic_missing="$critic_missing LLD"
+        +fi
+        +
+        +    libc_cv_with_lld=yes
+        +    ;;
+        +  *)
+        +    for ac_prog in $LD
+         do
+           # Extract the first word of "$ac_prog", so it can be a program name with args.
+         set dummy $ac_prog; ac_word=$2
+        @@ -4485,7 +4621,7 @@ $as_echo_n "checking version of $LD... "
+           ac_prog_version=`$LD --version 2>&1 | sed -n 's/^.*GNU ld.* \([0-9][0-9]*\.[0-9.]*\).*$/\1/p'`
+           case $ac_prog_version in
+             '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+        -    2.1[0-9][0-9]*|2.2[2-9]*|2.[3-9][0-9]*|[3-9].*|[1-9][0-9]*)
+        +    2.1[0-9][0-9]*|2.2[5-9]*|2.[3-9][0-9]*|[3-9].*|[1-9][0-9]*)
+                ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+             *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+
+        @@ -4494,9 +4630,14 @@ $as_echo_n "checking version of $LD... "
+         $as_echo "$ac_prog_version" >&6; }
+         fi
+         if test $ac_verc_fail = yes; then
+        -  LD=: critic_missing="$critic_missing ld"
+        +  LD=: critic_missing="$critic_missing GNU ld"
+         fi
+
+        +    ;;
+        +esac
+        +config_vars="$config_vars
+        +with-lld = $libc_cv_with_lld"
+        +
+
+         # These programs are version sensitive.
+      GLIBC_223_HEREDOC
+      case ARCH
+      when 'i686'
+        File.write('glibc_223_i686.patch', @glibc_223_i686_patch)
+        system 'patch -Np1 -i glibc_223_i686.patch'
+        # when 'armv7l', 'x86_64'
+        # @googlesource_branch = 'release-R91-13904.B'
+        # system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
+        # Dir.glob("googlesource/sys-libs/glibc/files/local/glibc-2.27/glibc-#{LIBC_VERSION}*.patch").each do |patch|
+        # puts patch
+        # system "patch -Np1 -i #{patch} || (echo 'Retrying #{patch}' && patch -Np0 -i #{patch})"
+        # end
+        ## Fix multiple definitions of __nss_*_database (bug 22918) in Glibc 2.27
+        # system 'curl -Ls "https://sourceware.org/git/?p=glibc.git;a=commitdiff_plain;h=eaf6753f8aac33a36deb98c1031d1bad7b593d2d;hp=4dc23804a220f917f400e2404bc4803cd60491c7" -o glibc_227_nss.patch'
+        # unless Digest::SHA256.hexdigest(File.read('glibc_227_nss.patch')) == '0c40630adf77292abb763362182158a87648e2c45904aebb5758b5ca38653ac9'
+        # abort 'Checksum mismatch :/ try again'
+        # end
+        # system 'patch -Np1 -i glibc_227_nss.patch || true'
+      end
       # Apply patch due to new version of binutils which causes compilation failure
       # http://lists.busybox.net/pipermail/buildroot/2017-August/199812.html
       Dir.chdir 'misc' do
@@ -98,11 +304,36 @@ class Glibc < Package
       Dir.glob('gentoopatches/patches/*.patch').each do |patch|
         system "patch -Np1 -i #{patch}"
       end
-      @googlesource_branch = 'release-R92-13982.B'
+      @googlesource_branch = 'release-R96-14268.B'
       system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
       Dir.glob('googlesource/sys-libs/glibc/files/local/glibc-2.32/*.patch').each do |patch|
         puts patch
         system "patch -Np1 < #{patch}"
+      end
+    when '2.33'
+      FileUtils.mkdir 'fedora'
+      # Patch to enable build-local-archive
+      system 'curl -Ls https://src.fedoraproject.org/rpms/glibc/raw/f30/f/glibc-fedora-locarchive.patch | \
+      hashpipe sha256 0acccf57d8c6e7de82871c61ccb845f7a1ae13ae1fbc65995d347de8367c7bb1 | \
+      patch -Np1 --binary'
+      system 'curl -Ls https://src.fedoraproject.org/rpms/glibc/raw/f30/f/build-locale-archive.c | \
+      hashpipe sha256 6834e8b8f2a987bf8adfd265c0e01665f102c7115db94b99ec36376b68e9d3fa > fedora/build-locale-archive.c'
+      system "sed -i 's,/lib/locale,/lib#{CREW_LIB_SUFFIX}/locale,g' fedora/build-locale-archive.c"
+      system "sed -i 's,/usr/sbin/tzdata-update,/bin/true,g' fedora/build-locale-archive.c"
+      system "sed -i 's,verbose,locale_verbose,g' fedora/build-locale-archive.c"
+      system "sed -i 's,be_quiet,locale_be_quiet,g' fedora/build-locale-archive.c"
+      FileUtils.mkdir_p 'gentoopatches'
+      system 'curl -Ls https://dev.gentoo.org/~dilfridge/distfiles/glibc-2.32-patches-8.tar.xz | \
+        hashpipe sha256 6653f1d0aadad10bd288f3bae274bd4e0a013d47f09ce78199fb5989b2d8fd9b | \
+        tar -xJf - -C gentoopatches'
+      Dir.glob('gentoopatches/patches/*.patch').each do |patch|
+        system "patch -Np1 -i #{patch} || true"
+      end
+      @googlesource_branch = 'release-R99-14469.B'
+      system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
+      Dir.glob('googlesource/sys-libs/glibc/files/local/glibc-2.33/*.patch').each do |patch|
+        puts patch
+        system "patch -Np1 < #{patch} || true"
       end
     end
   end
@@ -110,46 +341,57 @@ class Glibc < Package
   def self.build
     Dir.mkdir 'glibc_build'
     Dir.chdir 'glibc_build' do
+      # gold linker does not work for glibc 2.23, and maybe others.
+      FileUtils.mkdir_p 'binutils'
+      @binutils = IO.readlines("#{CREW_META_PATH}binutils.filelist")
+      @binutils.each do |bin|
+        FileUtils.cp bin.chomp, "binutils/#{File.basename(bin.chomp)}" if bin['/bin/']
+      end
+      FileUtils.cp 'binutils/ld.bfd', 'binutils/ld'
       case LIBC_VERSION
       when '2.23' # This is only for glibc 2.23
-        system '../configure',
-               "--prefix=#{CREW_PREFIX}",
-               "--libdir=#{CREW_LIB_PREFIX}",
-               "--with-headers=#{CREW_PREFIX}/include",
-               '--disable-werror',
-               '--disable-sanity-checks',
-               '--enable-shared',
-               '--disable-multilib',
-               'libc_cv_forced_unwind=yes',
-               'libc_cv_ssp=no',
-               'libc_cv_ssp_strong=no'
+        system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
+                 #{CREW_OPTIONS} \
+                 --with-headers=#{CREW_PREFIX}/include \
+                 --disable-werror \
+                 --disable-sanity-checks \
+                 --enable-shared \
+                 --disable-multilib \
+                 --with-binutils=binutils \
+                 --with-bugurl=https://github.com/chromebrew/chromebrew/issues/new \
+                 libc_cv_forced_unwind=yes \
+                 libc_cv_ssp=no \
+                 libc_cv_ssp_strong=no"
       when '2.27'
         case ARCH
         when 'armv7l', 'aarch64'
-          system '../configure',
-                 "--prefix=#{CREW_PREFIX}",
-                 "--libdir=#{CREW_LIB_PREFIX}",
-                 "--with-headers=#{CREW_PREFIX}/include",
-                 '--disable-werror',
-                 '--disable-sanity-checks',
-                 '--enable-shared',
-                 'libc_cv_forced_unwind=yes',
-                 '--without-selinux'
+          system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
+                   #{CREW_OPTIONS} \
+                   --with-headers=#{CREW_PREFIX}/include \
+                   --disable-werror \
+                   --disable-sanity-checks \
+                   --enable-shared \
+                   --with-binutils=binutils \
+                   --with-bugurl=https://github.com/chromebrew/chromebrew/issues/new \
+                   libc_cv_forced_unwind=yes \
+                   --without-selinux"
         when 'x86_64'
           IO.write('configparms', "slibdir=#{CREW_LIB_PREFIX}")
-          system '../configure',
-                 "--prefix=#{CREW_PREFIX}",
-                 "--libdir=#{CREW_LIB_PREFIX}",
-                 "--with-headers=#{CREW_PREFIX}/include",
-                 '--disable-werror',
-                 '--disable-sanity-checks',
-                 '--enable-shared',
-                 '--disable-multilib',
-                 'libc_cv_forced_unwind=yes',
-                 'libc_cv_ssp=no',
-                 'libc_cv_ssp_strong=no'
+          system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
+                   #{CREW_OPTIONS} \
+                   --with-headers=#{CREW_PREFIX}/include \
+                   --disable-werror \
+                   --disable-sanity-checks \
+                   --enable-shared \
+                   --with-binutils=binutils \
+                   --with-bugurl=https://github.com/chromebrew/chromebrew/issues/new \
+                   --disable-multilib \
+                   libc_cv_forced_unwind=yes \
+                   libc_cv_ssp=no \
+                   libc_cv_ssp_strong=no"
         end
-      when '2.32'
+      end
+      if LIBC_VERSION.to_f >= 2.32
         # Optimization flags from https://github.com/InBetweenNames/gentooLTO
         case ARCH
         when 'armv7l', 'aarch64'
@@ -187,9 +429,10 @@ class Glibc < Package
             libc_cv_z_nodelete=yes \
             libc_cv_z_nodlopen=yes \
             libc_cv_z_relro=yes \
+            --with-binutils=binutils \
+            --with-bugurl=https://github.com/chromebrew/chromebrew/issues/new \
             --without-cvs \
             --without-selinux \
-            --with-bugurl=https://github.com/skycocker/chromebrew/issues/new \
             "
           # install-symbolic-link segfaults on armv7l, but we're deleting
           # the libraries anyways, so it doesn't matter.
@@ -199,7 +442,7 @@ class Glibc < Package
           IO.write('configparms', "slibdir=#{CREW_LIB_PREFIX}")
           system "env \
           CFLAGS='-pipe -O2 -fipa-pta -fno-semantic-interposition -falign-functions=32 -fdevirtualize-at-ltrans' \
-          LD=ld ../configure \
+            ../configure \
             --prefix=#{CREW_PREFIX} \
             --libdir=#{CREW_LIB_PREFIX} \
             --with-headers=#{CREW_PREFIX}/include \
@@ -233,22 +476,22 @@ class Glibc < Package
             libc_cv_z_nodelete=yes \
             libc_cv_z_nodlopen=yes \
             libc_cv_z_relro=yes \
+            --with-binutils=binutils \
+            --with-bugurl=https://github.com/chromebrew/chromebrew/issues/new \
             --without-cvs \
             --without-selinux \
-            --with-bugurl=https://github.com/skycocker/chromebrew/issues/new \
             "
         end
       end
-      system 'make'
-      case @LIBC_VERSION
-      when '2.32'
+      system 'make -k'
+      if LIBC_VERSION.to_f >= 2.33
         system "gcc -Os -g -static -o build-locale-archive ../fedora/build-locale-archive.c \
-      ../glibc_build/locale/locarchive.o \
-      ../glibc_build/locale/md5.o \
-      ../glibc_build/locale/record-status.o \
-      -I. -DDATADIR=\\\"#{CREW_PREFIX}/share\\\" -DPREFIX=\\\"#{CREW_PREFIX}\\\" \
-      -L../glibc_build \
-      -B../glibc_build/csu/ -lc -lc_nonshared"
+          ../glibc_build/locale/locarchive.o \
+          ../glibc_build/locale/md5.o \
+          ../glibc_build/locale/record-status.o \
+          -I. -DDATADIR=\\\"#{CREW_PREFIX}/share\\\" -DPREFIX=\\\"#{CREW_PREFIX}\\\" \
+          -L../glibc_build \
+          -B../glibc_build/csu/ -lc -lc_nonshared"
       end
     end
   end
@@ -258,20 +501,77 @@ class Glibc < Package
     system "sed 's,/usr/#{ARCH_LIB}/libc_nonshared.a,#{CREW_LIB_PREFIX}/libc_nonshared.a,g' /usr/#{ARCH_LIB}/libc.so > #{CREW_DEST_LIB_PREFIX}/libc.so"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc"
     Dir.chdir 'glibc_build' do
-      system "install -Dt #{CREW_DEST_PREFIX}/bin -m755 build-locale-archive"
       system 'touch', "#{CREW_DEST_PREFIX}/etc/ld.so.conf"
       system "make DESTDIR=#{CREW_DEST_DIR} install" # "sln elf/symlink.list" fails on armv7l
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'localedata/install-locales'
+      case LIBC_VERSION
+      when '2.23', '2.27'
+        Dir.chdir 'localedata' do
+          system "mkdir -pv #{CREW_DEST_LIB_PREFIX}/locale"
+          puts 'Install minimum set of locales'.lightblue
+
+          # Assume old version of glibc is installed. -> use localedef.
+          # If not installed, we can move following instruction to postinstall
+          # Since glibc is a basic package, we prefer to provide pre-compiled package.
+          # No compilcated detect logics required -> make it as simple as possible
+          system "localedef --prefix=#{CREW_DEST_DIR} -i cs_CZ -f UTF-8 cs_CZ.UTF-8"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i de_DE -f ISO-8859-1 de_DE"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i de_DE@euro -f ISO-8859-15 de_DE@euro"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i de_DE -f UTF-8 de_DE.UTF-8"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i en_GB -f UTF-8 en_GB.UTF-8"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i en_HK -f ISO-8859-1 en_HK"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i en_PH -f ISO-8859-1 en_PH"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i en_US -f ISO-8859-1 en_US"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i en_US -f UTF-8 en_US.UTF-8"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i es_MX -f ISO-8859-1 es_MX"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i fa_IR -f UTF-8 fa_IR"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i fr_FR -f ISO-8859-1 fr_FR"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i fr_FR@euro -f ISO-8859-15 fr_FR@euro"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i fr_FR -f UTF-8 fr_FR.UTF-8"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i it_IT -f ISO-8859-1 it_IT"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i it_IT -f UTF-8 it_IT.UTF-8"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i ja_JP -f EUC-JP ja_JP"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i ru_RU -f KOI8-R ru_RU.KOI8-R"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i ru_RU -f UTF-8 ru_RU.UTF-8"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i tr_TR -f UTF-8 tr_TR.UTF-8"
+          system "localedef --prefix=#{CREW_DEST_DIR} -i zh_CN -f GB18030 zh_CN.GB18030"
+        end
+      end
+      if LIBC_VERSION.to_f >= 2.32
+        system "install -Dt #{CREW_DEST_PREFIX}/bin -m755 build-locale-archive"
+        system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'localedata/install-locales'
+      end
     end
+    # libnsl is provided by perl
+    FileUtils.rm_f Dir.glob("#{CREW_DEST_LIB_PREFIX}/libnsl.so*")
     # Remove libmount.so since it conflicts with the one from util_linux.
-    FileUtils.rm Dir.glob("#{CREW_DEST_LIB_PREFIX}/libmount.so.*")
+    FileUtils.rm Dir.glob("#{CREW_DEST_LIB_PREFIX}/libmount.so*")
+    # threads.h was introduced in glibc 2.28. This is a workaround for
+    # pre-M92 systems.
+    return unless LIBC_VERSION < '2.28'
+
+    system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
+    unless Digest::SHA256.hexdigest(File.read('threads.h')) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
+      abort 'Checksum mismatch. :/ Try again.'.lightred
+    end
+    FileUtils.cp 'threads.h', "#{CREW_DEST_PREFIX}/include/"
   end
 
-  # def self.check
-  # Dir.chdir 'glibc_build' do
-  # system "make -k -j#{CREW_NPROC} check"
-  # end
-  # end
+  def self.check
+    # /usr/local/bin/nm: /usr/local/tmp/crew/glibc.20211222010048.dir/glibc-2.23/glibc_build/elf/../string/rtld-memcpy-sse2-unaligned.os: no symbols
+    # /usr/local/bin/nm: /usr/local/tmp/crew/glibc.20211222010048.dir/glibc-2.23/glibc_build/elf/../string/rtld-memmove-sse2-unaligned.os: no symbols
+    # make[2]: Target 'tests' not remade because of errors.
+    # rm /usr/local/tmp/crew/glibc.20211222010048.dir/glibc-2.23/glibc_build/libc.dynsym /usr/local/tmp/crew/glibc.20211222010048.dir/glibc-2.23/glibc_build/elf/ld.dynsym
+    # make[2]: Leaving directory '/usr/local/tmp/crew/glibc.20211222010048.dir/glibc-2.23/elf'
+    # make[1]: *** [Makefile:214: elf/tests] Error 2
+    # make[1]: Target 'check' not remade because of errors.
+    # make[1]: Leaving directory '/usr/local/tmp/crew/glibc.20211222010048.dir/glibc-2.23'
+    # make: *** [Makefile:9: check] Error 2
+    # return if ARCH == 'i686'
+
+    # Dir.chdir 'glibc_build' do
+    # system "make -k -j#{CREW_NPROC} check || true"
+    # end
+  end
 
   def self.postinstall
     @crew_libcvertokens = `#{CREW_LIB_PREFIX}/libc.so.6`.lines.first.chomp.split(/\s/)
@@ -295,8 +595,7 @@ class Glibc < Package
         end
       end
     end
-    case LIBC_VERSION
-    when '2.32'
+    if LIBC_VERSION.to_f >= 2.32
       puts 'Paring locales to a minimal set.'.lightblue
       system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive'
       FileUtils.mv "#{CREW_LIB_PREFIX}/locale/locale-archive", "#{CREW_LIB_PREFIX}/locale/locale-archive.tmpl"
@@ -322,7 +621,6 @@ class Glibc < Package
 
             FileUtils.rm_f f
             @fpath = "#{localedir}/#{f}"
-            #puts "Removed #{@fpath}.".orange
             @filelist.reject! { |e| e =~ /#{@fpath}/ }
           end
         end

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -11,10 +11,11 @@ class Glibc < Package
   depends_on 'texinfo' => :build
   depends_on 'hashpipe' => :build
 
-  # enable-obsolete-rpc should NOT be included as a build option as
-  # this functionality is provided by libtirpc
-
-  if LIBC_VERSION == '2.23'.freeze
+  # @LIBC_VERSION = LIBC_VERSION
+  # Uncomment following line to build a version of glibc different
+  # from the one ChromeOS ships with.
+  @LIBC_VERSION = '2.33'
+  if @LIBC_VERSION == '2.23'.freeze
     version '2.23-3'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.23.tar.xz'
     source_sha256 '94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9'
@@ -25,7 +26,7 @@ class Glibc < Package
     binary_sha256({
       i686: '3ee19cbb907eb219a2c1b02df6de1ca13b09b0d375101657d54a2485aacdc445'
     })
-  elsif LIBC_VERSION == '2.27'
+  elsif @LIBC_VERSION == '2.27'
     version '2.27-3'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.27.tar.xz'
     source_sha256 '5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72'
@@ -40,7 +41,7 @@ class Glibc < Package
        armv7l: '9d71c001feb52fbe7dd201c4ae5a4cadb7b7b3f3020b299ff023624e48aa06db',
        x86_64: '1f1bff5247b0e47b7d48e950d24bbce6f9df9f2418ca9aa7b9880cb2c708eef2'
     })
-  elsif LIBC_VERSION == '2.32'.freeze # All architectures with updates past M92.
+  elsif @LIBC_VERSION == '2.32'.freeze # All architectures with updates past M92.
     version '2.32-2'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.32.tar.xz'
     source_sha256 '1627ea54f5a1a8467032563393e0901077626dc66f37f10ee6363bb722222836'
@@ -55,7 +56,7 @@ class Glibc < Package
        armv7l: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
        x86_64: '3e3eaa6551492ef0f1bc28600102503b721b19d0ee7396c4301771df402ea355'
     })
-  elsif LIBC_VERSION.to_f >= 2.33 # All architectures with updates past M97.
+  elsif @LIBC_VERSION.to_f >= 2.33 # All architectures with updates past M97.
     version '2.33'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.33.tar.xz'
     source_sha256 '2e2556000e105dbd57f0b6b2a32ff2cf173bde4f0d85dffccfd8b7e51a0677ff'
@@ -73,7 +74,7 @@ class Glibc < Package
   end
 
   def self.patch
-    case LIBC_VERSION
+    case @LIBC_VERSION
     when '2.23', '2.27'
       # Patch to avoid old ld issue on glibc 2.23 by using ld configure
       # portion from https://github.com/bminor/glibc/blob/master/configure
@@ -257,7 +258,7 @@ class Glibc < Package
       when 'armv7l', 'x86_64'
         # @googlesource_branch = 'release-R91-13904.B'
         # system "git clone --depth=1 -b  #{@googlesource_branch} https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay googlesource"
-        # Dir.glob("googlesource/sys-libs/glibc/files/local/glibc-2.27/glibc-#{LIBC_VERSION}*.patch").each do |patch|
+        # Dir.glob("googlesource/sys-libs/glibc/files/local/glibc-2.27/glibc-#{@LIBC_VERSION}*.patch").each do |patch|
         # puts patch
         # system "patch -Np1 -i #{patch} || (echo 'Retrying #{patch}' && patch -Np0 -i #{patch})"
         # end
@@ -341,7 +342,7 @@ class Glibc < Package
         FileUtils.cp bin.chomp, "binutils/#{File.basename(bin.chomp)}" if bin['/bin/']
       end
       FileUtils.cp 'binutils/ld.bfd', 'binutils/ld'
-      case LIBC_VERSION
+      case @LIBC_VERSION
       when '2.23' # This is only for glibc 2.23
         system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
                  #{CREW_OPTIONS} \
@@ -387,7 +388,7 @@ class Glibc < Package
                    libc_cv_ssp_strong=no"
         end
       end
-      if LIBC_VERSION.to_f >= 2.32
+      if @LIBC_VERSION.to_f >= 2.32
         # Optimization flags from https://github.com/InBetweenNames/gentooLTO
         case ARCH
         when 'armv7l', 'aarch64'
@@ -482,7 +483,7 @@ class Glibc < Package
         end
       end
       system 'make -k'
-      if LIBC_VERSION.to_f >= 2.33
+      if @LIBC_VERSION.to_f >= 2.32
         system "gcc -Os -g -static -o build-locale-archive ../fedora/build-locale-archive.c \
           ../glibc_build/locale/locarchive.o \
           ../glibc_build/locale/md5.o \
@@ -501,7 +502,7 @@ class Glibc < Package
     Dir.chdir 'glibc_build' do
       system 'touch', "#{CREW_DEST_PREFIX}/etc/ld.so.conf"
       system "make DESTDIR=#{CREW_DEST_DIR} install" # "sln elf/symlink.list" fails on armv7l
-      case LIBC_VERSION
+      case @LIBC_VERSION
       when '2.23', '2.27'
         Dir.chdir 'localedata' do
           system "mkdir -pv #{CREW_DEST_LIB_PREFIX}/locale"
@@ -534,7 +535,7 @@ class Glibc < Package
           system "localedef --prefix=#{CREW_DEST_DIR} -i zh_CN -f GB18030 zh_CN.GB18030"
         end
       end
-      if LIBC_VERSION.to_f >= 2.32
+      if @LIBC_VERSION.to_f >= 2.32
         system "install -Dt #{CREW_DEST_PREFIX}/bin -m755 build-locale-archive"
         system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'localedata/install-locales'
       end
@@ -545,7 +546,7 @@ class Glibc < Package
     FileUtils.rm Dir.glob("#{CREW_DEST_LIB_PREFIX}/libmount.so*")
     # threads.h was introduced in glibc 2.28. This is a workaround for
     # pre-M92 systems.
-    return unless LIBC_VERSION < '2.28'
+    return unless @LIBC_VERSION < '2.28'
 
     system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
     unless Digest::SHA256.hexdigest(File.read('threads.h')) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
@@ -593,7 +594,7 @@ class Glibc < Package
         end
       end
     end
-    if LIBC_VERSION.to_f >= 2.32
+    if @LIBC_VERSION.to_f >= 2.32
       puts 'Paring locales to a minimal set.'.lightblue
       system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive'
       FileUtils.mv "#{CREW_LIB_PREFIX}/locale/locale-archive", "#{CREW_LIB_PREFIX}/locale/locale-archive.tmpl"

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -62,13 +62,13 @@ class Glibc < Package
     source_sha256 '2e2556000e105dbd57f0b6b2a32ff2cf173bde4f0d85dffccfd8b7e51a0677ff'
 
     binary_url({
-      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_armv7l/glibc-2.32-6-chromeos-armv7l.tpxz',
-       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_armv7l/glibc-2.32-6-chromeos-armv7l.tpxz',
+      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.33_armv7l/glibc-2.33-chromeos-armv7l.tpxz',
+       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.33_armv7l/glibc-2.33-chromeos-armv7l.tpxz',
        x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.33_x86_64/glibc-2.33-chromeos-x86_64.tpxz'
     })
     binary_sha256({
-      aarch64: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
-       armv7l: 'ea89e4f2bcd1ec397108d17b834199e04652316f870e1ec0f6389db1ad864e6b',
+      aarch64: '13aeaaa63cc2124e776a992f7f56453f9cae9c7fb21d30c38cd5958bd17d004e',
+       armv7l: '13aeaaa63cc2124e776a992f7f56453f9cae9c7fb21d30c38cd5958bd17d004e',
        x86_64: 'bbdd07d1a4a962aebf365786db48d1da41a84a6bef8b78eef86f051ad01a9980'
     })
   end


### PR DESCRIPTION
Fixes #6643 

- Glibc 2.33 appears to work for people.
- glibc 2.27 builds keep segfaulting, so reverted to older binaries.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_test CREW_TESTING=1 crew update
```
If your system is broken because you just updated to M98 and you NEED glibc 2.33, try this:
Do this if you are on `x86_64`.
```
LD_LIBRARY_PATH=/usr/lib64 /usr/bin/curl -Ls https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.33_x86_64/glibc-2.33-chromeos-x86_64.tpxz -o /tmp/glibc-2.33-chromeos-x86_64.tpxz
LD_LIBRARY_PATH=/usr/lib64 tar -Ipixz -xf /tmp/glibc-2.33-chromeos-x86_64.tpxz --exclude=dlist --exclude=filelist -C /
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_test CREW_TESTING=1 crew update
crew upgrade
```
And if on `armv7l` do this.
```
LD_LIBRARY_PATH=/usr/lib /usr/bin/curl -Ls https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.33_armv7l/glibc-2.33-chromeos-armv7l.tpxz -o /tmp/glibc-2.33-chromeos-armv7l.tpxz
LD_LIBRARY_PATH=/usr/lib tar -Ipixz -xf /tmp/glibc-2.33-chromeos-armv7l.tpxz --exclude=dlist --exclude=filelist -C /
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_test CREW_TESTING=1 crew update
crew upgrade
```

If installing glibc 2.33 breaks your system:
Do this if you are on `x86_64`.
```
LD_LIBRARY_PATH=/usr/lib64 /usr/bin/curl -Ls https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_x86_64/glibc-2.32-2-chromeos-x86_64.tpxz -o /tmp/glibc-2.32-2-chromeos-x86_64.tpxz
LD_LIBRARY_PATH=/usr/lib64 tar -Ipixz -xf /tmp/glibc-2.32-2-chromeos-x86_64.tpxz --exclude=dlist --exclude=filelist -C /
crew postinstall glibc ; crew postinstall glibc
```
And if on `armv7l` do this.
```
LD_LIBRARY_PATH=/usr/lib /usr/bin/curl -Ls https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.32-2_armv7l/glibc-2.32-2-chromeos-armv7l.tpxz -o /tmp/glibc-2.32-2-chromeos-armv7l.tpxz
LD_LIBRARY_PATH=/usr/lib tar -Ipixz -xf /tmp/glibc-2.32-2-chromeos-armv7l.tpxz --exclude=dlist --exclude=filelist -C /
crew postinstall glibc ; crew postinstall glibc
```

