### PR TITLE
Remove build dependencies found in buildessential

### DIFF
--- a/packages/amtk.rb
+++ b/packages/amtk.rb
@@ -24,8 +24,6 @@ class Amtk < Package
 
   depends_on 'gtk3'
   depends_on 'gobject_introspection' => :build
-  depends_on 'gtk_doc' => :build
-  depends_on 'llvm' => :build
 
 
   def self.build

--- a/packages/apng2gif.rb
+++ b/packages/apng2gif.rb
@@ -24,7 +24,6 @@ class Apng2gif < Package
   })
 
   depends_on 'libpng'
-  depends_on 'help2man' => :build
 
   def self.patch
     system "sed -i 's:CC         = gcc:CC         = #{CREW_TGT}-gcc:' Makefile"

--- a/packages/at_spi2_atk.rb
+++ b/packages/at_spi2_atk.rb
@@ -22,7 +22,6 @@ class At_spi2_atk < Package
       x86_64: 'ce793ff57e4c0ba75b76e8f12934741f6cb26b4d02cc9080e647c28170b1f627',
   })
 
-  depends_on 'automake' => :build
   depends_on 'at_spi2_core'
   depends_on 'atk'
 

--- a/packages/cgroupfs_mount.rb
+++ b/packages/cgroupfs_mount.rb
@@ -22,8 +22,6 @@ class Cgroupfs_mount < Package
      x86_64: 'd01398e7d06e023f625bb36d5c80d20b25bd0db9d0d71d08bfa9e12c8cc36a2a',
   })
 
-  depends_on 'compressdoc' => :build
-
   def self.install
     system "install -Dm755 cgroupfs-mount #{CREW_DEST_PREFIX}/bin/cgroupfs-mount"
     system "install -Dm755 cgroupfs-umount #{CREW_DEST_PREFIX}/bin/cgroupfs-umount"

--- a/packages/clutter_gtk.rb
+++ b/packages/clutter_gtk.rb
@@ -26,7 +26,6 @@ class Clutter_gtk < Package
   depends_on 'gtk3'
   depends_on 'libgee'
   depends_on 'clutter'
-  depends_on 'valgrind' => :build
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} builddir"

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -34,7 +34,6 @@ class Cmake < Package
   depends_on 'libcurl'
   depends_on 'librhash'
   depends_on 'libuv'
-  depends_on 'llvm' => :build
 
   def self.patch
     if Dir.exist? "#{CREW_PREFIX}/include/ncursesw"

--- a/packages/compressdoc.rb
+++ b/packages/compressdoc.rb
@@ -23,8 +23,6 @@ class Compressdoc < Package
      x86_64: '7ced0fd4fc946a5cfc1ea22821be18e23572228436736b7787cb1e86e9e202a0',
   })
 
-  depends_on 'help2man' => :build
-
   def self.build
     system 'make'
   end

--- a/packages/cppunit.rb
+++ b/packages/cppunit.rb
@@ -22,7 +22,6 @@ class Cppunit < Package
      x86_64: 'e5f432ecd193119cb7201eec9881f3e89dd7bccbb78f3ba4cc8374471acbe236',
   })
 
-  depends_on 'doxygen' => :build
   depends_on 'graphviz' => :build
 
   def self.build

--- a/packages/cras.rb
+++ b/packages/cras.rb
@@ -28,7 +28,6 @@ class Cras < Package
   depends_on 'gtest' => :build
   depends_on 'iniparser' # R
   depends_on 'ladspa'
-  depends_on 'llvm' => :build
   depends_on 'rust' => :build
   depends_on 'sbc' # R
   depends_on 'speexdsp' # R

--- a/packages/dfc.rb
+++ b/packages/dfc.rb
@@ -22,7 +22,6 @@ class Dfc < Package
      x86_64: '9dccac46a97222d4f89002c7c5a8bc97b7b1d237b79a53251e03fdf9f4ff17e3',
   })
 
-  depends_on 'cmake' => :build
   depends_on 'gettext'
 
   def self.build

--- a/packages/dos2unix.rb
+++ b/packages/dos2unix.rb
@@ -22,8 +22,6 @@ class Dos2unix < Package
      x86_64: '249077651ae479e1888742a2925d41e003331f8836392986ed58b3fd18a6d123',
   })
 
-  depends_on 'gettext' => :build
-
   def self.build
     system 'make'
   end

--- a/packages/doxygen.rb
+++ b/packages/doxygen.rb
@@ -22,8 +22,6 @@ class Doxygen < Package
      x86_64: 'ff5909d7d941b2a9e29ffc2c1d54613f65c57ff5ac4bae186264f63614ee6be3',
   })
 
-  depends_on 'python2' => :build
-
   def self.build
     Dir.mkdir 'build'
     Dir.chdir 'build' do

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -33,7 +33,6 @@ class Epiphany < Package
   depends_on 'gmp' # R
   depends_on 'gobject_introspection' => :build
   depends_on 'gtk3' # R
-  depends_on 'help2man' => :build
   depends_on 'json_glib' # R
   depends_on 'libdazzle' # R
   depends_on 'libhandy' # R
@@ -43,7 +42,6 @@ class Epiphany < Package
   depends_on 'lsb_release' => :build
   depends_on 'pango' # R
   depends_on 'startup_notification' => :build
-  depends_on 'valgrind' => :build
   depends_on 'webkit2gtk_4' # R
 
   def self.build

--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -44,7 +44,6 @@ class Evince < Package
   depends_on 'nautilus' # R
   depends_on 'pango' # R
   depends_on 'poppler' # R
-  depends_on 'valgrind' => :build
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/exo.rb
+++ b/packages/exo.rb
@@ -25,7 +25,6 @@ class Exo < Package
 
   depends_on 'libxfce4ui'
   depends_on 'xfce4_dev_tools'
-  depends_on 'valgrind' => :build
 
   def self.patch
     FileUtils.mkdir_p 'm4'

--- a/packages/flex.rb
+++ b/packages/flex.rb
@@ -23,7 +23,6 @@ class Flex < Package
   })
 
   depends_on 'm4'
-  depends_on 'bison' => :build
 
   def self.build
     system "./configure", "--libdir=#{CREW_LIB_PREFIX}", "--with-pic", "--disable-static", "--enable-shared"

--- a/packages/gcc7.rb
+++ b/packages/gcc7.rb
@@ -26,8 +26,6 @@ class Gcc7 < Package
   depends_on 'mawk' => :build
   depends_on 'dejagnu' => :build # for test
   depends_on 'icu4c' => :build
-  depends_on 'python2' => :build
-  depends_on 'python3' => :build
 
   depends_on 'binutils'
   depends_on 'gmp'

--- a/packages/gcc8.rb
+++ b/packages/gcc8.rb
@@ -26,8 +26,6 @@ class Gcc8 < Package
   depends_on 'mawk' => :build
   depends_on 'dejagnu' => :build # for test
   depends_on 'icu4c' => :build
-  depends_on 'python2' => :build
-  depends_on 'python3' => :build
 
   depends_on 'binutils'
   depends_on 'gmp'

--- a/packages/geany_plugins.rb
+++ b/packages/geany_plugins.rb
@@ -21,7 +21,6 @@ class Geany_plugins < Package
   })
 
   depends_on 'libgit2' => :build
-  depends_on 'valgrind' => :build
   depends_on 'enchant' # R
   depends_on 'geany' # R
   depends_on 'libsoup2' # R

--- a/packages/gif2apng.rb
+++ b/packages/gif2apng.rb
@@ -24,7 +24,6 @@ class Gif2apng < Package
   })
 
   depends_on 'zopfli'
-  depends_on 'help2man' => :build
 
   def self.patch
     system "sed -i 's:CC         = gcc:CC         = #{CREW_TGT}-gcc:' Makefile"

--- a/packages/gn.rb
+++ b/packages/gn.rb
@@ -21,9 +21,6 @@ class Gn < Package
      x86_64: '385d47846ff117275793dc43d9ef004d4aa1075b29af3d9283f289cfc757d59f',
   })
 
-  depends_on 'python2' => :build
-  depends_on 'meson' => :build
-
   def self.build
     system "git clone https://gn.googlesource.com/gn"
     ENV['C_INCLUDE_PATH']="#{CREW_PREFIX}/include/"

--- a/packages/gparted.rb
+++ b/packages/gparted.rb
@@ -25,7 +25,6 @@ class Gparted < Package
 
   depends_on 'parted'
   depends_on 'gtkmm3'
-  depends_on 'intltool' => :build
   depends_on 'itstool' => :build
   depends_on 'yelp_tools' => :build
   depends_on 'xfsprogs'

--- a/packages/gspell.rb
+++ b/packages/gspell.rb
@@ -26,10 +26,8 @@ class Gspell < Package
   depends_on 'iso_codes'
   depends_on 'gobject_introspection' => :build
   depends_on 'vala' => :build
-  depends_on 'gtk_doc' => :build
   depends_on 'graphite' => :build
   depends_on 'harfbuzz' => :build
-  depends_on 'llvm' => :build
   depends_on 'hunspell'
 
   ENV['XML_CATALOG_FILES'] = "#{CREW_PREFIX}/etc/xml/catalog"

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -32,7 +32,6 @@ class Gtk3 < Package
   depends_on 'libsass' => :build
   depends_on 'libspectre' => :build
   depends_on 'mesa' => :build
-  depends_on 'valgrind' => :build
   depends_on 'graphene' => :build # Do we need this?
   depends_on 'graphite' => :build # Do we need this?
   depends_on 'libdeflate' => :build # Do we need this?

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -33,7 +33,6 @@ class Gtk4 < Package
   depends_on 'libsass' => :build
   depends_on 'libspectre' => :build
   depends_on 'mesa' => :build
-  depends_on 'valgrind' => :build
   depends_on 'py3_pygments' => :build # Is this needed?
   depends_on 'py3_six' => :build # Is this needed?
   depends_on 'vulkan_headers' => :build

--- a/packages/guile.rb
+++ b/packages/guile.rb
@@ -22,7 +22,6 @@ class Guile < Package
      x86_64: '11a28901148adef29d90c96b6b28e2ff0caee7479588683cf3a919b9cea825e9',
   })
 
-  depends_on 'diffutils' => :build
   depends_on 'libtool'
   depends_on 'bdwgc'
   depends_on 'libffi'

--- a/packages/htop.rb
+++ b/packages/htop.rb
@@ -22,8 +22,6 @@ class Htop < Package
      x86_64: 'ae62201f3496fd3b64c94002af594c9650f3e345ed34db7f1d9d04d667e03d5c'
   })
 
-  depends_on 'buildessential' => :build
-
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
     system "env #{CREW_ENV_OPTIONS} \

--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -24,7 +24,6 @@ class Inetutils < Package
   })
 
   depends_on 'linux_pam'
-  depends_on 'patchelf' => :build
   depends_on 'libcap'
 
   def self.build

--- a/packages/inkscape.rb
+++ b/packages/inkscape.rb
@@ -29,7 +29,6 @@ class Inkscape < Package
   depends_on 'hicolor_icon_theme'
   depends_on 'imagemagick6'
   depends_on 'imagemagick7'
-  depends_on 'llvm' => :build
   depends_on 'popt'
   depends_on 'xdg_base'
   depends_on 'sommelier'

--- a/packages/intltool.rb
+++ b/packages/intltool.rb
@@ -24,7 +24,6 @@ class Intltool < Package
 
   depends_on 'libtool'
   depends_on 'perl_xml_parser'
-  depends_on 'patch' => :build
 
   def self.patch
     system "curl -#LO https://raw.githubusercontent.com/Alexpux/MSYS2-packages/master/intltool/perl-5.22-compatibility.patch"

--- a/packages/js78.rb
+++ b/packages/js78.rb
@@ -24,7 +24,6 @@ class Js78 < Package
 
   depends_on 'autoconf213' => :build
   depends_on 'rust' => :build
-  depends_on 'llvm' => :build
   depends_on 'nspr'
 
   case ARCH

--- a/packages/js91.rb
+++ b/packages/js91.rb
@@ -24,7 +24,6 @@ class Js91 < Package
 
   depends_on 'autoconf213' => :build
   depends_on 'rust' => :build
-  depends_on 'llvm' => :build
   depends_on 'nspr'
 
   @rust_default_host = case ARCH

--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -26,9 +26,7 @@ class Ldc < Package                 # The first character of the class name must
   depends_on 'ncurses'
   depends_on 'zlibpkg'
   depends_on 'libconfig' => :build
-  depends_on 'cmake' => :build
   depends_on 'libedit' => :build
-  depends_on 'llvm' => :build
 
   def self.build                   # the steps required to build the package
     system "mkdir", "build"

--- a/packages/libass.rb
+++ b/packages/libass.rb
@@ -22,9 +22,6 @@ class Libass < Package
      x86_64: '5d4f11533ac29592c4af827480bed3609ee8d4ee48e3b34bb3b68934da7e1248',
   })
 
-  #depends_on 'automake' => :build
-  #depends_on 'autoconf' => :build
-  #depends_on 'libtool' => :build
   depends_on 'fribidi'
   depends_on 'fontconfig'
 

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -36,7 +36,6 @@ class Libcurl < Package
   depends_on 'openssl' # R
   depends_on 'py3_pip' => :build
   depends_on 'rust' => :build
-  depends_on 'valgrind' => :build
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 

--- a/packages/libcyrussasl.rb
+++ b/packages/libcyrussasl.rb
@@ -22,8 +22,6 @@ class Libcyrussasl < Package
      x86_64: 'f1bc40fa4566b8928447b59387a49268e4aa541a3e80d7f059e74e7d62e17a63'
   })
 
-  depends_on 'diffutils' => :build
-
   def self.patch
     system 'filefix'
   end

--- a/packages/libevdev.rb
+++ b/packages/libevdev.rb
@@ -22,9 +22,6 @@ class Libevdev < Package
      x86_64: '6afbae9d141ced6da39edb73127c4e247afd9abeae8a681b3dc8b62b7edc818d'
   })
 
-  depends_on 'doxygen' => :build
-  depends_on 'python3' => :build
-
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
       builddir"

--- a/packages/libglvnd.rb
+++ b/packages/libglvnd.rb
@@ -25,7 +25,6 @@ class Libglvnd < Package
   depends_on 'libxext'
   depends_on 'libx11'
   depends_on 'glproto'
-  depends_on 'python3' => :build
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/libgnome_keyring.rb
+++ b/packages/libgnome_keyring.rb
@@ -22,7 +22,6 @@ class Libgnome_keyring < Package
 
   depends_on 'dbus'
   depends_on 'libgcrypt'
-  depends_on 'llvm' => :build
 
   def self.build
     system "./configure #{CREW_OPTIONS} --enable-introspection=no --enable-vala=no"

--- a/packages/libinput.rb
+++ b/packages/libinput.rb
@@ -28,7 +28,6 @@ class Libinput < Package
   depends_on 'libwacom'
   depends_on 'libunwind'
   depends_on 'libcheck'
-  depends_on 'valgrind' => :build
 
   # If debug-gui feature is required, uncomment following lines and remove "-Ddebug-gui=false" to enable it
   # depends_on 'graphviz' => :build

--- a/packages/libmicrohttpd.rb
+++ b/packages/libmicrohttpd.rb
@@ -22,8 +22,6 @@ class Libmicrohttpd < Package
      x86_64: 'aa41e8d0577c54de70b7f830be5780d5b9f5d92ccafca54570d9a97a9b7fda15',
   })
 
-  depends_on 'diffutils' => :build
-
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system 'make'

--- a/packages/librsync.rb
+++ b/packages/librsync.rb
@@ -23,7 +23,6 @@ class Librsync < Package
      x86_64: 'fdcbab57b6c0ca16bbcb83a5d33577b6655d49c1ab3b8d86b243957f6ba76c05'
   })
 
-  depends_on 'cmake' => :build
   depends_on 'bz2'
   depends_on 'perl'
   depends_on 'popt'

--- a/packages/libtasn1.rb
+++ b/packages/libtasn1.rb
@@ -22,10 +22,6 @@ class Libtasn1 < Package
      x86_64: '45bb14fceafe35899eb7d379a6c61347428f7acaca451dc24798eb463939e898'
   })
 
-  # bison, diff, cmp are required at compile-time
-  depends_on 'bison' => :build
-  depends_on 'diffutils' => :build
-
   def self.build
     system "./configure #{CREW_OPTIONS} \
       #{CREW_ENV_OPTIONS} \

--- a/packages/libx11.rb
+++ b/packages/libx11.rb
@@ -22,7 +22,6 @@ class Libx11 < Package
      x86_64: '329c60bc8ff483f079024654d81bcf932c54b79d7dd0314606a3f0d1b436be94'
   })
 
-  depends_on 'llvm' => :build
   depends_on 'xorg_proto'
   depends_on 'libxcb'
   depends_on 'libxtrans'

--- a/packages/libxext.rb
+++ b/packages/libxext.rb
@@ -22,8 +22,6 @@ class Libxext < Package
      x86_64: '9024bf186472eeb3ed2fe0ea7c77716f76c9860248418d8f804f600d5b5c2704',
   })
 
-  depends_on 'llvm' => :build
-
   def self.build
     ENV['CFLAGS'] = "-fuse-ld=lld"
     ENV['CXXFLAGS'] = "-fuse-ld=lld"

--- a/packages/libxrandr.rb
+++ b/packages/libxrandr.rb
@@ -25,7 +25,6 @@ class Libxrandr < Package
   depends_on 'libx11'
   depends_on 'libxext'
   depends_on 'libxrender'
-  depends_on 'llvm' => :build
 
   def self.build
     ENV['CFLAGS'] = "-fuse-ld=lld"

--- a/packages/libxss.rb
+++ b/packages/libxss.rb
@@ -24,7 +24,6 @@ class Libxss < Package
   })
 
   depends_on 'libxext'
-  depends_on 'util_macros' => :build
 
   def self.build
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -41,10 +41,8 @@ class Mesa < Package
   depends_on 'libxv' # R
   depends_on 'libxxf86vm' # R
   # depends_on 'libva' => :build # Enable only during build to avoid circular dep.
-  depends_on 'llvm' => :build
   depends_on 'lm_sensors' # R
   depends_on 'py3_mako'
-  depends_on 'valgrind' => :build
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader' => :build
   depends_on 'wayland_protocols' => :build

--- a/packages/musl_bz2.rb
+++ b/packages/musl_bz2.rb
@@ -22,8 +22,6 @@ class Musl_bz2 < Package
      x86_64: '0491dda97107a65317cf6a6896d11654159623ed8f6107efdaafa710326723fe'
   })
 
-  depends_on 'patchelf' => :build
-
   def self.patch
     load "#{CREW_LIB_PATH}lib/musl.rb"
     # Modify Makefile from "ln -s $(PREFIX)/bin/xxx $(PREFIX)/bin/yyy" to

--- a/packages/musl_c_ares.rb
+++ b/packages/musl_c_ares.rb
@@ -29,7 +29,6 @@ class Musl_c_ares < Package
   depends_on 'musl_ncurses' => :build
   depends_on 'musl_openssl' => :build
   depends_on 'musl_krb5' => :build
-  depends_on 'patchelf' => :build
 
   is_static
 

--- a/packages/musl_curl.rb
+++ b/packages/musl_curl.rb
@@ -34,7 +34,6 @@ class Musl_curl < Package
   depends_on 'musl_zlib' => :build
   depends_on 'musl_zstd' => :build
   depends_on 'rust' => :build
-  depends_on 'valgrind' => :build
 
   is_static
 

--- a/packages/musl_perl.rb
+++ b/packages/musl_perl.rb
@@ -23,8 +23,6 @@ class Musl_perl < Package
      x86_64: '3e9f12c893b92fef6c38b57a22be90ff1d80a10156631fbdc8587031516983e8'
   })
 
-  depends_on 'patch' => :build
-  depends_on 'patchelf' => :build
   depends_on 'musl_native_toolchain'
   depends_on 'musl_zlib' => :build
   depends_on 'musl_bz2' => :build

--- a/packages/ncat.rb
+++ b/packages/ncat.rb
@@ -22,9 +22,6 @@ class Ncat < Package
      x86_64: '5660ea321436f1b9642d318a77e9b0b5c379825ac0611daaf5f82dd794753598',
   })
 
-  depends_on 'buildessential' => :build
-  depends_on 'filecmd' => :build   #configure uses file
-
   def self.build
     #fixup "/usr/bin/file" -> "file" in the configure script
 

--- a/packages/nping.rb
+++ b/packages/nping.rb
@@ -22,9 +22,6 @@ class Nping < Package
      x86_64: '558f8cc197f92003dfd44adab12ec4461b594f322e41d0498a8e961ae030f00a',
   })
 
-  depends_on 'buildessential' => :build
-  depends_on 'filecmd' => :build   #configure uses file
-
   def self.build
     #fixup "/usr/bin/file" -> "file" in the configure script
 

--- a/packages/opus.rb
+++ b/packages/opus.rb
@@ -22,8 +22,6 @@ class Opus < Package
       x86_64: 'f77d89ba219257e2b2d97776b0df5407e40b33dcca0d0ca49d0970145009c31e',
   })
 
-  depends_on 'doxygen' => :build
-
   def self.build
     system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
               --enable-custom-modes"

--- a/packages/percona_server.rb
+++ b/packages/percona_server.rb
@@ -22,7 +22,6 @@ class Percona_server < Package
      x86_64: '47431d59582a5be3361cbfd571de3da9a557b76cea40a01f4b58347988e7aa2c',
   })
 
-  depends_on 'cmake' => :build
   depends_on 'percona_boost'
   depends_on 'libaio'
   depends_on 'libtirpc'

--- a/packages/percona_toolkit.rb
+++ b/packages/percona_toolkit.rb
@@ -23,7 +23,6 @@ class Percona_toolkit < Package
   })
 
   depends_on 'percona_server'
-  depends_on 'perl' => :build
 
   def self.build
     system "perl Makefile.PL PREFIX=#{CREW_PREFIX}"

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -23,8 +23,6 @@ class Perl < Package
      x86_64: '8c12ba41052f0f49f1dccc7cc1de795d4b4c55ba70c4ed1eff866580405e300a'
   })
 
-  depends_on 'patch' => :build
-
   @perl_fullversion = @_ver.split('-')[0]
 
   @perl_version = @_ver.rpartition('.')[0]

--- a/packages/pixman.rb
+++ b/packages/pixman.rb
@@ -22,7 +22,6 @@ class Pixman < Package
      x86_64: 'a3c1b4c722e598ae10571fe8ef00dddc431ac6d833980f6f859b093a9ac385d1',
   })
 
-  depends_on 'llvm' => :build
   depends_on 'libpng'
 
   def self.build

--- a/packages/progress.rb
+++ b/packages/progress.rb
@@ -22,7 +22,6 @@ class Progress < Package
      x86_64: 'e3e4b39e3be040d3d1ce716b253a625d0aa77839cdc7e22d479649748bbfa403',
   })
 
-  depends_on 'pkgconfig' => :build
   depends_on 'ncurses'
 
   def self.build

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -52,7 +52,6 @@ class Pulseaudio < Package
   depends_on 'speexdsp' # R
   depends_on 'tcpwrappers' => :build
   depends_on 'tdb' # R
-  depends_on 'valgrind' => :build
   depends_on 'webrtc_audio_processing' # R
   depends_on 'xorg_lib' => :build
 

--- a/packages/qpdf.rb
+++ b/packages/qpdf.rb
@@ -23,7 +23,6 @@ class Qpdf < Package
   })
 
   depends_on 'libjpeg'
-  depends_on 'automake' => :build
 
   def self.build
     system './autogen.sh'

--- a/packages/rfkill.rb
+++ b/packages/rfkill.rb
@@ -22,8 +22,6 @@ class Rfkill < Package
      x86_64: 'b491bd154ece2066272972c2110f8bc5d6c9a3ce4a0189fda5825d3cbddb0d71',
   })
 
-  depends_on 'buildessential' => :build
-
   def self.build
     system "make"
   end

--- a/packages/sejda_console.rb
+++ b/packages/sejda_console.rb
@@ -22,7 +22,6 @@ class Sejda_console < Package
      x86_64: 'd59742c678df678145d00a86e82dca8ffa180299f099eafbc674d76641ea9506',
   })
 
-  depends_on 'help2man' => :build
   depends_on 'unzip' => :build
   depends_on 'jdk8'
 

--- a/packages/smem.rb
+++ b/packages/smem.rb
@@ -22,7 +22,6 @@ class Smem < Package
      x86_64: 'aff43254df620f1dcd080a5071a0f58b223d57b6f48d8545ed453062c115ada6',
   })
 
-  depends_on 'buildessential' => :build
   depends_on 'python27'
 
   def self.build

--- a/packages/squashfs.rb
+++ b/packages/squashfs.rb
@@ -22,8 +22,6 @@ class Squashfs < Package
      x86_64: '6a3f77adbef01926ed731f7a69dab7607218dd13b31dda230556d5590dd7eea3'
   })
 
-  depends_on 'compressdoc' => :build
-  depends_on 'help2man' => :build
   depends_on 'lzo'
 
   def self.build

--- a/packages/testdisk.rb
+++ b/packages/testdisk.rb
@@ -23,7 +23,6 @@ class Testdisk < Package
   })
 
   depends_on 'apriconv'
-  depends_on 'compressdoc' => :build
   depends_on 'libjpeg_turbo'
   depends_on 'ncurses'
   depends_on 'zlibpkg'

--- a/packages/ttf2pt1.rb
+++ b/packages/ttf2pt1.rb
@@ -22,8 +22,6 @@ class Ttf2pt1 < Package
      x86_64: 'e8faecc72638a7df553126f461d87b278ed0cb064a19bad8d9d1f28240ee8e76',
   })
 
-  depends_on 'help2man' => :build
-
   def self.patch
     system "sed -i '242,262d' Makefile"
     system "sed -i 's,/usr/bin/perl,#{CREW_PREFIX}/bin/perl,' scripts/inst_dir"

--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -22,9 +22,6 @@ class Unzip < Package
       x86_64: 'a58e8a34a46721674ba16198fa943297c6fa80c5933b956bd1ebb6fe91ac6b89',
   })
 
-  depends_on 'compressdoc' => :build
-  depends_on 'patch' => :build
-
   # adapted from the homebrew recipe as seen at: https://github.com/Homebrew/homebrew-dupes/blob/master/unzip.rb
   # Upstream is unmaintained so we use the Ubuntu unzip_6.0-25ubuntu1 patchset:
   # https://changelogs.ubuntu.com/changelogs/pool/main/u/unzip/unzip_6.0-25ubuntu1/changelog

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -35,7 +35,6 @@ class Webkit2gtk_4 < Package
   depends_on 'gobject_introspection' => :build
   depends_on 'gstreamer'
   depends_on 'gtk3'
-  depends_on 'gtk_doc' => :build
   depends_on 'harfbuzz'
   depends_on 'hyphen'
   depends_on 'libgcrypt'
@@ -56,7 +55,6 @@ class Webkit2gtk_4 < Package
   depends_on 'mesa'
   depends_on 'openjpeg'
   depends_on 'pango'
-  depends_on 'valgrind' => :build
   depends_on 'wayland'
   depends_on 'woff2'
   depends_on 'wpebackend_fdo'

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -34,7 +34,6 @@ class Weston < Package
   depends_on 'pango'
   depends_on 'dbus'
   depends_on 'libxxf86vm'
-  depends_on 'llvm' => :build
   depends_on 'xdg_base'
   depends_on 'libwebp'
   depends_on 'libva'

--- a/packages/xbitmaps.rb
+++ b/packages/xbitmaps.rb
@@ -22,8 +22,6 @@ class Xbitmaps < Package
      x86_64: '161b342836f77df11606c5fa965b38912022d108569313d504a0bc5d1bce4c16',
   })
 
-  depends_on 'util_macros' => :build
-
   def self.build
     system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
     system 'make'

--- a/packages/zile.rb
+++ b/packages/zile.rb
@@ -23,7 +23,6 @@ class Zile < Package
   })
 
   depends_on 'bdwgc'
-  depends_on 'help2man' => :build
 
   def self.build
     system './configure',


### PR DESCRIPTION
Since the dependencies removed are already in buildessential, their removal should make no difference and clean up the codebase a bit. 