### PR TITLE
dbus_glib => 0.112

### DIFF
--- a/packages/dbus_glib.rb
+++ b/packages/dbus_glib.rb
@@ -1,36 +1,23 @@
 require 'package'
 
 class Dbus_glib < Package
-  description 'The D-Bus GLib package contains GLib interfaces to the D-Bus API.'
-  homepage 'http://www.linuxfromscratch.org/blfs/view/svn/general/dbus-glib.html'
-  version '0.110'
+  description 'An obsolete, primarily unmaintained glib binding for libdbus.'
+  homepage 'https://dbus.freedesktop.org/doc/dbus-glib/index.html'
+  version '0.112'
   license 'GPL-2 or AFL-2.1'
   compatibility 'all'
-  source_url 'https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.110.tar.gz'
-  source_sha256 '7ce4760cf66c69148f6bd6c92feaabb8812dee30846b24cd0f7395c436d7e825'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus_glib/0.110_armv7l/dbus_glib-0.110-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus_glib/0.110_armv7l/dbus_glib-0.110-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus_glib/0.110_i686/dbus_glib-0.110-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus_glib/0.110_x86_64/dbus_glib-0.110-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '0845692e0819a80ebb4e6874dc707a07e619e12974aad74702709d7ac8840961',
-     armv7l: '0845692e0819a80ebb4e6874dc707a07e619e12974aad74702709d7ac8840961',
-       i686: '7ca87d44120d2bbe554e23aa71d01e4643002c77abc303e510feb8c9ea237f9f',
-     x86_64: 'be9ed1170dc5c36a905ecc3387e5cdea9d5c8eb597cf233936a5095bfb55107d',
-  })
+  source_url 'https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.112.tar.gz'
+  source_sha256 '7d550dccdfcd286e33895501829ed971eeb65c614e73aadb4a08aeef719b143a'
 
   depends_on 'dbus'
   depends_on 'glib'
 
   def self.build
-    system "./configure", "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
+    system "./configure #{CREW_OPTIONS}"
     system "make"
   end
 
   def self.install
-    system "make install DESTDIR=#{CREW_DEST_DIR}"
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/dbus_glib.rb
+++ b/packages/dbus_glib.rb
@@ -9,6 +9,19 @@ class Dbus_glib < Package
   source_url 'https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.112.tar.gz'
   source_sha256 '7d550dccdfcd286e33895501829ed971eeb65c614e73aadb4a08aeef719b143a'
 
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus_glib/0.112_armv7l/dbus_glib-0.112-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus_glib/0.112_armv7l/dbus_glib-0.112-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus_glib/0.112_i686/dbus_glib-0.112-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dbus_glib/0.112_x86_64/dbus_glib-0.112-chromeos-x86_64.tar.zst',
+  })
+  binary_sha256 ({
+    aarch64: 'dc2cea782f496613cd24b9f27afc015f5a02ebc73f63221f581c6bb5248bf8c9',
+     armv7l: 'dc2cea782f496613cd24b9f27afc015f5a02ebc73f63221f581c6bb5248bf8c9',
+       i686: 'c900b3a6e588fdea4219e52544e5c96718d0e3fcc3d862350efe9f71e3298fec',
+     x86_64: 'a1258d16b859c3ff11591871e97b8ad4ddb33ac45951931b196368a613451d76',
+  })
+
   depends_on 'dbus'
   depends_on 'glib'
 


### PR DESCRIPTION
builds on x86_64. needs binaries.

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=dbus_glib_0.112 CREW_TESTING=1 crew update
```