### PR TITLE
crew const: add MUSL_LIBC_VERSION if available

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.22.7'
+CREW_VERSION = '1.22.8'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -39,6 +39,7 @@ CREW_DEST_MAN_PREFIX = CREW_DEST_DIR + CREW_MAN_PREFIX
 # Put musl build dir under CREW_PREFIX/share/musl to avoid FHS incompatibility
 CREW_MUSL_PREFIX = CREW_PREFIX + '/share/musl'
 CREW_DEST_MUSL_PREFIX = CREW_DEST_DIR + CREW_MUSL_PREFIX
+MUSL_LIBC_VERSION = %x[#{CREW_MUSL_PREFIX}/lib/libc.so 2>&1 >/dev/null][/\bVersion\s+\K\S+/] || nil
 
 CREW_DEST_HOME = CREW_DEST_DIR + HOME
 


### PR DESCRIPTION
- Allows easy access to musl lib version, for use in versioning static libraries if necessary 
- if unavailable gets set to `nil`

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=musl CREW_TESTING=1 crew update
```
