### PR TITLE
have sommelier package use crossystem container check

### DIFF
--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -49,8 +49,8 @@ class Sommelier < Package
   end
 
   def self.preflight
-    @container_check = `grep :/docker /proc/self/cgroup | wc -l`
-    unless File.socket?('/var/run/chrome/wayland-0') || !@container_check.to_i.zero?
+    @container_check = `/usr/bin/crossystem inside_vm` == '1' ? true : false
+    unless File.socket?('/var/run/chrome/wayland-0') || @container_check
       abort 'This package is not compatible with your device :/'.lightred
     end
   end


### PR DESCRIPTION
- `/usr/bin/crossystem inside_vm` is available as far back as the i686 machines.
- This keeps us from being tied to docker, maybe.

Works properly:
- [x] x86_64


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=new_container_check CREW_TESTING=1 crew update
```
