### PR TITLE
sommelier => 20220207

### DIFF
--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -7,7 +7,7 @@ class Sommelier < Package
   license 'BSD-Google'
   compatibility 'all'
   source_url 'https://github.com/chromebrew/crew-package-sommelier.git'
-  git_hashtag '3b79e69513d83fecf740b61ad1a73a22e410838d'
+  git_hashtag '076b9b547a8019e2db88241c68f5ad24bc7b4fed'
 
   depends_on 'libdrm'
   depends_on 'libxcb'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,335 +3,105 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  version '20210109-6'
+  version '20211129'
   license 'BSD-Google'
   compatibility 'all'
-  source_url 'https://chromium.googlesource.com/chromiumos/platform2.git'
-  git_hashtag 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-6_armv7l/sommelier-20210109-6-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-6_armv7l/sommelier-20210109-6-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-6_i686/sommelier-20210109-6-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-6_x86_64/sommelier-20210109-6-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: 'f3cc665556ebd157487b98ab2daefadf067fea0c43971e0c2dcc15628d9c8061',
-     armv7l: 'f3cc665556ebd157487b98ab2daefadf067fea0c43971e0c2dcc15628d9c8061',
-       i686: '3e1d4d7cae1551bb3f53f91b3eef887c1e13b34d1feeb1b4706d1f5382b70a3f',
-     x86_64: '32ad19aba00b96889c936c8efec6e09c7eb739a5863742f4537d4bed91e306bc'
-  })
-
+  source_url 'https://github.com/supechicken/crew-sommelier.git'
+  git_branch 'main'
 
   depends_on 'libdrm'
   depends_on 'libxcb'
   depends_on 'libxcomposite' => :build
   depends_on 'libxfixes' => :build
   depends_on 'libxkbcommon'
+  depends_on 'llvm'
   depends_on 'mesa'
   depends_on 'pixman'
-  depends_on 'procps' # for pgrep in wrapper script
   depends_on 'psmisc'
   depends_on 'wayland'
   depends_on 'xauth'
   depends_on 'xdpyinfo' # for xdpyinfo in wrapper script
   depends_on 'xsetroot' # for xsetroot in sommelierrc script
-  depends_on 'xhost' # for xhost in sommelierd script
+  depends_on 'xhost' # for xhost in sommelierrc script
+  depends_on 'xrdb' # for xrdb in sommelierrc script
   depends_on 'xwayland'
-  depends_on 'xxd_standalone' # for xxd in wrapper script
 
   case ARCH
   when 'armv7l', 'aarch64'
     @peer_cmd_prefix = '/lib/ld-linux-armhf.so.3'
-  when 'i686'
-    @peer_cmd_prefix = '/lib/ld-linux.so.2'
   when 'x86_64'
     @peer_cmd_prefix = '/lib64/ld-linux-x86-64.so.2'
+  when 'i686'
+    @peer_cmd_prefix = '/lib/ld-linux.so.2'
   end
 
   def self.preflight
-    case ARCH
-    when 'armv7l', 'aarch64'
-      @container_check = File.exist?('/.dockerenv')
-    when 'i686', 'x86_64'
-      @container_check = `/usr/bin/crossystem inside_vm` == '1'
-    end
-    unless File.socket?('/var/run/chrome/wayland-0') || @container_check
-      abort 'This package is not compatible with your device :/'.lightred
-    end
   end
 
   def self.patch
-    # Patch to avoid error with GCC > 9.x
-    # ../sommelier.cc:3238:10: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 108 equals destination size [-Wstringop-truncation]
-    Kernel.system "sed -i 's/sizeof(addr.sun_path))/sizeof(addr.sun_path) - 1)/' sommelier.cc",
-                  chdir: 'vm_tools/sommelier'
+    system 'cat patches/*.patch | (cd sommelier_src; patch -p1)'
   end
 
   def self.build
-    Dir.chdir('vm_tools/sommelier') do
-      # lld is needed so libraries linked to system libraries (e.g. libgbm.so) can be linked against, since those are required for graphics acceleration.
-
-      system <<~BUILD
-        env CC=clang CXX=clang++ \
-          meson #{CREW_MESON_OPTIONS} \
+    Dir.chdir('sommelier_src') do
+      system CREW_ENV_OPTIONS_HASH.merge({ 'CC' => 'clang', 'CXX' => 'clang++' }), <<~BUILD
+        meson #{CREW_MESON_OPTIONS} \
           -Db_asneeded=false \
           -Db_lto=true \
           -Db_lto_mode=thin \
           -Dxwayland_path=#{CREW_PREFIX}/bin/Xwayland \
-          -Dxwayland_gl_driver_path=/usr/#{ARCH_LIB}/dri -Ddefault_library=both \
-          -Dxwayland_shm_driver=noop -Dshm_driver=noop -Dvirtwl_device=/dev/null \
-          -Dpeer_cmd_prefix="#{CREW_PREFIX}#{@peer_cmd_prefix}" \
+          -Dxwayland_gl_driver_path=#{CREW_PREFIX}/#{ARCH_LIB}/dri \
+          -Ddefault_library=both \
+          -Dwith_tests=false \
           builddir
       BUILD
 
       system 'meson configure builddir'
       system 'samu -C builddir'
-
-      Dir.chdir('builddir') do
-        system 'curl -L "https://chromium.googlesource.com/chromiumos/containers/sommelier/+/fbdefff6230026ac333eac0924d71cf824e6ecd8/sommelierrc?format=TEXT" | base64 --decode > sommelierrc'
-
-        @sommelierenv = <<~EOF
-          set -a
-          CLUTTER_BACKEND=wayland
-          DISPLAY=:0
-          GDK_BACKEND=x11
-          SCALE=1
-          SOMMELIER_ACCELERATORS='Super_L,<Alt>bracketleft,<Alt>bracketright'
-          WAYLAND_DISPLAY=wayland-0
-          XDG_RUNTIME_DIR=/var/run/chrome
-
-          case "$(uname -m)" in
-          x86_64|i686)
-            sort_result="$(sort -V <<< "$(uname -r)"$'\\n'"4.16.0" | tail -n1)"
-            if [[ "${sort_result}" == "4.16.0" ]]; then
-              MESA_LOADER_DRIVER_OVERRIDE=i965
-            fi
-          ;;
-          esac
-
-          if [ -f "~/.sommelier.env" ]; then
-            source ~/.sommelier.env
-          fi
-
-          set +a
-        EOF
-
-        # Create local startup and shutdown scripts
-
-        # sommelier_sh
-        # This file via:
-        # crostini: /opt/google/cros-containers/bin/sommelier
-        # https://source.chromium.org/chromium/chromium/src/+/master:third_party/chromite/third_party/lddtree.py;drc=46da9a8dfce28c96765dc7d061f0c6d7a52e7352;l=146
-        File.write 'sommelier_sh', <<~EOF
-          #!/bin/bash
-          function readlink(){
-            coreutils --coreutils-prog=readlink "$@"
-          }
-
-          if base=$(readlink "$0" 2>/dev/null); then
-            case $base in
-            /*) base=$(readlink -f "$0" 2>/dev/null);; # if $0 is abspath symlink, make symlink fully resolved.
-            *)  base=$(dirname "$0")/"${base}";;
-            esac
-          else
-            case $0 in
-            /*) base=$0;;
-            *)  base=${PWD:-`pwd`}/$0;;
-            esac
-          fi
-          basedir=${base%/*}
-          LD_ARGV0_REL="../bin/sommelier" \
-            exec "${basedir}/..#{@peer_cmd_prefix}" \
-              --library-path \
-              "${basedir}/../#{ARCH_LIB}" \
-              --inhibit-rpath '' \
-              "${base}.elf" \
-              "$@"
-        EOF
-
-        # sommelierd
-        File.write 'sommelierd', <<~EOF
-          #!/bin/bash -a
-
-          source ${CREW_PREFIX}/etc/env.d/sommelier.env &>/dev/null
-          set +a
-          mkdir -p #{CREW_PREFIX}/var/{log,run}
-          checksommelierwayland () {
-            [[ -f "#{CREW_PREFIX}/var/run/sommelier-wayland.pid" ]] || return 1
-            /sbin/ss --unix -a -p | grep "\b$(cat #{CREW_PREFIX}/var/run/sommelier-wayland.pid)" | grep wayland &>/dev/null
-          }
-          checksommelierxwayland () {
-            xdpyinfo -display "${DISPLAY}" &>/dev/null
-          }
-
-          ## As per https://www.reddit.com/r/chromeos/comments/8r5pvh/crouton_sommelier_openjdk_and_oracle_sql/e0pfknx/
-          ## One needs a second sommelier instance for wayland clients since at some point wl-drm was not implemented
-          ## in ChromeOS's wayland compositor.
-          #if ! checksommelierwayland ; then
-          #  pkill -F #{CREW_PREFIX}/var/run/sommelier-wayland.pid &>/dev/null
-          #  rm ${XDG_RUNTIME_DIR}/wayland-1*
-          #  sommelier --parent \
-          #    --peer-cmd-prefix="#{CREW_PREFIX}#{@peer_cmd_prefix}" \
-          #    --drm-device=/dev/dri/renderD128 --shm-driver=noop \
-          #    --data-driver=noop --display=wayland-0 --socket=wayland-1 \
-          #    --virtwl-device=/dev/null &> #{CREW_PREFIX}/var/log/sommelier.log &
-          #  echo "$!" > #{CREW_PREFIX}/var/run/sommelier-wayland.pid
-          #fi
-
-          if ! checksommelierxwayland; then
-            pkill -F #{CREW_PREFIX}/var/run/sommelier-xwayland.pid &>/dev/null
-            DISPLAY="${DISPLAY:0:3}"
-
-            sommelier -X \
-              --x-display=${DISPLAY}  \
-              --scale=${SCALE} --glamor \
-              --drm-device=/dev/dri/renderD128 \
-              --virtwl-device=/dev/null \
-              --shm-driver=noop --data-driver=noop \
-              --display=wayland-0 \
-              --xwayland-path=/usr/local/bin/Xwayland \
-              --xwayland-gl-driver-path=#{CREW_LIB_PREFIX}/dri \
-              --peer-cmd-prefix="#{CREW_PREFIX}#{@peer_cmd_prefix}" \
-              --no-exit-with-child \
-              /bin/sh -c "touch ~/.Xauthority
-                xauth -f ~/.Xauthority add ${DISPLAY} . $(xxd -l 16 -p /dev/urandom)
-                source #{CREW_PREFIX}/etc/sommelierrc" \
-            &>> #{CREW_PREFIX}/var/log/sommelier.log
-
-            echo "${!}" > #{CREW_PREFIX}/var/run/sommelier-xwayland.pid
-            xhost +si:localuser:root &>/dev/null
-          fi
-        EOF
-
-        # startsommelier
-        File.write 'startsommelier', <<~EOF
-          #!/bin/bash -a
-
-          source ~/.sommelier-default.env &>/dev/null
-          source ~/.sommelier.env &>/dev/null
-          set +a
-
-          checksommelierwayland () {
-            #if [ -f "#{CREW_PREFIX}/var/run/sommelier-wayland.pid" ]; then
-            #  /sbin/ss --unix -a -p |\
-            #    grep "\b$(cat #{CREW_PREFIX}/var/run/sommelier-wayland.pid)" |\
-            #    grep wayland &>/dev/null
-            #else
-            #  return 1
-            #fi
-            return 0
-          }
-          checksommelierxwayland () {
-            xdpyinfo -display "${DISPLAY}" &>/dev/null
-          }
-          if ! checksommelierwayland || ! checksommelierxwayland ; then
-            [ -f  #{CREW_PREFIX}/bin/stopbroadway ] && stopbroadway
-            #{CREW_PREFIX}/sbin/sommelierd &> /dev/null &
-          fi
-          wait=3
-          until checksommelierwayland && checksommelierxwayland; do
-            [ "${wait}" -le "0" ] && break
-            (( wait = wait - 1 ))
-            sleep 3
-          done
-
-          SOMMWPIDS="$(pgrep -f "sommelier.elf --parent" 2> /dev/null)"
-          SOMMWPROCS="$(pgrep -fa "sommelier.elf --parent" 2> /dev/null)"
-          SOMMXPIDS="$(pgrep -f "sommelier.elf -X" 2> /dev/null)"
-          SOMMXPROCS="$(pgrep -fa "sommelier.elf -X" 2> /dev/null)"
-
-          if checksommelierwayland && checksommelierxwayland ; then
-            echo -e "sommelier processes running: ${SOMMWPIDS} ${SOMMXPIDS}"
-          else
-            echo "some sommelier processes failed to start"
-            echo -e "sommelier processes running: ${SOMMWPROCS} \\n ${SOMMXPROCS}"
-            exit 1
-          fi
-        EOF
-
-        # stopsommelier
-        File.write 'stopsommelier', <<~EOF
-          #!/bin/bash
-          SOMM="$(pgrep -fc sommelier.elf 2> /dev/null)"
-          if [[ "${SOMM}" -gt "0" ]]; then
-            pkill -f sommelier.elf &>/dev/null
-            pkill -F #{CREW_PREFIX}/var/run/sommelier-wayland.pid &>/dev/null
-            pkill -F #{CREW_PREFIX}/var/run/sommelier-xwayland.pid &>/dev/null
-          else
-            exit 0
-          fi
-          if [[ "$(pgrep -fc sommelier.elf 2> /dev/null)" -gt "0" ]]; then
-            echo "sommelier failed to stop"
-            exit 1
-          else
-            echo "sommelier stopped"
-          fi
-        EOF
-
-        # restartsommelier
-        File.write 'restartsommelier', <<~EOF
-          #!/bin/bash
-          stopsommelier && startsommelier
-        EOF
-
-        # start sommelier from bash.d, which loads after all of env.d via #{CREW_PREFIX}/etc/profile
-        @bashd_sommelier = <<~EOF
-          startsommelier
-        EOF
-      end
     end
   end
 
   def self.install
-    FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/bin #{CREW_DEST_PREFIX}/sbin #{CREW_DEST_PREFIX}/etc/bash.d
-                         #{CREW_DEST_PREFIX}/etc/env.d CREW_DEST_HOME]
-    Dir.chdir('vm_tools/sommelier') do
-      system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
-      Dir.chdir('builddir') do
-        FileUtils.mv "#{CREW_DEST_PREFIX}/bin/sommelier", "#{CREW_DEST_PREFIX}/bin/sommelier.elf"
-        FileUtils.install 'sommelier_sh', "#{CREW_DEST_PREFIX}/bin/sommelier", mode: 0o755
-        FileUtils.install 'sommelierd', "#{CREW_DEST_PREFIX}/sbin/sommelierd", mode: 0o755
-        FileUtils.install 'startsommelier', "#{CREW_DEST_PREFIX}/bin/startsommelier", mode: 0o755
-        FileUtils.ln_sf 'startsommelier', "#{CREW_DEST_PREFIX}/bin/initsommelier"
-        FileUtils.install 'stopsommelier', "#{CREW_DEST_PREFIX}/bin/stopsommelier", mode: 0o755
-        FileUtils.install 'restartsommelier', "#{CREW_DEST_PREFIX}/bin/restartsommelier", mode: 0o755
-        FileUtils.install 'sommelierrc', "#{CREW_DEST_PREFIX}/etc/sommelierrc", mode: 0o644
-      end
-    end
+    FileUtils.mkdir_p %W[ #{CREW_DEST_PREFIX}/bin
+                          #{CREW_DEST_PREFIX}/sbin
+                          #{CREW_DEST_PREFIX}/etc/env.d
+                          #{CREW_DEST_PREFIX}/etc/bash.d
+                        ]
 
-    File.write("#{CREW_DEST_PREFIX}/etc/bash.d/sommelier", @bashd_sommelier)
-    File.write("#{CREW_DEST_PREFIX}/etc/env.d/sommelier", @sommelierenv)
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C sommelier_src/builddir install"
+
+    FileUtils.mv "#{CREW_DEST_PREFIX}/bin/sommelier", "#{CREW_DEST_PREFIX}/bin/sommelier.elf"
+
+    FileUtils.install 'sommelier-wrapper', "#{CREW_DEST_PREFIX}/bin/sommelier", mode: 0o755
+    FileUtils.install 'sommelierd', "#{CREW_DEST_PREFIX}/bin/sommelierd", mode: 0o755
+    FileUtils.install 'sommelierrc', "#{CREW_DEST_PREFIX}/etc/sommelierrc", mode: 0o644
+    FileUtils.install 'sommelier.env', "#{CREW_DEST_PREFIX}/etc/env.d/sommelier", mode: 0o644
+
+    FileUtils.ln_s 'sommelierd', "#{CREW_DEST_PREFIX}/bin/startsommelier"
+    FileUtils.ln_s 'sommelierd', "#{CREW_DEST_PREFIX}/bin/restartsommelier"
+    FileUtils.ln_s 'sommelierd', "#{CREW_DEST_PREFIX}/bin/stopsommelier"
+
+    File.write "#{CREW_DEST_PREFIX}/etc/bash.d/sommelier", 'startsommelier', perm: 0o644
   end
 
   def self.postinstall
-    # all tasks are done by sommelier.env now
-    puts
-    puts 'Removing old sommelier env variable loading code in ~/.bashrc'.lightblue
-    system 'sed -i "/[sS]ommelier/d" -i.backup ~/.bashrc'
-    puts 'To complete the installation, execute the following:'.orange
-    puts 'source ~/.bashrc'.orange
+    puts '', <<~EOT.orange
+      To complete the installation, execute the following:
+      source #{CREW_PREFIX}/etc/profile
+      restartsommelier
+    EOT
 
-    puts
-    FileUtils.touch "#{HOME}/.sommelier.env" unless File.exist? "#{HOME}/.sommelier.env"
     puts <<~EOT.lightblue
       To adjust sommelier environment variables, edit #{CREW_PREFIX}/etc/env.d/sommelier
       Default values are in #{CREW_PREFIX}/etc/env.d/sommelier
 
-      To start the sommelier daemon, run 'startsommelier'
-      To stop the sommelier daemon, run 'stopsommelier'
-      To restart the sommelier daemon, run 'restartsommelier'
-
+      Run `startsommelier` to start sommelier daemon.
+      Run `stopsommelier` to stop all sommelier daemon.
+      Run `restartsommelier` to restart sommelier daemon
     EOT
+
     puts <<~EOT.orange
-      Please be aware that gui applications may not work without the
-      sommelier daemon running.
-
-      The sommelier daemon may also have to be restarted with
-      'restartsommelier' after waking your device.
-
-      (If you are upgrading from an earlier version of sommelier,
-      also run 'restartsommelier'.)
+      Please be aware that GUI applications may not work without the sommelier daemon running.
     EOT
   end
 end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -10,6 +10,19 @@ class Sommelier < Package
   source_url 'https://github.com/chromebrew/crew-package-sommelier.git'
   git_hashtag @_ver
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_armv7l/sommelier-20220207-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_armv7l/sommelier-20220207-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_i686/sommelier-20220207-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_x86_64/sommelier-20220207-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '74aa4a3bb9f2839426124d31fe947859903a9f076ac58fda6576aedb3a8295c4',
+     armv7l: '74aa4a3bb9f2839426124d31fe947859903a9f076ac58fda6576aedb3a8295c4',
+       i686: '158a719de95d18cb98ec842da1201c75803e5e16dbdc6e51ca467e1a104349f1',
+     x86_64: '94feec18f9c496f2ac0d6c6b77584d70492105425815224cafe59e9086b101fe'
+  })
+
   depends_on 'libdrm'
   depends_on 'libxcb'
   depends_on 'libxcomposite' => :build
@@ -72,11 +85,12 @@ class Sommelier < Package
   end
 
   def self.install
-    FileUtils.mkdir_p %W[ #{CREW_DEST_PREFIX}/bin
-                          #{CREW_DEST_PREFIX}/sbin
-                          #{CREW_DEST_PREFIX}/etc/env.d
-                          #{CREW_DEST_PREFIX}/etc/bash.d
-                        ]
+    FileUtils.mkdir_p %W[
+      #{CREW_DEST_PREFIX}/bin
+      #{CREW_DEST_PREFIX}/sbin
+      #{CREW_DEST_PREFIX}/etc/env.d
+      #{CREW_DEST_PREFIX}/etc/bash.d
+    ]
 
     system "DESTDIR=#{CREW_DEST_DIR} samu -C sommelier_src/builddir install"
 
@@ -95,23 +109,23 @@ class Sommelier < Package
   end
 
   def self.postinstall
-    puts '', <<~EOT.orange
+    puts '', <<~RESTARTSOMMELIER_EOT.orange
       To complete the installation, execute the following:
       source #{CREW_PREFIX}/etc/profile
       restartsommelier
-    EOT
+    RESTARTSOMMELIER_EOT
 
-    puts <<~EOT.lightblue
+    puts <<~ENV_ADJUSTMENT_EOT.lightblue
       To adjust sommelier environment variables, edit #{CREW_PREFIX}/etc/env.d/sommelier
       Default values are in #{CREW_PREFIX}/etc/env.d/sommelier
 
       Run `startsommelier` to start sommelier daemon.
       Run `stopsommelier` to stop all sommelier daemon.
       Run `restartsommelier` to restart sommelier daemon
-    EOT
+    ENV_ADJUSTMENT_EOT
 
-    puts <<~EOT.orange
+    puts <<~GUI_WARNING_EOT.orange
       Please be aware that GUI applications may not work without the sommelier daemon running.
-    EOT
+    GUI_WARNING_EOT
   end
 end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -6,7 +6,7 @@ class Sommelier < Package
   version '20220207'
   license 'BSD-Google'
   compatibility 'all'
-  source_url 'https://github.com/supechicken/crew-sommelier.git'
+  source_url 'https://github.com/chromebrew/crew-package-sommelier.git'
   git_branch 'main'
 
   depends_on 'libdrm'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,11 +3,12 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  version '20220207'
+  @_ver = '20220207'
+  version @_ver
   license 'BSD-Google'
   compatibility 'all'
   source_url 'https://github.com/chromebrew/crew-package-sommelier.git'
-  git_hashtag '076b9b547a8019e2db88241c68f5ad24bc7b4fed'
+  git_hashtag @_ver
 
   depends_on 'libdrm'
   depends_on 'libxcb'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,7 +3,7 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  version '20211129'
+  version '20220207'
   license 'BSD-Google'
   compatibility 'all'
   source_url 'https://github.com/supechicken/crew-sommelier.git'
@@ -14,6 +14,7 @@ class Sommelier < Package
   depends_on 'libxcomposite' => :build
   depends_on 'libxfixes' => :build
   depends_on 'libxkbcommon'
+  depends_on 'llvm'
   depends_on 'mesa'
   depends_on 'pixman'
   depends_on 'psmisc'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -7,7 +7,7 @@ class Sommelier < Package
   license 'BSD-Google'
   compatibility 'all'
   source_url 'https://github.com/chromebrew/crew-package-sommelier.git'
-  git_branch 'main'
+  git_hashtag '3b79e69513d83fecf740b61ad1a73a22e410838d'
 
   depends_on 'libdrm'
   depends_on 'libxcb'

--- a/packages/xrdb.rb
+++ b/packages/xrdb.rb
@@ -1,0 +1,39 @@
+require 'package'
+
+class Xrdb < Package
+  description 'xrdb - X server resource database utility'
+  homepage 'https://x.org'
+  @_ver = '1.2.1'
+  version @_ver
+  license 'custom'
+  compatibility 'all'
+  source_url 'https://gitlab.freedesktop.org/xorg/app/xrdb.git'
+  git_hashtag "xrdb-#{@_ver}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xrdb/1.2.1_armv7l/xrdb-1.2.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xrdb/1.2.1_armv7l/xrdb-1.2.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xrdb/1.2.1_i686/xrdb-1.2.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xrdb/1.2.1_x86_64/xrdb-1.2.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '547cb971355f8c3a3b4550fde0268150c1ab45cb818c42f21ad3d5bbb93329f8',
+     armv7l: '547cb971355f8c3a3b4550fde0268150c1ab45cb818c42f21ad3d5bbb93329f8',
+       i686: '5751bc4b403de795dc53c34a0aef60714bb6c45a318032510e791b3c37622af2',
+     x86_64: '5725f1b269c6ec44f0c975bed5575299f7896105637a7e34cd4f967cee808207'
+  })
+
+  depends_on 'libx11' # R
+  depends_on 'libxmu' # R
+  depends_on 'libxdmcp' => :build
+
+  def self.build
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end


### PR DESCRIPTION
## Tested architectures
- [x] x86_64

## Changes
- All changes from #6405
- Move all scripts to https://github.com/chromebrew/crew-package-sommelier (more code comments will be added there)
- The `sommelier` source becomes a git submodule of the new repo now
- `sommelierd`: moved to ruby for better code management
- `sommelierd`: New command: `--log` (see https://github.com/chromebrew/crew-package-sommelier/blob/main/sommelierd)

## Working
- [x] Wayland acceleration
![Screenshot 2022-03-16 12 44 17 AM](https://user-images.githubusercontent.com/73414985/158442251-7b3123a8-e2aa-4500-ae29-99a55f8aa2ea.png)
- [x] X11 acceleration
```
name of display: :0
display: :0  screen: 0
direct rendering: Yes
Extended renderer info (GLX_MESA_query_renderer):
    Vendor: Intel (0x8086)
    Device: Mesa Intel(R) UHD Graphics (CML GT2) (0x9b41)
    Version: 21.3.7
    Accelerated: yes
    Video memory: 3072MB
    Unified memory: yes
    Preferred profile: core (0x1)
    Max core profile version: 4.6
    Max compat profile version: 4.6
    Max GLES1 profile version: 1.1
    Max GLES[23] profile version: 3.2
OpenGL vendor string: Intel
OpenGL renderer string: Mesa Intel(R) UHD Graphics (CML GT2)
OpenGL core profile version string: 4.6 (Core Profile) Mesa 21.3.7 (git-d5ec846bc8)
OpenGL core profile shading language version string: 4.60
OpenGL core profile context flags: (none)
OpenGL core profile profile mask: core profile

OpenGL version string: 4.6 (Compatibility Profile) Mesa 21.3.7 (git-d5ec846bc8)
OpenGL shading language version string: 4.60
OpenGL context flags: (none)
OpenGL profile mask: compatibility profile
```

## Run the following to test this pull request
```shell
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git \
CREW_TESTING_BRANCH=update_sommelier \
CREW_TESTING=1 \
crew update
crew reinstall sommelier
```
