### PR TITLE
wayland.rb: Do not override variables exported by sommelier

### DIFF
--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -4,18 +4,34 @@ class Wayland < Package
   description 'Wayland is intended as a simpler replacement for X, easier to develop and maintain.'
   homepage 'https://wayland.freedesktop.org'
   @_ver = '1.20.0'
-  version @_ver + '-1'
-  compatibility 'all'
+  version "#{@_ver}-1"
   license 'MIT'
+  compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/wayland/wayland.git'
   git_hashtag @_ver
 
+  binary_url({
+    aarch64: 'file:///usr/local/tmp/packages/wayland-1.20.0-1-chromeos-armv7l.tar.zst',
+     armv7l: 'file:///usr/local/tmp/packages/wayland-1.20.0-1-chromeos-armv7l.tar.zst',
+       i686: 'file:///usr/local/tmp/packages/wayland-1.20.0-1-chromeos-i686.tar.zst',
+     x86_64: 'file:///usr/local/tmp/packages/wayland-1.20.0-1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '62b00aaca85d9915fe016b8d12e0bb4dcfd5c96ed25284ce0a72eb3807149fb8',
+     armv7l: '62b00aaca85d9915fe016b8d12e0bb4dcfd5c96ed25284ce0a72eb3807149fb8',
+       i686: 'b4996e1d41e80fce12418356ed63a5b4090eabd71a5edf1aab014a75f023f422',
+     x86_64: '1123fd65e1ec4d681d0f6e19cbcecbc121b65888f75e1fbdcc70263b5fcc22ed'
+  })
+
   depends_on 'expat'
-  depends_on 'libpng'
-  depends_on 'libxslt'
+  depends_on 'libxml2'
+  depends_on 'gcc11'
+  depends_on 'icu4c'
+  depends_on 'zlibpkg'
+  depends_on 'libffi'
 
   def self.build
-    @env = <<~EOF
+    @wayland_env = <<~WAYLAND_ENV_EOF
       # environment set-up for Chrome OS built-in Wayland server
       set -a
 
@@ -24,7 +40,7 @@ class Wayland < Package
       : "${WAYLAND_DISPLAY:=wayland-0}"
       : "${CLUTTER_BACKEND:=wayland}"
       : "${GDK_BACKEND:=wayland}"
-    EOF
+    WAYLAND_ENV_EOF
 
     system "meson #{CREW_MESON_OPTIONS} -Ddocumentation=false builddir"
     system 'meson configure builddir'
@@ -34,6 +50,6 @@ class Wayland < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/etc/env.d/")
-    File.write("#{CREW_DEST_PREFIX}/etc/env.d/wayland", @env)
+    File.write("#{CREW_DEST_PREFIX}/etc/env.d/wayland", @wayland_env)
   end
 end

--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -4,24 +4,11 @@ class Wayland < Package
   description 'Wayland is intended as a simpler replacement for X, easier to develop and maintain.'
   homepage 'https://wayland.freedesktop.org'
   @_ver = '1.20.0'
-  version @_ver
+  version @_ver + '-1'
   compatibility 'all'
   license 'MIT'
   source_url 'https://gitlab.freedesktop.org/wayland/wayland.git'
   git_hashtag @_ver
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.20.0_armv7l/wayland-1.20.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.20.0_armv7l/wayland-1.20.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.20.0_i686/wayland-1.20.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.20.0_x86_64/wayland-1.20.0-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '459023ef9fb5fa1df1b9f3fa315b7d47c5466108d34fae3c0a94ed818a65ab88',
-     armv7l: '459023ef9fb5fa1df1b9f3fa315b7d47c5466108d34fae3c0a94ed818a65ab88',
-       i686: '73cac6d8b4dbcb585563925821c786122b3e770ba8cc8189c7085617bf5d565a',
-     x86_64: 'bced326d7fa76850e0c4314fcd9bad02ecc5ff9a5a53451f7ca4b7b1bb3d11a2'
-  })
 
   depends_on 'expat'
   depends_on 'libpng'
@@ -31,18 +18,15 @@ class Wayland < Package
     @env = <<~EOF
       # environment set-up for Chrome OS built-in Wayland server
       set -a
-      # all variables will export automatically
-      XDG_RUNTIME_DIR=/var/run/chrome
-      XDG_SESSION_TYPE=wayland
-      WAYLAND_DISPLAY=wayland-0
-      CLUTTER_BACKEND=wayland
-      GDK_BACKEND=wayland
-      set +a
+
+      : "${XDG_RUNTIME_DIR:=/var/run/chrome}"
+      : "${XDG_SESSION_TYPE:=wayland}"
+      : "${WAYLAND_DISPLAY:=wayland-0}"
+      : "${CLUTTER_BACKEND:=wayland}"
+      : "${GDK_BACKEND:=wayland}"
     EOF
 
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} \
-    -Ddocumentation=false \
-    builddir"
+    system "meson #{CREW_MESON_OPTIONS} -Ddocumentation=false builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end


### PR DESCRIPTION
This prevents the `WAYLAND_DISPLAY` set by `sommelier` (with acceleration available) from being overridden by exo's `WAYLAND_DISPLAY` (no acceleration)

Tested on `x86_64`