### PR TITLE
Fixup docbook packages

### DIFF
--- a/packages/docbook_xml.rb
+++ b/packages/docbook_xml.rb
@@ -3,18 +3,20 @@ require 'package'
 class Docbook_xml < Package
   description 'Meta package for all versions of docbook_xml'
   homepage 'http://www.docbook.org'
-  version '5.1-2-1'
+  version '5.1-2-2'
   license 'MIT'
   compatibility 'all'
 
   is_fake
 
-  FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d/"
-  @env = <<~EOF
-    # Docbook_xml configuration
-    XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog
-  EOF
-  IO.write("#{CREW_DEST_PREFIX}/etc/env.d/docbook_xml", @env)
+  unless File.exist?("#{CREW_PREFIX}/etc/env.d/docbook_xml")
+    FileUtils.mkdir_p "#{CREW_PREFIX}/etc/env.d/"
+    @env = <<~DOCBOOK_XML_EOF
+      # Docbook_xml configuration
+      XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog
+    DOCBOOK_XML_EOF
+    File.write("#{CREW_PREFIX}/etc/env.d/docbook_xml", @env)
+  end
 
   depends_on 'xmlcatmgr'
   depends_on 'docbook_xml412'

--- a/packages/docbook_xsl.rb
+++ b/packages/docbook_xsl.rb
@@ -4,23 +4,23 @@ class Docbook_xsl < Package
   description 'The DocBook XSL Stylesheets package contains XSL stylesheets. These are useful for performing transformations on XML DocBook files.'
   homepage 'https://github.com/docbook/xslt10-stylesheets'
   @_ver = '1.79.2'
-  version "#{@_ver}-3"
+  version "#{@_ver}-4"
   license 'custom'
   compatibility 'all'
   source_url "https://github.com/docbook/xslt10-stylesheets/releases/download/release/#{@_ver}/docbook-xsl-#{@_ver}.zip"
   source_sha256 '853dce096f5b32fe0b157d8018d8fecf92022e9c79b5947a98b365679c7e31d7'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl/1.79.2-3_armv7l/docbook_xsl-1.79.2-3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl/1.79.2-3_armv7l/docbook_xsl-1.79.2-3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl/1.79.2-3_i686/docbook_xsl-1.79.2-3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl/1.79.2-3_x86_64/docbook_xsl-1.79.2-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl/1.79.2-4_armv7l/docbook_xsl-1.79.2-4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl/1.79.2-4_armv7l/docbook_xsl-1.79.2-4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl/1.79.2-4_i686/docbook_xsl-1.79.2-4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl/1.79.2-4_x86_64/docbook_xsl-1.79.2-4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '25e813ecd0cf7daab83923b012c47b3ac40f2f4d517d2c815d032ab027f8a4c5',
-     armv7l: '25e813ecd0cf7daab83923b012c47b3ac40f2f4d517d2c815d032ab027f8a4c5',
-       i686: 'c222857e21fa14143be3e945136649984af40d19c6205942d69f9b6202f667f0',
-     x86_64: '3306fa4d5b31758b2393e7e6c241e23c9a050fe748df6bff272c58d1e37c8540'
+    aarch64: '73221262b792d4e3539f9e5916b4b9d6213f2c396b04fca17932705d90ae9c75',
+     armv7l: '73221262b792d4e3539f9e5916b4b9d6213f2c396b04fca17932705d90ae9c75',
+       i686: '939fdab9fdfe243644b2144dc61e259874d1d4d4e1f0f0ec70d914c1ca28776e',
+     x86_64: '0f2158867eb01d15aac465273bbee82c30028dff0733d9b0a0448d3156f18b53'
   })
 
   depends_on 'docbook_xml'
@@ -51,7 +51,7 @@ class Docbook_xsl < Package
         manpages params profiling roundtrip slides template tests tools \
         webhelp website xhtml xhtml-1_1 xhtml5
         do
-        install -Dt "#{@pkgroot}"/"$fn" -m644 "$fn"/*.{xml,xsl,dtd,ent}
+        install -Dt "#{@pkgroot}"/"$fn" -m644 "$fn"/*.{xml,xsl,dtd,ent} || true
         done
       )
     ADDFILES_HEREDOC
@@ -64,6 +64,12 @@ class Docbook_xsl < Package
     # For moreutils
     FileUtils.ln_s "#{CREW_PREFIX}/share/xml/docbook/xsl-stylesheets-#{@_ver}",
                    "#{CREW_DEST_PREFIX}/share/xml/docbook/stylesheet/docbook-xsl"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d/"
+    @env = <<~EOF
+      # Docbook_xml configuration
+      XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog
+    EOF
+    File.write("#{CREW_DEST_PREFIX}/etc/env.d/docbook_xml", @env)
   end
 
   def self.preinstall

--- a/packages/docbook_xsl_nons.rb
+++ b/packages/docbook_xsl_nons.rb
@@ -4,28 +4,28 @@ class Docbook_xsl_nons < Package
   description 'The DocBook XSL Stylesheets package contains XSL stylesheets. These are useful for performing transformations on XML DocBook files.'
   homepage 'https://github.com/docbook/xslt10-stylesheets'
   @_ver = '1.79.2'
-  version "#{@_ver}-2"
+  version "#{@_ver}-3"
   license 'custom'
   compatibility 'all'
   source_url "https://github.com/docbook/xslt10-stylesheets/releases/download/release/#{@_ver}/docbook-xsl-nons-#{@_ver}.zip"
   source_sha256 'ba41126fbf4021e38952f3074dc87cdf1e50f3981280c7a619f88acf31456822'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl_nons/1.79.2-2_armv7l/docbook_xsl_nons-1.79.2-2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl_nons/1.79.2-2_armv7l/docbook_xsl_nons-1.79.2-2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl_nons/1.79.2-2_i686/docbook_xsl_nons-1.79.2-2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl_nons/1.79.2-2_x86_64/docbook_xsl_nons-1.79.2-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl_nons/1.79.2-3_armv7l/docbook_xsl_nons-1.79.2-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl_nons/1.79.2-3_armv7l/docbook_xsl_nons-1.79.2-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl_nons/1.79.2-3_i686/docbook_xsl_nons-1.79.2-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docbook_xsl_nons/1.79.2-3_x86_64/docbook_xsl_nons-1.79.2-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '06af54afe6fc9395a43fd9ac1771d348f80e5914ecd0881313e5697dad3d11c5',
-     armv7l: '06af54afe6fc9395a43fd9ac1771d348f80e5914ecd0881313e5697dad3d11c5',
-       i686: '594d32e423a401d903c69c58e3c0f6c9397a1ce80d5da6e777739b25a37bbce3',
-     x86_64: 'b7e2266597a34c278188e8a0e6ff9efc1c3947db7ceb46d50f5f92ad3c8b9940'
+    aarch64: '8b2d037e40db4e9620283d65b54f74179e3ecdfc6aed68f8b6181b9f52f984c2',
+     armv7l: '8b2d037e40db4e9620283d65b54f74179e3ecdfc6aed68f8b6181b9f52f984c2',
+       i686: 'f9d1fe2df8bae0e071ba3634027cf1b9f4992c0b99b15d0b54459c74e6e337b4',
+     x86_64: 'eab7666304dd3ea6fc347523b3e341e805fa80c21b0598ac66adb9126e7c1bf6'
   })
 
   depends_on 'docbook_xml'
-  depends_on 'xmlcatmgr'
   depends_on 'libxml2'
+  depends_on 'xmlcatmgr'
 
   def self.patch
     downloader 'https://github.com/archlinux/svntogit-packages/raw/packages/docbook-xsl/trunk/765567_non-recursive_string_subst.patch'
@@ -51,7 +51,7 @@ class Docbook_xsl_nons < Package
         manpages params profiling roundtrip slides template tests tools \
         webhelp website xhtml xhtml-1_1 xhtml5
         do
-        install -Dt "#{@pkgroot}"/"$fn" -m644 "$fn"/*.{xml,xsl,dtd,ent}
+        install -Dt "#{@pkgroot}"/"$fn" -m644 "$fn"/*.{xml,xsl,dtd,ent} || true
         done
       )
     ADDFILES_HEREDOC


### PR DESCRIPTION
- prevent expected failure of parts of packaging script from stopping all XML files from being packaged.

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=docbook CREW_TESTING=1 crew update
```
