### PR TITLE
Fonts refactor: Fold cairo into harfbuzz, update (harfbuzz, fontconfig, freetype, librsvg), build fontconfig before harfbuzz

### DIFF
--- a/packages/a2png.rb
+++ b/packages/a2png.rb
@@ -22,7 +22,7 @@ class A2png < Package
      x86_64: 'b468b226e28cf717c3f38435849bf737067a8b9ec3c1928c01fed5488bb31464',
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
 
   def self.build
     system "./configure \

--- a/packages/appstream_glib.rb
+++ b/packages/appstream_glib.rb
@@ -22,7 +22,7 @@ class Appstream_glib < Package
      x86_64: 'bde94624a342e2db10151ec317e0d719a99638e76385be0b42f4b691f19949d5'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'docbook'
   depends_on 'fontconfig'
   depends_on 'freetype'

--- a/packages/balena_etcher.rb
+++ b/packages/balena_etcher.rb
@@ -22,7 +22,7 @@ class Balena_etcher < Package
 
   depends_on 'gtk2'
   depends_on 'freetype'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'xzutils'
   depends_on 'libnotify'
   depends_on 'nspr'

--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -6,47 +6,8 @@ class Cairo < Package
   version '1.17.5-ec54603'
   license 'LGPL-2.1 or MPL-1.1'
   compatibility 'all'
-  source_url 'https://gitlab.freedesktop.org/cairo/cairo.git'
-  git_hashtag 'ec54603366a39a5ad12c489aaf0bbb85859fa7a9'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_armv7l/cairo-1.17.5-ec54603-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_armv7l/cairo-1.17.5-ec54603-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_i686/cairo-1.17.5-ec54603-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_x86_64/cairo-1.17.5-ec54603-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: '1afe2c4afb826e35c549f786db7983a961a7cb1ca14d079ee448463949ad4626',
-     armv7l: '1afe2c4afb826e35c549f786db7983a961a7cb1ca14d079ee448463949ad4626',
-       i686: 'cbd2b8faf20bbc08751be0e2e37d38d8df6007b93b46ec82c06a8878c730a06e',
-     x86_64: 'bf0cf34ce1bced53bb91aa0d43c0769c436afea02c78773d2ccdb1ad40c4f105'
-  })
-
-  depends_on 'fontconfig'
-  depends_on 'freetype'
-  depends_on 'glib'
   depends_on 'harfbuzz'
-  depends_on 'libx11'
-  depends_on 'libxcb'
-  depends_on 'libxrender'
-  depends_on 'lzo'
-  depends_on 'mesa'
-  depends_on 'pixman'
+  is_fake
 
-  def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
-    --default-library=both \
-    -Dgl-backend=auto \
-    -Dglesv3=enabled \
-    -Dxlib-xcb=enabled \
-    -Dtee=enabled \
-    -Dtests=disabled \
-    builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
 end

--- a/packages/cairomm_1_0.rb
+++ b/packages/cairomm_1_0.rb
@@ -23,7 +23,7 @@ class Cairomm_1_0 < Package
      x86_64: '3ec47e52333e93b341c65d1af2d58bb51c6d60a9b4023b20b2b8c04fd5a42b5e'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'libsigcplusplus3'
   depends_on 'libxxf86vm'
   depends_on 'libxrender'

--- a/packages/cairomm_1_16.rb
+++ b/packages/cairomm_1_16.rb
@@ -23,7 +23,7 @@ class Cairomm_1_16 < Package
      x86_64: '69ad2d194716615b38b13eb321bd019c61cceb1124c787a990524d792d1eac6d'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'libsigcplusplus3'
   depends_on 'libxxf86vm'
   depends_on 'libxrender'

--- a/packages/chrome.rb
+++ b/packages/chrome.rb
@@ -10,7 +10,7 @@ class Chrome < Package
   source_sha256 '05ba6d17d2704ffff1e1d554b40aaddabca9256b7e63ff73e99c469393de8a1f'
 
   depends_on 'nspr'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'gtk3'
   depends_on 'expat'
   depends_on 'cras'

--- a/packages/codium.rb
+++ b/packages/codium.rb
@@ -21,7 +21,7 @@ class Codium < Package
   depends_on 'atk'
   depends_on 'at_spi2_atk'
   depends_on 'at_spi2_core'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'cups'
   depends_on 'dbus'
   depends_on 'gdk_pixbuf'

--- a/packages/darktable.rb
+++ b/packages/darktable.rb
@@ -16,7 +16,7 @@ class Darktable < Package
     x86_64: '793e78e4d9859fdbc72e7490b8a5395409dd5d941dcbfafefdd0a5317cb4b832',
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'colord'
   depends_on 'libcurl'
   depends_on 'dbus_glib'

--- a/packages/dia.rb
+++ b/packages/dia.rb
@@ -21,7 +21,7 @@ class Dia < Package
   })
 
   depends_on 'optipng' => :build
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'gtk2'
   depends_on 'libart'
   depends_on 'libpng'

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -24,7 +24,7 @@ class Epiphany < Package
   })
 
   depends_on 'atk' # R
-  depends_on 'cairo' # R
+  depends_on 'harfbuzz' # R
   depends_on 'docbook_xml' => :build
   depends_on 'freetype' => :build
   depends_on 'gcr' # R

--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -26,7 +26,7 @@ class Evince < Package
   })
 
   depends_on 'atk' # R
-  depends_on 'cairo' # R
+  depends_on 'harfbuzz' # R
   depends_on 'djvulibre' # R
   depends_on 'docbook_xsl' => :build
   depends_on 'gdk_pixbuf' # R

--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -19,7 +19,7 @@ class Firefox < Package
   no_compile_needed
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'dbus'
   depends_on 'dbus_glib'
   depends_on 'fontconfig'

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -3,32 +3,19 @@ require 'package'
 class Fontconfig < Package
   description 'Fontconfig is a library for configuring and customizing font access.'
   homepage 'https://www.freedesktop.org/software/fontconfig/front.html'
-  @_ver = '2.13.96'
+  @_ver = '2.14.0'
   version @_ver
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/fontconfig/fontconfig.git'
   git_hashtag @_ver
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_armv7l/fontconfig-2.13.96-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_armv7l/fontconfig-2.13.96-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_i686/fontconfig-2.13.96-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_x86_64/fontconfig-2.13.96-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: 'ee7900160a576c6402191b39c4a1764691d1eb97f18c19e0117bf2fd9fc0435c',
-     armv7l: 'ee7900160a576c6402191b39c4a1764691d1eb97f18c19e0117bf2fd9fc0435c',
-       i686: '5dc551362bc72fdcbd7734812e62d5035a97fee9b733b6690cae2286e6d4d69d',
-     x86_64: '0c0f777ba5352f92851c70a010b25824fa269dab2b389b95f823e03d890f4b15'
-  })
-
   depends_on 'gperf'
-  depends_on 'harfbuzz' => :build
   depends_on 'jsonc'
   depends_on 'util_linux'
   depends_on 'graphite'
   no_fhs
+  conflicts_ok # This will overwrite fontconfig built from harfbuzz
 
   # Remove fontconfig before rebuilding this package.
 
@@ -44,7 +31,7 @@ class Fontconfig < Package
     --localstatedir=#{CREW_PREFIX}/cache \
     --default-library=both \
     -Ddoc=disabled \
-    -Dfreetype2:harfbuzz=enabled \
+    -Dfreetype2:harfbuzz=disabled \
     -Dfreetype2:default_library=both \
     builddir"
     system 'meson configure builddir'
@@ -76,9 +63,13 @@ class Fontconfig < Package
       export FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts
     EOF
     File.write("#{CREW_DEST_PREFIX}/etc/env.d/fontconfig", @env)
+    #system "find #{CREW_DEST_DIR} -depth -name 'libpng*' -exec rm -r '{}' \\\;"
+    #system "find #{CREW_DEST_DIR} -depth -name '*freetype*' -exec rm -r '{}' \\\;"
   end
 
   def self.postinstall
+    # Need to remove conflicting files from harfbuzz filelist.
+
     # The following postinstall fails if graphite isn't installed when fontconfig
     # is being installed.
     system "env FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts fc-cache -fv || true"

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -10,12 +10,26 @@ class Fontconfig < Package
   source_url 'https://gitlab.freedesktop.org/fontconfig/fontconfig.git'
   git_hashtag @_ver
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_armv7l/fontconfig-2.14.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_armv7l/fontconfig-2.14.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_i686/fontconfig-2.14.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_x86_64/fontconfig-2.14.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '73da87e4645d2fb31682be0d4d58ba7dfab33bf5e7eebb3725b64dac9bbe0482',
+     armv7l: '73da87e4645d2fb31682be0d4d58ba7dfab33bf5e7eebb3725b64dac9bbe0482',
+       i686: '47f744211b28c0a5f44ec9f02a629310dc8952607d7481fb2c7a96374b16e4ad',
+     x86_64: 'bb28212f219e29c3bfd670189813e46f8d46ba79cd88259004dd4b6ad5f1f411'
+  })
+
+
+
   depends_on 'gperf'
   depends_on 'jsonc'
   depends_on 'util_linux'
   depends_on 'graphite'
   no_fhs
-  conflicts_ok # This will overwrite fontconfig built from harfbuzz
 
   # Remove fontconfig before rebuilding this package.
 
@@ -63,13 +77,9 @@ class Fontconfig < Package
       export FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts
     EOF
     File.write("#{CREW_DEST_PREFIX}/etc/env.d/fontconfig", @env)
-    #system "find #{CREW_DEST_DIR} -depth -name 'libpng*' -exec rm -r '{}' \\\;"
-    #system "find #{CREW_DEST_DIR} -depth -name '*freetype*' -exec rm -r '{}' \\\;"
   end
 
   def self.postinstall
-    # Need to remove conflicting files from harfbuzz filelist.
-
     # The following postinstall fails if graphite isn't installed when fontconfig
     # is being installed.
     system "env FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts fc-cache -fv || true"

--- a/packages/freerdp.rb
+++ b/packages/freerdp.rb
@@ -22,7 +22,7 @@ class Freerdp < Package
      x86_64: '46cf60d78f89cd9adab7d71a8d2d204a0633efef5362eacf8d1085f131bc0eac'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'cups'
   depends_on 'faac'
   depends_on 'faad2'

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -3,11 +3,24 @@ require 'package'
 class Freetype < Package
   description 'FreeType is a freely available software library to render fonts.'
   homepage 'https://www.freetype.org/'
-  version '2.11.1' # Update freetype in harfbuzz when updating freetype
+  version '2.12.0' # Update freetype in harfbuzz when updating freetype
   license 'FTL or GPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/freetype/freetype.git'
   git_hashtag "VER-#{version.tr('.', '-')}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_armv7l/freetype-2.12.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_armv7l/freetype-2.12.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_i686/freetype-2.12.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_x86_64/freetype-2.12.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '7ff2e02d08ead4e7b5fb1a16d4e8f5551a4420a51a8b0dae8f12d33d308d469a',
+     armv7l: '7ff2e02d08ead4e7b5fb1a16d4e8f5551a4420a51a8b0dae8f12d33d308d469a',
+       i686: 'b2c34d291f9324105f712434274c4d360c3e98b8b567162d44b54ff74b22b3ba',
+     x86_64: 'a49bad49bfc204855936a8124229f1e8b21cb11e719981dd925c76edfecea0de'
+  })
 
   depends_on 'brotli'
   depends_on 'bz2'
@@ -16,6 +29,7 @@ class Freetype < Package
   depends_on 'glib'
   depends_on 'graphite'
   depends_on 'harfbuzz'
+  depends_on 'librsvg'
   depends_on 'pcre'
   depends_on 'zlibpkg'
   # to avoid resetting mold usage
@@ -25,15 +39,8 @@ class Freetype < Package
   conflicts_ok
 
   def self.build
-    case ARCH
-    when 'aarch64', 'armv7l'
-      @meson_options = CREW_MESON_OPTIONS
-    when 'i686', 'x86_64'
-      @meson_options = CREW_MESON_OPTIONS.gsub('-Dc_args=\'-O2', '-Dc_args=\'-O2 -fuse-ld=mold').gsub('-Dcpp_args=\'-O2',
-                                                                                                      '-Dcpp_args=\'-O2 -fuse-ld=mold')
-    end
     system 'pip3 install docwriter'
-    system "meson #{@meson_options} \
+    system "meson #{CREW_MESON_OPTIONS} \
       -Dharfbuzz=enabled \
       builddir"
     system 'meson configure builddir'

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -9,19 +9,6 @@ class Freetype < Package
   source_url 'https://gitlab.freedesktop.org/freetype/freetype.git'
   git_hashtag "VER-#{version.tr('.', '-')}"
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_armv7l/freetype-2.11.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_armv7l/freetype-2.11.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_i686/freetype-2.11.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_x86_64/freetype-2.11.1-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: '5fb990e84010805de92eda4efac6b0cf183c8dee02eda7b2d1ed183028d0e857',
-     armv7l: '5fb990e84010805de92eda4efac6b0cf183c8dee02eda7b2d1ed183028d0e857',
-       i686: '2961cc77104f9a1eccd75905e957644ef1b21ef93fab368cbd1ed31c022dc43c',
-     x86_64: '3c2492c222856b9a45bc8eaec55398f59e49062f8b3c9e45edc8b129d38c641b'
-  })
-
   depends_on 'brotli'
   depends_on 'bz2'
   depends_on 'expat'

--- a/packages/gcr.rb
+++ b/packages/gcr.rb
@@ -23,7 +23,7 @@ class Gcr < Package
      x86_64: 'a7a7c8ecd1472f17269e33624ba2e91ca4dd699613f833ce9b566889a81ab45f'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'desktop_file_utilities'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'

--- a/packages/geany.rb
+++ b/packages/geany.rb
@@ -23,7 +23,7 @@ class Geany < Package
   })
 
   depends_on 'atk' # R
-  depends_on 'cairo' # R
+  depends_on 'harfbuzz' # R
   depends_on 'gdk_pixbuf' # R
   depends_on 'glib' # R
   depends_on 'gtk3' # R

--- a/packages/geany_plugins.rb
+++ b/packages/geany_plugins.rb
@@ -23,7 +23,7 @@ class Geany_plugins < Package
   })
 
   depends_on 'atk' # R
-  depends_on 'cairo' # R
+  depends_on 'harfbuzz' # R
   depends_on 'enchant' # R
   depends_on 'gdk_pixbuf' # R
   depends_on 'geany' # R

--- a/packages/gedit.rb
+++ b/packages/gedit.rb
@@ -24,7 +24,7 @@ class Gedit < Package
 
   depends_on 'amtk' # R
   depends_on 'atk' # R
-  depends_on 'cairo' # R
+  depends_on 'harfbuzz' # R
   depends_on 'gdk_pixbuf' # R
   depends_on 'glib' # R
   depends_on 'gobject_introspection' # R

--- a/packages/gegl.rb
+++ b/packages/gegl.rb
@@ -24,7 +24,7 @@ class Gegl < Package
 
   depends_on 'asciidoc'
   depends_on 'babl'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'enscript'
   depends_on 'ffmpeg'
   depends_on 'gdk_pixbuf'

--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -25,7 +25,7 @@ class Gemacs < Package
   })
 
   depends_on 'alsa_lib'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'freetype' => :build
   depends_on 'giflib'
   depends_on 'gpm'

--- a/packages/ghostscript.rb
+++ b/packages/ghostscript.rb
@@ -23,7 +23,7 @@ class Ghostscript < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'cups'
   depends_on 'fontconfig'
   depends_on 'freetype'

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -26,7 +26,7 @@ class Gimp < Package
   depends_on 'alsa_lib'
   depends_on 'atk'
   depends_on 'babl'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'ffmpeg'
   depends_on 'fontconfig'
   depends_on 'freetype'

--- a/packages/gjs.rb
+++ b/packages/gjs.rb
@@ -24,7 +24,7 @@ class Gjs < Package
      x86_64: '84cf5ab2dbe09170b7a60dc005988d97cbc573e064484935d91de910e3402d00'
   })
 
-  depends_on 'cairo' # R
+  depends_on 'harfbuzz' # R
   depends_on 'dbus' => :build
   depends_on 'dconf' => :build
   depends_on 'glib' # R

--- a/packages/gnome_autoar.rb
+++ b/packages/gnome_autoar.rb
@@ -25,7 +25,7 @@ class Gnome_autoar < Package
 
   depends_on 'atk'
   depends_on 'autoconf_archive' => :build
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build

--- a/packages/gnome_desktop.rb
+++ b/packages/gnome_desktop.rb
@@ -22,7 +22,7 @@ class Gnome_desktop < Package
      x86_64: 'c9dc4e63cc3c1e16a957e37064fd2efed590b96b5bb58b8fe3004ea2dcf825f2'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'eudev'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'

--- a/packages/gtk2.rb
+++ b/packages/gtk2.rb
@@ -23,7 +23,7 @@ class Gtk2 < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'cups'
   depends_on 'fontconfig'
   depends_on 'freetype'

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -28,7 +28,7 @@ class Gtk3 < Package
   depends_on 'adwaita_icon_theme' # L
   depends_on 'atk' # R
   depends_on 'at_spi2_atk' # R
-  depends_on 'cairo' # R
+  depends_on 'harfbuzz' # R
   depends_on 'cantarell_fonts' # L
   depends_on 'cups' # R
   depends_on 'docbook' => :build

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -43,7 +43,7 @@ class Gtk4 < Package
   depends_on 'hicolor_icon_theme' # L
   depends_on 'shared_mime_info' # L
   depends_on 'xdg_base' # L
-  depends_on 'cairo' # R
+  depends_on 'harfbuzz' # R
   depends_on 'cups' # R
   depends_on 'ffmpeg' # R
   depends_on 'fontconfig' # R

--- a/packages/gtk_engines_adwaita.rb
+++ b/packages/gtk_engines_adwaita.rb
@@ -24,7 +24,7 @@ class Gtk_engines_adwaita < Package
   depends_on 'gtk2'
   depends_on 'librsvg'
   depends_on 'gdk_pixbuf'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
 
   def self.build
     system 'sh autogen.sh'

--- a/packages/gtk_vnc.rb
+++ b/packages/gtk_vnc.rb
@@ -22,7 +22,7 @@ class Gtk_vnc < Package
      x86_64: '5001d552bfa4155bf2c77a1e1a7ee4714125566db0b9ce1e3e3c5e88ace8057d'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'glib'
   depends_on 'gobject_introspection'
   depends_on 'gtk3'

--- a/packages/gtksourceview_3.rb
+++ b/packages/gtksourceview_3.rb
@@ -22,7 +22,7 @@ class Gtksourceview_3 < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'fribidi'

--- a/packages/gtksourceview_4.rb
+++ b/packages/gtksourceview_4.rb
@@ -22,7 +22,7 @@ class Gtksourceview_4 < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'fribidi'

--- a/packages/gtksourceview_5.rb
+++ b/packages/gtksourceview_5.rb
@@ -24,7 +24,7 @@ class Gtksourceview_5 < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'fribidi'

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -8,10 +8,22 @@ class Harfbuzz < Package
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_armv7l/harfbuzz-4.2.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_armv7l/harfbuzz-4.2.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_i686/harfbuzz-4.2.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_x86_64/harfbuzz-4.2.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '0e2f9f45e620ec75db77481292a90273ad79b5afeca3c07afb24568917cef9c9',
+     armv7l: '0e2f9f45e620ec75db77481292a90273ad79b5afeca3c07afb24568917cef9c9',
+       i686: '14c173bb67126e2b0a862dd61b1071a7e3520d3235b923c9c95dd33a0564ac2d',
+     x86_64: 'ae8e1ceb094880512c493f8a8559ec1162393a06756b8363517d39343086c684'
+  })
   git_hashtag @_ver
 
   # provides libpng, freetype (sans harfbuzz), ragel, and cairo
-  # depends_on 'cairo' => :build (cairo is only needed for tests and tools)
   depends_on 'brotli'
   depends_on 'bz2'
   depends_on 'chafa'
@@ -22,7 +34,7 @@ class Harfbuzz < Package
   depends_on 'graphite'
   depends_on 'icu4c'
   depends_on 'libffi'
-  depends_on 'pixman' # via cairo subproject
+  depends_on 'pixman' # Needed for cairo subproject
   depends_on 'pcre'
   depends_on 'py3_six' => :build
   depends_on 'zlibpkg'

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -3,27 +3,14 @@ require 'package'
 class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
-  @_ver = '4.0.0'
-  version "#{@_ver}-1"
+  @_ver = '4.2.0'
+  version @_ver
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
   git_hashtag @_ver
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_i686/harfbuzz-4.0.0-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_x86_64/harfbuzz-4.0.0-1-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
-     armv7l: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
-       i686: 'fe23c57f63f0fd9d03cd8679076d0aa6aeb0db9880efd1099814385fe53c878f',
-     x86_64: 'c9ad1d2c137cfa65efcfbc855fc6b2a616130653d18ff730b53ece6676513a44'
-  })
-
-  # provides libpng, freetype (sans harfbuzz), and ragel
+  # provides libpng, freetype (sans harfbuzz), ragel, and cairo
   # depends_on 'cairo' => :build (cairo is only needed for tests and tools)
   depends_on 'brotli'
   depends_on 'bz2'
@@ -41,7 +28,8 @@ class Harfbuzz < Package
 
   def self.patch
     # Update to new versions of freetype as they come out.
-    system "sed -i 's,revision=VER-2-11-0,revision=VER-2-11-1,g' subprojects/freetype2.wrap"
+    system "sed -i 's,revision=VER-2-11-0,revision=VER-2-12-0,g' subprojects/freetype2.wrap"
+    system "sed -i 's,revision=c90faeb7492b1b778d18a796afe5c2e4b32a6356,revision=521a3a7bdb9299d511dcb1e4f243670141e53847,g' subprojects/cairo.wrap"
   end
 
   def self.build
@@ -49,7 +37,7 @@ class Harfbuzz < Package
       --wrap-mode=default \
       --default-library=both \
       -Dbenchmark=disabled \
-      -Dcairo=disabled \
+      -Dcairo=enabled \
       -Ddocs=disabled \
       -Dfreetype=enabled \
       -Dgraphite2=enabled \

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -18,6 +18,7 @@ class Harfbuzz < Package
   depends_on 'gcc11'
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build
+  depends_on 'fontconfig'
   depends_on 'graphite'
   depends_on 'icu4c'
   depends_on 'libffi'
@@ -26,6 +27,7 @@ class Harfbuzz < Package
   depends_on 'py3_six' => :build
   depends_on 'zlibpkg'
   no_env_options
+  conflicts_ok
 
   def self.patch
     # Update to new versions of freetype as they come out.

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -21,6 +21,7 @@ class Harfbuzz < Package
   depends_on 'graphite'
   depends_on 'icu4c'
   depends_on 'libffi'
+  depends_on 'pixman' # via cairo subproject
   depends_on 'pcre'
   depends_on 'py3_six' => :build
   depends_on 'zlibpkg'

--- a/packages/hwloc.rb
+++ b/packages/hwloc.rb
@@ -26,7 +26,7 @@ class Hwloc < Package
 
   depends_on 'libtool'
   depends_on 'libpciaccess'
-  depends_on 'cairo' => :build
+  depends_on 'harfbuzz' => :build
   depends_on 'libxml2' => :build
   depends_on 'pciutils' => :build
 

--- a/packages/ibus.rb
+++ b/packages/ibus.rb
@@ -24,7 +24,7 @@ class Ibus < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'dconf'
   depends_on 'fontconfig'
   depends_on 'freetype'

--- a/packages/igt_gpu_tools.rb
+++ b/packages/igt_gpu_tools.rb
@@ -21,7 +21,7 @@ class Igt_gpu_tools < Package
 
   depends_on 'libdrm'
   depends_on 'libpciaccess'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'libxrandr'
   depends_on 'procps'
   depends_on 'libkmod'

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -23,7 +23,7 @@ class Libadwaita < Package
      x86_64: 'd828e672cbf543de90112d024cf2db87ac2d38f68ccbab2d970f01059189b057'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build

--- a/packages/libchamplain.rb
+++ b/packages/libchamplain.rb
@@ -26,7 +26,7 @@ class Libchamplain < Package
 
   depends_on 'clutter_gtk'
   depends_on 'libsoup'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'gobject_introspection' => :build
   depends_on 'gtk_doc' => :build
   depends_on 'vala' => :build

--- a/packages/libdazzle.rb
+++ b/packages/libdazzle.rb
@@ -22,7 +22,7 @@ class Libdazzle < Package
      x86_64: '38c0d450cd7aacacb4f556f328d87e3b110189914906fff6e814e6d4cc5cacec'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
   depends_on 'gtk3'

--- a/packages/libgdiplus.rb
+++ b/packages/libgdiplus.rb
@@ -22,7 +22,7 @@ class Libgdiplus < Package
      x86_64: '9c4f2e47dc4f95c88a188838cef7a5424fd272177d8eb4a7d32dfbeb212fc0b6'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'giflib'

--- a/packages/libglade.rb
+++ b/packages/libglade.rb
@@ -23,7 +23,7 @@ class Libglade < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'gdk_pixbuf'

--- a/packages/libgxps.rb
+++ b/packages/libgxps.rb
@@ -25,7 +25,7 @@ class Libgxps < Package
      x86_64: '87bf32455bded966594a39131bf79ad198e06617df4ccc0327932c413b3d78b6'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'cups'
   depends_on 'fontconfig'
   depends_on 'freetype'

--- a/packages/libhandy.rb
+++ b/packages/libhandy.rb
@@ -24,7 +24,7 @@ class Libhandy < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'fribidi'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -22,7 +22,7 @@ class Librsvg < Package
      x86_64: 'dccf2e623cfb6da4c6995a3b0ad0fe8563a0126ed1e6fd4ecd8764ce15101245'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'harfbuzz' => :build

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -9,18 +9,6 @@ class Librsvg < Package
   source_url 'https://download.gnome.org/sources/librsvg/2.50/librsvg-2.50.3.tar.xz'
   source_sha256 'a4298a98e3a95fdd73c858c17d4dd018525fb09dbb13bbd668a0c2243989e958'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_armv7l/librsvg-2.50.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_armv7l/librsvg-2.50.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_i686/librsvg-2.50.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_x86_64/librsvg-2.50.3-1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: '40d0ff493b29670a4375a7fc35c236cdc44c249a6658bbc49ea54a435868d729',
-     armv7l: '40d0ff493b29670a4375a7fc35c236cdc44c249a6658bbc49ea54a435868d729',
-       i686: 'c3f61459db1d6007d9a17537ec9297967b176e7cca3ddb711113253bf731b24f',
-     x86_64: 'dccf2e623cfb6da4c6995a3b0ad0fe8563a0126ed1e6fd4ecd8764ce15101245'
-  })
 
   depends_on 'harfbuzz'
   depends_on 'fontconfig'

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -3,17 +3,27 @@ require 'package'
 class Librsvg < Package
   description 'SVG library for GNOME'
   homepage 'https://wiki.gnome.org/Projects/LibRsvg'
-  version '2.50.3-1'
+  version '2.52.8'
   license 'LGPL-2+'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/librsvg/2.50/librsvg-2.50.3.tar.xz'
-  source_sha256 'a4298a98e3a95fdd73c858c17d4dd018525fb09dbb13bbd668a0c2243989e958'
+  source_url 'https://gitlab.gnome.org/GNOME/librsvg.git'
+  git_hashtag version
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_armv7l/librsvg-2.52.8-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_armv7l/librsvg-2.52.8-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_i686/librsvg-2.52.8-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_x86_64/librsvg-2.52.8-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '3445bbd63ea8dd5c37285cb822cedaf9eb48fe040bbf40f46dbbb8e59c336d81',
+     armv7l: '3445bbd63ea8dd5c37285cb822cedaf9eb48fe040bbf40f46dbbb8e59c336d81',
+       i686: '50eef90138769cda46c1ab822bc756aa877f548026050e629d2654964060215b',
+     x86_64: 'f84307e2d4c55dbd92d11e0b9184918304733b4c70ef7ffe09b183258de91bdf'
+  })
 
-  depends_on 'harfbuzz'
   depends_on 'fontconfig'
-  depends_on 'freetype'
-  depends_on 'harfbuzz' => :build
+  depends_on 'harfbuzz'
   depends_on 'fribidi'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
@@ -21,29 +31,21 @@ class Librsvg < Package
   depends_on 'harfbuzz'
   depends_on 'libcroco'
   depends_on 'libjpeg'
-  depends_on 'libpng'
   depends_on 'pango'
   depends_on 'rust' => :build
   depends_on 'py3_six' => :build
   depends_on 'vala' => :build
+  gnome
 
   def self.build
     # Following rustup modification as per https://github.com/rust-lang/rustup/issues/1167#issuecomment-367061388
     system 'rustup install stable --profile minimal || (rm -frv ~/.rustup/toolchains/* && rustup install stable --profile minimal)'
     system 'rustup default stable'
-    system "env CFLAGS='-pipe -flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto' \
-      ./configure \
-      --prefix=#{CREW_PREFIX} \
-      --libdir=#{CREW_LIB_PREFIX} \
-      --mandir=#{CREW_MAN_PREFIX} \
-      --build=#{CREW_BUILD} \
-      --host=#{CREW_BUILD} \
-      --target=#{CREW_BUILD} \
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "./configure \
+      #{CREW_OPTIONS} \
       --enable-introspection=yes \
       --enable-vala=yes \
-      --disable-static \
       --enable-pixbuf-loader \
       --disable-tools"
     system 'make'

--- a/packages/mapserver.rb
+++ b/packages/mapserver.rb
@@ -23,7 +23,7 @@ class Mapserver < Package
   })
 
   depends_on 'cmake'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'libcurl'
   depends_on 'fribidi'
   depends_on 'gdal'

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -28,7 +28,7 @@ class Nautilus < Package
 
   depends_on 'appstream_glib' => :build
   depends_on 'atk' # R
-  depends_on 'cairo' # R
+  depends_on 'harfbuzz' # R
   depends_on 'dconf'
   depends_on 'gdk_pixbuf' # R
   depends_on 'gexiv2' # R

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -24,7 +24,7 @@ class Pango < Package
   })
 
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'fribidi' # Gets built inside install automatically.

--- a/packages/pixman.rb
+++ b/packages/pixman.rb
@@ -3,26 +3,24 @@ require 'package'
 class Pixman < Package
   description 'Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.'
   homepage 'http://www.pixman.org/'
-  version '285b9a9'
+  version '285b9a9-1'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/pixman/pixman.git'
   git_hashtag '285b9a907caffeb979322e629d4e57aa42061b5a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_armv7l/pixman-285b9a9-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_armv7l/pixman-285b9a9-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_i686/pixman-285b9a9-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_x86_64/pixman-285b9a9-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_armv7l/pixman-285b9a9-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_armv7l/pixman-285b9a9-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_i686/pixman-285b9a9-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_x86_64/pixman-285b9a9-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dc326a21317a03af7349f4b8f77210b027ab779e77021cff0a93036b7d341b5a',
-     armv7l: 'dc326a21317a03af7349f4b8f77210b027ab779e77021cff0a93036b7d341b5a',
-       i686: 'd14290d99d729a89764f39ac004486df18402954af13b0e672b88834ed39e04b',
-     x86_64: '7e281e451c1ab1a4dcd4b15f5b7ecd29205786126488c3fdf355d520a0df75ff'
+    aarch64: 'a7ec280be6f2dfab3576a91dcd9ea44c62bed128606bf9cae996f7035201f255',
+     armv7l: 'a7ec280be6f2dfab3576a91dcd9ea44c62bed128606bf9cae996f7035201f255',
+       i686: '8d8363d7502f4207f3f093e10a4853bd2cec872d084ea019cbd2b5a91294e9bd',
+     x86_64: '6f9d90580d13341db34078d1d3c4d03f2f746c471bb9a8aa35679663cf5a26b9'
   })
-
-  depends_on 'harfbuzz'
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/poppler.rb
+++ b/packages/poppler.rb
@@ -23,7 +23,7 @@ class Poppler < Package
      x86_64: 'f44903cd9abb9a0c58ef0f9554f5f877752cfbbc701620b1a81ef7c71e049b93'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'glib'

--- a/packages/py3_pycairo.rb
+++ b/packages/py3_pycairo.rb
@@ -23,7 +23,7 @@ class Py3_pycairo < Package
      x86_64: 'bdedb23f949e4bdcea77d3a1018d26bb1492b4498f383e6fc704e697b648e579'
   })
 
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'libxxf86vm'
   depends_on 'libxrender'
   depends_on 'py3_setuptools' => :build

--- a/packages/tcpflow.rb
+++ b/packages/tcpflow.rb
@@ -10,7 +10,7 @@ class Tcpflow < Package
   source_sha256 '20abe3353a49a13dcde17ad318d839df6312aa6e958203ea710b37bede33d988'
 
   depends_on 'boost'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'libpcap'
 
   binary_url ({

--- a/packages/tepl_5.rb
+++ b/packages/tepl_5.rb
@@ -24,7 +24,7 @@ class Tepl_5 < Package
   })
 
   depends_on 'amtk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'glib'
   depends_on 'gtk3'
   depends_on 'gtksourceview'

--- a/packages/tepl_6.rb
+++ b/packages/tepl_6.rb
@@ -23,7 +23,7 @@ class Tepl_6 < Package
   })
 
   depends_on 'amtk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'glib'
   depends_on 'gtk3'
   depends_on 'gtksourceview'

--- a/packages/tesseract.rb
+++ b/packages/tesseract.rb
@@ -24,7 +24,7 @@ class Tesseract < Package
   })
 
   depends_on 'asciidoc' => :build
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'docbook_xsl' => :build
   depends_on 'fontconfig'
   depends_on 'giflib'

--- a/packages/transmission.rb
+++ b/packages/transmission.rb
@@ -23,7 +23,7 @@ class Transmission < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'freetype' => :build
   depends_on 'gdk_pixbuf'
   depends_on 'glib'

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -24,7 +24,7 @@ class Webkit2gtk_4 < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'ccache' => :build
   depends_on 'dav1d'
   depends_on 'enchant'

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -24,7 +24,7 @@ class Webkit2gtk_5 < Package
   })
 
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'dav1d'
   depends_on 'enchant'
   depends_on 'fontconfig'

--- a/packages/yelp.rb
+++ b/packages/yelp.rb
@@ -25,7 +25,7 @@ class Yelp < Package
 
   depends_on 'appstream_glib'
   depends_on 'atk'
-  depends_on 'cairo'
+  depends_on 'harfbuzz'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
   depends_on 'gtk3'


### PR DESCRIPTION
- Currently have a problem with installing in the right order, and we need to do a `crew reinstall pixman fontconfig harfbuzz freetype` after  an upgrade.  @supechicken any ideas?

<!-- Mention things we might need to know. Like: -->
**_Testing..._**
Works properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=cairo_harfbuzz_freetype_librsvg CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
