### PR TITLE
crew: Fix patchelf use for glibc packages, use patchelf for zsh to fix breakage with sudo

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1051,10 +1051,7 @@ def prepare_package(destdir)
     strip_dir destdir
 
     # Use patchelf to set need paths for all binaries.
-    # Currently broken with glibc on armv7l, but musl is fine.
-    unless %w[aarch64 armv7l].include?(ARCH) and !@pkg.is_musl?
-      patchelf_set_need_paths destdir
-    end
+    patchelf_set_need_paths destdir
 
     # use upx on executables
     shrink_dir destdir
@@ -1083,6 +1080,10 @@ def patchelf_set_need_paths(dir)
 
       @neededlibs.each_line(chomp: true) do |neededlibspatch|
         next if neededlibspatch.include?(@patchelf_lib_prefix.to_s)
+        # Avoid segfaults from not using system libdl.so
+        next if !@pkg.is_musl? && neededlibspatch.include?('libdl.so')
+        # Avoid breakage on armv7l
+        next if !@pkg.is_musl? && neededlibspatch.include?('ld-linux-armhf.so.3')
 
         @neededlib_basename = File.basename(neededlibspatch)
         @neededlibspatchednamepath = "#{@patchelf_lib_prefix}/" + @neededlib_basename

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.11'
+CREW_VERSION = '1.23.12'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/packages/zsh.rb
+++ b/packages/zsh.rb
@@ -3,29 +3,30 @@ require 'package'
 class Zsh < Package
   description 'Zsh is a shell designed for interactive use, although it is also a powerful scripting language.'
   homepage 'http://zsh.sourceforge.net/'
-  version '5.8.1'
+  version '5.8.1-1'
   license 'ZSH and GPL-2'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/zsh/zsh/5.8.1/zsh-5.8.1.tar.xz'
   source_sha256 'b6973520bace600b4779200269b1e5d79e5f505ac4952058c11ad5bbf0dd9919'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1_armv7l/zsh-5.8.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1_armv7l/zsh-5.8.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1_i686/zsh-5.8.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1_x86_64/zsh-5.8.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1-1_armv7l/zsh-5.8.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1-1_armv7l/zsh-5.8.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1-1_i686/zsh-5.8.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zsh/5.8.1-1_x86_64/zsh-5.8.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '66be508e6f844d36f2d173965b253231204f206d95785fe74a1c8e4280217126',
-     armv7l: '66be508e6f844d36f2d173965b253231204f206d95785fe74a1c8e4280217126',
-       i686: '579921c5ea4c7c66254f63b061463dcd2bcc32bc77a6ff5278c6a54f0d4e0777',
-     x86_64: 'c8c3e4cb8ec2a85684a134de076ed5dd8bf4dc36a067d03d68aba0073eacfe36'
+    aarch64: 'e2823b5b07a21ead7390305256fd04328f07d9f536bbf3bc0d77da54f9ace214',
+     armv7l: 'e2823b5b07a21ead7390305256fd04328f07d9f536bbf3bc0d77da54f9ace214',
+       i686: 'af70de10fa62dd86541934214a2addcbd20ae1a776b466bc90ad8f4e5b19cfbc',
+     x86_64: '1cf958108388929dc8743c85b095e17e4794407037ab058d579648593fdb425b'
   })
 
   depends_on 'gdbm' # R
   depends_on 'glibc' # R
   depends_on 'ncurses' # R
   depends_on 'gcc' # R
+  patchelf
 
   def self.build
     system "./configure #{CREW_OPTIONS}"


### PR DESCRIPTION
Fixes #6975


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=patchelf_crew CREW_TESTING=1 crew update
```
