### PR TITLE
Packages which need modification of installs to allow for partial installs.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -933,14 +933,15 @@ end
 def pre_install(dest_dir, provides)
   Dir.chdir dest_dir do
     puts 'Performing pre-install...'
-    @pkgProvidesDefault = if @pkg.provides&.nil?
+    puts @pkg.provides.inspect
+    @pkgProvidesDefault = if @pkg.provides&.nil? or @pkg.provides&.empty?
                             'default'
                           else
                             @pkg.provides.split(
                               / /, -1
                             )[0]
                           end
-    abort('invalid provides!') if !@pkg.provides.includes?(provides) && !@pkgProvidesDefault&.includes?(provides)
+    abort('invalid provides!') if !@pkg.provides.include?(provides) && !@pkgProvidesDefault&.include?(provides)
     provides = '' if (provides == 'default') && (@pkgProvidesDefault == 'default')
     provides = @pkgProvidesDefault if provides.nil?
     @pkg.preinstall(provides)
@@ -1440,7 +1441,7 @@ def install
 
   unless @pkg.is_fake?
     # perform pre-install process
-    pre_install dest_dir @pkgProvides
+    pre_install(dest_dir,@pkgProvides)
 
     # perform install process
     install_package dest_dir
@@ -1800,10 +1801,10 @@ end
 
 def install_command(args)
   args["<name>"].each do |name|
-    if name.includes?(':')
+    if name.include?(':')
       @PkgArgs = name.split(/:/, 2)
       @pkgName = @PkgArgs[0]
-      @pkgProvides = @pkgArgs[1]
+      @pkgProvides = @PkgArgs[1]
     else
       @pkgName = name
       @pkgProvides = 'default'
@@ -1841,7 +1842,14 @@ end
 
 def reinstall_command(args)
   args["<name>"].each do |name|
-    @pkgName = name
+    if name.include?(':')
+      @PkgArgs = name.split(/:/, 2)
+      @pkgName = @PkgArgs[0]
+      @pkgProvides = @PkgArgs[1]
+    else
+      @pkgName = name
+      @pkgProvides = 'default'
+    end
     search @pkgName
     print_current_package
     @pkg.build_from_source = true if @opt_src or @opt_recursive or CREW_BUILD_FROM_SOURCE == '1'

--- a/bin/crew
+++ b/bin/crew
@@ -930,12 +930,23 @@ def pre_flight
   @pkg.preflight
 end
 
-def pre_install(dest_dir)
+def pre_install(dest_dir, provides)
   Dir.chdir dest_dir do
     puts 'Performing pre-install...'
-    @pkg.preinstall
+    @pkgProvidesDefault = if @pkg.provides&.nil?
+                            'default'
+                          else
+                            @pkg.provides.split(
+                              / /, -1
+                            )[0]
+                          end
+    abort('invalid provides!') if !@pkg.provides.includes?(provides) && !@pkgProvidesDefault&.includes?(provides)
+    provides = '' if (provides == 'default') && (@pkgProvidesDefault == 'default')
+    provides = @pkgProvidesDefault if provides.nil?
+    @pkg.preinstall(provides)
   end
 end
+
 
 def post_install
   # return unless the postinstall function was defined by the package recipe
@@ -1429,7 +1440,7 @@ def install
 
   unless @pkg.is_fake?
     # perform pre-install process
-    pre_install dest_dir
+    pre_install dest_dir @pkgProvides
 
     # perform install process
     install_package dest_dir
@@ -1789,7 +1800,14 @@ end
 
 def install_command(args)
   args["<name>"].each do |name|
-    @pkgName = name
+    if name.includes?(':')
+      @PkgArgs = name.split(/:/, 2)
+      @pkgName = @PkgArgs[0]
+      @pkgProvides = @pkgArgs[1]
+    else
+      @pkgName = name
+      @pkgProvides = 'default'
+    end
     search @pkgName
     print_current_package true
     @pkg.build_from_source = true if @opt_src or @opt_recursive or CREW_BUILD_FROM_SOURCE == '1'

--- a/bin/crew
+++ b/bin/crew
@@ -1252,29 +1252,53 @@ def install_package(pkgdir)
 
     rsync_available = true if File.exist?("#{CREW_PREFIX}/bin/rsync") and `#{CREW_PREFIX}/bin/rsync --version`.include? 'rsync  version'
     puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available or @pkg.name == 'rsync'
+    
+    # Create filelists for rsync and tar to use. Use standard paths since 
+    # builds always use these paths.
+    FileUtils.touch %w[
+      dflist.rsync.home dflist.rsync.usrlocal dflist.tar.home 
+      dflist.tar.usrlocal
+    ]
+    # Create filelists for rsync to use.
+    system "grep -s \"^/home/chronos/user\" #{CREW_META_PATH + @pkg.name + '.directorylist'} | cut -c 19- > dflist.rsync.home"
+    system "grep -s \"^/home/chronos/user\" #{CREW_META_PATH + @pkg.name + '.filelist'} | cut -c 19- >> dflist.rsync.home"
+    
+    system "grep -s \"^/usr/local\" #{CREW_META_PATH + @pkg.name + '.directorylist'} | cut -c 11- > dflist.rsync.usrlocal"
+    system "grep -s \"^/usr/local\" #{CREW_META_PATH + @pkg.name + '.filelist'} | cut -c 11- >> dflist.rsync.usrlocal"
+    # Create filelists for tar to use.
+    system "grep -s \"^/home/chronos/user\" #{CREW_META_PATH + @pkg.name + '.directorylist'} | cut -c 2- > dflist.tar.home"
+    system "grep -s \"^/home/chronos/user\" #{CREW_META_PATH + @pkg.name + '.filelist'} | cut -c 2- >> dflist.tar.home"
+    
+    system "grep -s \"^/usr/local\" #{CREW_META_PATH + @pkg.name + '.directorylist'} | cut -c 2- > dflist.tar.usrlocal"
+    system "grep -s \"^/usr/local\" #{CREW_META_PATH + @pkg.name + '.filelist'} | cut -c 2- >> dflist.tar.usrlocal"
+    
     if Dir.exist? "#{pkgdir}/#{HOME}" then
       if rsync_available
-        system "rsync -ahHAXW --remove-source-files ./#{HOME.delete_prefix('/')}/ #{HOME}"
+        system "rsync -ahHAXW#{@verbose} --remove-source-files --files-from=dflist.rsync.home ./home/chronos/user #{HOME}"
       else
-        system "tar -c#{@verbose}f - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
+        system "tar -c#{@verbose}f --verbatim-files-from -T dflist.tar.home - | (cd /; tar xp --keep-directory-symlink -f -)"
       end
     end
     if Dir.exist? "#{pkgdir}/usr/local" then
       if rsync_available
         # Adjust "./usr/local" if the build CREW_PREFIX ever changes.
-        system "rsync -ahHAXWx --remove-source-files ./usr/local/ #{CREW_PREFIX}"
+        system "rsync -ahHAXWx#{@verbose} --remove-source-files --files-from=dflist.rsync.usrlocal ./usr/local #{CREW_PREFIX}"
       else
-        system "tar -c#{@verbose}f - ./usr/* | (cd /; tar xp --keep-directory-symlink -f -)"
+        system "tar -c#{@verbose}f --verbatim-files-from -T dflist.tar.usrlocal - | (cd /; tar xp --keep-directory-symlink -f -)"
       end
     end
-    if Dir.exist? "#{pkgdir}/#{CREW_PREFIX}"
-      if rsync_available
-        # Adjust "./usr/local" if the build CREW_PREFIX ever changes.
-        system "rsync -ahHAXWx --remove-source-files ./#{CREW_PREFIX}/ #{CREW_PREFIX}"
-      else
-        system "cp -a#{@verbose} ./#{CREW_PREFIX}/* #{CREW_PREFIX}"
-      end
-    end
+    # This section is redundant.
+    #if Dir.exist? "#{pkgdir}/#{CREW_PREFIX}"
+      #if rsync_available
+        ## Adjust "./usr/local" if the build CREW_PREFIX ever changes.
+        #system "rsync -ahHAXWx --remove-source-files --files-from=dlist ./#{CREW_PREFIX}/ #{CREW_PREFIX}"
+        #system "rsync -ahHAXWx --remove-source-files --files-from=filelist ./#{CREW_PREFIX}/ #{CREW_PREFIX}"
+      #else
+        ## system "cp -a#{@verbose} ./#{CREW_PREFIX}/* #{CREW_PREFIX}"
+        #system "xargs --arg-file=dlist cp --target-directory=#{CREW_PREFIX}"
+        #system "xargs --arg-file=filelist cp --target-directory=#{CREW_PREFIX}"
+      #end
+    #end
   end
 end
 

--- a/bin/crew
+++ b/bin/crew
@@ -1210,6 +1210,12 @@ def shrink_dir(dir)
   end
 end
 
+def install_multiple_package(pkgdir)
+  Dir.chdir pkgdir do
+    @pkg.install_multiple
+  end
+end
+
 def install_package(pkgdir)
   Dir.chdir pkgdir do
     # install filelist, dlist and binary files
@@ -1406,6 +1412,9 @@ def install
   unless @pkg.is_fake?
     # perform pre-install process
     pre_install dest_dir
+
+    # perform install_multiple process
+    install_multiple_package dest_dir
 
     # perform install process
     install_package dest_dir

--- a/bin/crew
+++ b/bin/crew
@@ -1210,12 +1210,6 @@ def shrink_dir(dir)
   end
 end
 
-def install_multiple_package(pkgdir)
-  Dir.chdir pkgdir do
-    @pkg.install_multiple
-  end
-end
-
 def install_package(pkgdir)
   Dir.chdir pkgdir do
     # install filelist, dlist and binary files
@@ -1436,9 +1430,6 @@ def install
   unless @pkg.is_fake?
     # perform pre-install process
     pre_install dest_dir
-
-    # perform install_multiple process
-    install_multiple_package dest_dir
 
     # perform install process
     install_package dest_dir

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -9,17 +9,16 @@ class Package
                         is_static no_compile_needed no_env_options no_fhs 
                         no_patchelf no_zstd patchelf]
 
-  create_placeholder  :preflight,        # Function for checks to see if install should occur.
-                      :patch,            # Function to perform patch operations prior to build from source.
-                      :prebuild,         # Function to perform pre-build operations prior to build from source.
-                      :build,            # Function to perform build from source.
-                      :postbuild,        # Function to perform post-build for both source build and binary distribution.
-                      :check,            # Function to perform check from source build. (executes only during `crew build`)
-                      :preinstall,       # Function to perform pre-install operations prior to install.
-                      :install_multiple, # Function to perform multiple installs from source build.
-                      :install,          # Function to perform install from source build.
-                      :postinstall,      # Function to perform post-install for both source build and binary distribution.
-                      :remove            # Function to perform after package removal.
+  create_placeholder :preflight,   # Function for checks to see if install should occur.
+                     :patch,       # Function to perform patch operations prior to build from source.
+                     :prebuild,    # Function to perform pre-build operations prior to build from source.
+                     :build,       # Function to perform build from source.
+                     :postbuild,   # Function to perform post-build for both source build and binary distribution.
+                     :check,       # Function to perform check from source build. (executes only during `crew build`)
+                     :preinstall,  # Function to perform pre-install operations prior to install.
+                     :install,     # Function to perform install from source build.
+                     :postinstall, # Function to perform post-install for both source build and binary distribution.
+                     :remove       # Function to perform after package removal.
 
   class << self
     attr_accessor :name, :is_dep, :in_build, :build_from_source, :in_upgrade

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -3,7 +3,7 @@ require 'package_helpers'
 class Package
   property :description, :homepage, :version, :license, :compatibility,
            :binary_url, :binary_sha256, :source_url, :source_sha256,
-           :git_branch, :git_hashtag
+           :git_branch, :git_hashtag, :provides
 
   boolean_property = %i[conflicts_ok git_fetchtags gnome is_fake is_musl
                         is_static no_compile_needed no_env_options no_fhs 

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -9,18 +9,17 @@ class Package
                         is_static no_compile_needed no_env_options no_fhs 
                         no_patchelf no_zstd patchelf]
 
-  create_placeholder
-    :preflight,        # Function for checks to see if install should occur.
-    :patch,            # Function to perform patch operations prior to build from source.
-    :prebuild,         # Function to perform pre-build operations prior to build from source.
-    :build,            # Function to perform build from source.
-    :postbuild,        # Function to perform post-build for both source build and binary distribution.
-    :check,            # Function to perform check from source build. (executes only during `crew build`)
-    :preinstall,       # Function to perform pre-install operations prior to install.
-    :install_multiple, # Function to perform multiple installs from source build.
-    :install,          # Function to perform install from source build.
-    :postinstall,      # Function to perform post-install for both source build and binary distribution.
-    :remove            # Function to perform after package removal.
+  create_placeholder  :preflight,        # Function for checks to see if install should occur.
+                      :patch,            # Function to perform patch operations prior to build from source.
+                      :prebuild,         # Function to perform pre-build operations prior to build from source.
+                      :build,            # Function to perform build from source.
+                      :postbuild,        # Function to perform post-build for both source build and binary distribution.
+                      :check,            # Function to perform check from source build. (executes only during `crew build`)
+                      :preinstall,       # Function to perform pre-install operations prior to install.
+                      :install_multiple, # Function to perform multiple installs from source build.
+                      :install,          # Function to perform install from source build.
+                      :postinstall,      # Function to perform post-install for both source build and binary distribution.
+                      :remove            # Function to perform after package removal.
 
   class << self
     attr_accessor :name, :is_dep, :in_build, :build_from_source, :in_upgrade

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -9,16 +9,18 @@ class Package
                         is_static no_compile_needed no_env_options no_fhs 
                         no_patchelf no_zstd patchelf]
 
-  create_placeholder :preflight,   # Function for checks to see if install should occur.
-                     :patch,       # Function to perform patch operations prior to build from source.
-                     :prebuild,    # Function to perform pre-build operations prior to build from source.
-                     :build,       # Function to perform build from source.
-                     :postbuild,   # Function to perform post-build for both source build and binary distribution.
-                     :check,       # Function to perform check from source build. (executes only during `crew build`)
-                     :preinstall,  # Function to perform pre-install operations prior to install.
-                     :install,     # Function to perform install from source build.
-                     :postinstall, # Function to perform post-install for both source build and binary distribution.
-                     :remove       # Function to perform after package removal.
+  create_placeholder
+    :preflight,        # Function for checks to see if install should occur.
+    :patch,            # Function to perform patch operations prior to build from source.
+    :prebuild,         # Function to perform pre-build operations prior to build from source.
+    :build,            # Function to perform build from source.
+    :postbuild,        # Function to perform post-build for both source build and binary distribution.
+    :check,            # Function to perform check from source build. (executes only during `crew build`)
+    :preinstall,       # Function to perform pre-install operations prior to install.
+    :install_multiple, # Function to perform multiple installs from source build.
+    :install,          # Function to perform install from source build.
+    :postinstall,      # Function to perform post-install for both source build and binary distribution.
+    :remove            # Function to perform after package removal.
 
   class << self
     attr_accessor :name, :is_dep, :in_build, :build_from_source, :in_upgrade

--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -19,6 +19,7 @@ class Cairo < Package
   depends_on 'lzo'
   depends_on 'mesa'
   depends_on 'pixman'
+  conflicts_ok # because this overwrites the limited cairo from harfbuzz
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -3,24 +3,11 @@ require 'package'
 class Cairo < Package
   description 'Cairo is a 2D graphics library with support for multiple output devices.'
   homepage 'https://www.cairographics.org'
-  version '1.17.5-ec54603'
+  version '1.17.5-521a3a7'
   license 'LGPL-2.1 or MPL-1.1'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/cairo/cairo.git'
-  git_hashtag 'ec54603366a39a5ad12c489aaf0bbb85859fa7a9'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_armv7l/cairo-1.17.5-ec54603-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_armv7l/cairo-1.17.5-ec54603-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_i686/cairo-1.17.5-ec54603-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_x86_64/cairo-1.17.5-ec54603-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: '1afe2c4afb826e35c549f786db7983a961a7cb1ca14d079ee448463949ad4626',
-     armv7l: '1afe2c4afb826e35c549f786db7983a961a7cb1ca14d079ee448463949ad4626',
-       i686: 'cbd2b8faf20bbc08751be0e2e37d38d8df6007b93b46ec82c06a8878c730a06e',
-     x86_64: 'bf0cf34ce1bced53bb91aa0d43c0769c436afea02c78773d2ccdb1ad40c4f105'
-  })
+  git_hashtag '521a3a7bdb9299d511dcb1e4f243670141e53847'
 
   depends_on 'fontconfig'
   depends_on 'freetype'

--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -9,6 +9,19 @@ class Cairo < Package
   source_url 'https://gitlab.freedesktop.org/cairo/cairo.git'
   git_hashtag '521a3a7bdb9299d511dcb1e4f243670141e53847'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-521a3a7_armv7l/cairo-1.17.5-521a3a7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-521a3a7_armv7l/cairo-1.17.5-521a3a7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-521a3a7_i686/cairo-1.17.5-521a3a7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-521a3a7_x86_64/cairo-1.17.5-521a3a7-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'b25dd9988c79c6aec537112453482669e16cf3d213d3570cc74c5c36699e7bcc',
+     armv7l: 'b25dd9988c79c6aec537112453482669e16cf3d213d3570cc74c5c36699e7bcc',
+       i686: '22ae49c94736cb58b748a7808b61a3e76c6b759fba2cf0e4af5520a57fe18a62',
+     x86_64: '9d185159bee32c5600571ee922ce105558700c5c1c0c6057e19ea724fd9f3573'
+  })
+
   depends_on 'fontconfig'
   depends_on 'freetype'
   depends_on 'glib'

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -3,7 +3,7 @@ require 'package'
 class Fontconfig < Package
   description 'Fontconfig is a library for configuring and customizing font access.'
   homepage 'https://www.freedesktop.org/software/fontconfig/front.html'
-  @_ver = '2.13.96'
+  @_ver = '2.14.0'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,20 +11,21 @@ class Fontconfig < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_armv7l/fontconfig-2.13.96-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_armv7l/fontconfig-2.13.96-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_i686/fontconfig-2.13.96-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_x86_64/fontconfig-2.13.96-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_armv7l/fontconfig-2.14.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_armv7l/fontconfig-2.14.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_i686/fontconfig-2.14.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_x86_64/fontconfig-2.14.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ee7900160a576c6402191b39c4a1764691d1eb97f18c19e0117bf2fd9fc0435c',
-     armv7l: 'ee7900160a576c6402191b39c4a1764691d1eb97f18c19e0117bf2fd9fc0435c',
-       i686: '5dc551362bc72fdcbd7734812e62d5035a97fee9b733b6690cae2286e6d4d69d',
-     x86_64: '0c0f777ba5352f92851c70a010b25824fa269dab2b389b95f823e03d890f4b15'
+    aarch64: '73da87e4645d2fb31682be0d4d58ba7dfab33bf5e7eebb3725b64dac9bbe0482',
+     armv7l: '73da87e4645d2fb31682be0d4d58ba7dfab33bf5e7eebb3725b64dac9bbe0482',
+       i686: '47f744211b28c0a5f44ec9f02a629310dc8952607d7481fb2c7a96374b16e4ad',
+     x86_64: 'bb28212f219e29c3bfd670189813e46f8d46ba79cd88259004dd4b6ad5f1f411'
   })
 
+
+
   depends_on 'gperf'
-  depends_on 'harfbuzz' => :build
   depends_on 'jsonc'
   depends_on 'util_linux'
   depends_on 'graphite'
@@ -44,7 +45,7 @@ class Fontconfig < Package
     --localstatedir=#{CREW_PREFIX}/cache \
     --default-library=both \
     -Ddoc=disabled \
-    -Dfreetype2:harfbuzz=enabled \
+    -Dfreetype2:harfbuzz=disabled \
     -Dfreetype2:default_library=both \
     builddir"
     system 'meson configure builddir'

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -79,9 +79,15 @@ class Fontconfig < Package
     File.write("#{CREW_DEST_PREFIX}/etc/env.d/fontconfig", @env)
   end
 
+  def self.preinstall
+    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+    if @device[:installed_packages].any? { |elem| elem[:name] == 'freetype' }
+      system "sed -i '/freetype2/d;/libfreetype/d' filelist"
+      system "sed -i '/freetype2/d;/libfreetype/d' dlist"
+    end
+  end
+
   def self.postinstall
-    # The following postinstall fails if graphite isn't installed when fontconfig
-    # is being installed.
-    system "env FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts fc-cache -fv || true"
+    system "FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts fc-cache -fv || true"
   end
 end

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -3,23 +3,23 @@ require 'package'
 class Freetype < Package
   description 'FreeType is a freely available software library to render fonts.'
   homepage 'https://www.freetype.org/'
-  version '2.11.1' # Update freetype in harfbuzz when updating freetype
+  version '2.12.0' # Update freetype in harfbuzz when updating freetype
   license 'FTL or GPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/freetype/freetype.git'
   git_hashtag "VER-#{version.tr('.', '-')}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_armv7l/freetype-2.11.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_armv7l/freetype-2.11.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_i686/freetype-2.11.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_x86_64/freetype-2.11.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_armv7l/freetype-2.12.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_armv7l/freetype-2.12.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_i686/freetype-2.12.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_x86_64/freetype-2.12.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5fb990e84010805de92eda4efac6b0cf183c8dee02eda7b2d1ed183028d0e857',
-     armv7l: '5fb990e84010805de92eda4efac6b0cf183c8dee02eda7b2d1ed183028d0e857',
-       i686: '2961cc77104f9a1eccd75905e957644ef1b21ef93fab368cbd1ed31c022dc43c',
-     x86_64: '3c2492c222856b9a45bc8eaec55398f59e49062f8b3c9e45edc8b129d38c641b'
+    aarch64: '7ff2e02d08ead4e7b5fb1a16d4e8f5551a4420a51a8b0dae8f12d33d308d469a',
+     armv7l: '7ff2e02d08ead4e7b5fb1a16d4e8f5551a4420a51a8b0dae8f12d33d308d469a',
+       i686: 'b2c34d291f9324105f712434274c4d360c3e98b8b567162d44b54ff74b22b3ba',
+     x86_64: 'a49bad49bfc204855936a8124229f1e8b21cb11e719981dd925c76edfecea0de'
   })
 
   depends_on 'brotli'
@@ -29,6 +29,7 @@ class Freetype < Package
   depends_on 'glib'
   depends_on 'graphite'
   depends_on 'harfbuzz'
+  depends_on 'librsvg'
   depends_on 'pcre'
   depends_on 'zlibpkg'
   # to avoid resetting mold usage
@@ -38,15 +39,8 @@ class Freetype < Package
   conflicts_ok
 
   def self.build
-    case ARCH
-    when 'aarch64', 'armv7l'
-      @meson_options = CREW_MESON_OPTIONS
-    when 'i686', 'x86_64'
-      @meson_options = CREW_MESON_OPTIONS.gsub('-Dc_args=\'-O2', '-Dc_args=\'-O2 -fuse-ld=mold').gsub('-Dcpp_args=\'-O2',
-                                                                                                      '-Dcpp_args=\'-O2 -fuse-ld=mold')
-    end
     system 'pip3 install docwriter'
-    system "meson #{@meson_options} \
+    system "meson #{CREW_MESON_OPTIONS} \
       -Dharfbuzz=enabled \
       builddir"
     system 'meson configure builddir'

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -73,9 +73,7 @@ class Freetype < Package
       end
       conflicts.each do |conflict|
         conflict.each do |thisconflict|
-          # puts "This conflict is " + thisconflict.inspect
           singleconflict = thisconflict.split(':',-1)
-          puts singleconflict
           if @override_allowed.include?(singleconflict[0])
             system "sed -i '\\\?^#{singleconflict[1]}?d'  #{CREW_META_PATH}/#{singleconflict[0]}.filelist"
           end

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -66,7 +66,7 @@ class Freetype < Package
     conflicts.reject!(&:empty?)
     unless conflicts.empty?
       if self.conflicts_ok?
-        puts "Warning: There is a conflict with the same file in another package.".orange
+        puts "Handling conflict with the same file in another package.".orange
       else
         puts "Error: There is a conflict with the same file in another package.".lightred
         @_errors = 1

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.71.3'
+  @_ver = '2.72.0'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
@@ -12,16 +12,16 @@ class Glib < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_armv7l/glib-2.71.3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_armv7l/glib-2.71.3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_i686/glib-2.71.3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_x86_64/glib-2.71.3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_armv7l/glib-2.72.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_armv7l/glib-2.72.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_i686/glib-2.72.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_x86_64/glib-2.72.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'f790de63e82f702d061f2de152025f3f76294165c11b1412b914ef197876eed8',
-     armv7l: 'f790de63e82f702d061f2de152025f3f76294165c11b1412b914ef197876eed8',
-       i686: '9113fd3b36bbeba475fe1d02c30e3e5da480c1c0de9808a3ad3f0d4f4c2fe890',
-     x86_64: 'd2fc753604c45fc397ebceadefca2b9db3aea42384c70237688df6d33e5b60d8'
+    aarch64: '916c00b3ac163e3a526a2329eea9d0ef3008f72980208087741d9efc80418b00',
+     armv7l: '916c00b3ac163e3a526a2329eea9d0ef3008f72980208087741d9efc80418b00',
+       i686: 'ad226ebbe63163ec517a3340e7b7d658c8bdf5cf751533b189b784eea833a5fb',
+     x86_64: 'b8ba6860034f65920bab6a302f237196058e394ea696835cb97f8a9e2af340f8'
   })
 
   depends_on 'elfutils' # R
@@ -33,6 +33,7 @@ class Glib < Package
   depends_on 'util_linux' # R
   depends_on 'zlibpkg' # R
   no_env_options
+  gnome
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
@@ -46,9 +47,5 @@ class Glib < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
   end
 end

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -67,4 +67,12 @@ class Harfbuzz < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja install -C builddir"
   end
+
+  def self.install_multiple
+    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+    if @device[:installed_packages].any? { |elem| elem[:name] == 'freetype' }
+      system "sed -i '/*freetype*/d' filelist"
+      system "sed -i '/*freetype*/d' dlist"
+    end
+  end
 end

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -68,7 +68,7 @@ class Harfbuzz < Package
     system "DESTDIR=#{CREW_DEST_DIR} ninja install -C builddir"
   end
 
-  def self.install_multiple
+  def self.preinstall
     @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
     if @device[:installed_packages].any? { |elem| elem[:name] == 'freetype' }
       system "sed -i '/*freetype*/d' filelist"

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -3,45 +3,48 @@ require 'package'
 class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
-  @_ver = '4.0.0'
-  version "#{@_ver}-1"
+  @_ver = '4.2.0'
+  version @_ver
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
-  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_i686/harfbuzz-4.0.0-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_x86_64/harfbuzz-4.0.0-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_armv7l/harfbuzz-4.2.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_armv7l/harfbuzz-4.2.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_i686/harfbuzz-4.2.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_x86_64/harfbuzz-4.2.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
-     armv7l: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
-       i686: 'fe23c57f63f0fd9d03cd8679076d0aa6aeb0db9880efd1099814385fe53c878f',
-     x86_64: 'c9ad1d2c137cfa65efcfbc855fc6b2a616130653d18ff730b53ece6676513a44'
+    aarch64: '0e2f9f45e620ec75db77481292a90273ad79b5afeca3c07afb24568917cef9c9',
+     armv7l: '0e2f9f45e620ec75db77481292a90273ad79b5afeca3c07afb24568917cef9c9',
+       i686: '14c173bb67126e2b0a862dd61b1071a7e3520d3235b923c9c95dd33a0564ac2d',
+     x86_64: 'ae8e1ceb094880512c493f8a8559ec1162393a06756b8363517d39343086c684'
   })
+  git_hashtag @_ver
 
-  # provides libpng, freetype (sans harfbuzz), and ragel
-  # depends_on 'cairo' => :build (cairo is only needed for tests and tools)
+  # provides libpng, freetype (sans harfbuzz), ragel, and a non-x11 cairo stub
   depends_on 'brotli'
   depends_on 'bz2'
   depends_on 'chafa'
   depends_on 'gcc11'
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build
+  depends_on 'fontconfig'
   depends_on 'graphite'
   depends_on 'icu4c'
   depends_on 'libffi'
+  depends_on 'pixman' # Needed for cairo subproject
   depends_on 'pcre'
   depends_on 'py3_six' => :build
   depends_on 'zlibpkg'
   no_env_options
+  conflicts_ok
 
   def self.patch
     # Update to new versions of freetype as they come out.
-    system "sed -i 's,revision=VER-2-11-0,revision=VER-2-11-1,g' subprojects/freetype2.wrap"
+    system "sed -i 's,revision=VER-2-11-0,revision=VER-2-12-0,g' subprojects/freetype2.wrap"
+    system "sed -i 's,revision=c90faeb7492b1b778d18a796afe5c2e4b32a6356,revision=521a3a7bdb9299d511dcb1e4f243670141e53847,g' subprojects/cairo.wrap"
   end
 
   def self.build
@@ -49,7 +52,7 @@ class Harfbuzz < Package
       --wrap-mode=default \
       --default-library=both \
       -Dbenchmark=disabled \
-      -Dcairo=disabled \
+      -Dcairo=enabled \
       -Ddocs=disabled \
       -Dfreetype=enabled \
       -Dgraphite2=enabled \

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -94,9 +94,7 @@ class Harfbuzz < Package
       end
       conflicts.each do |conflict|
         conflict.each do |thisconflict|
-          # puts "This conflict is " + thisconflict.inspect
           singleconflict = thisconflict.split(':',-1)
-          puts singleconflict
           if @override_allowed.include?(singleconflict[0])
             system "sed -i '\\\?^#{singleconflict[1]}?d'  #{CREW_META_PATH}/#{singleconflict[0]}.filelist"
           end

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -3,29 +3,27 @@ require 'package'
 class Librsvg < Package
   description 'SVG library for GNOME'
   homepage 'https://wiki.gnome.org/Projects/LibRsvg'
-  version '2.50.3-1'
+  version '2.52.8'
   license 'LGPL-2+'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/librsvg/2.50/librsvg-2.50.3.tar.xz'
-  source_sha256 'a4298a98e3a95fdd73c858c17d4dd018525fb09dbb13bbd668a0c2243989e958'
+  source_url 'https://gitlab.gnome.org/GNOME/librsvg.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_armv7l/librsvg-2.50.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_armv7l/librsvg-2.50.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_i686/librsvg-2.50.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_x86_64/librsvg-2.50.3-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_armv7l/librsvg-2.52.8-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_armv7l/librsvg-2.52.8-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_i686/librsvg-2.52.8-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_x86_64/librsvg-2.52.8-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '40d0ff493b29670a4375a7fc35c236cdc44c249a6658bbc49ea54a435868d729',
-     armv7l: '40d0ff493b29670a4375a7fc35c236cdc44c249a6658bbc49ea54a435868d729',
-       i686: 'c3f61459db1d6007d9a17537ec9297967b176e7cca3ddb711113253bf731b24f',
-     x86_64: 'dccf2e623cfb6da4c6995a3b0ad0fe8563a0126ed1e6fd4ecd8764ce15101245'
+    aarch64: '3445bbd63ea8dd5c37285cb822cedaf9eb48fe040bbf40f46dbbb8e59c336d81',
+     armv7l: '3445bbd63ea8dd5c37285cb822cedaf9eb48fe040bbf40f46dbbb8e59c336d81',
+       i686: '50eef90138769cda46c1ab822bc756aa877f548026050e629d2654964060215b',
+     x86_64: 'f84307e2d4c55dbd92d11e0b9184918304733b4c70ef7ffe09b183258de91bdf'
   })
 
-  depends_on 'cairo'
   depends_on 'fontconfig'
-  depends_on 'freetype'
-  depends_on 'harfbuzz' => :build
+  depends_on 'harfbuzz'
   depends_on 'fribidi'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
@@ -33,29 +31,21 @@ class Librsvg < Package
   depends_on 'harfbuzz'
   depends_on 'libcroco'
   depends_on 'libjpeg'
-  depends_on 'libpng'
   depends_on 'pango'
   depends_on 'rust' => :build
   depends_on 'py3_six' => :build
   depends_on 'vala' => :build
+  gnome
 
   def self.build
     # Following rustup modification as per https://github.com/rust-lang/rustup/issues/1167#issuecomment-367061388
     system 'rustup install stable --profile minimal || (rm -frv ~/.rustup/toolchains/* && rustup install stable --profile minimal)'
     system 'rustup default stable'
-    system "env CFLAGS='-pipe -flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto' \
-      ./configure \
-      --prefix=#{CREW_PREFIX} \
-      --libdir=#{CREW_LIB_PREFIX} \
-      --mandir=#{CREW_MAN_PREFIX} \
-      --build=#{CREW_BUILD} \
-      --host=#{CREW_BUILD} \
-      --target=#{CREW_BUILD} \
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "./configure \
+      #{CREW_OPTIONS} \
       --enable-introspection=yes \
       --enable-vala=yes \
-      --disable-static \
       --enable-pixbuf-loader \
       --disable-tools"
     system 'make'

--- a/packages/libxdmcp.rb
+++ b/packages/libxdmcp.rb
@@ -23,6 +23,8 @@ class Libxdmcp < Package
      x86_64: '553304325808a09bc564a989a1e727046000b892ce75d1dec437df7d67ade648'
   })
 
+  depends_on 'libbsd' # R
+  depends_on 'libmd' # R
   depends_on 'xorg_proto'
 
   def self.build

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -7,6 +7,7 @@ class Llvm < Package
   version @_ver
   license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   compatibility 'all'
+  provides 'libs'
   source_url 'https://github.com/llvm/llvm-project.git'
   git_branch 'release/14.x'
   git_hashtag '23d08271a4b24f21a88bfe73a5ea31c1e2c6365c'

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -3,26 +3,25 @@ require 'package'
 class Llvm < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, libcxxabi, and openmp are included.'
   homepage 'http://llvm.org/'
-  @_ver = '14.0.1-23d0827'
+  @_ver = '14.0.1'
   version @_ver
-  license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   compatibility 'all'
   provides 'libs all'
+  license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   source_url 'https://github.com/llvm/llvm-project.git'
-  git_branch 'release/14.x'
-  git_hashtag '23d08271a4b24f21a88bfe73a5ea31c1e2c6365c'
+  git_hashtag 'llvmorg-14.0.1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1-23d0827_armv7l/llvm-14.0.1-23d0827-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1-23d0827_armv7l/llvm-14.0.1-23d0827-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1-23d0827_i686/llvm-14.0.1-23d0827-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1-23d0827_x86_64/llvm-14.0.1-23d0827-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1_armv7l/llvm-14.0.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1_armv7l/llvm-14.0.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1_i686/llvm-14.0.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1_x86_64/llvm-14.0.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd523ae68e6bfe71fa283eb5a6848eeec0a29205d416e1e61dc5af95cb43e04b6',
-     armv7l: 'd523ae68e6bfe71fa283eb5a6848eeec0a29205d416e1e61dc5af95cb43e04b6',
-       i686: '3e5bf4465857eb1b0f9b69af1ba0c6a9c8350c07fb0f5a22312e661de64af38a',
-     x86_64: 'aac129d50dd73272cf4a832bed21a65fae9d8e5607fd817d63a65fba56449242'
+    aarch64: '1fb330a76b8465c50786afc60a04f04ca2e57dfec5b02b1e18982311a26b4f95',
+     armv7l: '1fb330a76b8465c50786afc60a04f04ca2e57dfec5b02b1e18982311a26b4f95',
+       i686: '5ed6ca9e6cd709df0135b24dcb683b393294e18d861b43bdb4cad6f3084a483b',
+     x86_64: 'ce24efa733bfbd3fc826155b098e1bd7a3bab31ab81f7a53c62d0a41cfb8bd4f'
   })
 
   depends_on 'ocaml' => :build
@@ -30,12 +29,13 @@ class Llvm < Package
   depends_on 'ccache' => :build
   depends_on 'elfutils' # R
   depends_on 'gcc' # R
+  no_env_options
 
   case ARCH
   when 'aarch64', 'armv7l'
     # LLVM_TARGETS_TO_BUILD = 'ARM;AArch64;AMDGPU'
     # LLVM_TARGETS_TO_BUILD = 'all'.freeze
-    @ARCH_C_FLAGS = "-ltinfow -fPIC -march=armv7-a -mfloat-abi=hard -ccc-gcc-name #{CREW_BUILD}"
+    @ARCH_C_FLAGS = "-fPIC -march=armv7-a -mfloat-abi=hard -ccc-gcc-name #{CREW_BUILD}"
     @ARCH_CXX_FLAGS = "-fPIC -march=armv7-a -mfloat-abi=hard -ccc-gcc-name #{CREW_BUILD}"
     @ARCH_LDFLAGS = ''
     @ARCH_LTO_LDFLAGS = "#{@ARCH_LDFLAGS} -flto=thin"
@@ -53,7 +53,7 @@ class Llvm < Package
     # LLVM_TARGETS_TO_BUILD = 'X86'.freeze
     # Because ld.lld: error: undefined symbol: __atomic_store
     # Polly demands fPIC
-    @ARCH_C_FLAGS = '-ltinfow -latomic -fPIC'
+    @ARCH_C_FLAGS = '-latomic -fPIC'
     @ARCH_CXX_FLAGS = '-latomic -fPIC'
     # Because getting this error:
     # ld.lld: error: relocation R_386_PC32 cannot be used against symbol isl_map_fix_si; recompile with -fPIC
@@ -64,7 +64,7 @@ class Llvm < Package
   when 'x86_64'
     # LLVM_TARGETS_TO_BUILD = 'X86;AMDGPU'
     # LLVM_TARGETS_TO_BUILD = 'all'.freeze
-    @ARCH_C_FLAGS = '-ltinfow -fPIC'
+    @ARCH_C_FLAGS = '-fPIC'
     @ARCH_CXX_FLAGS = '-fPIC'
     @ARCH_LDFLAGS = ''
     @ARCH_LTO_LDFLAGS = "#{@ARCH_LDFLAGS} -flto=thin"
@@ -187,12 +187,11 @@ clang++ -fPIC  -rtlib=compiler-rt -stdlib=libc++ -cxx-isystem \${cxx_sys} -I \${
     end
   end
 
-  def self.preinstall(provide)
-    unless provide.include?('all')
-      system "sed '/\.so/!d' filelist"
-    end
-  end
-
+  # def self.preinstall(provide)
+  #  unless provide.include?('all')
+  #    system "sed '/\.so/!d' filelist"
+  #  end
+  # end
 
   def self.postinstall
     puts

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -7,7 +7,7 @@ class Llvm < Package
   version @_ver
   license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   compatibility 'all'
-  provides 'libs'
+  provides 'libs all'
   source_url 'https://github.com/llvm/llvm-project.git'
   git_branch 'release/14.x'
   git_hashtag '23d08271a4b24f21a88bfe73a5ea31c1e2c6365c'
@@ -186,6 +186,14 @@ clang++ -fPIC  -rtlib=compiler-rt -stdlib=libc++ -cxx-isystem \${cxx_sys} -I \${
       system 'samu check-lld || true'
     end
   end
+
+  def self.preinstall
+    case provides
+    when 'libs'
+      system "sed '/\.so/!d' filelist"
+    end
+  end
+
 
   def self.postinstall
     puts

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -3,25 +3,25 @@ require 'package'
 class Llvm < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, libcxxabi, and openmp are included.'
   homepage 'http://llvm.org/'
-  @_ver = '13.0.1-19b8'
+  @_ver = '14.0.1-23d0827'
   version @_ver
   license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'https://github.com/llvm/llvm-project.git'
-  git_branch 'release/13.x'
-  git_hashtag '19b8368225dc9ec5a0da547eae48c10dae13522d'
+  git_branch 'release/14.x'
+  git_hashtag '23d08271a4b24f21a88bfe73a5ea31c1e2c6365c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/13.0.1-19b8_armv7l/llvm-13.0.1-19b8-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/13.0.1-19b8_armv7l/llvm-13.0.1-19b8-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/13.0.1-19b8_i686/llvm-13.0.1-19b8-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/13.0.1-19b8_x86_64/llvm-13.0.1-19b8-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1-23d0827_armv7l/llvm-14.0.1-23d0827-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1-23d0827_armv7l/llvm-14.0.1-23d0827-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1-23d0827_i686/llvm-14.0.1-23d0827-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1-23d0827_x86_64/llvm-14.0.1-23d0827-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '02c756bc93eb4e9754dad06734abca94abf0bec54ca76147c8e12650a32fb83e',
-     armv7l: '02c756bc93eb4e9754dad06734abca94abf0bec54ca76147c8e12650a32fb83e',
-       i686: 'fee0d7cb0d862fdccb4efd180f17d102a970d7308c69839097303745297b4b0a',
-     x86_64: '83d5df5b4b1febe0b4c6805ab346231e46083ab9b0f516a02dd5d7eea2990852'
+    aarch64: 'd523ae68e6bfe71fa283eb5a6848eeec0a29205d416e1e61dc5af95cb43e04b6',
+     armv7l: 'd523ae68e6bfe71fa283eb5a6848eeec0a29205d416e1e61dc5af95cb43e04b6',
+       i686: '3e5bf4465857eb1b0f9b69af1ba0c6a9c8350c07fb0f5a22312e661de64af38a',
+     x86_64: 'aac129d50dd73272cf4a832bed21a65fae9d8e5607fd817d63a65fba56449242'
   })
 
   depends_on 'ocaml' => :build
@@ -85,29 +85,6 @@ class Llvm < Package
     # system "sudo rm /usr/lib#{CREW_LIB_SUFFIX}/libform.so || true"
     # system "sudo ln -s #{CREW_LIB_PREFIX}/libncurses.so.6 /lib#{CREW_LIB_SUFFIX}/libncurses.so.5 || true"
     # system "sudo ln -s #{CREW_LIB_PREFIX}/libform.so /usr/lib#{CREW_LIB_SUFFIX}/libform.so || true"
-
-    # Patch for i686 in llvm 13 via https://bugs.llvm.org/show_bug.cgi?id=51917
-    @llvm13_i686_patch = <<~LLVM_HEREDOC
-      --- a/lldb/source/Plugins/Process/Linux/IntelPTManager.cpp
-      +++ b/lldb/source/Plugins/Process/Linux/IntelPTManager.cpp
-      @@ -145,7 +145,11 @@ static Error CheckPsbPeriod(size_t psb_period) {
-       }
-
-       size_t IntelPTThreadTrace::GetTraceBufferSize() const {
-      +#ifndef PERF_ATTR_SIZE_VER5
-      +  llvm_unreachable("Intel PT Linux perf event not supported");
-      +#else
-         return m_mmap_meta->aux_size;
-      +#endif
-       }
-
-       static Expected<uint64_t>
-    LLVM_HEREDOC
-    case ARCH
-    when 'i686'
-      File.write('llvm13_i686.patch', @llvm13_i686_patch)
-      system 'patch -Np1 -i llvm13_i686.patch'
-    end
   end
 
   def self.build
@@ -203,9 +180,9 @@ clang++ -fPIC  -rtlib=compiler-rt -stdlib=libc++ -cxx-isystem \${cxx_sys} -I \${
 
   def self.check
     Dir.chdir('builddir') do
-      # system "samu check-llvm || true"
-      # system "samu check-clang || true"
-      # system "samu check-lld || true"
+      system 'samu check-llvm || true'
+      system 'samu check-clang || true'
+      system 'samu check-lld || true'
     end
   end
 

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -187,9 +187,8 @@ clang++ -fPIC  -rtlib=compiler-rt -stdlib=libc++ -cxx-isystem \${cxx_sys} -I \${
     end
   end
 
-  def self.preinstall
-    case provides
-    when 'libs'
+  def self.preinstall(provide)
+    unless provide.include?('all')
       system "sed '/\.so/!d' filelist"
     end
   end

--- a/packages/pixman.rb
+++ b/packages/pixman.rb
@@ -3,26 +3,24 @@ require 'package'
 class Pixman < Package
   description 'Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.'
   homepage 'http://www.pixman.org/'
-  version '285b9a9'
+  version '285b9a9-1'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/pixman/pixman.git'
   git_hashtag '285b9a907caffeb979322e629d4e57aa42061b5a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_armv7l/pixman-285b9a9-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_armv7l/pixman-285b9a9-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_i686/pixman-285b9a9-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_x86_64/pixman-285b9a9-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_armv7l/pixman-285b9a9-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_armv7l/pixman-285b9a9-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_i686/pixman-285b9a9-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_x86_64/pixman-285b9a9-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dc326a21317a03af7349f4b8f77210b027ab779e77021cff0a93036b7d341b5a',
-     armv7l: 'dc326a21317a03af7349f4b8f77210b027ab779e77021cff0a93036b7d341b5a',
-       i686: 'd14290d99d729a89764f39ac004486df18402954af13b0e672b88834ed39e04b',
-     x86_64: '7e281e451c1ab1a4dcd4b15f5b7ecd29205786126488c3fdf355d520a0df75ff'
+    aarch64: 'a7ec280be6f2dfab3576a91dcd9ea44c62bed128606bf9cae996f7035201f255',
+     armv7l: 'a7ec280be6f2dfab3576a91dcd9ea44c62bed128606bf9cae996f7035201f255',
+       i686: '8d8363d7502f4207f3f093e10a4853bd2cec872d084ea019cbd2b5a91294e9bd',
+     x86_64: '6f9d90580d13341db34078d1d3c4d03f2f746c471bb9a8aa35679663cf5a26b9'
   })
-
-  depends_on 'harfbuzz'
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \


### PR DESCRIPTION
- `llvm14` (which we need to modify the install of to allow only library install option.)
- Update `harfbuzz`, `fontconfig`, `freetype`, `cairo`, `librsvg`, `glib` and modify dependencies
- pixman also rebuilt to allow it to be used earlier in dependencies.
- Multiple packages here have overlapping files!
  - `harfbuzz` now contains , `ragel`, a `freetype` stub, and a `cairo` stub.
  - `fontconfig` now contains `libpng`, as fontconfig is a dep of `harfbuzz`.
- This PR is on HOLD until we have a way of upgrading all of these packages such that for instance freetype files from harfbuzz don't overwrite files from the full build of freetype. (see slack discussion) - because we can't ask people to run `crew upgrade ; crew reinstall pixman fontconfig harfbuzz librsvg freetype cairo`


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fonts CREW_TESTING=1 crew update
crew upgrade
crew install pixman fontconfig harfbuzz librsvg freetype cairo
```
