### PR TITLE
Don't let CREW_LINKER_FLAGS break cmake on armv7l

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.6'
+CREW_VERSION = '1.23.7'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -126,7 +126,7 @@ if ENV['CREW_LINKER'].to_s.empty?
   case ARCH
   when 'aarch64', 'armv7l'
     CREW_LINKER = 'gold'
-    CREW_LINKER_FLAGS = "-Wl,--threads -Wl,--thread-count,#{CREW_NPROC}"
+    CREW_LINKER_FLAGS = ''
   when 'i686', 'x86_64'
     CREW_LINKER = 'mold'
     CREW_LINKER_FLAGS = ''


### PR DESCRIPTION
Fixes #6914

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fix_arm_linker_flags  CREW_TESTING=1 crew update
```
