### PR TITLE
openssl -> 1.1.1n, curl -> 7.82.0

### DIFF
--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,7 +3,7 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.81.0'
+  @_ver = '7.82.0'
   version @_ver
   license 'curl'
   compatibility 'all'

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -3,24 +3,24 @@ require 'package'
 class Libcurl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.81.0'
+  @_ver = '7.82.0'
   version @_ver
   license 'curl'
   compatibility 'all'
   source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
-  source_sha256 'a067b688d1645183febc31309ec1f3cdce9213d02136b6a6de3d50f69c95a7d3'
+  source_sha256 '0aaa12d7bd04b0966254f2703ce80dd5c38dbbd76af0297d3d690cdce58a583c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.81.0_armv7l/libcurl-7.81.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.81.0_armv7l/libcurl-7.81.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.81.0_i686/libcurl-7.81.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.81.0_x86_64/libcurl-7.81.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0_armv7l/libcurl-7.82.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0_armv7l/libcurl-7.82.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0_i686/libcurl-7.82.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0_x86_64/libcurl-7.82.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '92eef28a611d71bf61031dcc97266cb8ca297a77e3bd4736cd6a4cb9806eabba',
-     armv7l: '92eef28a611d71bf61031dcc97266cb8ca297a77e3bd4736cd6a4cb9806eabba',
-       i686: '2c1b600dd8e66ce7e561f7c8f08026158db9e2f63d88e534720da751719b40ff',
-     x86_64: 'fb1a71b10267c947a800114c7af2b3b9c8559ba489ab4dee0c08fc9e628343bb'
+    aarch64: '4c93987529a02ef14f2febd2554ad0f8720605a12d4d3ed76c904b2386b2cc5a',
+     armv7l: '4c93987529a02ef14f2febd2554ad0f8720605a12d4d3ed76c904b2386b2cc5a',
+       i686: '4bf55e9a5cfd3eaf2114198969a5a536f74dd348c4398968128b36c52153b588',
+     x86_64: 'b43580537b314e0aad5aa99de45928618b302c9879c89cd18d13165a22fd6c96'
   })
 
   depends_on 'brotli' => :build
@@ -39,49 +39,6 @@ class Libcurl < Package
   depends_on 'valgrind' => :build
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
-
-  def self.patch
-    # Configure is broken in curl 7.81.0
-    # See https://github.com/curl/curl/pull/8230
-    @curl_781_configure_patch = <<~'CURL_CONFIGURE_HEREDOC'
-      --- a/m4/curl-functions.m4	2022-01-03 16:36:46.000000000 +0000
-      +++ b/m4/curl-functions.m4	2022-01-05 17:34:33.635107486 +0000
-      @@ -6515,16 +6515,21 @@ dnl changes contained within this macro.
-
-       AC_DEFUN([CURL_RUN_IFELSE], [
-          case $host_os in
-      -     darwin*) library_path_var=DYLD_LIBRARY_PATH ;;
-      -     *)       library_path_var=LD_LIBRARY_PATH ;;
-      +     darwin*)
-      +      old=$DYLD_LIBRARY_PATH
-      +      DYLD_LIBRARY_PATH=$CURL_LIBRARY_PATH:$old
-      +      export DYLD_LIBRARY_PATH
-      +      AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
-      +      DYLD_LIBRARY_PATH=$old # restore
-      +     ;;
-      +     *)
-      +      old=$LD_LIBRARY_PATH
-      +      LD_LIBRARY_PATH=$CURL_LIBRARY_PATH:$old
-      +      export LD_LIBRARY_PATH
-      +      AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
-      +      LD_LIBRARY_PATH=$old # restore
-      +     ;;
-          esac
-      -
-      -   eval "old=$$library_path_var"
-      -   eval "$library_path_var=\$CURL_LIBRARY_PATH:\$old"
-      -
-      -   eval "export $library_path_var"
-      -   AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
-      -   eval "$library_path_var=\$old" # restore
-       ])
-
-       dnl CURL_COVERAGE
-    CURL_CONFIGURE_HEREDOC
-    File.write('curl_781_configure.patch', @curl_781_configure_patch)
-    system 'patch -Np1 -i curl_781_configure.patch'
-    system 'autoreconf -fvi'
-  end
 
   def self.build
     @libssh = '--with-libssh'

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,24 +3,24 @@ require 'package'
 class Openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
-  @_ver = '1.1.1m'
+  @_ver = '1.1.1n'
   version @_ver
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
-  source_sha256 'f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96'
+  source_sha256 '40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1m_armv7l/openssl-1.1.1m-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1m_armv7l/openssl-1.1.1m-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1m_i686/openssl-1.1.1m-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1m_x86_64/openssl-1.1.1m-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1n_armv7l/openssl-1.1.1n-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1n_armv7l/openssl-1.1.1n-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1n_i686/openssl-1.1.1n-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1n_x86_64/openssl-1.1.1n-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '43e77202d3b41ff91e76296c86f5940cf48f9b3bbc301c7695ae24930950bfd9',
-     armv7l: '43e77202d3b41ff91e76296c86f5940cf48f9b3bbc301c7695ae24930950bfd9',
-       i686: 'd944bb541df0b7b760064da7bc619dacdaa26609c38bf25b72b4b21245f83f67',
-     x86_64: '8063f52834c2edddd08440adc7aa22334d9a937e937308c4b03c785f8624e5bc'
+    aarch64: 'c3db5187b994eca5957af581c1390e57bf87a9cc72cfa5354aa71f9a500144b2',
+     armv7l: 'c3db5187b994eca5957af581c1390e57bf87a9cc72cfa5354aa71f9a500144b2',
+       i686: '8797c98e2f9116c71ac86df5d448d7aaaf9b291c85c7febb73e872caeb3dec6b',
+     x86_64: '529c2dd2f5f65ae4a55f56985aa96cbec6cd6f214987fbdadb49a53c0dbee815'
   })
 
   depends_on 'ccache' => :build
@@ -44,7 +44,6 @@ class Openssl < Package
   @ARCH_LDFLAGS = '-flto'
   @ARCH_C_LTO_FLAGS = "#{@arch_c_flags} -flto"
   @ARCH_CXX_LTO_FLAGS = "#{@arch_cxx_flags} -flto"
-
 
   def self.build
     # This gives you the list of OpenSSL configure targets


### PR DESCRIPTION
- Updates `openssl` and `curl`/`libcurl` (which is built on this newer openssl.)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=openssl_curl CREW_TESTING=1 crew update
```
