### PR TITLE
Fix CREW_ESSENTIAL_FILES algorithm, and update zstd packages to 1.5.2, …

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1012,9 +1012,9 @@ def prepare_package(destdir)
 
     strip_dir destdir
 
-    # Use patchelf to set need paths for all binaries
-    # currently broken due to glibc issue on armv7l
-    unless %w[aarch64 armv7l].include?(ARCH)
+    # Use patchelf to set need paths for all binaries.
+    # Currently broken with glibc on armv7l, but musl is fine.
+    unless %w[aarch64 armv7l].include?(ARCH) and !@pkg.is_musl?
       patchelf_set_need_paths destdir
     end
 
@@ -1525,16 +1525,28 @@ def remove(pkgName)
     return
   end
 
+  # Preserve CREW_ESSENTIAL_FILES and make sure they are real files
+  # and not symlinks, because preserving symlinked libraries does not
+  # prevent breakage.
+  CREW_ESSENTIAL_FILES.each do |file|
+    next if !File.symlink?("#{CREW_LIB_PREFIX}/#{file}")
+
+    @canonicalized_file = `readlink -m #{CREW_LIB_PREFIX}/#{file}`.chomp
+    if File.exist?(@canonicalized_file) and @canonicalized_file.include?(CREW_PREFIX)
+      puts "Replacing symlinked essential #{file} with hard link to #{@canonicalized_file} to avoid breakage.".lightblue if @opt_verbose
+      FileUtils.ln(@canonicalized_file, "#{CREW_LIB_PREFIX}/#{file}", force: true)
+    end
+  end
   #if the filelist exists, remove the files and directories installed by the package
   if File.file?("#{CREW_META_PATH}#{pkgName}.filelist")
     Dir.chdir CREW_CONFIG_PATH do
       #remove all files installed by the package
       File.foreach("meta/#{pkgName}.filelist", chomp: true) do |line|
-        # Do not remove essential files from gcc or libssp which ruby
-        # relies on, especially during package upgrades or reinstalls.
+        # Do not remove essential files which crew (and dependencies)
+        # rely on, especially during package upgrades or reinstalls.
         # These essential files are enumerated in const.rb as
         # CREW_ESSENTIAL_FILES.
-        if CREW_ESSENTIAL_FILES.include?(line)
+        if CREW_ESSENTIAL_FILES.include?(File.basename(line))
           if @opt_verbose
             puts "Removing #{line} will break crew. It was " +
                  'NOT'.lightred + ' deleted.'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -222,3 +222,4 @@ CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
 # libatomic is in the gcc package
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten
+CREW_ESSENTIAL_FILES.uniq!

--- a/packages/musl_zstd.rb
+++ b/packages/musl_zstd.rb
@@ -17,8 +17,8 @@ class Musl_zstd < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2_x86_64/musl_zstd-1.5.2-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '3cef255a8af0fa12e19e7d91f9b14e4d3c57fd73415f651d5dfc1d78a2d573a9',
-     armv7l: '3cef255a8af0fa12e19e7d91f9b14e4d3c57fd73415f651d5dfc1d78a2d573a9',
+    aarch64: '926bd2feb65c37b05d220628368a01ae723c5062d4d9fef4838be7b6a55ace29',
+     armv7l: '926bd2feb65c37b05d220628368a01ae723c5062d4d9fef4838be7b6a55ace29',
        i686: '3f0adecdbc55e1c2114ff1013d21da3c11c468a28e5a28dfb54620ba54ea4f36',
      x86_64: '5a96064ca69ee5db65b6961f795a239f83ac5cbca16acea2b59a6f7472d54eb3'
   })

--- a/packages/zstd.rb
+++ b/packages/zstd.rb
@@ -3,7 +3,7 @@ require 'package'
 class Zstd < Package
   description 'Zstandard - Fast real-time compression algorithm'
   homepage 'http://www.zstd.net'
-  @_ver = '1.5.1'
+  @_ver = '1.5.2'
   version @_ver
   license 'BSD or GPL-2'
   compatibility 'all'
@@ -11,17 +11,19 @@ class Zstd < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.1_armv7l/zstd-1.5.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.1_armv7l/zstd-1.5.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.1_i686/zstd-1.5.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.1_x86_64/zstd-1.5.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.2_armv7l/zstd-1.5.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.2_armv7l/zstd-1.5.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.2_i686/zstd-1.5.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.2_x86_64/zstd-1.5.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '65798a76e98605c8dc68c646fafed3df6bab54cff68efd14f0bdfff847f1212a',
-     armv7l: '65798a76e98605c8dc68c646fafed3df6bab54cff68efd14f0bdfff847f1212a',
-       i686: '33c872308e4766f78c7cd038822c3e70950cf6051b68f18e574948fe19439f04',
-     x86_64: 'bbfd450202fba5e1eaf3b190086ceb9f2eccdb8691cb93387de2467aabd9898b'
+    aarch64: 'dcf0cc629f47f5e7ce23ef73948a859bdc8383b542ed6f6eb7689ced2541280a',
+     armv7l: 'dcf0cc629f47f5e7ce23ef73948a859bdc8383b542ed6f6eb7689ced2541280a',
+       i686: 'f2f95e2d6855b4591c8defe17f2e738d2cb6140af0245f005aa7889addba055f',
+     x86_64: '6829742f7ba7362ad22539c914ec114acfd52d78f755f5c057902e2924dbef1f'
   })
+
+  depends_on 'musl_zstd'
 
   def self.build
     Dir.chdir 'build/cmake' do
@@ -32,15 +34,20 @@ class Zstd < Package
         -DZSTD_BUILD_SHARED=ON \
         -DZSTD_LEGACY_SUPPORT=ON \
         -DZSTD_BUILD_CONTRIB=ON \
+        -DZSTD_PROGRAMS_LINK_SHARED=OFF \
         ../ -G Ninja"
       end
-      system 'ninja -C builddir'
+      system 'samu -C builddir'
     end
   end
 
   def self.install
     Dir.chdir 'build/cmake' do
-      system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+      system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+    end
+    # Convert symlinks to hard links in libdir.
+    Dir.chdir CREW_DEST_LIB_PREFIX do
+      system "find -type l -exec bash -c 'ln -f \"\$(readlink -m \"\$0\")\" \"\$0\"' {} \\\;"
     end
   end
 end


### PR DESCRIPTION
- Fix `CREW_ESSENTIAL_FILES` algorithm (don't break during upgrades)
- update `zstd` packages to 1.5.2
- fix armv7l `musl_zstd` package (use patchelf to set musl libc.so dependency)
- make `musl_zstd` a dependency of `zstd` to allow for a fallback.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=musl_fix CREW_TESTING=1 crew update
```