### PR TITLE
add more zstd & rsync fallback logic

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -824,8 +824,8 @@ def unpack(meta)
       if !File.exist?("#{CREW_PREFIX}/bin/tar") and %x[tar --version | head -n 1 | awk '{print $4}'] < '1.31'
         abort 'A newer version of tar may be needed for this install. Please install it first with \'crew install tar\''.lightred
       end
-      if !File.exist?("#{CREW_PREFIX}/bin/zstd")
-        abort 'zstd is needed for this install. Please install it first with \'crew install zstd\''.lightred
+      if !File.exist?("#{CREW_PREFIX}/bin/zstd") and !File.exist?("#{CREW_MUSL_PREFIX}/bin/zstd")
+        abort 'zstd is needed for this install. Please (re)install it first with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install zstd\''.lightred
       end
       puts "Unpacking archive using 'tar', this may take a while..."
       system "PATH=#{CREW_MUSL_PREFIX}/bin:\$PATH tar x#{@verbose}f #{meta[:filename]} -C #{@extract_dir}", exception: true
@@ -1205,17 +1205,16 @@ def install_package(pkgdir)
     end
 
     # check if the available rsync command support ACLs
-    rsync_available = File.exist?("#{CREW_PREFIX}/bin/rsync")
-    puts 'rsync is not working. Please install it with \'crew install rsync\''.lightred unless rsync_available
-
-    if Dir.exists? "#{pkgdir}/#{HOME}" then
+      rsync_available = true if `#{CREW_PREFIX}/bin/rsync --version`.include? 'rsync  version'
+      puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available
+    if Dir.exist? "#{pkgdir}/#{HOME}" then
       if rsync_available
         system "rsync -ahHAXW --remove-source-files ./#{HOME.delete_prefix('/')}/ #{HOME}"
       else
         system "tar -c#{@verbose}f - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
       end
     end
-    if Dir.exists? "#{pkgdir}/usr/local" then
+    if Dir.exist? "#{pkgdir}/usr/local" then
       if rsync_available
         # Adjust "./usr/local" if the build CREW_PREFIX ever changes.
         system "rsync -ahHAXWx --remove-source-files ./usr/local/ #{CREW_PREFIX}"
@@ -1223,7 +1222,7 @@ def install_package(pkgdir)
         system "tar -c#{@verbose}f - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
       end
     end
-    if Dir.exists? "#{pkgdir}/#{CREW_PREFIX}"
+    if Dir.exist? "#{pkgdir}/#{CREW_PREFIX}"
       if rsync_available
         # Adjust "./usr/local" if the build CREW_PREFIX ever changes.
         system "rsync -ahHAXWx --remove-source-files ./#{CREW_PREFIX}/ #{CREW_PREFIX}"

--- a/bin/crew
+++ b/bin/crew
@@ -1205,8 +1205,8 @@ def install_package(pkgdir)
     end
 
     # check if the available rsync command support ACLs
-      rsync_available = true if `#{CREW_PREFIX}/bin/rsync --version`.include? 'rsync  version'
-      puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available
+    rsync_available = true if `#{CREW_PREFIX}/bin/rsync --version`.include? 'rsync  version'
+    puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available
     if Dir.exist? "#{pkgdir}/#{HOME}" then
       if rsync_available
         system "rsync -ahHAXW --remove-source-files ./#{HOME.delete_prefix('/')}/ #{HOME}"

--- a/install.sh
+++ b/install.sh
@@ -217,10 +217,16 @@ function extract_install () {
 
     #extract and install
     echo_intra "Extracting ${1} ..."
-    if ! LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} pixz -h &> /dev/null; then
-      tar xpf ../"${2}"
+    if [[ "$2" == *".zst" ]];then
+      LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Izstd -xpf ../"${2}"
+    elif [[ "$2" == *".tpxz" ]];then
+      if ! LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} pixz -h &> /dev/null; then
+        tar xpf ../"${2}"
+      else
+        LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Ipixz -xpf ../"${2}"
+      fi
     else
-      LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Ipixz -xpf ../"${2}"
+      tar xpf ../"${2}"
     fi
     echo_intra "Installing ${1} ..."
     tar cpf - ./*/* | (cd /; tar xp --keep-directory-symlink -f -)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.22.5'
+CREW_VERSION = '1.22.6'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- rsync in crew needed a better algorithm to check if it worked.
- Added more verbose error messages to ensure successful recovery from a missing `libzstd.so.1`.
- Fixed `.zst` handling in `install.sh`

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=zstd_fallback CREW_TESTING=1 crew update
```
