### PR TITLE
crew: fix gnome postinstall dep

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -953,7 +953,7 @@ def post_install
           system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime"
         end
         # update icon cache, but only if gdk_pixbuf is already installed.
-        if @device[:installed_packages].any? { |elem| elem[:name] == 'gdk_pixbuf' }
+        if @device[:installed_packages].any? { |elem| elem[:name] == 'gtk3' }
           system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/* || true"
         end
       end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.8'
+CREW_VERSION = '1.23.9'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- `gtk-update-icon-cache` is actually in `gtk3`

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gnome_crew_fix  CREW_TESTING=1 crew update
```
