### PR TITLE
Make sure libxml2 is in xml/xsl deps so postinstall does not fail.

### DIFF
--- a/packages/docbook_xml42.rb
+++ b/packages/docbook_xml42.rb
@@ -24,6 +24,7 @@ class Docbook_xml42 < Package
   })
 
   depends_on 'docbook_xml'
+  depends_on 'libxml2'
   depends_on 'xmlcatmgr'
 
   def self.install

--- a/packages/docbook_xml43.rb
+++ b/packages/docbook_xml43.rb
@@ -24,6 +24,7 @@ class Docbook_xml43 < Package
   })
 
   depends_on 'docbook_xml'
+  depends_on 'libxml2'
   depends_on 'xmlcatmgr'
 
   def self.install

--- a/packages/docbook_xml44.rb
+++ b/packages/docbook_xml44.rb
@@ -25,6 +25,7 @@ class Docbook_xml44 < Package
 
   depends_on 'docbook_xml'
   depends_on 'xmlcatmgr'
+  depends_on 'libxml2'
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"

--- a/packages/docbook_xml45.rb
+++ b/packages/docbook_xml45.rb
@@ -25,6 +25,7 @@ class Docbook_xml45 < Package
 
   depends_on 'docbook_xml'
   depends_on 'xmlcatmgr'
+  depends_on 'libxml2'
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/xml/docbook/xml-dtd-#{@_ver}"

--- a/packages/docbook_xml50.rb
+++ b/packages/docbook_xml50.rb
@@ -24,6 +24,7 @@ class Docbook_xml50 < Package
   })
 
   depends_on 'docbook_xml'
+  depends_on 'libxml2'
   depends_on 'xmlcatmgr'
 
   def self.install

--- a/packages/docbook_xml51.rb
+++ b/packages/docbook_xml51.rb
@@ -24,6 +24,7 @@ class Docbook_xml51 < Package
   })
 
   depends_on 'docbook_xml'
+  depends_on 'libxml2'
   depends_on 'xmlcatmgr'
 
   def self.install

--- a/packages/docbook_xsl.rb
+++ b/packages/docbook_xsl.rb
@@ -24,6 +24,7 @@ class Docbook_xsl < Package
   })
 
   depends_on 'docbook_xml'
+  depends_on 'libxml2'
   depends_on 'xmlcatmgr'
 
   def self.patch

--- a/packages/docbook_xsl_nons.rb
+++ b/packages/docbook_xsl_nons.rb
@@ -25,6 +25,7 @@ class Docbook_xsl_nons < Package
 
   depends_on 'docbook_xml'
   depends_on 'xmlcatmgr'
+  depends_on 'libxml2'
 
   def self.patch
     downloader 'https://github.com/archlinux/svntogit-packages/raw/packages/docbook-xsl/trunk/765567_non-recursive_string_subst.patch'

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -22,9 +22,10 @@ class Libxml2 < Package
     x86_64: 'ebb3b81155231be702617246a78945a3698142f63b3138c5763b9813d57dbe19'
   })
 
-  depends_on 'zlibpkg'
-  depends_on 'readline'
   depends_on 'gcc'
+  depends_on 'icu4c'
+  depends_on 'readline'
+  depends_on 'zlibpkg'
 
   def self.patch
     # Fix encoding.c:1961:31: error: ‘TRUE’ undeclared (first use in this function)


### PR DESCRIPTION
Fixes #6737

- the `libxml2` dep was in some of the relevant packages before, but not all.
- also make sure that `icu4c` is set as a dep of `libxml2` just in case that is an issue.

Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=xmlfix CREW_TESTING=1 crew update
```
