### PR TITLE
Fix bugs with rkhunter

### DIFF
--- a/packages/rkhunter.rb
+++ b/packages/rkhunter.rb
@@ -18,7 +18,9 @@ class Rkhunter < Package
   end
 
   def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}"
     system './installer.sh --install'
+    system "sed -i 's,#{CREW_DEST_PREFIX},#{CREW_PREFIX},g' #{CREW_DEST_PREFIX}/etc/rkhunter.conf"
   end
 
   def self.postinstall


### PR DESCRIPTION
Fixes #6945.  Also fixes:
```
Invalid SCRIPTDIR configuration option: Non-existent pathname: /usr/local/tmp/crew/dest/usr/local/lib/rkhunter/scripts
```
Like an idoit, I was testing with the old version on yesterday's update.