### PR TITLE
Add ndctl package

### DIFF
--- a/packages/libkmod.rb
+++ b/packages/libkmod.rb
@@ -9,19 +9,6 @@ class Libkmod < Package
   source_url "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
   git_hashtag "v#{version}"
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libkmod/28_armv7l/libkmod-28-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libkmod/28_armv7l/libkmod-28-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libkmod/28_i686/libkmod-28-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libkmod/28_x86_64/libkmod-28-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-     aarch64: '57c5726cd378bf3e1458cdfebead52b9279557af8229550d5f91f0a3e04d4f10',
-      armv7l: '57c5726cd378bf3e1458cdfebead52b9279557af8229550d5f91f0a3e04d4f10',
-        i686: '95c805d62289d8751682d4bb1c8046deeae68958e0f06f6863e30eb74e941864',
-      x86_64: '258578c242a793bfda78e9dc98a9e029a8788e9971a809d0c6e42c2abe10b317',
-  })
-
   depends_on 'py3_cython'
   depends_on 'xzutils'
 

--- a/packages/libkmod.rb
+++ b/packages/libkmod.rb
@@ -3,11 +3,24 @@ require 'package'
 class Libkmod < Package
   description 'Linux kernel module handling library'
   homepage 'https://kernel.org'
-  version = '29'
+  version '29'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
+  source_url 'https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git'
   git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libkmod/29_armv7l/libkmod-29-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libkmod/29_armv7l/libkmod-29-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libkmod/29_i686/libkmod-29-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libkmod/29_x86_64/libkmod-29-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '40fe9af2580dbc280c5c8b44f9dccbd4869cdb439eeee510bc26468f2652fa32',
+     armv7l: '40fe9af2580dbc280c5c8b44f9dccbd4869cdb439eeee510bc26468f2652fa32',
+       i686: 'e3cbd134f96e7e25cba0eb1e721ecaa2372c218ff1deb5d5da9303691f6fc42b',
+     x86_64: 'a69c727d00f82f0e50dc12f2030e613a50f21095d070c80d59437f9eab02e372'
+  })
 
   depends_on 'py3_cython'
   depends_on 'xzutils'

--- a/packages/libkmod.rb
+++ b/packages/libkmod.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libkmod < Package
   description 'Linux kernel module handling library'
   homepage 'https://kernel.org'
-  @_ver = '28'
-  version @_ver
+  version = '29'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://mirrors.edge.kernel.org/pub/linux/utils/kernel/kmod/kmod-#{@_ver}.tar.xz"
-  source_sha256 '3969fc0f13daa98084256337081c442f8749310089e48aa695c9b4dfe1b3a26c'
+  source_url "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
+  git_hashtag "v#{version}"
 
   binary_url ({
      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libkmod/28_armv7l/libkmod-28-chromeos-armv7l.tar.xz',
@@ -23,10 +22,19 @@ class Libkmod < Package
       x86_64: '258578c242a793bfda78e9dc98a9e029a8788e9971a809d0c6e42c2abe10b317',
   })
 
+  depends_on 'py3_cython'
   depends_on 'xzutils'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-python --disable-maintainer-mode --with-openssl --with-zlib --with-xz"
+    system './autogen.sh'
+    system 'filefix'
+    system "./configure #{CREW_OPTIONS} \
+    --disable-maintainer-mode \
+    --enable-python \
+    --with-openssl \
+    --with-xz \
+    --with-zlib \
+    --with-zstd"
     system 'make'
   end
 

--- a/packages/ndctl.rb
+++ b/packages/ndctl.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Ndctl < Package
+  description 'Helper tools and libraries for managing the libnvdimm (non-volatile memory device) sub-system in the Linux kernel'
+  homepage 'https://github.com/pmem/ndctl'
+  version 'v72.1'    
+  license 'GPL-2.0'
+  compatibility 'all'
+  source_url 'https://github.com/pmem/ndctl/archive/refs/tags/v72.1.tar.gz'
+  source_sha256 '9059ee4b129730604cee6aba7a8bc207b6e9aa6466b6da9b3b29d1996bf3712a'
+
+  depends_on 'asciidoctor' => :build
+  depends_on 'bash_completion' => :build
+  depends_on 'iniparser' => :build
+  depends_on 'jsonc' => :build
+  depends_on 'keyutils' => :build
+  depends_on 'xmlto' => :build
+  
+  def self.build
+    system "./autogen.sh"
+    system "./configure CFLAGS='-g -O2' #{CREW_OPTIONS} --without-systemd"
+    system "make"
+  end
+
+  def self.check
+    system 'make check'
+  end
+ 
+  def self.install
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
+  end
+end

--- a/packages/ndctl.rb
+++ b/packages/ndctl.rb
@@ -5,9 +5,20 @@ class Ndctl < Package
   homepage 'https://github.com/pmem/ndctl'
   version '72.1'
   license 'GPL-2.0'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/pmem/ndctl.git'
   git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ndctl/72.1_armv7l/ndctl-72.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ndctl/72.1_armv7l/ndctl-72.1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ndctl/72.1_x86_64/ndctl-72.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'baade842dde6df21f38c6506d89d11b6c569d131c4c4a0bedf66992a952dfc1f',
+     armv7l: 'baade842dde6df21f38c6506d89d11b6c569d131c4c4a0bedf66992a952dfc1f',
+     x86_64: '6d1a0625c7c26687531cf8d63859bbe4bcdd44c5f1b623657491845c89a2a8bc'
+  })
 
   depends_on 'asciidoctor' => :build
   depends_on 'bash_completion' => :build
@@ -16,17 +27,18 @@ class Ndctl < Package
   depends_on 'keyutils' => :build
   depends_on 'libkmod' => :build
   depends_on 'xmlto' => :build
-  
+
   def self.build
-    system "./autogen.sh"
+    system './autogen.sh'
+    system 'filefix'
     system "./configure #{CREW_OPTIONS} --without-systemd"
-    system "make"
+    system 'make'
   end
 
   def self.check
     system 'make check'
   end
- 
+
   def self.install
     system "make install DESTDIR=#{CREW_DEST_DIR}"
   end

--- a/packages/ndctl.rb
+++ b/packages/ndctl.rb
@@ -3,22 +3,23 @@ require 'package'
 class Ndctl < Package
   description 'Helper tools and libraries for managing the libnvdimm (non-volatile memory device) sub-system in the Linux kernel'
   homepage 'https://github.com/pmem/ndctl'
-  version 'v72.1'    
+  version '72.1'
   license 'GPL-2.0'
   compatibility 'all'
-  source_url 'https://github.com/pmem/ndctl/archive/refs/tags/v72.1.tar.gz'
-  source_sha256 '9059ee4b129730604cee6aba7a8bc207b6e9aa6466b6da9b3b29d1996bf3712a'
+  source_url 'https://github.com/pmem/ndctl.git'
+  git_hashtag "v#{version}"
 
   depends_on 'asciidoctor' => :build
   depends_on 'bash_completion' => :build
   depends_on 'iniparser' => :build
   depends_on 'jsonc' => :build
   depends_on 'keyutils' => :build
+  depends_on 'libkmod' => :build
   depends_on 'xmlto' => :build
   
   def self.build
     system "./autogen.sh"
-    system "./configure CFLAGS='-g -O2' #{CREW_OPTIONS} --without-systemd"
+    system "./configure #{CREW_OPTIONS} --without-systemd"
     system "make"
   end
 


### PR DESCRIPTION
## Description
Adds the ndctl package (part of the same larger package as #6766).

## Additional information
This depends on #6809

- also updates `libkmod`
- build is dependent upon using a fixed `docbook_xsl` and also a rebuilt `asciidoctor`

Works properly:
- [x] x86_64
- [x] armv7l
- [ ] i686 (kernel too old to have a `linux/ndctl.h`)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=ndctl CREW_TESTING=1 crew update
```
---
