### PR TITLE
Patchelf -> 0.14.5, Update patchelf fxn in crew, rebuild util-linux

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1080,10 +1080,16 @@ def patchelf_set_need_paths(dir)
 
       @neededlibs.each_line(chomp: true) do |neededlibspatch|
         next if neededlibspatch.include?(@patchelf_lib_prefix.to_s)
-        # Avoid segfaults from not using system libdl.so
-        next if !@pkg.is_musl? && neededlibspatch.include?('libdl.so')
-        # Avoid breakage on armv7l
-        next if !@pkg.is_musl? && neededlibspatch.include?('ld-linux-armhf.so.3')
+
+        # Avoid segfaults from not using system versions of these files.
+        patchelf_veto_files = %w[
+        libdl.so
+        ld-linux.so.2
+        ld-linux-x86-64.so.2
+        ld-linux-armhf.so.3
+        libc.so.6
+        ]
+        next if !@pkg.is_musl? && patchelf_veto_files.any? { |i| neededlibspatch.include? i }
 
         @neededlib_basename = File.basename(neededlibspatch)
         @neededlibspatchednamepath = "#{@patchelf_lib_prefix}/" + @neededlib_basename

--- a/bin/crew
+++ b/bin/crew
@@ -1431,9 +1431,10 @@ def install
   end
   # Only copy over original if the write to the tmp file succeeds.
   FileUtils.cp "#{CREW_CONFIG_PATH}device.json.tmp","#{CREW_CONFIG_PATH}device.json"
+  # This may no longer be needed.
   # Update shared library cache after install is complete.
-  system "echo #{CREW_LIB_PREFIX} > #{CREW_PREFIX}/etc/ld.so.conf"
-  system "#{CREW_PREFIX}/sbin/ldconfig -f #{CREW_PREFIX}/etc/ld.so.conf -C #{CREW_PREFIX}/etc/ld.so.cache"
+  #system "echo #{CREW_LIB_PREFIX} > #{CREW_PREFIX}/etc/ld.so.conf"
+  #system "#{CREW_PREFIX}/sbin/ldconfig -f #{CREW_PREFIX}/etc/ld.so.conf -C #{CREW_PREFIX}/etc/ld.so.cache"
 end
 
 def resolve_dependencies_and_build

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.12'
+CREW_VERSION = '1.23.13'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/packages/patchelf.rb
+++ b/packages/patchelf.rb
@@ -7,11 +7,26 @@ class Patchelf < Package
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://github.com/NixOS/patchelf.git'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.14.5_armv7l/patchelf-0.14.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.14.5_armv7l/patchelf-0.14.5-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.14.5_i686/patchelf-0.14.5-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.14.5_x86_64/patchelf-0.14.5-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '81227e2a9b1de212fb041bc7dffd6282f844182e4c39ea6fb6e50084561929f0',
+     armv7l: '81227e2a9b1de212fb041bc7dffd6282f844182e4c39ea6fb6e50084561929f0',
+       i686: 'db817f6eff4c97d07b1849c634dc82087ad584e486d154fd2a0bc02072ec923f',
+     x86_64: '9bc6661f27094ce4033eadc302c042d923b9c0a544f959d1359cfc767971a9b6'
+  })
+
   git_hashtag version
+  no_env_options
 
   def self.build
     system './bootstrap.sh'
-    system "LDFLAGS='-flto=auto -static' ./configure #{CREW_OPTIONS}"
+    system "CFLAGS='-fuse-ld=gold' LDFLAGS='-flto=auto -static' ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/patchelf.rb
+++ b/packages/patchelf.rb
@@ -3,24 +3,11 @@ require 'package'
 class Patchelf < Package
   description 'PatchELF is a small utility to modify the dynamic linker and RPATH of ELF executables.'
   homepage 'http://nixos.org/patchelf.html'
-  version '0.14.3'
+  version '0.14.5'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://github.com/NixOS/patchelf.git'
   git_hashtag version
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.14.3_armv7l/patchelf-0.14.3-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.14.3_armv7l/patchelf-0.14.3-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.14.3_i686/patchelf-0.14.3-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/patchelf/0.14.3_x86_64/patchelf-0.14.3-chromeos-x86_64.tpxz'
-  })
-  binary_sha256({
-    aarch64: '76cf82fea05e417739a96bd96b0468be749d4dc2ed7edcfff73ee48fd2ed1130',
-     armv7l: '76cf82fea05e417739a96bd96b0468be749d4dc2ed7edcfff73ee48fd2ed1130',
-       i686: '41389fd3670f713ee2b085560071155ff99c453fc80c222fc26354ab6a840c04',
-     x86_64: '0f15080a932a654e0861f45145e9e76927f07db9cf3a032ad837426d95bb6a68'
-  })
 
   def self.build
     system './bootstrap.sh'

--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -3,27 +3,28 @@ require 'package'
 class Util_linux < Package
   description 'essential linux tools'
   homepage 'https://www.kernel.org/pub/linux/utils/util-linux/'
-  version '2.38'
+  version '2.38-1'
   license 'GPL-2, LGPL-2.1, BSD-4, MIT and public-domain'
   compatibility 'all'
   source_url 'https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-2.38.tar.xz'
   source_sha256 '6d111cbe4d55b336db2f1fbeffbc65b89908704c01136371d32aa9bec373eb64'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38_armv7l/util_linux-2.38-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38_armv7l/util_linux-2.38-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38_i686/util_linux-2.38-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38_x86_64/util_linux-2.38-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38-1_armv7l/util_linux-2.38-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38-1_armv7l/util_linux-2.38-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38-1_i686/util_linux-2.38-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38-1_x86_64/util_linux-2.38-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'bbf94a51e1728672294d33616f81d7047e0e1a95362e7a5b28ddb21e6fa573ad',
-     armv7l: 'bbf94a51e1728672294d33616f81d7047e0e1a95362e7a5b28ddb21e6fa573ad',
-       i686: '1ae9135cd1ab58f0850c8014fee85aab190cd5f2c5b836f845b1187dcda798f6',
-     x86_64: 'c73f881386e26993cac41782c241ed7ef24245bd83117868597aaf23d16c5a77'
+    aarch64: 'b8492be34581baf8ffec9de99bfcc00a95d3bc6f351ccefe77efe9b7556fe8cf',
+     armv7l: 'b8492be34581baf8ffec9de99bfcc00a95d3bc6f351ccefe77efe9b7556fe8cf',
+       i686: '711b11686f6f9a907bc495d8f453bf7e733ee07cb7db874e2fe7c80ed566a66b',
+     x86_64: 'c1f896ebee89f3155b8f4d4422b4bd9d9c16be77cac8587e86b3e3ab14f7fe8a'
   })
 
   depends_on 'libcap_ng'
   depends_on 'linux_pam'
+  depends_on 'ncurses'
   depends_on 'pcre2'
   depends_on 'libeconf'
   depends_on 'eudev' if ARCH == 'x86_64' # (for libudev.h)


### PR DESCRIPTION
Fixes #6988 

- Update patch elf -> 0.14.5
- Adjust patchelf function in crew to avoid hard coding paths to glibc files.
- rebuild util-linux with newer patchelf function to avoid segfaults.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=patchelf CREW_TESTING=1 crew update
```
