### PR TITLE
Fix upgrade of rsync binary breaking crew

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1231,7 +1231,7 @@ def install_package(pkgdir)
     # check if the available rsync command support ACLs
 
     rsync_available = true if File.exist?("#{CREW_PREFIX}/bin/rsync") and `#{CREW_PREFIX}/bin/rsync --version`.include? 'rsync  version'
-    puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available
+    puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available or @pkg.name == 'rsync'
     if Dir.exist? "#{pkgdir}/#{HOME}" then
       if rsync_available
         system "rsync -ahHAXW --remove-source-files ./#{HOME.delete_prefix('/')}/ #{HOME}"

--- a/bin/crew
+++ b/bin/crew
@@ -1229,7 +1229,8 @@ def install_package(pkgdir)
     end
 
     # check if the available rsync command support ACLs
-    rsync_available = true if `#{CREW_PREFIX}/bin/rsync --version`.include? 'rsync  version'
+
+    rsync_available = true if File.exist?("#{CREW_PREFIX}/bin/rsync") and `#{CREW_PREFIX}/bin/rsync --version`.include? 'rsync  version'
     puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available
     if Dir.exist? "#{pkgdir}/#{HOME}" then
       if rsync_available

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -231,5 +231,5 @@ PY_SETUP_INSTALL_OPTIONS = "#{PY_SETUP_INSTALL_OPTIONS_NO_SVEM} --single-version
 
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +
-                       %W[libzstd.so.1 libstdc++.so.6 #{CREW_PREFIX}/bin/rsync]
+                       %W[libzstd.so.1 libstdc++.so.6]
 CREW_ESSENTIAL_FILES.uniq!

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.1'
+CREW_VERSION = '1.23.2'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -231,5 +231,5 @@ PY_SETUP_INSTALL_OPTIONS = "#{PY_SETUP_INSTALL_OPTIONS_NO_SVEM} --single-version
 
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +
-                       %w[libzstd.so.1 libstdc++.so.6]
+                       %W[libzstd.so.1 libstdc++.so.6 #{CREW_PREFIX}/bin/rsync]
 CREW_ESSENTIAL_FILES.uniq!

--- a/lib/deb_utils.rb
+++ b/lib/deb_utils.rb
@@ -15,7 +15,7 @@ module DebUtils
     # get first line of the given file, should be a signature string (`!<arch>\n`) if it is a valid deb file
     signature = src_fileIO.gets
 
-    abort 'Malformed archive :/' unless signature == "!<arch>\n"
+    abort 'Malformed archive :/'.lightred unless signature == "!<arch>\n"
 
     # process each file in archive
     while (line = src_fileIO.gets) do
@@ -23,8 +23,12 @@ module DebUtils
       name, modtime, uid, gid, mode, size, end_char = \
         line.scan(/(.{16})(.{12})(.{6})(.{6})(.{8})(.{10})(.{1})/).flatten.map(&:strip)
 
+      # remove slash suffix from filename (if any)
+      # (a `.deb` ar archive does not support any directories, so we can confirm that all entries are normal files)
+      name.sub!(/\/$/, '')
+
       # check ending byte
-      abort "Malformed archive :/" unless end_char == '`'
+      abort 'Malformed archive :/'.lightred unless end_char == '`'
 
       # capture file in archive with given offset bytes (file size)
       fileContent = src_fileIO.read(size.to_i)
@@ -33,14 +37,12 @@ module DebUtils
       if target.is_a?(String) and name == target
         # if target is passed as string, write matched file to filesyetem and exit function
         # write to filesystem
-        File.open(name, 'wb') {|dst_fileIO| dst_fileIO.write(fileContent) }
-        # exit function
-        return true
+        return File.binwrite(name, fileContent, perm: mode.to_i(8))
       elsif target.is_a?(Regexp) and name =~ target
         # if target is passed as regex, write matched file to filesyetem and continue
         # searching for another matched file until EOF
         # write to filesystem
-        File.open(name, 'wb') {|dst_fileIO| dst_fileIO.write(fileContent) }
+        File.binwrite(name, fileContent, perm: mode.to_i(8))
         file_found = true
       end
     end

--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -3,37 +3,33 @@ require 'package'
 class Popt < Package
   description 'Library for parsing command line options'
   homepage 'https://directory.fsf.org/wiki/Popt'
-  version '1.18'
+  version '78ebda3'
   license 'MIT'
   compatibility 'all'
-  source_url "https://github.com/rpm-software-management/popt/archive/refs/tags/popt-#{version}-release.tar.gz"
-  source_sha256 '36245242c59b5a33698388e415a3e1efa2d48fc4aead91aeb2810b4c0744f4e3'
+  source_url 'https://github.com/rpm-software-management/popt.git'
+  git_hashtag '78ebda342ca9bec60e4dd5f1d5b720dade3ab4b2'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18_armv7l/popt-1.18-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18_armv7l/popt-1.18-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18_i686/popt-1.18-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18_x86_64/popt-1.18-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_armv7l/popt-78ebda3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_armv7l/popt-78ebda3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_i686/popt-78ebda3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_x86_64/popt-78ebda3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e301538c274369121eb26cf77d91d1a5c451cc4ec088a115361c1b31175a06c8',
-     armv7l: 'e301538c274369121eb26cf77d91d1a5c451cc4ec088a115361c1b31175a06c8',
-       i686: '8017bb16b0ee0094e66d1a130734463389721d060b31340b47ce5e2a2521ea4b',
-     x86_64: 'b6f09b9dcca99c16e61a7c71333ce0454c38ad99c7dfa0893cce9c44f8335f77'
+    aarch64: '2ba47ce5e9cf8493c82d371da80dc4e5a0e0d7bc0cf36996781b089d01e3b8d1',
+     armv7l: '2ba47ce5e9cf8493c82d371da80dc4e5a0e0d7bc0cf36996781b089d01e3b8d1',
+       i686: '611be7ffbadab77c9da3492f13fbc8860522ec01adefbfbb462fb9c1afc76530',
+     x86_64: '591ff491561a48dc2a993b718a554dc303fab823929dc622963d6144db6e5fe1'
   })
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "env CFLAGS='-flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
+    system "./configure #{CREW_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    system "gzip -9 #{CREW_DEST_PREFIX}/share/man/man3/popt.3"
   end
 end

--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -4,23 +4,23 @@ class Rsync < Package
   description 'rsync is an open source utility that provides fast incremental file transfer.'
   homepage 'https://rsync.samba.org/'
   @_ver = '3.2.3'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'GPL-3'
   compatibility 'all'
   source_url "http://rsync.samba.org/ftp/rsync/src/rsync-#{@_ver}.tar.gz"
   source_sha256 'becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-1_armv7l/rsync-3.2.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-1_armv7l/rsync-3.2.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-1_i686/rsync-3.2.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-1_x86_64/rsync-3.2.3-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_armv7l/rsync-3.2.3-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_armv7l/rsync-3.2.3-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_i686/rsync-3.2.3-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_x86_64/rsync-3.2.3-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a005ade8a7e03d1fcfb7b122c7db6ffd48ca759ff21d70dbf5d57eee26661f34',
-     armv7l: 'a005ade8a7e03d1fcfb7b122c7db6ffd48ca759ff21d70dbf5d57eee26661f34',
-       i686: '0c1b8db87c84c849710705b4f07fc75edf78d998056c97025dcc6e55de775a8f',
-     x86_64: '507cbeaafce02f9c0c55f378abae7e4fe7814ac29ad000f99aae1f2978caa1bd'
+    aarch64: 'ba288d6e49f3bef27932e810d58206b1c3c8c60bfb5ef3168bbded428ee89a0b',
+     armv7l: 'ba288d6e49f3bef27932e810d58206b1c3c8c60bfb5ef3168bbded428ee89a0b',
+       i686: '6eb5c8f79b5e29ad461f833738db4251bfbadb037ab2ea8030ed3516e709c1a4',
+     x86_64: '7f8006dc3358106d7f949b8a344746cc7b445c03bb9640238b1d48322f5c07ae'
   })
 
   depends_on 'xxhash'
@@ -29,9 +29,7 @@ class Rsync < Package
   depends_on 'zstd'
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} --disable-maintainer-mode"
+    system "./configure #{CREW_OPTIONS} --disable-maintainer-mode"
     system 'make'
   end
 

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -6,21 +6,12 @@ class Signal_desktop < Package
   version '5.34.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
-  source_url 'SKIP'
+  source_url "http://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
+  source_sha256 'b94e1626d77dab0ae31e0b0ad280e0fe909fff995f361a0c0c477f9475272f09'
 
-  depends_on 'alien' => :build
   depends_on 'at_spi2_atk'
   depends_on 'gtk3'
   depends_on 'sommelier'
-
-  def self.build
-    system "curl -L#O http://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-    unless Digest::SHA256.hexdigest( File.read("signal-desktop_#{version}_amd64.deb") ) == 'b94e1626d77dab0ae31e0b0ad280e0fe909fff995f361a0c0c477f9475272f09'
-      abort 'Checksum mismatch. :/ Try again.'.lightred
-    end
-    system "alien -tc signal-desktop_#{version}_amd64.deb"
-    system "tar xvf signal-desktop-#{version}.tgz"
-  end
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Signal_desktop < Package
+  description 'Private Messenger for Windows, Mac, and Linux'
+  homepage 'https://signal.org/'
+  version '5.34.0'
+  license 'AGPL-3.0'
+  compatibility 'x86_64'
+  source_url 'SKIP'
+
+  depends_on 'alien' => :build
+  depends_on 'at_spi2_atk'
+  depends_on 'gtk3'
+  depends_on 'sommelier'
+
+  def self.build
+    system "curl -L#O http://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
+    unless Digest::SHA256.hexdigest( File.read("signal-desktop_#{version}_amd64.deb") ) == 'b94e1626d77dab0ae31e0b0ad280e0fe909fff995f361a0c0c477f9475272f09'
+      abort 'Checksum mismatch. :/ Try again.'.lightred
+    end
+    system "alien -tc signal-desktop_#{version}_amd64.deb"
+    system "tar xvf signal-desktop-#{version}.tgz"
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mv 'usr/share', "#{CREW_DEST_PREFIX}"
+    FileUtils.mv 'opt/Signal', "#{CREW_DEST_PREFIX}/share"
+    FileUtils.ln_s "#{CREW_PREFIX}/share/Signal/signal-desktop", "#{CREW_DEST_PREFIX}/bin/signal-desktop"
+  end
+
+  def self.postinstall
+    puts "\nType 'signal-desktop' to get started.\n".lightblue
+  end
+end


### PR DESCRIPTION
- otherwise, we cannot upgrade `rsync`
- Fixed by not checking the output of the `rsync` command if `rsync` isn't available.
- Adds rebuild of `rsync` command against fixed `popt`

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rsync_essential CREW_TESTING=1 crew update ; crew upgrade
```
