### PR TITLE
Musl -> 1.2.3, git -> 2.35.1

### DIFF
--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,24 +3,24 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  @_ver = '2.34.1'
-  version @_ver
+  @_ver = '2.35.1'
+  version "#{@_ver}-1"
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.34.1.tar.gz'
-  source_sha256 'fc4eb5ecb9299db91cdd156c06cdeb41833f53adc5631ddf8c0cb13eaa2911c1'
+  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.35.1.tar.gz'
+  source_sha256 '9845a37dd01f9faaa7d8aa2078399d3aea91b43819a5efea6e2877b0af09bd43'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.34.1_armv7l/git-2.34.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.34.1_armv7l/git-2.34.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.34.1_i686/git-2.34.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.34.1_x86_64/git-2.34.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.1-1_armv7l/git-2.35.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.1-1_armv7l/git-2.35.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.1-1_i686/git-2.35.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.1-1_x86_64/git-2.35.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '62c32b857d959173de8b8981d3ffa6fb6c0e10a8732626ad6a64189e794203a4',
-     armv7l: '62c32b857d959173de8b8981d3ffa6fb6c0e10a8732626ad6a64189e794203a4',
-       i686: '5823cc34dfb018e731ec73f867c43e801608c1097353c17ceb6802ba8f4e0f74',
-     x86_64: '4e68335c044cae606598d503f31fba0c3516937003412c2df64dcc5202c64d10'
+    aarch64: '4584bad8f4e9554e5aee917abd078c13d553d6a3d73e18de368114f2a7663979',
+     armv7l: '4584bad8f4e9554e5aee917abd078c13d553d6a3d73e18de368114f2a7663979',
+       i686: '8a1788fe50dedc57d8f23ff93104616e594aa370156c8ac5b91cadc759248bc5',
+     x86_64: 'daa9a1b37e337a5b28fb63abd115f219d5ea32bee73f06a3c0972686aa1c79cd'
   })
 
   depends_on 'ca_certificates' => :build

--- a/packages/musl_brotli.rb
+++ b/packages/musl_brotli.rb
@@ -3,27 +3,28 @@ require 'package'
 class Musl_brotli < Package
   description 'Brotli compression format'
   homepage 'https://github.com/google/brotli'
-  version '1.0.9-1'
+  version '1.0.9-3'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/google/brotli/archive/v1.0.9.tar.gz'
   source_sha256 'f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_brotli/1.0.9-1_armv7l/musl_brotli-1.0.9-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_brotli/1.0.9-1_armv7l/musl_brotli-1.0.9-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_brotli/1.0.9-1_i686/musl_brotli-1.0.9-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_brotli/1.0.9-1_x86_64/musl_brotli-1.0.9-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_brotli/1.0.9-3_armv7l/musl_brotli-1.0.9-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_brotli/1.0.9-3_armv7l/musl_brotli-1.0.9-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_brotli/1.0.9-3_i686/musl_brotli-1.0.9-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_brotli/1.0.9-3_x86_64/musl_brotli-1.0.9-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'cc9db48c4b961fe608a7ce3e1992c13e2972dc8779127c0edc8b3a95dd76097c',
-     armv7l: 'cc9db48c4b961fe608a7ce3e1992c13e2972dc8779127c0edc8b3a95dd76097c',
-       i686: '57ee94d94b6e0ea798feaf49f002e3781c0e9ab6daf2795dcc9d938e9901744e',
-     x86_64: '4e85283bc1ee9747495df8c37662d4e4cb9a714718509492f2317b5c08f0ee76'
+    aarch64: '2c4f045fc242e8cc58d461cd8b632c7e5748c0e26b0ab81e0509b94ba2636c9d',
+     armv7l: '2c4f045fc242e8cc58d461cd8b632c7e5748c0e26b0ab81e0509b94ba2636c9d',
+       i686: '3e855179333bdae4b95c6cf96406e055cbafa2919e364485ecc455aff791bde3',
+     x86_64: '9426b67a46d536d0910cb384f7880e17b892100affda1baab7175929e14d7bc8'
   })
 
   depends_on 'musl_native_toolchain' => :build
 
+  is_musl
   is_static
 
   def self.build

--- a/packages/musl_expat.rb
+++ b/packages/musl_expat.rb
@@ -3,27 +3,30 @@ require 'package'
 class Musl_expat < Package
   description 'James Clark\'s Expat XML parser library in C.'
   homepage 'https://sourceforge.net/projects/expat/'
-  version '2.4.1-1'
+  @_ver = '2.4.8'
+  version @_ver
   license 'MIT'
   compatibility 'all'
-  source_url 'https://prdownloads.sourceforge.net/project/expat/expat/2.4.1/expat-2.4.1.tar.xz'
-  source_sha256 'cf032d0dba9b928636548e32b327a2d66b1aab63c4f4a13dd132c2d1d2f2fb6a'
+  source_url 'https://prdownloads.sourceforge.net/project/expat/expat/2.4.8/expat-2.4.8.tar.xz'
+  source_sha256 'f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_expat/2.4.1-1_armv7l/musl_expat-2.4.1-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_expat/2.4.1-1_armv7l/musl_expat-2.4.1-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_expat/2.4.1-1_i686/musl_expat-2.4.1-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_expat/2.4.1-1_x86_64/musl_expat-2.4.1-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_expat/2.4.8_armv7l/musl_expat-2.4.8-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_expat/2.4.8_armv7l/musl_expat-2.4.8-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_expat/2.4.8_i686/musl_expat-2.4.8-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_expat/2.4.8_x86_64/musl_expat-2.4.8-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '0d3de6837cb658a742d53ed9c6df190708dd0a454802bc42e15d448a8e9fbe46',
-     armv7l: '0d3de6837cb658a742d53ed9c6df190708dd0a454802bc42e15d448a8e9fbe46',
-       i686: 'c549a1c5c37d959f9c29dd9018c0e7621e3cff64af77e46c0ab16a43f43ccd85',
-     x86_64: 'dabf216e0c02afd4e7d98333c37de3f7aaba4fc0841d6079e6cb3be1db2811c3'
+    aarch64: 'da829889bc002774679a8ac8373a662b75469cd4e1e0efcf003165e3b1083e19',
+     armv7l: 'da829889bc002774679a8ac8373a662b75469cd4e1e0efcf003165e3b1083e19',
+       i686: 'e737950ec7ed54a5fa04d923e4f42710c063d1d8dd580a4f887d6b40e28a596d',
+     x86_64: '06bfcf25868d41925874458068e56155028d027be365db5989079a92bb3570b2'
   })
 
   depends_on 'musl_native_toolchain' => :build
 
+  is_musl
+  patchelf
   is_static
 
   def self.patch
@@ -31,9 +34,7 @@ class Musl_expat < Package
   end
 
   def self.build
-    load "#{CREW_LIB_PATH}lib/musl.rb"
     system "#{MUSL_ENV_OPTIONS} ./configure --prefix=#{CREW_MUSL_PREFIX} \
-        --disable-shared \
         --enable-static \
         --with-pic"
     system 'make'

--- a/packages/musl_libidn2.rb
+++ b/packages/musl_libidn2.rb
@@ -4,39 +4,40 @@ class Musl_libidn2 < Package
   description 'GNU Libidn is a fully documented implementation of the Stringprep, Punycode and IDNA 2003 specifications.'
   homepage 'https://www.gnu.org/software/libidn/'
   @_ver = '2.3.2'
-  version "#{@_ver}-1"
+  version "#{@_ver}-3"
   license 'GPL-2+ and LGPL-3+'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/libidn/libidn2-#{@_ver}.tar.gz"
   source_sha256 '76940cd4e778e8093579a9d195b25fff5e936e9dc6242068528b437a76764f91'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libidn2/2.3.2-1_armv7l/musl_libidn2-2.3.2-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libidn2/2.3.2-1_armv7l/musl_libidn2-2.3.2-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libidn2/2.3.2-1_i686/musl_libidn2-2.3.2-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libidn2/2.3.2-1_x86_64/musl_libidn2-2.3.2-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libidn2/2.3.2-3_armv7l/musl_libidn2-2.3.2-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libidn2/2.3.2-3_armv7l/musl_libidn2-2.3.2-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libidn2/2.3.2-3_i686/musl_libidn2-2.3.2-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libidn2/2.3.2-3_x86_64/musl_libidn2-2.3.2-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'fd3f74482aebcf9897c618eb74c45e6512ff77524f3f6135029ad7e746e5ecbe',
-     armv7l: 'fd3f74482aebcf9897c618eb74c45e6512ff77524f3f6135029ad7e746e5ecbe',
-       i686: '45c0aa8e6cac6846789851ae08a06d0f7165fbfe0ef8c8c3a331befa2d00edb9',
-     x86_64: '9919fe30f0b8710388e874a7289664a4867dae54b3bf2bbd494eecf92ebb8ac4'
+    aarch64: '1416d175baa8d27371ad680e92b014874aa19dafc1758ae217ae1e5a24210b32',
+     armv7l: '1416d175baa8d27371ad680e92b014874aa19dafc1758ae217ae1e5a24210b32',
+       i686: 'a301977e5cc8e3fe50a0c400740f6f2520bfdadcb30d800609a56f2ddfc1bd52',
+     x86_64: '8a53313e0858042a96a656749fbcd50d18627c71bffa86c254858334503b844c'
   })
 
   depends_on 'musl_native_toolchain' => :build
   depends_on 'musl_libunistring' => :build
   depends_on 'musl_zlib' => :build
 
+  is_musl
   is_static
+  patchelf
 
   def self.patch
     FileUtils.rm_f 'doc/idn2.1'
   end
 
   def self.build
-    load "#{CREW_LIB_PATH}lib/musl.rb"
     system "#{MUSL_ENV_OPTIONS} ./configure --prefix=#{CREW_MUSL_PREFIX} \
-        --disable-shared \
+        --enable-static \
         --disable-doc \
         --disable-rpath \
         --disable-gtk-doc \

--- a/packages/musl_libunistring.rb
+++ b/packages/musl_libunistring.rb
@@ -3,35 +3,37 @@ require 'package'
 class Musl_libunistring < Package
   description 'A library that provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.'
   homepage 'https://www.gnu.org/software/libunistring/'
-  version '0.9.10-1'
+  @_ver = '1.0'
+  version "#{@_ver}-1"
   license 'LGPL-3+ or GPL-2+ and FDL-1.2 or GPL-3+'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.xz'
-  source_sha256 'eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7'
+  source_url 'https://ftpmirror.gnu.org/libunistring/libunistring-1.0.tar.xz'
+  source_sha256 '5bab55b49f75d77ed26b257997e919b693f29fd4a1bc22e0e6e024c246c72741'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunistring/0.9.10-1_armv7l/musl_libunistring-0.9.10-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunistring/0.9.10-1_armv7l/musl_libunistring-0.9.10-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunistring/0.9.10-1_i686/musl_libunistring-0.9.10-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunistring/0.9.10-1_x86_64/musl_libunistring-0.9.10-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunistring/1.0-1_armv7l/musl_libunistring-1.0-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunistring/1.0-1_armv7l/musl_libunistring-1.0-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunistring/1.0-1_i686/musl_libunistring-1.0-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunistring/1.0-1_x86_64/musl_libunistring-1.0-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '7993833f0c924bbe1cc0886181287cf52a74252660ccdf7de9db2ca0f58fbf17',
-     armv7l: '7993833f0c924bbe1cc0886181287cf52a74252660ccdf7de9db2ca0f58fbf17',
-       i686: '460681fc32028b10be1365826a902e3f24e707a6d3fa45f038554af41d3494bc',
-     x86_64: '2ab6bc568ddd929c7cab3bf14fc2ad44746cbb943e3cbf896c10f28220a8a4e8'
+    aarch64: '652ce2e2858bffb5a9561c444882c182b0970fa3efcedc815ed8c2fdbedb8ea2',
+     armv7l: '652ce2e2858bffb5a9561c444882c182b0970fa3efcedc815ed8c2fdbedb8ea2',
+       i686: '00ad64cfae2ef01ce183c65f56ab1753b6ff3db16c51ab4625f953c24fa5c005',
+     x86_64: 'e654273339a3cfff68899371dbbba287c5396184043b0dcdf249c10cff71fd6b'
   })
 
   depends_on 'musl_native_toolchain' => :build
   depends_on 'musl_zlib' => :build
 
+  is_musl
   is_static
+  patchelf
 
   def self.build
-    load "#{CREW_LIB_PATH}lib/musl.rb"
     system "#{MUSL_ENV_OPTIONS} ./configure --prefix=#{CREW_MUSL_PREFIX} \
         --enable-static \
-        --disable-shared"
+        --enable-shared"
     system 'make'
   end
 

--- a/packages/musl_native_toolchain.rb
+++ b/packages/musl_native_toolchain.rb
@@ -3,29 +3,40 @@ require 'package'
 class Musl_native_toolchain < Package
   description 'A modern, simple, and fast C library implementation that strives to be lightweight, fast, simple, free, and correct in the sense of standards-conformance and safety.'
   homepage 'https://musl.cc/'
-  version 'd1395c'
+  @musl_version = '7a43f6fea9081bdd53d8a11cef9e9fab0348c53d'
+  # @_ver = (@musl_version[0, 7])
+  version '1.2.3'
   license 'MIT, LGPL-2 and GPL-2'
   compatibility 'all'
   source_url 'https://git.zv.io/toolchains/musl-cross-make.git'
   git_hashtag '53280e53a32202a0ee874911fc52005874db344b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/d1395c_armv7l/musl_native_toolchain-d1395c-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/d1395c_armv7l/musl_native_toolchain-d1395c-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/d1395c_i686/musl_native_toolchain-d1395c-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/d1395c_x86_64/musl_native_toolchain-d1395c-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.3_armv7l/musl_native_toolchain-1.2.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.3_armv7l/musl_native_toolchain-1.2.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.3_i686/musl_native_toolchain-1.2.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_native_toolchain/1.2.3_x86_64/musl_native_toolchain-1.2.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '67f4c90e9604f2f9faa1862389a72a7d4ed9a7d202ea52eeb6a4aaab1d0a1d07',
-     armv7l: '67f4c90e9604f2f9faa1862389a72a7d4ed9a7d202ea52eeb6a4aaab1d0a1d07',
-       i686: '77bb046c80ac1b48df0d38a6a55f603a1c6f83805f2b7c23b59303199618c9bc',
-     x86_64: 'a390c454918f3a3f4ada528f2f1f19e71ea276a293191b5ae9ecad2cb9b37bff'
+    aarch64: '71fe4ca61686a3675f7f5648fe3aae59b68f4c3c1e2678fabd215ec0f6be399e',
+     armv7l: '71fe4ca61686a3675f7f5648fe3aae59b68f4c3c1e2678fabd215ec0f6be399e',
+       i686: 'd29dcaab5ada61d0d0a0451d5fbf079f2f294457abd0d9ce4fb46cb73f5f74db',
+     x86_64: '332322c230a6f18e35c5a145386021d74c77c6191e51b4c647ef63bbc04dae28'
   })
 
+  # These libraries need to be built with the same version of gcc
+  # as being built below, as the LTO versions need to match.
+  depends_on 'zlibpkg' => :build
+  depends_on 'zstd' => :build
+
+  is_musl
+  conflicts_ok
+
   @archflags = ''
-  @linux_ver = '4.14.261'
+  @linux_ver = '4.14.275'
   @target_tuple = "#{ARCH}-linux-musl"
-  @gcc_version = '11-20220108'
+  @gcc_version = '11-20220402'
+
   case ARCH
   when 'aarch64', 'armv7l'
     @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-fpu=neon --with-tune=cortex-a15'
@@ -35,26 +46,116 @@ class Musl_native_toolchain < Package
   end
 
   def self.patch
-    load "#{CREW_LIB_PATH}lib/musl.rb"
+    FileUtils.mkdir_p "patches/musl-git-#{@musl_version}" if ARCH == 'i686'
+    # Patch via discussion on musl mailing list with Rich Felker
+    # working out issues on i686 Chromebooks for musl.
+    # https://www.openwall.com/lists/musl/2022/02/18/1
+    @i686_broken_kernel_patch = <<~'BROKEN_KERNEL_PATCH_EOF'
+      --- a/arch/i386/syscall_arch.h	2022-02-17 16:45:37.398583011 -0500
+      +++ b/arch/i386/syscall_arch.h	2022-02-17 16:50:02.311265598 -0500
+      @@ -9,11 +9,21 @@
+       #define SYSCALL_INSNS "call *%%gs:16"
+       #endif
+
+      +/*
+      + *  * This error code is special: arch syscall entry code will return
+      + *   * -ENOSYS if users try to call a syscall that doesn't exist.  To keep
+      + *    * failures of syscalls that really do exist distinguishable from
+      + *     * failures due to attempts to use a nonexistent syscall, syscall
+      + *      * implementations should refrain from returning -ENOSYS.
+      + *       */
+      +#define ENOSYS          38      /* Invalid system call number */
+      +
+       #define SYSCALL_INSNS_12 "xchg %%ebx,%%edx ; " SYSCALL_INSNS " ; xchg %%ebx,%%edx"
+       #define SYSCALL_INSNS_34 "xchg %%ebx,%%edi ; " SYSCALL_INSNS " ; xchg %%ebx,%%edi"
+
+       static inline long __syscall0(long n)
+       {
+      +	if (n>350) return -ENOSYS;
+       	unsigned long __ret;
+       	__asm__ __volatile__ (SYSCALL_INSNS : "=a"(__ret) : "a"(n) : "memory");
+       	return __ret;
+      @@ -21,6 +31,7 @@
+
+       static inline long __syscall1(long n, long a1)
+       {
+      +	if (n>350) return -ENOSYS;
+       	unsigned long __ret;
+       	__asm__ __volatile__ (SYSCALL_INSNS_12 : "=a"(__ret) : "a"(n), "d"(a1) : "memory");
+       	return __ret;
+      @@ -28,6 +39,7 @@
+
+       static inline long __syscall2(long n, long a1, long a2)
+       {
+      +	if (n>350) return -ENOSYS;
+       	unsigned long __ret;
+       	__asm__ __volatile__ (SYSCALL_INSNS_12 : "=a"(__ret) : "a"(n), "d"(a1), "c"(a2) : "memory");
+       	return __ret;
+      @@ -35,6 +47,7 @@
+
+       static inline long __syscall3(long n, long a1, long a2, long a3)
+       {
+      +	if (n>350) return -ENOSYS;
+       	unsigned long __ret;
+       #if !defined(__PIC__) || !defined(BROKEN_EBX_ASM)
+       	__asm__ __volatile__ (SYSCALL_INSNS : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3) : "memory");
+      @@ -46,6 +59,7 @@
+
+       static inline long __syscall4(long n, long a1, long a2, long a3, long a4)
+       {
+      +	if (n>350) return -ENOSYS;
+       	unsigned long __ret;
+       #if !defined(__PIC__) || !defined(BROKEN_EBX_ASM)
+       	__asm__ __volatile__ (SYSCALL_INSNS : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4) : "memory");
+      @@ -57,6 +71,7 @@
+
+       static inline long __syscall5(long n, long a1, long a2, long a3, long a4, long a5)
+       {
+      +	if (n>350) return -ENOSYS;
+       	unsigned long __ret;
+       #if !defined(__PIC__) || !defined(BROKEN_EBX_ASM)
+       	__asm__ __volatile__ (SYSCALL_INSNS
+      @@ -70,6 +85,7 @@
+
+       static inline long __syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6)
+       {
+      +	if (n>350) return -ENOSYS;
+       	unsigned long __ret;
+       #if !defined(__PIC__) || !defined(BROKEN_EBX_ASM)
+       	__asm__ __volatile__ ("pushl %7 ; push %%ebp ; mov 4(%%esp),%%ebp ; " SYSCALL_INSNS " ; pop %%ebp ; add $4,%%esp"
+    BROKEN_KERNEL_PATCH_EOF
+    # Patch only needed for i686 due to issues with
+    # ChromeOS 3.8.11 kernel.
+    if ARCH == 'i686'
+      File.write("patches/musl-git-#{@musl_version}/i686_broken_kernel.patch",
+                 @i686_broken_kernel_patch)
+    end
     @config_mak = <<~CONFIG_MAK_EOF
+      # Not building with static results in a toolchain built against
+      # glibc, which isn't what we want.
       STAT = -static --static
+
       FLAG = -g0 -O2 -pipe -fno-align-functions -fno-align-jumps -fno-align-loops -fno-align-labels -Wno-error -fPIC
 
       ifneq (\$(NATIVE),)
-      COMMON_CONFIG += CC="\$(HOST)-gcc \${STAT}" CXX="\$(HOST)-g++ \${STAT}" FC="\$(HOST)-gfortran \${STAT}"
+      COMMON_CONFIG += LIBRARY_PATH=#{CREW_MUSL_PREFIX}/lib:#{CREW_LIB_PREFIX} CC="\$(HOST)-gcc \${STAT}" CXX="\$(HOST)-g++ \${STAT}" FC="\$(HOST)-gfortran \${STAT}"
       else
-      COMMON_CONFIG += CC="gcc \${STAT}" CXX="g++ \${STAT}" FC="gfortran \${STAT}"
+      COMMON_CONFIG += LIBRARY_PATH=#{CREW_MUSL_PREFIX}/lib:#{CREW_LIB_PREFIX} CC="gcc \${STAT}" CXX="g++ \${STAT}" FC="gfortran \${STAT}"
       endif
 
-      COMMON_CONFIG += CFLAGS="\${FLAG}" CXXFLAGS="\${FLAG}" FFLAGS="\${FLAG}" LDFLAGS="-s \${STAT}"
+      COMMON_CONFIG += CFLAGS="\${FLAG}" CXXFLAGS="\${FLAG}" FFLAGS="\${FLAG}" LDFLAGS="-s -L#{CREW_LIB_PREFIX} \${STAT}"
 
       BINUTILS_CONFIG += --enable-gold --enable-plugins --enable-64-bit-bfd
-      GCC_CONFIG += --enable-default-pie --enable-static-pie --disable-cet --without-zstd #{@archflags}
+      GCC_CONFIG += --enable-default-pie --enable-static-pie --disable-cet --with-gcc-major-version-only #{@archflags} ZSTD_INC=#{CREW_PREFIX}/include ZSTD_LIB='#{CREW_LIB_PREFIX}/libzstd.a -pthread'
+
+      # MUSL_CONFIG += --enable-debug
 
       CONFIG_SUB_REV = 888c8e3d5f7b
       GCC_VER = #{@gcc_version}
-      BINUTILS_VER = 2.37
-      MUSL_VER = git-d1395c43c019aec6b855cf3c656bf47c8a719e7f
+      BINUTILS_VER = 2.38
+      # Newer musl versions cause breakage on i686 due to an issue with
+      # the ancient 3.8 kernel on there.
+      MUSL_VER = git-#{@musl_version}
       GMP_VER = 6.2.1
       ISL_VER = 0.23
       MPC_VER = 1.2.1
@@ -68,16 +169,28 @@ class Musl_native_toolchain < Package
     File.write('config.mak', @config_mak)
     File.write('hashes/linux-3.8.12.tar.xz.sha1',
                '13d4f4f8f447b721e4a18ca39ed60fb7055d1de1 linux-3.8.12.tar.xz')
-    File.write('hashes/linux-4.14.261.tar.xz.sha1',
-               '28247a5448ac33e4031afa2544f384a525547b20 linux-4.14.261.tar.xz')
-    File.write("hashes/gcc-#{@gcc_version}.tar.xz.sha1",
-               "f89942362a87cb9c49f53177e7fcc57c77238197 gcc-#{@gcc_version}.tar.xz")
+    File.write('hashes/linux-4.14.275.tar.xz.sha1',
+               '300405963f79403dc8dfa9404f23e48b263ec796 linux-4.14.275.tar.xz')
+    File.write('hashes/binutils-2.38.tar.xz.sha1',
+               '15d42de8f15404a4a43a912440cf367f994779d7 binutils-2.38.tar.xz')
+    File.write('hashes/gcc-11-20220108.tar.xz.sha1',
+               'f89942362a87cb9c49f53177e7fcc57c77238197 gcc-11-20220108.tar.xz')
+    File.write('hashes/gcc-11-20220205.tar.xz.sha1',
+               'bf47c2deb318a84daad4b5773c1cbd3e93b9c637 gcc-11-20220205.tar.xz')
+    File.write('hashes/gcc-11-20220212.tar.xz.sha1',
+               '7c12dfccd75678cf7df65cccae94406b5a326b52 gcc-11-20220212.tar.xz')
+    File.write('hashes/gcc-11-20220402.tar.xz.sha1',
+               '5c8ee76fedec6ac8112d8a351721ae26045489cf gcc-11-20220402.tar.xz')
+    # File.write("hashes/gcc-#{@gcc_version}.tar.xz.sha1",
+    #           "634ee2483dbebb23fd32edff0ebb93924524e5a2 gcc-#{@gcc_version}.tar.xz")
     FileUtils.mv 'patches/gcc-11-20211120', "patches/gcc-#{@gcc_version}"
   end
 
   def self.build
-    load "#{CREW_LIB_PATH}lib/musl.rb"
-    system 'make'
+    # This avoids an issue with the system zstd library being detected
+    # but not used, which makes the build fail.
+    system "make || ( (grep -rl \"ZSTD_INC =\" . | xargs sed -i 's,ZSTD_INC =,ZSTD_INC = #{CREW_PREFIX}/include ,g'; \
+    grep -rl \"ZSTD_LIB =\" . | xargs sed -i 's,ZSTD_LIB =,ZSTD_LIB = #{CREW_LIB_PREFIX}/libzstd.a -pthread ,g') && make)"
   end
 
   def self.install
@@ -97,16 +210,10 @@ class Musl_native_toolchain < Package
       FileUtils.ln "#{CREW_DEST_MUSL_PREFIX}/#{@target_tuple}/lib/libc.so", "#{CREW_DEST_MUSL_PREFIX}/lib/libc.so",
                    force: true
     end
-    Dir.chdir(CREW_DEST_MUSL_PREFIX) do
-      FileUtils.ln_sf 'lib', 'lib64' if ARCH == 'x86_64'
-    end
-  end
-
-  def self.postinstall
     return unless ARCH == 'i686'
 
     # perl needs this.
-    FileUtils.ln_sf "#{CREW_MUSL_PREFIX}/#{@target_tuple}/include/locale.h",
-                    "#{CREW_MUSL_PREFIX}/#{@target_tuple}/include/xlocale.h"
+    FileUtils.ln_sf "#{CREW_DEST_MUSL_PREFIX}/#{@target_tuple}/include/locale.h",
+                    "#{CREW_DEST_MUSL_PREFIX}/#{@target_tuple}/include/xlocale.h"
   end
 end

--- a/packages/musl_ncurses.rb
+++ b/packages/musl_ncurses.rb
@@ -3,23 +3,24 @@ require 'package'
 class Musl_ncurses < Package
   description 'The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0 (SVr4), and more. — Wide character'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '6.3-20220115'
+  @_ver = '6.3-20220402'
+  version @_ver
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/mirror/ncurses.git'
-  git_hashtag '91e462de27aeecd5b1c8965a6dba078f7a438003'
+  git_hashtag '64eb5fae1961774e65e46953fa536d12c12f6d76'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_ncurses/6.3-20220115_armv7l/musl_ncurses-6.3-20220115-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_ncurses/6.3-20220115_armv7l/musl_ncurses-6.3-20220115-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_ncurses/6.3-20220115_i686/musl_ncurses-6.3-20220115-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_ncurses/6.3-20220115_x86_64/musl_ncurses-6.3-20220115-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_ncurses/6.3-20220402_armv7l/musl_ncurses-6.3-20220402-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_ncurses/6.3-20220402_armv7l/musl_ncurses-6.3-20220402-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_ncurses/6.3-20220402_i686/musl_ncurses-6.3-20220402-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_ncurses/6.3-20220402_x86_64/musl_ncurses-6.3-20220402-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '8cd01482d8cda2bd798ed3ac249cb2500bc25a17e1c0173400fe4f906582cec3',
-     armv7l: '8cd01482d8cda2bd798ed3ac249cb2500bc25a17e1c0173400fe4f906582cec3',
-       i686: '8cd18fb303321334f520c282e36aeaa33c31b4cd4d92ed19837ff99c7bedff35',
-     x86_64: '793300816d2290bd7519c6edd4d3196470d9dc210c7aec8ba1b4d45a6aa2cf5d'
+    aarch64: '25144e3cc706bdf9be536b599a636aa93816937335376cdf76f6a3bdd6d34585',
+     armv7l: '25144e3cc706bdf9be536b599a636aa93816937335376cdf76f6a3bdd6d34585',
+       i686: '1a10f66028936530ebfcda1a1ef82ac8e23c0d643589b603539719875e56f32a',
+     x86_64: 'd001c2863a3851651c30d9b0d5b6d6168f7e806b193b8541041b333d4e57e665'
   })
 
   depends_on 'musl_native_toolchain' => :build
@@ -27,10 +28,11 @@ class Musl_ncurses < Package
   depends_on 'musl_libidn2' => :build
   depends_on 'musl_zlib' => :build
 
+  is_musl
   is_static
+  patchelf
 
   def self.build
-    load "#{CREW_LIB_PATH}lib/musl.rb"
     system "#{MUSL_ENV_OPTIONS} ./configure --prefix=#{CREW_MUSL_PREFIX} \
         --with-static \
         --with-cxx-static \

--- a/packages/musl_openssl.rb
+++ b/packages/musl_openssl.rb
@@ -3,24 +3,24 @@ require 'package'
 class Musl_openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
-  @_ver = '3.0.1'
+  @_ver = '3.0.2'
   version @_ver
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
-  source_sha256 'c311ad853353bce796edad01a862c50a8a587f62e7e2100ef465ab53ec9b06d1'
+  source_sha256 '98e91ccead4d4756ae3c9cde5e09191a8e586d9f4d50838e7ec09d6411dfdb63'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.1_armv7l/musl_openssl-3.0.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.1_armv7l/musl_openssl-3.0.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.1_i686/musl_openssl-3.0.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.1_x86_64/musl_openssl-3.0.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.2_armv7l/musl_openssl-3.0.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.2_armv7l/musl_openssl-3.0.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.2_i686/musl_openssl-3.0.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.2_x86_64/musl_openssl-3.0.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'b18e75dd8d59a179ec8e0c84ed50194253c3350494326059dcaadd0f1abb6d23',
-     armv7l: 'b18e75dd8d59a179ec8e0c84ed50194253c3350494326059dcaadd0f1abb6d23',
-       i686: '4e5f715a69c494f9d10b6a071a95771bdacde44253d692e4e9f84addad57de85',
-     x86_64: '745cc2cd4f4f861f4d7ac4be33f724ab7da1b1a1ec833fb9dbb5828d2dc5e6fd'
+    aarch64: '159c7b46cdff07ed3ae35c54c80a667d507a6613c9ee1f14f0f3c8c710993b06',
+     armv7l: '159c7b46cdff07ed3ae35c54c80a667d507a6613c9ee1f14f0f3c8c710993b06',
+       i686: '1098d4e577758cdb103edc861149d6053f2ebe1b79777da6461a7c1961eaadd5',
+     x86_64: '2f482f0922c4a4188622416df2f3e31b555cafac2b42635944452c72c7ab05c2'
   })
 
   depends_on 'musl_native_toolchain' => :build
@@ -29,19 +29,18 @@ class Musl_openssl < Package
   depends_on 'musl_zlib' => :build
   depends_on 'musl_ncurses' => :build
 
+  is_musl
   is_static
 
-  case ARCH
-  when 'aarch64', 'armv7l'
-    @openssl_configure_target = 'linux-generic32'
-  when 'i686'
-    @openssl_configure_target = 'linux-elf'
-  when 'x86_64'
-    @openssl_configure_target = 'linux-x86_64'
-  end
-
   def self.build
-    load "#{CREW_LIB_PATH}lib/musl.rb"
+    case ARCH
+    when 'aarch64', 'armv7l'
+      @openssl_configure_target = 'linux-generic32'
+    when 'i686'
+      @openssl_configure_target = 'linux-elf'
+    when 'x86_64'
+      @openssl_configure_target = 'linux-x86_64'
+    end
     system "#{MUSL_ENV_OPTIONS} ./Configure \
         --prefix=#{CREW_MUSL_PREFIX} \
         --openssldir=#{CREW_MUSL_PREFIX} \
@@ -62,6 +61,7 @@ class Musl_openssl < Package
         no-weak-ssl-ciphers \
         no-des \
         no-cast \
+        --with-rand-seed=rdcpu,os \
         -static --static \
         -Wl,-rpath=#{CREW_MUSL_PREFIX}/lib -Wl,--enable-new-dtags \
         -Wl,-Bsymbolic \

--- a/packages/musl_zlib.rb
+++ b/packages/musl_zlib.rb
@@ -4,31 +4,31 @@ class Musl_zlib < Package
   description 'zlib is a massively spiffy yet delicately unobtrusive compression library.'
   homepage 'https://www.zlib.net/'
   @_ver = '1.2.11'
-  version "#{@_ver}-1"
+  version "#{@_ver}-3"
   license 'zlib'
   compatibility 'all'
   source_url "https://www.zlib.net/zlib-#{@_ver}.tar.gz"
   source_sha256 'c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zlib/1.2.11-1_armv7l/musl_zlib-1.2.11-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zlib/1.2.11-1_armv7l/musl_zlib-1.2.11-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zlib/1.2.11-1_i686/musl_zlib-1.2.11-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zlib/1.2.11-1_x86_64/musl_zlib-1.2.11-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zlib/1.2.11-3_armv7l/musl_zlib-1.2.11-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zlib/1.2.11-3_armv7l/musl_zlib-1.2.11-3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zlib/1.2.11-3_i686/musl_zlib-1.2.11-3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zlib/1.2.11-3_x86_64/musl_zlib-1.2.11-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2ef3cfd50efbcd094cba24b4a776fe95f655f1ab9e36c3186355c3c710b95235',
-     armv7l: '2ef3cfd50efbcd094cba24b4a776fe95f655f1ab9e36c3186355c3c710b95235',
-       i686: '5e36e9ad564e7323524be1bcc6ba1ea5a5d161b37c2dc3a0b05bcd1daa7c6783',
-     x86_64: '3258869aa53a18df34f79f150becf9d1e6d2e69ee2a2ab6c31aa131981ae54f3'
+    aarch64: '571117513b5a9668145ab0bdd54202644cb4f0d955c36e1f87e7cb6f1db65eb7',
+     armv7l: '571117513b5a9668145ab0bdd54202644cb4f0d955c36e1f87e7cb6f1db65eb7',
+       i686: '8cb92c4a79f090c3ad19002a62d23d401aa73fbe36d9038fbca2e9e4df6557ab',
+     x86_64: 'c5f536dffcc2be62f4c5f131531418b4b4b24b6d27b7bc9dd531ea9a05f04074'
   })
 
   depends_on 'musl_native_toolchain' => :build
-
+  is_musl
+  patchelf
   is_static
 
   def self.build
-    load "#{CREW_LIB_PATH}lib/musl.rb"
     system "#{MUSL_ENV_OPTIONS} ./configure --prefix=#{CREW_MUSL_PREFIX} \
           --static"
     system "#{MUSL_ENV_OPTIONS} make"

--- a/packages/musl_zstd.rb
+++ b/packages/musl_zstd.rb
@@ -4,28 +4,27 @@ class Musl_zstd < Package
   description 'Zstandard - Fast real-time compression algorithm'
   homepage 'http://www.zstd.net'
   @_ver = '1.5.2'
-  version @_ver
+  version "#{@_ver}-2"
   license 'BSD or GPL-2'
   compatibility 'all'
   source_url 'https://github.com/facebook/zstd.git'
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2_armv7l/musl_zstd-1.5.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2_armv7l/musl_zstd-1.5.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2_i686/musl_zstd-1.5.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2_x86_64/musl_zstd-1.5.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2-2_armv7l/musl_zstd-1.5.2-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2-2_armv7l/musl_zstd-1.5.2-2-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2-2_i686/musl_zstd-1.5.2-2-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2-2_x86_64/musl_zstd-1.5.2-2-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '926bd2feb65c37b05d220628368a01ae723c5062d4d9fef4838be7b6a55ace29',
-     armv7l: '926bd2feb65c37b05d220628368a01ae723c5062d4d9fef4838be7b6a55ace29',
-       i686: '3f0adecdbc55e1c2114ff1013d21da3c11c468a28e5a28dfb54620ba54ea4f36',
-     x86_64: '5a96064ca69ee5db65b6961f795a239f83ac5cbca16acea2b59a6f7472d54eb3'
+    aarch64: 'fc17f3e5f3456deed345eced630e6c7836e81525a494c365bc54277ad6ee0d77',
+     armv7l: 'fc17f3e5f3456deed345eced630e6c7836e81525a494c365bc54277ad6ee0d77',
+       i686: '6c695a6fe0933b98f4b6bde67af84017975894fcd476318fc9b53f6f7006fb30',
+     x86_64: '57510ec4dd8dd6846d11c6d426023fea918399dda184b748d9b508dd10f76696'
   })
 
   depends_on 'musl_native_toolchain' => :build
 
-  is_static
   is_musl
   no_zstd
   patchelf
@@ -37,7 +36,7 @@ class Musl_zstd < Package
       system "#{MUSL_CMAKE_OPTIONS.gsub('-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE',
                                         '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF')} \
       -DZSTD_BUILD_STATIC=ON \
-      -DZSTD_BUILD_SHARED=OFF \
+      -DZSTD_BUILD_SHARED=ON \
       -DZSTD_BUILD_PROGRAMS=ON \
       -DZSTD_PROGRAMS_LINK_SHARED=OFF \
       -DPROGRAMS_ZSTD_LINK_TARGET=libzstd_static \


### PR DESCRIPTION
Fixes #6906 (hopefully)

- Rebuilds of git dependencies with newer musl release.
- Build order for git: musl_native_toolchain musl_zlib musl_libunistring musl_libidn2 musl_ncurses musl_openssl musl_zstd musl_brotli musl_expat musl_curl git

Works properly: (needs to be checked on hardware)
- [x] `x86_64` (works on `nocturne`)
- [x] `i686` (works on `alex`)
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=musl_1.2.3 CREW_TESTING=1 crew update
```
