### PR TITLE
libcap -> 2.6.3, avahi rebuild to reduce deps, remmina -> 1.4.25

### DIFF
--- a/packages/avahi.rb
+++ b/packages/avahi.rb
@@ -3,50 +3,45 @@ require 'package'
 class Avahi < Package
   description 'Avahi is a system which facilitates service discovery on a local network via the mDNS/DNS-SD protocol suite.'
   homepage 'http://www.avahi.org/'
-  version '0.8-3'
+  version '0.8-4'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://github.com/lathiat/avahi/releases/download/v0.8/avahi-0.8.tar.gz'
   source_sha256 '060309d7a333d38d951bc27598c677af1796934dbd98e1024e7ad8de798fedda'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avahi/0.8-3_armv7l/avahi-0.8-3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avahi/0.8-3_armv7l/avahi-0.8-3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avahi/0.8-3_i686/avahi-0.8-3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avahi/0.8-3_x86_64/avahi-0.8-3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avahi/0.8-4_armv7l/avahi-0.8-4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avahi/0.8-4_armv7l/avahi-0.8-4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avahi/0.8-4_i686/avahi-0.8-4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avahi/0.8-4_x86_64/avahi-0.8-4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1a2f3f2f1963ff4843ecf2212eaca985368d26ef532f953a68020c1518db0dcf',
-     armv7l: '1a2f3f2f1963ff4843ecf2212eaca985368d26ef532f953a68020c1518db0dcf',
-       i686: 'ca7e9694328710e7b14c22b5d0dd488363303cabca6d7e2ef5f82f484f56d666',
-     x86_64: 'a9b2f76d80af5ebd527cff54f928437f454824b7e5eda102fa7d1c568bb73063'
+    aarch64: '44967482fa6955e784d164cbfa534d54c3498705c71a12748fdfc4dc865ea8b6',
+     armv7l: '44967482fa6955e784d164cbfa534d54c3498705c71a12748fdfc4dc865ea8b6',
+       i686: '913d8179d378520eea8b1788d5261cd6fc9f31936dc4f123a3212e6fba7dc1fb',
+     x86_64: '7eebce85f0689787cbc42121b9f0052a7b9153f92a8cbbba233badf6dba9a839'
   })
 
-  depends_on 'atk'
-  depends_on 'cairo'
-  depends_on 'dbus'
-  depends_on 'gdk_pixbuf'
-  depends_on 'glib'
-  depends_on 'gtk3'
-  depends_on 'harfbuzz'
-  depends_on 'libcap'
-  depends_on 'libdaemon'
-  depends_on 'libevent'
-  depends_on 'libjpeg'
-  depends_on 'mono' => :build
-  depends_on 'pango'
-  depends_on 'qtbase' => :build
+  depends_on 'dbus' # R
+  depends_on 'glib' # R
+  depends_on 'libcap' => :build
+  depends_on 'libdaemon' # R
+  depends_on 'libevent' # R
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS} \
       --with-dbus-sys=#{CREW_PREFIX}/share/dbus-1 \
       --with-distro=none \
+      --disable-mono \
+      --disable-monodoc \
+      --disable-gtk \
+      --disable-gtk3 \
+      --disable-qt3 \
+      --disable-qt4 \
+      --disable-qt5 \
       --disable-python \
       --disable-xmltoman"
-    system "sed -i '695d' Makefile"
     system 'make'
   end
 

--- a/packages/dbus.rb
+++ b/packages/dbus.rb
@@ -22,10 +22,10 @@ class Dbus < Package
      x86_64: '3a459724ba6e7f14eacc089fb5500b20b7857aa3034cfc58edf2450ad8ac1c02'
   })
 
-  depends_on 'expat' # R
-  depends_on 'libice' # R
-  depends_on 'libsm' # R
-  depends_on 'libx11' # R
+  depends_on 'expat' => :build
+  depends_on 'libice' => :build
+  depends_on 'libsm' => :build
+  depends_on 'libx11' => :build
 
   def self.patch
     system 'filefix'

--- a/packages/jemalloc.rb
+++ b/packages/jemalloc.rb
@@ -22,7 +22,7 @@ class Jemalloc < Package
      x86_64: '5cd68973fac52dceefe6bd0cd50d1ecb43538206013c4e8c148c9581d1ec753e',
   })
 
-  depends_on 'libxslt'
+  depends_on 'libxslt' => :build
 
   def self.build
     system './configure',

--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libcap < Package
   description 'Libcap implements the user-space interfaces to the POSIX 1003.1e capabilities available in Linux kernels.'
   homepage 'https://directory.fsf.org/wiki/Libcap/'
-  @_ver = '2.62'
+  @_ver = '2.63'
   version @_ver
   license 'GPL-2 or BSD'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Libcap < Package
   git_hashtag "libcap-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.62_armv7l/libcap-2.62-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.62_armv7l/libcap-2.62-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.62_i686/libcap-2.62-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.62_x86_64/libcap-2.62-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.63_armv7l/libcap-2.63-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.63_armv7l/libcap-2.63-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.63_i686/libcap-2.63-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.63_x86_64/libcap-2.63-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ad1ba9eeb6311aa50cae4933861e6ef3c6660114f8f59fae8b38ec33cf52f4ba',
-     armv7l: 'ad1ba9eeb6311aa50cae4933861e6ef3c6660114f8f59fae8b38ec33cf52f4ba',
-       i686: 'fde7113445a251b6109911cbd5de39300ec2469091cdaea6bc6a57e726e0ef86',
-     x86_64: '3964a327f72a3323e1a192d5fbe4020f29e83ede75347e0d65582ace36f4f66b'
+    aarch64: 'b090422c28aa929a2a585c73739eda6c8c953379ecb0b90f1f596ad5e37706de',
+     armv7l: 'b090422c28aa929a2a585c73739eda6c8c953379ecb0b90f1f596ad5e37706de',
+       i686: '235e7deaec2896dd3db2af3b851699c1fd4dd680b6e2e02d91b895d54ca6d01b',
+     x86_64: '2e306e64bf4f170ad232ab0a64de65a5c4dbbb877ce6f5d7e7ebaa57c39acdde'
   })
 
   depends_on 'gperf' => :build

--- a/packages/remmina.rb
+++ b/packages/remmina.rb
@@ -10,15 +10,16 @@ class Remmina < Package
   source_sha256 'a730d5927232818d55c8e094dba69d504faacabab2288d0c5c0c30ee7e89be46'
 
   binary_url({
-    aarch64: 'file:///usr/local/tmp/packages/remmina-1.4.25-chromeos-armv7l.tar.zst',
-     armv7l: 'file:///usr/local/tmp/packages/remmina-1.4.25-chromeos-armv7l.tar.zst',
-     x86_64: 'file:///usr/local/tmp/packages/remmina-1.4.25-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.25_armv7l/remmina-1.4.25-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.25_armv7l/remmina-1.4.25-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.25_x86_64/remmina-1.4.25-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: 'c2a51556cb206a0a2d82daf8859b33e68c5141fa87b62ad3f700ec2a43cac6e3',
      armv7l: 'c2a51556cb206a0a2d82daf8859b33e68c5141fa87b62ad3f700ec2a43cac6e3',
      x86_64: '6b280475ba0d8778b5be2be2d697968ce893b12fbf78d448d7431770e8fb718c'
   })
+
 
   depends_on 'avahi'
   depends_on 'freerdp'

--- a/packages/remmina.rb
+++ b/packages/remmina.rb
@@ -3,21 +3,21 @@ require 'package'
 class Remmina < Package
   description 'The GTK Remmina Remote Desktop Client'
   homepage 'https://remmina.org/'
-  version '1.4.19'
+  version '1.4.25'
   license 'GPL-2+-with-openssl-exception'
   compatibility 'x86_64 aarch64 armv7l'
   source_url "https://gitlab.com/Remmina/Remmina/-/archive/v#{version}/Remmina-v#{version}.tar.bz2"
   source_sha256 'a730d5927232818d55c8e094dba69d504faacabab2288d0c5c0c30ee7e89be46'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.19_armv7l/remmina-1.4.19-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.19_armv7l/remmina-1.4.19-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.19_x86_64/remmina-1.4.19-chromeos-x86_64.tpxz'
+    aarch64: 'file:///usr/local/tmp/packages/remmina-1.4.25-chromeos-armv7l.tar.zst',
+     armv7l: 'file:///usr/local/tmp/packages/remmina-1.4.25-chromeos-armv7l.tar.zst',
+     x86_64: 'file:///usr/local/tmp/packages/remmina-1.4.25-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dab35fcbbc23c18cad70e6410f55add495cdae28056a5f32b135609918f4abf1',
-     armv7l: 'dab35fcbbc23c18cad70e6410f55add495cdae28056a5f32b135609918f4abf1',
-     x86_64: '5c0664d01de495b9e0a8c872d8f510c2523d19bcf9e4c7ae4f0c7c6ad4fcbb6d'
+    aarch64: 'c2a51556cb206a0a2d82daf8859b33e68c5141fa87b62ad3f700ec2a43cac6e3',
+     armv7l: 'c2a51556cb206a0a2d82daf8859b33e68c5141fa87b62ad3f700ec2a43cac6e3',
+     x86_64: '6b280475ba0d8778b5be2be2d697968ce893b12fbf78d448d7431770e8fb718c'
   })
 
   depends_on 'avahi'
@@ -33,13 +33,6 @@ class Remmina < Package
   depends_on 'webkit2gtk_4'
   depends_on 'xdg_utils' => :build
   depends_on 'sommelier'
-
-  def self.patch
-    # https://gitlab.com/Remmina/Remmina/-/issues/2542
-    system "curl -Ls https://gitlab.com/Remmina/Remmina/-/merge_requests/2290.patch | \
-    hashpipe sha256 618b6f759a40293c71cb622bbd16ed673c0474e9238b339095a5957c929e26a9 | \
-    patch -Np1 --binary"
-  end
 
   def self.build
     Dir.mkdir 'builddir'


### PR DESCRIPTION
- This started as a dependency cleanup.
- `jemalloc`only needs `libxslt` as a build dep.
- `dbus` has no other runtime deps.
- This also fixes a broken path in the libcap pkgconfig file.
- avahi depends upon libcap, which is why they are in the same PR.
- updates `remmina`, which this PR otherwise breaks.

## Additional information
<!-- Mention things we might need to know. Like: -->

Works properly:
- [x] `x86_64`
- [x] `i686` (except for remmina)
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libcapavahi CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
