### PR TITLE
GCC11 rebuilt w/ mold support, add mold to buildessentials, add libst…

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -220,5 +220,6 @@ CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
 
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +
+                       `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rdfind`.scan(/\t([^ ]+)/).flatten +
                        %w[libzstd.so.1]
 CREW_ESSENTIAL_FILES.uniq!

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -220,6 +220,5 @@ CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
 
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +
-                       `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rdfind`.scan(/\t([^ ]+)/).flatten +
-                       %w[libzstd.so.1]
+                       %w[libzstd.so.1 libstdc++.so.6]
 CREW_ESSENTIAL_FILES.uniq!

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -26,6 +26,9 @@ class Buildessential < Package
   depends_on 'pkgconfig'
   depends_on 'binutils'
 
+  # Linkers
+  depends_on 'mold'
+
   # typically required libraries & tools to configure packages
   # e.g. using "./autogen.sh"
   depends_on 'automake'

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -27,7 +27,10 @@ class Buildessential < Package
   depends_on 'binutils'
 
   # Linkers
-  depends_on 'mold'
+  case ARCH
+  when 'i686', 'x86_64'
+    depends_on 'mold'
+  end
 
   # typically required libraries & tools to configure packages
   # e.g. using "./autogen.sh"

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -12,14 +12,14 @@ class Bz2 < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_armv7l/bz2-1.0.8-1-chromeos-armv7l.tar.zst',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_armv7l/bz2-1.0.8-1-chromeos-armv7l.tar.zst',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_i686/bz2-1.0.8-1-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_x86_64/bz2-1.0.8-1-chromeos-x86_64.tar.zst'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_i686/bz2-1.0.8-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_x86_64/bz2-1.0.8-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '98fec974c6fda9d4f12988db8eed1338d136fe78866f80047db70fe0bab15bcf',
      armv7l: '98fec974c6fda9d4f12988db8eed1338d136fe78866f80047db70fe0bab15bcf',
-    i686: '2beb95c3ec8455c5eda6a4e6be3baa00a5f8ef24c9561f58750758ba62e9cc8e',
-  x86_64: 'e5dee3da36d88d602496925888f966d47453d4a52e684c4bc6a982906b3b9f32'
+       i686: '2beb95c3ec8455c5eda6a4e6be3baa00a5f8ef24c9561f58750758ba62e9cc8e',
+     x86_64: 'e5dee3da36d88d602496925888f966d47453d4a52e684c4bc6a982906b3b9f32'
   })
 
   def self.patch

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -3,61 +3,71 @@ require 'package'
 class Bz2 < Package
   description 'bzip2 is a freely available, patent free, high-quality data compressor.'
   homepage 'http://www.bzip.org/'
-  version '1.0.8'
+  version '1.0.8-1'
   license 'BZIP2'
   compatibility 'all'
   source_url 'https://fossies.org/linux/misc/bzip2-1.0.8.tar.gz'
   source_sha256 'ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8_armv7l/bz2-1.0.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8_armv7l/bz2-1.0.8-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8_i686/bz2-1.0.8-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8_x86_64/bz2-1.0.8-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_armv7l/bz2-1.0.8-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_armv7l/bz2-1.0.8-1-chromeos-armv7l.tar.zst',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_i686/bz2-1.0.8-1-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz2/1.0.8-1_x86_64/bz2-1.0.8-1-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '11fbd7bb0897446cfda34be28db698ecdcbfbcb70e23311fe405edf1aa9abec4',
-     armv7l: '11fbd7bb0897446cfda34be28db698ecdcbfbcb70e23311fe405edf1aa9abec4',
-       i686: '82f0c8f531c14cef34d9b2a7b1c3a8f1783d43fad87a3da19a12da91abf03857',
-     x86_64: '418cff679b9753a9f247a77bf0d61994fc73ee473e6eaed49cd8aa4a159166a7',
+  binary_sha256({
+    aarch64: '98fec974c6fda9d4f12988db8eed1338d136fe78866f80047db70fe0bab15bcf',
+     armv7l: '98fec974c6fda9d4f12988db8eed1338d136fe78866f80047db70fe0bab15bcf',
+    i686: '2beb95c3ec8455c5eda6a4e6be3baa00a5f8ef24c9561f58750758ba62e9cc8e',
+  x86_64: 'e5dee3da36d88d602496925888f966d47453d4a52e684c4bc6a982906b3b9f32'
   })
 
+  def self.patch
+    system "sed -i 's,^LDFLAGS=,LDFLAGS=-flto,' Makefile"
+    system "sed -i 's,^CFLAGS=-Wall,CFLAGS=-Wall -flto,' Makefile"
+    system "sed -i 's,^CFLAGS=-fpic,CFLAGS=-fpic -flto,' Makefile-libbz2_so"
+  end
+
   def self.build
-    system "make -f Makefile-libbz2_so"
+    system 'make -f Makefile-libbz2_so'
   end
 
   def self.install
     # bz2 Makefile doesn't have DESTDIR, so we need several tricks
     # to make it install files correctly.
-
+    FileUtils.mkdir_p %W[
+      #{CREW_DEST_PREFIX}/bin
+      #{CREW_DEST_LIB_PREFIX}
+    ]
     # Modify Makefile from "ln -s $(PREFIX)/bin/xxx $(PREFIX)/bin/yyy" to
     # "ln -s xxx $(PREFIX)/bin/yyy"
     system "sed -i Makefile -e '/ln -s/s:$(PREFIX)/bin/::'"
 
     # Use PREFIX instead of DESTDIR
-    system "make", "PREFIX=#{CREW_DEST_PREFIX}", "install"
-
-    # Remove static library
-    system "rm #{CREW_DEST_PREFIX}/lib/libbz2.a"
+    system 'make', "PREFIX=#{CREW_DEST_PREFIX}", 'install'
+    FileUtils.mv "#{CREW_DEST_PREFIX}/lib/libbz2.a", "#{CREW_DEST_LIB_PREFIX}/libbz2.a" if ARCH == 'x86_64'
 
     # Install bzip2 using shared library by hand
-    system "cp -p bzip2-shared bzip2"
-    system "install -Dm755 bzip2 #{CREW_DEST_PREFIX}/bin/bzip2"
-    system "ln -sf bzip2 #{CREW_DEST_PREFIX}/bin/bunzip2"
-    system "ln -sf bzip2 #{CREW_DEST_PREFIX}/bin/bzcat"
+    FileUtils.install 'bzip2-shared', "#{CREW_DEST_PREFIX}/bin/bzip2", mode: 0o755
+    Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
+      FileUtils.ln_sf 'bzip2', 'bunzip2'
+      FileUtils.ln_sf 'bzip2', 'bzcat'
+    end
 
     # Install shared library by hand
-    system "install -Dm644 libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0.8"
-    system "ln -s libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0"
-    system "ln -s libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so.1"
-    system "ln -s libbz2.so.1.0.8 #{CREW_DEST_LIB_PREFIX}/libbz2.so"
+    FileUtils.install 'libbz2.so.1.0.8', "#{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0.8", mode: 0o644
+    Dir.chdir CREW_DEST_LIB_PREFIX do
+      FileUtils.ln_s 'libbz2.so.1.0.8', "#{CREW_DEST_LIB_PREFIX}/libbz2.so.1.0"
+      FileUtils.ln_s 'libbz2.so.1.0.8', "#{CREW_DEST_LIB_PREFIX}/libbz2.so.1"
+      FileUtils.ln_s 'libbz2.so.1.0.8', "#{CREW_DEST_LIB_PREFIX}/libbz2.so"
+    end
 
     # Move manpages
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share")
-    system "mv #{CREW_DEST_PREFIX}/man #{CREW_DEST_PREFIX}/share/"
+    FileUtils.mv "#{CREW_DEST_PREFIX}/man", "#{CREW_DEST_PREFIX}/share/"
   end
 
   def self.check
-    system "make", "test"
+    system 'make', 'test'
   end
 end

--- a/packages/chafa.rb
+++ b/packages/chafa.rb
@@ -6,38 +6,36 @@ require 'package'
 class Chafa < Package
   description 'Image-to-text converter supporting a wide range of symbols and palettes, transparency, animations, etc.'
   homepage 'https://hpjansson.org/chafa/'
-  version '1.8.0'
+  version 'cf15d59'
   license 'LGPL'
   compatibility 'all'
-  source_url 'https://github.com/hpjansson/chafa/releases/download/1.8.0/chafa-1.8.0.tar.xz'
-  source_sha256 '21ff652d836ba207098c40c459652b2f1de6c8a64fbffc62e7c6319ced32286b'
+  source_url 'https://github.com/hpjansson/chafa.git'
+  git_hashtag 'cf15d59da7ccc6a79f8900e21d0926bea08074e9'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_armv7l/chafa-1.8.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_armv7l/chafa-1.8.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_i686/chafa-1.8.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/1.8.0_x86_64/chafa-1.8.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/cf15d59_armv7l/chafa-cf15d59-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/cf15d59_armv7l/chafa-cf15d59-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/cf15d59_i686/chafa-cf15d59-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/chafa/cf15d59_x86_64/chafa-cf15d59-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '8e4a30680cb863f3735e8e21f33332dae55aa894648719ac8f26028d99cc178e',
-     armv7l: '8e4a30680cb863f3735e8e21f33332dae55aa894648719ac8f26028d99cc178e',
-       i686: '7a5d976bd6c4790a9bf3612ce18ff2160103d1fac5fbda282f8655ae9e443715',
-     x86_64: '0a7c5213a65a6058a766022ec58867f6c435a0759ee27d69727c43f2f9db2c9b'
+    aarch64: 'd53beb7ca506c4df22a1722a4de31c9f08d9726ea73af281c4dfe59019961512',
+     armv7l: 'd53beb7ca506c4df22a1722a4de31c9f08d9726ea73af281c4dfe59019961512',
+       i686: 'f75740d4e7863e7e7c8ef7bfa8270232a62456eadc3881ef67102791458bed48',
+     x86_64: '5aec91cd2979e938db4da44cdf3251338e7f7d81e38939f19f680e2a11dea21b'
   })
 
-  depends_on 'imagemagick7' => :build
-  depends_on 'freetype_sub' => :build
+  depends_on 'glib'
   depends_on 'libxslt'
-  depends_on 'gtk_doc' => ':build'
-
-  def self.patch
-    system 'filefix'
-  end
 
   def self.build
+    system 'autoreconf -fiv'
+    system 'filefix'
     system "#{CREW_ENV_OPTIONS} \
       ./configure \
-      #{CREW_OPTIONS}"
+      #{CREW_OPTIONS} \
+      --without-tools \
+      --enable-gtk-doc=no"
     system 'make'
   end
 

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -69,6 +69,7 @@ class Core < Package
   depends_on 'py3_wheel'
   depends_on 'python2'
   depends_on 'python3'
+  depends_on 'rdfind'
   depends_on 'readline'
   depends_on 'rsync'
   depends_on 'rtmpdump'

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -69,7 +69,6 @@ class Core < Package
   depends_on 'py3_wheel'
   depends_on 'python2'
   depends_on 'python3'
-  depends_on 'rdfind'
   depends_on 'readline'
   depends_on 'rsync'
   depends_on 'rtmpdump'

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -24,7 +24,7 @@ class Fontconfig < Package
   })
 
   depends_on 'gperf'
-  depends_on 'freetype_sub' => :build
+  depends_on 'harfbuzz' => :build
   depends_on 'jsonc'
   depends_on 'util_linux'
   depends_on 'graphite'

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -24,7 +24,7 @@ class Fontconfig < Package
   })
 
   depends_on 'gperf'
-  depends_on 'freetype_sub'
+  depends_on 'freetype_sub' => :build
   depends_on 'jsonc'
   depends_on 'util_linux'
   depends_on 'graphite'

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -7,7 +7,7 @@ class Freetype < Package
   license 'FTL or GPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/freetype/freetype.git'
-  git_hashtag "VER-#{version.gsub('.', '-')}"
+  git_hashtag "VER-#{version.tr('.', '-')}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_armv7l/freetype-2.11.1-chromeos-armv7l.tar.zst',

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -3,40 +3,56 @@ require 'package'
 class Freetype < Package
   description 'FreeType is a freely available software library to render fonts.'
   homepage 'https://www.freetype.org/'
-  version '2.11.0'
+  version '2.11.1'
   license 'FTL or GPL-2+'
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.xz'
-  source_sha256 '8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7'
+  source_url 'https://gitlab.freedesktop.org/freetype/freetype.git'
+  git_hashtag "VER-#{version.gsub('.', '-')}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_armv7l/freetype-2.11.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_armv7l/freetype-2.11.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_i686/freetype-2.11.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.0_x86_64/freetype-2.11.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_armv7l/freetype-2.11.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_armv7l/freetype-2.11.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_i686/freetype-2.11.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_x86_64/freetype-2.11.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '24c9fee8ddd769952dd1eb0927020892b61677f8097e8d70fccf7ee4902680e4',
-     armv7l: '24c9fee8ddd769952dd1eb0927020892b61677f8097e8d70fccf7ee4902680e4',
-       i686: 'c4d4948ff5f63714de352e88f2b8ddcc167a30e2ae6af7979d3dc4815d123d64',
-     x86_64: '8a173447f2471d35512e6ea75cda0f53f18ae930e990881f94c7dbea9011b402'
+    aarch64: '4c91e5b7cb45c37c7ee444a2cd182e303d5e287727e04facdebecf7071464b78',
+     armv7l: '4c91e5b7cb45c37c7ee444a2cd182e303d5e287727e04facdebecf7071464b78',
+       i686: '20a3049b57dc11db42c30c722ddfa6036845787daecd2c0841160f5a845e652c',
+     x86_64: 'b7fdf58d7b78165226c18223f6c3585cbb14f64212b372f8c352dbbe2a235144'
   })
 
+  depends_on 'brotli'
   depends_on 'expat'
-  depends_on 'libpng'   # freetype needs zlib optionally. zlib is also the dependency of libpng
+  depends_on 'libpng'  # freetype needs zlib optionally. zlib is also the dependency of libpng
   depends_on 'bz2'
   depends_on 'harfbuzz'
+  conflicts_ok
+  no_env_options
 
   def self.build
+    case ARCH
+    when 'aarch64', 'armv7l'
+      @meson_options = CREW_MESON_OPTIONS
+    when 'i686', 'x86_64'
+      @meson_options = CREW_MESON_OPTIONS.gsub('-Dc_args=\'-O2', '-Dc_args=\'-O2 -fuse-ld=mold').gsub('-Dcpp_args=\'-O2',
+                                                                                                      '-Dcpp_args=\'-O2 -fuse-ld=mold')
+    end
     system 'pip3 install docwriter'
-    system "sed -i 's,/usr/include/freetype2,#{CREW_PREFIX}/include/freetype2,g' configure"
-    system "./configure CFLAGS=' -fPIC' #{CREW_OPTIONS} --enable-freetype-config --with-harfbuzz"
-    system 'make'
+    system "meson #{@meson_options} \
+      -Dharfbuzz=enabled \
+      builddir"
+    system 'meson configure builddir'
+    system 'samu -C builddir'
     system 'pip3 uninstall docwriter -y'
     system "pip3 install docwriter --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+
+  def self.postinstall
+    system "find #{CREW_BREW_DIR}/* -name freetype*.tar | xargs rm -rf"  # make sure to delete downloaded files
   end
 end

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -3,7 +3,7 @@ require 'package'
 class Freetype < Package
   description 'FreeType is a freely available software library to render fonts.'
   homepage 'https://www.freetype.org/'
-  version '2.11.1'
+  version '2.11.1' # Update freetype in harfbuzz when updating freetype
   license 'FTL or GPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/freetype/freetype.git'
@@ -16,19 +16,26 @@ class Freetype < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_x86_64/freetype-2.11.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4c91e5b7cb45c37c7ee444a2cd182e303d5e287727e04facdebecf7071464b78',
-     armv7l: '4c91e5b7cb45c37c7ee444a2cd182e303d5e287727e04facdebecf7071464b78',
-       i686: '20a3049b57dc11db42c30c722ddfa6036845787daecd2c0841160f5a845e652c',
-     x86_64: 'b7fdf58d7b78165226c18223f6c3585cbb14f64212b372f8c352dbbe2a235144'
+    aarch64: '5fb990e84010805de92eda4efac6b0cf183c8dee02eda7b2d1ed183028d0e857',
+     armv7l: '5fb990e84010805de92eda4efac6b0cf183c8dee02eda7b2d1ed183028d0e857',
+       i686: '2961cc77104f9a1eccd75905e957644ef1b21ef93fab368cbd1ed31c022dc43c',
+     x86_64: '3c2492c222856b9a45bc8eaec55398f59e49062f8b3c9e45edc8b129d38c641b'
   })
 
   depends_on 'brotli'
-  depends_on 'expat'
-  depends_on 'libpng'  # freetype needs zlib optionally. zlib is also the dependency of libpng
   depends_on 'bz2'
+  depends_on 'expat'
+  depends_on 'gcc11'
+  depends_on 'glib'
+  depends_on 'graphite'
   depends_on 'harfbuzz'
-  conflicts_ok
+  depends_on 'pcre'
+  depends_on 'zlibpkg'
+  # to avoid resetting mold usage
   no_env_options
+  # This overwrites the freetype in harfbuzz, which have
+  # epicircular dependencies on each other.
+  conflicts_ok
 
   def self.build
     case ARCH
@@ -53,6 +60,7 @@ class Freetype < Package
   end
 
   def self.postinstall
-    system "find #{CREW_BREW_DIR}/* -name freetype*.tar | xargs rm -rf"  # make sure to delete downloaded files
+    # make sure to delete downloaded files
+    system "find #{CREW_BREW_DIR}/* -name freetype*.tar -exec rm -rf {} \+"
   end
 end

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -53,5 +53,16 @@ class Freetype_sub < Package
 
   def self.postinstall
     system "find #{CREW_BREW_DIR}/* -name freetype*.tar | xargs rm -rf"  # make sure to delete downloaded files
+    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+    if @device[:installed_packages].any? 'freetype'
+      puts "Please reinstall freetype with 'crew reinstall freetype' as this installation may have broken freetype.".lightred
+    end
+  end
+
+  def self.remove
+    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+    if @device[:installed_packages].any? 'freetype'
+      puts "Please reinstall freetype with 'crew reinstall freetype' as this removal may have broken freetype.".lightred
+    end
   end
 end

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -54,14 +54,14 @@ class Freetype_sub < Package
   def self.postinstall
     system "find #{CREW_BREW_DIR}/* -name freetype*.tar | xargs rm -rf"  # make sure to delete downloaded files
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    if @device[:installed_packages].any? 'freetype'
+    if @device[:installed_packages].any? do |elem| elem[:name] == 'freetype' end
       puts "Please reinstall freetype with 'crew reinstall freetype' as this installation may have broken freetype.".lightred
     end
   end
 
   def self.remove
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    if @device[:installed_packages].any? 'freetype'
+    if @device[:installed_packages].any? do |elem| elem[:name] == 'freetype' end
       puts "Please reinstall freetype with 'crew reinstall freetype' as this removal may have broken freetype.".lightred
     end
   end

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -3,41 +3,52 @@ require 'package'
 class Freetype_sub < Package
   description 'Freetype_sub is a version without harfbuzz. It is intended to handle circular dependency betwwen freetype and harfbuzz.'
   homepage 'https://www.freetype.org/'
-  version '2.11.0'
+  version '2.11.1'
   license 'FTL or GPL-2+'
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.xz'
-  source_sha256 '8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7'
+  source_url 'https://gitlab.freedesktop.org/freetype/freetype.git'
+  git_hashtag "VER-#{version.gsub('.', '-')}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_armv7l/freetype_sub-2.11.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_armv7l/freetype_sub-2.11.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_i686/freetype_sub-2.11.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.0_x86_64/freetype_sub-2.11.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.1_armv7l/freetype_sub-2.11.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.1_armv7l/freetype_sub-2.11.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.1_i686/freetype_sub-2.11.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.1_x86_64/freetype_sub-2.11.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '7cb416b93f2b41dcef3f7fa9cc5624467e5cc89a720a2850b0edde19f48999b7',
-     armv7l: '7cb416b93f2b41dcef3f7fa9cc5624467e5cc89a720a2850b0edde19f48999b7',
-       i686: '1f83220dee2819353ce9fdf268397b969b9c368b6d4088d8e0a92772170eb0f3',
-     x86_64: '5abc6e6e8c4b68d6e1e860f4a9b421578ed2b3a21180a3f2ac880af629ee2afd'
+    aarch64: 'dade3724751a8464424a46ba371709dc59cc2ffe77bc6ed3d8d33915509722cb',
+     armv7l: 'dade3724751a8464424a46ba371709dc59cc2ffe77bc6ed3d8d33915509722cb',
+       i686: 'd9a07e30d8916c0350f4153dd2237c9c813da5237666b06b5c2f5261c2d7138a',
+     x86_64: 'a39929de0a9505e42d2631d8bea2a77cdb67b5ef61fbe83ed6a4192eb89192b5'
   })
 
+  depends_on 'brotli'
   depends_on 'expat'
-  depends_on 'libpng'   # freetype needs zlib optionally. zlib is also the dependency of libpng
+  depends_on 'libpng'  # freetype needs zlib optionally. zlib is also the dependency of libpng
   depends_on 'bz2'
+  conflicts_ok
+  no_env_options
 
   def self.build
+    case ARCH
+    when 'aarch64', 'armv7l'
+      @meson_options = CREW_MESON_OPTIONS
+    when 'i686', 'x86_64'
+      @meson_options = CREW_MESON_OPTIONS.gsub('-Dc_args=\'-O2', '-Dc_args=\'-O2 -fuse-ld=mold').gsub('-Dcpp_args=\'-O2',
+                                                                                                      '-Dcpp_args=\'-O2 -fuse-ld=mold')
+    end
     system 'pip3 install docwriter'
-    system "./configure CFLAGS=' -fPIC' #{CREW_OPTIONS} --disable-freetype-config --without-harfbuzz"
-    system 'make'
+    system "meson #{@meson_options} \
+      -Dharfbuzz=disabled \
+      builddir"
+    system 'meson configure builddir'
+    system 'samu -C builddir'
     system 'pip3 uninstall docwriter -y'
     system "pip3 install docwriter --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
   end
 
   def self.install
-    ENV['CREW_CONFLICTS_ONLY_ADVISORY'] = '1'
-    reload_constants
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 
   def self.postinstall

--- a/packages/freetype_sub.rb
+++ b/packages/freetype_sub.rb
@@ -1,68 +1,13 @@
 require 'package'
 
 class Freetype_sub < Package
-  description 'Freetype_sub is a version without harfbuzz. It is intended to handle circular dependency betwwen freetype and harfbuzz.'
+  description 'Freetype_sub was a version w/o harfbuzz, now handled within harfbuzz'
   homepage 'https://www.freetype.org/'
-  version '2.11.1'
+  version '1.0'
   license 'FTL or GPL-2+'
   compatibility 'all'
-  source_url 'https://gitlab.freedesktop.org/freetype/freetype.git'
-  git_hashtag "VER-#{version.gsub('.', '-')}"
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.1_armv7l/freetype_sub-2.11.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.1_armv7l/freetype_sub-2.11.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.1_i686/freetype_sub-2.11.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype_sub/2.11.1_x86_64/freetype_sub-2.11.1-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: 'dade3724751a8464424a46ba371709dc59cc2ffe77bc6ed3d8d33915509722cb',
-     armv7l: 'dade3724751a8464424a46ba371709dc59cc2ffe77bc6ed3d8d33915509722cb',
-       i686: 'd9a07e30d8916c0350f4153dd2237c9c813da5237666b06b5c2f5261c2d7138a',
-     x86_64: 'a39929de0a9505e42d2631d8bea2a77cdb67b5ef61fbe83ed6a4192eb89192b5'
-  })
+  depends_on 'freetype'
+  is_fake
 
-  depends_on 'brotli'
-  depends_on 'expat'
-  depends_on 'libpng'  # freetype needs zlib optionally. zlib is also the dependency of libpng
-  depends_on 'bz2'
-  conflicts_ok
-  no_env_options
-
-  def self.build
-    case ARCH
-    when 'aarch64', 'armv7l'
-      @meson_options = CREW_MESON_OPTIONS
-    when 'i686', 'x86_64'
-      @meson_options = CREW_MESON_OPTIONS.gsub('-Dc_args=\'-O2', '-Dc_args=\'-O2 -fuse-ld=mold').gsub('-Dcpp_args=\'-O2',
-                                                                                                      '-Dcpp_args=\'-O2 -fuse-ld=mold')
-    end
-    system 'pip3 install docwriter'
-    system "meson #{@meson_options} \
-      -Dharfbuzz=disabled \
-      builddir"
-    system 'meson configure builddir'
-    system 'samu -C builddir'
-    system 'pip3 uninstall docwriter -y'
-    system "pip3 install docwriter --root #{CREW_DEST_DIR} --prefix #{CREW_PREFIX}"
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
-  end
-
-  def self.postinstall
-    system "find #{CREW_BREW_DIR}/* -name freetype*.tar | xargs rm -rf"  # make sure to delete downloaded files
-    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    if @device[:installed_packages].any? do |elem| elem[:name] == 'freetype' end
-      puts "Please reinstall freetype with 'crew reinstall freetype' as this installation may have broken freetype.".lightred
-    end
-  end
-
-  def self.remove
-    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    if @device[:installed_packages].any? do |elem| elem[:name] == 'freetype' end
-      puts "Please reinstall freetype with 'crew reinstall freetype' as this removal may have broken freetype.".lightred
-    end
-  end
 end

--- a/packages/gcc11.rb
+++ b/packages/gcc11.rb
@@ -4,23 +4,23 @@ require 'open3'
 class Gcc11 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '11.2.1-20220108'
+  version '11.2.1-20220305'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   compatibility 'all'
-  source_url 'https://gcc.gnu.org/pub/gcc/snapshots/11-20220108/gcc-11-20220108.tar.xz'
-  source_sha256 'a433837a85087c2357a456145ae140bd588e75d44a90031ed57c29de66e46468'
+  source_url 'https://gcc.gnu.org/pub/gcc/snapshots/11-20220305/gcc-11-20220305.tar.xz'
+  source_sha256 '097a4369fb148044ee82fba5fa15f2224dee01218e0ca997ffcc99dd66eb71b6'
 
   binary_url({
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220108_i686/gcc11-11.2.1-20220108-chromeos-i686.tar.xz',
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220108_armv7l/gcc11-11.2.1-20220108-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220108_armv7l/gcc11-11.2.1-20220108-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220108_x86_64/gcc11-11.2.1-20220108-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220305_armv7l/gcc11-11.2.1-20220305-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220305_armv7l/gcc11-11.2.1-20220305-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220305_i686/gcc11-11.2.1-20220305-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220305_x86_64/gcc11-11.2.1-20220305-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-       i686: '96cbdec476c3c75a41ae01e9b63060cca42f5ccb262253840c0083f8f7571a54',
-    aarch64: 'cc48b179ccb035a15042e8a7534366ed0358cb69c84521659f7592b4ce08307b',
-     armv7l: 'cc48b179ccb035a15042e8a7534366ed0358cb69c84521659f7592b4ce08307b',
-     x86_64: 'f54549bbae4b15e8360cb73c72a168e168ce603ab4c16470c1b400efe8ca69f4'
+    aarch64: '1bd3f9ff1a404c1af0dac747766a617d5110375e69f5e81661bb86743b42ac82',
+     armv7l: '1bd3f9ff1a404c1af0dac747766a617d5110375e69f5e81661bb86743b42ac82',
+       i686: '28c70e51a3c97078167f340df22ced293d752b8b166bbf5d914b9a5951d2f9e9',
+     x86_64: '5e8c934ccb5a4a18d7395904f81efbdc8376993f3b83228ebcaa373023ad561a'
   })
 
   depends_on 'ccache' => :build
@@ -32,67 +32,28 @@ class Gcc11 < Package
   depends_on 'mpfr' # R
   depends_on 'libssp' # L
   depends_on 'zstd' # R
+  no_env_options
 
   @gcc_version = version.split('-')[0].partition('.')[0]
 
-  @gcc_global_opts = '--disable-bootstrap \
-  --disable-install-libiberty \
-  --disable-libmpx \
-  --disable-libssp \
-  --disable-multilib \
-  --disable-werror \
-  --enable-cet=auto \
-  --enable-checking=release \
-  --enable-clocale=gnu \
-  --enable-default-pie \
-  --enable-default-ssp \
-  --enable-gnu-indirect-function \
-  --enable-gnu-unique-object \
-  --enable-host-shared \
-  --enable-lto \
-  --enable-plugin \
-  --enable-shared \
-  --enable-symvers \
-  --enable-static \
-  --enable-threads=posix \
-  --with-gcc-major-version-only \
-  --with-gmp \
-  --with-isl \
-  --with-mpc \
-  --with-mpfr \
-  --with-pic \
-  --with-system-libunwind \
-  --with-system-zlib'
-
-  @cflags = '-fPIC -pipe'
-  @cxxflags = '-fPIC -pipe'
-  @languages = 'c,c++,jit,objc,fortran,go'
-  case ARCH
-  when 'armv7l', 'aarch64'
-    @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-fpu=neon --with-tune=cortex-a15'
-  when 'x86_64'
-    @archflags = '--with-arch-64=x86-64'
-  when 'i686'
-    @archflags = '--with-arch-32=i686'
-  end
-
+  # Reimplement gcc preflight section during gcc12 release cycle.
   # def self.preflight
-  ## Use full gcc path to bypass ccache
-  # stdout_and_stderr, status = Open3.capture2e('bash', '-c',
-  # "#{CREW_PREFIX}/bin/gcc -dumpversion 2>&1 | tail -1 | cut -d' ' -f1")
-  # if status.success?
-  # installed_gccver = stdout_and_stderr.chomp
-  ## One gets "-dumpversion" or "bash:" with no gcc installed.
-  # unless installed_gccver.to_s == '-dumpversion' ||
-  # installed_gccver.to_s == 'bash:' ||
-  # installed_gccver.to_s == @gcc_version.to_s ||
-  # installed_gccver.partition('.')[0].to_s == @gcc_version.partition('.')[0].to_s
-  # warn "GCC version #{installed_gccver} is currently installed.".lightred
-  # warn "To use #{to_s.downcase} please run:".lightgreen
-  # warn "crew remove gcc#{installed_gccver} && crew install #{to_s.downcase}".lightgreen
-  # exit 1
-  # end
-  # end
+  #   # Use full gcc path to bypass ccache
+  #   stdout_and_stderr, status = Open3.capture2e('bash', '-c',
+  #                                               "#{CREW_PREFIX}/bin/gcc -dumpversion 2>&1 | tail -1 | cut -d' ' -f1")
+  #   if status.success?
+  #     installed_gccver = stdout_and_stderr.chomp
+  #     # One gets "-dumpversion" or "bash:" with no gcc installed.
+  #     unless installed_gccver.to_s == '-dumpversion' ||
+  #       installed_gccver.to_s == 'bash:' ||
+  #       installed_gccver.to_s == @gcc_version.to_s ||
+  #       installed_gccver.partition('.')[0].to_s == @gcc_version.partition('.')[0].to_s
+  #       warn "GCC version #{installed_gccver} is currently installed.".lightred
+  #       warn "To use #{to_s.downcase} please run:".lightgreen
+  #       warn "crew remove gcc#{installed_gccver} && crew install #{to_s.downcase}".lightgreen
+  #       exit 1
+  #     end
+  #   end
   # end
 
   def self.patch
@@ -104,6 +65,234 @@ class Gcc11 < Package
     system "grep  -q 4096 libsanitizer/asan/asan_linux.cpp || (sed -i '77a #endif' libsanitizer/asan/asan_linux.cpp &&
     sed -i '77a #define PATH_MAX 4096' libsanitizer/asan/asan_linux.cpp &&
     sed -i '77a #ifndef PATH_MAX' libsanitizer/asan/asan_linux.cpp)"
+
+    # Mold patches backported from GCC 12.
+    @mold_patch = <<~MOLD_PATCH_EOF
+      From ca60317a60ee20ce848b36588b905b5a63d81350 Mon Sep 17 00:00:00 2001
+      From: Martin Liska <mliska@suse.cz>
+      Date: Tue, 21 Dec 2021 17:43:55 +0100
+      Subject: [PATCH] Support ld.mold linker.
+
+      gcc/ChangeLog:
+
+      	* collect2.c (main): Add ld.mold.
+      	* common.opt: Add -fuse-ld=mold.
+      	* doc/invoke.texi: Document it.
+      	* gcc.c (driver_handle_option): Handle -fuse-ld=mold.
+      	* opts.c (common_handle_option): Likewise.
+      ---
+       gcc/collect2.c      | 10 +++++++---
+       gcc/common.opt      |  4 ++++
+       gcc/doc/invoke.texi |  4 ++++
+       gcc/gcc.c           |  4 ++++
+       gcc/opts.c          |  1 +
+       5 files changed, 20 insertions(+), 3 deletions(-)
+
+      diff --git a/gcc/collect2.c b/gcc/collect2.c
+      index d47fe3f9195..b322527847c 100644
+      --- a/gcc/collect2.c
+      +++ b/gcc/collect2.c
+      @@ -776,6 +776,7 @@ main (int argc, char **argv)
+             USE_GOLD_LD,
+             USE_BFD_LD,
+             USE_LLD_LD,
+      +      USE_MOLD_LD,
+             USE_LD_MAX
+           } selected_linker = USE_DEFAULT_LD;
+         static const char *const ld_suffixes[USE_LD_MAX] =
+      @@ -784,7 +785,8 @@ main (int argc, char **argv)
+             PLUGIN_LD_SUFFIX,
+             "ld.gold",
+             "ld.bfd",
+      -      "ld.lld"
+      +      "ld.lld",
+      +      "ld.mold"
+           };
+         static const char *const real_ld_suffix = "real-ld";
+         static const char *const collect_ld_suffix = "collect-ld";
+      @@ -957,6 +959,8 @@ main (int argc, char **argv)
+       	  selected_linker = USE_GOLD_LD;
+       	else if (strcmp (argv[i], "-fuse-ld=lld") == 0)
+       	  selected_linker = USE_LLD_LD;
+      +	else if (strcmp (argv[i], "-fuse-ld=mold") == 0)
+      +	  selected_linker = USE_MOLD_LD;
+       	else if (startswith (argv[i], "-o"))
+       	  {
+       	    /* Parse the output filename if it's given so that we can make
+      @@ -1048,7 +1052,7 @@ main (int argc, char **argv)
+         ld_file_name = 0;
+       #ifdef DEFAULT_LINKER
+         if (selected_linker == USE_BFD_LD || selected_linker == USE_GOLD_LD ||
+      -      selected_linker == USE_LLD_LD)
+      +      selected_linker == USE_LLD_LD || selected_linker == USE_MOLD_LD)
+           {
+             char *linker_name;
+       # ifdef HOST_EXECUTABLE_SUFFIX
+      @@ -1283,7 +1287,7 @@ main (int argc, char **argv)
+       	      else if (!use_collect_ld
+       		       && startswith (arg, "-fuse-ld="))
+       		{
+      -		  /* Do not pass -fuse-ld={bfd|gold|lld} to the linker. */
+      +		  /* Do not pass -fuse-ld={bfd|gold|lld|mold} to the linker. */
+       		  ld1--;
+       		  ld2--;
+       		}
+      diff --git a/gcc/common.opt b/gcc/common.opt
+      index 2ed818d6057..dba3fa886f9 100644
+      --- a/gcc/common.opt
+      +++ b/gcc/common.opt
+      @@ -3046,6 +3046,10 @@ fuse-ld=lld
+       Common Driver Negative(fuse-ld=lld)
+       Use the lld LLVM linker instead of the default linker.
+      #{' '}
+      +fuse-ld=mold
+      +Common Driver Negative(fuse-ld=mold)
+      +Use the Modern linker (MOLD) linker instead of the default linker.
+      +
+       fuse-linker-plugin
+       Common Undocumented Var(flag_use_linker_plugin)
+      #{' '}
+      diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+      index e644c63767b..54fa75ba138 100644
+      --- a/gcc/doc/invoke.texi
+      +++ b/gcc/doc/invoke.texi
+      @@ -16266,6 +16266,10 @@ Use the @command{gold} linker instead of the default linker.
+       @opindex fuse-ld=lld
+       Use the LLVM @command{lld} linker instead of the default linker.
+      #{' '}
+      +@item -fuse-ld=mold
+      +@opindex fuse-ld=mold
+      +Use the Modern Linker (@command{mold}) instead of the default linker.
+      +
+       @cindex Libraries
+       @item -l@var{library}
+       @itemx -l @var{library}
+      diff --git a/gcc/gcc.c b/gcc/gcc.c
+      index b75b50b87b2..06e18a75b52 100644
+      --- a/gcc/gcc.c
+      +++ b/gcc/gcc.c
+      @@ -4282,6 +4282,10 @@ driver_handle_option (struct gcc_options *opts,
+              use_ld = ".gold";
+              break;
+      #{' '}
+      +    case OPT_fuse_ld_mold:
+      +       use_ld = ".mold";
+      +       break;
+      +
+           case OPT_fcompare_debug_second:
+             compare_debug_second = 1;
+             break;
+      diff --git a/gcc/opts.c b/gcc/opts.c
+      index e4e47ff77b3..f820052307c 100644
+      --- a/gcc/opts.c
+      +++ b/gcc/opts.c
+      @@ -3105,6 +3105,7 @@ common_handle_option (struct gcc_options *opts,
+           case OPT_fuse_ld_bfd:
+           case OPT_fuse_ld_gold:
+           case OPT_fuse_ld_lld:
+      +    case OPT_fuse_ld_mold:
+           case OPT_fuse_linker_plugin:
+             /* No-op. Used by the driver and passed to us because it starts with f.*/
+             break;
+      --#{' '}
+      2.34.1
+
+      From: Martin Liska <mliska@suse.cz>
+      Date: Thu, 3 Mar 2022 15:47:19 +0100
+      Subject: [PATCH] configure: enable plugin support for ld.mold
+
+      gcc/ChangeLog:
+
+      	* configure.ac: Now ld.mold support LTO plugin API, use it.
+      	* configure: Regenerate.
+      ---
+       gcc/configure    | 2 ++
+       gcc/configure.ac | 2 ++
+       2 files changed, 4 insertions(+)
+
+      diff --git a/gcc/configure b/gcc/configure
+      index 22eb3451e3d..6f5fc20fcf3 100755
+      --- a/gcc/configure
+      +++ b/gcc/configure
+      @@ -26037,6 +26037,8 @@ if test -f liblto_plugin.la; then
+           # Allow -fuse-linker-plugin to enable plugin support in GNU gold 2.20.
+           elif test "$ld_is_gold" = yes -a "$ld_vers_major" -eq 2 -a "$ld_vers_minor" -eq 20; then
+             gcc_cv_lto_plugin=1
+      +    elif test "$ld_is_mold" = yes; then
+      +      gcc_cv_lto_plugin=1
+           fi
+         fi
+      #{' '}
+      diff --git a/gcc/configure.ac b/gcc/configure.ac
+      index 20da90901f8..3d85d33bc80 100644
+      --- a/gcc/configure.ac
+      +++ b/gcc/configure.ac
+      @@ -4278,6 +4278,8 @@ changequote([,])dnl
+           # Allow -fuse-linker-plugin to enable plugin support in GNU gold 2.20.
+           elif test "$ld_is_gold" = yes -a "$ld_vers_major" -eq 2 -a "$ld_vers_minor" -eq 20; then
+             gcc_cv_lto_plugin=1
+      +    elif test "$ld_is_mold" = yes; then
+      +      gcc_cv_lto_plugin=1
+           fi
+         fi
+      #{' '}
+      --#{' '}
+      2.27.0
+      From c083e654bd0f29a365ec957c4c0d4e713fb0b010 Mon Sep 17 00:00:00 2001
+      From: Martin Liska <mliska@suse.cz>
+      Date: Thu, 3 Mar 2022 17:28:45 +0100
+      Subject: [PATCH] configure: use linker plug-in by default for ld.mold
+
+      gcc/ChangeLog:
+
+      	* configure.ac: Use linker plug-in by default.
+      	* configure: Regenerate.
+      ---
+       gcc/configure    | 4 ++--
+       gcc/configure.ac | 4 ++--
+       2 files changed, 4 insertions(+), 4 deletions(-)
+
+      diff --git a/gcc/configure b/gcc/configure
+      index 6f5fc20fcf3..14b19c8fe0c 100755
+      --- a/gcc/configure
+      +++ b/gcc/configure
+      @@ -26034,11 +26034,11 @@ if test -f liblto_plugin.la; then
+           # Require GNU ld or gold 2.21+ for plugin support by default.
+           if test "$ld_vers_major" -eq 2 -a "$ld_vers_minor" -ge 21; then
+             gcc_cv_lto_plugin=2
+      +    elif test "$ld_is_mold" = yes; then
+      +      gcc_cv_lto_plugin=2
+           # Allow -fuse-linker-plugin to enable plugin support in GNU gold 2.20.
+           elif test "$ld_is_gold" = yes -a "$ld_vers_major" -eq 2 -a "$ld_vers_minor" -eq 20; then
+             gcc_cv_lto_plugin=1
+      -    elif test "$ld_is_mold" = yes; then
+      -      gcc_cv_lto_plugin=1
+           fi
+         fi
+      #{' '}
+      diff --git a/gcc/configure.ac b/gcc/configure.ac
+      index 3d85d33bc80..90cad309762 100644
+      --- a/gcc/configure.ac
+      +++ b/gcc/configure.ac
+      @@ -4275,11 +4275,11 @@ changequote([,])dnl
+           # Require GNU ld or gold 2.21+ for plugin support by default.
+           if test "$ld_vers_major" -eq 2 -a "$ld_vers_minor" -ge 21; then
+             gcc_cv_lto_plugin=2
+      +    elif test "$ld_is_mold" = yes; then
+      +      gcc_cv_lto_plugin=2
+           # Allow -fuse-linker-plugin to enable plugin support in GNU gold 2.20.
+           elif test "$ld_is_gold" = yes -a "$ld_vers_major" -eq 2 -a "$ld_vers_minor" -eq 20; then
+             gcc_cv_lto_plugin=1
+      -    elif test "$ld_is_mold" = yes; then
+      -      gcc_cv_lto_plugin=1
+           fi
+         fi
+      #{' '}
+      --#{' '}
+      2.27.0
+    MOLD_PATCH_EOF
+    File.write('mold.patch', @mold_patch)
+    system 'patch -Np1 -F3 -i mold.patch'
   end
 
   def self.prebuild
@@ -137,6 +326,49 @@ class Gcc11 < Package
   end
 
   def self.build
+    @gcc_global_opts = '--disable-bootstrap \
+      --disable-install-libiberty \
+      --disable-libmpx \
+      --disable-libssp \
+      --disable-multilib \
+      --disable-werror \
+      --enable-cet=auto \
+      --enable-checking=release \
+      --enable-clocale=gnu \
+      --enable-default-pie \
+      --enable-default-ssp \
+      --enable-gnu-indirect-function \
+      --enable-gnu-unique-object \
+      --enable-host-shared \
+      --enable-lto \
+      --enable-plugin \
+      --enable-shared \
+      --enable-symvers \
+      --enable-static \
+      --enable-threads=posix \
+      --with-gcc-major-version-only \
+      --with-gmp \
+      --with-isl \
+      --with-mpc \
+      --with-mpfr \
+      --with-pic \
+      --with-system-libunwind \
+      --with-system-zlib'
+
+    @cflags = '-fPIC -pipe'
+    @cxxflags = '-fPIC -pipe'
+    # @languages = 'c,c++,jit,objc,fortran,go'
+    # go build fails on 20220305 snapshot
+    @languages = 'c,c++,jit,objc,fortran'
+    case ARCH
+    when 'armv7l', 'aarch64'
+      @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-fpu=neon --with-tune=cortex-a15'
+    when 'x86_64'
+      @archflags = '--with-arch-64=x86-64'
+    when 'i686'
+      @archflags = '--with-arch-32=i686'
+    end
+
     # Set ccache sloppiness as per
     # https://wiki.archlinux.org/index.php/Ccache#Sloppiness
     system 'ccache --set-config=sloppiness=file_macro,locale,time_macros'

--- a/packages/graphite.rb
+++ b/packages/graphite.rb
@@ -22,7 +22,7 @@ class Graphite < Package
      x86_64: '298e03f04acb71d5b8fdfb340b0bc6387fe4ecf2ac2b0ebad7ecb21101c85e66'
   })
 
-  depends_on 'freetype_sub'
+  depends_on 'freetype_sub' => :build
 
   def self.build
     Dir.mkdir 'build'

--- a/packages/graphite.rb
+++ b/packages/graphite.rb
@@ -3,26 +3,29 @@ require 'package'
 class Graphite < Package
   description 'Reimplementation of the SIL Graphite text processing engine'
   homepage 'https://github.com/silnrsi/graphite'
-  version '1.3.14-2'
+  version '425da3d'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url 'https://github.com/silnrsi/graphite/releases/download/1.3.14/graphite2-1.3.14.tgz'
-  source_sha256 'f99d1c13aa5fa296898a181dff9b82fb25f6cc0933dbaa7a475d8109bd54209d'
+  source_url 'https://github.com/silnrsi/graphite.git'
+  git_hashtag '425da3d08926b9cf321fc0014dfa979c24d2cf64'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_armv7l/graphite-1.3.14-2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_armv7l/graphite-1.3.14-2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_i686/graphite-1.3.14-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/1.3.14-2_x86_64/graphite-1.3.14-2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/425da3d_armv7l/graphite-425da3d-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/425da3d_armv7l/graphite-425da3d-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/425da3d_i686/graphite-425da3d-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphite/425da3d_x86_64/graphite-425da3d-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4b7ccb98e54afb311014eedeaee7a262cc8d46c0ee9ca4102cc5aee8a38660e0',
-     armv7l: '4b7ccb98e54afb311014eedeaee7a262cc8d46c0ee9ca4102cc5aee8a38660e0',
-       i686: '457ed635172c5ba7f61b95cfa2036efdfa1183ae2a77e4e9f06b9d33f9dbe763',
-     x86_64: '298e03f04acb71d5b8fdfb340b0bc6387fe4ecf2ac2b0ebad7ecb21101c85e66'
+    aarch64: '94516aa9980b775d1134a8d1ccdfc22cc1cfe205214da799d725ddbb23994968',
+     armv7l: '94516aa9980b775d1134a8d1ccdfc22cc1cfe205214da799d725ddbb23994968',
+       i686: '085fdc5fd0b57b89d924bee3db23499cdb2804351e4da10830f6b99fe8dd5ba8',
+     x86_64: '7731c7c3bfc32f76f80294621cc1b37cb1270828bc1f80c0226f44e9f28abce7'
   })
 
-  depends_on 'freetype_sub' => :build
+  def self.patch
+    # remove font tools dependent tests
+    system "sed -i '/cmptest/d' tests/CMakeLists.txt"
+  end
 
   def self.build
     Dir.mkdir 'build'

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -112,7 +112,7 @@ class Gtk3 < Package
     system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
     # update icon cache, but only if gdk_pixbuf is already installed.
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    return unless @device[:installed_packages].any? 'gdk_pixbuf'
+    return unless @device[:installed_packages].any? do |elem| elem[:name] == 'gdk_pixbuf' end
 
     system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/*"
   end

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -120,7 +120,7 @@ class Gtk4 < Package
     system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
     # update icon cache, but only if gdk_pixbuf is already installed.
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    return unless @device[:installed_packages].any? 'gdk_pixbuf'
+    return unless @device[:installed_packages].any? do |elem| elem[:name] == 'gdk_pixbuf' end
 
     system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/*"
   end

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -17,15 +17,14 @@ class Harfbuzz < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_x86_64/harfbuzz-4.0.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e69add397691fe19a99f8edc4978f6edfbd2d152e421b12f369533c49d97831b',
-     armv7l: 'e69add397691fe19a99f8edc4978f6edfbd2d152e421b12f369533c49d97831b',
-       i686: 'f50293058773d244afadb69e3a7935ac86e9ecba0ce099ce72783ff035d1fb61',
-     x86_64: '4cb0f15732365e61b9cc893432a51bb3099bb982208c33f167a7fcf46b376c43'
+    aarch64: 'fd912abd074e585e83fd13ae01cc5b816be8571bac45e0a3b026788456fae979',
+     armv7l: 'fd912abd074e585e83fd13ae01cc5b816be8571bac45e0a3b026788456fae979',
+       i686: '090fb8f6bac5538b809c64c49a1b57c39f14ad958f222899f5201e93f9d85271',
+     x86_64: '41222eb56ead7816f86ed6bb70f710c78799f140c699604d3385cc8b970f79d0'
   })
 
-
   # provides libpng, freetype (sans harfbuzz), and ragel
-  # depends_on 'cairo' => :build (only needed for tests and tools)
+  # depends_on 'cairo' => :build (cairo is only needed for tests and tools)
   depends_on 'chafa' => :build
   depends_on 'glib' => :build
   depends_on 'gobject_introspection'
@@ -34,6 +33,7 @@ class Harfbuzz < Package
   no_env_options
 
   def self.patch
+    # Update to new versions of freetype as they come out.
     system "sed -i 's,revision=VER-2-11-0,revision=VER-2-11-1,g' subprojects/freetype2.wrap"
   end
 

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -3,7 +3,7 @@ require 'package'
 class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
-  @_ver = '3.1.1'
+  @_ver = '4.0.0'
   version @_ver
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
@@ -11,29 +11,39 @@ class Harfbuzz < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.1.1_armv7l/harfbuzz-3.1.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.1.1_armv7l/harfbuzz-3.1.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.1.1_i686/harfbuzz-3.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/3.1.1_x86_64/harfbuzz-3.1.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_armv7l/harfbuzz-4.0.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_armv7l/harfbuzz-4.0.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_i686/harfbuzz-4.0.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_x86_64/harfbuzz-4.0.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '36fa3b23aa11ec3aee2cebef48edf3fc5b82b5c74bb56ec4889717c6981bde62',
-     armv7l: '36fa3b23aa11ec3aee2cebef48edf3fc5b82b5c74bb56ec4889717c6981bde62',
-       i686: '917efea7629e652ecc10b261c9efbbb98b4993cf958f2eebd926891e7b70e989',
-     x86_64: '06a8f9366cec6772f2a9d2ab3da03402f46e1fa768a9b60bc3fd0d5ac0c0e167'
+    aarch64: '0efa561d9870cb8eab422f276de82ecfd37167abe29f8d183f01d6f330536940',
+     armv7l: '0efa561d9870cb8eab422f276de82ecfd37167abe29f8d183f01d6f330536940',
+       i686: 'bfa15553901736cc2a1b05f85b221763c0c3111b8da8bcf19d2c036bb595a8d7',
+     x86_64: '32d005399a05f64424ab682f77550c272f6df0932a7756b91cda3cb2cf732c8a'
   })
 
   depends_on 'cairo' => :build
   depends_on 'chafa' => :build
   depends_on 'glib' => :build
   depends_on 'gobject_introspection'
-  depends_on 'ragel' => :build
   depends_on 'freetype_sub'
   depends_on 'py3_six' => :build
   depends_on 'graphite' => :build
+  no_env_options
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    if File.exist?("#{CREW_META_PATH}/freetype.filelist")
+      puts 'Please reinstall freetype_sub after other dependencies are installed before building.'.yellow
+    end
+    case ARCH
+    when 'aarch64', 'armv7l'
+      @meson_options = CREW_MESON_OPTIONS
+    when 'i686', 'x86_64'
+      @meson_options = CREW_MESON_OPTIONS.gsub('-Dc_args=\'-O2', '-Dc_args=\'-O2 -fuse-ld=mold').gsub('-Dcpp_args=\'-O2',
+                                                                                                      '-Dcpp_args=\'-O2 -fuse-ld=mold')
+    end
+    system "meson #{@meson_options} \
     --default-library=both \
     -Dintrospection=enabled \
     -Dbenchmark=disabled \

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -35,7 +35,7 @@ class Harfbuzz < Package
 
   def self.build
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    if @device[:installed_packages].any? 'freetype'
+    if @device[:installed_packages].any? do |elem| elem[:name] == 'freetype' end
       puts 'Please reinstall freetype_sub after other dependencies are installed before building.'.yellow
     end
     case ARCH

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -17,19 +17,26 @@ class Harfbuzz < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_x86_64/harfbuzz-4.0.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'fd912abd074e585e83fd13ae01cc5b816be8571bac45e0a3b026788456fae979',
-     armv7l: 'fd912abd074e585e83fd13ae01cc5b816be8571bac45e0a3b026788456fae979',
-       i686: '090fb8f6bac5538b809c64c49a1b57c39f14ad958f222899f5201e93f9d85271',
-     x86_64: '41222eb56ead7816f86ed6bb70f710c78799f140c699604d3385cc8b970f79d0'
+    aarch64: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
+     armv7l: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
+       i686: 'fe23c57f63f0fd9d03cd8679076d0aa6aeb0db9880efd1099814385fe53c878f',
+     x86_64: 'c9ad1d2c137cfa65efcfbc855fc6b2a616130653d18ff730b53ece6676513a44'
   })
 
   # provides libpng, freetype (sans harfbuzz), and ragel
   # depends_on 'cairo' => :build (cairo is only needed for tests and tools)
-  depends_on 'chafa' => :build
-  depends_on 'glib' => :build
-  depends_on 'gobject_introspection'
+  depends_on 'brotli'
+  depends_on 'bz2'
+  depends_on 'chafa'
+  depends_on 'gcc11'
+  depends_on 'glib'
+  depends_on 'gobject_introspection' => :build
+  depends_on 'graphite'
+  depends_on 'icu4c'
+  depends_on 'libffi'
+  depends_on 'pcre'
   depends_on 'py3_six' => :build
-  depends_on 'graphite' => :build
+  depends_on 'zlibpkg'
   no_env_options
 
   def self.patch

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -34,7 +34,8 @@ class Harfbuzz < Package
   no_env_options
 
   def self.build
-    if File.exist?("#{CREW_META_PATH}/freetype.filelist")
+    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+    if @device[:installed_packages].any? 'freetype'
       puts 'Please reinstall freetype_sub after other dependencies are installed before building.'.yellow
     end
     case ARCH

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -27,7 +27,8 @@ class Harfbuzz < Package
   depends_on 'chafa' => :build
   depends_on 'glib' => :build
   depends_on 'gobject_introspection'
-  depends_on 'freetype_sub'
+  depends_on 'freetype_sub' => :build
+  # Hopefully regular freetype gets pulled in by some other package dep.
   depends_on 'py3_six' => :build
   depends_on 'graphite' => :build
   no_env_options

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -25,7 +25,7 @@ class Librsvg < Package
   depends_on 'cairo'
   depends_on 'fontconfig'
   depends_on 'freetype'
-  depends_on 'freetype_sub' => :build
+  depends_on 'harfbuzz' => :build
   depends_on 'fribidi'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -25,7 +25,7 @@ class Librsvg < Package
   depends_on 'cairo'
   depends_on 'fontconfig'
   depends_on 'freetype'
-  depends_on 'freetype_sub'
+  depends_on 'freetype_sub' => :build
   depends_on 'fribidi'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'

--- a/packages/libxfont2.rb
+++ b/packages/libxfont2.rb
@@ -26,7 +26,7 @@ class Libxfont2 < Package
   depends_on 'libxtrans'
   depends_on 'libfontenc'
   depends_on 'libx11'
-  depends_on 'freetype_sub'
+  depends_on 'freetype_sub' => :build
   depends_on 'xmlto' => :build
 
   def self.build

--- a/packages/libxfont2.rb
+++ b/packages/libxfont2.rb
@@ -26,7 +26,7 @@ class Libxfont2 < Package
   depends_on 'libxtrans'
   depends_on 'libfontenc'
   depends_on 'libx11'
-  depends_on 'freetype_sub' => :build
+  depends_on 'harfbuzz' => :build
   depends_on 'xmlto' => :build
 
   def self.build

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -7,19 +7,15 @@ class Mold < Package
   description 'A Modern Linker'
   homepage 'https://github.com/rui314/mold'
   version '1.1.1'
-  compatibility 'all'
+  compatibility 'i686, x86_64'
   source_url 'https://github.com/rui314/mold.git'
   git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.1.1_armv7l/mold-1.1.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.1.1_armv7l/mold-1.1.1-chromeos-armv7l.tar.zst',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.1.1_i686/mold-1.1.1-chromeos-i686.tar.zst',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.1.1_x86_64/mold-1.1.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'af8d0ad4094a02d26508da23af2e8b000f40c982c3d4ee43e25b42806d139dbe',
-     armv7l: 'af8d0ad4094a02d26508da23af2e8b000f40c982c3d4ee43e25b42806d139dbe',
        i686: '966053e7967f58f131d03d213f1e0f26d969a6d7296b90b78e245f471af5b34d',
      x86_64: '622f44f74252163a17a418bdb7efe42c3a59d1956790260666268f462a3b8930'
   })

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -5,24 +5,29 @@ class Zlibpkg < Package
   homepage 'https://www.zlib.net/'
   # When upgrading zlibpkg, be sure to upgrade minizip in tandem.
   @_ver = '1.2.11'
-  version "#{@_ver}-6"
+  version "#{@_ver}-7"
   license 'zlib'
   compatibility 'all'
   source_url "https://www.zlib.net/zlib-#{@_ver}.tar.gz"
   source_sha256 'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-6_armv7l/zlibpkg-1.2.11-6-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-6_armv7l/zlibpkg-1.2.11-6-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-6_i686/zlibpkg-1.2.11-6-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-6_x86_64/zlibpkg-1.2.11-6-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-7_armv7l/zlibpkg-1.2.11-7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-7_armv7l/zlibpkg-1.2.11-7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-7_i686/zlibpkg-1.2.11-7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zlibpkg/1.2.11-7_x86_64/zlibpkg-1.2.11-7-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '0012a9c80b2c224cd51556b14cfd52095559a38aaca25a943164e5a1bff04488',
-     armv7l: '0012a9c80b2c224cd51556b14cfd52095559a38aaca25a943164e5a1bff04488',
-       i686: '2c1fbea91e0287064e7a5323b5298af74dc5ae29ee53cb9636e90c7c4842c8d3',
-     x86_64: '6a213888ddd3ff584c8f354a107fdf00f11b8570b5a5dac909a95bc4c165a0cd'
+    aarch64: '929afe8f670183e7719d06bb1fc83fc115bd74c7c41f1ac7bb86450c8c5d3c7f',
+     armv7l: '929afe8f670183e7719d06bb1fc83fc115bd74c7c41f1ac7bb86450c8c5d3c7f',
+       i686: 'a55c4ddd77260fb7c043d23e9dbfd822cec2cdb8c71e7690856e5305c5b3ba52',
+     x86_64: '887c6ffde269a62eb3c7b995f8488bdb2795faa8777b00ec76fca7258862fe25'
   })
+
+  def self.patch
+    system "sed -i 's,CMAKE_INSTALL_PREFIX}/lib,CMAKE_INSTALL_PREFIX}/#{ARCH_LIB},g' CMakeLists.txt"
+    system "sed -i 's,CMAKE_INSTALL_PREFIX}/share/pkgconfig,CMAKE_INSTALL_PREFIX}/#{ARCH_LIB}/pkgconfig,g' CMakeLists.txt"
+  end
 
   def self.build
     # Build zlib proper


### PR DESCRIPTION
- `gcc11` rebuilt w/ `mold` support (i.e. support for `-fuse-ld=mold` which has also been accepted into GCC12), off of the GCC 11 stable branch.
- `mold` added to `buildessentials` for non-armv7l architectures (adds ~ 3mb, but may be order of magnitude faster than existing linkers)
- Add `libstdc++.so.6` to1 `CREW_ESSENTIAL_FILES`, since rdfind uses it.
- This does _NOT_ replace `-fuse-ld=gold` with `-fuse-ld=mold` in `const.rb`, but that would be the next step, once mold is updated to support `armv7l`.

- Also fixes circular dependencies in `graphite`, `freetype`, `chafa`, and `harfbuzz`, with `freetype` modified to use `mold` except on `armv7l` due to  upstream issue reported with `-ld-fuse=mold` https://github.com/rui314/mold/issues/389
- Updates packages which use `freetype_sub` to have dependency on `harfbuzz`.
- Updates `gtk3` and `gtk4` to fix `:installed_packages` algorithm used to be in line with what works inside `crew`

Works properly:
- [x] x86_64 
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gcc_mold CREW_TESTING=1 crew update ; crew upgrade
```