### PR TITLE
Fix `=> :build` tags on some packages

### DIFF
--- a/packages/chafa.rb
+++ b/packages/chafa.rb
@@ -28,7 +28,7 @@ class Chafa < Package
   depends_on 'imagemagick7' => :build
   depends_on 'freetype_sub' => :build
   depends_on 'libxslt'
-  depends_on 'gtk_doc' => ':build'
+  depends_on 'gtk_doc' => :build
 
   def self.patch
     system 'filefix'

--- a/packages/duktape.rb
+++ b/packages/duktape.rb
@@ -26,7 +26,7 @@ class Duktape < Package
      x86_64: '5f5787b8f9893d2b838e41c9391022f7fd9f0f7bacf45059b40e061ec7654ed1'
   })
 
-  depends_on 'setconf' => ':build'
+  depends_on 'setconf' => :build
 
   def self.build
     FileUtils.mv 'Makefile.sharedlibrary', 'Makefile'

--- a/packages/fcft.rb
+++ b/packages/fcft.rb
@@ -29,7 +29,7 @@ class Fcft < Package
   depends_on 'harfbuzz'
   depends_on 'utf8proc'
   depends_on 'pixman'
-  depends_on 'tllist' => ':build'
+  depends_on 'tllist' => :build
 
   def self.patch
     # threads.h was introduced in glibc 2.28. This is a workaround for

--- a/packages/foot.rb
+++ b/packages/foot.rb
@@ -31,8 +31,8 @@ class Foot < Package
   depends_on 'utf8proc'
   depends_on 'ncurses'
   depends_on 'fcft'
-  depends_on 'wayland_protocols' => ':build'
-  depends_on 'tllist' => ':build'
+  depends_on 'wayland_protocols' => :build
+  depends_on 'tllist' => :build
 
   def self.patch
     # threads.h was introduced in glibc 2.28. This is a workaround for

--- a/packages/gnome_text_editor.rb
+++ b/packages/gnome_text_editor.rb
@@ -31,10 +31,10 @@ class Gnome_text_editor < Package
   depends_on 'pango'
   depends_on 'pcre'
   depends_on 'pygobject'
-  depends_on 'yelp_tools' => ':build'
-  depends_on 'vala' => ':build'
-  depends_on 'gobject_introspection' => ':build'
-  depends_on 'gtk_doc' => ':build'
+  depends_on 'yelp_tools' => :build
+  depends_on 'vala' => :build
+  depends_on 'gobject_introspection' => :build
+  depends_on 'gtk_doc' => :build
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/hwloc.rb
+++ b/packages/hwloc.rb
@@ -26,9 +26,9 @@ class Hwloc < Package
 
   depends_on 'libtool'
   depends_on 'libpciaccess'
-  depends_on 'cairo' => ':build'
-  depends_on 'libxml2' => ':build'
-  depends_on 'pciutils' => ':build'
+  depends_on 'cairo' => :build
+  depends_on 'libxml2' => :build
+  depends_on 'pciutils' => :build
 
   def self.build
     system './autogen.sh'

--- a/packages/lilv.rb
+++ b/packages/lilv.rb
@@ -26,12 +26,12 @@ class Lilv < Package
   })
 
   depends_on 'lv2'
-  depends_on 'libsndfile' => ':build'
-  depends_on 'serd' => ':build'
-  depends_on 'sord' => ':build'
-  depends_on 'sratom' => ':build'
-  depends_on 'swig' => ':build'
-  depends_on 'waf' => ':build'
+  depends_on 'libsndfile' => :build
+  depends_on 'serd' => :build
+  depends_on 'sord' => :build
+  depends_on 'sratom' => :build
+  depends_on 'swig' => :build
+  depends_on 'waf' => :build
 
   def self.build
     # let wscript(s) find the custom waf scripts

--- a/packages/lv2.rb
+++ b/packages/lv2.rb
@@ -26,9 +26,9 @@ class Lv2 < Package
 
   depends_on 'gtk2'
   depends_on 'py3_pygments' => :build
-  depends_on 'asciidoc' => ':build'
-  depends_on 'doxygen' => ':build'
-  depends_on 'libsndfile' => ':build'
+  depends_on 'asciidoc' => :build
+  depends_on 'doxygen' => :build
+  depends_on 'libsndfile' => :build
 
   def self.build
     # let wscript(s) find the custom waf scripts

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -24,7 +24,7 @@ class Mold < Package
      x86_64: '622f44f74252163a17a418bdb7efe42c3a59d1956790260666268f462a3b8930'
   })
 
-  depends_on 'xxhash' => ':build'
+  depends_on 'xxhash' => :build
   no_env_options
 
   def self.patch

--- a/packages/openmp.rb
+++ b/packages/openmp.rb
@@ -25,7 +25,7 @@ class Openmp < Package
   })
 
   depends_on 'libffi'
-  depends_on 'llvm' => ':build'
+  depends_on 'llvm' => :build
 
   def self.build
     Dir.mkdir 'builddir'

--- a/packages/serd.rb
+++ b/packages/serd.rb
@@ -24,7 +24,7 @@ class Serd < Package
      x86_64: '9d44f52a0f18e146458ccb8ef8478be1cba0e1fcd1d1ed76743bbd10d861bb4d'
   })
 
-  depends_on 'waf' => ':build'
+  depends_on 'waf' => :build
 
   def self.build
     # let wscript(s) find the custom waf scripts

--- a/packages/sord.rb
+++ b/packages/sord.rb
@@ -26,7 +26,7 @@ class Sord < Package
 
   depends_on 'serd'
   depends_on 'pcre'
-  depends_on 'waf' => ':build'
+  depends_on 'waf' => :build
 
   def self.build
     # let wscript(s) find the custom waf scripts

--- a/packages/sratom.rb
+++ b/packages/sratom.rb
@@ -25,9 +25,9 @@ class Sratom < Package
   })
 
   depends_on 'lv2'
-  depends_on 'serd' => ':build'
-  depends_on 'sord' => ':build'
-  depends_on 'waf' => ':build'
+  depends_on 'serd' => :build
+  depends_on 'sord' => :build
+  depends_on 'waf' => :build
 
   def self.build
     # let wscript(s) find the custom waf scripts

--- a/packages/tbb.rb
+++ b/packages/tbb.rb
@@ -25,7 +25,7 @@ class Tbb < Package
   })
 
   depends_on 'hwloc'
-  depends_on 'swig' => ':build'
+  depends_on 'swig' => :build
 
   def self.build
     @tbb_cmake_options = if ARCH == 'i686'


### PR DESCRIPTION
The `:build` tag should be a symbol and no quotes are needed, extra quotes were removed.