### PR TITLE
Make mold default x86 linker, plus harfbuzz + initial libpng cleanup

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -812,7 +812,7 @@ def download
           system 'git checkout FETCH_HEAD'
         end
         system 'git submodule update --init --recursive'
-        if !!@pkg.git_fetchtags
+        if @pkg.git_fetchtags?
           system 'git fetch --tags', exception: true
         end
         puts 'Repository downloaded.'.lightgreen

--- a/bin/crew
+++ b/bin/crew
@@ -632,20 +632,6 @@ def upgrade
       end
     end
 
-    # Adjust package install ordering for upgrades.
-    CREW_FIRST_PACKAGES.each do |pkg|
-      # Add package to beginning.
-      toBeUpdated.insert(0,toBeUpdated.delete(pkg)) if toBeUpdated.include? pkg
-    end
-    CREW_LAST_PACKAGES.each do |pkg|
-      if toBeUpdated.include? pkg
-        # Add package to beginning.
-        toBeUpdated.insert(0,toBeUpdated.delete(pkg))
-        # Now rotate first package to last package.
-        toBeUpdated=toBeUpdated.rotate(1)
-      end
-    end
-
     unless toBeUpdated.empty?
       puts 'Updating packages...'
       toBeUpdated.each do |package|

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.0'
+CREW_VERSION = '1.23.1'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -115,8 +115,14 @@ when 'x86_64'
   CREW_BUILD = 'x86_64-cros-linux-gnu'
 end
 
-CREW_COMMON_FLAGS = '-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=gold'
-CREW_COMMON_FNO_LTO_FLAGS = '-O2 -pipe -fno-lto -fPIC -fuse-ld=gold'
+case ARCH
+when 'aarch64', 'armv7l'
+  CREW_LINKER = 'gold'
+when 'i686', 'x86_64'
+  CREW_LINKER = 'mold'
+end
+CREW_COMMON_FLAGS = "-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=#{CREW_LINKER}"
+CREW_COMMON_FNO_LTO_FLAGS = "-O2 -pipe -fno-lto -fPIC -fuse-ld=#{CREW_LINKER}"
 CREW_LDFLAGS = '-flto'
 CREW_FNO_LTO_LDFLAGS = '-fno-lto'
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -115,7 +115,7 @@ when 'x86_64'
   CREW_BUILD = 'x86_64-cros-linux-gnu'
 end
 
-unless ENV['CREW_LINKER'].to_s.empty?
+if ENV['CREW_LINKER'].to_s.empty?
   case ARCH
   when 'aarch64', 'armv7l'
     CREW_LINKER = 'gold'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -119,15 +119,18 @@ unless ENV['CREW_LINKER'].to_s.empty?
   case ARCH
   when 'aarch64', 'armv7l'
     CREW_LINKER = 'gold'
+    CREW_LINKER_FLAGS = "-Wl,--threads -Wl,--thread-count,#{CREW_NPROC}"
   when 'i686', 'x86_64'
     CREW_LINKER = 'mold'
+    CREW_LINKER_FLAGS = ''
   end
 else
   CREW_LINKER = ENV['CREW_LINKER']
 end
-CREW_COMMON_FLAGS = "-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=#{CREW_LINKER}"
-CREW_COMMON_FNO_LTO_FLAGS = "-O2 -pipe -fno-lto -fPIC -fuse-ld=#{CREW_LINKER}"
-CREW_LDFLAGS = '-flto'
+
+CREW_COMMON_FLAGS = "-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"
+CREW_COMMON_FNO_LTO_FLAGS = "-O2 -pipe -fno-lto -fPIC -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"
+CREW_LDFLAGS = "-flto #{CREW_LINKER_FLAGS}"
 CREW_FNO_LTO_LDFLAGS = '-fno-lto'
 
 unless CREW_DISABLE_ENV_OPTIONS

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -215,8 +215,8 @@ PY2_SETUP_BUILD_OPTIONS = "--executable=#{CREW_PREFIX}/bin/python2"
 PY_SETUP_INSTALL_OPTIONS_NO_SVEM = "--root=#{CREW_DEST_DIR} --prefix=#{CREW_PREFIX} -O2 --compile"
 PY_SETUP_INSTALL_OPTIONS = "#{PY_SETUP_INSTALL_OPTIONS_NO_SVEM} --single-version-externally-managed"
 
-CREW_FIRST_PACKAGES = %w[libssh curl git pixz shared_mime_info]
-CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier]
+CREW_FIRST_PACKAGES = %w[libssh curl git pixz shared_mime_info harfbuzz]
+CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier freetype]
 
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -115,11 +115,15 @@ when 'x86_64'
   CREW_BUILD = 'x86_64-cros-linux-gnu'
 end
 
-case ARCH
-when 'aarch64', 'armv7l'
-  CREW_LINKER = 'gold'
-when 'i686', 'x86_64'
-  CREW_LINKER = 'mold'
+unless ENV['CREW_LINKER'].to_s.empty?
+  case ARCH
+  when 'aarch64', 'armv7l'
+    CREW_LINKER = 'gold'
+  when 'i686', 'x86_64'
+    CREW_LINKER = 'mold'
+  end
+else
+  CREW_LINKER = ENV['CREW_LINKER']
 end
 CREW_COMMON_FLAGS = "-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=#{CREW_LINKER}"
 CREW_COMMON_FNO_LTO_FLAGS = "-O2 -pipe -fno-lto -fPIC -fuse-ld=#{CREW_LINKER}"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -225,9 +225,6 @@ PY2_SETUP_BUILD_OPTIONS = "--executable=#{CREW_PREFIX}/bin/python2"
 PY_SETUP_INSTALL_OPTIONS_NO_SVEM = "--root=#{CREW_DEST_DIR} --prefix=#{CREW_PREFIX} -O2 --compile"
 PY_SETUP_INSTALL_OPTIONS = "#{PY_SETUP_INSTALL_OPTIONS_NO_SVEM} --single-version-externally-managed"
 
-CREW_FIRST_PACKAGES = %w[libssh curl git pixz shared_mime_info harfbuzz]
-CREW_LAST_PACKAGES = %w[ghc mandb gtk3 gtk4 sommelier freetype]
-
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +
                        %w[libzstd.so.1 libstdc++.so.6]

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -126,6 +126,7 @@ unless ENV['CREW_LINKER'].to_s.empty?
   end
 else
   CREW_LINKER = ENV['CREW_LINKER']
+  CREW_LINKER_FLAGS = ENV['CREW_LINKER_FLAGS']
 end
 
 CREW_COMMON_FLAGS = "-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"

--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -3,29 +3,29 @@ require 'package'
 class Cairo < Package
   description 'Cairo is a 2D graphics library with support for multiple output devices.'
   homepage 'https://www.cairographics.org'
-  version '1.17.5-a047'
+  version '1.17.5-ec54603'
   license 'LGPL-2.1 or MPL-1.1'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/cairo/cairo.git'
-  git_hashtag 'a04786b9330109ce54bf7f65c7068281419cec6a'
+  git_hashtag 'ec54603366a39a5ad12c489aaf0bbb85859fa7a9'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-a047_armv7l/cairo-1.17.5-a047-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-a047_armv7l/cairo-1.17.5-a047-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-a047_i686/cairo-1.17.5-a047-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-a047_x86_64/cairo-1.17.5-a047-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_armv7l/cairo-1.17.5-ec54603-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_armv7l/cairo-1.17.5-ec54603-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_i686/cairo-1.17.5-ec54603-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_x86_64/cairo-1.17.5-ec54603-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '77e9eb5646d4c3db1faaf63223027bffb79cb4353a97dc1cabe94debfa8604a8',
-     armv7l: '77e9eb5646d4c3db1faaf63223027bffb79cb4353a97dc1cabe94debfa8604a8',
-       i686: 'cc91b1482cf26d5eb23b88225f644f364e721c5fabe213a132da88444c13ade4',
-     x86_64: '9d24a1127d2d7103a0be565bf773c8f49952524c53b8a17c356ea30b213b911c'
+    aarch64: '1afe2c4afb826e35c549f786db7983a961a7cb1ca14d079ee448463949ad4626',
+     armv7l: '1afe2c4afb826e35c549f786db7983a961a7cb1ca14d079ee448463949ad4626',
+       i686: 'cbd2b8faf20bbc08751be0e2e37d38d8df6007b93b46ec82c06a8878c730a06e',
+     x86_64: 'bf0cf34ce1bced53bb91aa0d43c0769c436afea02c78773d2ccdb1ad40c4f105'
   })
 
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'glib'
-  depends_on 'libpng'
+  depends_on 'harfbuzz'
   depends_on 'libx11'
   depends_on 'libxcb'
   depends_on 'libxrender'

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -3,24 +3,24 @@ require 'package'
 class Fontconfig < Package
   description 'Fontconfig is a library for configuring and customizing font access.'
   homepage 'https://www.freedesktop.org/software/fontconfig/front.html'
-  @_ver = '2.13.93'
-  version "#{@_ver}-2"
+  @_ver = '2.13.96'
+  version @_ver
   license 'MIT'
   compatibility 'all'
-  source_url "https://github.com/freedesktop/fontconfig/archive/#{@_ver}.tar.gz"
-  source_sha256 'f8452c78d1a12f6966455b0d584f89553b13e970b40644c3650f690ec0b3b4fe'
+  source_url 'https://gitlab.freedesktop.org/fontconfig/fontconfig.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.93-2_armv7l/fontconfig-2.13.93-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.93-2_armv7l/fontconfig-2.13.93-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.93-2_i686/fontconfig-2.13.93-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.93-2_x86_64/fontconfig-2.13.93-2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_armv7l/fontconfig-2.13.96-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_armv7l/fontconfig-2.13.96-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_i686/fontconfig-2.13.96-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_x86_64/fontconfig-2.13.96-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '0047a707a1fc8531fa6bfc6fa45f2aead43ece0e65d1eaad094e4e98f3e43ec0',
-     armv7l: '0047a707a1fc8531fa6bfc6fa45f2aead43ece0e65d1eaad094e4e98f3e43ec0',
-       i686: 'abef1aab53d6880c0f43fc188a6de1ca1bf9b60c20c3f6459cdbcb40b32cb80a',
-     x86_64: '762b2f4a1d0d593f7f4c5000b651e9d03e98b11759a113bac0c260cc45830391'
+    aarch64: 'ee7900160a576c6402191b39c4a1764691d1eb97f18c19e0117bf2fd9fc0435c',
+     armv7l: 'ee7900160a576c6402191b39c4a1764691d1eb97f18c19e0117bf2fd9fc0435c',
+       i686: '5dc551362bc72fdcbd7734812e62d5035a97fee9b733b6690cae2286e6d4d69d',
+     x86_64: '0c0f777ba5352f92851c70a010b25824fa269dab2b389b95f823e03d890f4b15'
   })
 
   depends_on 'gperf'
@@ -28,8 +28,9 @@ class Fontconfig < Package
   depends_on 'jsonc'
   depends_on 'util_linux'
   depends_on 'graphite'
+  no_fhs
 
-  # Remove freetype and fontconfig before rebuilding this package.
+  # Remove fontconfig before rebuilding this package.
 
   def self.build
     # Fix build failure from font directories not being writable.
@@ -38,7 +39,7 @@ class Fontconfig < Package
       import sys
       sys.exit()
     INSTALLCACHE_HEREDOC
-    IO.write('install-cache', @install_cache, perm: 0o666)
+    File.write('install-cache', @install_cache, perm: 0o666)
     system "meson #{CREW_MESON_OPTIONS} \
     --localstatedir=#{CREW_PREFIX}/cache \
     --default-library=both \
@@ -67,14 +68,14 @@ class Fontconfig < Package
         <cachedir>~/.fontconfig</cachedir>
       </fontconfig>
     FONTCONF_HEREDOC
-    IO.write("#{CREW_DEST_PREFIX}/etc/fonts/conf.d/52-chromebrew.conf", @fonts_conf, perm: 0o666)
+    File.write("#{CREW_DEST_PREFIX}/etc/fonts/conf.d/52-chromebrew.conf", @fonts_conf, perm: 0o666)
 
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d/"
     @env = <<~EOF
       # Fontconfig configuration
       export FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts
     EOF
-    IO.write("#{CREW_DEST_PREFIX}/etc/env.d/fontconfig", @env)
+    File.write("#{CREW_DEST_PREFIX}/etc/env.d/fontconfig", @env)
   end
 
   def self.postinstall

--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -10,6 +10,19 @@ class Gdk_pixbuf < Package
   source_url 'https://gitlab.gnome.org/GNOME/gdk-pixbuf.git'
   git_hashtag @_ver
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6-1_armv7l/gdk_pixbuf-2.42.6-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6-1_armv7l/gdk_pixbuf-2.42.6-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6-1_i686/gdk_pixbuf-2.42.6-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6-1_x86_64/gdk_pixbuf-2.42.6-1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '1c577ba59a852aaaffd4612ef72396b2d37f44c3cf81fcee85376b8b14b3bb7f',
+     armv7l: '1c577ba59a852aaaffd4612ef72396b2d37f44c3cf81fcee85376b8b14b3bb7f',
+       i686: '4aa97c61517ec11c151336b3a9ec9cd64db27f79bff70f321b0807effd5f663e',
+     x86_64: '441ce2ef5883ca7f98671f44498cc66f7f2be344473fd911c307d06c794e0f0f'
+  })
+
   depends_on 'glib' # R
   depends_on 'gobject_introspection' => :build
   depends_on 'harfbuzz' # R

--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -4,44 +4,95 @@ class Gdk_pixbuf < Package
   description 'GdkPixbuf is a library for image loading and manipulation.'
   homepage 'https://developer.gnome.org/gdk-pixbuf'
   @_ver = '2.42.6'
-  version @_ver
+  version "#{@_ver}-1"
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gdk-pixbuf.git'
   git_hashtag @_ver
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6_armv7l/gdk_pixbuf-2.42.6-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6_armv7l/gdk_pixbuf-2.42.6-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6_i686/gdk_pixbuf-2.42.6-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6_x86_64/gdk_pixbuf-2.42.6-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: 'e34b1d8685646cfcf999bb84c699e19c749d6cefd9d5346702bf8bc611293234',
-     armv7l: 'e34b1d8685646cfcf999bb84c699e19c749d6cefd9d5346702bf8bc611293234',
-       i686: 'e96ec7db0611cc7701754b3466b4b1d337123a62eefd06be0976254482b50027',
-     x86_64: '275ea5531916a62aa263e2f94c3eeb23af85140dfc4034ed513c044ad2277d6f'
-  })
-
   depends_on 'glib' # R
   depends_on 'gobject_introspection' => :build
-  depends_on 'jasper' => :build
+  depends_on 'harfbuzz' # R
   depends_on 'libjpeg' # R
-  depends_on 'libpng' # R
-  depends_on 'libtiff' # R
-  depends_on 'libwebp' => :build
+  # depends_on 'libtiff' # R This drags gtk3 into the deps via libwebp
+  # depends_on 'libwebp' => :build This drags gtk3 into the deps.
   depends_on 'pango' => :build
-  depends_on 'py3_six' => :build
   depends_on 'py3_markdown' => :build
+  depends_on 'py3_six' => :build
   depends_on 'py3_typogrify' => :build
+
+  def self.patch
+    @gif_overflow_patch = <<~'PATCH_EOF'
+      From 0cf97225c9c227d11fc4ddf9cba8e8480672ee1b Mon Sep 17 00:00:00 2001
+      From: Robert Ancell <robert.ancell@canonical.com>
+      Date: Wed, 2 Feb 2022 12:38:45 +1300
+      Subject: [PATCH 2/4] Add an assertion that checks for maximum LZW code size
+
+      ---
+       gdk-pixbuf/lzw.c | 2 ++
+       1 file changed, 2 insertions(+)
+
+      diff --git a/gdk-pixbuf/lzw.c b/gdk-pixbuf/lzw.c
+      index 105daf2b1..15293560b 100644
+      --- a/gdk-pixbuf/lzw.c
+      +++ b/gdk-pixbuf/lzw.c
+      @@ -121,6 +121,8 @@ lzw_decoder_new (guint8 code_size)
+               LZWDecoder *self;
+               int i;
+       
+      +        g_return_val_if_fail (code_size <= LZW_CODE_MAX, NULL);
+      +
+               self = g_object_new (lzw_decoder_get_type (), NULL);
+       
+               self->min_code_size = code_size;
+      -- 
+      GitLab
+
+
+      From 19ebba03117aefc9d0312f675f3a210ffdcc4907 Mon Sep 17 00:00:00 2001
+      From: Robert Ancell <robert.ancell@canonical.com>
+      Date: Wed, 2 Feb 2022 14:03:13 +1300
+      Subject: [PATCH 3/4] Fix the check for maximum value of LZW initial code size.
+
+      This value is the number of bits for each symbol (i.e. colour index) decoded via LZW.
+      The maximum LZW code is specified as 12 bits, so the value here can only be 11 as two additional code words are required (clear and end of information) that immediately uses an additional bit.
+      This implementation has always been wrong, and the Firefox implementation has the same issue so it seems a common misinterpretation of the spec.
+      This has been changed here to avoid an assertion later in the LZW decoder.
+      Note that there is never any reason for a GIF to be encoded with more than 8 bits of colour information, as the colour tables only support up to 8 bits.
+      ---
+       gdk-pixbuf/io-gif.c | 4 ++--
+       1 file changed, 2 insertions(+), 2 deletions(-)
+
+      diff --git a/gdk-pixbuf/io-gif.c b/gdk-pixbuf/io-gif.c
+      index 1befba155..310bdff6a 100644
+      --- a/gdk-pixbuf/io-gif.c
+      +++ b/gdk-pixbuf/io-gif.c
+      @@ -499,8 +499,8 @@ gif_prepare_lzw (GifContext *context)
+       		/*g_message (_("GIF: EOF / read error on image data\n"));*/
+       		return -1;
+       	}
+      -        
+      -        if (context->lzw_set_code_size > 12) {
+      +
+      +        if (context->lzw_set_code_size >= 12) {
+                       g_set_error_literal (context->error,
+                                            GDK_PIXBUF_ERROR,
+                                            GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
+      -- 
+      GitLab
+
+    PATCH_EOF
+    File.write('gif_overflow.patch', @gif_overflow_patch)
+    system 'patch -p1 -i gif_overflow.patch || true'
+  end
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
       -Dinstalled_tests=false \
       -Dbuiltin_loaders=all \
       -Drelocatable=true \
-      -Djasper=true \
       -Ddebug=false \
+      -Dgtk_doc=false \
       -Dman=true \
       builddir"
     system 'samu -C builddir'
@@ -59,7 +110,7 @@ class Gdk_pixbuf < Package
       export GDK_PIXBUF_MODULEDIR=#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders
       export GDK_PIXBUF_MODULE_FILE=#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders.cache
     GDK_PIXBUF_ENV_EOF
-    IO.write("#{CREW_DEST_PREFIX}/etc/env.d/gdk_pixbuf", @gdk_pixbuf_env)
+    File.write("#{CREW_DEST_PREFIX}/etc/env.d/gdk_pixbuf", @gdk_pixbuf_env)
   end
 
   def self.postinstall

--- a/packages/glew.rb
+++ b/packages/glew.rb
@@ -34,7 +34,7 @@ class Glew < Package
   end
 
   def self.build
-    ENV['GLEW_DEST'] = CREW_PREFIX.to_s
+    ENV['GLEW_DEST'] = CREW_PREFIX
     Dir.chdir 'glew-2.2.0/build' do
       system "cmake #{CREW_CMAKE_OPTIONS} cmake"
       system 'make', 'SYSTEM=linux-egl'

--- a/packages/glew.rb
+++ b/packages/glew.rb
@@ -10,10 +10,10 @@ class Glew < Package
   source_sha256 'd4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1'
 
   binary_url({
-    aarch64: 'file:///usr/local/tmp/packages/glew-2.2.0-chromeos-armv7l.tar.zst',
-     armv7l: 'file:///usr/local/tmp/packages/glew-2.2.0-chromeos-armv7l.tar.zst',
-       i686: 'file:///usr/local/tmp/packages/glew-2.2.0-chromeos-i686.tar.zst',
-     x86_64: 'file:///usr/local/tmp/packages/glew-2.2.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glew/2.2.0_armv7l/glew-2.2.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glew/2.2.0_armv7l/glew-2.2.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glew/2.2.0_i686/glew-2.2.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glew/2.2.0_x86_64/glew-2.2.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '20c0ed7ae6a12d3a3b852d7d3b9f27bb9bcc9eeb13843767a599b055cde8f77e',

--- a/packages/glew.rb
+++ b/packages/glew.rb
@@ -3,29 +3,29 @@ require 'package'
 class Glew < Package
   description 'GLEW provides efficient run-time mechanisms for determining which OpenGL extensions are supported on the target platform'
   homepage 'http://glew.sourceforge.net/'
-  version '2.2.0-rc3'
+  version '2.2.0'
   license 'BSD and MIT'
   compatibility 'all'
-  source_url 'https://sourceforge.net/projects/glew/files/glew/snapshots/glew-20200115.tgz/download'
-  source_sha256 '314219ba1db50d49b99705e8eb00e83b230ee7e2135289a00b5b570e4a4db43a'
+  source_url 'https://sourceforge.net/projects/glew/files/glew/2.2.0/glew-2.2.0.tgz/download'
+  source_sha256 'd4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glew/2.2.0-rc3_armv7l/glew-2.2.0-rc3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glew/2.2.0-rc3_armv7l/glew-2.2.0-rc3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glew/2.2.0-rc3_i686/glew-2.2.0-rc3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glew/2.2.0-rc3_x86_64/glew-2.2.0-rc3-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'file:///usr/local/tmp/packages/glew-2.2.0-chromeos-armv7l.tar.zst',
+     armv7l: 'file:///usr/local/tmp/packages/glew-2.2.0-chromeos-armv7l.tar.zst',
+       i686: 'file:///usr/local/tmp/packages/glew-2.2.0-chromeos-i686.tar.zst',
+     x86_64: 'file:///usr/local/tmp/packages/glew-2.2.0-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '0912816e2c59d5a677f0b777ac92b7ac92262a9bf8daa5ab5c9e182b95cb9836',
-     armv7l: '0912816e2c59d5a677f0b777ac92b7ac92262a9bf8daa5ab5c9e182b95cb9836',
-       i686: 'f2b24b7826fe5c8b46a333ae7ece33a1d3a6a73f2f499c769a8a22fae4d7b53e',
-     x86_64: '3c79783cf39d26b793fed5b0b9d655febda3ec57336cdacd597f574fc29253bb',
+  binary_sha256({
+    aarch64: '20c0ed7ae6a12d3a3b852d7d3b9f27bb9bcc9eeb13843767a599b055cde8f77e',
+     armv7l: '20c0ed7ae6a12d3a3b852d7d3b9f27bb9bcc9eeb13843767a599b055cde8f77e',
+       i686: '645d6b9697d3543d819cc9fc3b6877f4d849707fcaa11c79a2f77656a6958b42',
+     x86_64: '4ac9705c4f6836b04286e85d8e0da547c59de28c98119e3654358f27c1b387a3'
   })
 
   depends_on 'mesa'
 
   def self.patch
-    system 'tar fxv ../download'
+    system 'tar fxv download'
     Dir.chdir 'glew-2.2.0/build' do
       # As per https://github.com/nigels-com/glew/pull/268
       system "sed -i 's/OpenGL::EGL/NOT OpenGL_EGL_FOUND/' cmake/CMakeLists.txt"
@@ -34,17 +34,10 @@ class Glew < Package
   end
 
   def self.build
-    #ENV['CFLAGS.EXTRA'] = "-fuse-ld=lld"
-    #ENV['CFLAGS'] = "-fuse-ld=lld"
-    #ENV['CXXFLAGS'] = "-fuse-ld=lld"
-    ENV['GLEW_DEST'] = "#{CREW_PREFIX}"
+    ENV['GLEW_DEST'] = CREW_PREFIX.to_s
     Dir.chdir 'glew-2.2.0/build' do
-      system 'cmake',
-             '-DCMAKE_BUILD_TYPE=Release',
-             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
-             "-DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX}",
-             './cmake'
-      system 'make', "SYSTEM=linux-egl"
+      system "cmake #{CREW_CMAKE_OPTIONS} cmake"
+      system 'make', 'SYSTEM=linux-egl'
     end
   end
 

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.71.1'
+  @_ver = '2.71.3'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
@@ -12,22 +12,27 @@ class Glib < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.1_armv7l/glib-2.71.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.1_armv7l/glib-2.71.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.1_i686/glib-2.71.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.1_x86_64/glib-2.71.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_armv7l/glib-2.71.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_armv7l/glib-2.71.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_i686/glib-2.71.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_x86_64/glib-2.71.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dc75987cfd4ded17f8ac719d80dc3ff1508e5e0876f739cf78ede64c03f4e2d0',
-     armv7l: 'dc75987cfd4ded17f8ac719d80dc3ff1508e5e0876f739cf78ede64c03f4e2d0',
-       i686: 'b59137669a2c2fad2c8cf39db576678412559826e7ad69ae34851ed1ae13d827',
-     x86_64: 'b1b45e35cfddc29d84c1a73d87cc0447fedcd16fbf1813eae64f23d1b8f7444c'
+    aarch64: 'f790de63e82f702d061f2de152025f3f76294165c11b1412b914ef197876eed8',
+     armv7l: 'f790de63e82f702d061f2de152025f3f76294165c11b1412b914ef197876eed8',
+       i686: '9113fd3b36bbeba475fe1d02c30e3e5da480c1c0de9808a3ad3f0d4f4c2fe890',
+     x86_64: 'd2fc753604c45fc397ebceadefca2b9db3aea42384c70237688df6d33e5b60d8'
   })
 
-  depends_on 'shared_mime_info' # L
-  depends_on 'py3_six' => :build
+  depends_on 'elfutils' # R
+  depends_on 'libffi' # R
+  depends_on 'pcre' # R
   depends_on 'py3_pygments' => :build
+  depends_on 'py3_six' => :build
+  depends_on 'shared_mime_info' # L
   depends_on 'util_linux' # R
+  depends_on 'zlibpkg' # R
+  no_env_options
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -11,6 +11,19 @@ class Gtk3 < Package
   source_url 'https://gitlab.gnome.org/GNOME/gtk.git'
   git_hashtag @_ver
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.33_armv7l/gtk3-3.24.33-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.33_armv7l/gtk3-3.24.33-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.33_i686/gtk3-3.24.33-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.33_x86_64/gtk3-3.24.33-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '651888d424ed031a023d9d7473bb2cb8f3996e4aeac262fa6bbad4c6643ddf22',
+     armv7l: '651888d424ed031a023d9d7473bb2cb8f3996e4aeac262fa6bbad4c6643ddf22',
+       i686: '6c62f793c25f0bbae8b1d7df68f1f187a315aaf2791a49ee74265d91fcbc7590',
+     x86_64: '433d3ec60a0582d31cc70f9b041ca309b7bc3182cafe2abc2ff759f3a1e2bb23'
+  })
+
   # L = Logical Dependency, R = Runtime Dependency
   depends_on 'adwaita_icon_theme' # L
   depends_on 'atk' # R
@@ -99,7 +112,7 @@ class Gtk3 < Package
     system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
     # update icon cache, but only if gdk_pixbuf is already installed.
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    return unless @device[:installed_packages].any? do |elem| elem[:name] == 'gdk_pixbuf' end
+    return unless @device[:installed_packages].any? { |elem| elem[:name] == 'gdk_pixbuf' }
 
     system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/*"
   end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gtk3 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk3/3.0/'
-  @_ver = '3.24.31'
+  @_ver = '3.24.33'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
@@ -11,51 +11,33 @@ class Gtk3 < Package
   source_url 'https://gitlab.gnome.org/GNOME/gtk.git'
   git_hashtag @_ver
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.31_armv7l/gtk3-3.24.31-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.31_armv7l/gtk3-3.24.31-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.31_i686/gtk3-3.24.31-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.31_x86_64/gtk3-3.24.31-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '7df7bcce97f9ceca4bb6819b2306f3d5b0470a7b3a789d10a35b2e9071f386de',
-     armv7l: '7df7bcce97f9ceca4bb6819b2306f3d5b0470a7b3a789d10a35b2e9071f386de',
-       i686: '6fdcaf10062f4c1a8880c3d3eb897cacb27193f5817346041b4048608f362f74',
-     x86_64: '6273b79151dc38fa8a240100e75b72a3cba6a868611f3c25fe7862f98751a106'
-  })
-
   # L = Logical Dependency, R = Runtime Dependency
-  depends_on 'docbook' => :build
-  depends_on 'ghostscript' => :build
-  depends_on 'gobject_introspection' => :build
-  depends_on 'iso_codes' => :build
-  depends_on 'libsass' => :build
-  depends_on 'libspectre' => :build
-  depends_on 'mesa' => :build
-  depends_on 'valgrind' => :build
-  depends_on 'graphene' => :build # Do we need this?
-  depends_on 'graphite' => :build # Do we need this?
-  depends_on 'libdeflate' => :build # Do we need this?
-  depends_on 'libjpeg' => :build # Do we need this?
-  depends_on 'py3_six' => :build # Do we need this?
   depends_on 'adwaita_icon_theme' # L
-  depends_on 'cantarell_fonts' # L
-  depends_on 'gnome_icon_theme' # L
-  depends_on 'hicolor_icon_theme' # L
-  depends_on 'shared_mime_info' # L
-  depends_on 'xdg_base' # L
   depends_on 'atk' # R
   depends_on 'at_spi2_atk' # R
   depends_on 'cairo' # R
+  depends_on 'cantarell_fonts' # L
   depends_on 'cups' # R
+  depends_on 'docbook' => :build
   depends_on 'fontconfig' # R
   depends_on 'freetype' # R
   depends_on 'fribidi' # R
   depends_on 'gdk_pixbuf' # R
+  depends_on 'ghostscript' => :build
   depends_on 'glib' # R
+  depends_on 'gnome_icon_theme' # L
+  depends_on 'gobject_introspection' => :build
+  depends_on 'graphene' => :build # Do we need this?
+  depends_on 'graphite' => :build # Do we need this?
   depends_on 'harfbuzz' # R
+  depends_on 'hicolor_icon_theme' # L
+  depends_on 'iso_codes' => :build
   depends_on 'json_glib' # R
+  depends_on 'libdeflate' => :build # Do we need this?
   depends_on 'libepoxy' # R
+  depends_on 'libjpeg' => :build # Do we need this?
+  depends_on 'libsass' => :build
+  depends_on 'libspectre' => :build
   depends_on 'libx11' # R
   depends_on 'libxcomposite' # R
   depends_on 'libxcursor' # R
@@ -66,9 +48,14 @@ class Gtk3 < Package
   depends_on 'libxi' # R
   depends_on 'libxkbcommon' # R
   depends_on 'libxrandr' # R
+  depends_on 'mesa' => :build
   depends_on 'pango' # R
+  depends_on 'py3_six' => :build # Do we need this?
   depends_on 'rest' # R
+  depends_on 'shared_mime_info' # L
+  depends_on 'valgrind' => :build
   depends_on 'wayland' # R
+  depends_on 'xdg_base' # L
 
   def self.patch
     # Use locally build subprojects

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -114,6 +114,6 @@ class Gtk3 < Package
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
     return unless @device[:installed_packages].any? { |elem| elem[:name] == 'gdk_pixbuf' }
 
-    system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/*"
+    system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/* || true"
   end
 end

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gtk4 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk4/'
-  @_ver = '4.6.0'
+  @_ver = '4.6.1'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
@@ -12,16 +12,16 @@ class Gtk4 < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.6.0_armv7l/gtk4-4.6.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.6.0_armv7l/gtk4-4.6.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.6.0_i686/gtk4-4.6.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.6.0_x86_64/gtk4-4.6.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.6.1_armv7l/gtk4-4.6.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.6.1_armv7l/gtk4-4.6.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.6.1_i686/gtk4-4.6.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.6.1_x86_64/gtk4-4.6.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a90c62de22c3e1bda68d5f1618a323f1dffd26a4cbdcc50cbd7b2a913e868f65',
-     armv7l: 'a90c62de22c3e1bda68d5f1618a323f1dffd26a4cbdcc50cbd7b2a913e868f65',
-       i686: 'e5d022bb65e8346015ca25d26101a04307b59aa467ec2e29a2c1360ef2d1abd6',
-     x86_64: '2903de6c81e7d7fecba9a3ff6aa5425fce0f61a2ddb1eb5a6a9ae305cc982d30'
+    aarch64: '0822c46fdce44847664517eede126d7c4dde04f2a912c7ee395761e2a015365e',
+     armv7l: '0822c46fdce44847664517eede126d7c4dde04f2a912c7ee395761e2a015365e',
+       i686: '82c907d171ed166e98e420b10766ac85066f8f6154afc0c499b7bf2bd11cfbab',
+     x86_64: '348f052b349e1cecf1cb82396b8e999a43bc35f50ee2e2e48e8ec442175a955c'
   })
 
   # L = Logical Dependency, R = Runtime Dependency
@@ -120,7 +120,7 @@ class Gtk4 < Package
     system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
     # update icon cache, but only if gdk_pixbuf is already installed.
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    return unless @device[:installed_packages].any? do |elem| elem[:name] == 'gdk_pixbuf' end
+    return unless @device[:installed_packages].any? { |elem| elem[:name] == 'gdk_pixbuf' }
 
     system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/*"
   end

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -122,6 +122,6 @@ class Gtk4 < Package
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
     return unless @device[:installed_packages].any? { |elem| elem[:name] == 'gdk_pixbuf' }
 
-    system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/*"
+    system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/* || true"
   end
 end

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -4,17 +4,17 @@ class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
   @_ver = '4.0.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_armv7l/harfbuzz-4.0.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_armv7l/harfbuzz-4.0.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_i686/harfbuzz-4.0.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0_x86_64/harfbuzz-4.0.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_i686/harfbuzz-4.0.0-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_x86_64/harfbuzz-4.0.0-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -1,49 +1,13 @@
 require 'package'
 
 class Libpng < Package
-  description 'libpng is the official PNG reference library. Patched with APNG support.'
+  description 'libpng is the official PNG reference library. Now built inside harfbuzz'
   homepage 'http://libpng.org/pub/png/libpng.html'
-  @_ver = '1.6.37'
-  version "#{@_ver}-3"
+  version "1.0"
   license 'libpng2'
   compatibility 'all'
-  source_url "https://downloads.sourceforge.net/project/libpng/libpng16/#{@_ver}/libpng-#{@_ver}.tar.xz"
-  source_sha256 '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_armv7l/libpng-1.6.37-3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_armv7l/libpng-1.6.37-3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_i686/libpng-1.6.37-3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37-3_x86_64/libpng-1.6.37-3-chromeos-x86_64.tpxz',
-  })
-  binary_sha256 ({
-    aarch64: '267f2ef6f7261612350b576acadbfa258471122365a68c1f81bf5785b65631d0',
-     armv7l: '267f2ef6f7261612350b576acadbfa258471122365a68c1f81bf5785b65631d0',
-       i686: '39cb6b94600b6fa4619941ddacc42972d176aa9ac8e2372bdaf469644c2caf35',
-     x86_64: '374bdf9e5ff3f15a966990bbc6def09dd45898966a2be1075e1ebd3a52b69402',
-  })
+  depends_on 'harfbuzz'
+  is_fake
 
-  depends_on 'shared_mime_info'
-
-  def self.patch
-    system 'filefix'
-    # patch in APNG (animated PNG) support
-    system "curl -#LO https://sourceforge.net/projects/apng/files/libpng/libpng16/libpng-#{@_ver}-apng.patch.gz"
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read("libpng-#{@_ver}-apng.patch.gz") ) == '10d9e0cb60e2b387a79b355eb7527c0bee2ed8cbd12cf04417cabc4d6976683c'
-    system "gunzip libpng-#{@_ver}-apng.patch.gz"
-    system "patch -Np0 -i libpng-#{@_ver}-apng.patch"
-  end
-
-  def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.postinstall
-    system 'update-mime-database', "#{CREW_PREFIX}/share/mime"
-  end
 end

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Libpng < Package
-  description 'libpng is the official PNG reference library. Now built inside harfbuzz'
+  description 'libpng is the official PNG reference library. Now bundled with harfbuzz.'
   homepage 'http://libpng.org/pub/png/libpng.html'
   version "1.0"
   license 'libpng2'

--- a/packages/libva.rb
+++ b/packages/libva.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libva < Package
   description 'Libva is an implementation for VA-API (Video Acceleration API)'
   homepage 'https://01.org/linuxmedia'
-  @_ver = '2.12.0'
+  @_ver = '2.14.0'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Libva < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.12.0_armv7l/libva-2.12.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.12.0_armv7l/libva-2.12.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.12.0_i686/libva-2.12.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.12.0_x86_64/libva-2.12.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_armv7l/libva-2.14.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_armv7l/libva-2.14.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_i686/libva-2.14.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_x86_64/libva-2.14.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e64a354e9607f5b220a22d33ebe24cf8b933a0cd97bad7efa0376fdd8ef27c52',
-     armv7l: 'e64a354e9607f5b220a22d33ebe24cf8b933a0cd97bad7efa0376fdd8ef27c52',
-       i686: '7949cad8c32e05368d58243cfdc956e40350d570333a517f2c8c891f5ba0895d',
-     x86_64: '7cdc4741dd68458cdff0fff55ef4600af6fcf3b0fc385acc5649eda4bfcea0be'
+    aarch64: '1177ea4f0e3d8218a917070ba4943a8850ffb48c92be88c53373a77c35063c08',
+     armv7l: '1177ea4f0e3d8218a917070ba4943a8850ffb48c92be88c53373a77c35063c08',
+       i686: 'e77eafe870dde013f5868eabebdd1ea0980ae642c28b11d5d4ee8b8f60c0fbfe',
+     x86_64: '4f330f77b5cdec5d11bcce6436c601db00c3def6fe07ebaaebd163068eb566ed'
   })
 
   depends_on 'libdrm'

--- a/packages/libx11.rb
+++ b/packages/libx11.rb
@@ -3,33 +3,35 @@ require 'package'
 class Libx11 < Package
   description 'C interface to the X window system'
   homepage 'https://x.org'
-  version '1.7.2'
+  version '1.7.3.1'
   license 'custom'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/xorg/lib/libx11.git'
   git_hashtag "libX11-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.2_armv7l/libx11-1.7.2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.2_armv7l/libx11-1.7.2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.2_i686/libx11-1.7.2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.2_x86_64/libx11-1.7.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.3.1_armv7l/libx11-1.7.3.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.3.1_armv7l/libx11-1.7.3.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.3.1_i686/libx11-1.7.3.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.3.1_x86_64/libx11-1.7.3.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e066f82ad7b8578f672c472d8e132683426ebfc7707b036aa13891027b63fe8d',
-     armv7l: 'e066f82ad7b8578f672c472d8e132683426ebfc7707b036aa13891027b63fe8d',
-       i686: 'ad26fb5dbad41b0d1d8d3550fca22c48d3ca395bf5bb0440af5f6b701e1371df',
-     x86_64: '329c60bc8ff483f079024654d81bcf932c54b79d7dd0314606a3f0d1b436be94'
+    aarch64: '23bdd5b1b635e3cca9d434b7f6d60057e8c16bcd7edfbf612337fc16382f9449',
+     armv7l: '23bdd5b1b635e3cca9d434b7f6d60057e8c16bcd7edfbf612337fc16382f9449',
+       i686: 'd7ac187627f55b2bdf5052d68b03dbe107ac70fe4378ecabb68aab4d42ef3ba2',
+     x86_64: 'c84e961c5e4fd95e684a2c2d2f6a041bdb5a0289f66eb414f99e184f70a3c42d'
   })
 
   depends_on 'llvm' => :build
   depends_on 'xorg_proto'
   depends_on 'libxcb'
+  depends_on 'libxdmcp'
   depends_on 'libxtrans'
 
   def self.build
     system 'NOCONFIGURE=1 ./autogen.sh'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system 'filefix'
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxdmcp.rb
+++ b/packages/libxdmcp.rb
@@ -3,30 +3,31 @@ require 'package'
 class Libxdmcp < Package
   description 'The libXdmcp package contains a library implementing the X Display Manager Control Protocol.'
   homepage 'http://www.x.org'
-  @_ver = '1.1.3'
-  version "#{@_ver}-2"
+  @_ver = '4a71fdf'
+  version @_ver
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/xorg/lib/libxdmcp.git'
-  git_hashtag "libXdmcp-#{@_ver}"
+  git_hashtag '4a71fdf6d34df67d3f1335590da6ae3050128fb2'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-2_armv7l/libxdmcp-1.1.3-2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-2_armv7l/libxdmcp-1.1.3-2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-2_i686/libxdmcp-1.1.3-2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/1.1.3-2_x86_64/libxdmcp-1.1.3-2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/4a71fdf_armv7l/libxdmcp-4a71fdf-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/4a71fdf_armv7l/libxdmcp-4a71fdf-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/4a71fdf_i686/libxdmcp-4a71fdf-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxdmcp/4a71fdf_x86_64/libxdmcp-4a71fdf-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a1540e554724bfb3f0eb2525e332c6a5b47d15827596c5d163af7b6efb7c16dd',
-     armv7l: 'a1540e554724bfb3f0eb2525e332c6a5b47d15827596c5d163af7b6efb7c16dd',
-       i686: 'c638d631e3b94580f8e4060a561bf1867e9daaf3ea05d3015469a982bf88b1ca',
-     x86_64: '7567bb45cc60b081c21b72c1526ffb3f9b5bb1016bb3737405bbcd5a4a85a3b7'
+    aarch64: '591a059b27c7095f45adf57a4d1ac4b045fb2e6be8ea55bac8aa2b2eef1b3c16',
+     armv7l: '591a059b27c7095f45adf57a4d1ac4b045fb2e6be8ea55bac8aa2b2eef1b3c16',
+       i686: 'a91f416ab907be4f4183b4c5da505e4d25586736b22185e3f58b64c36a1f9ca1',
+     x86_64: '553304325808a09bc564a989a1e727046000b892ce75d1dec437df7d67ade648'
   })
 
   depends_on 'xorg_proto'
 
   def self.build
     system './autogen.sh'
+    system 'filefix'
     system "./configure #{CREW_OPTIONS}"
     system 'make'
   end

--- a/packages/libxdmcp.rb
+++ b/packages/libxdmcp.rb
@@ -26,7 +26,7 @@ class Libxdmcp < Package
   depends_on 'xorg_proto'
 
   def self.build
-    system './autogen.sh'
+    system 'NOCONFIGURE=1 ./autogen.sh'
     system 'filefix'
     system "./configure #{CREW_OPTIONS}"
     system 'make'

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -3,24 +3,24 @@ require 'package'
 class Pango < Package
   description 'Pango is a library for laying out and rendering of text, with an emphasis on internationalization.'
   homepage 'http://www.pango.org/'
-  @_ver = '1.49.1'
-  version "#{@_ver}-1"
+  @_ver = '1.50.5'
+  version @_ver
   license 'LGPL-2+ and FTL'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/pango.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1-1_armv7l/pango-1.49.1-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1-1_armv7l/pango-1.49.1-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1-1_i686/pango-1.49.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.49.1-1_x86_64/pango-1.49.1-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.50.5_armv7l/pango-1.50.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.50.5_armv7l/pango-1.50.5-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.50.5_i686/pango-1.50.5-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.50.5_x86_64/pango-1.50.5-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5ac0e10a9a277da0c66477d153787f491ffc5c6a7c7fb8fd7329f939ab4601f2',
-     armv7l: '5ac0e10a9a277da0c66477d153787f491ffc5c6a7c7fb8fd7329f939ab4601f2',
-       i686: '5017a2dd7da73298ea89400e8be15d546e4cb5aa07f2bc253cd1aadfa762b1e1',
-     x86_64: '99a850bbfbac333ae89ec458a4a65109c341d3953e233149a25db960c2e27de5'
+    aarch64: 'f8b38d2b96f4da443d316f4fd45137324f51c91394c1e9c2a1849b1e04213ad2',
+     armv7l: 'f8b38d2b96f4da443d316f4fd45137324f51c91394c1e9c2a1849b1e04213ad2',
+       i686: '6e6c1b69695ba150cbeb20b72a57fc9de5f585a7d46432c2a1bc8c72d91af0a3',
+     x86_64: 'e0ac8c3dd0b95e6db046d2c3e68536d903a8ba8671dc01e1914852912e3ea082'
   })
 
   depends_on 'cairo'

--- a/packages/pixman.rb
+++ b/packages/pixman.rb
@@ -3,36 +3,39 @@ require 'package'
 class Pixman < Package
   description 'Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.'
   homepage 'http://www.pixman.org/'
-  version '0.40.0-0'
+  version '285b9a9'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.cairographics.org/releases/pixman-0.40.0.tar.gz'
-  source_sha256 '6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc'
+  source_url 'https://gitlab.freedesktop.org/pixman/pixman.git'
+  git_hashtag '285b9a907caffeb979322e629d4e57aa42061b5a'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/0.40.0-0_armv7l/pixman-0.40.0-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/0.40.0-0_armv7l/pixman-0.40.0-0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/0.40.0-0_i686/pixman-0.40.0-0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/0.40.0-0_x86_64/pixman-0.40.0-0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_armv7l/pixman-285b9a9-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_armv7l/pixman-285b9a9-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_i686/pixman-285b9a9-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_x86_64/pixman-285b9a9-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: 'fbf99db1fcf954a8932ba8590964e6029b13e0bd08fbed118eb368d4263e4b77',
-     armv7l: 'fbf99db1fcf954a8932ba8590964e6029b13e0bd08fbed118eb368d4263e4b77',
-       i686: 'ba6b20c7263f551506d65ac72a7d1f334dc492e8dbf1970d184c393db3ecb71b',
-     x86_64: 'a3c1b4c722e598ae10571fe8ef00dddc431ac6d833980f6f859b093a9ac385d1',
+  binary_sha256({
+    aarch64: 'dc326a21317a03af7349f4b8f77210b027ab779e77021cff0a93036b7d341b5a',
+     armv7l: 'dc326a21317a03af7349f4b8f77210b027ab779e77021cff0a93036b7d341b5a',
+       i686: 'd14290d99d729a89764f39ac004486df18402954af13b0e672b88834ed39e04b',
+     x86_64: '7e281e451c1ab1a4dcd4b15f5b7ecd29205786126488c3fdf355d520a0df75ff'
   })
 
-  depends_on 'llvm' => :build
-  depends_on 'libpng'
+  depends_on 'harfbuzz'
 
   def self.build
-    ENV['CFLAGS'] = "-fuse-ld=lld"
-    ENV['CXXFLAGS'] = "-fuse-ld=lld"
-    system "./configure #{CREW_OPTIONS}"
-    system 'make'
+    system "meson #{CREW_MESON_OPTIONS} \
+    --default-library=both \
+    -Dgtk=disabled \
+    -Dlibpng=disabled \
+    -Dtests=disabled \
+    builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/ragel.rb
+++ b/packages/ragel.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Ragel < Package
-  description 'Ragel compiles executable finite state machines from regular languages. Now built inside harfbuzz'
+  description 'Ragel compiles executable finite state machines from regular languages. Now bundled with harfbuzz.'
   homepage 'https://www.colm.net/open-source/ragel/'
   version '1.0'
   license 'MIT' # Previously was GPL-2

--- a/packages/ragel.rb
+++ b/packages/ragel.rb
@@ -1,33 +1,13 @@
 require 'package'
 
 class Ragel < Package
-  description 'Ragel compiles executable finite state machines from regular languages.'
+  description 'Ragel compiles executable finite state machines from regular languages. Now built inside harfbuzz'
   homepage 'https://www.colm.net/open-source/ragel/'
-  version '6.10'
+  version '1.0'
   license 'MIT' # Previously was GPL-2
   compatibility 'all'
-  source_url 'https://www.colm.net/files/ragel/ragel-6.10.tar.gz'
-  source_sha256 '5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ragel/6.10_armv7l/ragel-6.10-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ragel/6.10_armv7l/ragel-6.10-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ragel/6.10_i686/ragel-6.10-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ragel/6.10_x86_64/ragel-6.10-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '2efdeff57b498308def95b8fb8ac9efdc232909b245d0a8522a4259f82d9767c',
-     armv7l: '2efdeff57b498308def95b8fb8ac9efdc232909b245d0a8522a4259f82d9767c',
-       i686: '238950153c3a07bd9465f20918b26bc9986fc45ce97936d739a8bf25edcf7de6',
-     x86_64: 'dcb064549487d9ba7916e83ff4676673b9f2b01a437cd31d162c34a8b5fe1597',
-  })
+  depends_on 'harfbuzz'
+  is_fake
 
-  def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
-  end
-
-  def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
-  end
 end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -18,9 +18,10 @@ class Sommelier < Package
   binary_sha256({
     aarch64: 'f3cc665556ebd157487b98ab2daefadf067fea0c43971e0c2dcc15628d9c8061',
      armv7l: 'f3cc665556ebd157487b98ab2daefadf067fea0c43971e0c2dcc15628d9c8061',
-       i686: 'b370bc7c96b6018b3c348ee37262eee7981af0b32520649c3e6d2f8680d6e753',
+       i686: '3e1d4d7cae1551bb3f53f91b3eef887c1e13b34d1feeb1b4706d1f5382b70a3f',
      x86_64: '32ad19aba00b96889c936c8efec6e09c7eb739a5863742f4537d4bed91e306bc'
   })
+
 
   depends_on 'libdrm'
   depends_on 'libxcb'
@@ -43,7 +44,7 @@ class Sommelier < Package
   when 'armv7l', 'aarch64'
     @peer_cmd_prefix = '/lib/ld-linux-armhf.so.3'
   when 'i686'
-    @peer_cmd_prefix = '/lib/ld-linux-i686.so.2'
+    @peer_cmd_prefix = '/lib/ld-linux.so.2'
   when 'x86_64'
     @peer_cmd_prefix = '/lib64/ld-linux-x86-64.so.2'
   end


### PR DESCRIPTION
- make mold linker default for x86, leave gold as default for arm
- Fix git cached builds also caching all tags in crew
- libpng is now generated by harfbuzz as part of that package's build (yes this removes the animated png patch @saltedcoffii but it makes the builds of many other packages simpler.)
- ragel is now generated by harfbuzz as part of that package's build, 
- update libpng dependent packages, which means a whole bunch of x11 and gnome stuff, including `gtk3` and `gtk4`

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libpng CREW_TESTING=1 crew update
```
