### PR TITLE
Add keyutils package

### DIFF
--- a/packages/keyutils.rb
+++ b/packages/keyutils.rb
@@ -52,6 +52,10 @@ CXXFLAGS\t\t:= #{CREW_COMMON_FLAGS}
     system 'make'
   end
 
+  def self.check
+    system 'make test'
+  end
+
   def self.install
     system "make install DESTDIR=#{CREW_DEST_DIR}"
   end

--- a/packages/keyutils.rb
+++ b/packages/keyutils.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Keyutils < Package
+  description 'Keyutils is a set of utilities for managing the key retention facility in the kernel, which can be used by filesystems, block devices and more to gain and retain the authorization and encryption keys required to perform secure operations.'
+  homepage 'https://people.redhat.com/~dhowells/keyutils/'
+  version '1.6.1'    
+  license 'GPL-2.0'
+  compatibility 'all'
+  source_url 'https://people.redhat.com/~dhowells/keyutils/keyutils-1.6.1.tar.bz2'
+  source_sha256 'c8b15722ae51d95b9ad76cc6d49a4c2cc19b0c60f72f61fb9bf43eea7cbd64ce'
+  
+  depends_on 'hashpipe' => :build
+  
+  def self.patch
+    system "curl -L 'https://gist.githubusercontent.com/Zopolis4/1a0f93d982c87587bc0bb4e4cb0595b8/raw/5e2d7d523740d92c45af1d98a730a7323038db36/keyutils_chromebrew.patch' | hashpipe sha256 861cfd398475cafb50c7009d0d496ca86917d0d13f79406ecbd0c8e3ab2128f1 | patch -u Makefile"
+  end
+
+  def self.build
+    system "make"
+  end
+
+  def self.install
+    system "make install LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/keyutils.rb
+++ b/packages/keyutils.rb
@@ -3,23 +3,56 @@ require 'package'
 class Keyutils < Package
   description 'Keyutils is a set of utilities for managing the key retention facility in the kernel, which can be used by filesystems, block devices and more to gain and retain the authorization and encryption keys required to perform secure operations.'
   homepage 'https://people.redhat.com/~dhowells/keyutils/'
-  version '1.6.1'    
+  version '1.6.3'
   license 'GPL-2.0'
   compatibility 'all'
-  source_url 'https://people.redhat.com/~dhowells/keyutils/keyutils-1.6.1.tar.bz2'
-  source_sha256 'c8b15722ae51d95b9ad76cc6d49a4c2cc19b0c60f72f61fb9bf43eea7cbd64ce'
-  
-  depends_on 'hashpipe' => :build
-  
+  source_url 'https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/keyutils/1.6.3_armv7l/keyutils-1.6.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/keyutils/1.6.3_armv7l/keyutils-1.6.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/keyutils/1.6.3_i686/keyutils-1.6.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/keyutils/1.6.3_x86_64/keyutils-1.6.3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '18a3e216463811ab600854d806b41ddc87c2e07dfd05fde19ae2a84256fb591d',
+     armv7l: '18a3e216463811ab600854d806b41ddc87c2e07dfd05fde19ae2a84256fb591d',
+       i686: 'cf6a0538616941ddb4188f8c69bd10413451c03169c3ac65bd2f19ce403fec92',
+     x86_64: '9f8ffd4e80ebe08b0b2244b558130157f1d93f26ff9b34378f76f2de140cc72f'
+  })
+
   def self.patch
-    system "curl -L 'https://gist.githubusercontent.com/Zopolis4/1a0f93d982c87587bc0bb4e4cb0595b8/raw/5e2d7d523740d92c45af1d98a730a7323038db36/keyutils_chromebrew.patch' | hashpipe sha256 861cfd398475cafb50c7009d0d496ca86917d0d13f79406ecbd0c8e3ab2128f1 | patch -u Makefile"
+    system "sed -i 's,/usr,#{CREW_PREFIX},g' Makefile"
+    system "sed -i 's,ETCDIR		:= /etc,ETCDIR		:= #CREW_PREFIX#/etc,g' Makefile"
+    system "sed -i 's,BINDIR		:= /bin,BINDIR		:= #CREW_PREFIX#/bin,g' Makefile"
+    system "sed -i 's,SBINDIR		:= /sbin,SBINDIR		:= #CREW_PREFIX#/sbin,g' Makefile"
+    system "sed -i 's,:= /lib*\$,:= #CREW_LIB_PREFIX#,g' Makefile"
+    system "sed -i 's,:= /lib64*\$,:= #CREW_LIB_PREFIX#,g' Makefile"
+    system "sed -i '1,/PREFIX/ {/PREFIX/a\
+USRLIBDIR		:= #CREW_LIB_PREFIX#
+}' Makefile"
+    system "sed -i '1,/PREFIX/ {/PREFIX/a\
+LIBDIR		:= #CREW_LIB_PREFIX#
+}' Makefile"
+    system "sed -i '/^CXXFLAGS/d' Makefile"
+    system "sed -i '/^CFLAGS/d' Makefile"
+    system "sed -i '1,/CPPFLAGS/ {/CPPFLAGS/a\
+CFLAGS\t\t:= #{CREW_COMMON_FLAGS}
+}' Makefile"
+    system "sed -i '1,/CPPFLAGS/ {/CPPFLAGS/a\
+CXXFLAGS\t\t:= #{CREW_COMMON_FLAGS}
+}' Makefile"
+    system "sed -i 's,/usr/local/lib/,#CREW_LIB_PREFIX#/,g' Makefile"
+    system "sed -i 's,#CREW_LIB_PREFIX#,#{CREW_LIB_PREFIX},g' Makefile"
+    system "sed -i 's,#CREW_PREFIX#,#{CREW_LIB_PREFIX},g' Makefile"
   end
 
   def self.build
-    system "make"
+    system 'make'
   end
 
   def self.install
-    system "make install LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR}"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end


### PR DESCRIPTION
## Description
Adds the keyutils package (part of the same larger package as #6766).

## Additional information
The makefile patch is to remove erroneous rpm errors and to fix the install directories, as the upstream makefile sets them manually.

Works properly:
- [x] armv7l [keyutils-1.6.1-chromeos-armv7l.zip](https://github.com/skycocker/chromebrew/files/8167256/keyutils-1.6.1-chromeos-armv7l.zip)


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=keyutils CREW_TESTING=1 crew update
```
---
