### PR TITLE
FFmpeg fix

### DIFF
--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -45,10 +45,11 @@ class Ffmpeg < Package
   depends_on 'libaom' # R
   depends_on 'libass' # R
   depends_on 'lilv' # R
-  depends_on 'leptonica' => :build
+  depends_on 'leptonica' # R
   depends_on 'libavc1394' # R
   depends_on 'libbluray' # R
   depends_on 'libdrm' # R
+  depends_on 'libfdk_aac' # R
   depends_on 'libiec61883' # R
   depends_on 'libmfx' if ARCH == 'i686' && `grep -c 'GenuineIntel' /proc/cpuinfo`.to_i.positive? # R
   depends_on 'libmodplug' # R
@@ -80,8 +81,11 @@ class Ffmpeg < Package
   depends_on 'pulseaudio' # R
   depends_on 'rav1e' # R
   depends_on 'rubberband' # R
+  depends_on 'serd' # R
   depends_on 'snappy' # R
+  depends_on 'sord' # R
   depends_on 'speex' # R
+  depends_on 'sratom' # R
   depends_on 'srt' # R
   depends_on 'tesseract' # R
   depends_on 'v4l_utils' # R
@@ -89,6 +93,7 @@ class Ffmpeg < Package
   depends_on 'vmaf' # R
   depends_on 'zeromq' # R
   depends_on 'zimg' # R
+  depends_on 'zvbi' # R
 
   def self.build
     case ARCH
@@ -109,8 +114,8 @@ class Ffmpeg < Package
     # ChromeOS awk employs sandbox redirection protections which screw
     # up configure script generation, so use mawk.
     system "sed -i 's/awk/mawk/g' configure"
-    system "CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE #{@lto} -fuse-ld=gold' \
-        CXXFLAGS='-pipe -U_FORTIFY_SOURCE #{@lto} -fuse-ld=gold' \
+    system "CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE #{@lto} -fuse-ld=#{CREW_LINKER}' \
+        CXXFLAGS='-pipe -U_FORTIFY_SOURCE #{@lto} -fuse-ld=#{CREW_LINKER}' \
         LDFLAGS='-U_FORTIFY_SOURCE #{@lto}' \
         ./configure \
         --arch=#{ARCH} \

--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -4,7 +4,7 @@ class Ffmpeg < Package
   description 'Complete solution to record, convert and stream audio and video'
   homepage 'https://ffmpeg.org/'
   @_ver = '5.0'
-  version @_ver
+  version @_ver + '-1'
   license 'LGPL-2,1, GPL-2, GPL-3, and LGPL-3' # When changing ffmpeg's configure options, make sure this variable is still accurate.
   compatibility 'all'
   source_url 'https://git.ffmpeg.org/ffmpeg.git'

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -10,6 +10,15 @@ class Harfbuzz < Package
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
   git_hashtag @_ver
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-2_i686/harfbuzz-4.0.0-2-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-2_x86_64/harfbuzz-4.0.0-2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'afd0782a34ce9ced64a627430c4d2c3bbc1ea1e47a581a0f659e009cd21ddfe0',
+  x86_64: '7dde8560b5f00549deb73cc44e80e3658b8eb8d55eed902e1ca5041bd6f6451b'
+  })
+
   # provides libpng, freetype (sans harfbuzz), and ragel
   # depends_on 'cairo' => :build (cairo is only needed for tests and tools)
   depends_on 'brotli'

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -4,24 +4,11 @@ class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
   @_ver = '4.0.0'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
   git_hashtag @_ver
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_i686/harfbuzz-4.0.0-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_x86_64/harfbuzz-4.0.0-1-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
-     armv7l: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
-       i686: 'fe23c57f63f0fd9d03cd8679076d0aa6aeb0db9880efd1099814385fe53c878f',
-     x86_64: 'c9ad1d2c137cfa65efcfbc855fc6b2a616130653d18ff730b53ece6676513a44'
-  })
 
   # provides libpng, freetype (sans harfbuzz), and ragel
   # depends_on 'cairo' => :build (cairo is only needed for tests and tools)
@@ -34,6 +21,7 @@ class Harfbuzz < Package
   depends_on 'graphite'
   depends_on 'icu4c'
   depends_on 'libffi'
+  depends_on 'libpng'
   depends_on 'pcre'
   depends_on 'py3_six' => :build
   depends_on 'zlibpkg'

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -1,13 +1,29 @@
 require 'package'
 
 class Libpng < Package
-  description 'libpng is the official PNG reference library. Now bundled with harfbuzz.'
+  description 'libpng is the official PNG reference library, with APNG support packaged in.'
   homepage 'http://libpng.org/pub/png/libpng.html'
-  version "1.0"
+  version '1.6.37'
   license 'libpng2'
   compatibility 'all'
+  source_url 'https://sourceforge.net/projects/libpng/files/libpng16/1.6.37/libpng-1.6.37.tar.xz'
+  source_sha256 '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
 
-  depends_on 'harfbuzz'
-  is_fake
+  def self.patch
+    downloader 'https://sourceforge.net/projects/libpng-apng/files/libpng16/1.6.37/libpng-1.6.37-apng.patch.gz'
+    system 'gunzip -c libpng-1.6.37-apng.patch.gz | patch -Np1'
+  end
 
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
 end

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -20,6 +20,7 @@ class Libpng < Package
 
   def self.patch
     downloader 'https://sourceforge.net/projects/libpng-apng/files/libpng16/1.6.37/libpng-1.6.37-apng.patch.gz'
+    abort 'Checksum mismatch :/ try again'.lightred unless Digest::SHA256.hexdigest(File.read('libpng-1.6.37-apng.patch.gz')) == '823bb2d1f09dc7dae4f91ff56d6c22b4b533e912cbd6c64e8762255e411100b6'
     system 'gunzip -c libpng-1.6.37-apng.patch.gz | patch -Np1'
   end
 

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -9,6 +9,15 @@ class Libpng < Package
   source_url 'https://sourceforge.net/projects/libpng/files/libpng16/1.6.37/libpng-1.6.37.tar.xz'
   source_sha256 '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37_i686/libpng-1.6.37-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpng/1.6.37_x86_64/libpng-1.6.37-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '1cff84fce9bfa50410881ceb77514c5b44a72220d06107f4b696e7af225f5949',
+  x86_64: '36b7ae1f9dec4db1d91953c9c4aa03ed17b25d785d8f87d546dce38bdfc2ee0d'
+  })
+
   def self.patch
     downloader 'https://sourceforge.net/projects/libpng-apng/files/libpng16/1.6.37/libpng-1.6.37-apng.patch.gz'
     system 'gunzip -c libpng-1.6.37-apng.patch.gz | patch -Np1'

--- a/packages/libva.rb
+++ b/packages/libva.rb
@@ -4,11 +4,20 @@ class Libva < Package
   description 'Libva is an implementation for VA-API (Video Acceleration API)'
   homepage 'https://01.org/linuxmedia'
   @_ver = '2.14.0'
-  version @_ver + '-1'
+  version "#{@_ver}-1"
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/intel/libva.git'
   git_hashtag @_ver
+
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0-1_i686/libva-2.14.0-1-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0-1_x86_64/libva-2.14.0-1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '1700a56897fe819b81ea1f9eab16a440c29176bea367d502438baa5b17c44b18',
+  x86_64: '308c44dc90c0dd695865aab25f3054af5bcdc6845202e079262d4e70b1aca1d9'
+  })
 
   depends_on 'libdrm'
   depends_on 'libx11'

--- a/packages/libva.rb
+++ b/packages/libva.rb
@@ -4,24 +4,11 @@ class Libva < Package
   description 'Libva is an implementation for VA-API (Video Acceleration API)'
   homepage 'https://01.org/linuxmedia'
   @_ver = '2.14.0'
-  version @_ver
+  version @_ver + '-1'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/intel/libva.git'
   git_hashtag @_ver
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_armv7l/libva-2.14.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_armv7l/libva-2.14.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_i686/libva-2.14.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_x86_64/libva-2.14.0-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: '1177ea4f0e3d8218a917070ba4943a8850ffb48c92be88c53373a77c35063c08',
-     armv7l: '1177ea4f0e3d8218a917070ba4943a8850ffb48c92be88c53373a77c35063c08',
-       i686: 'e77eafe870dde013f5868eabebdd1ea0980ae642c28b11d5d4ee8b8f60c0fbfe',
-     x86_64: '4f330f77b5cdec5d11bcce6436c601db00c3def6fe07ebaaebd163068eb566ed'
-  })
 
   depends_on 'libdrm'
   depends_on 'libx11'
@@ -42,5 +29,9 @@ class Libva < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+
+  def self.check
+    system 'ninja -C builddir test'
   end
 end


### PR DESCRIPTION
Background:
FFmpeg is currently broken (try running the binary on an install, it's missing a lot of libraries).

Changes:
- Add dependencies to FFmpeg: libfdk_aac, serd, sord, sratom, zvbi
- Bump FFmpeg version so new dependencies are installed if not already
- Use mold on appropriate architectures when building FFmpeg in the future
- Unbundle libpng from harfbuzz. Harfbuzz's libpng library doesn't work with leptonica, zvbi and other packages.
- Add animated png support to libpng
- Recompile libva with x11 support
- Add libva checks

Run the following to get this pull request's changes locally for testing:
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=ffmpeg_5.0_fix CREW_TESTING=1 crew update
```

Need armv7l binaries. Building order: `libpng libva harfbuzz`