### PR TITLE
`mc` => 4.8.27

### DIFF
--- a/packages/mc.rb
+++ b/packages/mc.rb
@@ -3,24 +3,11 @@ require 'package'
 class Mc < Package
   description 'GNU Midnight Commander is a visual file manager'
   homepage 'http://midnight-commander.org/'
-  version '4.8.26'
+  version '4.8.27'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://github.com/MidnightCommander/mc/archive/#{version}.tar.gz"
-  source_sha256 'e585508ee4e0066c13d304e4c7135d7c6140f5c5027e01a024b3a508a6cf8025'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mc/4.8.26_armv7l/mc-4.8.26-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mc/4.8.26_armv7l/mc-4.8.26-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mc/4.8.26_i686/mc-4.8.26-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mc/4.8.26_x86_64/mc-4.8.26-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '0613a92137481949becea8a8780b06db5fd7945184dee96e4866d5faf5336681',
-     armv7l: '0613a92137481949becea8a8780b06db5fd7945184dee96e4866d5faf5336681',
-       i686: 'c486a081d10adbc367c104f5b1cb9a7ea37cc3609956e6fe6f0b5af444c4a452',
-     x86_64: 'de22c3351082961fee8499be803a5bd9261de9de42e8510e9c567c0cbf160bc0'
-  })
+  source_url 'https://github.com/MidnightCommander/mc.git'
+  git_hashtag '4.8.27'
 
   depends_on 'glib' => :build
   depends_on 'aspell' => :build

--- a/packages/mc.rb
+++ b/packages/mc.rb
@@ -7,7 +7,20 @@ class Mc < Package
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/MidnightCommander/mc.git'
-  git_hashtag '4.8.27'
+  git_hashtag version
+
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mc/4.8.27_armv7l/mc-4.8.27-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mc/4.8.27_armv7l/mc-4.8.27-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mc/4.8.27_i686/mc-4.8.27-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mc/4.8.27_x86_64/mc-4.8.27-chromeos-x86_64.tar.zst',
+  })
+  binary_sha256 ({
+    aarch64: '9983684570b813813665b0b01925c95e692b49d7e16af51028731db69249d47d',
+     armv7l: '9983684570b813813665b0b01925c95e692b49d7e16af51028731db69249d47d',
+       i686: '571b209953497deb0a06b762a78e3b071c349f250a9ec5a4b51397638f1c6bb5',
+     x86_64: '4194ab8ee4a1add191419107a3e9a7bb6ac0591b08e6a45943cdf55cddb13081',
+  })
 
   depends_on 'glib' => :build
   depends_on 'aspell' => :build


### PR DESCRIPTION
Automatically generated by GitHub Actions CI workflow.

Build successfully with docker image: [`supechicken/cros-image-eve`](https://hub.docker.com/repository/docker/supechicken/cros-image-eve)

- `make check` --- Failed
```
============================================================================
Testsuite summary for "/lib/mcconfig"
============================================================================
# TOTAL: 2
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
============================================================================
See tests/lib/mcconfig/test-suite.log
Please report to https://www.midnight-commander.org/wiki/NewTicket
============================================================================
```

- `cat /etc/lsb-release`
```
CHROMEOS_ARC_ANDROID_SDK_VERSION=28
CHROMEOS_ARC_VERSION=7982014
CHROMEOS_AUSERVER=https://tools.google.com/service/update2
CHROMEOS_BOARD_APPID={01906EA2-3EB2-41F1-8F62-F0B7120EFD2E}
CHROMEOS_CANARY_APPID={90F229CE-83E2-4FAF-8479-E368A34938B1}
CHROMEOS_DEVSERVER=
CHROMEOS_RELEASE_APPID={01906EA2-3EB2-41F1-8F62-F0B7120EFD2E}
CHROMEOS_RELEASE_BOARD=eve-signed-mp-v2keys
CHROMEOS_RELEASE_BRANCH_NUMBER=67
CHROMEOS_RELEASE_BUILDER_PATH=eve-release/R96-14268.67.0
CHROMEOS_RELEASE_BUILD_NUMBER=14268
CHROMEOS_RELEASE_BUILD_TYPE=Official Build
CHROMEOS_RELEASE_CHROME_MILESTONE=96
CHROMEOS_RELEASE_DESCRIPTION=14268.67.0 (Official Build) stable-channel eve 
CHROMEOS_RELEASE_KEYSET=mp-v2
CHROMEOS_RELEASE_NAME=Chrome OS
CHROMEOS_RELEASE_PATCH_NUMBER=0
CHROMEOS_RELEASE_TRACK=stable-channel
CHROMEOS_RELEASE_UNIBUILD=1
CHROMEOS_RELEASE_VERSION=14268.67.0
DEVICETYPE=CHROMEBOOK
GOOGLE_RELEASE=14268.67.0
```
- [Build artifacts (binaries generated by `crew build`) (CircleCI)](https://app.circleci.com/pipelines/github/supechicken/crew-package-updater/17/workflows/899f46c7-1bee-4acf-a3c7-eb8c8491aa2c/jobs/17/artifacts)
- [Full build log (CircleCI)](https://app.circleci.com/pipelines/github/supechicken/crew-package-updater/17/workflows/899f46c7-1bee-4acf-a3c7-eb8c8491aa2c/jobs/17)