### PR TITLE
Test usage of --yjit for ruby in crew

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env -S ruby --yjit
 require_relative '../lib/color'
 
 # Disallow sudo

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.2'
+CREW_VERSION = '1.23.3'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- Please test this on actual hardware. This might improve startup times for qemu containers.

Works properly:
- [x] x86_64


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_jit CREW_TESTING=1 crew update
```
