### PR TITLE
Mesa -> 21.3.8

### DIFF
--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -98,10 +98,12 @@ class Mesa < Package
     end
     # llvm 13/14 patch  See https://gitlab.freedesktop.org/mesa/mesa/-/issues/5455
     # & https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/13273.patch
-    system 'curl -OLf https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/13273.diff'
+    downloader 'https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/13273.diff',
+               '76d2dd16532336837bccd4885c40efed0ab5f1de8e8fa114a7835dc269f221ac'
     system 'patch -Np1 -i 13273.diff'
     # mesa: Implement ANGLE_sync_control_rate (used by Chrome browser)
-    system 'curl -OLf https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/15381.diff'
+    downloader 'https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/15381.diff',
+               '6d8531215e33f95c91ec54a0176d847eeb7d0b3b9543adb6bc5e58879e61ade7'
     system 'patch -Np1 -i 15381.diff'
   end
 

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -10,6 +10,19 @@ class Mesa < Package
   source_url 'https://gitlab.freedesktop.org/mesa/mesa.git'
   git_hashtag "mesa-#{@_ver}"
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/22.0.1_armv7l/mesa-22.0.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/22.0.1_armv7l/mesa-22.0.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.3.8_i686/mesa-21.3.8-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.3.8_x86_64/mesa-21.3.8-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '814a1bc4217b73c0a12d13a5d0631eebe478ce5f5daee25f5f708bbe0418c759',
+     armv7l: '814a1bc4217b73c0a12d13a5d0631eebe478ce5f5daee25f5f708bbe0418c759',
+       i686: 'ca79bf6252a36b9cc7f8ba78e99e0385d9ad85559496b4df3bb2ebfddcc22f2e',
+     x86_64: '6c8a9829d33aea1edb3f89d0a27ccda44142be19865cfdec1126a3ce25fc4ba8'
+  })
+
   depends_on 'glslang' => :build
   depends_on 'libdrm' # R
   depends_on 'libomxil_bellagio' => :build

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -11,14 +11,14 @@ class Mesa < Package
   git_hashtag "mesa-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/22.0.1_armv7l/mesa-22.0.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/22.0.1_armv7l/mesa-22.0.1-chromeos-armv7l.tar.zst',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.3.8_armv7l/mesa-21.3.8-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.3.8_armv7l/mesa-21.3.8-chromeos-armv7l.tar.zst',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.3.8_i686/mesa-21.3.8-chromeos-i686.tar.zst',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/21.3.8_x86_64/mesa-21.3.8-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '814a1bc4217b73c0a12d13a5d0631eebe478ce5f5daee25f5f708bbe0418c759',
-     armv7l: '814a1bc4217b73c0a12d13a5d0631eebe478ce5f5daee25f5f708bbe0418c759',
+    aarch64: '2ba3d26240c1f9b950416cf8cab50abbda041be52a57208e61749883f6099236',
+     armv7l: '2ba3d26240c1f9b950416cf8cab50abbda041be52a57208e61749883f6099236',
        i686: 'ca79bf6252a36b9cc7f8ba78e99e0385d9ad85559496b4df3bb2ebfddcc22f2e',
      x86_64: '6c8a9829d33aea1edb3f89d0a27ccda44142be19865cfdec1126a3ce25fc4ba8'
   })


### PR DESCRIPTION
- added patch for egl support w/ Google Chrome (makes video smoother.)
- Use gitlab merge request diff instead of patch, since the patches appear to be based upon the first commit in a MR.
- This is the last official release of the 21.3 series before it switches to legacy mode.
- The 22.x series no longer has support for the older drivers for pre-4.16 kernels. It works without acceleration on older kernels.
- Maybe it's time to start using crosvm for machines on M7x or newer for GUI stuff?

Works properly:
- [x] `x86_64` (still has acceleration)
- [x] `i686` (builds...)
- [x] `armv7l` (builds...)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=mesa_21.3.8 CREW_TESTING=1 crew update
```
