### PR TITLE
downloader: Fallback to `curl` if an error is raised by `securerandom`

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -1,11 +1,23 @@
 require 'io/console'
 require 'digest/sha2'
-require 'net/http'
-require 'uri'
-require 'resolv-replace'
 require_relative 'const'
 require_relative 'color'
 require_relative 'convert_size'
+
+begin
+  require 'securerandom'
+  require 'net/http'
+  require 'uri'
+  require 'resolv-replace'
+rescue RuntimeError => e
+  # hide the error message and fallback to curl if securerandom raise an error
+  if e.message == 'failed to get urandom'
+    Object.send(:remove_const, :CREW_USE_CURL)
+    CREW_USE_CURL = true
+  else
+    abort e.full_message
+  end
+end
 
 def setTermSize
   # setTermSize: set progress bar size based on terminal width

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -6,9 +6,6 @@ require_relative 'convert_size'
 
 begin
   require 'securerandom'
-  require 'net/http'
-  require 'uri'
-  require 'resolv-replace'
 rescue RuntimeError => e
   # hide the error message and fallback to curl if securerandom raise an error
   if e.message == 'failed to get urandom'
@@ -18,6 +15,10 @@ rescue RuntimeError => e
     abort e.full_message
   end
 end
+
+require 'net/http'
+require 'uri'
+require 'resolv-replace'
 
 def setTermSize
   # setTermSize: set progress bar size based on terminal width


### PR DESCRIPTION
Fix #6996 #6854 