### PR TITLE
Add libdmraid package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 release/
 *.bz2
 *.gz
+*.tgz
 *.sha256
 *.xz
 *.zip
+/.vs

--- a/packages/libdmraid.rb
+++ b/packages/libdmraid.rb
@@ -3,20 +3,33 @@ require 'package'
 class Libdmraid < Package
   description 'Device-Mapper Software RAID support tool'
   homepage 'http://people.redhat.com/~heinzm/sw/dmraid/'
-  version '1.0.0.rc16-3'    
+  version '1.0.0.rc16-3'
   license 'GPL-2.0'
   compatibility 'all'
   source_url 'http://people.redhat.com/~heinzm/sw/dmraid/src/dmraid-1.0.0.rc16-3.tar.bz2'
   source_sha256 '93421bd169d71ff5e7d2db95b62b030bfa205a12010b6468dcdef80337d6fbd8'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdmraid/1.0.0.rc16-3_armv7l/libdmraid-1.0.0.rc16-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdmraid/1.0.0.rc16-3_armv7l/libdmraid-1.0.0.rc16-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdmraid/1.0.0.rc16-3_i686/libdmraid-1.0.0.rc16-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdmraid/1.0.0.rc16-3_x86_64/libdmraid-1.0.0.rc16-3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'bf6a85cf7fada37b4c6eaf3e20bc029b478ac150910f5b621baa8c5190c098d3',
+     armv7l: 'bf6a85cf7fada37b4c6eaf3e20bc029b478ac150910f5b621baa8c5190c098d3',
+       i686: '960b0acb4d557f5d3768e7323f4472e75439dc9f240753a3a62aec27e6843223',
+     x86_64: '826735e71f3ffc850583862bb58d46369170d7f945efd14406c4bcef8865c428'
+  })
+
   depends_on 'gawk' => :build
   depends_on 'lvm2' => :build
-  
+
   def self.build
     Dir.chdir '1.0.0.rc16-3/dmraid' do
-      system "autoreconf -fvi"
+      system 'autoreconf -fvi'
       system "./configure #{CREW_OPTIONS}"
-      system "make || make"
+      system 'make || make'
     end
   end
 

--- a/packages/libdmraid.rb
+++ b/packages/libdmraid.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Libdmraid < Package
+  description 'Device-Mapper Software RAID support tool'
+  homepage 'http://people.redhat.com/~heinzm/sw/dmraid/'
+  version '1.0.0.rc16-3'    
+  license 'GPL-2.0'
+  compatibility 'all'
+  source_url 'http://people.redhat.com/~heinzm/sw/dmraid/src/dmraid-1.0.0.rc16-3.tar.bz2'
+  source_sha256 '93421bd169d71ff5e7d2db95b62b030bfa205a12010b6468dcdef80337d6fbd8'
+
+  depends_on 'gawk' => :build
+  depends_on 'lvm2' => :build
+  
+  def self.build
+    Dir.chdir '1.0.0.rc16-3/dmraid' do
+      system "autoreconf -fvi"
+      system "./configure #{CREW_OPTIONS}"
+      system "make || make"
+    end
+  end
+
+  def self.install
+    Dir.chdir '1.0.0.rc16-3/dmraid' do
+      system "make install DESTDIR=#{CREW_DEST_DIR}"
+    end
+  end
+end

--- a/packages/lvm2.rb
+++ b/packages/lvm2.rb
@@ -3,25 +3,12 @@ require 'package'
 class Lvm2 < Package
   description 'LVM2 refers to the userspace toolset that provide logical volume management facilities on linux.'
   homepage 'https://sourceware.org/lvm2'
-  @_ver = '2.03.11'
+  @_ver = '2.03.15'
   version @_ver
   license 'GPL-2'
   compatibility 'all'
   source_url "https://www.sourceware.org/pub/lvm2/releases/LVM2.#{@_ver}.tgz"
-  source_sha256 '842c4510d4653990927d4518a5bf2743126a37531671a05842cdaf8d54bb9dd4'
-
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lvm2/2.03.11_armv7l/lvm2-2.03.11-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lvm2/2.03.11_armv7l/lvm2-2.03.11-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lvm2/2.03.11_i686/lvm2-2.03.11-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lvm2/2.03.11_x86_64/lvm2-2.03.11-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-     aarch64: 'a60be47b7f7011234587ebba6e28adb36d27138b4bb182aa88da8af7fc6a6079',
-      armv7l: 'a60be47b7f7011234587ebba6e28adb36d27138b4bb182aa88da8af7fc6a6079',
-        i686: '62fbf27d3a75a5bf043c02b24ecf4f55f428a14192a59289bb97fd14cd073d78',
-      x86_64: 'd1b98a8b2c8ca75d78a4fd744a2d1aad44b0c23f102b588f8b5e7a7ed17d42c0',
-  })
+  source_sha256 '935283a51ee17abd752a545a0ed1cf4edc993359265bc9e562edf81500edc99e'
 
   depends_on 'libaio'
 
@@ -30,6 +17,10 @@ class Lvm2 < Package
       ./configure \
       #{CREW_OPTIONS} \
       --disable-selinux \
+      --enable-cmdlib \
+      --enable-dmeventd \
+      --enable-pkgconfig \
+      --with-symvers=no \
       --with-confdir=#{CREW_PREFIX}/etc"
     system "make"
   end

--- a/packages/lvm2.rb
+++ b/packages/lvm2.rb
@@ -3,18 +3,34 @@ require 'package'
 class Lvm2 < Package
   description 'LVM2 refers to the userspace toolset that provide logical volume management facilities on linux.'
   homepage 'https://sourceware.org/lvm2'
-  @_ver = '2.03.15'
-  version @_ver
+  version '2.03.15'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://www.sourceware.org/pub/lvm2/releases/LVM2.#{@_ver}.tgz"
-  source_sha256 '935283a51ee17abd752a545a0ed1cf4edc993359265bc9e562edf81500edc99e'
+  source_url 'https://sourceware.org/git/lvm2.git'
+  git_hashtag "v#{version.gsub('.', '_')}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lvm2/2.03.15_armv7l/lvm2-2.03.15-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lvm2/2.03.15_armv7l/lvm2-2.03.15-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lvm2/2.03.15_i686/lvm2-2.03.15-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lvm2/2.03.15_x86_64/lvm2-2.03.15-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '8cfc43361bba3afa4985b060648be0d72adcb7a2e0f27a7fdf771e26adef7219',
+     armv7l: '8cfc43361bba3afa4985b060648be0d72adcb7a2e0f27a7fdf771e26adef7219',
+       i686: 'fcc82c8f6189cd3e7050db3b6a2d4b2e18f920888e438c94bbe1620331aa2932',
+     x86_64: 'c0cd04e473acf8aec4ca3030fce901c793b0b40947f1aa44b2be8b7fea863f24'
+  })
 
   depends_on 'libaio'
+  no_env_options
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      ./configure \
+    # gold linker gives error: ltrans0.ltrans.o: multiple definition of 'dm_bitset_parse_list'
+    FileUtils.mkdir_p 'bin'
+    @pwd = `pwd`.chomp
+    FileUtils.cp "#{CREW_PREFIX}/bin/ld.lld", 'bin/ld'
+    system "#{CREW_ENV_OPTIONS.gsub('-fuse-ld=gold', '')} LD=ld.lld PATH=#{@pwd}/bin:\$PATH ./configure \
       #{CREW_OPTIONS} \
       --disable-selinux \
       --enable-cmdlib \
@@ -22,10 +38,10 @@ class Lvm2 < Package
       --enable-pkgconfig \
       --with-symvers=no \
       --with-confdir=#{CREW_PREFIX}/etc"
-    system "make"
+    system "PATH=#{@pwd}/bin:\$PATH make"
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
## Description
Adds the libdmraid package (part of the same larger package as #6766).

## Additional information
Updates lvm2 to compile the deventd daemon as that's a dependency of libdmraid, and bumps the version of lvm2 to avoid conflicts. Also updates the .gitignore to prevent Visual Studio or build files to accidentally being uploaded.

Works properly:
- [x] armv7l

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=dmraid CREW_TESTING=1 crew update
```
---
