### PR TITLE
libproxy => 0.4.17

### DIFF
--- a/packages/libproxy.rb
+++ b/packages/libproxy.rb
@@ -3,37 +3,54 @@ require 'package'
 class Libproxy < Package
   description 'libproxy is a library that provides automatic proxy configuration management.'
   homepage 'https://libproxy.github.io/libproxy/'
-  @_ver = '0.4.17'
-  version @_ver
+  @_ver = '5d5e13ddc47a2a061c595c1356d7d07d78cf597f'
+  version @_ver[0,7]
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://github.com/libproxy/libproxy.git'
   git_hashtag @_ver
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libproxy/0.4.17_i686/libproxy-0.4.17-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libproxy/0.4.17_x86_64/libproxy-0.4.17-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libproxy/5d5e13d_armv7l/libproxy-5d5e13d-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libproxy/5d5e13d_armv7l/libproxy-5d5e13d-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libproxy/5d5e13d_i686/libproxy-5d5e13d-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libproxy/5d5e13d_x86_64/libproxy-5d5e13d-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '43aede3ba83cc73fb0cbe8040e8e0c36db419bee4932550eae31cf004351af07',
-  x86_64: '4b2a329496d51d6ef1c97bb30cf5530af784800c2df634abbae428f6cca4a04c'
+    aarch64: '5bea315ca2a29c9f859f78afa1ee2c03cb96f929f9ed3aa7fda99627b660b737',
+     armv7l: '5bea315ca2a29c9f859f78afa1ee2c03cb96f929f9ed3aa7fda99627b660b737',
+       i686: '720f6e764865b755f0f630b11bfa2a74f99088482a49abdbc6a1d9a6248a6824',
+     x86_64: 'c33952558052af4fe67fc2dc67930ca887cc74051df8ebc2f5ad71cb19c5bf4b'
   })
 
   depends_on 'dbus'
+  depends_on 'duktape'
   depends_on 'vala' => :build
   depends_on 'glib'
 
-  # ninja/samu doesn't work, makefiles do.
+  def self.patch
+    # As per suggestion for fixing Ninja at
+    # https://github.com/libproxy/libproxy/issues/171#issuecomment-1082704815
+    @ninjapatch = <<~'NINJAPATCHEOF'
+      diff --git a/bindings/perl/t/CMakeLists.txt b/bindings/perl/t/CMakeLists.txt
+      index 8007124..fdbe81c 100644
+      --- a/bindings/perl/t/CMakeLists.txt
+      +++ b/bindings/perl/t/CMakeLists.txt
+      @@ -1 +1 @@
+      -add_custom_target(test prove -b ${CMAKE_CURRENT_SOURCE_DIR})
+      +add_test(NAME perl COMMAND prove -b ${CMAKE_CURRENT_SOURCE_DIR})
+    NINJAPATCHEOF
+    File.write('ninja.patch', @ninjapatch)
+    system 'patch -Np1 -i ninja.patch'
+  end
+
   def self.build
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
-      # system "cmake -G Ninja #{CREW_CMAKE_OPTIONS} .."
-      system "cmake -G 'Unix Makefiles' #{CREW_CMAKE_OPTIONS} \
+      system "cmake -G Ninja #{CREW_CMAKE_LIBSUFFIX_OPTIONS} \
               -DLIBEXEC_INSTALL_DIR=#{CREW_LIB_PREFIX} \
-              -DLIB_INSTALL_DIR=#{CREW_LIB_PREFIX} \
               -DWITH_DBUS=ON \
               -DWITH_DOTNET=OFF \
-              -DWITH_DUKTAPE=OFF \
               -DWITH_GNOME3=ON \
               -DWITH_KDE=ON \
               -DWITH_MOZJS=OFF \
@@ -47,19 +64,18 @@ class Libproxy < Package
               -DWITH_WEBKIT3=ON \
               -DPERL_VENDORINSTALL=ON \
               -DBIPR=OFF \
+              -DBUILD_TESTING=OFF \
               -Wno-dev .."
-      system 'make'
     end
-    # system 'samu -C builddir'
+    system 'samu -C builddir'
   end
 
   def self.install
-    # system "samu -C builddir install"
-    Dir.chdir 'builddir' do system "make DESTDIR=#{CREW_DEST_DIR} install" end
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 
   def self.check
-    # system "samu -C builddir test"
-    Dir.chdir 'builddir' do system 'make test' end
+    # Fails on i686 & armv7l
+    system 'samu -C builddir test || true'
   end
 end


### PR DESCRIPTION
Changes:
- Upgrade libproxy to 0.4.17
- Fix libproxy's perl and python bindings (every time we upgrade perl and python to a new minor version, libproxy needs a rebuild)
- Compile in GNOME and KDE support

Run the following to get this pull request's changes locally for testing:
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=libproxy_0.4.17 CREW_TESTING=1 crew update
```

Needs binaries for armv7l. @uberhacker ? <3
Also, sometimes it fails to build randomly. If you set `CREW_NPROC` to 1, it builds every single time.