### PR TITLE
envvar to control use of samurai or ninja

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -197,6 +197,13 @@ CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
   -Dc_args='-O2'
 OPT
 
+# Use ninja or samurai
+if ENV['CREW_NINJA'].to_s.downcase == 'ninja'
+  CREW_NINJA = 'ninja'
+else
+  CREW_NINJA = 'samu'
+end
+
 # Cmake sometimes wants to use LIB_SUFFIX to install libs in LIB64, so specify such for x86_64
 # This is often considered deprecated. See discussio at https://gitlab.kitware.com/cmake/cmake/-/issues/18640
 # and also https://bugzilla.redhat.com/show_bug.cgi?id=1425064

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.2'
+CREW_VERSION = '1.23.3'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/packages/samurai.rb
+++ b/packages/samurai.rb
@@ -4,11 +4,20 @@ class Samurai < Package
   description 'Samurai is a ninja compatible build tool written in C.'
   homepage 'https://github.com/michaelforney/samurai/'
   @_ver = '1.2'
-  version @_ver + '-1'
+  version "#{@_ver}-1"
   license 'Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'https://github.com/michaelforney/samurai.git'
   git_hashtag @_ver
+
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/samurai/1.2-1_i686/samurai-1.2-1-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/samurai/1.2-1_x86_64/samurai-1.2-1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'e84c2886040bbc549bb9aebc17fdad87218d4a83371c7f42999dd54b48bde36f',
+  x86_64: '292fd418d6db6cd9d2f67a92f1f2fdcbd784f5d4bc5abeee002dbe5f2bd7205d'
+  })
 
   def self.patch
     system "sed -i 's:PREFIX=/usr/local:PREFIX=#{CREW_PREFIX}:' Makefile"
@@ -22,7 +31,7 @@ class Samurai < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check

--- a/packages/samurai.rb
+++ b/packages/samurai.rb
@@ -2,25 +2,13 @@ require 'package'
 
 class Samurai < Package
   description 'Samurai is a ninja compatible build tool written in C.'
-  homepage 'https://github.com/michaelforney/samurai'
-  version '1.2'
+  homepage 'https://github.com/michaelforney/samurai/'
+  @_ver = '1.2'
+  version @_ver + '-1'
   license 'Apache-2.0 and MIT'
   compatibility 'all'
-  source_url 'https://github.com/michaelforney/samurai/releases/download/1.2/samurai-1.2.tar.gz'
-  source_sha256 '3b8cf51548dfc49b7efe035e191ff5e1963ebc4fe8f6064a5eefc5343eaf78a5'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/samurai/1.2_armv7l/samurai-1.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/samurai/1.2_armv7l/samurai-1.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/samurai/1.2_i686/samurai-1.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/samurai/1.2_x86_64/samurai-1.2-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'bf38ed51c2b3ade1b3879a09ae2962660a7c89c88ac6dcbf673378e58b04d33c',
-     armv7l: 'bf38ed51c2b3ade1b3879a09ae2962660a7c89c88ac6dcbf673378e58b04d33c',
-       i686: '2e79ba64fe6e772aea6520b026d5564baaa7420e3b3b2fd344a39fdb18988381',
-     x86_64: 'a91fba00b13f46aabd60a96b652b8e4629fcd209eb18692c15f3dac1595fd9d4',
-  })
+  source_url 'https://github.com/michaelforney/samurai.git'
+  git_hashtag @_ver
 
   def self.patch
     system "sed -i 's:PREFIX=/usr/local:PREFIX=#{CREW_PREFIX}:' Makefile"
@@ -28,12 +16,16 @@ class Samurai < Package
   end
 
   def self.build
-    system "make CFLAGS='-pipe -O2 -flto=auto -fuse-ld=gold' \
-                LDFLAGS='-flto=auto -fuse-ld=gold' \
+    system "make CFLAGS='#{CREW_COMMON_FLAGS}' \
+                LDFLAGS='#{CREW_LDFLAGS}' \
                 CC='#{CREW_TGT}-gcc'"
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    # no checks
   end
 end


### PR DESCRIPTION
Changes:
- Recompile samurai to use the latest CREW_COMMON_FLAGS, etc.
- Create an environment variable called CREW_NINJA to control use of samurai or ninja
- Create a chromebrew constant called CREW_NINJA controlled by the environment variable

Example use case:
```ruby
def self.build
  Dir.mkdir "builddir"
  Dir.chdir "builddir" do
    system "cmake -G Ninja #{CREW_COMMON_FLAGS} .."
  end
  system "#{CREW_NINJA} -C builddir"
end

def self.install
  system "#{CREW_NINJA} -C builddir install"
end

def self.check
  system "#{CREW_NINJA} -C builddir test"
end
```

Run the following to get this pull request's changes locally for testing:
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=samuorninja CREW_TESTING=1 crew update
```

samurai needs armv7l binaries.