### PR TITLE
Add upm package

### DIFF
--- a/packages/upm.rb
+++ b/packages/upm.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Upm < Package
+  description 'Universal Password Manager (UPM) allows you to store usernames, passwords, URLs and generic notes in an encrypted database protected by one master password.'
+  homepage 'http://upm.sourceforge.net/'
+  version '1.15.1'
+  license 'GPL-2'
+  compatibility 'all'
+  source_url 'https://downloads.sourceforge.net/project/upm/upm-1.15.1/upm-1.15.1.tar.gz'
+  source_sha256 'c8ade41ec0fe6f387f6e44b941ce5f17a3c2e2d096b4be766bed29ee606ac078'
+
+  depends_on 'jdk8'
+  depends_on 'sommelier'
+
+  def self.build
+    upm = <<~EOF
+      #!/bin/bash
+      cd #{CREW_PREFIX}/share/upm
+      ./upm.sh "$@"
+    EOF
+    File.write('upm', upm)
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/upm"
+    FileUtils.cp_r Dir['.'], "#{CREW_DEST_PREFIX}/share/upm"
+    FileUtils.install 'upm', "#{CREW_DEST_PREFIX}/bin/upm", mode: 0o755
+  end
+end


### PR DESCRIPTION
Universal Password Manager (UPM) allows you to store usernames, passwords, URLs and generic notes in an encrypted database protected by one master password. See http://upm.sourceforge.net/. Tested on all architectures. Only aarch64, armv7l and x86_64 work, however.  Note for @satmandu: The database is added by the user and could be any name stored anywhere so it is not possible to locate initially or remove.