### PR TITLE
downloader.rb: Fix progress bar overflow, add support for external downloaders

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -704,12 +704,7 @@ def download
         end
       end
       # Download file if not cached.
-      # use curl if CREW_USE_CURL environment variable is set to 1
-      unless CREW_USE_CURL
-        downloader url, filename, @opt_verbose
-      else
-        system "curl --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
-      end
+      downloader url, filename, @opt_verbose
 
       abort 'Checksum mismatch. 😔 Try again.'.lightred unless
         Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum || sha256sum =~ /^SKIP$/i
@@ -735,12 +730,7 @@ def download
       @git = true
     else
       Dir.mkdir @extract_dir
-      # use curl if CREW_USE_CURL environment variable is set to 1
-      unless CREW_USE_CURL
-        downloader url, filename, @opt_verbose
-      else
-        system "curl --retry 3 -#{@verbose}#LC - --insecure \'#{url}\' --output #{filename}"
-      end
+      downloader url, filename, @opt_verbose
 
       abort 'Checksum mismatch. 😔 Try again.'.lightred unless
         Digest::SHA256.hexdigest( File.read(filename) ) == sha256sum || sha256sum =~ /^SKIP$/i

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.1'
+CREW_VERSION = '1.23.2'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -83,6 +83,10 @@ end
 # If CREW_USE_CURL environment variable exists use curl in lieu of net/http.
 CREW_USE_CURL = ENV['CREW_USE_CURL'] == '1'
 
+# Use an external downloader instead of net/http if CREW_DOWNLOADER is set, see lib/downloader.rb for more info
+# About the format of the CREW_DOWNLOADER variable, see line 130-133 in lib/downloader.rb
+CREW_DOWNLOADER = ( ENV['CREW_DOWNLOADER'].to_s.empty? ) ? nil : ENV['CREW_DOWNLOADER']
+
 # set certificate file location for lib/downloader.rb
 SSL_CERT_FILE = if ENV['SSL_CERT_FILE'].to_s.empty? || !File.exist?(ENV['SSL_CERT_FILE'])
                   if File.exist?("#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt")

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -112,7 +112,7 @@ def http_downloader (url, filename = File.basename(url), retry_count = 0, verbos
             percentage = (downloaded_size / file_size) * 100
             # show progress bar, file size and progress percentage
             printf "\r""[%-#{@progBarW}.#{@progBarW}s] %9.9s %3d%%",
-                   '#' * ( @progBarW * (percentage / 100) ).to_i,
+                   '#' * ( @progBarW * (percentage / 100) ),
                    human_size(file_size),
                    percentage
           end


### PR DESCRIPTION
Tested on `x86_64`

### Fixes
- The progress bar might overflow if the server returned a wrong `content-length` (aka "file size") that is smaller than the actual size of the file (mostly happened when fetching patches from github)

### Changes
- Set maximum limit for the width of the progress bar to terminal width to prevent overflow
- Moved the `CREW_USE_CURL` logic to `downloader.rb`
- Also added support for using external command-line downloaders (inspired from #6472):
```shell
# set an external downloader (see downloader.rb for a detailed format), for example, `wget`
$ export CREW_DOWNLOADER="wget -O %<output>s %<verbose>s %<url>s"

# wget is used for downloading now
$ crew reinstall wget
wget: GNU Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS.
Performing pre-flight checks...
Precompiled binary available, downloading...
--2022-03-11 13:53:17--  https://gitlab.com/api/v4/projects/26210301/packages/generic/wget/1.21.3_x86_64/wget-1.21.3-chromeos-x86_64.tar.zst
Resolving gitlab.com (gitlab.com)... 172.65.251.78, 2606:4700:90:0:f22e:fbec:5bed:a9b9
Connecting to gitlab.com (gitlab.com)|172.65.251.78|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 332655 (325K) [application/octet-stream]
Saving to: ‘wget-1.21.3-chromeos-x86_64.tar.zst’

wget-1.21.3-chromeos-x86_64.tar.zst  100%[====================================>] 324.86K  2.08MB/s    in 0.2s    

2022-03-11 13:53:20 (2.08 MB/s) - ‘wget-1.21.3-chromeos-x86_64.tar.zst’ saved [332655/332655]

Wget archive downloaded.
```