### PR TITLE
Add memory lower limit for using pixz for package compression

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1435,9 +1435,8 @@ end
 
 def archive_package(pwd)
   @ramfree = %x(free).split(" ")[7]
-  # Set minimum ram for running pixz to be ~ 8Gb. (This number is just
-  # below that on a RPI4B used for building armv7l packages.)
-  unless @ramfree < '7999000' || CREW_NOT_USE_PIXZ || !File.exist?("#{CREW_PREFIX}/bin/pixz")
+  # Set minimum ram for running pixz to be ~ 4 Gb.
+  unless @ramfree < '3999500' || CREW_NOT_USE_PIXZ || !File.exist?("#{CREW_PREFIX}/bin/pixz")
     puts "Using pixz to compress archive."
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tpxz"
     Dir.chdir CREW_DEST_DIR do

--- a/bin/crew
+++ b/bin/crew
@@ -1434,7 +1434,10 @@ def build_package(pwd)
 end
 
 def archive_package(pwd)
-  unless CREW_NOT_USE_PIXZ || !File.exist?("#{CREW_PREFIX}/bin/pixz")
+  @ramfree = %x(free).split(" ")[7]
+  # Set minimum ram for running pixz to be ~ 8Gb. (This number is just
+  # below that on a RPI4B used for building armv7l packages.)
+  unless @ramfree < '7999000' || CREW_NOT_USE_PIXZ || !File.exist?("#{CREW_PREFIX}/bin/pixz")
     puts "Using pixz to compress archive."
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tpxz"
     Dir.chdir CREW_DEST_DIR do

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.22.1'
+CREW_VERSION = '1.22.2'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- Fixes issue with `pixz` failing to compress on systems with less ram
- Solution is to just avoid using `pixz` for compression on such systems.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=pixz_ram_check CREW_TESTING=1 crew update
```
