### PR TITLE
Point linter config url to chromebrew repo url

### DIFF
--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -42,11 +42,7 @@ class Ruby_rubocop < Package
   def self.install
     # system "gem install --build=#{CREW_DEST_DIR} pkg/rubocop-#{version}.gem"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/.config/rubocop"
-
-    # Remove following line after merge of this PR.
-    downloader 'https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml', 'SKIP', "#{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
-    # Uncomment after merge
-    # downloader 'https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml', 'SKIP', "#{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
+    downloader 'https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml', 'SKIP', "#{CREW_DEST_PREFIX}/.config/rubocop/config.yml"
   end
 
   def self.postinstall
@@ -56,10 +52,7 @@ class Ruby_rubocop < Package
     puts "Installing Chromebrew rubocop config file at #{@xdg_config_home}/rubocop/config.yml".lightblue
     puts 'This can be overridden by a ~/.rubocop.yml'.lightblue
     FileUtils.mkdir_p "#{@xdg_config_home}/rubocop"
-    # Remove following line after merge of this PR.
-    downloader 'https://github.com/satmandu/chromebrew/raw/rubocop_yaml/.rubocop.yml', 'SKIP', "#{@xdg_config_home}/rubocop/config.yml"
-    # Uncomment after merge
-    # downloader 'https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml', 'SKIP', "#{@xdg_config_home}/rubocop/config.yml"
+    downloader 'https://github.com/skycocker/chromebrew/raw/master/.rubocop.yml', 'SKIP', "#{@xdg_config_home}/rubocop/config.yml"
   end
 
   def self.remove


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=linter_cleanup CREW_TESTING=1 crew update
```
