### PR TITLE
lib/package.rb: Exclude `buildessential` dependency on some packages which have prebuilt binary as source

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -889,20 +889,22 @@ end
 
 def build_and_preconfigure(target_dir)
   Dir.chdir target_dir do
-    puts 'Building from source, this may take a while...'
+    unless @pkg.no_compile_needed?
+      puts 'Building from source, this may take a while...'
 
-    if CREW_LA_RENAME_ENABLED
-      # Rename *.la files temporarily to *.la_tmp to avoid
-      # libtool: link: '*.la' is not a valid libtool archive.
-      # See https://gnunet.org/faq-la-files and
-      # https://stackoverflow.com/questions/42963653/libquadmath-la-is-not-a-valid-libtool-archive-when-configuring-openmpi-with-g
-      puts 'Rename all *.la files to *.la_tmp'.lightblue
+      if CREW_LA_RENAME_ENABLED
+        # Rename *.la files temporarily to *.la_tmp to avoid
+        # libtool: link: '*.la' is not a valid libtool archive.
+        # See https://gnunet.org/faq-la-files and
+        # https://stackoverflow.com/questions/42963653/libquadmath-la-is-not-a-valid-libtool-archive-when-configuring-openmpi-with-g
+        puts 'Rename all *.la files to *.la_tmp'.lightblue
 
-      system "find #{CREW_LIB_PREFIX} -type f -name *.la -print0 | xargs --null -I{} mv #{@short_verbose} {} {}_tmp"
+        system "find #{CREW_LIB_PREFIX} -type f -name *.la -print0 | xargs --null -I{} mv #{@short_verbose} {} {}_tmp"
+      end
+
+      # Load musl options only if package is targeted at the musl toolchain
+      load "#{CREW_LIB_PATH}lib/musl.rb" if @pkg.is_musl?
     end
-
-    # Load musl options only if package is targeted at the musl toolchain
-    load "#{CREW_LIB_PATH}lib/musl.rb" if @pkg.is_musl?
 
     @pkg.in_build = true
     @pkg.patch
@@ -910,11 +912,11 @@ def build_and_preconfigure(target_dir)
     @pkg.build
     @pkg.in_build = false
     # wipe crew destdir
-    FileUtils.rm_rf Dir.glob("#{CREW_DEST_DIR}/*"), verbose: @fileutils_verbose
+    FileUtils.rm_rf Dir["#{CREW_DEST_DIR}/*"], verbose: @fileutils_verbose
     puts 'Preconfiguring package...'
     @pkg.install
 
-    if CREW_LA_RENAME_ENABLED
+    unless @pkg.no_compile_needed? and !CREW_LA_RENAME_ENABLED
       # Rename all *.la_tmp back to *.la to avoid
       # cannot access '*.la': No such file or directory
       puts 'Rename all *.la_tmp files back to *.la'.lightblue

--- a/bin/crew
+++ b/bin/crew
@@ -1113,7 +1113,7 @@ def strip_find_files(find_cmd, strip_option = "")
 end
 
 def strip_dir(dir)
-  unless CREW_NOT_STRIP
+  unless CREW_NOT_STRIP or @pkg.no_compile_needed?
     Dir.chdir dir do
       # Strip libraries with -S
       puts "Stripping libraries..."

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.7'
+CREW_VERSION = '1.23.8'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -6,8 +6,8 @@ class Package
            :git_branch, :git_hashtag
 
   boolean_property = %i[conflicts_ok git_fetchtags gnome is_fake is_musl
-                        is_static no_env_options no_fhs no_patchelf
-                        no_zstd patchelf]
+                        is_static no_compile_needed no_env_options no_fhs 
+                        no_patchelf no_zstd patchelf]
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.
                      :patch,       # Function to perform patch operations prior to build from source.
@@ -61,6 +61,7 @@ class Package
 
     # append buildessential to deps if building from source is needed/specified
     if ( include_build_deps == true or (include_build_deps == 'auto' and is_source) ) and \
+       !pkgObj.no_compile_needed? and \
        !exclude_buildessential and \
        !@checked_list.keys.include?('buildessential')
 

--- a/packages/arduino_ide.rb
+++ b/packages/arduino_ide.rb
@@ -1,5 +1,3 @@
-ENV['CREW_NOT_STRIP'] = 'true'
-
 require 'package'
 
 class Arduino_ide < Package
@@ -10,6 +8,8 @@ class Arduino_ide < Package
   compatibility 'all'
   source_url 'https://github.com/arduino/Arduino/releases/download/1.8.10/arduino-1.8.10.tar.xz'
   source_sha256 '862e4b100d5214ca51d501edcc095467d7a4e3dc39b306146001da8b0c63343e'
+
+  no_compile_needed
 
   binary_url ({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/arduino_ide/1.8.10_armv7l/arduino_ide-1.8.10-chromeos-armv7l.tar.xz',
@@ -67,5 +67,3 @@ class Arduino_ide < Package
     end
   end
 end
-
-ENV['CREW_NOT_STRIP'] = ''

--- a/packages/balena_etcher.rb
+++ b/packages/balena_etcher.rb
@@ -7,14 +7,18 @@ class Balena_etcher < Package
   version @_ver
   license 'Apache-2.0'
   compatibility 'x86_64, i686'
-  case ARCH
-  when 'x86_64'
-    source_url "https://github.com/balena-io/etcher/releases/download/v#{@_ver}/balenaEtcher-#{@_ver}-x64.AppImage"
-    source_sha256 'b2432729ad79e6aa1d6292465db065b078b627c5ec6ddedea8580434088cb74f'
-  when 'i686'
-    source_url "https://github.com/balena-io/etcher/releases/download/v#{@_ver}/balenaEtcher-#{@_ver}-ia32.AppImage"
-    source_sha256 'c9a2c976f0edff0521c71b9e4e948dc6f133749cd7e60ffc3796a6743d17e841'
-  end
+
+  source_url ({
+    x86_64: "https://github.com/balena-io/etcher/releases/download/v#{@_ver}/balenaEtcher-#{@_ver}-x64.AppImage",
+      i686: "https://github.com/balena-io/etcher/releases/download/v#{@_ver}/balenaEtcher-#{@_ver}-ia32.AppImage"
+  })
+
+  source_sha256 ({
+    x86_64: 'b2432729ad79e6aa1d6292465db065b078b627c5ec6ddedea8580434088cb74f',
+      i686: 'c9a2c976f0edff0521c71b9e4e948dc6f133749cd7e60ffc3796a6743d17e841'
+  })
+
+  no_compile_needed
 
   depends_on 'gtk2'
   depends_on 'freetype'
@@ -40,7 +44,6 @@ class Balena_etcher < Package
   end
 
   def self.install
-    ENV['CREW_NOT_STRIP'] = '1'
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/balena-etcher"
     FileUtils.install 'etcher.sh', "#{CREW_DEST_PREFIX}/bin/etcher", mode: 0755

--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -9,6 +9,8 @@ class Brave < Package
   source_url 'https://github.com/brave/brave-browser/releases/download/v1.36.122/brave-browser-1.36.122-linux-amd64.zip'
   source_sha256 '101c2814aed8d88ce085ca18e368473885d0e1ac110c819cbaf0bfbe17bb1768'
 
+  no_compile_needed
+
   depends_on 'gtk3'
   depends_on 'libcom_err'
   depends_on 'xdg_base'

--- a/packages/chrome.rb
+++ b/packages/chrome.rb
@@ -16,6 +16,8 @@ class Chrome < Package
   depends_on 'cras'
   depends_on 'sommelier'
 
+  no_compile_needed
+
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
 

--- a/packages/cpu_x.rb
+++ b/packages/cpu_x.rb
@@ -9,10 +9,7 @@ class Cpu_x < Package
   source_url 'https://github.com/X0rg/CPU-X/releases/download/v4.3.0/CPU-X-v4.3.0-x86_64.AppImage'
   source_sha256 '119cc4207d1548a866664077f9f8535659f045b9708a3c6e2b2db973ec1ea2bc'
 
-  binary_url ({
-  })
-  binary_sha256 ({
-  })
+  no_compile_needed
 
   depends_on 'gtk3'
   depends_on 'sommelier'
@@ -27,13 +24,10 @@ class Cpu_x < Package
   end
 
   def self.install
-    prev = ENV['CREW_NOT_STRIP']
-    ENV['CREW_NOT_STRIP'] = '1'
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/cpu-x"
     FileUtils.install 'cpu-x.sh', "#{CREW_DEST_PREFIX}/bin/cpu-x", mode: 0755
-    FileUtils.mv Dir.glob('*'), "#{CREW_DEST_PREFIX}/share/cpu-x"
-    ENV['CREW_NOT_STRIP'] = prev
+    FileUtils.mv Dir['*'], "#{CREW_DEST_PREFIX}/share/cpu-x"
   end
 
   def self.postinstall

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -8,6 +8,7 @@ class Crew_profile_base < Package
   compatibility 'all'
   source_url 'SKIP'
 
+  no_compile_needed
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d"

--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -10,6 +10,8 @@ class Edge < Package
   source_url 'https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_99.0.1150.52-1_amd64.deb'
   source_sha256 '30b671031d675925cdaddc55686e0a442fa08468c4cd1b560281aafdc52d778a'
 
+  no_compile_needed
+
   depends_on 'libcom_err'
   depends_on 'sommelier'
 
@@ -30,8 +32,9 @@ class Edge < Package
     FileUtils.ln_sf "#{CREW_MAN_PREFIX}/man1/microsoft-edge.1.gz", "#{CREW_DEST_MAN_PREFIX}/man1/msedge.1.gz"
 
     # Add icon for use with crew-launcher
-    system 'curl -L# https://cdn.icon-icons.com/icons2/2552/PNG/128/edge_browser_logo_icon_152998.png -o microsoft-edge.png'
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest( File.read('microsoft-edge.png') ) == 'ae7b1378a5d9d84314b459b6a16c3ec14aae0b88eeb78040f7bc28156cf2d753'
+    downloader 'https://cdn.icon-icons.com/icons2/2552/PNG/128/edge_browser_logo_icon_152998.png',
+               'ae7b1378a5d9d84314b459b6a16c3ec14aae0b88eeb78040f7bc28156cf2d753', 'microsoft-edge.png'
+
     icon_path = "#{CREW_DEST_PREFIX}/share/icons/hicolor/128x128/apps"
     FileUtils.mkdir_p "#{icon_path}"
     FileUtils.mv 'microsoft-edge.png', "#{icon_path}"

--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -6,6 +6,7 @@ class Firefox < Package
   version '98.0.2'
   license 'MPL-2.0, GPL-2 and LGPL-2.1'
   compatibility 'i686,x86_64'
+
   source_url ({
       i686: "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-i686/en-US/firefox-#{version}.tar.bz2",
     x86_64: "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-x86_64/en-US/firefox-#{version}.tar.bz2"
@@ -14,6 +15,8 @@ class Firefox < Package
       i686: '888db6752eb5703af5fe5ab4b1575f2a35dbd204614552fbe3a276042a3509d5',
     x86_64: '07c5f3dad0850a92d5c609278fb1fe682b2562fa55e6733c09a6b4da7373bfcc'
   })
+
+  no_compile_needed
 
   depends_on 'atk'
   depends_on 'cairo'

--- a/packages/krita.rb
+++ b/packages/krita.rb
@@ -9,6 +9,8 @@ class Krita < Package
   source_url 'https://download.kde.org/stable/krita/5.0.2/krita-5.0.2-x86_64.appimage'
   source_sha256 '139e621ec3a4ec1918e6046bdd7be4c0b392cdf2571ca83a065a3e2f00f585e8'
 
+  no_compile_needed
+
   depends_on 'gtk3'
   depends_on 'sommelier'
 
@@ -33,8 +35,6 @@ class Krita < Package
 
   def self.install
     conflicts_ok
-    ENV['CREW_NOT_STRIP'] = '1'
-    reload_constants
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.cp_r 'usr/share', CREW_DEST_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/krita"

--- a/packages/natron.rb
+++ b/packages/natron.rb
@@ -9,6 +9,8 @@ class Natron < Package
   source_url 'https://github.com/NatronGitHub/Natron/releases/download/v2.4.0/Natron-2.4.0-Linux-64.tgz'
   source_sha256 '7e8f2ec343f553799f34dce89aa250c410024f17e2c9ccfb5e22544db3e46bb4'
 
+  no_compile_needed
+
   binary_url ({
     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/natron/2.4.0_x86_64/natron-2.4.0-chromeos-x86_64.tpxz'
   })
@@ -19,11 +21,6 @@ class Natron < Package
   depends_on 'desktop_file_utils'
   depends_on 'libglu'
   depends_on 'sommelier'
-
-  @strip = ENV['CREW_NOT_STRIP']
-  @shrink = ENV['CREW_NOT_SHRINK_ARCHIVE']
-  ENV['CREW_NOT_STRIP'] = '1'
-  ENV['CREW_NOT_SHRINK_ARCHIVE'] = '1'
 
   def self.install
     # IMPORTANT BUILD/INSTALL FROM SOURCE INSTRUCTIONS BELOW:
@@ -51,7 +48,4 @@ class Natron < Package
       end
     end
   end
-
-  ENV['CREW_NOT_SHRINK_ARCHIVE'] = @shrink
-  ENV['CREW_NOT_STRIP'] = @strip
 end

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -6,6 +6,9 @@ class Opera < Package
   version '85.0.4341.28'
   license 'OPERA-2018'
   compatibility 'x86_64'
+
+  # faster apt mirror, but only works when downloading latest version of opera
+  # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://get.opera.com/pub/opera/desktop/#{version}/linux/opera-stable_#{version}_amd64.deb"
   source_sha256 '2344d2e12342785cf5ad095811f2f142cb54f697251dab72bb347e9932c22cfc'
 
@@ -17,10 +20,9 @@ class Opera < Package
   depends_on 'libcom_err'
   depends_on 'sommelier'
 
-  def self.install
-    # llvm-strip doesn't works with opera
-    ENV['CREW_NOT_STRIP'] = '1'
+  no_compile_needed
 
+  def self.install
     # Since opera puts the executable in a location that is not in the path,
     # we need to link it to bin directory.
     FileUtils.ln_sf "#{CREW_PREFIX}/share/x86_64-linux-gnu/opera/opera", 'bin/opera'

--- a/packages/packer.rb
+++ b/packages/packer.rb
@@ -19,9 +19,9 @@ class Packer < Package
      x86_64: '1c8c176dd30f3b9ec3b418f8cb37822261ccebdaf0b01d9b8abf60213d1205cb',
   })
 
+  no_compile_needed
+
   def self.install
-    ENV['CREW_NOT_STRIP'] = '1'
-    reload_constants
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.install 'packer', "#{CREW_DEST_PREFIX}/bin/packer", mode: 0o755
   end

--- a/packages/udeler.rb
+++ b/packages/udeler.rb
@@ -9,6 +9,8 @@ class Udeler < Package
   source_url 'https://github.com/FaisalUmair/udemy-downloader-gui/releases/download/v1.8.2/Udeler-1.8.2-linux-x86_x64.AppImage'
   source_sha256 'b6c1001d25f12661e4c20c84274d7987ce7c6b5b78bdef5ca72aa0f6f82c4c44'
 
+  no_compile_needed
+
   depends_on 'gtk3'
   depends_on 'sommelier'
 
@@ -26,8 +28,6 @@ class Udeler < Package
   end
 
   def self.install
-    prev = ENV['CREW_NOT_STRIP']
-    ENV['CREW_NOT_STRIP'] = '1'
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.cp_r 'usr/share', CREW_DEST_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/udeler"
@@ -35,7 +35,6 @@ class Udeler < Package
     FileUtils.mv 'udeler.desktop', "#{CREW_DEST_PREFIX}/share/applications"
     FileUtils.install 'udeler.sh', "#{CREW_DEST_PREFIX}/bin/udeler", mode: 0755
     FileUtils.mv Dir['*'], "#{CREW_DEST_PREFIX}/share/udeler"
-    ENV['CREW_NOT_STRIP'] = prev
   end
 
   def self.postinstall

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -7,6 +7,8 @@ class Vivaldi < Package
   compatibility 'aarch64,armv7l,x86_64'
   license 'Vivaldi'
 
+  no_compile_needed
+
   depends_on 'cras'
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'


### PR DESCRIPTION
Fixes #6917 

Tested on `x86_64`

### Changes
- Added a flag named `no_compile_needed` at `lib/package.rb`, also appended it on some packages with scripts/official prebuilt binary as the source.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=allow_without_buildessential CREW_TESTING=1 crew update
```