### PR TITLE
gstreamer -> 1.20.0

### DIFF
--- a/packages/cogl.rb
+++ b/packages/cogl.rb
@@ -27,7 +27,7 @@ class Cogl < Package
   depends_on 'mesa'
   depends_on 'pango'
   depends_on 'gdk_pixbuf'
-  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
   depends_on 'wayland'
   depends_on 'glib'
   depends_on 'gobject_introspection'

--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -33,7 +33,6 @@ class Evince < Package
   depends_on 'glib' # R
   depends_on 'gnome_desktop' # R
   depends_on 'gobject_introspection' => :build
-  depends_on 'gst_plugins_base' # R
   depends_on 'gstreamer' # R
   depends_on 'gtk3' # R
   depends_on 'gtk_doc' => :build

--- a/packages/freerdp.rb
+++ b/packages/freerdp.rb
@@ -28,7 +28,7 @@ class Freerdp < Package
   depends_on 'faad2'
   depends_on 'ffmpeg'
   depends_on 'gsm'
-  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
   depends_on 'libfdk_aac'
   depends_on 'linux_pam'
   depends_on 'pulseaudio'

--- a/packages/gst_editing_services.rb
+++ b/packages/gst_editing_services.rb
@@ -25,7 +25,6 @@ class Gst_editing_services < Package
 
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build
-  depends_on 'gst_plugins_base'
   depends_on 'gstreamer'
   depends_on 'gtk_doc' => :build
   depends_on 'pygobject' => :build

--- a/packages/gst_plugins_bad.rb
+++ b/packages/gst_plugins_bad.rb
@@ -3,81 +3,13 @@ require 'package'
 class Gst_plugins_bad < Package
   description 'Multimedia graph framework - bad plugins'
   homepage 'https://gstreamer.freedesktop.org/'
-  @_ver = '1.18.4'
+  @_ver = '1.20.0'
   version @_ver
   license 'LGPL-2'
   compatibility 'all'
-  source_url "https://github.com/GStreamer/gst-plugins-bad/archive/#{@_ver}.tar.gz"
-  source_sha256 '30178ddcabcf71faccca8808f402a6e02394dfe3f821e2abe7a1b397f01eeaed'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_bad/1.18.4_armv7l/gst_plugins_bad-1.18.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_bad/1.18.4_armv7l/gst_plugins_bad-1.18.4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_bad/1.18.4_i686/gst_plugins_bad-1.18.4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_bad/1.18.4_x86_64/gst_plugins_bad-1.18.4-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'd730e940fa02c687cf4a3a1ff7b9a2d6fa2a295525aa409fc63e589956a71b40',
-     armv7l: 'd730e940fa02c687cf4a3a1ff7b9a2d6fa2a295525aa409fc63e589956a71b40',
-       i686: 'ac42eaad61b8e7de0764ee7620eb95582c6d2b6a4451834de9d0245aaef5308d',
-     x86_64: 'a1ea51c581260ea4da46238533ec0a4e17d58b08e63800d5addbd4fed5500de2'
-  })
+  is_fake
 
-  depends_on 'cairo'
-  depends_on 'chromaprint' => :build
-  depends_on 'faad2'
-  depends_on 'glib'
-  depends_on 'gst_plugins_base'
   depends_on 'gstreamer'
-  depends_on 'lcms'
-  depends_on 'libass'
-  depends_on 'libdca' => :build
-  depends_on 'libdrm'
-  depends_on 'libdvdnav'
-  depends_on 'libdvdread'
-  depends_on 'libfdk_aac'
-  depends_on 'libgudev'
-  depends_on 'libmms'
-  depends_on 'librsvg'
-  depends_on 'libsndfile'
-  depends_on 'libusb'
-  depends_on 'libva'
-  depends_on 'libvdpau'
-  depends_on 'libwebp'
-  depends_on 'libx11'
-  depends_on 'mjpegtools'
-  depends_on 'openal'
-  depends_on 'openjpeg'
-  depends_on 'orc'
-  depends_on 'pango'
-  depends_on 'wayland'
 
-  def self.build
-    system "meson \
-      #{CREW_MESON_OPTIONS} \
-      -Ddirectfb=disabled \
-      -Ddoc=disabled \
-      -Dflite=disabled \
-      -Dgsm=disabled \
-      -Diqa=disabled \
-      -Dmagicleap=disabled \
-      -Dmsdk=disabled \
-      -Dopenh264=disabled \
-      -Dopenmpt=disabled \
-      -Dopenni2=disabled \
-      -Dopensles=disabled \
-      -Dtinyalsa=disabled \
-      -Dvoaacenc=disabled \
-      -Dvoamrwbenc=disabled \
-      -Dwasapi2=disabled \
-      -Dwasapi=disabled \
-      -Dgobject-cast-checks=disabled \
-      builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
 end

--- a/packages/gst_plugins_base.rb
+++ b/packages/gst_plugins_base.rb
@@ -3,66 +3,13 @@ require 'package'
 class Gst_plugins_base < Package
   description 'An essential, exemplary set of elements for GStreamer'
   homepage 'https://gstreamer.freedesktop.org/modules/gst-plugins-base.html'
-  @_ver = '1.18.4'
+  @_ver = '1.20.0'
   version @_ver
   license 'GPL-2+ and LGPL-2+'
   compatibility 'all'
-  source_url "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-#{@_ver}.tar.xz"
-  source_sha256 '29e53229a84d01d722f6f6db13087231cdf6113dd85c25746b9b58c3d68e8323'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_base/1.18.4_armv7l/gst_plugins_base-1.18.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_base/1.18.4_armv7l/gst_plugins_base-1.18.4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_base/1.18.4_i686/gst_plugins_base-1.18.4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_base/1.18.4_x86_64/gst_plugins_base-1.18.4-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '6fc2e6d6b63ab3c869a4d136f9eeb85f4334a0fb271fea43829e7f20a83a6d29',
-     armv7l: '6fc2e6d6b63ab3c869a4d136f9eeb85f4334a0fb271fea43829e7f20a83a6d29',
-       i686: '87a676cce612d50d26ce80f1a22c8c4c82caae930f5153d05e9332019418e172',
-     x86_64: '91f0cc7eab04f890592a0675cf8c7e59f163f1e6543c850778c17af134de9a05'
-  })
+  is_fake
 
-  depends_on 'alsa_lib'
-  depends_on 'cairo'
-  depends_on 'gdk_pixbuf'
-  depends_on 'glib'
-  depends_on 'graphene'
   depends_on 'gstreamer'
-  depends_on 'libdrm'
-  depends_on 'libglu'
-  depends_on 'libgudev'
-  depends_on 'libjpeg'
-  depends_on 'libogg'
-  depends_on 'libpng'
-  depends_on 'libtheora'
-  depends_on 'libvisual'
-  depends_on 'libvorbis'
-  depends_on 'libx11'
-  depends_on 'libxcb'
-  depends_on 'libxcomposite'
-  depends_on 'libxext'
-  depends_on 'libxshmfence'
-  depends_on 'libxv'
-  depends_on 'mesa'
-  depends_on 'opus'
-  depends_on 'pango'
-  depends_on 'wayland'
 
-  def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
-    -Dgst_debug=false \
-    -Dexamples=disabled \
-    builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
-
-  def self.check
-    # system 'make', 'check' # All the GL tests fail, as an X terminal is not running.
-  end
 end

--- a/packages/gst_plugins_good.rb
+++ b/packages/gst_plugins_good.rb
@@ -3,72 +3,10 @@ require 'package'
 class Gst_plugins_good < Package
   description 'Multimedia graph framework - good plugins'
   homepage 'https://gstreamer.freedesktop.org/'
-  @_ver = '1.18.4'
-  version "#{@_ver}-1"
-  license 'LGPL-2.1+'
+  @_ver = '1.20.0'
+  version @_ver
+  license 'LGPL-2'
   compatibility 'all'
-  source_url "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-#{@_ver}.tar.xz"
-  source_sha256 'b6e50e3a9bbcd56ee6ec71c33aa8332cc9c926b0c1fae995aac8b3040ebe39b0'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_good/1.18.4-1_armv7l/gst_plugins_good-1.18.4-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_good/1.18.4-1_armv7l/gst_plugins_good-1.18.4-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_good/1.18.4-1_i686/gst_plugins_good-1.18.4-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gst_plugins_good/1.18.4-1_x86_64/gst_plugins_good-1.18.4-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'c6bd8050a3c0f1b314c710a325211955179befb161ad265c6aeea8aec1e4f262',
-     armv7l: 'c6bd8050a3c0f1b314c710a325211955179befb161ad265c6aeea8aec1e4f262',
-       i686: '9d81667abfe65600e5b248de3c2de29ce6eb7f1e352929015c033809423324ea',
-     x86_64: '1ce70592cf499cda3a46f519db2ba479e0e8ca56acf43d44366b884d59b73487'
-  })
-
-  # L = Logical Dependency, R = Runtime Dependency
-  depends_on 'libjpeg' => :build
-  depends_on 'nasm' => :build
-  depends_on 'gst_plugins_base' # L
-  depends_on 'aalib' # R
-  depends_on 'cairo' # R
-  depends_on 'gdk_pixbuf' # R
-  depends_on 'glib' # R
-  depends_on 'gst_plugins_base' # R
-  depends_on 'gstreamer' # R
-  depends_on 'gtk3' # R
-  depends_on 'jack' # R
-  depends_on 'libavc1394' # R
-  depends_on 'libcaca' # R
-  depends_on 'libdv' # R
-  depends_on 'libgudev' # R
-  depends_on 'libiec61883' # R
-  depends_on 'libmp3lame' # R
-  depends_on 'libpng' # R
-  depends_on 'libraw1394' # R
-  depends_on 'libsoup2' # R
-  depends_on 'libvpx' # R
-  depends_on 'libx11' # R
-  depends_on 'libxdamage' # R
-  depends_on 'libxext' # R
-  depends_on 'libxfixes' # R
-  depends_on 'mpg123' # R
-  depends_on 'orc' # R
-  depends_on 'pipewire' # R
-  depends_on 'pulseaudio' # R
-  depends_on 'speex' # R
-  depends_on 'taglib' # R
-  depends_on 'v4l_utils' # R
-  depends_on 'wavpack' # R
-
-  def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} \
-      -Ddoc=disabled \
-      -Drpicamsrc=disabled \
-      -Dgobject-cast-checks=disabled \
-      builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  is_fake
 end

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -3,24 +3,24 @@ require 'package'
 class Gstreamer < Package
   description 'GStreamer is a library for constructing graphs of media-handling components.'
   homepage 'https://gstreamer.freedesktop.org/'
-  @_ver = '1.18.4'
+  @_ver = '1.20.0'
   version @_ver
   license 'LGPL-2+'
   compatibility 'all'
-  source_url "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-#{@_ver}.tar.xz"
-  source_sha256 '9aeec99b38e310817012aa2d1d76573b787af47f8a725a65b833880a094dfbc5'
+  source_url 'https://gitlab.freedesktop.org/gstreamer/gstreamer.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gstreamer/1.18.4_armv7l/gstreamer-1.18.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gstreamer/1.18.4_armv7l/gstreamer-1.18.4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gstreamer/1.18.4_i686/gstreamer-1.18.4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gstreamer/1.18.4_x86_64/gstreamer-1.18.4-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gstreamer/1.20.0_armv7l/gstreamer-1.20.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gstreamer/1.20.0_armv7l/gstreamer-1.20.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gstreamer/1.20.0_i686/gstreamer-1.20.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gstreamer/1.20.0_x86_64/gstreamer-1.20.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '6c9267fa671cd0127e8f677e211b3b260d79f85e865b7e9e98bdcfd726360e5a',
-     armv7l: '6c9267fa671cd0127e8f677e211b3b260d79f85e865b7e9e98bdcfd726360e5a',
-       i686: 'd38f98eeff929f20a089fa31fb8f39ab35dfef882b2179e68779488f22de88e1',
-     x86_64: '3754e3981352103d7f02b66ea1c8784e01317092c2f313462e9ac7dea7d1c288'
+    aarch64: '9a4806b7ec63fefdc4b5b6383b7b6be98b3b0099fb98cced7ba9e17243955583',
+     armv7l: '9a4806b7ec63fefdc4b5b6383b7b6be98b3b0099fb98cced7ba9e17243955583',
+       i686: '8cb9f9a360d5da37127c0117c413e85726f9479504919432f166527cea935d3b',
+     x86_64: '3fa6ddf28c4fd03777040377d482f224261b859b176fe2a803dc7433edd6dab0'
   })
 
   depends_on 'elfutils'
@@ -30,9 +30,16 @@ class Gstreamer < Package
   depends_on 'libcap'
   depends_on 'libunwind'
 
+  conflicts_ok # conflicts with orc, gst_plugins_{base,bad}
   def self.build
+    @plugins = ''
+    case ARCH
+    when 'i686'
+      @plugins = '-Dgst-plugins-bad:msdk=disabled'
+    end
     system "meson #{CREW_MESON_OPTIONS} \
-    -Dgst_debug=false \
+    -Dgpl=enabled \
+    -Dtests=disabled #{@plugins}\
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -51,8 +51,6 @@ class Gtk4 < Package
   depends_on 'gdk_pixbuf' # R
   depends_on 'glib' # R
   depends_on 'graphene' # R
-  depends_on 'gst_plugins_bad' # R
-  depends_on 'gst_plugins_base' # R
   depends_on 'gstreamer' # R
   depends_on 'harfbuzz' # R
   depends_on 'json_glib' # R

--- a/packages/libvips.rb
+++ b/packages/libvips.rb
@@ -34,7 +34,7 @@ class Libvips < Package
   depends_on 'librsvg'
   depends_on 'libtiff'
   depends_on 'libwebp'
-  depends_on 'orc'
+  depends_on 'gstreamer'
   depends_on 'poppler'
 
   def self.build

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -36,7 +36,6 @@ class Nautilus < Package
   depends_on 'gnome_autoar' # R
   depends_on 'gnome_desktop' # R
   depends_on 'gobject_introspection' => :build
-  depends_on 'gst_plugins_base' # R
   depends_on 'gstreamer' # R
   depends_on 'gtk3' # R
   depends_on 'gtk_doc' => :build

--- a/packages/orc.rb
+++ b/packages/orc.rb
@@ -7,33 +7,9 @@ class Orc < Package
   version @_ver
   license 'BSD and BSD-2'
   compatibility 'all'
-  source_url "https://github.com/GStreamer/orc/archive/#{@_ver}.tar.gz"
-  source_sha256 '6a7349d2ab4a73476cd4de36212e8c3c6524998081aaa04cf3a891ef792dd50f'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/orc/0.4.32_armv7l/orc-0.4.32-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/orc/0.4.32_armv7l/orc-0.4.32-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/orc/0.4.32_i686/orc-0.4.32-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/orc/0.4.32_x86_64/orc-0.4.32-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'f1454d82feafc44e7925e22d43ebce845536ce8931b939ea5a0098dbe0f78880',
-     armv7l: 'f1454d82feafc44e7925e22d43ebce845536ce8931b939ea5a0098dbe0f78880',
-       i686: '2782668ca3e7d98ea1c5034560fa2e734dc1f5fdd868944999eeaf164a03c5ec',
-     x86_64: '31c20cfc000b15c7bffceb6aec67bb337a7240eef8c62d74349cd553ed615b6d'
-  })
+  is_fake
 
-  depends_on 'valgrind' => :build
-  depends_on 'gtk_doc' => :build
+  depends_on 'gstreamer'
 
-  def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
-      builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
 end

--- a/packages/pidgin.rb
+++ b/packages/pidgin.rb
@@ -23,7 +23,7 @@ class Pidgin < Package
   })
 
   depends_on 'glib'
-  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
   depends_on 'gtk2'
   depends_on 'libidn2'
   depends_on 'sommelier'

--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -29,7 +29,6 @@ class Pipewire < Package
   depends_on 'eudev' # R
   depends_on 'glib' # R
   depends_on 'gsettings_desktop_schemas' => :build
-  depends_on 'gst_plugins_base' # R
   depends_on 'gstreamer' # R
   depends_on 'jack' # R
   depends_on 'libsndfile' # R

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -35,8 +35,6 @@ class Pulseaudio < Package
   depends_on 'glibc' # R
   depends_on 'glib' # R
   depends_on 'gsettings_desktop_schemas' # L
-  depends_on 'gst_plugins_base' # R
-  depends_on 'gstreamer' # R
   depends_on 'jack' # R
   depends_on 'jsonc' => :build
   depends_on 'libcap' # R
@@ -49,7 +47,7 @@ class Pulseaudio < Package
   depends_on 'libx11' # R
   depends_on 'libxcb' # R
   depends_on 'libxtst' # R
-  depends_on 'orc' # R
+  depends_on 'gstreamer' # R
   depends_on 'pipewire' # R
   depends_on 'speexdsp' # R
   depends_on 'tcpwrappers' => :build

--- a/packages/spice_gtk.rb
+++ b/packages/spice_gtk.rb
@@ -30,8 +30,7 @@ class Spice_gtk < Package
   depends_on 'libjpeg'
   depends_on 'opus'
   depends_on 'usbredir'
-  depends_on 'gst_plugins_base'
-  depends_on 'gst_plugins_good'
+  depends_on 'gstreamer'
   depends_on 'gobject_introspection' => :build
   depends_on 'py3_pygments' => :build
   depends_on 'py3_pygments' => :build

--- a/packages/tracker3_miners.rb
+++ b/packages/tracker3_miners.rb
@@ -29,7 +29,6 @@ class Tracker3_miners < Package
   depends_on 'exempi'
   depends_on 'giflib'
   depends_on 'glib'
-  depends_on 'gst_plugins_base'
   depends_on 'gstreamer'
   depends_on 'libcue'
   depends_on 'libexif'

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -33,7 +33,6 @@ class Webkit2gtk_4 < Package
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build
-  depends_on 'gst_plugins_base'
   depends_on 'gstreamer'
   depends_on 'gtk3'
   depends_on 'gtk_doc' => :build

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -33,7 +33,6 @@ class Webkit2gtk_5 < Package
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build
   depends_on 'graphene'
-  depends_on 'gst_plugins_base'
   depends_on 'gstreamer'
   depends_on 'gtk4'
   depends_on 'gtk_doc' => :build

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -39,7 +39,6 @@ class Weston < Package
   depends_on 'libwebp'
   depends_on 'libva'
   depends_on 'gstreamer'
-  depends_on 'gst_plugins_base'
   depends_on 'libwacom'
 
   def self.build

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -26,7 +26,6 @@ class Wine < Package
   depends_on 'alsa_lib'
   depends_on 'eudev'
   depends_on 'glib'
-  depends_on 'gst_plugins_base'
   depends_on 'gstreamer'
   depends_on 'lcms'
   depends_on 'libgphoto'

--- a/packages/wxwidgets.rb
+++ b/packages/wxwidgets.rb
@@ -21,7 +21,7 @@ class Wxwidgets < Package
      x86_64: 'fef36327456b2b3fe3aa73af54a028aef85bbd9e312f5ddce5954a8eb3900a22',
   })
 
-  depends_on 'gst_plugins_base'
+  depends_on 'gstreamer'
   depends_on 'libnotify'
   depends_on 'libsdl'
   depends_on 'libsecret'


### PR DESCRIPTION
- Replace `gst_plugins_{good,bad,base}` and `orc` with successor `gstreamer` package which builds all deps.

Builds properly:
- [x] x86_64
- [x] armv7l
- [x] i686
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gstreamer CREW_TESTING=1 crew update
```
