### PR TITLE
libdrm -> 2.4.110

### DIFF
--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libdrm < Package
   description 'Cross-driver middleware for DRI protocol.'
   homepage 'https://dri.freedesktop.org'
-  @_ver = '2.4.108'
+  @_ver = '2.4.110'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Libdrm < Package
   git_hashtag "libdrm-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.108_armv7l/libdrm-2.4.108-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.108_armv7l/libdrm-2.4.108-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.108_i686/libdrm-2.4.108-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.108_x86_64/libdrm-2.4.108-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.110_armv7l/libdrm-2.4.110-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.110_armv7l/libdrm-2.4.110-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.110_i686/libdrm-2.4.110-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.110_x86_64/libdrm-2.4.110-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3661c7f7e58a7f9ce46545b32a26d917d77fbed1a23f0c266710a5acfb9710a1',
-     armv7l: '3661c7f7e58a7f9ce46545b32a26d917d77fbed1a23f0c266710a5acfb9710a1',
-       i686: '52183d84631bb78959238f9ffeb3695ea95b90089f7e0c6b1a80157c66ad810e',
-     x86_64: '0e2520f4dff148baab2c9f8649093e6422c1596613c755662d1b9bdcb0fb8c16'
+    aarch64: '17358ed1f87950f483410a3079757d77c7d62f8893571b61e4b93a24e0f50b9a',
+     armv7l: '17358ed1f87950f483410a3079757d77c7d62f8893571b61e4b93a24e0f50b9a',
+       i686: 'b9dff811d3f6a7fc04e2abb259d1e3f1f5486b1609d21e2cd11f5d31435f472e',
+     x86_64: '64ff40876627b172d3d3a92d641e38bffebb4363a52cb1dbc281f09afa0863a1'
   })
 
   depends_on 'libpciaccess' # R


### PR DESCRIPTION

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libdrm_2.4.110 CREW_TESTING=1 crew update
```
