### PR TITLE
Add libblockdev package

### DIFF
--- a/packages/gpgme.rb
+++ b/packages/gpgme.rb
@@ -3,33 +3,30 @@ require 'package'
 class Gpgme < Package
   description 'GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG easier for applications.'
   homepage 'https://www.gnupg.org/related_software/gpgme/index.html'
-  @_ver = '1.15.1'
+  @_ver = '1.17.0'
   version @_ver
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
   source_url "https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-#{@_ver}.tar.bz2"
-  source_sha256 'eebc3c1b27f1c8979896ff361ba9bb4778b508b2496c2fc10e3775a40b1de1ad'
+  source_sha256 '4ed3f50ceb7be2fce2c291414256b20c9ebf4c03fddb922c88cda99c119a69f5'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gpgme/1.15.1_armv7l/gpgme-1.15.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gpgme/1.15.1_armv7l/gpgme-1.15.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gpgme/1.15.1_i686/gpgme-1.15.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gpgme/1.15.1_x86_64/gpgme-1.15.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gpgme/1.17.0_armv7l/gpgme-1.17.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gpgme/1.17.0_armv7l/gpgme-1.17.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gpgme/1.17.0_i686/gpgme-1.17.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gpgme/1.17.0_x86_64/gpgme-1.17.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'cefc164ba4ee3297c69c23c247c48cc26aea6f8bf060ff428d03d3288bffbffb',
-     armv7l: 'cefc164ba4ee3297c69c23c247c48cc26aea6f8bf060ff428d03d3288bffbffb',
-       i686: '828ebe648f313eb3849d0fc1b09f287159ec658438b0917d2cea9938da173924',
-     x86_64: '63a1accd77f24e417dc9ca519a142303d2083f1fa49af2bb3edb6b3fc08e0677'
+    aarch64: '37a3825a92c97935d1ec0aec7551ec0daae0c314db0428c6bba752ffd66e7c4c',
+     armv7l: '37a3825a92c97935d1ec0aec7551ec0daae0c314db0428c6bba752ffd66e7c4c',
+       i686: '6331885eac641a14e0bc47b9d01cc75a093b67acce0291e143e91345952ea486',
+     x86_64: 'dbe4671b83a5bae3696abc15f50ee6cb8226c11379d7f8a444a2d23aa8e754a4'
   })
 
   depends_on 'gnupg'
 
   def self.build
-    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libblockdev.rb
+++ b/packages/libblockdev.rb
@@ -3,11 +3,22 @@ require 'package'
 class Libblockdev < Package
   description 'A library for manipulating block devices.'
   homepage 'https://github.com/storaged-project/libblockdev'
-  version '2.26-1'    
+  version '2.26'
   license 'LGPL-2.1'
-  compatibility 'all'
-  source_url 'https://github.com/storaged-project/libblockdev/releases/download/2.26-1/libblockdev-2.26.tar.gz'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url "https://github.com/storaged-project/libblockdev/releases/download/#{version}-1/libblockdev-#{version}.tar.gz"
   source_sha256 'c4c0e10b35ac632bda8ce6d200b5601184984dec387fe59185921eb42432e069'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libblockdev/2.26_armv7l/libblockdev-2.26-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libblockdev/2.26_armv7l/libblockdev-2.26-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libblockdev/2.26_x86_64/libblockdev-2.26-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '20413e951e4b4d593ca0ca42789932a1ea624f53a33a022c190a318ba868d718',
+     armv7l: '20413e951e4b4d593ca0ca42789932a1ea624f53a33a022c190a318ba868d718',
+     x86_64: 'f4ebe749826e5b659043b618d759891d5a6a1e9f2540e855ae2927b2dd9711a5'
+  })
 
   depends_on 'cryptsetup' => :build
   depends_on 'eudev' => :build
@@ -23,29 +34,14 @@ class Libblockdev < Package
   depends_on 'parted' => :build
   depends_on 'polkit' => :build
   depends_on 'volume_key' => :build
-    
-    ## crew install buildessential lvm2 cryptsetup libbytesize libdmraid volume_key
-#No package 'glib-2.0' found (solvable by glib)
-#No package 'gobject-2.0' found (solvable by glib but it still checks for gobject_introspection)
-#No package 'gio-2.0' found
-#No package 'libudev' found
-#No package 'libkmod' found (solvable by libkmod)
-#No package 'libcryptsetup' found
-#No package 'nss' found
-#libvolume_key.h not available
-#No package 'libparted' found (solvable by parted)
-#No package 'mount' found
-#No package 'blkid' found (solvable by util_linux)
-#No package 'uuid' found
-#No package 'libndctl' found
 
   def self.build
-   #system "ln -s /bin/sed /usr/local/bin/sed"
-    system "./configure"
-    system "make"
+    system 'filefix'
+    system "./configure #{CREW_OPTIONS} --with-gtk-doc=no"
+    system 'make'
   end
 
   def self.install
-    system "make install"
+    system "make install DESTDIR=#{CREW_DEST_DIR}"
   end
 end

--- a/packages/libblockdev.rb
+++ b/packages/libblockdev.rb
@@ -1,0 +1,51 @@
+require 'package'
+
+class Libblockdev < Package
+  description 'A library for manipulating block devices.'
+  homepage 'https://github.com/storaged-project/libblockdev'
+  version '2.26-1'    
+  license 'LGPL-2.1'
+  compatibility 'all'
+  source_url 'https://github.com/storaged-project/libblockdev/releases/download/2.26-1/libblockdev-2.26.tar.gz'
+  source_sha256 'c4c0e10b35ac632bda8ce6d200b5601184984dec387fe59185921eb42432e069'
+
+  depends_on 'cryptsetup' => :build
+  depends_on 'eudev' => :build
+  depends_on 'glib' => :build
+  depends_on 'gobject_introspection' => :build
+  depends_on 'gpgme' => :build
+  depends_on 'libbytesize' => :build
+  depends_on 'libdmraid' => :build
+  depends_on 'libkmod' => :build
+  depends_on 'libnvme' => :build
+  depends_on 'ndctl' => :build
+  depends_on 'nss' => :build
+  depends_on 'parted' => :build
+  depends_on 'polkit' => :build
+  depends_on 'volume_key' => :build
+    
+    ## crew install buildessential lvm2 cryptsetup libbytesize libdmraid volume_key
+#No package 'glib-2.0' found (solvable by glib)
+#No package 'gobject-2.0' found (solvable by glib but it still checks for gobject_introspection)
+#No package 'gio-2.0' found
+#No package 'libudev' found
+#No package 'libkmod' found (solvable by libkmod)
+#No package 'libcryptsetup' found
+#No package 'nss' found
+#libvolume_key.h not available
+#No package 'libparted' found (solvable by parted)
+#No package 'mount' found
+#No package 'blkid' found (solvable by util_linux)
+#No package 'uuid' found
+#No package 'libndctl' found
+
+  def self.build
+   #system "ln -s /bin/sed /usr/local/bin/sed"
+    system "./configure"
+    system "make"
+  end
+
+  def self.install
+    system "make install"
+  end
+end


### PR DESCRIPTION
## Description
Adds the libblockdev package (part of the same larger package as #6766).

- Also updated `gpgme`

## Additional information
Depends on #6775 

Works properly:
- [x] armv7l
- [x] x86_64
- [ ] i686 (dependency does not build for this arch)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=libblockdev CREW_TESTING=1 crew update
```
---
