### PR TITLE
Gnome macro

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -941,6 +941,7 @@ def post_install
       puts "Performing post-install for #{@pkg.name}...".lightblue
       @pkg.postinstall
       if @pkg.gnome?
+        puts "Performing Gnome post-installs for #{@pkg.name}...".lightblue
         # Is this needed here?
         @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
         # generate schemas

--- a/bin/crew
+++ b/bin/crew
@@ -940,6 +940,22 @@ def post_install
     Dir.chdir post_install_tempdir do
       puts "Performing post-install for #{@pkg.name}...".lightblue
       @pkg.postinstall
+      if @pkg.gnome?
+        # Is this needed here?
+        @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+        # generate schemas
+        if @device[:installed_packages].any? { |elem| elem[:name] == 'glib' }
+          system "#{CREW_PREFIX}/bin/glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
+        end
+        # update mime database
+        if @device[:installed_packages].any? { |elem| elem[:name] == 'shared_mime_info' }
+          system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
+        end
+        # update icon cache, but only if gdk_pixbuf is already installed.
+        if @device[:installed_packages].any? { |elem| elem[:name] == 'gdk_pixbuf' }
+          system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/* || true"
+        end
+      end
     end
   end
 end
@@ -1294,6 +1310,13 @@ def resolve_dependencies
   abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @device[:compatible_packages].any? {|elem| elem[:name] == @pkg.name }
 
   @dependencies = []
+  if @pkg.gnome?
+    GNOME_DEPS.each do |dep|
+      return if @pkg.name == dep
+
+      @dependendencies.push(dep) unless @device[:installed_packages].any? { |pkg| pkg[:name] == dep }
+    end
+  end
   expand_dependencies
 
   # leave only not installed packages in dependencies

--- a/bin/crew
+++ b/bin/crew
@@ -1313,7 +1313,7 @@ def resolve_dependencies
   @dependencies = []
   if @pkg.gnome?
     GNOME_DEPS.each do |dep|
-      return if @pkg.name == dep
+      continue if @pkg.name == dep
 
       @dependendencies.push(dep) unless @device[:installed_packages].any? { |pkg| pkg[:name] == dep }
     end

--- a/bin/crew
+++ b/bin/crew
@@ -941,9 +941,7 @@ def post_install
       puts "Performing post-install for #{@pkg.name}...".lightblue
       @pkg.postinstall
       if @pkg.gnome?
-        puts "Performing Gnome post-installs for #{@pkg.name}...".lightblue
-        # Is this needed here?
-        @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+        puts "Performing Gnome post-installs for #{@pkg.name}...".lightblue if @opt_verbose
         # generate schemas
         if @device[:installed_packages].any? { |elem| elem[:name] == 'glib' }
           system "#{CREW_PREFIX}/bin/glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"

--- a/bin/crew
+++ b/bin/crew
@@ -1309,13 +1309,6 @@ def resolve_dependencies
   abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @device[:compatible_packages].any? {|elem| elem[:name] == @pkg.name }
 
   @dependencies = []
-  if @pkg.gnome?
-    GNOME_DEPS.each do |dep|
-      continue if @pkg.name == dep
-
-      @dependendencies.push(dep) unless @device[:installed_packages].any? { |pkg| pkg[:name] == dep }
-    end
-  end
   expand_dependencies
 
   # leave only not installed packages in dependencies

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -247,9 +247,3 @@ CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +
                        %w[libzstd.so.1 libstdc++.so.6]
 CREW_ESSENTIAL_FILES.uniq!
-
-GNOME_DEPS = %w[
-glib
-shared_mime_info
-gdk_pixbuf
-]

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.6'
+CREW_VERSION = '1.23.7'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -247,3 +247,9 @@ CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +
                        %w[libzstd.so.1 libstdc++.so.6]
 CREW_ESSENTIAL_FILES.uniq!
+
+GNOME_DEPS = %w[
+glib
+shared_mime_info
+gdk_pixbuf
+]

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -5,7 +5,7 @@ class Package
            :binary_url, :binary_sha256, :source_url, :source_sha256,
            :git_branch, :git_hashtag
 
-  boolean_property = %i[conflicts_ok git_fetchtags is_fake is_musl
+  boolean_property = %i[conflicts_ok git_fetchtags gnome is_fake is_musl
                         is_static no_env_options no_fhs no_patchelf
                         no_zstd patchelf]
 

--- a/packages/baobab.rb
+++ b/packages/baobab.rb
@@ -27,6 +27,7 @@ class Baobab < Package
   depends_on 'itstool' => :build
   depends_on 'vala' => :build
   depends_on 'sommelier'
+  gnome
 
   def self.build
     system "meson  --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
@@ -35,9 +36,5 @@ class Baobab < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
-
-  def self.postinstall
-    system "update-mime-database #{CREW_PREFIX}/share/mime"
   end
 end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -69,6 +69,7 @@ class Gtk3 < Package
   depends_on 'valgrind' => :build
   depends_on 'wayland' # R
   depends_on 'xdg_base' # L
+  gnome
 
   def self.patch
     # Use locally build subprojects
@@ -103,17 +104,5 @@ class Gtk3 < Package
     system "sed -i 's,null,,g'  #{CREW_DEST_LIB_PREFIX}/pkgconfig/gtk*.pc"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/gtk-3.0"
     File.write("#{CREW_DEST_PREFIX}/etc/gtk-3.0/settings.ini", @gtk3settings)
-  end
-
-  def self.postinstall
-    # generate schemas
-    system "#{CREW_PREFIX}/bin/glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
-    # update mime database
-    system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
-    # update icon cache, but only if gdk_pixbuf is already installed.
-    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    return unless @device[:installed_packages].any? { |elem| elem[:name] == 'gdk_pixbuf' }
-
-    system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/* || true"
   end
 end

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -71,6 +71,7 @@ class Gtk4 < Package
   depends_on 'rest' # R
   depends_on 'vulkan_icd_loader' # R
   depends_on 'wayland' # R
+  gnome
 
   def self.patch
     case ARCH
@@ -111,17 +112,5 @@ class Gtk4 < Package
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/gtk-4.0"
     File.write("#{CREW_DEST_PREFIX}/etc/gtk-4.0/settings.ini", @gtk4settings)
-  end
-
-  def self.postinstall
-    # generate schemas
-    system "#{CREW_PREFIX}/bin/glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
-    # update mime database
-    system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
-    # update icon cache, but only if gdk_pixbuf is already installed.
-    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
-    return unless @device[:installed_packages].any? { |elem| elem[:name] == 'gdk_pixbuf' }
-
-    system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/* || true"
   end
 end


### PR DESCRIPTION
Fixes #6894 
- Use macro for gnome package postinstalls.
- I expect this might require some revisions.. .suggestions welcome!

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gnome_macro CREW_TESTING=1 crew update
```