### PR TITLE
vte -> 0.67.90

### DIFF
--- a/packages/vte.rb
+++ b/packages/vte.rb
@@ -3,28 +3,29 @@ require 'package'
 class Vte < Package
   description 'Virtual Terminal Emulator widget for use with GTK'
   homepage 'https://wiki.gnome.org/Apps/Terminal/VTE'
-  @_ver = '0.64.2'
+  @_ver = '0.67.90'
   version @_ver
   license 'LGPL-2+ and GPL-3+'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/vte.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.64.2_armv7l/vte-0.64.2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.64.2_armv7l/vte-0.64.2-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.64.2_x86_64/vte-0.64.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.67.90_armv7l/vte-0.67.90-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.67.90_armv7l/vte-0.67.90-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.67.90_i686/vte-0.67.90-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.67.90_x86_64/vte-0.67.90-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '28d3e1ec594f547221c5a806b89017f4f44817053238a3c75eef000a856c7a29',
-     armv7l: '28d3e1ec594f547221c5a806b89017f4f44817053238a3c75eef000a856c7a29',
-     x86_64: '3c8d0ddce8365705d966bdc2b1102d77dd660c0265b0e36ff9a7848e400614e0'
+    aarch64: 'dcfdd849cf41e7eebdbf4898736f3a4a4110bce26bdfb46fb8b2e2ed6abca976',
+     armv7l: 'dcfdd849cf41e7eebdbf4898736f3a4a4110bce26bdfb46fb8b2e2ed6abca976',
+       i686: 'df376361939b8573ab907b9a2be807c1086bf37b9979829153d8f73194ca3fa4',
+     x86_64: '646cc0968db68d6db74c294a134ad05a1b3b04af0661416b0f19997e6492867b'
   })
 
   depends_on 'gobject_introspection' => :build
   depends_on 'fribidi'
   depends_on 'gtk3'
-  depends_on 'gtk4'
 
   def self.build
     system <<~CONFIGURE
@@ -33,7 +34,7 @@ class Vte < Package
       -D_systemd=false \
       -Dfribidi=true \
       -Dgtk3=true \
-      -Dgtk4=true \
+      -Dgtk4=false \
       -Dgir=false \
       -Dvapi=false \
       builddir


### PR DESCRIPTION
- "fixes" installing geany on i686.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=vte CREW_TESTING=1 crew update
```
