### PR TITLE
mold -> 1.2.1, enable mold on armv7l

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -123,18 +123,11 @@ when 'x86_64'
 end
 
 if ENV['CREW_LINKER'].to_s.empty?
-  case ARCH
-  when 'aarch64', 'armv7l'
-    CREW_LINKER = 'gold'
-    CREW_LINKER_FLAGS = ''
-  when 'i686', 'x86_64'
-    CREW_LINKER = 'mold'
-    CREW_LINKER_FLAGS = ''
-  end
+  CREW_LINKER = 'mold'
 else
   CREW_LINKER = ENV['CREW_LINKER']
-  CREW_LINKER_FLAGS = ENV['CREW_LINKER_FLAGS']
 end
+CREW_LINKER_FLAGS = ENV['CREW_LINKER_FLAGS']
 
 CREW_COMMON_FLAGS = "-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"
 CREW_COMMON_FNO_LTO_FLAGS = "-O2 -pipe -fno-lto -fPIC -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -27,10 +27,7 @@ class Buildessential < Package
   depends_on 'binutils'
 
   # Linkers
-  case ARCH
-  when 'i686', 'x86_64'
-    depends_on 'mold'
-  end
+  depends_on 'mold'
 
   # typically required libraries & tools to configure packages
   # e.g. using "./autogen.sh"

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -6,22 +6,22 @@ require 'package'
 class Mold < Package
   description 'A Modern Linker'
   homepage 'https://github.com/rui314/mold'
-  version '1.2.0'
+  version '1.2.1'
   compatibility 'all'
   source_url 'https://github.com/rui314/mold.git'
   git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.0_armv7l/mold-1.2.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.0_armv7l/mold-1.2.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.0_i686/mold-1.2.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.0_x86_64/mold-1.2.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1_armv7l/mold-1.2.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1_armv7l/mold-1.2.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1_i686/mold-1.2.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1_x86_64/mold-1.2.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1d006972a44a96820a1f75bf84cb48332380d607672b9d9ae4ae293811b615eb',
-     armv7l: '1d006972a44a96820a1f75bf84cb48332380d607672b9d9ae4ae293811b615eb',
-       i686: '766197f6e67e22f7bd7ae2d67cf5f54d13cbee85827a9cf67b41b3e72da02bef',
-     x86_64: 'c0969ca649aedd3a4f30a0a62263a40c3e6d0064eb6ced1539c0a9544babfc73'
+    aarch64: 'c5d2cb41de614fd6348195619e6f6132e1382ab08a3ef914b90b640fab48d2ac',
+     armv7l: 'c5d2cb41de614fd6348195619e6f6132e1382ab08a3ef914b90b640fab48d2ac',
+       i686: '659f6da41b604fcc900c70e5805209b1ac0b3b8d3e026c719f0d57f222944e8d',
+     x86_64: '7cd47648337aacc6f8b137693b2626bff44649b5ba4c0422f9a9fadc27504150'
   })
 
   depends_on 'xxhash' => :build


### PR DESCRIPTION
- Mold is now supportd on armv7l.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=mold_arm CREW_TESTING=1 crew update
```
