### PR TITLE
fix ruby.rb: fix grep algorithm in postinstall

### DIFF
--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -64,7 +64,7 @@ class Ruby < Package
 
   def self.postinstall
     puts 'Updating ruby gems. This may take a while...'
-    if Kernel.system 'grep', '-vq', 'gem: --no-document', "#{HOME}/.gemrc"
+    if (File.exist?("#{HOME}/.gemrc") && !Kernel.system("grep -q \"gem: --no-document\" #{HOME}/.gemrc")) || !File.exist?("#{HOME}/.gemrc")
       File.write("#{HOME}/.gemrc", "gem: --no-document\n", mode: 'a')
     end
     silent = @opt_verbose ? '' : '--silent'


### PR DESCRIPTION
- `grep` of non-existent file gives an errorcode of 2, which ruby sees as true. Thus we need to check to see if the file exists before doing a grep if we are going to act based upon a boolean error-code.

Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ruby_fix CREW_TESTING=1 crew update
```
