### PR TITLE
Ffmpeg rebuild

### DIFF
--- a/packages/asciidoc.rb
+++ b/packages/asciidoc.rb
@@ -3,39 +3,35 @@ require 'package'
 class Asciidoc < Package
   description 'AsciiDoc is a presentable text document format for writing articles, UNIX man pages and other small to medium sized documents.'
   homepage 'http://asciidoc.org/'
-  @_ver = '9.1.0'
+  @_ver = '10.1.4'
   version @_ver
   license 'GPL-2'
   compatibility 'all'
   source_url "https://github.com/asciidoc/asciidoc-py3/releases/download/#{@_ver}/asciidoc-#{@_ver}.tar.gz"
-  source_sha256 'fd499fcf51317b1aaf27336fb5e919c44c1f867f1ae6681ee197365d3065238b'
+  source_sha256 'e4da7cc2af7fa12029156c0788fde2a53db1352d7dcb3e674a9d546b3bdba93f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoc/9.1.0_armv7l/asciidoc-9.1.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoc/9.1.0_armv7l/asciidoc-9.1.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoc/9.1.0_i686/asciidoc-9.1.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoc/9.1.0_x86_64/asciidoc-9.1.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoc/10.1.4_armv7l/asciidoc-10.1.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoc/10.1.4_armv7l/asciidoc-10.1.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoc/10.1.4_i686/asciidoc-10.1.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoc/10.1.4_x86_64/asciidoc-10.1.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2b38a7ec2050abd4df05fe90a4bb85199c3d45d7961ad0c5bcbf065b2f411857',
-     armv7l: '2b38a7ec2050abd4df05fe90a4bb85199c3d45d7961ad0c5bcbf065b2f411857',
-       i686: '2ff48243579ceb94ebcbda0ee8b5f626dcae7d42494260eda8b24a4d430b6e75',
-     x86_64: 'f666c49abfa66b17013130de84ad2822f9ffbaa48063f1d742950d5acea1f3f1'
+    aarch64: '8aa6102c4aa68f5d8309af9ebfb27b683b8e636634dc526ec1d3a563b12af962',
+     armv7l: '8aa6102c4aa68f5d8309af9ebfb27b683b8e636634dc526ec1d3a563b12af962',
+       i686: 'd86b85c86cbbf6e47edf276c72acaa88d2961332806e2b5ce71212db4fcb51b7',
+     x86_64: '7cdf448d6defb19aed9dcdfa41010349334719cef7c7d52fe65f564cf1699049'
   })
 
   def self.build
     system 'autoconf'
     system "sed -i 's,/etc/vim,#{CREW_PREFIX}/etc/vim,g' Makefile.in"
-    system "env CFLAGS='-flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 
   def self.install
     system "mkdir -p #{CREW_DEST_PREFIX}/etc/vim"
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    system "compressdoc --gzip -9 #{CREW_DEST_PREFIX}/share/man/man1"
   end
 end

--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -4,23 +4,23 @@ class Ffmpeg < Package
   description 'Complete solution to record, convert and stream audio and video'
   homepage 'https://ffmpeg.org/'
   @_ver = '5.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'LGPL-2,1, GPL-2, GPL-3, and LGPL-3' # When changing ffmpeg's configure options, make sure this variable is still accurate.
   compatibility 'all'
   source_url 'https://git.ffmpeg.org/ffmpeg.git'
   git_hashtag "n#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0_armv7l/ffmpeg-5.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0_armv7l/ffmpeg-5.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0_i686/ffmpeg-5.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0_x86_64/ffmpeg-5.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_armv7l/ffmpeg-5.0-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_armv7l/ffmpeg-5.0-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_i686/ffmpeg-5.0-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_x86_64/ffmpeg-5.0-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5f9ab043558a4a059bb7ae75b5b763179cca3b164729197c39bb8cd3397714dc',
-     armv7l: '5f9ab043558a4a059bb7ae75b5b763179cca3b164729197c39bb8cd3397714dc',
-       i686: 'ba11082bdc94dbd5d2e9939880dcbc3e3e0602661afdc0d3c16578928eda7b61',
-     x86_64: '47dcdcba48fd60d40856138eca3818c5bfdcb506d1a4261a7b5a2897c7d49575'
+    aarch64: 'b55ea0c0549d576e0c946180d0b0a3c560aae01d9074ad8b0c5bee2045a3955e',
+     armv7l: 'b55ea0c0549d576e0c946180d0b0a3c560aae01d9074ad8b0c5bee2045a3955e',
+       i686: '91e328f13cdaa3e433ed1a3ebe862b2b81e1c689ba5babc6e7787ba688bfb1b6',
+     x86_64: '7eeca38e7677f959d8516faf79019b2502e578b9aee41ad075d2157aae55c667'
   })
 
   depends_on 'avisynthplus' # ?
@@ -29,6 +29,7 @@ class Ffmpeg < Package
   depends_on 'wavpack' # ?
   depends_on 'zvbi' # ?
   depends_on 'ccache' => :build
+  depends_on 'harfbuzz'
   depends_on 'libdc1394' => :build
   depends_on 'libfdk_aac' => :build
   depends_on 'libfrei0r' => :build
@@ -45,10 +46,11 @@ class Ffmpeg < Package
   depends_on 'libaom' # R
   depends_on 'libass' # R
   depends_on 'lilv' # R
-  depends_on 'leptonica' => :build
+  depends_on 'leptonica' # R
   depends_on 'libavc1394' # R
   depends_on 'libbluray' # R
   depends_on 'libdrm' # R
+  depends_on 'libfdk_aac' # R
   depends_on 'libiec61883' # R
   depends_on 'libmfx' if ARCH == 'i686' && `grep -c 'GenuineIntel' /proc/cpuinfo`.to_i.positive? # R
   depends_on 'libmodplug' # R
@@ -80,8 +82,11 @@ class Ffmpeg < Package
   depends_on 'pulseaudio' # R
   depends_on 'rav1e' # R
   depends_on 'rubberband' # R
+  depends_on 'serd' # R
   depends_on 'snappy' # R
+  depends_on 'sord' # R
   depends_on 'speex' # R
+  depends_on 'sratom' # R
   depends_on 'srt' # R
   depends_on 'tesseract' # R
   depends_on 'v4l_utils' # R
@@ -89,6 +94,7 @@ class Ffmpeg < Package
   depends_on 'vmaf' # R
   depends_on 'zeromq' # R
   depends_on 'zimg' # R
+  depends_on 'zvbi' # R
 
   def self.build
     case ARCH
@@ -109,8 +115,8 @@ class Ffmpeg < Package
     # ChromeOS awk employs sandbox redirection protections which screw
     # up configure script generation, so use mawk.
     system "sed -i 's/awk/mawk/g' configure"
-    system "CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE #{@lto} -fuse-ld=gold' \
-        CXXFLAGS='-pipe -U_FORTIFY_SOURCE #{@lto} -fuse-ld=gold' \
+    system "CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE #{@lto} -fuse-ld=#{CREW_LINKER}' \
+        CXXFLAGS='-pipe -U_FORTIFY_SOURCE #{@lto} -fuse-ld=#{CREW_LINKER}' \
         LDFLAGS='-U_FORTIFY_SOURCE #{@lto}' \
         ./configure \
         --arch=#{ARCH} \
@@ -178,7 +184,7 @@ class Ffmpeg < Package
         --enable-shared \
         --enable-version3 \
         #{@mfx}  \
-        --host-cflags='-pipe -fno-stack-protector -U_FORTIFY_SOURCE #{@lto} -fuse-ld=gold' \
+        --host-cflags='-pipe -fno-stack-protector -U_FORTIFY_SOURCE #{@lto} -fuse-ld=#{CREW_LINKER}' \
         --host-ldflags='-fno-stack-protector -U_FORTIFY_SOURCE #{@lto}' \
         #{CREW_OPTIONS.sub(/--build=.*/, '')}"
 

--- a/packages/leptonica.rb
+++ b/packages/leptonica.rb
@@ -3,29 +3,29 @@ require 'package'
 class Leptonica < Package
   description 'Software that is broadly useful for image processing and image analysis applications'
   homepage 'http://www.leptonica.com/'
-  @_ver = '1.80.0'
-  version "#{@_ver}-1"
+  @_ver = '1.82.0'
+  version @_ver.to_s
   license 'Apache-2.0'
   compatibility 'all'
-  source_url "https://github.com/DanBloomberg/leptonica/archive/#{@_ver}.tar.gz"
-  source_sha256 '3952b974ec057d24267aae48c54bca68ead8275604bf084a73a4b953ff79196e'
+  source_url 'https://github.com/DanBloomberg/leptonica.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/leptonica/1.80.0-1_armv7l/leptonica-1.80.0-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/leptonica/1.80.0-1_armv7l/leptonica-1.80.0-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/leptonica/1.80.0-1_i686/leptonica-1.80.0-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/leptonica/1.80.0-1_x86_64/leptonica-1.80.0-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/leptonica/1.82.0_armv7l/leptonica-1.82.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/leptonica/1.82.0_armv7l/leptonica-1.82.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/leptonica/1.82.0_i686/leptonica-1.82.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/leptonica/1.82.0_x86_64/leptonica-1.82.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd4ae243ebd485e3bc061701f07bdd031f02916c79e6e7c0bc4353321c79ec66b',
-     armv7l: 'd4ae243ebd485e3bc061701f07bdd031f02916c79e6e7c0bc4353321c79ec66b',
-       i686: 'b7bc070a1fc98059cdb24339f7bc1dd5bbcacbc0c90a67ec5f35b20f8330a2d2',
-     x86_64: 'b9ab621fe8a76d9b38cc21af0f4ba4f3818b0be7af471baf1995064d20428496'
+    aarch64: 'e2a96595f055b95b9aa4692ce8e85a0871ecdf61c913bb7c880d6213f3be367f',
+     armv7l: 'e2a96595f055b95b9aa4692ce8e85a0871ecdf61c913bb7c880d6213f3be367f',
+       i686: 'd87be48dbc0a38bf17449b47683561006df9009087e50a14becdaa68bcef7e59',
+     x86_64: 'bd99bd57833ce674b0edd95223df38b7ca65cc1b2d357312f200d771a6d532c1'
   })
 
   depends_on 'giflib'
   depends_on 'libjpeg'
-  depends_on 'libpng'
+  depends_on 'harfbuzz'
   depends_on 'libtiff'
   depends_on 'libwebp'
   depends_on 'openjpeg'

--- a/packages/libva.rb
+++ b/packages/libva.rb
@@ -4,23 +4,23 @@ class Libva < Package
   description 'Libva is an implementation for VA-API (Video Acceleration API)'
   homepage 'https://01.org/linuxmedia'
   @_ver = '2.14.0'
-  version @_ver
+  version "#{@_ver}-2"
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/intel/libva.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_armv7l/libva-2.14.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_armv7l/libva-2.14.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_i686/libva-2.14.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0_x86_64/libva-2.14.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0-2_armv7l/libva-2.14.0-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0-2_armv7l/libva-2.14.0-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0-2_i686/libva-2.14.0-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.14.0-2_x86_64/libva-2.14.0-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1177ea4f0e3d8218a917070ba4943a8850ffb48c92be88c53373a77c35063c08',
-     armv7l: '1177ea4f0e3d8218a917070ba4943a8850ffb48c92be88c53373a77c35063c08',
-       i686: 'e77eafe870dde013f5868eabebdd1ea0980ae642c28b11d5d4ee8b8f60c0fbfe',
-     x86_64: '4f330f77b5cdec5d11bcce6436c601db00c3def6fe07ebaaebd163068eb566ed'
+    aarch64: 'fccd32adece0312102e7294dc451ca4c8abb267abaf4726470da491891423101',
+     armv7l: 'fccd32adece0312102e7294dc451ca4c8abb267abaf4726470da491891423101',
+       i686: '98c2d3379fe1b513f4c1f8edfdc7424e84d940408141d63a065c29a92503e162',
+     x86_64: '7baea1dbbeb4fac85e384403151c0b8baefb366c8d7c982bac63c6ef15990fde'
   })
 
   depends_on 'libdrm'
@@ -42,5 +42,9 @@ class Libva < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+
+  def self.check
+    system 'ninja -C builddir test'
   end
 end

--- a/packages/tesseract.rb
+++ b/packages/tesseract.rb
@@ -3,28 +3,29 @@ require 'package'
 class Tesseract < Package
   description 'A neural net (LSTM) based OCR engine which is focused on line recognition & an older OCR engine which recognizes character patterns.'
   homepage 'https://github.com/tesseract-ocr/tesseract'
-  @_ver = '4.1.1'
-  version "#{@_ver}-2"
+  @_ver = '5.1.0'
+  version @_ver
   license 'Apache-2.0'
   compatibility 'all'
-  source_url "https://github.com/tesseract-ocr/tesseract/archive/#{@_ver}.tar.gz"
-  source_sha256 '2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb'
+  source_url 'https://github.com/tesseract-ocr/tesseract.git'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/4.1.1-2_armv7l/tesseract-4.1.1-2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/4.1.1-2_armv7l/tesseract-4.1.1-2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/4.1.1-2_i686/tesseract-4.1.1-2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/4.1.1-2_x86_64/tesseract-4.1.1-2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.1.0_armv7l/tesseract-5.1.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.1.0_armv7l/tesseract-5.1.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.1.0_i686/tesseract-5.1.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.1.0_x86_64/tesseract-5.1.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dd19e48f5511792037333cb2b6945c9dd37cc87233d815932cdbf8a43bb30d01',
-     armv7l: 'dd19e48f5511792037333cb2b6945c9dd37cc87233d815932cdbf8a43bb30d01',
-       i686: 'eb365e5d43659b1ea285aaf81db2dc9c520fb00248212dae571571ec0d5a3d60',
-     x86_64: '611623a2484006193d0a9506cc277f5ffb39a6c8de9229663c6d81da984d2b45'
+    aarch64: '866199b054c0f0b73da596873330d161512a8c78be8f73157732aee7186887d3',
+     armv7l: '866199b054c0f0b73da596873330d161512a8c78be8f73157732aee7186887d3',
+       i686: 'aa036d11efbddd231af55bede9ac2a6cb3c97729727dbd4f1c572888f0e4f030',
+     x86_64: '769d295e22bd108230cceab03b1ea3bc0daf88c6140166883e671339955f7566'
   })
 
   depends_on 'asciidoc' => :build
   depends_on 'cairo'
+  depends_on 'docbook_xsl' => :build
   depends_on 'fontconfig'
   depends_on 'giflib'
   depends_on 'glib'
@@ -32,17 +33,18 @@ class Tesseract < Package
   depends_on 'libarchive'
   depends_on 'libcurl'
   depends_on 'libjpeg'
-  depends_on 'libpng'
+  depends_on 'harfbuzz'
   depends_on 'libtiff'
   depends_on 'pango'
+  git_fetchtags
 
   def self.build
     system '[ -x configure ] || ./autogen.sh'
     system 'filefix'
-    system "[ -f Makefile ] || env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -fno-math-errno -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -fno-math-errno -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+    system "[ -f Makefile ] || #{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    # XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog does not get set
+    # in the Makefile without this, which results in errors at install
+    system "find . -name 'Makefile' -exec sed -i 's,XML_CATALOG_FILES = ,XML_CATALOG_FILES = #{CREW_PREFIX}/etc/xml/catalog,g' {} +"
     system 'make'
     system 'make training'
   end
@@ -51,6 +53,6 @@ class Tesseract < Package
     system "make DESTDIR=#{CREW_DEST_DIR} install"
     system "make DESTDIR=#{CREW_DEST_DIR} training-install"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/tessdata"
-    system "curl -Ls https://github.com/tesseract-ocr/tessdata/raw/4767ea922bcc460e70b87b1d303ebdfed0897da8/eng.traineddata -o #{CREW_DEST_PREFIX}/share/tessdata/osd.traineddata"
+    system "curl -Ls https://github.com/tesseract-ocr/tessdata/blob/c2b2e0df86272ce11be323f23f96cf656565ed41/eng.traineddata -o #{CREW_DEST_PREFIX}/share/tessdata/osd.traineddata"
   end
 end

--- a/packages/zvbi.rb
+++ b/packages/zvbi.rb
@@ -3,29 +3,36 @@ require 'package'
 class Zvbi < Package
   description 'The Zapping VBI library, in short ZVBI, provides functions to capture and decode VBI data.'
   homepage 'http://zapping.sourceforge.net/ZVBI/'
-  version '0.2.35-1'
-  compatibility 'all'
+  version '0.2.35-2'
   license 'GPL-2 and LGPL-2'
+  compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/zapping/zvbi/0.2.35/zvbi-0.2.35.tar.bz2'
   source_sha256 'fc883c34111a487c4a783f91b1b2bb5610d8d8e58dcba80c7ab31e67e4765318'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zvbi/0.2.35-1_armv7l/zvbi-0.2.35-1-chromeos-armv7l.tpxz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zvbi/0.2.35-1_armv7l/zvbi-0.2.35-1-chromeos-armv7l.tpxz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zvbi/0.2.35-1_i686/zvbi-0.2.35-1-chromeos-i686.tpxz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zvbi/0.2.35-1_x86_64/zvbi-0.2.35-1-chromeos-x86_64.tpxz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zvbi/0.2.35-2_armv7l/zvbi-0.2.35-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zvbi/0.2.35-2_armv7l/zvbi-0.2.35-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zvbi/0.2.35-2_i686/zvbi-0.2.35-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zvbi/0.2.35-2_x86_64/zvbi-0.2.35-2-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-     aarch64: '41b4539eea8ae06c8ba26874c084cbda7fb2f241e6529bcb2e22906fb81f6ce7',
-      armv7l: '41b4539eea8ae06c8ba26874c084cbda7fb2f241e6529bcb2e22906fb81f6ce7',
-        i686: '2957624655028f18bb32a4ddc5a19b6a114daa756fb4ccdfb61fb44e163bde22',
-      x86_64: 'a7ae368f0e5f3d010a44928d0536f809aaca88b28ffe5a037d4e2d31349c9603',
+  binary_sha256({
+    aarch64: '8540c8bf13aa2b9e8df2e1652d11d54c3eee1cc94aa8f282d9f1fa9d72fbf61f',
+     armv7l: '8540c8bf13aa2b9e8df2e1652d11d54c3eee1cc94aa8f282d9f1fa9d72fbf61f',
+       i686: 'bc08d5d03f44f8db298e76fa5dd25328d06e6d88914ea1944092d4dfdc1eb2c2',
+     x86_64: '1646789cf7bae04f328d2000d5a40829798f9aa6a0955cd2b7ce41aa84a56a1d'
   })
 
-  depends_on 'libpng'
+  depends_on 'harfbuzz'
+
+  def self.patch
+    system 'filefix'
+    # png.h path isn't found for build properly
+    @png_h_path = `crew whatprovides png.h | grep "png.h$" | awk '{print $2}'`.chomp.gsub("#{CREW_PREFIX}/include/", '')
+    system "sed -i 's,png.h,#{@png_h_path},g' src/exp-gfx.c"
+  end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 


### PR DESCRIPTION
Fixes #6874 
-rebuild of `ffmpeg` and deps/build deps, including `libva`, `leptonica`, tesseract`, `zvbi`
- update `asciidoc`
- Uses most of packages from https://github.com/skycocker/chromebrew/pull/6874`, which this supersedes
- Does not bring back animated png support. (sorry @saltedcoffii )


Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 

Confirme to work properly:
- [x] `x86_64`


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ffmpeg_rebuild  CREW_TESTING=1 crew update
```