### PR TITLE
crew: Fix postinstall, remove extra `!` in `const.rb`

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -939,7 +939,7 @@ end
 
 def post_install
   # return unless the postinstall function was defined by the package recipe
-  return if @pkg.method(:postinstall).source_location[0].include?(@pkg.name)
+  return unless @pkg.method(:postinstall).source_location[0].include?(@pkg.name)
 
   Dir.mktmpdir do |post_install_tempdir|
     Dir.chdir post_install_tempdir do

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -56,14 +56,14 @@ FileUtils.mkdir_p CREW_CACHE_DIR unless Dir.exist?(CREW_CACHE_DIR)
 CREW_NPROC = ( ENV['CREW_NPROC'].to_s.empty? ) ? `nproc`.chomp : ENV['CREW_NPROC']
 
 # Set following as boolean if environment variables exist.
-CREW_CACHE_ENABLED = !!( ENV['CREW_CACHE_ENABLED'].to_s.empty? )
-CREW_CONFLICTS_ONLY_ADVISORY = !!( ENV['CREW_CONFLICTS_ONLY_ADVISORY'].to_s.empty? ) # or use conflicts_ok
-CREW_DISABLE_ENV_OPTIONS = !!( ENV['CREW_DISABLE_ENV_OPTIONS'].to_s.empty? ) # or use no_env_options
-CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY = !!( ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'].to_s.empty? ) # or use no_fhs
-CREW_LA_RENAME_ENABLED = !!( ENV['CREW_LA_RENAME_ENABLED'].to_s.empty? )
-CREW_NOT_COMPRESS = !!( ENV['CREW_NOT_COMPRESS'].to_s.empty? )
-CREW_NOT_STRIP = !!( ENV['CREW_NOT_STRIP'].to_s.empty? )
-CREW_NOT_SHRINK_ARCHIVE = !!( ENV['CREW_NOT_SHRINK_ARCHIVE'].to_s.empty? )
+CREW_CACHE_ENABLED = !( ENV['CREW_CACHE_ENABLED'].to_s.empty? )
+CREW_CONFLICTS_ONLY_ADVISORY = !( ENV['CREW_CONFLICTS_ONLY_ADVISORY'].to_s.empty? ) # or use conflicts_ok
+CREW_DISABLE_ENV_OPTIONS = !( ENV['CREW_DISABLE_ENV_OPTIONS'].to_s.empty? ) # or use no_env_options
+CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY = !( ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'].to_s.empty? ) # or use no_fhs
+CREW_LA_RENAME_ENABLED = !( ENV['CREW_LA_RENAME_ENABLED'].to_s.empty? )
+CREW_NOT_COMPRESS = !( ENV['CREW_NOT_COMPRESS'].to_s.empty? )
+CREW_NOT_STRIP = !( ENV['CREW_NOT_STRIP'].to_s.empty? )
+CREW_NOT_SHRINK_ARCHIVE = !( ENV['CREW_NOT_SHRINK_ARCHIVE'].to_s.empty? )
 
 # Set testing constants from environment variables
 CREW_TESTING_BRANCH = ENV['CREW_TESTING_BRANCH']

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.10'
+CREW_VERSION = '1.23.11'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Fixes #6960 

### Changes
- Use `unless` instead of `if` in `def post_install` (Line 942)
- Remove extra `!` in `const.rb`

Tested on `x86_64`