### PR TITLE
git -> 2.35.2, {musl_}libunbound -> 1.15.0

### DIFF
--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,24 +3,24 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  @_ver = '2.35.1'
-  version "#{@_ver}-1"
+  @_ver = '2.35.2'
+  version @_ver
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.35.1.tar.gz'
-  source_sha256 '9845a37dd01f9faaa7d8aa2078399d3aea91b43819a5efea6e2877b0af09bd43'
+  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.35.2.tar.xz'
+  source_sha256 'c73d0c4fa5dcebdb2ccc293900952351cc5fb89224bb133c116305f45ae600f3'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.1-1_armv7l/git-2.35.1-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.1-1_armv7l/git-2.35.1-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.1-1_i686/git-2.35.1-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.1-1_x86_64/git-2.35.1-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.2_armv7l/git-2.35.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.2_armv7l/git-2.35.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.2_i686/git-2.35.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.35.2_x86_64/git-2.35.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4584bad8f4e9554e5aee917abd078c13d553d6a3d73e18de368114f2a7663979',
-     armv7l: '4584bad8f4e9554e5aee917abd078c13d553d6a3d73e18de368114f2a7663979',
-       i686: '8a1788fe50dedc57d8f23ff93104616e594aa370156c8ac5b91cadc759248bc5',
-     x86_64: 'daa9a1b37e337a5b28fb63abd115f219d5ea32bee73f06a3c0972686aa1c79cd'
+    aarch64: '0181109f2590546f6a21979acbbec1b97001567b5e37f7cf5df3a181cb8c7320',
+     armv7l: '0181109f2590546f6a21979acbbec1b97001567b5e37f7cf5df3a181cb8c7320',
+       i686: '2f03b9f5f0cdeeb8e14c403bafe5e3aab56f9df2ea8f45b4d7415a64728c8595',
+     x86_64: 'b12809698fd1b68d4621bce8e827c8d069c9d902aed7ac2b5e7eee6b310c699d'
   })
 
   depends_on 'ca_certificates' => :build
@@ -28,6 +28,7 @@ class Git < Package
   depends_on 'rust' => :build
   depends_on 'musl_brotli' => :build
   depends_on 'musl_libidn2' => :build
+  depends_on 'musl_libunbound' => :build
   depends_on 'musl_libunistring' => :build
   depends_on 'musl_native_toolchain' => :build
   depends_on 'musl_ncurses' => :build
@@ -36,10 +37,10 @@ class Git < Package
   depends_on 'musl_zstd' => :build
   depends_on 'musl_expat' => :build
 
+  is_musl
   is_static
 
   def self.patch
-    load "#{CREW_LIB_PATH}lib/musl.rb"
     # Patch to prevent error function conflict with libidn2
     # By replacing all calls to error with git_error.
     system "sed -i 's,^#undef error\$,#undef git_error,' usage.c"

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -3,24 +3,24 @@ require 'package'
 class Libunbound < Package
   description 'Unbound is a validating, recursive, and caching DNS resolver.'
   homepage 'https://nlnetlabs.nl/projects/unbound/about/'
-  @_ver = '1.13.1'
+  @_ver = '1.15.0'
   version @_ver
   license 'BSD and GPL-2'
   compatibility 'all'
   source_url "https://nlnetlabs.nl/downloads/unbound/unbound-#{@_ver}.tar.gz"
-  source_sha256 '8504d97b8fc5bd897345c95d116e0ee0ddf8c8ff99590ab2b4bd13278c9f50b8'
+  source_sha256 'a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.1_armv7l/libunbound-1.13.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.1_armv7l/libunbound-1.13.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.1_i686/libunbound-1.13.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.13.1_x86_64/libunbound-1.13.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.15.0_armv7l/libunbound-1.15.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.15.0_armv7l/libunbound-1.15.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.15.0_i686/libunbound-1.15.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.15.0_x86_64/libunbound-1.15.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1e6999af00f48993d63ff36bff111796a1a79894808499ff0afafcf12a6e5c32',
-     armv7l: '1e6999af00f48993d63ff36bff111796a1a79894808499ff0afafcf12a6e5c32',
-       i686: 'eb5e0d99f4a98ed55e6842d01782e3326045c7a9e3e99e4a3867113d2113a30f',
-     x86_64: 'fe16753a6cb9a8c69cf759201f39dec701d29b9de75954c77a2225e32e7a3edc'
+    aarch64: '138691148c63f343b99d70e58405f26a5efc185cefb0aa6e7f9d96a8e5738131',
+     armv7l: '138691148c63f343b99d70e58405f26a5efc185cefb0aa6e7f9d96a8e5738131',
+       i686: '1eb7e176be91f7fa902a75295a81d1116745b3fd71ef87588964b7c2e129c363',
+     x86_64: '5c4125bce66bb83fc775a5fe236718dee958b9724d5b6adf55d3b682c2b05401'
   })
 
   depends_on 'openssl' # On i686 openssl needs to be installed before libunbound.

--- a/packages/musl_libunbound.rb
+++ b/packages/musl_libunbound.rb
@@ -3,39 +3,38 @@ require 'package'
 class Musl_libunbound < Package
   description 'Unbound is a validating, recursive, and caching DNS resolver.'
   homepage 'https://nlnetlabs.nl/projects/unbound/about/'
-  @_ver = '1.14.0'
+  @_ver = '1.15.0'
   version @_ver
   license 'BSD and GPL-2'
   compatibility 'all'
   source_url "https://nlnetlabs.nl/downloads/unbound/unbound-#{@_ver}.tar.gz"
-  source_sha256 '6ef91cbf02d5299eab39328c0857393de7b4885a2fe7233ddfe3c124ff5a89c8'
+  source_sha256 'a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunbound/1.14.0_armv7l/musl_libunbound-1.14.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunbound/1.14.0_armv7l/musl_libunbound-1.14.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunbound/1.14.0_i686/musl_libunbound-1.14.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunbound/1.14.0_x86_64/musl_libunbound-1.14.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunbound/1.15.0_armv7l/musl_libunbound-1.15.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunbound/1.15.0_armv7l/musl_libunbound-1.15.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunbound/1.15.0_i686/musl_libunbound-1.15.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libunbound/1.15.0_x86_64/musl_libunbound-1.15.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '6a4fff3a80696455b624ae2ba0e1304148142390bfbf363e571d3deb927f67f3',
-     armv7l: '6a4fff3a80696455b624ae2ba0e1304148142390bfbf363e571d3deb927f67f3',
-       i686: 'f72c7bdb7092fc431f5b99c37b2350975410b268c8c92ef768503bca8c285692',
-     x86_64: 'f25952a3c365543c2404da2b0b14138d8dfa7caac01e1cadf6444fcaa37b5e4f'
+    aarch64: '004be055e9469e11e3eb71de62e6c87ffbbfaca1456be4767557d77eab60509d',
+     armv7l: '004be055e9469e11e3eb71de62e6c87ffbbfaca1456be4767557d77eab60509d',
+       i686: '15257766348413069da6a5828767baaa60616ec16bf476cb2188e4ca9af698aa',
+     x86_64: '1f98e9d769f46e7d707cbafa37c731bde2c37af3d8340d660948517d40998014'
   })
 
   depends_on 'musl_openssl' => :build
   depends_on 'musl_expat' => :build
   depends_on 'musl_native_toolchain' => :build
 
+  is_musl
   is_static
 
   def self.patch
-    load "#{CREW_LIB_PATH}lib/musl.rb"
     system 'filefix'
   end
 
   def self.build
-    system './configure --help'
     system "#{MUSL_ENV_OPTIONS} ./configure \
       --prefix=#{CREW_MUSL_PREFIX} \
       --disable-shared \


### PR DESCRIPTION
- Security update for git
- Update libunbound since it is a git dep.


Works properly:
- [x] `x86_64` (tested on `nocturne`)
- [x] `i686` (tested on `alex`)
- [x] `armv7l` (tested in container)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=git_2.35.2 CREW_TESTING=1 crew update
```