### PR TITLE
gh_pages: Fix image glitches in light mode

### DIFF
--- a/css/crew-specific.css
+++ b/css/crew-specific.css
@@ -17,7 +17,7 @@
 
 @media (prefers-color-scheme: light) {
   .container .jumbotron {
-    background-color: #1e1e1e;
+    background-color: #fff;
     color: #5F5F5F;
   }
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,13 @@
 
       <div class="jumbotron">
         <div class="center">
-          <img src="images/brew-title.png" alt="centered image" width="29%" height="29%">
+          <img id="crew-icon" src="images/brew.png" alt="centered image" width="29%" height="29%">
+          <script>
+            if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+              // use brew-title.png (with transparent background) when in dark mode
+              document.getElementById('crew-icon').src = 'images/brew-title.png'
+            }
+          </script>
         </div>
         <h1>Chromebrew</h1>
         <p class="lead">The missing package manager for Chrome OS</p>


### PR DESCRIPTION
When browsing in light mode, the crew icon (`brew-title.png`, with transparent background) is having some glitches, changed back to `brew.png` (not transparent) for light mode only.

Just discovered this problem while opening the chromebrew homepage on my phone😅