### PR TITLE
polkit fixes for CVE-2021-4034

### DIFF
--- a/packages/duktape.rb
+++ b/packages/duktape.rb
@@ -9,7 +9,7 @@ class Duktape < Package
   version '2.6.0'
   compatibility 'all'
   license 'MIT'
-  source_url 'https://duktape.org/duktape-2.6.0.tar.xz'
+  source_url "https://duktape.org/duktape-#{version}.tar.xz"
   source_sha256 '96f4a05a6c84590e53b18c59bb776aaba80a205afbbd92b82be609ba7fe75fa7'
 
   binary_url({
@@ -48,7 +48,8 @@ class Duktape < Package
   end
 
   def self.install
-    system "install -Dm644 duktape.pc #{CREW_DEST_LIB_PREFIX}/pkgconfig/duktape.pc"
+    FileUtils.mkdir_p %W[#{CREW_DEST_LIB_PREFIX}/pkgconfig]
+    FileUtils.install 'duktape.pc', "#{CREW_DEST_LIB_PREFIX}/pkgconfig/duktape.pc", mode: 0o644
     system 'make install'
   end
 end

--- a/packages/duktape.rb
+++ b/packages/duktape.rb
@@ -6,10 +6,11 @@ require 'package'
 class Duktape < Package
   description 'Embeddable Javascript engine'
   homepage 'https://duktape.org/'
-  version '2.6.0'
+  @_ver = '2.6.0'
+  version @_ver
   compatibility 'all'
   license 'MIT'
-  source_url "https://duktape.org/duktape-#{version}.tar.xz"
+  source_url "https://duktape.org/duktape-#{@_ver}.tar.xz"
   source_sha256 '96f4a05a6c84590e53b18c59bb776aaba80a205afbbd92b82be609ba7fe75fa7'
 
   binary_url({
@@ -40,7 +41,7 @@ class Duktape < Package
 
       Name: duktape
       Description: Embeddable Javascript engine
-      Version: 2.6.0
+      Version: #{@_ver}
       Libs: -L\${libdir} -lduktape
       Cflags: -I\${includedir}
     DUKTAPEPCEOF

--- a/packages/duktape.rb
+++ b/packages/duktape.rb
@@ -1,0 +1,54 @@
+# Adapted from Arch Linux duktape PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/duktape/trunk/PKGBUILD
+
+require 'package'
+
+class Duktape < Package
+  description 'Embeddable Javascript engine'
+  homepage 'https://duktape.org/'
+  version '2.6.0'
+  compatibility 'all'
+  license 'MIT'
+  source_url 'https://duktape.org/duktape-2.6.0.tar.xz'
+  source_sha256 '96f4a05a6c84590e53b18c59bb776aaba80a205afbbd92b82be609ba7fe75fa7'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/duktape/2.6.0_armv7l/duktape-2.6.0-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/duktape/2.6.0_armv7l/duktape-2.6.0-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/duktape/2.6.0_i686/duktape-2.6.0-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/duktape/2.6.0_x86_64/duktape-2.6.0-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'c734d031be824d9bdaa17efe89f88a527e585fdd4665ec406251d0451ad1b77f',
+     armv7l: 'c734d031be824d9bdaa17efe89f88a527e585fdd4665ec406251d0451ad1b77f',
+       i686: '5e4bfca44b948812f3f20730ff779c7d92358dca39e958105a011cbb856069da',
+     x86_64: '5f5787b8f9893d2b838e41c9391022f7fd9f0f7bacf45059b40e061ec7654ed1'
+  })
+
+  depends_on 'setconf' => ':build'
+
+  def self.build
+    FileUtils.mv 'Makefile.sharedlibrary', 'Makefile'
+    system "sed -i 's/-Wall -Wextra/$(CFLAGS) -D DUK_USE_FASTINT -w/g' Makefile"
+    system "sed -i 's,$(INSTALL_PREFIX)/lib,#{CREW_DEST_LIB_PREFIX},g' Makefile"
+    system "setconf Makefile INSTALL_PREFIX #{CREW_DEST_PREFIX}"
+    @duktapepc = <<~DUKTAPEPCEOF
+      prefix=#{CREW_PREFIX}
+      exec_prefix=\${prefix}
+      libdir=#{CREW_LIB_PREFIX}
+      includedir=\${prefix}/include
+
+      Name: duktape
+      Description: Embeddable Javascript engine
+      Version: 2.6.0
+      Libs: -L\${libdir} -lduktape
+      Cflags: -I\${includedir}
+    DUKTAPEPCEOF
+    File.write('duktape.pc', @duktapepc)
+  end
+
+  def self.install
+    system "install -Dm644 duktape.pc #{CREW_DEST_LIB_PREFIX}/pkgconfig/duktape.pc"
+    system 'make install'
+  end
+end

--- a/packages/polkit.rb
+++ b/packages/polkit.rb
@@ -3,35 +3,42 @@ require 'package'
 class Polkit < Package
   description 'Application development toolkit for controlling system-wide privileges'
   homepage 'https://www.freedesktop.org/wiki/Software/polkit/'
-  version '0.120-7a99b'
+  version '0.120-a2bf5c'
   license 'LGPL-2'
   compatibility 'all'
-  source_url 'https://gitlab.freedesktop.org/xry111/polkit.git'
-  git_branch 'xry111/js91'
-  git_hashtag '7a99b67429b48357b36d29b3b650783af4b51ac1'
+  source_url 'https://gitlab.freedesktop.org/polkit/polkit.git'
+  git_hashtag 'a2bf5c9c83b6ae46cbd5c779d3055bff81ded683'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/polkit/0.120-7a99b_armv7l/polkit-0.120-7a99b-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/polkit/0.120-7a99b_armv7l/polkit-0.120-7a99b-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/polkit/0.120-7a99b_i686/polkit-0.120-7a99b-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/polkit/0.120-7a99b_x86_64/polkit-0.120-7a99b-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/polkit/0.120-a2bf5c_armv7l/polkit-0.120-a2bf5c-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/polkit/0.120-a2bf5c_armv7l/polkit-0.120-a2bf5c-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/polkit/0.120-a2bf5c_i686/polkit-0.120-a2bf5c-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/polkit/0.120-a2bf5c_x86_64/polkit-0.120-a2bf5c-chromeos-x86_64.tpxz'
   })
   binary_sha256({
-    aarch64: '41b4b9c4dc68b2f1960f571f09632422187fb3d726fccf90fe48e48539564e4c',
-     armv7l: '41b4b9c4dc68b2f1960f571f09632422187fb3d726fccf90fe48e48539564e4c',
-       i686: 'dc377359a5b4c77cd0fa429ff11134614b5c6766cb55dfbf85b4a3bcb29ba77c',
-     x86_64: 'ced0c15bbae3c494e287a217268fd5cb62e133d71a347b6d8224392f96c2d43f'
+    aarch64: '64f33f2ac0ab70d6aef5e1678bd83a5dbd9487ae50641402ffc5bd049409b4bf',
+     armv7l: '64f33f2ac0ab70d6aef5e1678bd83a5dbd9487ae50641402ffc5bd049409b4bf',
+       i686: 'd36368005afc56910018fbba79b8292aed5802db7fc8d9e6f593a3b81988292e',
+     x86_64: '7b775cbb16b44bde17a539955b33e14f97146ba10237ebeb01ec2ea700acafc7'
   })
 
-  depends_on 'js91'
+  depends_on 'duktape'
   depends_on 'elogind'
   depends_on 'gtk_doc' => :build
   depends_on 'gobject_introspection' => :build
+
+  def self.patch
+    # Fix meson 0.60+ compatibility
+    system 'curl -OLf https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/99.patch'
+    system 'patch -F3 -Np1 -i 99.patch'
+  end
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
     -Dsession_tracking=libelogind \
     -Dsystemdsystemunitdir=#{CREW_PREFIX}/etc/elogind/ \
+    -Djs_engine=duktape \
+    -Dos_type=gentoo \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/polkit.rb
+++ b/packages/polkit.rb
@@ -29,7 +29,34 @@ class Polkit < Package
 
   def self.patch
     # Fix meson 0.60+ compatibility
-    system 'curl -OLf https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/99.patch'
+    # https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/99
+    @polkit_meson_patch = <<~'POLKIT_MESON_PATCH_HEREDOC'
+      diff --git a/actions/meson.build b/actions/meson.build
+      index 2abaaf3..1e3f370 100644
+      --- a/actions/meson.build
+      +++ b/actions/meson.build
+      @@ -1,7 +1,6 @@
+       policy = 'org.freedesktop.policykit.policy'
+
+       i18n.merge_file(
+      -  policy,
+         input: policy + '.in',
+         output: '@BASENAME@',
+         po_dir: po_dir,
+      diff --git a/src/examples/meson.build b/src/examples/meson.build
+      index c6305ab..8c18de5 100644
+      --- a/src/examples/meson.build
+      +++ b/src/examples/meson.build
+      @@ -1,7 +1,6 @@
+       policy = 'org.freedesktop.policykit.examples.pkexec.policy'
+
+       i18n.merge_file(
+      -  policy,
+         input: policy + '.in',
+         output: '@BASENAME@',
+         po_dir: po_dir,
+    POLKIT_MESON_PATCH_HEREDOC
+    File.write('99.patch', @polkit_meson_patch)
     system 'patch -F3 -Np1 -i 99.patch'
   end
 

--- a/packages/setconf.rb
+++ b/packages/setconf.rb
@@ -9,7 +9,7 @@ class Setconf < Package
   version '0.7.7'
   compatibility 'all'
   license 'GPL2'
-  source_url 'https://setconf.roboticoverlords.org/setconf-0.7.7.tar.xz'
+  source_url "https://setconf.roboticoverlords.org/setconf-#{version}.tar.xz"
   source_sha256 '19315574540b3181fec31a4059b9e058381e0192317f153d181e7e7e2aa84d86'
 
   binary_url({
@@ -28,7 +28,8 @@ class Setconf < Package
   depends_on 'python3'
 
   def self.install
-    system "install -Dm755 setconf.py #{CREW_DEST_PREFIX}/bin/setconf"
-    system "install -Dm644 setconf.1.gz #{CREW_DEST_MAN_PREFIX}/man1/setconf.1.gz"
+    FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/bin #{CREW_DEST_MAN_PREFIX}/man1]
+    FileUtils.install 'setconf.py', "#{CREW_DEST_PREFIX}/bin/setconf", mode: 0o755
+    FileUtils.install 'setconf.1.gz', "#{CREW_DEST_MAN_PREFIX}/man1/setconf.1.gz", mode: 0o644
   end
 end

--- a/packages/setconf.rb
+++ b/packages/setconf.rb
@@ -1,0 +1,34 @@
+# Adapted from Arch Linux setconf PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/setconf/trunk/PKGBUILD
+
+require 'package'
+
+class Setconf < Package
+  description 'Utility for easily changing settings in configuration files'
+  homepage 'https://setconf.roboticoverlords.org/'
+  version '0.7.7'
+  compatibility 'all'
+  license 'GPL2'
+  source_url 'https://setconf.roboticoverlords.org/setconf-0.7.7.tar.xz'
+  source_sha256 '19315574540b3181fec31a4059b9e058381e0192317f153d181e7e7e2aa84d86'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/setconf/0.7.7_armv7l/setconf-0.7.7-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/setconf/0.7.7_armv7l/setconf-0.7.7-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/setconf/0.7.7_i686/setconf-0.7.7-chromeos-i686.tpxz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/setconf/0.7.7_x86_64/setconf-0.7.7-chromeos-x86_64.tpxz'
+  })
+  binary_sha256({
+    aarch64: 'd8106e68200d60bd648b24cf982e38e4a02b4ef06fc4f59b861925f1259e4788',
+     armv7l: 'd8106e68200d60bd648b24cf982e38e4a02b4ef06fc4f59b861925f1259e4788',
+       i686: 'ae85bdab10a698f6bfed275dc4b6cb560efcfc83d96ceb91035fc27a96e4911e',
+     x86_64: '152a3f9c7d5a4a7a505913cef5dec91820427faf5a50096c4f42fc36b27e1398'
+  })
+
+  depends_on 'python3'
+
+  def self.install
+    system "install -Dm755 setconf.py #{CREW_DEST_PREFIX}/bin/setconf"
+    system "install -Dm644 setconf.1.gz #{CREW_DEST_MAN_PREFIX}/man1/setconf.1.gz"
+  end
+end


### PR DESCRIPTION
- Fix for [CVE-2021-4034](https://www.qualys.com/2022/01/25/cve-2021-4034/pwnkit.txt) 
- removed `js_` dep and replaced with `duktape` and its build dep `setconf`

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=polkit CREW_TESTING=1 crew update
```
