### PR TITLE
gh-pages: Add dark mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# chromebrew-GH pages
-Package manager's Homepage for Chrome OS
+# Chromebrew GitHub pages
+Chromebrew's homepage, hosted on GitHub Pages

--- a/css/bs-example.css
+++ b/css/bs-example.css
@@ -47,13 +47,6 @@
     border-radius: 4px 4px 0 0;
     box-shadow: none;
   }
-
-  @media (prefers-color-scheme: dark) {
-    .bs-example {
-      background-color: #2e2d2d;
-      border-color: #1e1e1e;
-    }
-  }
                                            
   .bs-example + .highlight {
     margin-top: -16px;
@@ -62,6 +55,13 @@
     border-width: 1px;
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .bs-example {
+    background-color: #2e2d2d;
+    border-color: #1e1e1e;
   }
 }
 

--- a/css/bs-example.css
+++ b/css/bs-example.css
@@ -1,138 +1,159 @@
 /*
  * Examples
-  *
-   * Isolated sections of example content for each component or feature. Usually
-    * followed by a code snippet.
-     */
+ *
+ * Isolated sections of example content for each component or feature. Usually
+ * followed by a code snippet.
+ */
 
-     .bs-example {
-         position: relative;
-           padding: 15px 15px 15px;
-             margin: 0 -15px 15px;
-               background-color: #fafafa;
-                 box-shadow: inset 0 3px 6px rgba(0,0,0,.05);
-                   border-color: #e5e5e5 #eee #eee;
-                     border-style: solid;
-                       border-width: 1px 0;
-     }
-     /* Echo out a label for the example */
-     /*.bs-example:after {
-         content: "";
-           position: absolute;
-             top:  15px;
-               left: 15px;
-                 font-size: 12px;
-                   font-weight: bold;
-                     color: #bbb;
-                       text-transform: uppercase;
-                         letter-spacing: 1px;
-     }*/
+.bs-example {
+  position: relative;
+  padding: 15px 15px 15px;
+  margin: 0 -15px 15px;
+  background-color: #fafafa;
+  box-shadow: inset 0 3px 6px rgba(0,0,0,.05);
+  border-color: #e5e5e5 #eee #eee;
+  border-style: solid;
+  border-width: 1px 0;
+}
 
-     /* Tweak display of the code snippets when following an example */
-     .bs-example + .highlight {
-         margin: -15px -15px 15px;
-           border-radius: 0;
-             border-width: 0 0 1px;
-     }
+/* Echo out a label for the example */
+/*.bs-example:after {
+  content: "";
+  position: absolute;
+  top:  15px;
+  left: 15px;
+  font-size: 12px;
+  font-weight: bold;
+  color: #bbb;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}*/
 
-     /* Make the examples and snippets not full-width */
-     @media screen and (min-width: 768px) {
-         .bs-example {
-               margin-left: 0;
-                   margin-right: 0;
-                       background-color: #fff;
-                           border-width: 1px;
-                               border-color: #ddd;
-                                   border-radius: 4px 4px 0 0;
-                                       box-shadow: none;
-                                         }
-                                           .bs-example + .highlight {
-                                                 margin-top: -16px;
-                                                     margin-left: 0;
-                                                         margin-right: 0;
-                                                             border-width: 1px;
-                                                                 border-bottom-left-radius: 4px;
-                                                                     border-bottom-right-radius: 4px;
-                                                                       }
-     }
+/* Tweak display of the code snippets when following an example */
+.bs-example + .highlight {
+  margin: -15px -15px 15px;
+  border-radius: 0;
+  border-width: 0 0 1px;
+}
 
-     /* Tweak content of examples for optimum awesome */
-     .bs-example > p:last-child,
-     .bs-example > ul:last-child,
-     .bs-example > ol:last-child,
-     .bs-example > blockquote:last-child,
-     .bs-example > .form-control:last-child,
-     .bs-example > .table:last-child,
-     .bs-example > .navbar:last-child,
-     .bs-example > .jumbotron:last-child,
-     .bs-example > .alert:last-child,
-     .bs-example > .panel:last-child,
-     .bs-example > .list-group:last-child,
-     .bs-example > .well:last-child,
-     .bs-example > .progress:last-child,
-     .bs-example > .table-responsive:last-child > .table {
-         margin-bottom: 0;
-     }
-     .bs-example > p > .close {
-         float: none;
-     }
+/* Make the examples and snippets not full-width */
+@media screen and (min-width: 768px) {
+  .bs-example {
+    margin-left: 0;
+    margin-right: 0;
+    background-color: #fff;
+    border-width: 1px;
+    border-color: #ddd;
+    border-radius: 4px 4px 0 0;
+    box-shadow: none;
+  }
 
-     /* Typography */
-     .bs-example-type .table td:last-child {
-         color: #999;
-           vertical-align: middle;
-     }
-     .bs-example-type .table td {
-         padding: 15px 0;
-           border-color: #eee;
-     }
-     .bs-example-type .table tr:first-child td {
-         border-top: 0;
-     }
-     .bs-example-type h1,
-     .bs-example-type h2,
-     .bs-example-type h3,
-     .bs-example-type h4,
-     .bs-example-type h5,
-     .bs-example-type h6 {
-         margin: 0;
-     }
+  @media (prefers-color-scheme: dark) {
+    .bs-example {
+      background-color: #2e2d2d;
+      border-color: #1e1e1e;
+    }
+  }
+                                           
+  .bs-example + .highlight {
+    margin-top: -16px;
+    margin-left: 0;
+    margin-right: 0;
+    border-width: 1px;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+}
 
-     /* Images */
-     .bs-example > .img-circle,
-     .bs-example > .img-rounded,
-     .bs-example > .img-thumbnail {
-         margin: 5px;
-     }
+/* Tweak content of examples for optimum awesome */
+.bs-example > p:last-child,
+.bs-example > ul:last-child,
+.bs-example > ol:last-child,
+.bs-example > blockquote:last-child,
+.bs-example > .form-control:last-child,
+.bs-example > .table:last-child,
+.bs-example > .navbar:last-child,
+.bs-example > .jumbotron:last-child,
+.bs-example > .alert:last-child,
+.bs-example > .panel:last-child,
+.bs-example > .list-group:last-child,
+.bs-example > .well:last-child,
+.bs-example > .progress:last-child,
+.bs-example > .table-responsive:last-child > .table {
+  margin-bottom: 0;
+}
 
-     /* Buttons */
-     .bs-example > .btn,
-     .bs-example > .btn-group {
-         margin-top: 5px;
-           margin-bottom: 5px;
-     }
-     .bs-example > .btn-toolbar + .btn-toolbar {
-         margin-top: 10px;
-     }
+.bs-example > p > .close {
+  float: none;
+}
 
-     /* Forms */
-     .bs-example-control-sizing select,
-     .bs-example-control-sizing input[type="text"] + input[type="text"] {
-         margin-top: 10px;
-     }
-     .bs-example-form .input-group {
-         margin-bottom: 10px;
-     }
-     .bs-example > textarea.form-control {
-         resize: vertical;
-     }
+/* Typography */
+.bs-example-type .table td:last-child {
+  color: #999;
+  vertical-align: middle;
+}
 
-     /* List groups */
-     .bs-example > .list-group {
-         max-width: 400px;
-     }
+@media (prefers-color-scheme: light) {
+  .bs-example-type .table td {
+    padding: 15px 0;
+    border-color: #eee;
+  }
+}
 
-     /* Navbars */
-     .bs-example .navbar:last-child {
-         margin-bottom: 0;
-     }
+@media (prefers-color-scheme: dark) {
+  .bs-example-type .table td {
+    padding: 15px 0;
+    border-color: #000;
+  }
+}
+
+.bs-example-type .table tr:first-child td {
+  border-top: 0;
+}
+.bs-example-type h1,
+.bs-example-type h2,
+.bs-example-type h3,
+.bs-example-type h4,
+.bs-example-type h5,
+.bs-example-type h6 {
+  margin: 0;
+}
+
+/* Images */
+.bs-example > .img-circle,
+.bs-example > .img-rounded,
+.bs-example > .img-thumbnail {
+  margin: 5px;
+}
+
+/* Buttons */
+.bs-example > .btn,
+.bs-example > .btn-group {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+.bs-example > .btn-toolbar + .btn-toolbar {
+  margin-top: 10px;
+}
+
+/* Forms */
+.bs-example-control-sizing select,
+.bs-example-control-sizing input[type="text"] + input[type="text"] {
+  margin-top: 10px;
+}
+.bs-example-form .input-group {
+  margin-bottom: 10px;
+}
+.bs-example > textarea.form-control {
+  resize: vertical;
+}
+
+/* List groups */
+.bs-example > .list-group {
+  max-width: 400px;
+}
+
+/* Navbars */
+.bs-example .navbar:last-child {
+  margin-bottom: 0;
+}

--- a/css/crew-specific.css
+++ b/css/crew-specific.css
@@ -14,10 +14,27 @@
 .footer .name-first {
   opacity: 0.7;
 }
-.container .jumbotron {
-  background-color: #fff;
-  color: #5F5F5F;
+
+@media (prefers-color-scheme: light) {
+  .container .jumbotron {
+    background-color: #1e1e1e;
+    color: #5F5F5F;
+  }
+
+  .highlight pre {
+    background-color: #D7E3FC;
+  }
 }
-.highlight pre {
-  background-color: #D7E3FC;
+
+@media (prefers-color-scheme: dark) {
+  .container, .jumbotron, body {
+    background-color: #1a1919;
+    color: #bdc1c6;
+  }
+
+  .highlight pre, pre, code {
+    background-color: #000;
+    color: rgb(209, 209, 209);
+    border: #000000;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="The missing package manager for Chrome OS">
     <meta name="author" content="Michal Siwek">
-    <link rel="shortcut icon" href="https://skycocker.github.io/chromebrew/favicon.png">
 
     <title>Chromebrew - the software source you missed so much</title>
 
@@ -24,15 +23,13 @@
 
   <body>
     <div class="container">
-     
-<ul>
-          <a href="https://github.com/skycocker/chromebrew"><img class="forkme" src="images/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
-        </ul>
-      
+      <ul>
+        <a href="https://github.com/skycocker/chromebrew"><img class="forkme" src="images/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+      </ul>
 
       <div class="jumbotron">
         <div class="center">
-          <img src="images/brew.png" alt="centered image">
+          <img src="images/brew-title.png" alt="centered image" width="29%" height="29%">
         </div>
         <h1>Chromebrew</h1>
         <p class="lead">The missing package manager for Chrome OS</p>
@@ -112,15 +109,15 @@
         <p>
           The idea is that you may be on a weak internet connection and cannot download too much data, but you don't have Crouton and need just a few small packages. Also, you may be on a good internet connection and need just a few small packages. Also, why not use Chrome OS as the operating system?
         </p>
-<h3>Is GUI supported?</h3>
-<p>
-  Chromebrew supports most GUI apps with help from the sommelier daemon. We don't support i686 architecture, due to Google dropping support.
-</p>
+        <h3>Is GUI supported?</h3>
+          <p>
+            Chromebrew supports most GUI apps with help from the sommelier daemon. We don't support i686 architecture, due to Google dropping support.
+        </p>
         <h3 id="howcanihelp">How can I help?</h3>
         <p>
-          If you have a compatible Chromebook, you can fork my Github repo and add new packages to the <code>packages</code> directory if you managed to build them from source successfully on your device. Package recipes are simple Ruby files - here is an example:
+          If you have a compatible Chromebook, you can fork my Github repo and add new packages to the <code>packages/</code> directory if you managed to build them from source successfully on your device. Package recipes are simple Ruby files - here is an example:
         </p>
-<pre># It is recommended that you investigate other files in the 'packages/' directory
+        <pre># It is recommended that you investigate other files in the 'packages/' directory
 # to help get an idea of how existing packages are being installed through Chromebrew.
 
 require 'package'
@@ -129,16 +126,17 @@ class Template &lt; Package
   description ''
   homepage ''
   version ''
+  license '' # Package license
   compatibility '' # Package compatibility
-  source_url '*.tar.gz'
+  source_url '*.tar.{gz,bz2,lz,etc}'
   source_sha256 ''
 
 # Optional: Prebuilt binary
 #  binary_url ({
-#    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/*-chromeos-armv7l.tar.xz',
-#     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/*-chromeos-armv7l.tar.xz',
-#       i686: 'https://dl.bintray.com/chromebrew/chromebrew/*-chromeos-i686.tar.xz',
-#     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/*-chromeos-x86_64.tar.xz',
+#    aarch64: '',
+#     armv7l: '',
+#       i686: '',
+#     x86_64: '',
 #  })
 #  binary_sha256 ({
 #    aarch64: '',
@@ -153,7 +151,11 @@ class Template &lt; Package
   # depends_on '*'
   #
 
+  # Function for checks to see if install should occur.
+  def self.preflight
 
+  end
+=
   # Function to perform pre-install operations prior to install for both source build and binary distribution.
   def self.preinstall
 
@@ -171,6 +173,10 @@ class Template &lt; Package
 
   end
 
+  # Function to perform pre-install operations prior to install.
+  def self.preinstall
+
+  end
 
   # Function to perform install from source build.
   def self.install
@@ -199,6 +205,4 @@ end
         <pre>© 2013-2022 Michal Siwek</pre>
       </div>
     </div> <!-- /container -->
-  
-
 </body></html>

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@ class Template &lt; Package
   def self.preflight
 
   end
-=
+
   # Function to perform pre-install operations prior to install for both source build and binary distribution.
   def self.preinstall
 


### PR DESCRIPTION
### Changes
- Add dark mode support for Chromebrew's homepage (it will be enabled automatically if the browser color scheme is dark mode)
- Fix formatting (the original one is terrible😅)
- Update package template

### Preview
![Screenshot 2022-03-17 5 09 06 PM](https://user-images.githubusercontent.com/73414985/158775751-dab78471-b25b-4ceb-9e34-3e04f729ce88.png)
