### PR TITLE
crew: Add more robustness against zstd breakage

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -821,14 +821,26 @@ def unpack(meta)
       puts "Unpacking archive using 'tar', this may take a while..."
       system "tar x#{@verbose}f #{meta[:filename]} -C #{@extract_dir}", exception: true
     when /\.tar\.zst$/i
-      if !File.exist?("#{CREW_PREFIX}/bin/tar") and %x[tar --version | head -n 1 | awk '{print $4}'] < '1.31'
-        abort 'A newer version of tar may be needed for this install. Please install it first with \'crew install tar\''.lightred
+      # Check to see that there is a working zstd
+      if File.exist?("#{CREW_PREFIX}/bin/zstd")
+        @crew_prefix_zstd_available = `#{CREW_PREFIX}/bin/zstd --version`.include?('zstd command line interface') ? true : nil
       end
-      if !File.exist?("#{CREW_PREFIX}/bin/zstd") and !File.exist?("#{CREW_MUSL_PREFIX}/bin/zstd")
+      if File.exist?("#{CREW_MUSL_PREFIX}/bin/zstd")
+        @crew_musl_prefix_zstd_available = `#{CREW_MUSL_PREFIX}/bin/zstd --version`.include?('zstd command line interface') ? true : nil
+      end
+      unless @crew_prefix_zstd_available or @crew_musl_prefix_zstd_available
         abort 'zstd is needed for this install. Please (re)install it first with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install zstd\''.lightred
       end
       puts "Unpacking archive using 'tar', this may take a while..."
-      system "PATH=#{CREW_MUSL_PREFIX}/bin:\$PATH tar x#{@verbose}f #{meta[:filename]} -C #{@extract_dir}", exception: true
+      # Use the zstd found to be working. This should correct for
+      # situations where the libzstd library is unavailable.
+      if @crew_prefix_zstd_available
+        puts "Using standard zstd".lightblue if @opt_verbose
+        system "tar -Izstd -x#{@verbose}f #{meta[:filename]} -C #{@extract_dir}", exception: true
+      elsif @crew_musl_prefix_zstd_available
+        puts "Using musl zstd".lightblue if @opt_verbose
+        system "PATH=#{CREW_MUSL_PREFIX}/bin:\$PATH tar -Izstd -x#{@verbose}f #{meta[:filename]} -C #{@extract_dir}", exception: true
+      end
     when /\.deb$/i
       puts "Unpacking '.deb' archive, this may take a while..."
       DebUtils::extract_deb(meta[:filename], /data\..*/)

--- a/bin/crew
+++ b/bin/crew
@@ -1508,7 +1508,14 @@ def build_package(pwd)
 end
 
 def archive_package(pwd)
-  unless %x[tar --version | head -n 1 | awk '{print $4}'] < '1.31' || !File.exist?("#{CREW_PREFIX}/bin/zstd") || @pkg.no_zstd?
+  # Check to see that there is a working zstd
+  if File.exist?("#{CREW_PREFIX}/bin/zstd")
+    @crew_prefix_zstd_available = `#{CREW_PREFIX}/bin/zstd --version`.include?('zstd command line interface') ? true : nil
+  end
+  if File.exist?("#{CREW_MUSL_PREFIX}/bin/zstd")
+    @crew_musl_prefix_zstd_available = `#{CREW_MUSL_PREFIX}/bin/zstd --version`.include?('zstd command line interface') ? true : nil
+  end
+  unless @pkg.no_zstd? || (!@crew_prefix_zstd_available && !@crew_musl_prefix_zstd_available)
     puts "Using zstd to compress package. This may take some time.".lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.zst"
     Dir.chdir CREW_DEST_DIR do
@@ -1516,7 +1523,13 @@ def archive_package(pwd)
       # decompression speed over compression speed.
       # See https://lists.archlinux.org/pipermail/arch-dev-public/2019-March/029542.html
       # Use nice so that user can (possibly) do other things during compression.
-      system "PATH=#{CREW_MUSL_PREFIX}/bin:\$PATH tar c#{@verbose} * | nice -n 20 zstd -c -T0 --ultra -20 - > #{pwd}/#{pkg_name}"
+      if @crew_prefix_zstd_available
+        puts "Using standard zstd".lightblue if @opt_verbose
+        system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{pwd}/#{pkg_name}"
+      elsif @crew_musl_prefix_zstd_available
+        puts "Using musl zstd".lightblue if @opt_verbose
+        system "tar c#{@verbose} * | nice -n 20 #{CREW_MUSL_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{pwd}/#{pkg_name}"
+      end
     end
   else
     puts "Using xz to compress package. This may take some time.".lightblue

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 ARCH="${ARCH/armv8l/armv7l}"
 
 # BOOTSTRAP_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
-BOOTSTRAP_PACKAGES="tar musl_zstd pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd rsync ruby"
+BOOTSTRAP_PACKAGES="musl_zstd pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd rsync ruby"
 
 # Add musl bin to path
 PATH=/usr/local/share/musl/bin:$PATH

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.22.6'
+CREW_VERSION = '1.22.7'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -218,8 +218,7 @@ PY_SETUP_INSTALL_OPTIONS = "#{PY_SETUP_INSTALL_OPTIONS_NO_SVEM} --single-version
 CREW_FIRST_PACKAGES = %w[libssh curl git pixz shared_mime_info]
 CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
 
-# libssp is in the libssp package
-# libatomic is in the gcc package
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
-                       `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten
+                       `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +
+                       %w[libzstd.so.1]
 CREW_ESSENTIAL_FILES.uniq!

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -126,4 +126,8 @@ class Buildessential < Package
   depends_on 'rdfind'
   depends_on 'symlinks'
   depends_on 'upx'
+
+  # Packages needed for compressing archives
+  depends_on 'zstd'
+
 end

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -119,10 +119,6 @@ class Buildessential < Package
   # Samurai
   #depends_on 'samurai'
 
-  # Tar
-  # Version > 1.30 needed for zstd support
-  depends_on 'tar' if ARCH == 'i686'
-
   # xorg protocol headers
   #depends_on 'xorg_proto'
 

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -75,7 +75,6 @@ class Core < Package
   depends_on 'ruby'
   depends_on 'slang'
   depends_on 'sqlite'
-  depends_on 'tar' if ARCH == 'i686'
   depends_on 'uchardet'
   depends_on 'unzip'
   depends_on 'xzutils'


### PR DESCRIPTION
- Handle edge case of `libzstd.so.1` missing causing tar to fail to extract `.tar.zst` packages (by adding to `const.rb`'s `CREW_ESSENTIAL_FILES`.
- Handle edge case of `#{CREW_PREFIX}/bin/zstd` working but `#{CREW_MUSL_PREFIX}/bin/zstd` being broken.
- Older versions of tar should work fine using `tar -Izstd` to extract `tar.zst` files so there is no longer a need to have the`tar` package in `buildessential`, `core`, or`install.sh`'s `BOOTSTRAP_PACKAGES`.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_tar_options CREW_TESTING=1 crew update
```