### PR TITLE
deb_utils: Ignore trailing newline

### DIFF
--- a/lib/deb_utils.rb
+++ b/lib/deb_utils.rb
@@ -20,8 +20,8 @@ module DebUtils
 
     # process each file in archive
     while (line = src_fileIO.gets) do
-      # early return if trailing newline is detected
       if line.chomp.empty? and file_size == src_fileIO.tell
+        # early return if trailing newline is detected
         break
       elsif line.chomp.empty?
         STDERR.puts "Unexpected newline in offset #{src_fileIO.tell}, ignoring...".yellow

--- a/lib/deb_utils.rb
+++ b/lib/deb_utils.rb
@@ -21,7 +21,7 @@ module DebUtils
     # process each file in archive
     while (line = src_fileIO.gets) do
       # early return if trailing newline is detected
-      if line.chomp.empty? and (file_size - src_fileIO.tell) == 1
+      if line.chomp.empty? and file_size == src_fileIO.tell
         break
       elsif line.chomp.empty?
         STDERR.puts "Unexpected newline in offset #{src_fileIO.tell}, ignoring...".yellow


### PR DESCRIPTION
Fixes #6865 

Skip trailing newline in archive, ignore unexpected newlines

Tested on `x86_64`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=deb_utils CREW_TESTING=1 crew update
```
