### PR TITLE
`nano` => 6.1

### DIFF
--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -3,25 +3,11 @@ require 'package'
 class Nano < Package
   description 'Nano\'s ANOther editor, an enhanced free Pico clone.'
   homepage 'https://www.nano-editor.org/'
-  @_ver = '5.8'
-  version @_ver
+  version '6.1'
   license 'GPL-3'
   compatibility 'all'
-  source_url "https://nano-editor.org/dist/v5/nano-#{@_ver}.tar.xz"
-  source_sha256 'e43b63db2f78336e2aa123e8d015dbabc1720a15361714bfd4b1bb4e5e87768c'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nano/5.8_armv7l/nano-5.8-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nano/5.8_armv7l/nano-5.8-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nano/5.8_i686/nano-5.8-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nano/5.8_x86_64/nano-5.8-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '23b77943e240929c4acf71ea4c0f40ef107524b6368bbcc35e8cc5f6bd751ee8',
-     armv7l: '23b77943e240929c4acf71ea4c0f40ef107524b6368bbcc35e8cc5f6bd751ee8',
-       i686: '0e21d468927c646e377e9aa848032b401eb7a6c160a564d45d4e809a7f20f8c7',
-     x86_64: '00651b1b81c2479b9b924325e5308530e49dacaa925f67903893347e8f295628'
-  })
+  source_url 'https://nano-editor.org/dist/v6/nano-6.1.tar.xz'
+  source_sha256 '3d57ec893fbfded12665b7f0d563d74431fc43abeaccacedea23b66af704db40'
 
   depends_on 'xdg_base'
 

--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -9,14 +9,28 @@ class Nano < Package
   source_url 'https://nano-editor.org/dist/v6/nano-6.1.tar.xz'
   source_sha256 '3d57ec893fbfded12665b7f0d563d74431fc43abeaccacedea23b66af704db40'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nano/6.1_armv7l/nano-6.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nano/6.1_armv7l/nano-6.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nano/6.1_i686/nano-6.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/nano/6.1_x86_64/nano-6.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '5e1c05739831b22109ff5b342e26b2a6060a4d7eedbf85429071717b0e68dc6e',
+     armv7l: '5e1c05739831b22109ff5b342e26b2a6060a4d7eedbf85429071717b0e68dc6e',
+       i686: '213937bceb48bdd1e96fcc7e658183ee835ea98218a279748a4479048d5a4a7c',
+     x86_64: 'ef01d254db458f10046ad8ca64e90d486242ca737a32736d2656598c998a5c56'
+  })
+
   depends_on 'xdg_base'
+  no_env_options
 
   def self.patch
     system "sed -i '/SIGWINCH/d' src/nano.c"
   end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} \
+    system "CFLAGS=-flto LDFLAGS=-static \
       ./configure #{CREW_OPTIONS} \
       --enable-threads=posix \
       --enable-nls \


### PR DESCRIPTION
Automatically generated by GitHub Actions CI workflow.

Build successfully with docker image: [`supechicken/cros-image-eve`](https://hub.docker.com/repository/docker/supechicken/cros-image-eve)

- `cat /etc/lsb-release`
```
CHROMEOS_ARC_ANDROID_SDK_VERSION=28
CHROMEOS_ARC_VERSION=7982014
CHROMEOS_AUSERVER=https://tools.google.com/service/update2
CHROMEOS_BOARD_APPID={01906EA2-3EB2-41F1-8F62-F0B7120EFD2E}
CHROMEOS_CANARY_APPID={90F229CE-83E2-4FAF-8479-E368A34938B1}
CHROMEOS_DEVSERVER=
CHROMEOS_RELEASE_APPID={01906EA2-3EB2-41F1-8F62-F0B7120EFD2E}
CHROMEOS_RELEASE_BOARD=eve-signed-mp-v2keys
CHROMEOS_RELEASE_BRANCH_NUMBER=67
CHROMEOS_RELEASE_BUILDER_PATH=eve-release/R96-14268.67.0
CHROMEOS_RELEASE_BUILD_NUMBER=14268
CHROMEOS_RELEASE_BUILD_TYPE=Official Build
CHROMEOS_RELEASE_CHROME_MILESTONE=96
CHROMEOS_RELEASE_DESCRIPTION=14268.67.0 (Official Build) stable-channel eve 
CHROMEOS_RELEASE_KEYSET=mp-v2
CHROMEOS_RELEASE_NAME=Chrome OS
CHROMEOS_RELEASE_PATCH_NUMBER=0
CHROMEOS_RELEASE_TRACK=stable-channel
CHROMEOS_RELEASE_UNIBUILD=1
CHROMEOS_RELEASE_VERSION=14268.67.0
DEVICETYPE=CHROMEBOOK
GOOGLE_RELEASE=14268.67.0
```
- [Build artifacts (binaries generated by `crew build`) (CircleCI)](https://app.circleci.com/pipelines/github/supechicken/crew-package-updater/17/workflows/899f46c7-1bee-4acf-a3c7-eb8c8491aa2c/jobs/17/artifacts)
- [Full build log (CircleCI)](https://app.circleci.com/pipelines/github/supechicken/crew-package-updater/17/workflows/899f46c7-1bee-4acf-a3c7-eb8c8491aa2c/jobs/17)