### PR TITLE
crew: Only perform postinstall only if it is defined by package, hide error when `ctrl+c`

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -938,6 +938,9 @@ def pre_install(dest_dir)
 end
 
 def post_install
+  # return unless the postinstall function was defined by the package recipe
+  return if @pkg.method(:postinstall).source_location[0].include?(@pkg.name)
+
   Dir.mktmpdir do |post_install_tempdir|
     Dir.chdir post_install_tempdir do
       puts "Performing post-install for #{@pkg.name}...".lightblue
@@ -1875,6 +1878,10 @@ end
 
 def is_command(name)
   return !!!name[/^[-<]/]
+end
+
+trap('INT') do
+  abort 'Interrupted.'.lightred
 end
 
 command_name = args.select { |k, v| v and is_command(k) } .keys[0]

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.9'
+CREW_VERSION = '1.23.10'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -56,14 +56,14 @@ FileUtils.mkdir_p CREW_CACHE_DIR unless Dir.exist?(CREW_CACHE_DIR)
 CREW_NPROC = ( ENV['CREW_NPROC'].to_s.empty? ) ? `nproc`.chomp : ENV['CREW_NPROC']
 
 # Set following as boolean if environment variables exist.
-CREW_CACHE_ENABLED = ( ENV['CREW_CACHE_ENABLED'].to_s.empty? ) ? false : true
-CREW_CONFLICTS_ONLY_ADVISORY = ( ENV['CREW_CONFLICTS_ONLY_ADVISORY'].to_s.empty? ) ? false : true # or use conflicts_ok
-CREW_DISABLE_ENV_OPTIONS = ( ENV['CREW_DISABLE_ENV_OPTIONS'].to_s.empty? ) ? false : true # or use no_env_options
-CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY = ( ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'].to_s.empty? ) ? false : true # or use no_fhs
-CREW_LA_RENAME_ENABLED = ( ENV['CREW_LA_RENAME_ENABLED'].to_s.empty? ) ? false : true
-CREW_NOT_COMPRESS = ( ENV['CREW_NOT_COMPRESS'].to_s.empty? ) ? false : true
-CREW_NOT_STRIP = ( ENV['CREW_NOT_STRIP'].to_s.empty? ) ? false : true
-CREW_NOT_SHRINK_ARCHIVE = ( ENV['CREW_NOT_SHRINK_ARCHIVE'].to_s.empty? ) ? false : true
+CREW_CACHE_ENABLED = !!( ENV['CREW_CACHE_ENABLED'].to_s.empty? )
+CREW_CONFLICTS_ONLY_ADVISORY = !!( ENV['CREW_CONFLICTS_ONLY_ADVISORY'].to_s.empty? ) # or use conflicts_ok
+CREW_DISABLE_ENV_OPTIONS = !!( ENV['CREW_DISABLE_ENV_OPTIONS'].to_s.empty? ) # or use no_env_options
+CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY = !!( ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'].to_s.empty? ) # or use no_fhs
+CREW_LA_RENAME_ENABLED = !!( ENV['CREW_LA_RENAME_ENABLED'].to_s.empty? )
+CREW_NOT_COMPRESS = !!( ENV['CREW_NOT_COMPRESS'].to_s.empty? )
+CREW_NOT_STRIP = !!( ENV['CREW_NOT_STRIP'].to_s.empty? )
+CREW_NOT_SHRINK_ARCHIVE = !!( ENV['CREW_NOT_SHRINK_ARCHIVE'].to_s.empty? )
 
 # Set testing constants from environment variables
 CREW_TESTING_BRANCH = ENV['CREW_TESTING_BRANCH']


### PR DESCRIPTION
### Changes
- Only perform `@pkg.postinstall` and show `post-install` message only if the `self.postinstall` function is defined (used) by the package recipe
- Hide backtrace when interrupted (`ctrl+c`)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=postinstall_check CREW_TESTING=1 crew update
```
