### PR TITLE
crew: Download `source_url` as a normal file even if it is not an archive

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -731,10 +731,20 @@ def download
 
     when /^SKIP$/i
       Dir.mkdir @extract_dir
-
-    # Source URLs which end with .git are git sources.
-    when /\.git$/i
+    when /\.git$/i # Source URLs which end with .git are git sources.
       @git = true
+    else
+      Dir.mkdir @extract_dir
+      # use curl if CURL environment variable set
+      if CURL == 'curl'
+        downloader url, filename, @opt_verbose
+      else
+        system "#{CURL} --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
+      end
+
+      abort 'Checksum mismatch. 😔 Try again.'.lightred unless
+        Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum || sha256sum =~ /^SKIP$/i
+      puts "#{@pkg.name.capitalize} file downloaded.".lightgreen
     end
 
     # Handle git sources.

--- a/bin/crew
+++ b/bin/crew
@@ -744,7 +744,7 @@ def download
 
       abort 'Checksum mismatch. 😔 Try again.'.lightred unless
         Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum || sha256sum =~ /^SKIP$/i
-      puts "#{@pkg.name.capitalize} file downloaded.".lightgreen
+      puts "#{filename}: File downloaded.".lightgreen
 
       FileUtils.mv filename, "#{@extract_dir}/#{filename}"
     end

--- a/bin/crew
+++ b/bin/crew
@@ -704,11 +704,11 @@ def download
         end
       end
       # Download file if not cached.
-      # use curl if CURL environment variable set
-      if CURL == 'curl'
+      # use curl if CREW_USE_CURL environment variable is set to 1
+      unless CREW_USE_CURL
         downloader url, filename, @opt_verbose
       else
-        system "#{CURL} --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
+        system "curl --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
       end
 
       abort 'Checksum mismatch. 😔 Try again.'.lightred unless
@@ -735,11 +735,11 @@ def download
       @git = true
     else
       Dir.mkdir @extract_dir
-      # use curl if CURL environment variable set
-      if CURL == 'curl'
+      # use curl if CREW_USE_CURL environment variable is set to 1
+      unless CREW_USE_CURL
         downloader url, filename, @opt_verbose
       else
-        system "#{CURL} --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
+        system "curl --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
       end
 
       abort 'Checksum mismatch. 😔 Try again.'.lightred unless

--- a/bin/crew
+++ b/bin/crew
@@ -745,6 +745,8 @@ def download
       abort 'Checksum mismatch. 😔 Try again.'.lightred unless
         Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum || sha256sum =~ /^SKIP$/i
       puts "#{@pkg.name.capitalize} file downloaded.".lightgreen
+
+      FileUtils.mv filename, "#{@extract_dir}/#{filename}"
     end
 
     # Handle git sources.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -71,7 +71,6 @@ CREW_TESTING_REPO = ENV['CREW_TESTING_REPO']
 
 CREW_TESTING = ( CREW_TESTING_BRANCH.to_s.empty? or CREW_TESTING_REPO.to_s.empty? ) ? '0' : ENV['CREW_TESTING']
 
-
 USER = `whoami`.chomp
 
 CHROMEOS_RELEASE = if File.exist?('/etc/lsb-release')
@@ -81,7 +80,7 @@ else
   ENV['CHROMEOS_RELEASE_CHROME_MILESTONE']
 end
 
-# If CURL environment variable exists use it in lieu of curl.
+# If CREW_USE_CURL environment variable exists use it in lieu of curl.
 CREW_USE_CURL = ENV['CREW_USE_CURL'] == '1'
 
 # set certificate file location for lib/downloader.rb

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -80,7 +80,7 @@ else
   ENV['CHROMEOS_RELEASE_CHROME_MILESTONE']
 end
 
-# If CREW_USE_CURL environment variable exists use it in lieu of curl.
+# If CREW_USE_CURL environment variable exists use curl in lieu of net/http.
 CREW_USE_CURL = ENV['CREW_USE_CURL'] == '1'
 
 # set certificate file location for lib/downloader.rb

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.22.8'
+CREW_VERSION = '1.22.9'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -82,7 +82,7 @@ else
 end
 
 # If CURL environment variable exists use it in lieu of curl.
-CURL = ENV['CURL'] || 'curl'
+CREW_USE_CURL = ENV['CREW_USE_CURL'] == '1'
 
 # set certificate file location for lib/downloader.rb
 SSL_CERT_FILE = if ENV['SSL_CERT_FILE'].to_s.empty? || !File.exist?(ENV['SSL_CERT_FILE'])


### PR DESCRIPTION
Currently, the download algorithm will not download the `source_url` if it is not an archive or `git` URL. Added a part to this PR that handles normal files.

Tested on `x86_64`

### Run the following to get this pull request's changes locally for testing.
```shell
CREW_TESTING=1 CREW_TESTING_REPO=https://github.com/supechicken/chromebrew CREW_TESTING_BRANCH=download_file crew update
```