### PR TITLE
Fix rsync upgrade breaking crew

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1229,8 +1229,9 @@ def install_package(pkgdir)
     end
 
     # check if the available rsync command support ACLs
-    rsync_available = true if `#{CREW_PREFIX}/bin/rsync --version`.include? 'rsync  version'
-    puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available
+
+    rsync_available = true if File.exist?("#{CREW_PREFIX}/bin/rsync") and `#{CREW_PREFIX}/bin/rsync --version`.include? 'rsync  version'
+    puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available or @pkg.name == 'rsync'
     if Dir.exist? "#{pkgdir}/#{HOME}" then
       if rsync_available
         system "rsync -ahHAXW --remove-source-files ./#{HOME.delete_prefix('/')}/ #{HOME}"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.1'
+CREW_VERSION = '1.23.2'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -4,23 +4,23 @@ class Rsync < Package
   description 'rsync is an open source utility that provides fast incremental file transfer.'
   homepage 'https://rsync.samba.org/'
   @_ver = '3.2.3'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'GPL-3'
   compatibility 'all'
   source_url "http://rsync.samba.org/ftp/rsync/src/rsync-#{@_ver}.tar.gz"
   source_sha256 'becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-1_armv7l/rsync-3.2.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-1_armv7l/rsync-3.2.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-1_i686/rsync-3.2.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-1_x86_64/rsync-3.2.3-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_armv7l/rsync-3.2.3-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_armv7l/rsync-3.2.3-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_i686/rsync-3.2.3-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_x86_64/rsync-3.2.3-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a005ade8a7e03d1fcfb7b122c7db6ffd48ca759ff21d70dbf5d57eee26661f34',
-     armv7l: 'a005ade8a7e03d1fcfb7b122c7db6ffd48ca759ff21d70dbf5d57eee26661f34',
-       i686: '0c1b8db87c84c849710705b4f07fc75edf78d998056c97025dcc6e55de775a8f',
-     x86_64: '507cbeaafce02f9c0c55f378abae7e4fe7814ac29ad000f99aae1f2978caa1bd'
+    aarch64: 'ba288d6e49f3bef27932e810d58206b1c3c8c60bfb5ef3168bbded428ee89a0b',
+     armv7l: 'ba288d6e49f3bef27932e810d58206b1c3c8c60bfb5ef3168bbded428ee89a0b',
+       i686: '6eb5c8f79b5e29ad461f833738db4251bfbadb037ab2ea8030ed3516e709c1a4',
+     x86_64: '7f8006dc3358106d7f949b8a344746cc7b445c03bb9640238b1d48322f5c07ae'
   })
 
   depends_on 'xxhash'
@@ -29,9 +29,7 @@ class Rsync < Package
   depends_on 'zstd'
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} --disable-maintainer-mode"
+    system "./configure #{CREW_OPTIONS} --disable-maintainer-mode"
     system 'make'
   end
 


### PR DESCRIPTION
- crew breaks when rsync is missing.
- Fixed by not checking the output of the `rsync` command if `rsync` isn't available.
- Adds rebuild of `rsync` command against fixed `popt`

Works properly:
- [x] x86_64
- [x] i686
- [x] armv7l

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rsync_fix CREW_TESTING=1 crew update ; crew upgrade
```