### PR TITLE
lib/deb_utils.rb: Improve `.deb` unarchive algorithm

### DIFF
--- a/lib/deb_utils.rb
+++ b/lib/deb_utils.rb
@@ -15,7 +15,7 @@ module DebUtils
     # get first line of the given file, should be a signature string (`!<arch>\n`) if it is a valid deb file
     signature = src_fileIO.gets
 
-    abort 'Malformed archive :/' unless signature == "!<arch>\n"
+    abort 'Malformed archive :/'.lightred unless signature == "!<arch>\n"
 
     # process each file in archive
     while (line = src_fileIO.gets) do

--- a/lib/deb_utils.rb
+++ b/lib/deb_utils.rb
@@ -28,7 +28,7 @@ module DebUtils
       name.sub!(/\/$/, '')
 
       # check ending byte
-      abort 'Malformed archive :/' unless end_char == '`'
+      abort 'Malformed archive :/'.lightred unless end_char == '`'
 
       # capture file in archive with given offset bytes (file size)
       fileContent = src_fileIO.read(size.to_i)

--- a/lib/deb_utils.rb
+++ b/lib/deb_utils.rb
@@ -23,8 +23,12 @@ module DebUtils
       name, modtime, uid, gid, mode, size, end_char = \
         line.scan(/(.{16})(.{12})(.{6})(.{6})(.{8})(.{10})(.{1})/).flatten.map(&:strip)
 
+      # remove slash suffix from filename (if any)
+      # (a `.deb` ar archive does not support any directories, so we can confirm that all entries are normal files)
+      name.sub!(/\/$/, '')
+
       # check ending byte
-      abort "Malformed archive :/" unless end_char == '`'
+      abort 'Malformed archive :/' unless end_char == '`'
 
       # capture file in archive with given offset bytes (file size)
       fileContent = src_fileIO.read(size.to_i)
@@ -33,14 +37,12 @@ module DebUtils
       if target.is_a?(String) and name == target
         # if target is passed as string, write matched file to filesyetem and exit function
         # write to filesystem
-        File.open(name, 'wb') {|dst_fileIO| dst_fileIO.write(fileContent) }
-        # exit function
-        return true
+        return File.binwrite(name, fileContent, perm: mode.to_i(8))
       elsif target.is_a?(Regexp) and name =~ target
         # if target is passed as regex, write matched file to filesyetem and continue
         # searching for another matched file until EOF
         # write to filesystem
-        File.open(name, 'wb') {|dst_fileIO| dst_fileIO.write(fileContent) }
+        File.binwrite(name, fileContent, perm: mode.to_i(8))
         file_found = true
       end
     end

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -6,21 +6,13 @@ class Signal_desktop < Package
   version '5.34.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
-  source_url 'SKIP'
+  source_url "http://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
+  source_sha256 'b94e1626d77dab0ae31e0b0ad280e0fe909fff995f361a0c0c477f9475272f09'
 
   depends_on 'alien' => :build
   depends_on 'at_spi2_atk'
   depends_on 'gtk3'
   depends_on 'sommelier'
-
-  def self.build
-    system "curl -L#O http://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-    unless Digest::SHA256.hexdigest( File.read("signal-desktop_#{version}_amd64.deb") ) == 'b94e1626d77dab0ae31e0b0ad280e0fe909fff995f361a0c0c477f9475272f09'
-      abort 'Checksum mismatch. :/ Try again.'.lightred
-    end
-    system "alien -tc signal-desktop_#{version}_amd64.deb"
-    system "tar xvf signal-desktop-#{version}.tgz"
-  end
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -9,7 +9,6 @@ class Signal_desktop < Package
   source_url "http://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
   source_sha256 'b94e1626d77dab0ae31e0b0ad280e0fe909fff995f361a0c0c477f9475272f09'
 
-  depends_on 'alien' => :build
   depends_on 'at_spi2_atk'
   depends_on 'gtk3'
   depends_on 'sommelier'


### PR DESCRIPTION
### About
In `lib/deb_utils.rb`, all contents in the `.deb` archive should be files (folders are not supported in `ar` format archive), so any trailing slash in the filename is not expected (and no reason to be appended), but some packages are exceptions:
```
$ head -n4 signal-desktop_5.34.0_amd64.deb 
!<arch>                  
debian-binary/  0           0     0     644     4         `
2.0
control.tar.gz/ 0           0     0     644     6020      `
```
(all files in this archive have an `/` suffix, which should not be added)

### Changes
- Automatically remove `/` suffix for filenames (if any)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=deb_utils_fix CREW_TESTING=1 crew update
```