### PR TITLE
Fix dependency resolver to include only one version of jdk

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1298,6 +1298,9 @@ def resolve_dependencies
 
   # leave only not installed packages in dependencies
   @dependencies.select! {|name| @device[:installed_packages].none? {|pkg| pkg[:name] == name}}
+  ['jdk11','jdk15','jdk16','jdk17'].each do |jdk|
+    @dependencies.delete('jdk8') if @dependencies.include?(jdk)
+  end
 
   return if @dependencies.empty?
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.5'
+CREW_VERSION = '1.23.6'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Fixes #6886.

This is not the most elegant solution but it gets the job done.