### PR TITLE
crew: Allow package name starts with digits

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -181,10 +181,14 @@ def set_package(pkgName, pkgPath)
     puts "#{e.class}: #{e.message}".red
   end
 
-  # add `PKG_` to the beginning of pkgName if it starts with a digit
-  pkgName = 'PKG_' + pkgName if pkgName =~ /^[0-9]/
+  # add `PKG_` to the beginning of class name if it starts with a digit
+  if pkgName =~ /^[0-9]/
+    className = 'PKG_' + pkgName
+  else
+    className = pkgName.capitalize
+  end
 
-  @pkg = Object.const_get(pkgName.capitalize)
+  @pkg = Object.const_get(className)
   @pkg.build_from_source = true if @opt_recursive
   @pkg.name = pkgName
 end

--- a/bin/crew
+++ b/bin/crew
@@ -181,8 +181,8 @@ def set_package(pkgName, pkgPath)
     puts "#{e.class}: #{e.message}".red
   end
 
-  # add an underscore to the beginning of pkgName if it starts with a digit
-  pkgName = '_' + pkgName if pkgName =~ /^[0-9]/
+  # add `PKG_` to the beginning of pkgName if it starts with a digit
+  pkgName = 'PKG_' + pkgName if pkgName =~ /^[0-9]/
 
   @pkg = Object.const_get(pkgName.capitalize)
   @pkg.build_from_source = true if @opt_recursive

--- a/bin/crew
+++ b/bin/crew
@@ -180,6 +180,10 @@ def set_package(pkgName, pkgPath)
   rescue SyntaxError => e
     puts "#{e.class}: #{e.message}".red
   end
+
+  # add an underscore to the beginning of pkgName if it starts with a digit
+  pkgName = '_' + pkgName if pkgName =~ /^[0-9]/
+
   @pkg = Object.const_get(pkgName.capitalize)
   @pkg.build_from_source = true if @opt_recursive
   @pkg.name = pkgName

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.22.8'
+CREW_VERSION = '1.22.10'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Due to the restriction with ruby's `class` naming system (a capital letter must be the first character of a `class` name), we are unable to name packages with a name that starts with digits (like `class 7_zip < Package`).

This PR allows package names with digits as the beginning, but the package class needs to be named with the prefix `PKG_`.

Tested on `x86_64`

### Example:
```ruby
# an `PKG_` prefix is not needed in the package recipe's filename
# /usr/local/lib/crew/packages/7_zip.rb

# an `PKG_` prefix is needed in the package's class name
class PKG_7_zip < Package
```

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=pkgname_start_with_number CREW_TESTING=1 crew update
```
