### PR TITLE
perl => 5.34.1

### DIFF
--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -40,7 +40,7 @@ class Perl < Package
       -Dvendorarch=#{CREW_LIB_PREFIX}/perl5/#{@_ver}/vendor_perl \
       -Dcc=#{CREW_TGT}-gcc \
       -Doptimize='#{CREW_COMMON_FLAGS}' \
-      -Dlldlflags='-shared #{CREW_LDFLAGS}' -Dldflags=#{CREW_LDFLAGS} \
+      -Dlldlflags='-shared #{CREW_LDFLAGS}' -Dldflags='#{CREW_LDFLAGS}' \
       -Dusethreads \
       -Dinstallusrbinperl=n \
       -Duseshrplib -Dman1dir=#{CREW_MAN_PREFIX}/man1 -Dman3dir=#{CREW_MAN_PREFIX}/man3"

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -12,10 +12,6 @@ class Perl < Package
 
   depends_on 'patch' => :build
 
-  def self.prebuild
-    downloader 'https://cpanmin.us', 'cpanm'
-  end
-
   def self.build
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_LIB_PREFIX}/libnsl.so"
     # Use system zlib and bzip2
@@ -54,8 +50,6 @@ class Perl < Package
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_DEST_LIB_PREFIX}/libnsl.so"
     # Avoid File conflict with tcl, ocaml
     FileUtils.mv "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3", "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3perl"
-
-    FileUtils.install 'cpanm', "#{CREW_DEST_PREFIX}/bin/cpanm", mode: 0o755
   end
 
   def self.check

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -11,10 +11,14 @@ class Perl < Package
   source_sha256 '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7'
 
   binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_armv7l/perl-5.34.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_armv7l/perl-5.34.1-chromeos-armv7l.tar.zst',
     i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_i686/perl-5.34.1-chromeos-i686.tar.zst',
   x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_x86_64/perl-5.34.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
+    aarch64: 'dfffdd358c4863f28a7865e7087f6a716478509b7ebeafab0b1200bc5e65fe3d',
+     armv7l: 'dfffdd358c4863f28a7865e7087f6a716478509b7ebeafab0b1200bc5e65fe3d',
     i686: '49c0701b82abe192ec20a22f435df153689c7269f36da9ab38299496a6360233',
   x86_64: '09abf3ae359466bb0451e9ed890b4d95bc7721de05fa65f8acba5ee131797b46'
   })

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -15,8 +15,8 @@ class Perl < Package
   x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_x86_64/perl-5.34.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'e0c08dfff35c805a4e03d8a0ba2ffbda28ec5952520c4a3dbffdfd6b1970f332',
-  x86_64: 'd61ffae41e25817580f5d7b9b0102c04ea0b670499f8593a78db96148e081008'
+    i686: '49c0701b82abe192ec20a22f435df153689c7269f36da9ab38299496a6360233',
+  x86_64: '09abf3ae359466bb0451e9ed890b4d95bc7721de05fa65f8acba5ee131797b46'
   })
 
   depends_on 'patch' => :build
@@ -80,6 +80,6 @@ diff -ur perl-5.22.1.orig/t/lib/warnings/regexec perl-5.22.1/t/lib/warnings/rege
 EOF'
 
     # test
-    system 'make test || true'
+    # system 'make test || true'
   end
 end

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -12,8 +12,11 @@ class Perl < Package
 
   depends_on 'patch' => :build
 
-  def self.build
+  def self.prebuild
     downloader 'https://cpanmin.us', 'cpanm'
+  end
+
+  def self.build
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_LIB_PREFIX}/libnsl.so"
     # Use system zlib and bzip2
     # Create shared library

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -10,9 +10,19 @@ class Perl < Package
   source_url "https://www.cpan.org/src/5.0/perl-#{@_ver}.tar.xz"
   source_sha256 '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_i686/perl-5.34.1-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_x86_64/perl-5.34.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'e0c08dfff35c805a4e03d8a0ba2ffbda28ec5952520c4a3dbffdfd6b1970f332',
+  x86_64: 'd61ffae41e25817580f5d7b9b0102c04ea0b670499f8593a78db96148e081008'
+  })
+
   depends_on 'patch' => :build
 
   def self.build
+    downloader 'https://cpanmin.us', 'cpanm'
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_LIB_PREFIX}/libnsl.so"
     # Use system zlib and bzip2
     # Create shared library
@@ -50,6 +60,8 @@ class Perl < Package
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_DEST_LIB_PREFIX}/libnsl.so"
     # Avoid File conflict with tcl, ocaml
     FileUtils.mv "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3", "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3perl"
+
+    FileUtils.install 'cpanm', "#{CREW_DEST_PREFIX}/bin/cpanm", mode: 0o755
   end
 
   def self.check
@@ -71,6 +83,6 @@ diff -ur perl-5.22.1.orig/t/lib/warnings/regexec perl-5.22.1/t/lib/warnings/rege
 EOF'
 
     # test
-    system 'make test || true'
+    # || true'
   end
 end

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -3,66 +3,61 @@ require 'package'
 class Perl < Package
   description 'Perl 5 is a highly capable, feature-rich programming language with over 29 years of development.'
   homepage 'https://www.perl.org/'
-  @_ver = '5.32.1'
+  @_ver = '5.34.1'
   version @_ver
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url "http://www.cpan.org/src/5.0/perl-#{@_ver}.tar.gz"
-  source_sha256 '03b693901cd8ae807231b1787798cf1f2e0b8a56218d07b7da44f784a7caeb2c'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.32.1_armv7l/perl-5.32.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.32.1_armv7l/perl-5.32.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.32.1_i686/perl-5.32.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.32.1_x86_64/perl-5.32.1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '8f96c4ac4e4927ff643670ba362568e5483ba4ef970acd742877ef49b48829df',
-     armv7l: '8f96c4ac4e4927ff643670ba362568e5483ba4ef970acd742877ef49b48829df',
-       i686: '2193da9719f91be5aa261471aae0314b19da430ae3f09006c30d7d276b5f230d',
-     x86_64: '8c12ba41052f0f49f1dccc7cc1de795d4b4c55ba70c4ed1eff866580405e300a'
-  })
+  source_url "https://www.cpan.org/src/5.0/perl-#{@_ver}.tar.xz"
+  source_sha256 '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7'
 
   depends_on 'patch' => :build
 
-  @perl_fullversion = @_ver.split('-')[0]
-
-  @perl_version = @_ver.rpartition('.')[0]
-
   def self.build
+    downloader 'https://cpanmin.us', 'cpanm'
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_LIB_PREFIX}/libnsl.so"
     # Use system zlib and bzip2
     # Create shared library
     # Install manual files into #{CREW_PREFIX}/share/man/man* even if groff is not installed.
     system "env AR=gcc-ar RANLIB=gcc-ranlib NM=gcc-nm \
-      CFLAGS='-Os -pipe -flto=auto' \
-      CXXFLAGS='-Os -pipe -flto=auto' \
-      LDFLAGS='-Wl,-z,relro -Wl,--as-needed -Wl,-z,now -flto -fuse-linker-plugin' \
       BUILD_ZLIB=False BUILD_BZIP2=0 \
       ./Configure \
-      -Doptimize='-Os -pipe -flto=auto' \
+      -de \
+      -Dprefix=#{CREW_PREFIX} \
+      -Dvendorprefix=#{CREW_PREFIX} \
+      -Dprivlib=#{CREW_PREFIX}/share/perl5/core_perl \
+      -Darchlib=#{CREW_LIB_PREFIX}/perl5/#{@_ver}/core_perl \
+      -Dsitelib=#{CREW_PREFIX}/share/perl5/site_perl \
+      -Dsitearch=#{CREW_LIB_PREFIX}/perl5/#{@_ver}/site_perl \
+      -Dvendorlib=#{CREW_PREFIX}/share/perl5/vendor_perl \
+      -Dvendorarch=#{CREW_LIB_PREFIX}/perl5/#{@_ver}/vendor_perl \
+      -Dcc=#{CREW_TGT}-gcc \
+      -Doptimize='#{CREW_COMMON_FLAGS}' \
+      -Dlldlflags='-shared #{CREW_LDFLAGS}' -Dldflags=#{CREW_LDFLAGS} \
       -Dusethreads \
-      -de -Duseshrplib -Dman1dir=#{CREW_MAN_PREFIX}/man1 -Dman3dir=#{CREW_MAN_PREFIX}/man3"
+      -Dinstallusrbinperl=n \
+      -Duseshrplib -Dman1dir=#{CREW_MAN_PREFIX}/man1 -Dman3dir=#{CREW_MAN_PREFIX}/man3"
     system 'make'
-    system 'curl -o cpanm https://cpanmin.us'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
-    FileUtils.ln_sf "#{CREW_PREFIX}/lib/perl5/#{@perl_fullversion}/#{ARCH}-linux-thread-multi/CORE/libperl.so",
-                    "#{CREW_DEST_LIB_PREFIX}/libperl.so"
+#    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
+    libperl_so = "#{CREW_PREFIX}/lib/perl5/#{@perl_fullversion}/#{ARCH}-linux-thread-multi/CORE/libperl.so"
+    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{@_ver.sub(/^5\./, '')}" # e.g., libperl.so.34.1
+    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{@_ver.sub(/^5\./, '').sub(/\.\d$/, '')}" # e.g., libperl.so.34
+    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so" # e.g., libperl.so
+    # Consider adding this symlink to the glibc package
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_DEST_LIB_PREFIX}/libnsl.so"
     # Avoid File conflict with tcl, ocaml
     FileUtils.mv "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3", "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3perl"
-    system "install -Dm755 cpanm #{CREW_DEST_PREFIX}/bin/cpanm"
+    FileUtils.install 'cpanm', "#{CREW_DEST_PREFIX}/bin/cpanm", mode: 0o755
   end
 
   def self.check
     # having strange error as explained at https://patchwork.openembedded.org/patch/95795/
     # so, apply patch from https://github.com/habitat-sh/core-plans/blob/master/perl/skip-wide-character-test.patch
     # to ignore this single test
-    system 'patch -p1 << EOF
+    system 'patch -Np1 << EOF
 diff -ur perl-5.22.1.orig/t/lib/warnings/regexec perl-5.22.1/t/lib/warnings/regexec
 --- perl-5.22.1.orig/t/lib/warnings/regexec     2015-10-30 21:14:29.000000000 +0000
 +++ perl-5.22.1/t/lib/warnings/regexec  2016-01-19 05:05:50.218474114 +0000

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -13,14 +13,14 @@ class Perl < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_armv7l/perl-5.34.1-chromeos-armv7l.tar.zst',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_armv7l/perl-5.34.1-chromeos-armv7l.tar.zst',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_i686/perl-5.34.1-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_x86_64/perl-5.34.1-chromeos-x86_64.tar.zst'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_i686/perl-5.34.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl/5.34.1_x86_64/perl-5.34.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: 'dfffdd358c4863f28a7865e7087f6a716478509b7ebeafab0b1200bc5e65fe3d',
      armv7l: 'dfffdd358c4863f28a7865e7087f6a716478509b7ebeafab0b1200bc5e65fe3d',
-    i686: '49c0701b82abe192ec20a22f435df153689c7269f36da9ab38299496a6360233',
-  x86_64: '09abf3ae359466bb0451e9ed890b4d95bc7721de05fa65f8acba5ee131797b46'
+       i686: '49c0701b82abe192ec20a22f435df153689c7269f36da9ab38299496a6360233',
+     x86_64: '09abf3ae359466bb0451e9ed890b4d95bc7721de05fa65f8acba5ee131797b46'
   })
 
   depends_on 'patch' => :build

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -41,15 +41,17 @@ class Perl < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-#    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
+    # Make libperl symlinks into standard locations
     libperl_so = "#{CREW_PREFIX}/lib/perl5/#{@perl_fullversion}/#{ARCH}-linux-thread-multi/CORE/libperl.so"
-    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{@_ver.sub(/^5\./, '')}" # e.g., libperl.so.34.1
-    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{@_ver.sub(/^5\./, '').sub(/\.\d$/, '')}" # e.g., libperl.so.34
+    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{@_ver}" # e.g., libperl.so.5.34.1
+    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{@_ver.sub(/\.\d$/, '')}" # e.g., libperl.so.5.34
+    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so#{@_ver.sub(/\.\d\.\d$/, '')}" # e.g., libperl.so.5
     FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so" # e.g., libperl.so
     # Consider adding this symlink to the glibc package
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_DEST_LIB_PREFIX}/libnsl.so"
     # Avoid File conflict with tcl, ocaml
     FileUtils.mv "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3", "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3perl"
+
     FileUtils.install 'cpanm', "#{CREW_DEST_PREFIX}/bin/cpanm", mode: 0o755
   end
 

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -22,7 +22,6 @@ class Perl < Package
   depends_on 'patch' => :build
 
   def self.build
-    downloader 'https://cpanmin.us', 'cpanm'
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_LIB_PREFIX}/libnsl.so"
     # Use system zlib and bzip2
     # Create shared library
@@ -60,8 +59,6 @@ class Perl < Package
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_DEST_LIB_PREFIX}/libnsl.so"
     # Avoid File conflict with tcl, ocaml
     FileUtils.mv "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3", "#{CREW_DEST_MAN_PREFIX}/man3/Thread.3perl"
-
-    FileUtils.install 'cpanm', "#{CREW_DEST_PREFIX}/bin/cpanm", mode: 0o755
   end
 
   def self.check
@@ -83,6 +80,6 @@ diff -ur perl-5.22.1.orig/t/lib/warnings/regexec perl-5.22.1/t/lib/warnings/rege
 EOF'
 
     # test
-    # || true'
+    system 'make test || true'
   end
 end

--- a/packages/perl_app_cpanminus.rb
+++ b/packages/perl_app_cpanminus.rb
@@ -9,6 +9,15 @@ class Perl_app_cpanminus < Package
   source_url 'https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7045.tar.gz'
   source_sha256 'ac4e4adc23fec0ab54f088aca511f5a57d95e6c97a12a1cb98eed1fe0fe0e99c'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_app_cpanminus/1.7045_i686/perl_app_cpanminus-1.7045-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_app_cpanminus/1.7045_x86_64/perl_app_cpanminus-1.7045-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'c4242cf166543fc1bca251e32346c00f6c2035f8e4108a010dc8485e2e6de461',
+  x86_64: 'f6448d53166638b53d376d4cd5358acfd65de7da839313d81234618abf56347e'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_app_cpanminus.rb
+++ b/packages/perl_app_cpanminus.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Perl_app_cpanminus < Package
+  description 'App::cpanminus - get, unpack, build and install modules from CPAN'
+  homepage 'https://metacpan.org/pod/App::cpanminus'
+  version '1.7045'
+  license 'GPL-1+ or Artistic'
+  compatibility 'all'
+  source_url 'https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7045.tar.gz'
+  source_sha256 'ac4e4adc23fec0ab54f088aca511f5a57d95e6c97a12a1cb98eed1fe0fe0e99c'
+
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/perl_app_cpanminus.rb
+++ b/packages/perl_app_cpanminus.rb
@@ -10,12 +10,16 @@ class Perl_app_cpanminus < Package
   source_sha256 'ac4e4adc23fec0ab54f088aca511f5a57d95e6c97a12a1cb98eed1fe0fe0e99c'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_app_cpanminus/1.7045_i686/perl_app_cpanminus-1.7045-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_app_cpanminus/1.7045_x86_64/perl_app_cpanminus-1.7045-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_app_cpanminus/1.7045_armv7l/perl_app_cpanminus-1.7045-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_app_cpanminus/1.7045_armv7l/perl_app_cpanminus-1.7045-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_app_cpanminus/1.7045_i686/perl_app_cpanminus-1.7045-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_app_cpanminus/1.7045_x86_64/perl_app_cpanminus-1.7045-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'c4242cf166543fc1bca251e32346c00f6c2035f8e4108a010dc8485e2e6de461',
-  x86_64: 'f6448d53166638b53d376d4cd5358acfd65de7da839313d81234618abf56347e'
+    aarch64: '688d1f8c904ef638932f871b8364492ae6d487e0ce1b0a3357eec9749555dc66',
+     armv7l: '688d1f8c904ef638932f871b8364492ae6d487e0ce1b0a3357eec9749555dc66',
+       i686: 'c4242cf166543fc1bca251e32346c00f6c2035f8e4108a010dc8485e2e6de461',
+     x86_64: 'f6448d53166638b53d376d4cd5358acfd65de7da839313d81234618abf56347e'
   })
 
   def self.prebuild

--- a/packages/perl_carp_clan.rb
+++ b/packages/perl_carp_clan.rb
@@ -10,12 +10,16 @@ class Perl_carp_clan < Package
   source_sha256 'c75f92e34422cc5a65ab05d155842b701452434e9aefb649d6e2289c47ef6708'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-2_i686/perl_carp_clan-6.08-2-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-2_x86_64/perl_carp_clan-6.08-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-2_armv7l/perl_carp_clan-6.08-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-2_armv7l/perl_carp_clan-6.08-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-2_i686/perl_carp_clan-6.08-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-2_x86_64/perl_carp_clan-6.08-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'bfe068d90471ef074e81ec0ad3f2be44dce6a1abb74ab99c770e24308a8c9359',
-  x86_64: 'f00f6525e8eaaf590f37318f100f5a8906e3bd369f23c030f993acd58fa6b96b'
+    aarch64: '42846add31b8c3a6f2253cc8464acc389065a5116ac4ba8bde5436c6396103bc',
+     armv7l: '42846add31b8c3a6f2253cc8464acc389065a5116ac4ba8bde5436c6396103bc',
+       i686: 'bfe068d90471ef074e81ec0ad3f2be44dce6a1abb74ab99c770e24308a8c9359',
+     x86_64: 'f00f6525e8eaaf590f37318f100f5a8906e3bd369f23c030f993acd58fa6b96b'
   })
 
   def self.prebuild

--- a/packages/perl_carp_clan.rb
+++ b/packages/perl_carp_clan.rb
@@ -9,6 +9,15 @@ class Perl_carp_clan < Package
   source_url 'https://cpan.metacpan.org/authors/id/E/ET/ETHER/Carp-Clan-6.08.tar.gz'
   source_sha256 'c75f92e34422cc5a65ab05d155842b701452434e9aefb649d6e2289c47ef6708'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-2_i686/perl_carp_clan-6.08-2-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-2_x86_64/perl_carp_clan-6.08-2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'bfe068d90471ef074e81ec0ad3f2be44dce6a1abb74ab99c770e24308a8c9359',
+  x86_64: 'f00f6525e8eaaf590f37318f100f5a8906e3bd369f23c030f993acd58fa6b96b'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_carp_clan.rb
+++ b/packages/perl_carp_clan.rb
@@ -1,29 +1,20 @@
 require 'package'
 
 class Perl_carp_clan < Package
-  description 'Report errors from perspective of caller of a "clan" of modules'
+  description 'Carp::Clan - Report errors from perspective of caller of a "clan" of modules'
   homepage 'https://metacpan.org/pod/Carp::Clan'
-  version '6.08-1'
+  version '6.08-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/E/ET/ETHER/Carp-Clan-6.08.tar.gz'
   source_sha256 'c75f92e34422cc5a65ab05d155842b701452434e9aefb649d6e2289c47ef6708'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-1_armv7l/perl_carp_clan-6.08-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-1_armv7l/perl_carp_clan-6.08-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-1_i686/perl_carp_clan-6.08-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_carp_clan/6.08-1_x86_64/perl_carp_clan-6.08-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'f3ebb5e1420ae2fb02e2043326019a84515432d33510749ae0cd7e917aeee109',
-     armv7l: 'f3ebb5e1420ae2fb02e2043326019a84515432d33510749ae0cd7e917aeee109',
-       i686: '44a337556d4ac69e3fa7d441b748653aad1a028309b0693ab79b2db99f03eacf',
-     x86_64: '295172aab40d44e24afc5a3f0dc6eed4303339b19b3b93a2366181a1e2b46b1f'
-  })
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
 
   def self.build
-    system 'perl', 'Makefile.PL'
     system 'make'
   end
 

--- a/packages/perl_date_calc.rb
+++ b/packages/perl_date_calc.rb
@@ -10,12 +10,16 @@ class Perl_date_calc < Package
   source_sha256 '7ce137b2e797b7c0901f3adf1a05a19343356cd1f04676aa1c56a9f624f859ad'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-2_i686/perl_date_calc-6.4-2-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-2_x86_64/perl_date_calc-6.4-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-2_armv7l/perl_date_calc-6.4-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-2_armv7l/perl_date_calc-6.4-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-2_i686/perl_date_calc-6.4-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-2_x86_64/perl_date_calc-6.4-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'f0151fb996a7f559e28bce2b8c823fe5e6059d9668915fcaf74df3b1535a670a',
-  x86_64: 'd8b045b14ec0d3be8b6cb03e9dd1565382ce2b07226bcb7fdef48573aa62dcf6'
+    aarch64: '3dc10029a15f7c6156d435166a96fa1c1412dba99188bf50685a428ee12dae1f',
+     armv7l: '3dc10029a15f7c6156d435166a96fa1c1412dba99188bf50685a428ee12dae1f',
+       i686: 'f0151fb996a7f559e28bce2b8c823fe5e6059d9668915fcaf74df3b1535a670a',
+     x86_64: 'd8b045b14ec0d3be8b6cb03e9dd1565382ce2b07226bcb7fdef48573aa62dcf6'
   })
 
   def self.prebuild

--- a/packages/perl_date_calc.rb
+++ b/packages/perl_date_calc.rb
@@ -3,27 +3,18 @@ require 'package'
 class Perl_date_calc < Package
   description 'Gregorian calendar date calculations'
   homepage 'https://metacpan.org/pod/Date::Calc'
-  version '6.4-1'
+  version '6.4-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/S/ST/STBEY/Date-Calc-6.4.tar.gz'
   source_sha256 '7ce137b2e797b7c0901f3adf1a05a19343356cd1f04676aa1c56a9f624f859ad'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-1_armv7l/perl_date_calc-6.4-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-1_armv7l/perl_date_calc-6.4-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-1_i686/perl_date_calc-6.4-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-1_x86_64/perl_date_calc-6.4-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '794fba788fdccc502c07cf8d213e8c4f116658beaa508a0964bbea36ce4d07fb',
-     armv7l: '794fba788fdccc502c07cf8d213e8c4f116658beaa508a0964bbea36ce4d07fb',
-       i686: 'a1b37b825b42512d796d38486f1d63696c68257a7c0d6f5be1e64784610d3d5d',
-     x86_64: 'f91b5551c3b2f7487d9dedec2a910c9a881bed5dbd732d7fe759adfcb843f186'
-  })
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
 
   def self.build
-    system 'perl', 'Makefile.PL'
     system 'make'
   end
 

--- a/packages/perl_date_calc.rb
+++ b/packages/perl_date_calc.rb
@@ -9,6 +9,15 @@ class Perl_date_calc < Package
   source_url 'https://cpan.metacpan.org/authors/id/S/ST/STBEY/Date-Calc-6.4.tar.gz'
   source_sha256 '7ce137b2e797b7c0901f3adf1a05a19343356cd1f04676aa1c56a9f624f859ad'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-2_i686/perl_date_calc-6.4-2-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_calc/6.4-2_x86_64/perl_date_calc-6.4-2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'f0151fb996a7f559e28bce2b8c823fe5e6059d9668915fcaf74df3b1535a670a',
+  x86_64: 'd8b045b14ec0d3be8b6cb03e9dd1565382ce2b07226bcb7fdef48573aa62dcf6'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_date_format.rb
+++ b/packages/perl_date_format.rb
@@ -9,21 +9,12 @@ class Perl_date_format < Package
   source_url 'https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/TimeDate-2.33.tar.gz'
   source_sha256 'c0b69c4b039de6f501b0d9f13ec58c86b040c1f7e9b27ef249651c143d605eb2'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_armv7l/perl_date_format-2.33-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_armv7l/perl_date_format-2.33-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_i686/perl_date_format-2.33-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_x86_64/perl_date_format-2.33-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '58c1886e79ef37627314f0ffa838d11190e45de6ff17e02de21af1d129bff4b3',
-     armv7l: '58c1886e79ef37627314f0ffa838d11190e45de6ff17e02de21af1d129bff4b3',
-       i686: 'f81f2743e65366196693cf781d30ec7b0a0c9387cee583b6789245f81eb2ffeb',
-     x86_64: '2998c9fed1b23f2b438c4320dae495129b3f7067e770cce38983a868088f1db5'
-  })
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
 
   def self.build
-    system 'perl', 'Makefile.PL'
     system 'make'
   end
 
@@ -31,6 +22,6 @@ class Perl_date_format < Package
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
 
     # Conflict with perl_xml_parser package.
-    FileUtils.rm "#{CREW_PREFIX}/lib/perl5/site_perl/5.32.1/Date/Language/Amharic.pm"
+    #FileUtils.rm "#{CREW_PREFIX}/lib/perl5/site_perl/5.32.1/Date/Language/Amharic.pm"
   end
 end

--- a/packages/perl_date_format.rb
+++ b/packages/perl_date_format.rb
@@ -10,12 +10,16 @@ class Perl_date_format < Package
   source_sha256 'c0b69c4b039de6f501b0d9f13ec58c86b040c1f7e9b27ef249651c143d605eb2'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_i686/perl_date_format-2.33-1-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_x86_64/perl_date_format-2.33-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_armv7l/perl_date_format-2.33-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_armv7l/perl_date_format-2.33-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_i686/perl_date_format-2.33-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_x86_64/perl_date_format-2.33-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'a5fcdf8239f0b75d83a538271c059d06a21500fc6481873b64645edd68081bd6',
-  x86_64: '21bac07991851bab2cb245661415a9803c00cdfe690c7a840642df6eebf54275'
+    aarch64: 'ea4056a6df7f78a035114cf2d33410d41d0bd65b2a7087cf06d65acf5530d2c0',
+     armv7l: 'ea4056a6df7f78a035114cf2d33410d41d0bd65b2a7087cf06d65acf5530d2c0',
+       i686: 'a5fcdf8239f0b75d83a538271c059d06a21500fc6481873b64645edd68081bd6',
+     x86_64: '21bac07991851bab2cb245661415a9803c00cdfe690c7a840642df6eebf54275'
   })
 
   conflicts_ok #  conflicts with perl_xml_parser

--- a/packages/perl_date_format.rb
+++ b/packages/perl_date_format.rb
@@ -18,6 +18,8 @@ class Perl_date_format < Package
   x86_64: '21bac07991851bab2cb245661415a9803c00cdfe690c7a840642df6eebf54275'
   })
 
+  conflicts_ok #  conflicts with perl_xml_parser
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_date_format.rb
+++ b/packages/perl_date_format.rb
@@ -9,6 +9,15 @@ class Perl_date_format < Package
   source_url 'https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/TimeDate-2.33.tar.gz'
   source_sha256 'c0b69c4b039de6f501b0d9f13ec58c86b040c1f7e9b27ef249651c143d605eb2'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_i686/perl_date_format-2.33-1-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_format/2.33-1_x86_64/perl_date_format-2.33-1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'a5fcdf8239f0b75d83a538271c059d06a21500fc6481873b64645edd68081bd6',
+  x86_64: '21bac07991851bab2cb245661415a9803c00cdfe690c7a840642df6eebf54275'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
@@ -22,6 +31,6 @@ class Perl_date_format < Package
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
 
     # Conflict with perl_xml_parser package.
-    #FileUtils.rm "#{CREW_PREFIX}/lib/perl5/site_perl/5.32.1/Date/Language/Amharic.pm"
+    # FileUtils.rm "#{CREW_PREFIX}/lib/perl5/site_perl/5.32.1/Date/Language/Amharic.pm"
   end
 end

--- a/packages/perl_date_manip.rb
+++ b/packages/perl_date_manip.rb
@@ -9,6 +9,15 @@ class Perl_date_manip < Package
   source_url 'https://cpan.metacpan.org/authors/id/S/SB/SBECK/Date-Manip-6.86.tar.gz'
   source_sha256 'b5203782d03c79aa5822cf33d1828aaa3b4db93a275d4a428c89f56f4713361f'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.86_i686/perl_date_manip-6.86-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.86_x86_64/perl_date_manip-6.86-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '76657f3f2cc037f83597b4ca2d01e8281b86b886365bd12ff2d824323f21fab9',
+  x86_64: '12f9ce224833afc565ab0818e6809752d88860f2b3d48a66ea60ab65d62f3e33'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_date_manip.rb
+++ b/packages/perl_date_manip.rb
@@ -10,12 +10,16 @@ class Perl_date_manip < Package
   source_sha256 'b5203782d03c79aa5822cf33d1828aaa3b4db93a275d4a428c89f56f4713361f'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.86_i686/perl_date_manip-6.86-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.86_x86_64/perl_date_manip-6.86-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.86_armv7l/perl_date_manip-6.86-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.86_armv7l/perl_date_manip-6.86-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.86_i686/perl_date_manip-6.86-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.86_x86_64/perl_date_manip-6.86-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '76657f3f2cc037f83597b4ca2d01e8281b86b886365bd12ff2d824323f21fab9',
-  x86_64: '12f9ce224833afc565ab0818e6809752d88860f2b3d48a66ea60ab65d62f3e33'
+    aarch64: '6c728a87e7326bac9ce2c24941226395918d4547c50c4fbf65b0c2d85c0924a8',
+     armv7l: '6c728a87e7326bac9ce2c24941226395918d4547c50c4fbf65b0c2d85c0924a8',
+       i686: '76657f3f2cc037f83597b4ca2d01e8281b86b886365bd12ff2d824323f21fab9',
+     x86_64: '12f9ce224833afc565ab0818e6809752d88860f2b3d48a66ea60ab65d62f3e33'
   })
 
   def self.prebuild

--- a/packages/perl_date_manip.rb
+++ b/packages/perl_date_manip.rb
@@ -1,29 +1,20 @@
 require 'package'
 
 class Perl_date_manip < Package
-  description 'Date manipulation routines'
+  description 'Date::Manip - Date manipulation routines'
   homepage 'https://metacpan.org/pod/Date::Manip'
-  version '6.82-1'
+  version '6.86'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/S/SB/SBECK/Date-Manip-6.82.tar.gz'
-  source_sha256 'fa96bcf94c6b4b7d3333f073f5d0faad59f546e5aec13ac01718f2e6ef14672a'
+  source_url 'https://cpan.metacpan.org/authors/id/S/SB/SBECK/Date-Manip-6.86.tar.gz'
+  source_sha256 'b5203782d03c79aa5822cf33d1828aaa3b4db93a275d4a428c89f56f4713361f'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.82-1_armv7l/perl_date_manip-6.82-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.82-1_armv7l/perl_date_manip-6.82-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.82-1_i686/perl_date_manip-6.82-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_date_manip/6.82-1_x86_64/perl_date_manip-6.82-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '96b6434cacbc4c44472b663f92f8f1f66fa017aade85cf73b589cbc92b0cd988',
-     armv7l: '96b6434cacbc4c44472b663f92f8f1f66fa017aade85cf73b589cbc92b0cd988',
-       i686: '5d0213058c1d5c1d20eae4223cadde99c563f23a66cd7637553d1c35797bf7df',
-     x86_64: 'aac6357483d49208f09ee9b1c71087ca10924ddba8268fbf054fb3efc3ed7a5d'
-  })
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
 
   def self.build
-    system 'perl', 'Makefile.PL'
     system 'make'
   end
 

--- a/packages/perl_file_tail.rb
+++ b/packages/perl_file_tail.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Perl_file_tail < Package
-  description 'File::Tail - Perl extension for reading from continously updated files'
+  description 'File::Tail - Perl extension for reading from continuously updated files'
   homepage 'https://metacpan.org/pod/File::Tail'
   version '1.3-2'
   license 'GPL-1+ or Artistic'

--- a/packages/perl_file_tail.rb
+++ b/packages/perl_file_tail.rb
@@ -9,6 +9,15 @@ class Perl_file_tail < Package
   source_url 'https://cpan.metacpan.org/authors/id/M/MG/MGRABNAR/File-Tail-1.3.tar.gz'
   source_sha256 '26d09f81836e43eae40028d5283fe5620fe6fe6278bf3eb8eb600c48ec34afc7'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-2_i686/perl_file_tail-1.3-2-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-2_x86_64/perl_file_tail-1.3-2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'b0320cc0f1832ccd1b78bfa6cf668f0bdd7064e84a793ce2803c9510225dbb60',
+  x86_64: '6577ddae800348de9ae655fdbbb24d16ac51bf41b9e73555926ea2f53d6abec2'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_file_tail.rb
+++ b/packages/perl_file_tail.rb
@@ -10,12 +10,16 @@ class Perl_file_tail < Package
   source_sha256 '26d09f81836e43eae40028d5283fe5620fe6fe6278bf3eb8eb600c48ec34afc7'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-2_i686/perl_file_tail-1.3-2-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-2_x86_64/perl_file_tail-1.3-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-2_armv7l/perl_file_tail-1.3-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-2_armv7l/perl_file_tail-1.3-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-2_i686/perl_file_tail-1.3-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-2_x86_64/perl_file_tail-1.3-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'b0320cc0f1832ccd1b78bfa6cf668f0bdd7064e84a793ce2803c9510225dbb60',
-  x86_64: '6577ddae800348de9ae655fdbbb24d16ac51bf41b9e73555926ea2f53d6abec2'
+    aarch64: 'c5f9386679af386e3fa96ee921871549900359ead67d3655f652ed4ad7601c8b',
+     armv7l: 'c5f9386679af386e3fa96ee921871549900359ead67d3655f652ed4ad7601c8b',
+       i686: 'b0320cc0f1832ccd1b78bfa6cf668f0bdd7064e84a793ce2803c9510225dbb60',
+     x86_64: '6577ddae800348de9ae655fdbbb24d16ac51bf41b9e73555926ea2f53d6abec2'
   })
 
   def self.prebuild

--- a/packages/perl_file_tail.rb
+++ b/packages/perl_file_tail.rb
@@ -1,29 +1,20 @@
 require 'package'
 
 class Perl_file_tail < Package
-  description 'Perl extension for reading from continuously updated files'
+  description 'File::Tail - Perl extension for reading from continously updated files'
   homepage 'https://metacpan.org/pod/File::Tail'
-  version '1.3-1'
+  version '1.3-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/M/MG/MGRABNAR/File-Tail-1.3.tar.gz'
   source_sha256 '26d09f81836e43eae40028d5283fe5620fe6fe6278bf3eb8eb600c48ec34afc7'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-1_armv7l/perl_file_tail-1.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-1_armv7l/perl_file_tail-1.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-1_i686/perl_file_tail-1.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_file_tail/1.3-1_x86_64/perl_file_tail-1.3-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'a4ef2b1c64d500ab70f1e2bfa1eea3b9c4872ff1cd0479a340a8953583237e80',
-     armv7l: 'a4ef2b1c64d500ab70f1e2bfa1eea3b9c4872ff1cd0479a340a8953583237e80',
-       i686: 'e7598c65f241246fe6d4c95db13288675d3d150ba7fbc6285fee5ee01d9f6fa8',
-     x86_64: '2eb28e0e5cca3cab45a9bada46f58cbb793464df95f033e2dac025c44d65efd3'
-  })
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
 
   def self.build
-    system 'perl', 'Makefile.PL'
     system 'make'
   end
 

--- a/packages/perl_gcstring_linebreak.rb
+++ b/packages/perl_gcstring_linebreak.rb
@@ -3,31 +3,9 @@ require 'package'
 class Perl_gcstring_linebreak < Package
   description 'UAX 14 Unicode Line Breaking Algorithm - Perl binding Unicode::LineBreak Unicode::GCString'
   homepage 'http://search.cpan.org/~nezumi/Unicode-LineBreak-2018.003/lib/Unicode/LineBreak.pod'
-  version '2019.001-1'
+  version '2019.001-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://github.com/hatukanezumi/Unicode-LineBreak.git'
-  git_hashtag 'Unicode-LineBreak-2019.001'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_gcstring_linebreak/2019.001-1_armv7l/perl_gcstring_linebreak-2019.001-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_gcstring_linebreak/2019.001-1_armv7l/perl_gcstring_linebreak-2019.001-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_gcstring_linebreak/2019.001-1_i686/perl_gcstring_linebreak-2019.001-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_gcstring_linebreak/2019.001-1_x86_64/perl_gcstring_linebreak-2019.001-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '376dfc3b39d861076e0ead658cc62ae07d5d753eaaf86bb70d440a537c3a4da4',
-     armv7l: '376dfc3b39d861076e0ead658cc62ae07d5d753eaaf86bb70d440a537c3a4da4',
-       i686: 'bedf57b7890ffb8ad84fce620bc07b28c1128901829a9453905ce8f64982a3eb',
-     x86_64: '2ccb5f0a0e9d96e02b13d1d4e16719b9df93d82354642f8f94feae76fa0cbd87'
-  })
-
-  def self.build
-    system 'perl', 'Makefile.PL'
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  is_fake
 end

--- a/packages/perl_io_socket_ssl.rb
+++ b/packages/perl_io_socket_ssl.rb
@@ -10,12 +10,16 @@ class Perl_io_socket_ssl < Package
   source_sha256 '36486b6be49da4d029819cf7069a7b41ed48af0c87e23be0f8e6aba23d08a832'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.074_i686/perl_io_socket_ssl-2.074-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.074_x86_64/perl_io_socket_ssl-2.074-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.074_armv7l/perl_io_socket_ssl-2.074-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.074_armv7l/perl_io_socket_ssl-2.074-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.074_i686/perl_io_socket_ssl-2.074-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.074_x86_64/perl_io_socket_ssl-2.074-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '7ff44795e5843c9dad03ffb6a033e1ab92c8cb302622092ad77a94b31e11680a',
-  x86_64: 'c5bb85cb8cf6a216f6ae8acdaf16f083c799eb2c528c3468d80644a99d3ef9af'
+    aarch64: '365cbbc9e9ca765e9d42666ac73b0405c7f1c4bfdd9d53c5b46cebc028489c47',
+     armv7l: '365cbbc9e9ca765e9d42666ac73b0405c7f1c4bfdd9d53c5b46cebc028489c47',
+       i686: '7ff44795e5843c9dad03ffb6a033e1ab92c8cb302622092ad77a94b31e11680a',
+     x86_64: 'c5bb85cb8cf6a216f6ae8acdaf16f083c799eb2c528c3468d80644a99d3ef9af'
   })
 
   depends_on 'perl_net_ssleay'

--- a/packages/perl_io_socket_ssl.rb
+++ b/packages/perl_io_socket_ssl.rb
@@ -9,6 +9,15 @@ class Perl_io_socket_ssl < Package
   source_url 'https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.074.tar.gz'
   source_sha256 '36486b6be49da4d029819cf7069a7b41ed48af0c87e23be0f8e6aba23d08a832'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.074_i686/perl_io_socket_ssl-2.074-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.074_x86_64/perl_io_socket_ssl-2.074-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '7ff44795e5843c9dad03ffb6a033e1ab92c8cb302622092ad77a94b31e11680a',
+  x86_64: 'c5bb85cb8cf6a216f6ae8acdaf16f083c799eb2c528c3468d80644a99d3ef9af'
+  })
+
   depends_on 'perl_net_ssleay'
   depends_on 'perl_mozilla_ca'
 

--- a/packages/perl_io_socket_ssl.rb
+++ b/packages/perl_io_socket_ssl.rb
@@ -3,34 +3,25 @@ require 'package'
 class Perl_io_socket_ssl < Package
   description 'IO::Socket::SSL - SSL sockets with IO::Socket interface'
   homepage 'https://metacpan.org/pod/IO::Socket::SSL'
-  version '2.071'
+  version '2.074'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.071.tar.gz'
-  source_sha256 '40da40948ecc9c787ed39c95715872679eebfd54243721174993a2003e32ab0a'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.071_armv7l/perl_io_socket_ssl-2.071-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.071_armv7l/perl_io_socket_ssl-2.071-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.071_i686/perl_io_socket_ssl-2.071-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_io_socket_ssl/2.071_x86_64/perl_io_socket_ssl-2.071-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '9fc1e546ec21478fb4ed274e0a06bcbf62b1cd255e55f27368548f925ced9a5a',
-     armv7l: '9fc1e546ec21478fb4ed274e0a06bcbf62b1cd255e55f27368548f925ced9a5a',
-       i686: 'a6d658776f94b42cf15d63e53c7a85ce11e7624842a16f6c077560d050db2a5b',
-     x86_64: 'edb13970364eda495488af15f78716f4959fa907645574667ef9dddf5e3281cf'
-  })
+  source_url 'https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.074.tar.gz'
+  source_sha256 '36486b6be49da4d029819cf7069a7b41ed48af0c87e23be0f8e6aba23d08a832'
 
   depends_on 'perl_net_ssleay'
   depends_on 'perl_mozilla_ca'
 
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
+
   def self.build
-    system "yes | perl Makefile.PL PREFIX=#{CREW_PREFIX} DESTDIR=#{CREW_DEST_DIR}"
     system 'make'
   end
 
   def self.install
-    system 'make', 'install'
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/perl_locale_gettext.rb
+++ b/packages/perl_locale_gettext.rb
@@ -9,6 +9,15 @@ class Perl_locale_gettext < Package
   source_url 'https://cpan.metacpan.org/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz'
   source_sha256 '909d47954697e7c04218f972915b787bd1244d75e3bd01620bc167d5bbc49c15'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-3_i686/perl_locale_gettext-1.07-3-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-3_x86_64/perl_locale_gettext-1.07-3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'fef52c8881d250360e06e2620acc4973fdd383ca0ec033d1c43d487368256c38',
+  x86_64: 'fed7d57b687fc8ec6b3705f85bed9fe510404f847207de4208e3886d3741e238'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_locale_gettext.rb
+++ b/packages/perl_locale_gettext.rb
@@ -14,8 +14,8 @@ class Perl_locale_gettext < Package
   x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-3_x86_64/perl_locale_gettext-1.07-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'fef52c8881d250360e06e2620acc4973fdd383ca0ec033d1c43d487368256c38',
-  x86_64: 'fed7d57b687fc8ec6b3705f85bed9fe510404f847207de4208e3886d3741e238'
+    i686: '741691fa07003c4a48271729f3132963347ce1fece484a3c7afbbdf181653fdd',
+  x86_64: '9ffa2023c67efa19ee4bce9f720b26e452a72110d675aeca7232a122338cea22'
   })
 
   def self.prebuild

--- a/packages/perl_locale_gettext.rb
+++ b/packages/perl_locale_gettext.rb
@@ -4,39 +4,21 @@ class Perl_locale_gettext < Package
   description 'Locale::gettext - message handling functions'
   homepage 'https://metacpan.org/pod/Locale::gettext'
   license 'GPL-1+ or Artistic'
-  version '1.07-2'
+  version '1.07-3'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz'
   source_sha256 '909d47954697e7c04218f972915b787bd1244d75e3bd01620bc167d5bbc49c15'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-2_armv7l/perl_locale_gettext-1.07-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-2_armv7l/perl_locale_gettext-1.07-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-2_i686/perl_locale_gettext-1.07-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-2_x86_64/perl_locale_gettext-1.07-2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '5ba4484084fe099eb2bb9c2db6ac7461fd9b951e41992bc4105cd68ae48094a8',
-     armv7l: '5ba4484084fe099eb2bb9c2db6ac7461fd9b951e41992bc4105cd68ae48094a8',
-       i686: 'de64c0415d97e2d0f5fd5cc6cee55f55f511d86528442c8b382eb7223214c13f',
-     x86_64: '9cf2b992dad51c31253e717dadc1ea3318efa56eb0261958e389d554bb6436b3'
-  })
-
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_locale_gettext.rb
+++ b/packages/perl_locale_gettext.rb
@@ -10,12 +10,16 @@ class Perl_locale_gettext < Package
   source_sha256 '909d47954697e7c04218f972915b787bd1244d75e3bd01620bc167d5bbc49c15'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-3_i686/perl_locale_gettext-1.07-3-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-3_x86_64/perl_locale_gettext-1.07-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-3_armv7l/perl_locale_gettext-1.07-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-3_armv7l/perl_locale_gettext-1.07-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-3_i686/perl_locale_gettext-1.07-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_gettext/1.07-3_x86_64/perl_locale_gettext-1.07-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '741691fa07003c4a48271729f3132963347ce1fece484a3c7afbbdf181653fdd',
-  x86_64: '9ffa2023c67efa19ee4bce9f720b26e452a72110d675aeca7232a122338cea22'
+    aarch64: '4a5989e5abe52832555940fdd822060668995e90214af56863615d0f91b6da1f',
+     armv7l: '4a5989e5abe52832555940fdd822060668995e90214af56863615d0f91b6da1f',
+       i686: '741691fa07003c4a48271729f3132963347ce1fece484a3c7afbbdf181653fdd',
+     x86_64: '9ffa2023c67efa19ee4bce9f720b26e452a72110d675aeca7232a122338cea22'
   })
 
   def self.prebuild

--- a/packages/perl_locale_messages.rb
+++ b/packages/perl_locale_messages.rb
@@ -9,6 +9,15 @@ class Perl_locale_messages < Package
   source_url 'https://cpan.metacpan.org/authors/id/G/GU/GUIDO/libintl-perl-1.32.tar.gz'
   source_sha256 '80108298f2564ecbfc7110a3042008e665ed00c2e155b36b0188e6c1135ceba5'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.32_i686/perl_locale_messages-1.32-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.32_x86_64/perl_locale_messages-1.32-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '05ca31eeda58be92c2510c96702c0e8d9d9ee39a2ee2452445ca5f27c721a482',
+  x86_64: '4708965e84aba6bf3c46f342261b5972c44f5a33bcaf0686c37fe0412324a6f3'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_locale_messages.rb
+++ b/packages/perl_locale_messages.rb
@@ -1,42 +1,24 @@
 require 'package'
 
 class Perl_locale_messages < Package
-  description 'Perl Locale::Messages - Gettext Like Message Retrieval.'
+  description 'Perl Locale::Messages - Gettext Like Message Retrieval'
   homepage 'https://metacpan.org/pod/Locale::Messages'
-  version '1.31-1'
+  version '1.32'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/G/GU/GUIDO/libintl-perl-1.31.tar.gz'
-  source_sha256 'cad0b1fd0abfa1340dea089ec45ee3dacd9710c9fd942c064bb8124273b3caa9'
+  source_url 'https://cpan.metacpan.org/authors/id/G/GU/GUIDO/libintl-perl-1.32.tar.gz'
+  source_sha256 '80108298f2564ecbfc7110a3042008e665ed00c2e155b36b0188e6c1135ceba5'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.31-1_armv7l/perl_locale_messages-1.31-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.31-1_armv7l/perl_locale_messages-1.31-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.31-1_i686/perl_locale_messages-1.31-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.31-1_x86_64/perl_locale_messages-1.31-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'fda26b093588628e08bf3f7b4cce646b70ffe7074fc00458af7ee02ddbcc44dd',
-     armv7l: 'fda26b093588628e08bf3f7b4cce646b70ffe7074fc00458af7ee02ddbcc44dd',
-       i686: 'df20e08e1dfa946e067eb00bff209397d3901d7cec5f115d805d67d3b67b0b9b',
-     x86_64: 'c4ff271866c9dab9e707a591157c0fafa7a3230294473a6ee77f17a95bc4b978'
-  })
-
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_locale_messages.rb
+++ b/packages/perl_locale_messages.rb
@@ -10,12 +10,16 @@ class Perl_locale_messages < Package
   source_sha256 '80108298f2564ecbfc7110a3042008e665ed00c2e155b36b0188e6c1135ceba5'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.32_i686/perl_locale_messages-1.32-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.32_x86_64/perl_locale_messages-1.32-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.32_armv7l/perl_locale_messages-1.32-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.32_armv7l/perl_locale_messages-1.32-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.32_i686/perl_locale_messages-1.32-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_locale_messages/1.32_x86_64/perl_locale_messages-1.32-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '05ca31eeda58be92c2510c96702c0e8d9d9ee39a2ee2452445ca5f27c721a482',
-  x86_64: '4708965e84aba6bf3c46f342261b5972c44f5a33bcaf0686c37fe0412324a6f3'
+    aarch64: '2d6426086396e891db101df18b9ac96acd4826946582386b49989054a61d3725',
+     armv7l: '2d6426086396e891db101df18b9ac96acd4826946582386b49989054a61d3725',
+       i686: '05ca31eeda58be92c2510c96702c0e8d9d9ee39a2ee2452445ca5f27c721a482',
+     x86_64: '4708965e84aba6bf3c46f342261b5972c44f5a33bcaf0686c37fe0412324a6f3'
   })
 
   def self.prebuild

--- a/packages/perl_module_build.rb
+++ b/packages/perl_module_build.rb
@@ -3,40 +3,22 @@ require 'package'
 class Perl_module_build < Package
   description 'Module::Build - Build and install Perl modules'
   homepage 'https://metacpan.org/pod/Module::Build'
-  version '0.4231-1'
+  version '0.4231-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-0.4231.tar.gz'
   source_sha256 '7e0f4c692c1740c1ac84ea14d7ea3d8bc798b2fb26c09877229e04f430b2b717'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-1_armv7l/perl_module_build-0.4231-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-1_armv7l/perl_module_build-0.4231-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-1_i686/perl_module_build-0.4231-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-1_x86_64/perl_module_build-0.4231-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '20d2dc51249d27c1f77b8a07b9b5a0f184e15581df486192f8b62bdda579669b',
-     armv7l: '20d2dc51249d27c1f77b8a07b9b5a0f184e15581df486192f8b62bdda579669b',
-       i686: '5dc94b6562c86fefa1501fc1ae895c3159a3b0449fbce685a892286d7715e11e',
-     x86_64: 'e3178127a60be8154cd3f2bf57611959651e8d050ddb8b8682320e045db82cfa'
-  })
-
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_module_build.rb
+++ b/packages/perl_module_build.rb
@@ -10,12 +10,16 @@ class Perl_module_build < Package
   source_sha256 '7e0f4c692c1740c1ac84ea14d7ea3d8bc798b2fb26c09877229e04f430b2b717'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-2_i686/perl_module_build-0.4231-2-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-2_x86_64/perl_module_build-0.4231-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-2_armv7l/perl_module_build-0.4231-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-2_armv7l/perl_module_build-0.4231-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-2_i686/perl_module_build-0.4231-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-2_x86_64/perl_module_build-0.4231-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '9060e0b4fc75e4285ad0f576c41c001538036af5f4d9f85778f2d77c73f5dc42',
-  x86_64: '5b0e542f3d7e05657ae7edf082cb6ed904310d211f997f7b2f976d0d97c0ae14'
+    aarch64: '1d18315cd8eaa350e3b7348b8396348cd31ff880b2d22c657b4fa06811874507',
+     armv7l: '1d18315cd8eaa350e3b7348b8396348cd31ff880b2d22c657b4fa06811874507',
+       i686: '9060e0b4fc75e4285ad0f576c41c001538036af5f4d9f85778f2d77c73f5dc42',
+     x86_64: '5b0e542f3d7e05657ae7edf082cb6ed904310d211f997f7b2f976d0d97c0ae14'
   })
 
   def self.prebuild

--- a/packages/perl_module_build.rb
+++ b/packages/perl_module_build.rb
@@ -9,6 +9,15 @@ class Perl_module_build < Package
   source_url 'https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-0.4231.tar.gz'
   source_sha256 '7e0f4c692c1740c1ac84ea14d7ea3d8bc798b2fb26c09877229e04f430b2b717'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-2_i686/perl_module_build-0.4231-2-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_module_build/0.4231-2_x86_64/perl_module_build-0.4231-2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '9060e0b4fc75e4285ad0f576c41c001538036af5f4d9f85778f2d77c73f5dc42',
+  x86_64: '5b0e542f3d7e05657ae7edf082cb6ed904310d211f997f7b2f976d0d97c0ae14'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_mozilla_ca.rb
+++ b/packages/perl_mozilla_ca.rb
@@ -10,12 +10,16 @@ class Perl_mozilla_ca < Package
   source_sha256 '122c8900000a9d388aa8e44f911cab6c118fe8497417917a84a8ec183971b449'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20211001_i686/perl_mozilla_ca-20211001-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20211001_x86_64/perl_mozilla_ca-20211001-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20211001_armv7l/perl_mozilla_ca-20211001-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20211001_armv7l/perl_mozilla_ca-20211001-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20211001_i686/perl_mozilla_ca-20211001-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20211001_x86_64/perl_mozilla_ca-20211001-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'b7b7376352fc4b2f6e7deebaced880eb5fcf986b1ee7b1678652de7c098edce3',
-  x86_64: '5bc064a7d5d2485fdc9837a70733d58e973dcb495b592435e05745f37ac9d441'
+    aarch64: '22f611b19be5a58ea4c13d60120e5da4357f0cc9c476c27e56bb8d150e790753',
+     armv7l: '22f611b19be5a58ea4c13d60120e5da4357f0cc9c476c27e56bb8d150e790753',
+       i686: 'b7b7376352fc4b2f6e7deebaced880eb5fcf986b1ee7b1678652de7c098edce3',
+     x86_64: '5bc064a7d5d2485fdc9837a70733d58e973dcb495b592435e05745f37ac9d441'
   })
 
   def self.prebuild

--- a/packages/perl_mozilla_ca.rb
+++ b/packages/perl_mozilla_ca.rb
@@ -1,33 +1,24 @@
 require 'package'
 
 class Perl_mozilla_ca < Package
-  description 'Mozilla CA cert bundle in PEM format'
-  homepage 'https://metacpan.org/release/Mozilla-CA'
-  version '20200520'
+  description "Mozilla::CA - Mozilla's CA cert bundle in PEM format"
+  homepage 'https://metacpan.org/pod/Mozilla::CA'
+  version '20211001'
   license 'GPL2'
   compatibility 'all'
-  source_url "https://search.cpan.org/CPAN/authors/id/A/AB/ABH/Mozilla-CA-#{version}.tar.gz"
+  source_url "https://cpan.metacpan.org/authors/id/A/AB/ABH/Mozilla-CA-20211001.tar.gz"
   source_sha256 'b3ca0002310bf24a16c0d5920bdea97a2f46e77e7be3e7377e850d033387c726'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20200520_armv7l/perl_mozilla_ca-20200520-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20200520_armv7l/perl_mozilla_ca-20200520-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20200520_i686/perl_mozilla_ca-20200520-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20200520_x86_64/perl_mozilla_ca-20200520-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: 'dc31de4d9867145e4bbab0e568fe879203bd7c07fbab47691c3ff8e9231fbe6a',
-     armv7l: 'dc31de4d9867145e4bbab0e568fe879203bd7c07fbab47691c3ff8e9231fbe6a',
-       i686: '3a324c5509d571aadb9e17b4ed2c63ba58034149379cbdbb475ab8a286b25637',
-     x86_64: '1a34e9effb91e7814ca05fed4622461ea9af1c6917a6dc82dc0d407deeca2e9a'
-  })
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
 
   def self.build
-    system "yes | perl Makefile.PL PREFIX=#{CREW_PREFIX} DESTDIR=#{CREW_DEST_DIR}"
     system 'make'
   end
 
   def self.install
-    system 'make', 'install'
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/perl_mozilla_ca.rb
+++ b/packages/perl_mozilla_ca.rb
@@ -7,7 +7,7 @@ class Perl_mozilla_ca < Package
   license 'GPL2'
   compatibility 'all'
   source_url "https://cpan.metacpan.org/authors/id/A/AB/ABH/Mozilla-CA-20211001.tar.gz"
-  source_sha256 'b3ca0002310bf24a16c0d5920bdea97a2f46e77e7be3e7377e850d033387c726'
+  source_sha256 '122c8900000a9d388aa8e44f911cab6c118fe8497417917a84a8ec183971b449'
 
   def self.prebuild
     system 'perl', 'Makefile.PL'

--- a/packages/perl_mozilla_ca.rb
+++ b/packages/perl_mozilla_ca.rb
@@ -6,8 +6,17 @@ class Perl_mozilla_ca < Package
   version '20211001'
   license 'GPL2'
   compatibility 'all'
-  source_url "https://cpan.metacpan.org/authors/id/A/AB/ABH/Mozilla-CA-20211001.tar.gz"
+  source_url 'https://cpan.metacpan.org/authors/id/A/AB/ABH/Mozilla-CA-20211001.tar.gz'
   source_sha256 '122c8900000a9d388aa8e44f911cab6c118fe8497417917a84a8ec183971b449'
+
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20211001_i686/perl_mozilla_ca-20211001-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_mozilla_ca/20211001_x86_64/perl_mozilla_ca-20211001-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'b7b7376352fc4b2f6e7deebaced880eb5fcf986b1ee7b1678652de7c098edce3',
+  x86_64: '5bc064a7d5d2485fdc9837a70733d58e973dcb495b592435e05745f37ac9d441'
+  })
 
   def self.prebuild
     system 'perl', 'Makefile.PL'

--- a/packages/perl_net_ssleay.rb
+++ b/packages/perl_net_ssleay.rb
@@ -6,8 +6,17 @@ class Perl_net_ssleay < Package
   version '1.92'
   license 'BSD'
   compatibility 'all'
-  source_url "https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.92.tar.gz"
+  source_url 'https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.92.tar.gz'
   source_sha256 '47c2f2b300f2e7162d71d699f633dd6a35b0625a00cbda8c50ac01144a9396a9'
+
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.92_i686/perl_net_ssleay-1.92-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.92_x86_64/perl_net_ssleay-1.92-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'a2d76b5d37e390359a50c5f8b61dfabd9e0860b7766f27ed8e4caa8d575e88d1',
+  x86_64: 'bcd0aa317e6c2f0edffec3e46cb8e5722280ed0ebc2d6d4eb382f66ea627ea7b'
+  })
 
   def self.prebuild
     system 'perl', 'Makefile.PL'

--- a/packages/perl_net_ssleay.rb
+++ b/packages/perl_net_ssleay.rb
@@ -1,33 +1,24 @@
 require 'package'
 
 class Perl_net_ssleay < Package
-  description 'Perl extension for using OpenSSL'
-  homepage 'https://search.cpan.org/dist/Net-SSLeay/'
-  version '1.90'
+  description 'Net::SSLeay - Perl bindings for OpenSSL and LibreSSL'
+  homepage 'https://metacpan.org/pod/Net::SSLeay'
+  version '1.92'
   license 'BSD'
   compatibility 'all'
-  source_url "https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-#{version}.tar.gz"
-  source_sha256 'f8696cfaca98234679efeedc288a9398fcf77176f1f515dbc589ada7c650dc93'
+  source_url "https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.92.tar.gz"
+  source_sha256 '47c2f2b300f2e7162d71d699f633dd6a35b0625a00cbda8c50ac01144a9396a9'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.90_armv7l/perl_net_ssleay-1.90-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.90_armv7l/perl_net_ssleay-1.90-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.90_i686/perl_net_ssleay-1.90-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.90_x86_64/perl_net_ssleay-1.90-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '4ed9c05974afa9edf1006c363e3f7a58607b3bff2714013feacad40a6b071f1c',
-     armv7l: '4ed9c05974afa9edf1006c363e3f7a58607b3bff2714013feacad40a6b071f1c',
-       i686: '2418b10e45d07d03c76615eeaa7a4d247de4252f64672d5243e0e43cc053bfcf',
-     x86_64: '65271f786fbf6480fea9b9e95e05d15227add6cb418e1dae9ba97bfe7e35424e'
-  })
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
 
   def self.build
-    system "yes | perl Makefile.PL PREFIX=#{CREW_PREFIX} DESTDIR=#{CREW_DEST_DIR}"
     system 'make'
   end
 
   def self.install
-    system 'make', 'install'
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/perl_net_ssleay.rb
+++ b/packages/perl_net_ssleay.rb
@@ -10,12 +10,16 @@ class Perl_net_ssleay < Package
   source_sha256 '47c2f2b300f2e7162d71d699f633dd6a35b0625a00cbda8c50ac01144a9396a9'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.92_i686/perl_net_ssleay-1.92-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.92_x86_64/perl_net_ssleay-1.92-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.92_armv7l/perl_net_ssleay-1.92-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.92_armv7l/perl_net_ssleay-1.92-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.92_i686/perl_net_ssleay-1.92-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_net_ssleay/1.92_x86_64/perl_net_ssleay-1.92-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'a2d76b5d37e390359a50c5f8b61dfabd9e0860b7766f27ed8e4caa8d575e88d1',
-  x86_64: 'bcd0aa317e6c2f0edffec3e46cb8e5722280ed0ebc2d6d4eb382f66ea627ea7b'
+    aarch64: '6e1556a75adbb106daa2c4378c238caefb783c0639868b8ebc66d32f1650e6eb',
+     armv7l: '6e1556a75adbb106daa2c4378c238caefb783c0639868b8ebc66d32f1650e6eb',
+       i686: 'a2d76b5d37e390359a50c5f8b61dfabd9e0860b7766f27ed8e4caa8d575e88d1',
+     x86_64: 'bcd0aa317e6c2f0edffec3e46cb8e5722280ed0ebc2d6d4eb382f66ea627ea7b'
   })
 
   def self.prebuild

--- a/packages/perl_parse_yapp.rb
+++ b/packages/perl_parse_yapp.rb
@@ -1,47 +1,24 @@
-# Adapted from Arch Linux perl-parse-yapp PKGBUILD at:
-# https://github.com/archlinux/svntogit-community/raw/packages/perl-parse-yapp/trunk/PKGBUILD
-
 require 'package'
 
 class Perl_parse_yapp < Package
-  description 'Yapp : Generates OO LALR parser modules'
-  homepage 'https://search.cpan.org/dist/Parse-Yapp'
-  version '1.22'
+  description 'Parse::Yapp - Perl extension for generating and using LALR parsers.'
+  homepage 'https://metacpan.org/pod/Parse::Yapp'
+  version '1.21-1'
   license 'GPL'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz'
   source_sha256 '3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.22_armv7l/perl_parse_yapp-1.22-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.22_armv7l/perl_parse_yapp-1.22-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.22_i686/perl_parse_yapp-1.22-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.22_x86_64/perl_parse_yapp-1.22-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'cdc7fdd872f79b166421a6fcdcf02d15ef8b5612da90f4d5c6e87c127ad9436d',
-     armv7l: 'cdc7fdd872f79b166421a6fcdcf02d15ef8b5612da90f4d5c6e87c127ad9436d',
-       i686: 'f44f9ab5cb9b8a71d4ef86e0b2f0e503bdbab015a9ccae86e0a9c34dd30af5bb',
-     x86_64: 'bff95a47e92184654a9b1a2caac5b921b92d19c26bc4160a1306b91b5bde1e8c'
-  })
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '--force', '.'
-
-    # install bin
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.cp 'build/bin/yapp', "#{CREW_DEST_PREFIX}/bin/"
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_parse_yapp.rb
+++ b/packages/perl_parse_yapp.rb
@@ -9,6 +9,15 @@ class Perl_parse_yapp < Package
   source_url 'https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz'
   source_sha256 '3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.21-1_i686/perl_parse_yapp-1.21-1-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.21-1_x86_64/perl_parse_yapp-1.21-1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '236dd0236351c72cbf0ff69d87769d8aa7c9e34c371408b073724e31541bd94c',
+  x86_64: '80e5532ac054c4617f2c5d036d5751ac26d2c8ef3213d55d3a2cbe119495b6af'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_parse_yapp.rb
+++ b/packages/perl_parse_yapp.rb
@@ -10,12 +10,16 @@ class Perl_parse_yapp < Package
   source_sha256 '3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.21-1_i686/perl_parse_yapp-1.21-1-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.21-1_x86_64/perl_parse_yapp-1.21-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.21-1_armv7l/perl_parse_yapp-1.21-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.21-1_armv7l/perl_parse_yapp-1.21-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.21-1_i686/perl_parse_yapp-1.21-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_parse_yapp/1.21-1_x86_64/perl_parse_yapp-1.21-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '236dd0236351c72cbf0ff69d87769d8aa7c9e34c371408b073724e31541bd94c',
-  x86_64: '80e5532ac054c4617f2c5d036d5751ac26d2c8ef3213d55d3a2cbe119495b6af'
+    aarch64: '5dda591925731219ea3047d0f323a26838ba93db258044dffded63895670ef6a',
+     armv7l: '5dda591925731219ea3047d0f323a26838ba93db258044dffded63895670ef6a',
+       i686: '236dd0236351c72cbf0ff69d87769d8aa7c9e34c371408b073724e31541bd94c',
+     x86_64: '80e5532ac054c4617f2c5d036d5751ac26d2c8ef3213d55d3a2cbe119495b6af'
   })
 
   def self.prebuild

--- a/packages/perl_pod_parser.rb
+++ b/packages/perl_pod_parser.rb
@@ -10,12 +10,16 @@ class Perl_pod_parser < Package
   source_sha256 'dbe0b56129975b2f83a02841e8e0ed47be80f060686c66ea37e529d97aa70ccd'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-2_i686/perl_pod_parser-1.63-2-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-2_x86_64/perl_pod_parser-1.63-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-2_armv7l/perl_pod_parser-1.63-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-2_armv7l/perl_pod_parser-1.63-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-2_i686/perl_pod_parser-1.63-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-2_x86_64/perl_pod_parser-1.63-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '887a43228afe65ff3fadfd6187d82dacd325e2bcd18647ccde28cf93c345ee47',
-  x86_64: '50447fab41d9e1c1d18e6ff73fe111c5b340ef49ac5414940d2ad2c998bef6bd'
+    aarch64: '97cd18fd9d32ee8b9d524e06d9735c21cf8c4a49ba312f035615f6d921649c98',
+     armv7l: '97cd18fd9d32ee8b9d524e06d9735c21cf8c4a49ba312f035615f6d921649c98',
+       i686: '887a43228afe65ff3fadfd6187d82dacd325e2bcd18647ccde28cf93c345ee47',
+     x86_64: '50447fab41d9e1c1d18e6ff73fe111c5b340ef49ac5414940d2ad2c998bef6bd'
   })
 
   def self.prebuild

--- a/packages/perl_pod_parser.rb
+++ b/packages/perl_pod_parser.rb
@@ -9,6 +9,15 @@ class Perl_pod_parser < Package
   source_url 'https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Parser-1.63.tar.gz'
   source_sha256 'dbe0b56129975b2f83a02841e8e0ed47be80f060686c66ea37e529d97aa70ccd'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-2_i686/perl_pod_parser-1.63-2-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-2_x86_64/perl_pod_parser-1.63-2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '887a43228afe65ff3fadfd6187d82dacd325e2bcd18647ccde28cf93c345ee47',
+  x86_64: '50447fab41d9e1c1d18e6ff73fe111c5b340ef49ac5414940d2ad2c998bef6bd'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_pod_parser.rb
+++ b/packages/perl_pod_parser.rb
@@ -3,40 +3,22 @@ require 'package'
 class Perl_pod_parser < Package
   description 'Perl Pod::Parser - base class for creating POD filters and translators'
   homepage 'https://metacpan.org/pod/Pod::Parser'
-  version '1.63-1'
+  version '1.63-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Parser-1.63.tar.gz'
   source_sha256 'dbe0b56129975b2f83a02841e8e0ed47be80f060686c66ea37e529d97aa70ccd'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-1_armv7l/perl_pod_parser-1.63-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-1_armv7l/perl_pod_parser-1.63-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-1_i686/perl_pod_parser-1.63-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_pod_parser/1.63-1_x86_64/perl_pod_parser-1.63-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '8ba74165129311c52ccf8add610eda8aba4ef5e7b24e4a7ed365fbe825837710',
-     armv7l: '8ba74165129311c52ccf8add610eda8aba4ef5e7b24e4a7ed365fbe825837710',
-       i686: 'a0ae78e4d2aafd3ef90d2b23fdf5bd5f43da4638b17183ac9e1cf7914e349625',
-     x86_64: '75ee5ada7995eb9c7bc6c5199069c944107fe555cd1ef2a9df67ac60b5269908'
-  })
-
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '--force', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_read_key.rb
+++ b/packages/perl_read_key.rb
@@ -1,33 +1,14 @@
 require 'package'
 
 class Perl_read_key < Package
-  description 'Character mode terminal access for Perl Term::ReadKey'
-  homepage 'https://metacpan.org/source/JSTOWE/TermReadKey-2.37/'
-  version '2.38-1'
+  description 'Term::ReadKey - A perl module for simple terminal control'
+  homepage 'https://metacpan.org/pod/Term::ReadKey'
+  version '2.38-3'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://github.com/jonathanstowe/TermReadKey/archive/2.38.tar.gz'
-  source_sha256 'bb669c422d7094e19fa85d43676b67933b86d4a1f6b39fed5dbfaaaa97716c1d'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_read_key/2.38-1_armv7l/perl_read_key-2.38-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_read_key/2.38-1_armv7l/perl_read_key-2.38-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_read_key/2.38-1_i686/perl_read_key-2.38-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_read_key/2.38-1_x86_64/perl_read_key-2.38-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '76f4f39f14ad060edeca2bcf605985be09aa03296dcf3b4883bdebfa6984c2e6',
-     armv7l: '76f4f39f14ad060edeca2bcf605985be09aa03296dcf3b4883bdebfa6984c2e6',
-       i686: '896d0bcd908ab549c756b065b9edb0f4c6fe1977dd2719c63929f4756d49a543',
-     x86_64: 'a7694ccb4d399c07c92027268d5548223ad54c1234ae2a9248d8eaa9e73851b6'
-  })
+  is_fake
 
-  def self.build
-    system 'perl', 'Makefile.PL'
-    system 'make'
-  end
+  depends_on 'perl_term_readkey'
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
 end

--- a/packages/perl_sgmls.rb
+++ b/packages/perl_sgmls.rb
@@ -1,44 +1,26 @@
 require 'package'
 
 class Perl_sgmls < Package
-  description 'a set of Perl5 routines for processing the output from the onsgmls SGML parsers.'
-  homepage 'http://search.cpan.org/dist/SGMLSpm/'
-  version '1.1-2'
+  description 'SGMLS - class for postprocessing the output from the sgmls and nsgmls parsers.'
+  homepage 'https://search.cpan.org/dist/SGMLSpm/'
+  version '1.1-3'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/R/RA/RAAB/SGMLSpm-1.1.tar.gz'
   source_sha256 '550c9245291c8df2242f7e88f7921a0f636c7eec92c644418e7d89cfea70b2bd'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-2_armv7l/perl_sgmls-1.1-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-2_armv7l/perl_sgmls-1.1-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-2_i686/perl_sgmls-1.1-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-2_x86_64/perl_sgmls-1.1-2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'bd2e6e4160a9ba8357f88c438641eb2d9147c0346467a046a0434a41ee391d7b',
-     armv7l: 'bd2e6e4160a9ba8357f88c438641eb2d9147c0346467a046a0434a41ee391d7b',
-       i686: 'c5d9783e0d0394548a6fbf6ee2f34e14dd3c5c4cd696f6b9ae36e1af268077d7',
-     x86_64: 'a11acbe5d5f8ccb9da8eb99144e199253b71d8798f886bb8c1652a2a359b64ad'
-  })
-
   depends_on 'perl_module_build'
 
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '.' # remove '--self-contained' here, since it will build module_build again.
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_sgmls.rb
+++ b/packages/perl_sgmls.rb
@@ -10,12 +10,16 @@ class Perl_sgmls < Package
   source_sha256 '550c9245291c8df2242f7e88f7921a0f636c7eec92c644418e7d89cfea70b2bd'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-3_i686/perl_sgmls-1.1-3-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-3_x86_64/perl_sgmls-1.1-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-3_armv7l/perl_sgmls-1.1-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-3_armv7l/perl_sgmls-1.1-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-3_i686/perl_sgmls-1.1-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-3_x86_64/perl_sgmls-1.1-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'df471c87b091c534624f113108e315af9e3ae96aee3d4d5d60f8f85b14aafdec',
-  x86_64: '415e030d98d8af9d7afbafc97027e107fb1f3489a44c8615697694379cc79adf'
+    aarch64: '623f608b766f6defa64f3aa67ccc94d7ac3ad56be8a62c6d0bfaf5aa2958a501',
+     armv7l: '623f608b766f6defa64f3aa67ccc94d7ac3ad56be8a62c6d0bfaf5aa2958a501',
+       i686: 'df471c87b091c534624f113108e315af9e3ae96aee3d4d5d60f8f85b14aafdec',
+     x86_64: '415e030d98d8af9d7afbafc97027e107fb1f3489a44c8615697694379cc79adf'
   })
 
   depends_on 'perl_module_build'

--- a/packages/perl_sgmls.rb
+++ b/packages/perl_sgmls.rb
@@ -11,6 +11,11 @@ class Perl_sgmls < Package
 
   depends_on 'perl_module_build'
 
+  def self.patch
+    # For some reason this file doesn't have the proper permissions in the tarball
+    system 'chmod 0644 MYMETA.yml'
+  end
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_sgmls.rb
+++ b/packages/perl_sgmls.rb
@@ -9,6 +9,15 @@ class Perl_sgmls < Package
   source_url 'https://cpan.metacpan.org/authors/id/R/RA/RAAB/SGMLSpm-1.1.tar.gz'
   source_sha256 '550c9245291c8df2242f7e88f7921a0f636c7eec92c644418e7d89cfea70b2bd'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-3_i686/perl_sgmls-1.1-3-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_sgmls/1.1-3_x86_64/perl_sgmls-1.1-3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'df471c87b091c534624f113108e315af9e3ae96aee3d4d5d60f8f85b14aafdec',
+  x86_64: '415e030d98d8af9d7afbafc97027e107fb1f3489a44c8615697694379cc79adf'
+  })
+
   depends_on 'perl_module_build'
 
   def self.patch

--- a/packages/perl_stow.rb
+++ b/packages/perl_stow.rb
@@ -9,27 +9,12 @@ class Perl_stow < Package
   source_url 'https://ftpmirror.gnu.org/stow/stow-2.3.1.tar.gz'
   source_sha256 '09d5d99671b78537fd9b2c0b39a5e9761a7a0e979f6fdb7eabfa58ee45f03d4b'
 
-  def self.prebuild
-    system 'cpan App::cpanminus'
-  end
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_armv7l/perl_stow-2.3.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_armv7l/perl_stow-2.3.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_i686/perl_stow-2.3.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_x86_64/perl_stow-2.3.1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '503b01aab3beaf36bd629ab7b8aee2d98e29b780bbc20becdb2e1d0cacdfe150',
-     armv7l: '503b01aab3beaf36bd629ab7b8aee2d98e29b780bbc20becdb2e1d0cacdfe150',
-       i686: '5a38f30a09b1815beda68dd24ae3ea298183eb40b23b6c455cc990314159d17f',
-     x86_64: 'bd129677fb5214d53531b7fde7afd8bc22160e04d55fd05b3c9c1dc8b0c21867'
-  })
+  depends_on 'perl_app_cpanminus' => :build
+  depends_on 'perl_test_output' => :build
 
   def self.build
-    system 'cpanm Test::Output'
     system "./configure #{CREW_OPTIONS} \
-      --with-pmdir=$(PERL5LIB= perl -le 'print $INC[0]')"
+      --with-pmdir=#{CREW_PREFIX}/share/perl5/vendor_perl"
     system 'make'
   end
 

--- a/packages/perl_stow.rb
+++ b/packages/perl_stow.rb
@@ -10,12 +10,16 @@ class Perl_stow < Package
   source_sha256 '09d5d99671b78537fd9b2c0b39a5e9761a7a0e979f6fdb7eabfa58ee45f03d4b'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_i686/perl_stow-2.3.1-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_x86_64/perl_stow-2.3.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_armv7l/perl_stow-2.3.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_armv7l/perl_stow-2.3.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_i686/perl_stow-2.3.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_x86_64/perl_stow-2.3.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'ece16431913257aef01c0b4b95a8872f9c215099bac4f2975648974d836d333c',
-  x86_64: 'eb73e9e9a2084abb31fc08e9b4ff80e145fc94ee7f3e2a034d74af18c721c16f'
+    aarch64: 'c72e956c2871eb63497a181baaafa6e83d9e1778179b23d990c48a9fc0299a5e',
+     armv7l: 'c72e956c2871eb63497a181baaafa6e83d9e1778179b23d990c48a9fc0299a5e',
+       i686: 'ece16431913257aef01c0b4b95a8872f9c215099bac4f2975648974d836d333c',
+     x86_64: 'eb73e9e9a2084abb31fc08e9b4ff80e145fc94ee7f3e2a034d74af18c721c16f'
   })
 
   depends_on 'perl_app_cpanminus' => :build

--- a/packages/perl_stow.rb
+++ b/packages/perl_stow.rb
@@ -9,6 +9,15 @@ class Perl_stow < Package
   source_url 'https://ftpmirror.gnu.org/stow/stow-2.3.1.tar.gz'
   source_sha256 '09d5d99671b78537fd9b2c0b39a5e9761a7a0e979f6fdb7eabfa58ee45f03d4b'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_i686/perl_stow-2.3.1-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_stow/2.3.1_x86_64/perl_stow-2.3.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'ece16431913257aef01c0b4b95a8872f9c215099bac4f2975648974d836d333c',
+  x86_64: 'eb73e9e9a2084abb31fc08e9b4ff80e145fc94ee7f3e2a034d74af18c721c16f'
+  })
+
   depends_on 'perl_app_cpanminus' => :build
 
   def self.build

--- a/packages/perl_stow.rb
+++ b/packages/perl_stow.rb
@@ -10,7 +10,6 @@ class Perl_stow < Package
   source_sha256 '09d5d99671b78537fd9b2c0b39a5e9761a7a0e979f6fdb7eabfa58ee45f03d4b'
 
   depends_on 'perl_app_cpanminus' => :build
-  depends_on 'perl_test_output' => :build
 
   def self.build
     system "./configure #{CREW_OPTIONS} \

--- a/packages/perl_term_ansicolor.rb
+++ b/packages/perl_term_ansicolor.rb
@@ -2,28 +2,19 @@ require 'package'
 
 class Perl_term_ansicolor < Package
   description 'Character mode terminal access for Perl Term::ANSIColor'
-  homepage 'https://www.eyrie.org/~eagle/software/ansicolor/'
-  version '5.01-1'
+  homepage 'https://metacpan.org/pod/Term::ANSIColor'
+  version '5.01-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://github.com/rra/ansicolor/archive/release/5.01.tar.gz'
-  source_sha256 'c4865a9fe2ce3a46fd4f11215dcba05a9d5603e797a2623abc19cc14b4a0609a'
+  source_url 'https://cpan.metacpan.org/authors/id/R/RR/RRA/Term-ANSIColor-5.01.tar.gz'
+  source_sha256 '6281bd87cced7a885c38aa104498e3cd4b5f4c276087442cf68c67379318f27d'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_ansicolor/5.01-1_armv7l/perl_term_ansicolor-5.01-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_ansicolor/5.01-1_armv7l/perl_term_ansicolor-5.01-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_ansicolor/5.01-1_i686/perl_term_ansicolor-5.01-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_ansicolor/5.01-1_x86_64/perl_term_ansicolor-5.01-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '3007f881b95506691c56c97be273587e1155dd520ffcf680624628de15cf3abf',
-     armv7l: '3007f881b95506691c56c97be273587e1155dd520ffcf680624628de15cf3abf',
-       i686: 'ea4224102ff52f47853d1bafdd80a77eb49680f86138f7733dcf9ae918e7e677',
-     x86_64: '736e5f517bcefe676c75ebe6f251972119b6593b7be2acc6dc7504f1edc819ef'
-  })
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
 
   def self.build
-    system 'perl', 'Makefile.PL'
     system 'make'
   end
 

--- a/packages/perl_term_ansicolor.rb
+++ b/packages/perl_term_ansicolor.rb
@@ -6,19 +6,7 @@ class Perl_term_ansicolor < Package
   version '5.01-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/R/RR/RRA/Term-ANSIColor-5.01.tar.gz'
-  source_sha256 '6281bd87cced7a885c38aa104498e3cd4b5f4c276087442cf68c67379318f27d'
 
-  def self.prebuild
-    system 'perl', 'Makefile.PL'
-    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
-  end
-
-  def self.build
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  # included in main perl package
+  is_fake
 end

--- a/packages/perl_term_readkey.rb
+++ b/packages/perl_term_readkey.rb
@@ -9,6 +9,15 @@ class Perl_term_readkey < Package
   source_url 'https://cpan.metacpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz'
   source_sha256 '5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-2_i686/perl_term_readkey-2.38-2-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-2_x86_64/perl_term_readkey-2.38-2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'bc2946c9827d4d986c2fddb906545e2a100540b2548652ba701179ed7052f3ec',
+  x86_64: '7aa01f6ee9583f44efdf9fa3ffb9b9defbac3e52082f97d72acc1fc2bb7bd6a9'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_term_readkey.rb
+++ b/packages/perl_term_readkey.rb
@@ -3,38 +3,22 @@ require 'package'
 class Perl_term_readkey < Package
   description 'Term::ReadKey - A perl module for simple terminal control'
   homepage 'https://metacpan.org/pod/Term::ReadKey'
-  version '2.38-1'
+  version '2.38-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz'
   source_sha256 '5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-1_armv7l/perl_term_readkey-2.38-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-1_armv7l/perl_term_readkey-2.38-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-1_i686/perl_term_readkey-2.38-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-1_x86_64/perl_term_readkey-2.38-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '9cf3b95873bdfc2ba4e05c01afb25fec814f38d8601e766cbee82c86a7c46618',
-     armv7l: '9cf3b95873bdfc2ba4e05c01afb25fec814f38d8601e766cbee82c86a7c46618',
-       i686: '8e312e6fa55096ff34a84852c6056860ce377e8d5ddb2bbad68db29e08a4cc30',
-     x86_64: '85630e55516ebd09fb3b7f7c5a089062952a7352a7136579ef7e30ba8b4c373a'
-  })
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '--force', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_term_readkey.rb
+++ b/packages/perl_term_readkey.rb
@@ -10,12 +10,16 @@ class Perl_term_readkey < Package
   source_sha256 '5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-2_i686/perl_term_readkey-2.38-2-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-2_x86_64/perl_term_readkey-2.38-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-2_armv7l/perl_term_readkey-2.38-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-2_armv7l/perl_term_readkey-2.38-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-2_i686/perl_term_readkey-2.38-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_term_readkey/2.38-2_x86_64/perl_term_readkey-2.38-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'bc2946c9827d4d986c2fddb906545e2a100540b2548652ba701179ed7052f3ec',
-  x86_64: '7aa01f6ee9583f44efdf9fa3ffb9b9defbac3e52082f97d72acc1fc2bb7bd6a9'
+    aarch64: '41103c448aa3ea3f160fe01189a398a5fd4459d8543caec8ab29a0a01fa444e1',
+     armv7l: '41103c448aa3ea3f160fe01189a398a5fd4459d8543caec8ab29a0a01fa444e1',
+       i686: 'bc2946c9827d4d986c2fddb906545e2a100540b2548652ba701179ed7052f3ec',
+     x86_64: '7aa01f6ee9583f44efdf9fa3ffb9b9defbac3e52082f97d72acc1fc2bb7bd6a9'
   })
 
   def self.prebuild

--- a/packages/perl_test_output.rb
+++ b/packages/perl_test_output.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Perl_yaml_tiny < Package
+class Perl_test_output < Package
   description 'Test::Output - Utilities to test STDOUT and STDERR messages.'
   homepage 'https://metacpan.org/pod/Test::Output'
   version '1.033'

--- a/packages/perl_test_output.rb
+++ b/packages/perl_test_output.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Perl_yaml_tiny < Package
+  description 'Test::Output - Utilities to test STDOUT and STDERR messages.'
+  homepage 'https://metacpan.org/pod/Test::Output'
+  version '1.033'
+  license 'GPL-1+ or Artistic'
+  compatibility 'all'
+  source_url 'https://cpan.metacpan.org/authors/id/B/BD/BDFOY/Test-Output-1.033.tar.gz'
+  source_sha256 'f6a8482740b075fad22aaf4d987d38ef927c6d2b452d4ae0d0bd8f779830556e'
+
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/perl_test_output.rb
+++ b/packages/perl_test_output.rb
@@ -9,6 +9,15 @@ class Perl_test_output < Package
   source_url 'https://cpan.metacpan.org/authors/id/B/BD/BDFOY/Test-Output-1.033.tar.gz'
   source_sha256 'f6a8482740b075fad22aaf4d987d38ef927c6d2b452d4ae0d0bd8f779830556e'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_test_output/1.033_i686/perl_test_output-1.033-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_test_output/1.033_x86_64/perl_test_output-1.033-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '3555ac1e4fd68659ba84588fa24f47f76b79501fc7d292181f62460b82eba1ac',
+  x86_64: 'a98fdc62483cce143ef99ed7f35f6241577580e54448b382a3eb71e6fe42eb3d'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_test_output.rb
+++ b/packages/perl_test_output.rb
@@ -10,12 +10,16 @@ class Perl_test_output < Package
   source_sha256 'f6a8482740b075fad22aaf4d987d38ef927c6d2b452d4ae0d0bd8f779830556e'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_test_output/1.033_i686/perl_test_output-1.033-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_test_output/1.033_x86_64/perl_test_output-1.033-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_test_output/1.033_armv7l/perl_test_output-1.033-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_test_output/1.033_armv7l/perl_test_output-1.033-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_test_output/1.033_i686/perl_test_output-1.033-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_test_output/1.033_x86_64/perl_test_output-1.033-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '3555ac1e4fd68659ba84588fa24f47f76b79501fc7d292181f62460b82eba1ac',
-  x86_64: 'a98fdc62483cce143ef99ed7f35f6241577580e54448b382a3eb71e6fe42eb3d'
+    aarch64: 'c599b532a22d1d4e4d634d114f20fa5cb002751e5e135acce91ceeea29aa6849',
+     armv7l: 'c599b532a22d1d4e4d634d114f20fa5cb002751e5e135acce91ceeea29aa6849',
+       i686: '3555ac1e4fd68659ba84588fa24f47f76b79501fc7d292181f62460b82eba1ac',
+     x86_64: 'a98fdc62483cce143ef99ed7f35f6241577580e54448b382a3eb71e6fe42eb3d'
   })
 
   def self.prebuild

--- a/packages/perl_text_charwidth.rb
+++ b/packages/perl_text_charwidth.rb
@@ -9,6 +9,15 @@ class Perl_text_charwidth < Package
   source_url 'https://cpan.metacpan.org/authors/id/K/KU/KUBOTA/Text-CharWidth-0.04.tar.gz'
   source_sha256 'abded5f4fdd9338e89fd2f1d8271c44989dae5bf50aece41b6179d8e230704f8'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-3_i686/perl_text_charwidth-0.04-3-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-3_x86_64/perl_text_charwidth-0.04-3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'd1338224a059f68a880d875cf9bd3e4e0063ca387295bf64d610ca0297aa347d',
+  x86_64: '835d7b09829d483ed99d39d56986363c43ee7cd2966b69eaa0819592d8f91785'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_text_charwidth.rb
+++ b/packages/perl_text_charwidth.rb
@@ -10,12 +10,16 @@ class Perl_text_charwidth < Package
   source_sha256 'abded5f4fdd9338e89fd2f1d8271c44989dae5bf50aece41b6179d8e230704f8'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-3_i686/perl_text_charwidth-0.04-3-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-3_x86_64/perl_text_charwidth-0.04-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-3_armv7l/perl_text_charwidth-0.04-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-3_armv7l/perl_text_charwidth-0.04-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-3_i686/perl_text_charwidth-0.04-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-3_x86_64/perl_text_charwidth-0.04-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'd1338224a059f68a880d875cf9bd3e4e0063ca387295bf64d610ca0297aa347d',
-  x86_64: '835d7b09829d483ed99d39d56986363c43ee7cd2966b69eaa0819592d8f91785'
+    aarch64: '5cdc12e2f3e5364befe19ed143aad3dae7f1f0402e0a5cd88e679b54dd586858',
+     armv7l: '5cdc12e2f3e5364befe19ed143aad3dae7f1f0402e0a5cd88e679b54dd586858',
+       i686: 'd1338224a059f68a880d875cf9bd3e4e0063ca387295bf64d610ca0297aa347d',
+     x86_64: '835d7b09829d483ed99d39d56986363c43ee7cd2966b69eaa0819592d8f91785'
   })
 
   def self.prebuild

--- a/packages/perl_text_charwidth.rb
+++ b/packages/perl_text_charwidth.rb
@@ -3,40 +3,22 @@ require 'package'
 class Perl_text_charwidth < Package
   description 'Text::CharWidth - Get number of occupied columns of a string on terminals'
   homepage 'https://metacpan.org/pod/Text::CharWidth'
-  version '0.04-2'
+  version '0.04-3'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/K/KU/KUBOTA/Text-CharWidth-0.04.tar.gz'
   source_sha256 'abded5f4fdd9338e89fd2f1d8271c44989dae5bf50aece41b6179d8e230704f8'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-2_armv7l/perl_text_charwidth-0.04-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-2_armv7l/perl_text_charwidth-0.04-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-2_i686/perl_text_charwidth-0.04-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_charwidth/0.04-2_x86_64/perl_text_charwidth-0.04-2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '965175c70ca4cc515bdf139a4668434b6dd02ab565ae5b84705b508af005028e',
-     armv7l: '965175c70ca4cc515bdf139a4668434b6dd02ab565ae5b84705b508af005028e',
-       i686: 'ca46530e55475d03663fc0d821ee20e02eedafc4fa32ded01d622cd1af35d621',
-     x86_64: '38a4a507e655a9bbd3b4aeae1a49f32e9ef27b1a5ef2c5e7e9efef760f3e98ed'
-  })
-
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_text_unidecode.rb
+++ b/packages/perl_text_unidecode.rb
@@ -10,12 +10,16 @@ class Perl_text_unidecode < Package
   source_sha256 '6c24f14ddc1d20e26161c207b73ca184eed2ef57f08b5fb2ee196e6e2e88b1c6'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-3_i686/perl_text_unidecode-1.30-3-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-3_x86_64/perl_text_unidecode-1.30-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-3_armv7l/perl_text_unidecode-1.30-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-3_armv7l/perl_text_unidecode-1.30-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-3_i686/perl_text_unidecode-1.30-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-3_x86_64/perl_text_unidecode-1.30-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '8bed41f94818af7023c983bdf2e0974a1c7465056b22d1e20e6c9761dfa764af',
-  x86_64: '8580a3912f3760c45fbb0fb0a8b9d5faf2e963dcd699e64bfb52a7be300bc5f0'
+    aarch64: 'ccbe0cfc4c936ec4a7b56c08cea0eb00fd3624ab25d51bf8b1da66fea6d9cf11',
+     armv7l: 'ccbe0cfc4c936ec4a7b56c08cea0eb00fd3624ab25d51bf8b1da66fea6d9cf11',
+       i686: '8bed41f94818af7023c983bdf2e0974a1c7465056b22d1e20e6c9761dfa764af',
+     x86_64: '8580a3912f3760c45fbb0fb0a8b9d5faf2e963dcd699e64bfb52a7be300bc5f0'
   })
 
   def self.prebuild

--- a/packages/perl_text_unidecode.rb
+++ b/packages/perl_text_unidecode.rb
@@ -9,6 +9,15 @@ class Perl_text_unidecode < Package
   source_url 'https://cpan.metacpan.org/authors/id/S/SB/SBURKE/Text-Unidecode-1.30.tar.gz'
   source_sha256 '6c24f14ddc1d20e26161c207b73ca184eed2ef57f08b5fb2ee196e6e2e88b1c6'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-3_i686/perl_text_unidecode-1.30-3-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-3_x86_64/perl_text_unidecode-1.30-3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '8bed41f94818af7023c983bdf2e0974a1c7465056b22d1e20e6c9761dfa764af',
+  x86_64: '8580a3912f3760c45fbb0fb0a8b9d5faf2e963dcd699e64bfb52a7be300bc5f0'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_text_unidecode.rb
+++ b/packages/perl_text_unidecode.rb
@@ -3,40 +3,22 @@ require 'package'
 class Perl_text_unidecode < Package
   description 'Perl Text::Unidecode -- plain ASCII transliterations of Unicode text.'
   homepage 'https://metacpan.org/pod/Text::Unidecode'
-  version '1.30-2'
+  version '1.30-3'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/S/SB/SBURKE/Text-Unidecode-1.30.tar.gz'
   source_sha256 '6c24f14ddc1d20e26161c207b73ca184eed2ef57f08b5fb2ee196e6e2e88b1c6'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-2_armv7l/perl_text_unidecode-1.30-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-2_armv7l/perl_text_unidecode-1.30-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-2_i686/perl_text_unidecode-1.30-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_unidecode/1.30-2_x86_64/perl_text_unidecode-1.30-2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'c26b735942fd9bb1fc193ecfdffdab25bce5c208dc3ed61c819e21b7fda5f502',
-     armv7l: 'c26b735942fd9bb1fc193ecfdffdab25bce5c208dc3ed61c819e21b7fda5f502',
-       i686: '4fc5095c5d47286e895ed3ef2b5c631a061c1ab62a0781dbfe5ffb141cc36bb9',
-     x86_64: '763201f6d7fc90327300341c4a33b43e2a60164fa33ce20c1c9f47e00231d5e3'
-  })
-
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_text_wrapi18n.rb
+++ b/packages/perl_text_wrapi18n.rb
@@ -9,6 +9,15 @@ class Perl_text_wrapi18n < Package
   source_url 'https://cpan.metacpan.org/authors/id/K/KU/KUBOTA/Text-WrapI18N-0.06.tar.gz'
   source_sha256 '4bd29a17f0c2c792d12c1005b3c276f2ab0fae39c00859ae1741d7941846a488'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-3_i686/perl_text_wrapi18n-0.06-3-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-3_x86_64/perl_text_wrapi18n-0.06-3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'ca96847a5e011fefa633ea7db40909dee0675646bc7e55941defbcc04722ebd1',
+  x86_64: 'e5ff4381cfb80b6d4729e59a41e56b48130506c8beddb46a4466447ea8d1f6c2'
+  })
+
   depends_on 'perl_text_charwidth'
 
   def self.prebuild

--- a/packages/perl_text_wrapi18n.rb
+++ b/packages/perl_text_wrapi18n.rb
@@ -10,12 +10,16 @@ class Perl_text_wrapi18n < Package
   source_sha256 '4bd29a17f0c2c792d12c1005b3c276f2ab0fae39c00859ae1741d7941846a488'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-3_i686/perl_text_wrapi18n-0.06-3-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-3_x86_64/perl_text_wrapi18n-0.06-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-3_armv7l/perl_text_wrapi18n-0.06-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-3_armv7l/perl_text_wrapi18n-0.06-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-3_i686/perl_text_wrapi18n-0.06-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-3_x86_64/perl_text_wrapi18n-0.06-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'ca96847a5e011fefa633ea7db40909dee0675646bc7e55941defbcc04722ebd1',
-  x86_64: 'e5ff4381cfb80b6d4729e59a41e56b48130506c8beddb46a4466447ea8d1f6c2'
+    aarch64: '73c382d02a1f51ff81656322b8e0d5e5f77d430e85f977a90644ff8349a600bd',
+     armv7l: '73c382d02a1f51ff81656322b8e0d5e5f77d430e85f977a90644ff8349a600bd',
+       i686: 'ca96847a5e011fefa633ea7db40909dee0675646bc7e55941defbcc04722ebd1',
+     x86_64: 'e5ff4381cfb80b6d4729e59a41e56b48130506c8beddb46a4466447ea8d1f6c2'
   })
 
   depends_on 'perl_text_charwidth'

--- a/packages/perl_text_wrapi18n.rb
+++ b/packages/perl_text_wrapi18n.rb
@@ -3,42 +3,24 @@ require 'package'
 class Perl_text_wrapi18n < Package
   description 'Text::WrapI18N - Line wrapping module with support for multibyte, fullwidth, and combining characters and languages without whitespaces between words.'
   homepage 'https://metacpan.org/pod/Text::WrapI18N'
-  version '0.06-2'
+  version '0.06-3'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/K/KU/KUBOTA/Text-WrapI18N-0.06.tar.gz'
   source_sha256 '4bd29a17f0c2c792d12c1005b3c276f2ab0fae39c00859ae1741d7941846a488'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-2_armv7l/perl_text_wrapi18n-0.06-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-2_armv7l/perl_text_wrapi18n-0.06-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-2_i686/perl_text_wrapi18n-0.06-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_text_wrapi18n/0.06-2_x86_64/perl_text_wrapi18n-0.06-2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'baad1da36dc023de04364df3ee4f799d71cc7b6210016737b23e0d1015899159',
-     armv7l: 'baad1da36dc023de04364df3ee4f799d71cc7b6210016737b23e0d1015899159',
-       i686: 'f23dc5661e9721815a4504e57f82ac0c12513b830b31983d0454e628911cdd71',
-     x86_64: '3abbedc8db8e87eb086dafba589ebeda760ff2c16d9f97698e09dc15f1fdc309'
-  })
-
   depends_on 'perl_text_charwidth'
 
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '.' #  remove --self-contained
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_time_hires.rb
+++ b/packages/perl_time_hires.rb
@@ -2,28 +2,19 @@ require 'package'
 
 class Perl_time_hires < Package
   description 'High resolution alarm, sleep, gettimeofday, interval timers Time::HiRes'
-  homepage 'https://metacpan.org/release/Time-HiRes'
-  version '1.9758-2'
+  homepage 'https://metacpan.org/pod/Time::HiRes'
+  version '1.9764'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/J/JH/JHI/Time-HiRes-1.9758.tar.gz'
-  source_sha256 '5bfa145bc11e70a8e337543b1084a293743a690691b568493455dedf58f34b1e'
+  source_url 'https://cpan.metacpan.org/authors/id/J/JH/JHI/Time-HiRes-1.9764.tar.gz'
+  source_sha256 'f33c27745f2bd87344be790465ef984a972fd539dc83bd4f61d4242c607ef1ee'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_time_hires/1.9758-2_armv7l/perl_time_hires-1.9758-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_time_hires/1.9758-2_armv7l/perl_time_hires-1.9758-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_time_hires/1.9758-2_i686/perl_time_hires-1.9758-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_time_hires/1.9758-2_x86_64/perl_time_hires-1.9758-2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'ffb188bb4deb933432df4a898c61139feb37a80e109fba522abc6b4ccb0e8e97',
-     armv7l: 'ffb188bb4deb933432df4a898c61139feb37a80e109fba522abc6b4ccb0e8e97',
-       i686: 'bf2394f78d35cdd3037ea4fd6436cffdb6ecac2376395f76a3bf5ae9a8644deb',
-     x86_64: 'b745056ffef107653bcd19139a58bf8f24c8e254656089195c0334bb80069923'
-  })
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
 
   def self.build
-    system 'perl', 'Makefile.PL'
     system 'make'
   end
 

--- a/packages/perl_time_hires.rb
+++ b/packages/perl_time_hires.rb
@@ -6,19 +6,7 @@ class Perl_time_hires < Package
   version '1.9764'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/J/JH/JHI/Time-HiRes-1.9764.tar.gz'
-  source_sha256 'f33c27745f2bd87344be790465ef984a972fd539dc83bd4f61d4242c607ef1ee'
 
-  def self.prebuild
-    system 'perl', 'Makefile.PL'
-    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
-  end
-
-  def self.build
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  # included in main perl package
+  is_fake
 end

--- a/packages/perl_unicode_eastasianwidth.rb
+++ b/packages/perl_unicode_eastasianwidth.rb
@@ -9,6 +9,15 @@ class Perl_unicode_eastasianwidth < Package
   source_url 'https://cpan.metacpan.org/authors/id/A/AU/AUDREYT/Unicode-EastAsianWidth-12.0.tar.gz'
   source_sha256 '2a5bfd926c4fe5f77e6137da2c31ac2545282ae5fec6e9af0fdd403555a90ff4'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-3_i686/perl_unicode_eastasianwidth-12.0-3-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-3_x86_64/perl_unicode_eastasianwidth-12.0-3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'e20824f9b8574b51cc6765297686d426ac0cc294db24d587cdb55ab1fbf95dff',
+  x86_64: 'd53287ba65526e878280aeec684193f34dc30738d1c99f80ff503f6d4c01b151'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_unicode_eastasianwidth.rb
+++ b/packages/perl_unicode_eastasianwidth.rb
@@ -3,24 +3,11 @@ require 'package'
 class Perl_unicode_eastasianwidth < Package
   description 'Perl Unicode::EastAsianWidth - East Asian Width properties.'
   homepage 'https://metacpan.org/pod/Unicode::EastAsianWidth'
-  version '12.0-2'
+  version '12.0-3'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/A/AU/AUDREYT/Unicode-EastAsianWidth-12.0.tar.gz'
   source_sha256 '2a5bfd926c4fe5f77e6137da2c31ac2545282ae5fec6e9af0fdd403555a90ff4'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-2_armv7l/perl_unicode_eastasianwidth-12.0-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-2_armv7l/perl_unicode_eastasianwidth-12.0-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-2_i686/perl_unicode_eastasianwidth-12.0-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-2_x86_64/perl_unicode_eastasianwidth-12.0-2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '8a72eba49c075cbb13b7e8a7575df34f463c7d4e73f4e9fadcd7b4c3ea3d0c7c',
-     armv7l: '8a72eba49c075cbb13b7e8a7575df34f463c7d4e73f4e9fadcd7b4c3ea3d0c7c',
-       i686: '98e1a3e9f2591f5342d512b67c916f87480d43276ee492d2238972ae8235d3f5',
-     x86_64: '7f8e2ade0b2d5481d8efe3f5a830baa814aacfb9897844aae067b7cb340b9183'
-  })
 
   def self.prebuild
     system 'perl', 'Makefile.PL'

--- a/packages/perl_unicode_eastasianwidth.rb
+++ b/packages/perl_unicode_eastasianwidth.rb
@@ -10,12 +10,16 @@ class Perl_unicode_eastasianwidth < Package
   source_sha256 '2a5bfd926c4fe5f77e6137da2c31ac2545282ae5fec6e9af0fdd403555a90ff4'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-3_i686/perl_unicode_eastasianwidth-12.0-3-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-3_x86_64/perl_unicode_eastasianwidth-12.0-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-3_armv7l/perl_unicode_eastasianwidth-12.0-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-3_armv7l/perl_unicode_eastasianwidth-12.0-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-3_i686/perl_unicode_eastasianwidth-12.0-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_eastasianwidth/12.0-3_x86_64/perl_unicode_eastasianwidth-12.0-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'e20824f9b8574b51cc6765297686d426ac0cc294db24d587cdb55ab1fbf95dff',
-  x86_64: 'd53287ba65526e878280aeec684193f34dc30738d1c99f80ff503f6d4c01b151'
+    aarch64: '3b835e5f74b86606da08cf160c10a39746b259ef16cddcd7841406d0c65f3e40',
+     armv7l: '3b835e5f74b86606da08cf160c10a39746b259ef16cddcd7841406d0c65f3e40',
+       i686: 'e20824f9b8574b51cc6765297686d426ac0cc294db24d587cdb55ab1fbf95dff',
+     x86_64: 'd53287ba65526e878280aeec684193f34dc30738d1c99f80ff503f6d4c01b151'
   })
 
   def self.prebuild

--- a/packages/perl_unicode_linebreak.rb
+++ b/packages/perl_unicode_linebreak.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Perl_unicode_linebreak < Package
+  description 'Unicode::LineBreak - UAX #14 Unicode Line Breaking Algorithm'
+  homepage 'http://search.cpan.org/~nezumi/Unicode-LineBreak-2018.003/lib/Unicode/LineBreak.pod'
+  version '2019.001-2'
+  license 'GPL-1+ or Artistic'
+  compatibility 'all'
+  source_url 'https://github.com/hatukanezumi/Unicode-LineBreak.git'
+  git_hashtag 'Unicode-LineBreak-2019.001'
+
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/perl_unicode_linebreak.rb
+++ b/packages/perl_unicode_linebreak.rb
@@ -9,6 +9,15 @@ class Perl_unicode_linebreak < Package
   source_url 'https://github.com/hatukanezumi/Unicode-LineBreak.git'
   git_hashtag 'Unicode-LineBreak-2019.001'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_linebreak/2019.001-2_i686/perl_unicode_linebreak-2019.001-2-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_linebreak/2019.001-2_x86_64/perl_unicode_linebreak-2019.001-2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '88fd6c7ba13998040d725c83befef32e63e6047c22a93dba099fdaaa2864e463',
+  x86_64: '7cee8353db2d0da6fc91915f6be07e77fe4746f3ab60e0e145c46cdf52150b75'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_unicode_linebreak.rb
+++ b/packages/perl_unicode_linebreak.rb
@@ -10,12 +10,16 @@ class Perl_unicode_linebreak < Package
   git_hashtag 'Unicode-LineBreak-2019.001'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_linebreak/2019.001-2_i686/perl_unicode_linebreak-2019.001-2-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_linebreak/2019.001-2_x86_64/perl_unicode_linebreak-2019.001-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_linebreak/2019.001-2_armv7l/perl_unicode_linebreak-2019.001-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_linebreak/2019.001-2_armv7l/perl_unicode_linebreak-2019.001-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_linebreak/2019.001-2_i686/perl_unicode_linebreak-2019.001-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_unicode_linebreak/2019.001-2_x86_64/perl_unicode_linebreak-2019.001-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '88fd6c7ba13998040d725c83befef32e63e6047c22a93dba099fdaaa2864e463',
-  x86_64: '7cee8353db2d0da6fc91915f6be07e77fe4746f3ab60e0e145c46cdf52150b75'
+    aarch64: '1f71d4967b901d3963686dc939a741fdb400097c09df8dc549a6cd41b6517843',
+     armv7l: '1f71d4967b901d3963686dc939a741fdb400097c09df8dc549a6cd41b6517843',
+       i686: '88fd6c7ba13998040d725c83befef32e63e6047c22a93dba099fdaaa2864e463',
+     x86_64: '7cee8353db2d0da6fc91915f6be07e77fe4746f3ab60e0e145c46cdf52150b75'
   })
 
   def self.prebuild

--- a/packages/perl_xml_namespacesupport.rb
+++ b/packages/perl_xml_namespacesupport.rb
@@ -10,12 +10,16 @@ class Perl_xml_namespacesupport < Package
   source_sha256 '47e995859f8dd0413aa3f22d350c4a62da652e854267aa0586ae544ae2bae5ef'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_namespacesupport/1.12_i686/perl_xml_namespacesupport-1.12-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_namespacesupport/1.12_x86_64/perl_xml_namespacesupport-1.12-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_namespacesupport/1.12_armv7l/perl_xml_namespacesupport-1.12-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_namespacesupport/1.12_armv7l/perl_xml_namespacesupport-1.12-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_namespacesupport/1.12_i686/perl_xml_namespacesupport-1.12-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_namespacesupport/1.12_x86_64/perl_xml_namespacesupport-1.12-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'd9ed95a088dee03433450150a53d3a734255fb50ccbc6ec1341001280ed07c09',
-  x86_64: '5a7709014959928cfc89c3d9755d8c31e3243e37579b4e8dd94661e9a49166bc'
+    aarch64: 'f2aa35ec8928eaa44e36faa97cfb8159a74c678f27dc9c4552a67a0268a6effe',
+     armv7l: 'f2aa35ec8928eaa44e36faa97cfb8159a74c678f27dc9c4552a67a0268a6effe',
+       i686: 'd9ed95a088dee03433450150a53d3a734255fb50ccbc6ec1341001280ed07c09',
+     x86_64: '5a7709014959928cfc89c3d9755d8c31e3243e37579b4e8dd94661e9a49166bc'
   })
 
   def self.prebuild

--- a/packages/perl_xml_namespacesupport.rb
+++ b/packages/perl_xml_namespacesupport.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Perl_xml_namespacesupport < Package
+  description 'XML::NamespaceSupport - A simple generic namespace processor'
+  homepage 'https://metacpan.org/pod/XML::NamespaceSupport'
+  version '1.12'
+  license 'GPL-1+ or Artistic'
+  compatibility 'all'
+  source_url 'https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN/XML-NamespaceSupport-1.12.tar.gz'
+  source_sha256 '47e995859f8dd0413aa3f22d350c4a62da652e854267aa0586ae544ae2bae5ef'
+
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
+  end
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/perl_xml_namespacesupport.rb
+++ b/packages/perl_xml_namespacesupport.rb
@@ -9,6 +9,15 @@ class Perl_xml_namespacesupport < Package
   source_url 'https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN/XML-NamespaceSupport-1.12.tar.gz'
   source_sha256 '47e995859f8dd0413aa3f22d350c4a62da652e854267aa0586ae544ae2bae5ef'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_namespacesupport/1.12_i686/perl_xml_namespacesupport-1.12-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_namespacesupport/1.12_x86_64/perl_xml_namespacesupport-1.12-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'd9ed95a088dee03433450150a53d3a734255fb50ccbc6ec1341001280ed07c09',
+  x86_64: '5a7709014959928cfc89c3d9755d8c31e3243e37579b4e8dd94661e9a49166bc'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_xml_parser.rb
+++ b/packages/perl_xml_parser.rb
@@ -10,12 +10,16 @@ class Perl_xml_parser < Package
   source_sha256 'd331332491c51cccfb4cb94ffc44f9cd73378e618498d4a37df9e043661c515d'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-2_i686/perl_xml_parser-2.46-2-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-2_x86_64/perl_xml_parser-2.46-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-2_armv7l/perl_xml_parser-2.46-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-2_armv7l/perl_xml_parser-2.46-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-2_i686/perl_xml_parser-2.46-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-2_x86_64/perl_xml_parser-2.46-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '9f0efeb52efc43f2a14301a0ebe8198bb8a2f3d2c9e8a420d791ae91c0691061',
-  x86_64: '97451760fa4ddf1320025a4bba9d0b34ff3a5385befde7857a14b90d2b810cb3'
+    aarch64: '54c7e396349f8da1269d3c4f77299c1a9a401dd337dd7cdc2523e868e075c69f',
+     armv7l: '54c7e396349f8da1269d3c4f77299c1a9a401dd337dd7cdc2523e868e075c69f',
+       i686: '9f0efeb52efc43f2a14301a0ebe8198bb8a2f3d2c9e8a420d791ae91c0691061',
+     x86_64: '97451760fa4ddf1320025a4bba9d0b34ff3a5385befde7857a14b90d2b810cb3'
   })
 
   depends_on 'expat'

--- a/packages/perl_xml_parser.rb
+++ b/packages/perl_xml_parser.rb
@@ -9,6 +9,15 @@ class Perl_xml_parser < Package
   source_url 'https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz'
   source_sha256 'd331332491c51cccfb4cb94ffc44f9cd73378e618498d4a37df9e043661c515d'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-2_i686/perl_xml_parser-2.46-2-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-2_x86_64/perl_xml_parser-2.46-2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '9f0efeb52efc43f2a14301a0ebe8198bb8a2f3d2c9e8a420d791ae91c0691061',
+  x86_64: '97451760fa4ddf1320025a4bba9d0b34ff3a5385befde7857a14b90d2b810cb3'
+  })
+
   depends_on 'expat'
 
   def self.prebuild

--- a/packages/perl_xml_parser.rb
+++ b/packages/perl_xml_parser.rb
@@ -19,6 +19,7 @@ class Perl_xml_parser < Package
   })
 
   depends_on 'expat'
+  conflicts_ok # conflicts with perl_date_format
 
   def self.prebuild
     system 'perl', 'Makefile.PL'

--- a/packages/perl_xml_parser.rb
+++ b/packages/perl_xml_parser.rb
@@ -3,42 +3,24 @@ require 'package'
 class Perl_xml_parser < Package
   description 'Perl XML::Parser - A perl module for parsing XML documents'
   homepage 'https://metacpan.org/pod/XML::Parser'
-  version '2.46-1'
+  version '2.46-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz'
   source_sha256 'd331332491c51cccfb4cb94ffc44f9cd73378e618498d4a37df9e043661c515d'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-1_armv7l/perl_xml_parser-2.46-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-1_armv7l/perl_xml_parser-2.46-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-1_i686/perl_xml_parser-2.46-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_parser/2.46-1_x86_64/perl_xml_parser-2.46-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '3c536628600008c19d089766ced4ebc96ebf3ec8beb5c99578ea452fc9e8c1d3',
-     armv7l: '3c536628600008c19d089766ced4ebc96ebf3ec8beb5c99578ea452fc9e8c1d3',
-       i686: 'e7cd0964006d7fa61d9ad49498443e956f0855821dd95777b808b79506eccde1',
-     x86_64: '83042563b3c4e95218c01fb384e55c190ec0066e6dddda67dcae7e353aab9975'
-  })
-
   depends_on 'expat'
 
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '--force', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_xml_sax.rb
+++ b/packages/perl_xml_sax.rb
@@ -1,15 +1,13 @@
 require 'package'
 
-class Perl_xml_sax_parserfactory < Package
-  description 'XML::SAX::ParserFactory is a factory class for providing an application with a Perl SAX2 XML parser.'
-  homepage 'https://metacpan.org/pod/XML::SAX::ParserFactory'
+class Perl_xml_sax < Package
+  description 'XML::SAX - Simple API for XML'
+  homepage 'https://metacpan.org/pod/XML::SAX'
   version '1.02-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-1.02.tar.gz'
   source_sha256 '4506c387043aa6a77b455f00f57409f3720aa7e553495ab2535263b4ed1ea12a'
-
-  depends_on 'perl_xml_sax'
 
   def self.prebuild
     system 'perl', 'Makefile.PL'

--- a/packages/perl_xml_sax.rb
+++ b/packages/perl_xml_sax.rb
@@ -9,6 +9,15 @@ class Perl_xml_sax < Package
   source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-1.02.tar.gz'
   source_sha256 '4506c387043aa6a77b455f00f57409f3720aa7e553495ab2535263b4ed1ea12a'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax/1.02_i686/perl_xml_sax-1.02-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax/1.02_x86_64/perl_xml_sax-1.02-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'b967b46a1d777e550ec9173605cc1ab19f7149fbd3e901d26ade3f05d065e46d',
+  x86_64: 'a5c4f62598b738a7846fbb86d3db1ba3ef67fe30cfb34fea90b2d1513794402e'
+  })
+
   depends_on 'perl_xml_sax_base'
   depends_on 'perl_xml_namespacesupport'
 

--- a/packages/perl_xml_sax_base.rb
+++ b/packages/perl_xml_sax_base.rb
@@ -10,12 +10,16 @@ class Perl_xml_sax_base < Package
   source_sha256 '66cb355ba4ef47c10ca738bd35999723644386ac853abbeb5132841f5e8a2ad0'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_base/1.09_i686/perl_xml_sax_base-1.09-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_base/1.09_x86_64/perl_xml_sax_base-1.09-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_base/1.09_armv7l/perl_xml_sax_base-1.09-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_base/1.09_armv7l/perl_xml_sax_base-1.09-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_base/1.09_i686/perl_xml_sax_base-1.09-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_base/1.09_x86_64/perl_xml_sax_base-1.09-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '247313834036ebfadbec0ea6830057a290fba8cd605adc276bd21eadaf2995bc',
-  x86_64: '37934d05df2097c8d6e19795a2054ea8fa0dd0b9eeb2e129d6ce14b1c37b0d16'
+    aarch64: '09a89d696a4606e9c11547883a5e7e14ff016c39df71f3cd85780844b1ca7210',
+     armv7l: '09a89d696a4606e9c11547883a5e7e14ff016c39df71f3cd85780844b1ca7210',
+       i686: '247313834036ebfadbec0ea6830057a290fba8cd605adc276bd21eadaf2995bc',
+     x86_64: '37934d05df2097c8d6e19795a2054ea8fa0dd0b9eeb2e129d6ce14b1c37b0d16'
   })
 
   def self.prebuild

--- a/packages/perl_xml_sax_base.rb
+++ b/packages/perl_xml_sax_base.rb
@@ -9,6 +9,15 @@ class Perl_xml_sax_base < Package
   source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-Base-1.09.tar.gz'
   source_sha256 '66cb355ba4ef47c10ca738bd35999723644386ac853abbeb5132841f5e8a2ad0'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_base/1.09_i686/perl_xml_sax_base-1.09-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_base/1.09_x86_64/perl_xml_sax_base-1.09-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '247313834036ebfadbec0ea6830057a290fba8cd605adc276bd21eadaf2995bc',
+  x86_64: '37934d05df2097c8d6e19795a2054ea8fa0dd0b9eeb2e129d6ce14b1c37b0d16'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_xml_sax_base.rb
+++ b/packages/perl_xml_sax_base.rb
@@ -1,16 +1,13 @@
 require 'package'
 
-class Perl_xml_sax < Package
+class Perl_xml_sax_base < Package
   description 'XML::SAX - Simple API for XML'
   homepage 'https://metacpan.org/pod/XML::SAX'
-  version '1.02'
+  version '1.09'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-1.02.tar.gz'
-  source_sha256 '4506c387043aa6a77b455f00f57409f3720aa7e553495ab2535263b4ed1ea12a'
-
-  depends_on 'perl_xml_sax_base'
-  depends_on 'perl_xml_namespacesupport'
+  source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-Base-1.09.tar.gz'
+  source_sha256 '66cb355ba4ef47c10ca738bd35999723644386ac853abbeb5132841f5e8a2ad0'
 
   def self.prebuild
     system 'perl', 'Makefile.PL'

--- a/packages/perl_xml_sax_parserfactory.rb
+++ b/packages/perl_xml_sax_parserfactory.rb
@@ -6,21 +6,6 @@ class Perl_xml_sax_parserfactory < Package
   version '1.02-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-1.02.tar.gz'
-  source_sha256 '4506c387043aa6a77b455f00f57409f3720aa7e553495ab2535263b4ed1ea12a'
 
-  depends_on 'perl_xml_sax'
-
-  def self.prebuild
-    system 'perl', 'Makefile.PL'
-    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
-  end
-
-  def self.build
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  is_fake
 end

--- a/packages/perl_xml_sax_parserfactory.rb
+++ b/packages/perl_xml_sax_parserfactory.rb
@@ -3,40 +3,22 @@ require 'package'
 class Perl_xml_sax_parserfactory < Package
   description 'XML::SAX::ParserFactory is a factory class for providing an application with a Perl SAX2 XML parser.'
   homepage 'https://metacpan.org/source/GRANTM/XML-SAX-0.99/SAX/'
-  version '1.02-1'
+  version '1.02-2'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-SAX-1.02.tar.gz'
   source_sha256 '4506c387043aa6a77b455f00f57409f3720aa7e553495ab2535263b4ed1ea12a'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_parserfactory/1.02-1_armv7l/perl_xml_sax_parserfactory-1.02-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_parserfactory/1.02-1_armv7l/perl_xml_sax_parserfactory-1.02-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_parserfactory/1.02-1_i686/perl_xml_sax_parserfactory-1.02-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_sax_parserfactory/1.02-1_x86_64/perl_xml_sax_parserfactory-1.02-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '8ea748d73c2228eab13bc2d50b1cf920e73e45ca4f68063b8e1aaee232bb0725',
-     armv7l: '8ea748d73c2228eab13bc2d50b1cf920e73e45ca4f68063b8e1aaee232bb0725',
-       i686: '606e6b8bb6f39207b06f372b9f2b5e0570b32bf43e74fb3591337fd5587d963b',
-     x86_64: 'c4cd67e75427b61962ede81353888fe8cf13fb974803562ba541c1fff13a38bd'
-  })
-
-  def self.build; end
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end

--- a/packages/perl_xml_simple.rb
+++ b/packages/perl_xml_simple.rb
@@ -9,6 +9,15 @@ class Perl_xml_simple < Package
   source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-Simple-2.25.tar.gz'
   source_sha256 '531fddaebea2416743eb5c4fdfab028f502123d9a220405a4100e68fc480dbf8'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-3_i686/perl_xml_simple-2.25-3-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-3_x86_64/perl_xml_simple-2.25-3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'e27342b9bb17969c0ec3e5bd1ef71f1a55c8c59300ac00bcda54d1c12853ad50',
+  x86_64: '3e412a9ffcccf45908cf651af554ba7cc89576753c0e9930d3f6f86cd18545c1'
+  })
+
   depends_on 'perl_xml_parser'
 
   def self.prebuild

--- a/packages/perl_xml_simple.rb
+++ b/packages/perl_xml_simple.rb
@@ -10,12 +10,16 @@ class Perl_xml_simple < Package
   source_sha256 '531fddaebea2416743eb5c4fdfab028f502123d9a220405a4100e68fc480dbf8'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-3_i686/perl_xml_simple-2.25-3-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-3_x86_64/perl_xml_simple-2.25-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-3_armv7l/perl_xml_simple-2.25-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-3_armv7l/perl_xml_simple-2.25-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-3_i686/perl_xml_simple-2.25-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-3_x86_64/perl_xml_simple-2.25-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'e27342b9bb17969c0ec3e5bd1ef71f1a55c8c59300ac00bcda54d1c12853ad50',
-  x86_64: '3e412a9ffcccf45908cf651af554ba7cc89576753c0e9930d3f6f86cd18545c1'
+    aarch64: 'a3f24faeee658cd3f468e1f09b1a9c90774b00f8ebcf25eec5b1ec1ef275c213',
+     armv7l: 'a3f24faeee658cd3f468e1f09b1a9c90774b00f8ebcf25eec5b1ec1ef275c213',
+       i686: 'e27342b9bb17969c0ec3e5bd1ef71f1a55c8c59300ac00bcda54d1c12853ad50',
+     x86_64: '3e412a9ffcccf45908cf651af554ba7cc89576753c0e9930d3f6f86cd18545c1'
   })
 
   depends_on 'perl_xml_parser'

--- a/packages/perl_xml_simple.rb
+++ b/packages/perl_xml_simple.rb
@@ -3,24 +3,11 @@ require 'package'
 class Perl_xml_simple < Package
   description 'XML::Simple - An API for simple XML files'
   homepage 'https://metacpan.org/pod/XML::Simple'
-  version '2.25-2'
+  version '2.25-3'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/G/GR/GRANTM/XML-Simple-2.25.tar.gz'
   source_sha256 '531fddaebea2416743eb5c4fdfab028f502123d9a220405a4100e68fc480dbf8'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-2_armv7l/perl_xml_simple-2.25-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-2_armv7l/perl_xml_simple-2.25-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-2_i686/perl_xml_simple-2.25-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_xml_simple/2.25-2_x86_64/perl_xml_simple-2.25-2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'c75d6a80e668aa4ca4515c0d4eaf57c81d95f43db722818b201f87e96a66295d',
-     armv7l: 'c75d6a80e668aa4ca4515c0d4eaf57c81d95f43db722818b201f87e96a66295d',
-       i686: '84d43b1ff8994d610b58d4084dc859a78cfbd1b614b037009b6af3149bc28434',
-     x86_64: 'ae76a1851970fb669756a75b9f2b51b48e4687da515ab015c448eeb4eac9c422'
-  })
 
   depends_on 'perl_xml_parser'
 

--- a/packages/perl_yaml_tiny.rb
+++ b/packages/perl_yaml_tiny.rb
@@ -10,12 +10,16 @@ class Perl_yaml_tiny < Package
   source_sha256 'bc315fa12e8f1e3ee5e2f430d90b708a5dc7e47c867dba8dce3a6b8fbe257744'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-3_i686/perl_yaml_tiny-1.73-3-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-3_x86_64/perl_yaml_tiny-1.73-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-3_armv7l/perl_yaml_tiny-1.73-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-3_armv7l/perl_yaml_tiny-1.73-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-3_i686/perl_yaml_tiny-1.73-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-3_x86_64/perl_yaml_tiny-1.73-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '3d237617f73685eaf6ea747b793acbdd52cfdbbe6b20c4eaf0a7c008ede59082',
-  x86_64: 'ded5fecb255389c52e7062a426df6b0b6c0beab9631917855941716c5b163fe4'
+    aarch64: '5f9c777daec7fd8be9cd93839547bbd2866a7b90c57ffb6e55487b081cb7fe77',
+     armv7l: '5f9c777daec7fd8be9cd93839547bbd2866a7b90c57ffb6e55487b081cb7fe77',
+       i686: '3d237617f73685eaf6ea747b793acbdd52cfdbbe6b20c4eaf0a7c008ede59082',
+     x86_64: 'ded5fecb255389c52e7062a426df6b0b6c0beab9631917855941716c5b163fe4'
   })
 
   def self.prebuild

--- a/packages/perl_yaml_tiny.rb
+++ b/packages/perl_yaml_tiny.rb
@@ -9,6 +9,15 @@ class Perl_yaml_tiny < Package
   source_url 'https://cpan.metacpan.org/authors/id/E/ET/ETHER/YAML-Tiny-1.73.tar.gz'
   source_sha256 'bc315fa12e8f1e3ee5e2f430d90b708a5dc7e47c867dba8dce3a6b8fbe257744'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-3_i686/perl_yaml_tiny-1.73-3-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-3_x86_64/perl_yaml_tiny-1.73-3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '3d237617f73685eaf6ea747b793acbdd52cfdbbe6b20c4eaf0a7c008ede59082',
+  x86_64: 'ded5fecb255389c52e7062a426df6b0b6c0beab9631917855941716c5b163fe4'
+  })
+
   def self.prebuild
     system 'perl', 'Makefile.PL'
     system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"

--- a/packages/perl_yaml_tiny.rb
+++ b/packages/perl_yaml_tiny.rb
@@ -3,38 +3,22 @@ require 'package'
 class Perl_yaml_tiny < Package
   description 'YAML::Tiny - Read/Write YAML files with as little code as possible'
   homepage 'https://metacpan.org/pod/YAML::Tiny'
-  version '1.73-2'
+  version '1.73-3'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
   source_url 'https://cpan.metacpan.org/authors/id/E/ET/ETHER/YAML-Tiny-1.73.tar.gz'
   source_sha256 'bc315fa12e8f1e3ee5e2f430d90b708a5dc7e47c867dba8dce3a6b8fbe257744'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-2_armv7l/perl_yaml_tiny-1.73-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-2_armv7l/perl_yaml_tiny-1.73-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-2_i686/perl_yaml_tiny-1.73-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/perl_yaml_tiny/1.73-2_x86_64/perl_yaml_tiny-1.73-2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'e81f1c52c71e2c0557a8b5f935c4d55b4820b35d8564624b3008dbe124ea6bb1',
-     armv7l: 'e81f1c52c71e2c0557a8b5f935c4d55b4820b35d8564624b3008dbe124ea6bb1',
-       i686: 'd7f605c0c4c9cae7851f6647ec6513e0e0f400113cbd4236c3801b083d27eef6',
-     x86_64: 'a530bb292e61f1bd709b94fec1414d44f0b70656493fcb061ae1efac00444428'
-  })
-
-  def self.install
-    # install files to build directory
-    system 'cpanm', '-l', 'build', '--self-contained', '--force', '.'
-
-    # install lib
-    libdir = CREW_DEST_DIR + `perl -e 'require Config; print $Config::Config{'"'installsitelib'"'};'`
-    FileUtils.mkdir_p libdir
-    system "(cd build/lib/perl5; tar cf - .) | (cd #{libdir}; tar xfp -)"
-
-    # install man
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
-    system "(cd build/man; tar cf - .) | (cd #{CREW_DEST_MAN_PREFIX}; tar xfp -)"
+  def self.prebuild
+    system 'perl', 'Makefile.PL'
+    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
   end
 
-  def self.check; end
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
 end


### PR DESCRIPTION
Changes:
- Upgrade `perl` to the latest stable version
- Move arch independent and version independent perl code to #{CREW_PREFIX}/share
- Upgrade all `^perl_*` packages if need be
- Recompile all binaries for `^perl_*` packages due to item 2
- Do not attempt to install a perl binary at `/usr/bin/perl`
- Use LTO and the other #{CREW_COMMON_FLAGS} when compiling perl
- Specify that GCC is the C compiler for perl, not just "cc"
- Add more version-specific libperl.so libraries to #{CREW_LIB_PREFIX}
- Move arch dependent perl code to #{CREW_LIB_PREFIX}, instead of #{CREW_PREFIX}/lib
- Remove the `cpanm` executable from perl itself, as `perl_app_cpanminus` provides it
- Deduplicate `^perl_` packages as needed

##### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=perl_5.34.1 CREW_TESTING=1 crew update
```

@satmandu armv7l still needs binaries. Compiling order: `perl $(crew list available | grep ^perl_)`
