### PR TITLE
fix musl_native_toolchain postinstall for i686

### DIFF
--- a/packages/musl_native_toolchain.rb
+++ b/packages/musl_native_toolchain.rb
@@ -106,7 +106,7 @@ class Musl_native_toolchain < Package
     return unless ARCH == 'i686'
 
     # perl needs this.
-    FileUtils.ln_s "#{CREW_MUSL_PREFIX}/#{@target_tuple}/include/locale.h",
-                   "#{CREW_MUSL_PREFIX}/#{@target_tuple}/include/xlocale.h"
+    FileUtils.ln_sf "#{CREW_MUSL_PREFIX}/#{@target_tuple}/include/locale.h",
+                    "#{CREW_MUSL_PREFIX}/#{@target_tuple}/include/xlocale.h"
   end
 end


### PR DESCRIPTION
- need to force symlink creation in the i686 postinstall to prevent upgrades of the package from breaking.

Works properly:
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=musl_native_fix CREW_TESTING=1 crew update
```
