### PR TITLE
Fix preinstall library path error for docbook_xml412

### DIFF
--- a/packages/docbook_xml412.rb
+++ b/packages/docbook_xml412.rb
@@ -38,17 +38,17 @@ class Docbook_xml412 < Package
     FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
-      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
-      system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
+      system "LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog || true"
     end
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
-      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
       system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
     end


### PR DESCRIPTION
- Fix this issue on chromebrew installs:
```
#12 48.11 ^[[1;34mdocbook_xml412^[[0m^[[1;34m: A widely used XML scheme for writing documentation and help^[[0m
#12 48.11 Precompiled binary available, downloading...
#12 48.11 ^[[1;32mArchive found in cache^[[0m
#12 48.11 Unpacking archive using 'tar', this may take a while...
#12 48.12 Performing pre-install...
#12 48.12 Creating /usr/local/etc/xml/catalog
#12 48.12 xmlcatalog: /usr/lib/libgcc_s.so.1: version `GCC_7.0.0' not found (required by /usr/local/lib/libicui18n.so.69)
```
- hide puts behind verbose flag

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=docbook_xml_fix CREW_TESTING=1 crew update
```