### PR TITLE
sommelier => 20220324

### DIFF
--- a/packages/libevdev.rb
+++ b/packages/libevdev.rb
@@ -3,25 +3,26 @@ require 'package'
 class Libevdev < Package
   description 'libevdev is a wrapper library for evdev devices.'
   homepage 'https://www.freedesktop.org/wiki/Software/libevdev'
-  version '1.11.0'
+  version '1.12.1'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.freedesktop.org/software/libevdev/libevdev-1.11.0.tar.xz'
-  source_sha256 '63f4ea1489858a109080e0b40bd43e4e0903a1e12ea888d581db8c495747c2d0'
+  source_url 'https://www.freedesktop.org/software/libevdev/libevdev-1.12.1.tar.xz'
+  source_sha256 '1dbba41bc516d3ca7abc0da5b862efe3ea8a7018fa6e9b97ce9d39401b22426c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libevdev/1.11.0_armv7l/libevdev-1.11.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libevdev/1.11.0_armv7l/libevdev-1.11.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libevdev/1.11.0_i686/libevdev-1.11.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libevdev/1.11.0_x86_64/libevdev-1.11.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libevdev/1.12.1_armv7l/libevdev-1.12.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libevdev/1.12.1_armv7l/libevdev-1.12.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libevdev/1.12.1_i686/libevdev-1.12.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libevdev/1.12.1_x86_64/libevdev-1.12.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3b4008a79759fdb098e2e93a5455aed90965d670d5a4328b67b49f4936584eb6',
-     armv7l: '3b4008a79759fdb098e2e93a5455aed90965d670d5a4328b67b49f4936584eb6',
-       i686: 'c4d8bad0f712c1cfacc725e7d317be45aa15bb67d281f8d73ca92a9e803dd116',
-     x86_64: '6afbae9d141ced6da39edb73127c4e247afd9abeae8a681b3dc8b62b7edc818d'
+    aarch64: 'ef21c213c561863ccb9cea8a5b88501fdec31c094af3238bac482b3db7b4b053',
+     armv7l: 'ef21c213c561863ccb9cea8a5b88501fdec31c094af3238bac482b3db7b4b053',
+       i686: 'c950e9e171bb65513f22ed76a1195caa4706cde60397f4ba0e1d0c213e9edd99',
+     x86_64: '175b179c49706e118bdb1da0dfa4d216271396eecf3bd289f0db6fc11f631a64'
   })
 
+  depends_on 'check' => :build
   depends_on 'doxygen' => :build
   depends_on 'python3' => :build
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -125,6 +125,8 @@ class Sommelier < Package
       If the UI scale does not match the Chrome OS browser settings, execute the following:
 
         echo 'SOMMELIER_APPLY_DPI_FIX=1' >> #{CREW_PREFIX}/etc/env.d/sommelier
+        stopsommelier
+        source #{CREW_PREFIX}/etc/profile
     DPI_EOT
   end
 end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -13,16 +13,15 @@ class Sommelier < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220324_armv7l/sommelier-20220324-chromeos-armv7l.tar.zst',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220324_armv7l/sommelier-20220324-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_i686/sommelier-20220207-chromeos-i686.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220324_i686/sommelier-20220324-chromeos-i686.tar.zst',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220324_x86_64/sommelier-20220324-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '8ea59a37b1f1df699f008b81e96e7074364cac4910f1bb3c31bbcbf647a087a8',
      armv7l: '8ea59a37b1f1df699f008b81e96e7074364cac4910f1bb3c31bbcbf647a087a8',
-       i686: '158a719de95d18cb98ec842da1201c75803e5e16dbdc6e51ca467e1a104349f1',
+       i686: 'c7111b976ede9766b8a12e2786e2dca6980a79058e297a4e54c3033c67da58b5',
      x86_64: '134733b296032026a8d17906638b039c929b0ad6bd2dfc174150567ff7ccebb9'
   })
-
 
   depends_on 'libdrm'
   depends_on 'libevdev'
@@ -75,6 +74,13 @@ class Sommelier < Package
   end
 
   def self.build
+    # Gamepad functionality requires newer kernel support for the
+    # Linux Gamepad Specification not available in older kernels on i686.
+    @gamepad = 'true'
+    case ARCH
+    when 'i686'
+      @gamepad = 'false'
+    end
     Dir.chdir('sommelier_src') do
       system CREW_ENV_OPTIONS_HASH.merge({ 'CC' => 'clang', 'CXX' => 'clang++' }), <<~BUILD
         meson #{CREW_MESON_OPTIONS} \
@@ -85,7 +91,7 @@ class Sommelier < Package
           -Dxwayland_gl_driver_path=#{CREW_LIB_PREFIX}/dri \
           -Ddefault_library=both \
           -Dwith_tests=false \
-          -Dgamepad=true \
+          -Dgamepad=#{@gamepad} \
           builddir
       BUILD
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -49,7 +49,8 @@ class Sommelier < Package
 
     # this version of sommelier should not depends on libminigbm,
     # prebuilt binaries should links to mesa's gbm but not libminigbm
-    puts "libminigbm installed. Will build with libminigbm".yellow if File.exist?("#{CREW_META_PATH}/libminigbm.filelist")
+    @device = JSON.load_file("#{CREW_CONFIG_PATH}device.json", symbolize_names: true)
+    puts "libminigbm installed. Will build with libminigbm".yellow if @device[:installed_packages].any? { |elem| elem[:name] == 'libminigbm' }
   end
 
   def self.patch

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -124,7 +124,7 @@ class Sommelier < Package
     puts <<~DPI_EOT.lightcyan
       If the UI scale does not match the Chrome OS browser settings, execute the following:
 
-        echo 'SOMMELIER_APPLY_DPI_FIX=1' > #{CREW_PREFIX}/etc/env.d/sommelier
+        echo 'SOMMELIER_APPLY_DPI_FIX=1' >> #{CREW_PREFIX}/etc/env.d/sommelier
     DPI_EOT
   end
 end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -68,6 +68,7 @@ class Sommelier < Package
           -Dxwayland_gl_driver_path=#{CREW_PREFIX}/#{ARCH_LIB}/dri \
           -Ddefault_library=both \
           -Dwith_tests=false \
+          -Dgamepad=true \
           builddir
       BUILD
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -65,11 +65,11 @@ class Sommelier < Package
           -Db_lto=true \
           -Db_lto_mode=thin \
           -Dxwayland_path=#{CREW_PREFIX}/bin/Xwayland \
-          -Dxwayland_gl_driver_path=#{CREW_PREFIX}/#{ARCH_LIB}/dri \
+          -Dxwayland_gl_driver_path=#{CREW_LIB_PREFIX}/dri \
           -Ddefault_library=both \
           -Dwith_tests=false \
           -Dgamepad=true \
-          builddir
+        builddir
       BUILD
 
       system 'meson configure builddir'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -10,7 +10,22 @@ class Sommelier < Package
   source_url 'https://github.com/chromebrew/crew-package-sommelier.git'
   git_hashtag @_ver
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220324_armv7l/sommelier-20220324-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220324_armv7l/sommelier-20220324-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_i686/sommelier-20220207-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220324_x86_64/sommelier-20220324-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '8ea59a37b1f1df699f008b81e96e7074364cac4910f1bb3c31bbcbf647a087a8',
+     armv7l: '8ea59a37b1f1df699f008b81e96e7074364cac4910f1bb3c31bbcbf647a087a8',
+       i686: '158a719de95d18cb98ec842da1201c75803e5e16dbdc6e51ca467e1a104349f1',
+     x86_64: '134733b296032026a8d17906638b039c929b0ad6bd2dfc174150567ff7ccebb9'
+  })
+
+
   depends_on 'libdrm'
+  depends_on 'libevdev'
   depends_on 'libxcb'
   depends_on 'libxcomposite' => :build
   depends_on 'libxfixes' => :build
@@ -50,7 +65,9 @@ class Sommelier < Package
     # this version of sommelier should not depends on libminigbm,
     # prebuilt binaries should links to mesa's gbm but not libminigbm
     @device = JSON.load_file("#{CREW_CONFIG_PATH}device.json", symbolize_names: true)
-    puts "libminigbm installed. Will build with libminigbm".yellow if @device[:installed_packages].any? { |elem| elem[:name] == 'libminigbm' }
+    puts 'libminigbm installed. Will build with libminigbm'.yellow if @device[:installed_packages].any? do |elem|
+                                                                        elem[:name] == 'libminigbm'
+                                                                      end
   end
 
   def self.patch

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -112,9 +112,9 @@ class Sommelier < Package
       To adjust sommelier environment variables, edit #{CREW_PREFIX}/etc/env.d/sommelier
       Default values are in #{CREW_PREFIX}/etc/env.d/sommelier
 
-      Run `startsommelier` to start sommelier daemon.
-      Run `stopsommelier` to stop all sommelier daemon.
-      Run `restartsommelier` to restart sommelier daemon
+      Run 'startsommelier' to start sommelier daemon.
+      Run 'stopsommelier' to stop all sommelier daemon.
+      Run 'restartsommelier' to restart sommelier daemon
     ENV_ADJUSTMENT_EOT
 
     puts <<~GUI_WARNING_EOT.orange

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -68,7 +68,7 @@ class Sommelier < Package
           -Ddefault_library=both \
           -Dwith_tests=false \
           -Dgamepad=true \
-        builddir
+          builddir
       BUILD
 
       system 'meson configure builddir'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -7,9 +7,8 @@ class Sommelier < Package
   version @_ver
   license 'BSD-Google'
   compatibility 'all'
-  source_url 'https://github.com/supechicken/crew-package-sommelier.git'
-  git_branch 'sommelier-20220324'
-  #git_hashtag @_ver
+  source_url 'https://github.com/chromebrew/crew-package-sommelier.git'
+  git_hashtag @_ver
 
   depends_on 'libdrm'
   depends_on 'libxcb'

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -103,8 +103,9 @@ class Sommelier < Package
   def self.postinstall
     puts '', <<~RESTARTSOMMELIER_EOT.orange
       To complete the installation, execute the following:
-      source #{CREW_PREFIX}/etc/profile
-      restartsommelier
+
+        source #{CREW_PREFIX}/etc/profile
+        restartsommelier
     RESTARTSOMMELIER_EOT
 
     puts <<~ENV_ADJUSTMENT_EOT.lightblue
@@ -119,5 +120,11 @@ class Sommelier < Package
     puts <<~GUI_WARNING_EOT.orange
       Please be aware that GUI applications may not work without the sommelier daemon running.
     GUI_WARNING_EOT
+
+    puts <<~DPI_EOT.lightcyan
+      If the UI scale does not match the Chrome OS browser settings, execute the following:
+
+        echo 'SOMMELIER_APPLY_DPI_FIX=1' > #{CREW_PREFIX}/etc/env.d/sommelier
+    DPI_EOT
   end
 end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,25 +3,13 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  @_ver = '20220207'
+  @_ver = '20220324'
   version @_ver
   license 'BSD-Google'
   compatibility 'all'
-  source_url 'https://github.com/chromebrew/crew-package-sommelier.git'
-  git_hashtag @_ver
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_armv7l/sommelier-20220207-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_armv7l/sommelier-20220207-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_i686/sommelier-20220207-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20220207_x86_64/sommelier-20220207-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: '74aa4a3bb9f2839426124d31fe947859903a9f076ac58fda6576aedb3a8295c4',
-     armv7l: '74aa4a3bb9f2839426124d31fe947859903a9f076ac58fda6576aedb3a8295c4',
-       i686: '158a719de95d18cb98ec842da1201c75803e5e16dbdc6e51ca467e1a104349f1',
-     x86_64: '94feec18f9c496f2ac0d6c6b77584d70492105425815224cafe59e9086b101fe'
-  })
+  source_url 'https://github.com/supechicken/crew-package-sommelier.git'
+  git_branch 'sommelier-20220324'
+  #git_hashtag @_ver
 
   depends_on 'libdrm'
   depends_on 'libxcb'
@@ -59,6 +47,10 @@ class Sommelier < Package
     unless File.socket?('/var/run/chrome/wayland-0') || @container_check
       abort 'This package is not compatible with your device :/'.lightred
     end
+
+    # this version of sommelier should not depends on libminigbm,
+    # prebuilt binaries should links to mesa's gbm but not libminigbm
+    puts "libminigbm installed. Will build with libminigbm".yellow if File.exist?("#{CREW_META_PATH}/libminigbm.filelist")
   end
 
   def self.patch


### PR DESCRIPTION
Fixes #6937 

### Changes
- Update `sommelier` to 20220324 (commit [e2a86f9](https://chromium.googlesource.com/chromiumos/platform2/+/e2a86f919de76e9d8d5ce94980121e8c203cfc62))
- Enable gamepad support
- Make DPI fix optional (`sommelierrc`)
- Add `--disable-all` option to `ruby` shebang (`sommelierd`) for faster command start time
- Don't use the render node provided by `vgem` if there have two or more DRM render nodes available (`sommelier-wrapper`)
- Only apply `MESA_LOADER_DRIVER_OVERRIDE` on Intel's iGPU (`sommelier-env`)

Feel free to suggest changes on `chromebrew/crew-package-sommelier` :)

### Tested on
- [x] `x86_64` (VM with `virgl`)
- [x] `x86_64` (real hardware)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=sommelier_20220324 CREW_TESTING=1 crew update
```