### PR TITLE
Add zstd to install.sh BOOTSTRAP_PACKAGES and rsync deps

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 ARCH="${ARCH/armv8l/armv7l}"
 
 # BOOTSTRAP_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
-BOOTSTRAP_PACKAGES="pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl rsync ruby"
+BOOTSTRAP_PACKAGES="pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd rsync ruby"
 
 RED='\e[1;91m';    # Use Light Red for errors.
 YELLOW='\e[1;33m'; # Use Yellow for informational messages.

--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -26,6 +26,7 @@ class Rsync < Package
   depends_on 'xxhash'
   depends_on 'lz4'
   depends_on 'popt'
+  depends_on 'zstd'
 
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \


### PR DESCRIPTION
Fixes install issue with rsync complaining about a missing `libzstd.so.1`:

<img width="831" alt="Screen Shot 2022-01-25 at 1 40 15 PM" src="https://user-images.githubusercontent.com/1096701/151039303-3c8c5972-f27b-49c5-a723-c4bdfb460336.png">

- Adds `zstd` to `BOOTSTRAP_PACKAGES` in `install.sh`
- Adds `zstd` to the deps for `rsync`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=zstd_install.sh CREW_TESTING=1 crew update
```
