### PR TITLE
add mold linker package and deps

### DIFF
--- a/packages/hwloc.rb
+++ b/packages/hwloc.rb
@@ -1,0 +1,46 @@
+# Adapted from Arch Linux hwloc PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/hwloc/trunk/PKGBUILD
+
+require 'package'
+
+class Hwloc < Package
+  description 'Portable Hardware Locality is a portable abstraction of hierarchical architectures'
+  homepage 'https://www.open-mpi.org/projects/hwloc/'
+  version '2.7.0'
+  compatibility 'all'
+  source_url 'https://github.com/open-mpi/hwloc.git'
+  git_hashtag "hwloc-#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/hwloc/2.7.0_armv7l/hwloc-2.7.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/hwloc/2.7.0_armv7l/hwloc-2.7.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/hwloc/2.7.0_i686/hwloc-2.7.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/hwloc/2.7.0_x86_64/hwloc-2.7.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'd08caff4ec00dcb51f41b021341619aa1c4739fffcab3c6f106eb18682542c33',
+     armv7l: 'd08caff4ec00dcb51f41b021341619aa1c4739fffcab3c6f106eb18682542c33',
+       i686: 'e2def1fa639efd0e9cafaba06662cc7adc82b3234f148617314b768c77035565',
+     x86_64: 'f565d3fd29a314c2bbebffee5d993b28b2c918e70d37bf4dbc38638628ded810'
+  })
+
+  depends_on 'libtool'
+  depends_on 'libpciaccess'
+  depends_on 'cairo' => ':build'
+  depends_on 'libxml2' => ':build'
+  depends_on 'pciutils' => ':build'
+
+  def self.build
+    system './autogen.sh'
+    system 'filefix'
+    system "#{CREW_ENV_OPTIONS} ./configure \
+      #{CREW_OPTIONS} \
+      --enable-plugins \
+      --sysconfdir=#{CREW_PREFIX}/etc"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/mimalloc.rb
+++ b/packages/mimalloc.rb
@@ -1,0 +1,42 @@
+# Adapted from Arch Linux mimalloc PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/mimalloc/trunk/PKGBUILD
+
+require 'package'
+
+class Mimalloc < Package
+  description 'General-purpose allocator with excellent performance characteristics'
+  homepage 'https://github.com/microsoft/mimalloc'
+  version '2.0.3'
+  compatibility 'all'
+  source_url 'https://github.com/microsoft/mimalloc.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mimalloc/2.0.3_armv7l/mimalloc-2.0.3-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mimalloc/2.0.3_armv7l/mimalloc-2.0.3-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mimalloc/2.0.3_i686/mimalloc-2.0.3-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mimalloc/2.0.3_x86_64/mimalloc-2.0.3-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'd9c85c5b382e541e381d9377a3b79c21aa7218b61eb737aeb006ec4fb59f1138',
+     armv7l: 'd9c85c5b382e541e381d9377a3b79c21aa7218b61eb737aeb006ec4fb59f1138',
+       i686: '3116831532dee7c13bccc0e8a8edf20586486ddffb34c301692bb2b7b25deb47',
+     x86_64: 'e95daf94c2b590a11b56063375a2b6b92e437dffd737ee726dd11aea3b18af3a'
+  })
+
+  def self.build
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+      -DMI_INSTALL_TOPLEVEL=ON \
+      -DMI_USE_CXX=ON \
+      -DMI_BUILD_TESTS=OFF \
+      ../ -G Ninja"
+    end
+    system 'samu -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+end

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -1,0 +1,44 @@
+# Adapted from Arch Linux mold PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/mold/trunk/PKGBUILD
+
+require 'package'
+
+class Mold < Package
+  description 'A Modern Linker'
+  homepage 'https://github.com/rui314/mold'
+  version '1.0.2'
+  compatibility 'all'
+  source_url 'https://github.com/rui314/mold.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.0.2_i686/mold-1.0.2-chromeos-i686.tpxz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.0.2_armv7l/mold-1.0.2-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.0.2_armv7l/mold-1.0.2-chromeos-armv7l.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.0.2_x86_64/mold-1.0.2-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+       i686: 'ed41e4e4ac350f821d7c0eed871a8970d7b39f4cf0f0c74078de357d3befa11a',
+    aarch64: 'e2b5d700b6915c10c677054f2b1e2191111468eaeeb4ac7b5d514382dcedb9c6',
+     armv7l: 'e2b5d700b6915c10c677054f2b1e2191111468eaeeb4ac7b5d514382dcedb9c6',
+     x86_64: '345bac27ef1f3323e33ad52efb13c9fe83a5cbea228ee882eb7059931bf936bc'
+  })
+
+  depends_on 'mimalloc'
+  depends_on 'tbb'
+  depends_on 'xxhash' => ':build'
+
+  def self.patch
+    system "sed -i 's,PREFIX = /usr/local,PREFIX = #{CREW_PREFIX},g' Makefile"
+    system "sed -i 's,LIBDIR = \$(PREFIX)/lib,LIBDIR = #{CREW_LIB_PREFIX},g' Makefile"
+  end
+
+  def self.build
+    system "LTO=1 SYSTEM_MIMALLOC=1 SYSTEM_TBB=1 \
+      #{CREW_OPTIONS.sub(/--program-prefix=.*/, '').gsub('--', '')} make #{CREW_ENV_OPTIONS}"
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/tbb.rb
+++ b/packages/tbb.rb
@@ -1,0 +1,50 @@
+# Adapted from Arch Linux tbb PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/tbb/trunk/PKGBUILD
+
+require 'package'
+
+class Tbb < Package
+  description 'High level abstract threading library'
+  homepage 'https://www.threadingbuildingblocks.org/'
+  version '2021.5.0'
+  compatibility 'all'
+  source_url 'https://github.com/oneapi-src/oneTBB.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tbb/2021.5.0_armv7l/tbb-2021.5.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tbb/2021.5.0_armv7l/tbb-2021.5.0-chromeos-armv7l.tpxz',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tbb/2021.5.0_i686/tbb-2021.5.0-chromeos-i686.tpxz',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tbb/2021.5.0_x86_64/tbb-2021.5.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'f4e39ecbe901b49bc1923cc10b136b5fd01f5c73148d5d15a4dc78455ad80a07',
+     armv7l: 'f4e39ecbe901b49bc1923cc10b136b5fd01f5c73148d5d15a4dc78455ad80a07',
+    i686: '7c3f26b5adca0413f399967769810420a00472f96189b98d9f474545da1f8086',
+  x86_64: 'e74dd3ba705401c6aba67c459a3522712c56aaacb0768312ddaeb5e5a257f04b'
+  })
+
+  depends_on 'hwloc'
+  depends_on 'swig' => ':build'
+
+  def self.build
+    @tbb_cmake_options = if ARCH == 'i686'
+                           CREW_CMAKE_OPTIONS.gsub("_FLAGS='-O2",
+                                                   "_FLAGS='-O2 -mwaitpkg")
+                         else
+                           CREW_CMAKE_OPTIONS
+                         end
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake #{@tbb_cmake_options} \
+      -DTBB4PY_BUILD=ON \
+      -DTBB_TEST=OFF \
+      ../ -G Ninja"
+    end
+    system 'samu -C builddir python_build all'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+end


### PR DESCRIPTION
- Mold is allegedly faster than gold & uses fallback to gold for `lto`, which it doesn't support yet.
- `-fuse-ld=mold` will be in gcc12
- this just adds the mold package.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686 (needs to be built on a machine with a 3.x kernel)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=mold CREW_TESTING=1 crew update
```
