### PR TITLE
Add gettext dep to bison

### DIFF
--- a/packages/bison.rb
+++ b/packages/bison.rb
@@ -23,6 +23,8 @@ class Bison < Package
      x86_64: 'e671fd14e25757fd0fc45d65443ff55d13df428e34e80fc2f642d86aa5a9df14'
   })
 
+  depends_on 'gettext'
+
   def self.build
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'


### PR DESCRIPTION
Fixes #6741

- Until we replace the dependency algorithm, best to keep deps people are noticing didn't get installed inside package files, even if they are listed in core.
 
Works properly:
- [x] x86_64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=bison_dep CREW_TESTING=1 crew update
```
