### PR TITLE
zsh -> 5.8.1

### DIFF
--- a/packages/zsh.rb
+++ b/packages/zsh.rb
@@ -3,24 +3,29 @@ require 'package'
 class Zsh < Package
   description 'Zsh is a shell designed for interactive use, although it is also a powerful scripting language.'
   homepage 'http://zsh.sourceforge.net/'
-  version '5.8'
+  version '5.8.1'
   license 'ZSH and GPL-2'
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/project/zsh/zsh/5.8/zsh-5.8.tar.xz'
-  source_sha256 'dcc4b54cc5565670a65581760261c163d720991f0d06486da61f8d839b52de27'
+  source_url 'https://downloads.sourceforge.net/project/zsh/zsh/5.8.1/zsh-5.8.1.tar.xz'
+  source_sha256 'b6973520bace600b4779200269b1e5d79e5f505ac4952058c11ad5bbf0dd9919'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8_armv7l/zsh-5.8-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8_armv7l/zsh-5.8-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8_i686/zsh-5.8-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8_x86_64/zsh-5.8-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1_armv7l/zsh-5.8.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1_armv7l/zsh-5.8.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1_i686/zsh-5.8.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1_x86_64/zsh-5.8.1-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '8f06f08ffefdbe17a1026eab0140c74a103c3dc4b710fad9f9a158a215ba3376',
-     armv7l: '8f06f08ffefdbe17a1026eab0140c74a103c3dc4b710fad9f9a158a215ba3376',
-       i686: '7a1748369c926f9296b3cd9f2bfd4866c6ccdacd179882adce875f3b8ac54709',
-     x86_64: '1d2aca16006b4e79c2c5d438eee0503f21933c61c7c1daeccd4995750b171ab4',
+  binary_sha256({
+    aarch64: '66be508e6f844d36f2d173965b253231204f206d95785fe74a1c8e4280217126',
+     armv7l: '66be508e6f844d36f2d173965b253231204f206d95785fe74a1c8e4280217126',
+       i686: '579921c5ea4c7c66254f63b061463dcd2bcc32bc77a6ff5278c6a54f0d4e0777',
+     x86_64: 'c8c3e4cb8ec2a85684a134de076ed5dd8bf4dc36a067d03d68aba0073eacfe36'
   })
+
+  depends_on 'gdbm' # R
+  depends_on 'glibc' # R
+  depends_on 'ncurses' # R
+  depends_on 'gcc' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS}"


### PR DESCRIPTION
Fixes #6971 #6972

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

![image](https://user-images.githubusercontent.com/1096701/163515634-0f957e0d-1765-4493-ae84-cff45cef1afe.png)


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=zsh CREW_TESTING=1 crew update
```