### PR TITLE
popt: pass CREW_OPTIONS to configure

### DIFF
--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -3,37 +3,33 @@ require 'package'
 class Popt < Package
   description 'Library for parsing command line options'
   homepage 'https://directory.fsf.org/wiki/Popt'
-  version '1.18'
+  version '78ebda3'
   license 'MIT'
   compatibility 'all'
-  source_url "https://github.com/rpm-software-management/popt/archive/refs/tags/popt-#{version}-release.tar.gz"
-  source_sha256 '36245242c59b5a33698388e415a3e1efa2d48fc4aead91aeb2810b4c0744f4e3'
+  source_url 'https://github.com/rpm-software-management/popt.git'
+  git_hashtag '78ebda342ca9bec60e4dd5f1d5b720dade3ab4b2'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18_armv7l/popt-1.18-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18_armv7l/popt-1.18-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18_i686/popt-1.18-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18_x86_64/popt-1.18-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_armv7l/popt-78ebda3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_armv7l/popt-78ebda3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_i686/popt-78ebda3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_x86_64/popt-78ebda3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e301538c274369121eb26cf77d91d1a5c451cc4ec088a115361c1b31175a06c8',
-     armv7l: 'e301538c274369121eb26cf77d91d1a5c451cc4ec088a115361c1b31175a06c8',
-       i686: '8017bb16b0ee0094e66d1a130734463389721d060b31340b47ce5e2a2521ea4b',
-     x86_64: 'b6f09b9dcca99c16e61a7c71333ce0454c38ad99c7dfa0893cce9c44f8335f77'
+    aarch64: '2ba47ce5e9cf8493c82d371da80dc4e5a0e0d7bc0cf36996781b089d01e3b8d1',
+     armv7l: '2ba47ce5e9cf8493c82d371da80dc4e5a0e0d7bc0cf36996781b089d01e3b8d1',
+       i686: '611be7ffbadab77c9da3492f13fbc8860522ec01adefbfbb462fb9c1afc76530',
+     x86_64: '591ff491561a48dc2a993b718a554dc303fab823929dc622963d6144db6e5fe1'
   })
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "env CFLAGS='-flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
+    system "./configure #{CREW_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    system "gzip -9 #{CREW_DEST_PREFIX}/share/man/man3/popt.3"
   end
 end


### PR DESCRIPTION
- `popt` was missing `CREW_OPTIONS`

Works properly:
- [x] x86_64
- [x] armv7l
- [x] i686

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=popt_fix CREW_TESTING=1 crew update
```
