### PR TITLE
meson => 0.61.3

### DIFF
--- a/packages/meson.rb
+++ b/packages/meson.rb
@@ -3,25 +3,12 @@ require 'package'
 class Meson < Package
   description 'Meson is an open source build system meant to be both extremely fast and user friendly.'
   homepage 'https://mesonbuild.com/'
-  @_ver = '0.61.1'
+  @_ver = '0.61.3'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/mesonbuild/meson.git'
   git_hashtag @_ver
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.1_armv7l/meson-0.61.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.1_armv7l/meson-0.61.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.1_i686/meson-0.61.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.1_x86_64/meson-0.61.1-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '89471f377e91165418858f9dfb13e524e816f878ea3944636af042c9ddb42ffb',
-     armv7l: '89471f377e91165418858f9dfb13e524e816f878ea3944636af042c9ddb42ffb',
-       i686: 'b941660b357c7c215ae2da568f74184106acf942ba5e3452058f6c1b57e53637',
-     x86_64: 'a17eb696f9f1ef5c6d03143f0f8c7ad2ee0b7454604660f302c738402e0f8197'
-  })
 
   depends_on 'ninja'
   depends_on 'samurai'

--- a/packages/meson.rb
+++ b/packages/meson.rb
@@ -10,6 +10,15 @@ class Meson < Package
   source_url 'https://github.com/mesonbuild/meson.git'
   git_hashtag @_ver
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.3_i686/meson-0.61.3-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.3_x86_64/meson-0.61.3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '18788f704936ea4780d23bf8c62cc92c285061f8234319f9cda94183aaf2f524',
+  x86_64: '4e6a6c90dd4bd7383c63d8b8e4c4bbddac0bf01b11cfcb371f991c2554ece7d6'
+  })
+
   depends_on 'ninja'
   depends_on 'samurai'
   depends_on 'py3_setuptools' => :build

--- a/packages/meson.rb
+++ b/packages/meson.rb
@@ -11,12 +11,16 @@ class Meson < Package
   git_hashtag @_ver
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.3_i686/meson-0.61.3-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.3_x86_64/meson-0.61.3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.3_armv7l/meson-0.61.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.3_armv7l/meson-0.61.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.3_i686/meson-0.61.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.61.3_x86_64/meson-0.61.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '18788f704936ea4780d23bf8c62cc92c285061f8234319f9cda94183aaf2f524',
-  x86_64: '4e6a6c90dd4bd7383c63d8b8e4c4bbddac0bf01b11cfcb371f991c2554ece7d6'
+    aarch64: '6eaaf072f96c0e188081cb326e364881de6c565f4bd6e6e4a715443a6347cf30',
+     armv7l: '6eaaf072f96c0e188081cb326e364881de6c565f4bd6e6e4a715443a6347cf30',
+       i686: '18788f704936ea4780d23bf8c62cc92c285061f8234319f9cda94183aaf2f524',
+     x86_64: '4e6a6c90dd4bd7383c63d8b8e4c4bbddac0bf01b11cfcb371f991c2554ece7d6'
   })
 
   depends_on 'ninja'


### PR DESCRIPTION
Changes:
- Upgrade meson

```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=meson_0.61.3 CREW_TESTING=1 crew update
```

Needs armv7l binaries, however meson is arch independent, so maybe we don't need to compile more, we can just use the x86_64 or i686 ones? Sidenote: chromebrew should have a way to handle arch independent packages.