### PR TITLE
rebuild httrack

### DIFF
--- a/packages/httrack.rb
+++ b/packages/httrack.rb
@@ -3,33 +3,35 @@ require 'package'
 class Httrack < Package
   description 'HTTrack is a free (GPL, libre/free software) and easy-to-use offline browser utility. It allows you to download a World Wide Web site from the Internet to a local directory, building recursively all directories, getting HTML, images, and other files from the server to your computer.'
   homepage 'http://www.httrack.com/'
-  version '3.49.2-1'
+  version '3.49.2-2'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://mirror.httrack.com/httrack-3.49.2.tar.gz'
   source_sha256 '3477a0e5568e241c63c9899accbfcdb6aadef2812fcce0173688567b4c7d4025'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/httrack/3.49.2-1_armv7l/httrack-3.49.2-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/httrack/3.49.2-1_armv7l/httrack-3.49.2-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/httrack/3.49.2-1_i686/httrack-3.49.2-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/httrack/3.49.2-1_x86_64/httrack-3.49.2-1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/httrack/3.49.2-2_armv7l/httrack-3.49.2-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/httrack/3.49.2-2_armv7l/httrack-3.49.2-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/httrack/3.49.2-2_i686/httrack-3.49.2-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/httrack/3.49.2-2_x86_64/httrack-3.49.2-2-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '332ff037e21446d4bf593826221ce95895a6824ae2cb56d10bfff2e2827446c3',
-     armv7l: '332ff037e21446d4bf593826221ce95895a6824ae2cb56d10bfff2e2827446c3',
-       i686: '3e7799279a34e92db45e902bc478c0667c6b6623524d25c03556726012a99a52',
-     x86_64: '2065795d69e14009464820aae2c13fad266e3be9c14243bf27a7c7f14f0eae0e',
+  binary_sha256({
+    aarch64: '65be9f112bd18ec49d3d0425e9b49d9c0e4a1242419ea1b4bb28ac68ec29cc8b',
+     armv7l: '65be9f112bd18ec49d3d0425e9b49d9c0e4a1242419ea1b4bb28ac68ec29cc8b',
+       i686: '708949b7a3910a98d66c41db1c872ce1451e9afe43af38b06463a9218905cf17',
+     x86_64: 'e2d6bd8daf3d21577b4f908a3e1c585791365d3befe7b0df450898f8fc8dba60'
   })
 
+  def self.patch
+    system 'filefix'
+  end
+
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
Fixes #6910

- rebuilds `httrack`

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=httrack_rebuild  CREW_TESTING=1 crew update
```
