### PR TITLE
Gparted -> 1.40 and X deps updates

### DIFF
--- a/packages/gparted.rb
+++ b/packages/gparted.rb
@@ -3,24 +3,24 @@ require 'package'
 class Gparted < Package
   description 'A Partition Magic clone, frontend to GNU Parted'
   homepage 'https://gparted.org/'
-  @_ver = '1.3.1'
+  @_ver = '1.4.0'
   version @_ver
   license 'GPL-2+ and FDL-1.2+'
   compatibility 'all'
   source_url "https://downloads.sourceforge.net/project/gparted/gparted/gparted-#{@_ver}/gparted-#{@_ver}.tar.gz"
-  source_sha256 '5eee2e6d74b15ef96b13b3a2310c868ed2298e03341021e7d12a5a98a1d1e109'
+  source_sha256 'e5293a792e53fdbeba29c4a834113cd9603d0d639330da931a468bf3687887be'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gparted/1.3.1_armv7l/gparted-1.3.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gparted/1.3.1_armv7l/gparted-1.3.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gparted/1.3.1_i686/gparted-1.3.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gparted/1.3.1_x86_64/gparted-1.3.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gparted/1.4.0_armv7l/gparted-1.4.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gparted/1.4.0_armv7l/gparted-1.4.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gparted/1.4.0_i686/gparted-1.4.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gparted/1.4.0_x86_64/gparted-1.4.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '9036f953c9fa9d23d4a1214c853a3c16ca995f4b5b31b8850cf4c83ff346ce35',
-     armv7l: '9036f953c9fa9d23d4a1214c853a3c16ca995f4b5b31b8850cf4c83ff346ce35',
-       i686: '570508eb7d9f970540a0160cd616ee49ed5554c24e378d1b3f89ba8616a4ee04',
-     x86_64: 'ed4c39343af25733424d215b8eeb51674371afb34d627829ae627e89d35b4a34'
+    aarch64: '789aedda96b2cd62cc48460b638af8f94b3cb2773ca6bc0a7d009ad109d94f4f',
+     armv7l: '789aedda96b2cd62cc48460b638af8f94b3cb2773ca6bc0a7d009ad109d94f4f',
+       i686: '59716f3f302de5e7134c51a97329083a0f325c59f5e796a94f79825e2e0601de',
+     x86_64: '4d74f091eb9ce93c896f18784bbe715c0f300f2a15d04c9e7fb659651932a216'
   })
 
   depends_on 'parted'
@@ -37,6 +37,7 @@ class Gparted < Package
   depends_on 'librsvg'
   depends_on 'xhost'
   depends_on 'sommelier'
+  patchelf
 
   def self.build
     system "./configure #{CREW_OPTIONS} \

--- a/packages/libice.rb
+++ b/packages/libice.rb
@@ -3,35 +3,36 @@ require 'package'
 class Libice < Package
   description 'X.org X Inter Client Exchange Library'
   homepage 'http://www.x.org'
-  version '1.0.9-0'
+  version '1.0.10'
   license 'X11'
   compatibility 'all'
-  source_url 'https://www.x.org/archive/individual/lib/libICE-1.0.9.tar.gz'
-  source_sha256 '7812a824a66dd654c830d21982749b3b563d9c2dfe0b88b203cefc14a891edc0'
+  source_url 'https://www.x.org/archive/individual/lib/libICE-1.0.10.tar.gz'
+  source_sha256 '1116bc64c772fd127a0d0c0ffa2833479905e3d3d8197740b3abd5f292f22d2d'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libice/1.0.9-0_armv7l/libice-1.0.9-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libice/1.0.9-0_armv7l/libice-1.0.9-0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libice/1.0.9-0_i686/libice-1.0.9-0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libice/1.0.9-0_x86_64/libice-1.0.9-0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libice/1.0.10_armv7l/libice-1.0.10-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libice/1.0.10_armv7l/libice-1.0.10-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libice/1.0.10_i686/libice-1.0.10-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libice/1.0.10_x86_64/libice-1.0.10-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '9950466b86446a797a1331d6778a5d339af17960cad8c2c9a8e5a038c63c5b57',
-     armv7l: '9950466b86446a797a1331d6778a5d339af17960cad8c2c9a8e5a038c63c5b57',
-       i686: 'b5591b7c29b39dc1490481990590ca062f62ca717a0decdd342f8b1ce62a7145',
-     x86_64: 'f12df0a9802c23816595d13ddaa15ca46727b9ace7c7f57ede4cdbcc1ecbd8f8',
+  binary_sha256({
+    aarch64: '47981dc8ab3d21b12cdd36f69ca5c81da33d87c11da279a6cff8f37b146538c8',
+     armv7l: '47981dc8ab3d21b12cdd36f69ca5c81da33d87c11da279a6cff8f37b146538c8',
+       i686: 'acebe9d03d26e8fa5e47079d3f68346fd8af17b0820ad2f6738e9c1b153f9295',
+     x86_64: 'af7d070f98f27176345c0735a53a8fd1434d8843683dc282180091dde7efc030'
   })
 
   depends_on 'libxtrans'
   depends_on 'libx11'
   depends_on 'libbsd'
+  patchelf
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libsm.rb
+++ b/packages/libsm.rb
@@ -3,34 +3,35 @@ require 'package'
 class Libsm < Package
   description 'X.org X Session Management Library'
   homepage 'http://www.x.org'
-  version '1.2.2'
+  version '1.2.3'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.x.org/archive/individual/lib/libSM-1.2.2.tar.gz'
-  source_sha256 '14bb7c669ce2b8ff712fbdbf48120e3742a77edcd5e025d6b3325ed30cf120f4'
+  source_url 'https://www.x.org/archive/individual/lib/libSM-1.2.3.tar.gz'
+  source_sha256 '1e92408417cb6c6c477a8a6104291001a40b3bb56a4a60608fdd9cd2c5a0f320'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsm/1.2.2_armv7l/libsm-1.2.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsm/1.2.2_armv7l/libsm-1.2.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsm/1.2.2_i686/libsm-1.2.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsm/1.2.2_x86_64/libsm-1.2.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsm/1.2.3_armv7l/libsm-1.2.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsm/1.2.3_armv7l/libsm-1.2.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsm/1.2.3_i686/libsm-1.2.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsm/1.2.3_x86_64/libsm-1.2.3-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '37e41534cb72c0816c7836f5e042183bc03062367b09d2da556b355be4cd541f',
-     armv7l: '37e41534cb72c0816c7836f5e042183bc03062367b09d2da556b355be4cd541f',
-       i686: '43c197b6a44e70314c6c6593e719e35b011ac20776ebc9a2114b4af06e6448a0',
-     x86_64: '9516fc81d7106f5f611bfd0f47fc4d44bf3562cddf9c2f83a18a50e3960e9386',
+  binary_sha256({
+    aarch64: '7d6702a3ba19eae8a974a69614c262f50ae7c6f7b1b514bd52591131192bb086',
+     armv7l: '7d6702a3ba19eae8a974a69614c262f50ae7c6f7b1b514bd52591131192bb086',
+       i686: '8ecb14d2b98abcb482d222fabcb04e036525ae02e29556ee0f5ec6632403a7b6',
+     x86_64: 'f994171ce6971904dbba890e78e2a95db68c99c0509730e62cb53f6ef71ce88a'
   })
 
   depends_on 'libice'
   depends_on 'libx11'
+  patchelf
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libx11.rb
+++ b/packages/libx11.rb
@@ -3,30 +3,31 @@ require 'package'
 class Libx11 < Package
   description 'C interface to the X window system'
   homepage 'https://x.org'
-  version '1.7.3.1'
+  version '1.7.5'
   license 'custom'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/xorg/lib/libx11.git'
-  git_hashtag "libX11-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.3.1_armv7l/libx11-1.7.3.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.3.1_armv7l/libx11-1.7.3.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.3.1_i686/libx11-1.7.3.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.3.1_x86_64/libx11-1.7.3.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.5_armv7l/libx11-1.7.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.5_armv7l/libx11-1.7.5-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.5_i686/libx11-1.7.5-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libx11/1.7.5_x86_64/libx11-1.7.5-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '23bdd5b1b635e3cca9d434b7f6d60057e8c16bcd7edfbf612337fc16382f9449',
-     armv7l: '23bdd5b1b635e3cca9d434b7f6d60057e8c16bcd7edfbf612337fc16382f9449',
-       i686: 'd7ac187627f55b2bdf5052d68b03dbe107ac70fe4378ecabb68aab4d42ef3ba2',
-     x86_64: 'c84e961c5e4fd95e684a2c2d2f6a041bdb5a0289f66eb414f99e184f70a3c42d'
+    aarch64: '929405c796f836e64620cb1d751c9651a71387467a84302b352a41a953872c16',
+     armv7l: '929405c796f836e64620cb1d751c9651a71387467a84302b352a41a953872c16',
+       i686: '32fd6f90c8dc7886c23063ba59fa5858ddae011244ec8da1c8361db6c70c501d',
+     x86_64: 'adbf1fda20914f22186dfacbe96d549a46319e58c3c7869530e3ab6b860b96b8'
   })
+  git_hashtag "libX11-#{version}"
 
   depends_on 'llvm' => :build
   depends_on 'xorg_proto'
   depends_on 'libxcb'
   depends_on 'libxdmcp'
   depends_on 'libxtrans'
+  patchelf
 
   def self.build
     system 'NOCONFIGURE=1 ./autogen.sh'

--- a/packages/libxmu.rb
+++ b/packages/libxmu.rb
@@ -3,36 +3,37 @@ require 'package'
 class Libxmu < Package
   description 'X.org X interface library for miscellaneous utilities not part of the Xlib standard'
   homepage 'https://www.x.org'
-  version '1.1.2'
+  version '1.1.3'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.x.org/archive/individual/lib/libXmu-1.1.2.tar.gz'
-  source_sha256 'e5fd4bacef068f9509b8226017205040e38d3fba8d2de55037200e7176c13dba'
+  source_url 'https://www.x.org/archive/individual/lib/libXmu-1.1.3.tar.gz'
+  source_sha256 '5bd9d4ed1ceaac9ea023d86bf1c1632cd3b172dce4a193a72a94e1d9df87a62e'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxmu/1.1.2_armv7l/libxmu-1.1.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxmu/1.1.2_armv7l/libxmu-1.1.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxmu/1.1.2_i686/libxmu-1.1.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxmu/1.1.2_x86_64/libxmu-1.1.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxmu/1.1.3_armv7l/libxmu-1.1.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxmu/1.1.3_armv7l/libxmu-1.1.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxmu/1.1.3_i686/libxmu-1.1.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxmu/1.1.3_x86_64/libxmu-1.1.3-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: 'b0e35fa7604228c0bc7e556a3425e928a90f9f00707126c6007c235b9162c75c',
-     armv7l: 'b0e35fa7604228c0bc7e556a3425e928a90f9f00707126c6007c235b9162c75c',
-       i686: '6780b8d82aa0b43aae9af514546741dcde6758c32ecbafdf0b181aeb74600b47',
-     x86_64: '66b75c1f3488973f36f4520fa283f860bdebdea608716a082776e8364a092d4f',
+  binary_sha256({
+    aarch64: '13b7e9be2a0605f57496e57a4dbf928ed6ea1cfb07e682a7b47348572bda714c',
+     armv7l: '13b7e9be2a0605f57496e57a4dbf928ed6ea1cfb07e682a7b47348572bda714c',
+       i686: 'a28796da18c49538711e5f69ea5fdd0c9a040c15acb66b5e5199ac64d273fdc9',
+     x86_64: 'c69a0f76d5622da115b48cb108c46e3bd2d8c862c6582b77842b022f62defc40'
   })
 
   depends_on 'libxt'
   depends_on 'libxext'
   depends_on 'util_macros'
   depends_on 'libx11'
+  patchelf
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libxt.rb
+++ b/packages/libxt.rb
@@ -3,34 +3,35 @@ require 'package'
 class Libxt < Package
   description 'X.org X Toolkit Library'
   homepage 'https://www.x.org'
-  version '1.1.5-0'
+  version '1.2.1'
   license 'custom'
   compatibility 'all'
-  source_url 'https://www.x.org/archive/individual/lib/libXt-1.1.5.tar.gz'
-  source_sha256 'b59bee38a9935565fa49dc1bfe84cb30173e2e07e1dcdf801430d4b54eb0caa3'
+  source_url 'https://www.x.org/archive/individual/lib/libXt-1.2.1.tar.gz'
+  source_sha256 '6da1bfa9dd0ed87430a5ce95b129485086394df308998ebe34d98e378e3dfb33'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxt/1.1.5-0_armv7l/libxt-1.1.5-0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxt/1.1.5-0_armv7l/libxt-1.1.5-0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxt/1.1.5-0_i686/libxt-1.1.5-0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxt/1.1.5-0_x86_64/libxt-1.1.5-0-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxt/1.2.1_armv7l/libxt-1.2.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxt/1.2.1_armv7l/libxt-1.2.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxt/1.2.1_i686/libxt-1.2.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxt/1.2.1_x86_64/libxt-1.2.1-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '168593f2dd1628c1816c4504beec2fc997932b28b1fc0e2ddb9043d1400f5523',
-     armv7l: '168593f2dd1628c1816c4504beec2fc997932b28b1fc0e2ddb9043d1400f5523',
-       i686: '70220d5f6b186bf700907b8b2a92665608f24944dfab22cc9b077a3dd6b18437',
-     x86_64: 'ccc5cd728842864ab67d48a85420ba8eb05c19d3a1beb9a5e6ac473ed7a5c9e0',
+  binary_sha256({
+    aarch64: 'a7ff82ccb3d878142449b1b61b4523a37c02a6341588165541159175d313dabf',
+     armv7l: 'a7ff82ccb3d878142449b1b61b4523a37c02a6341588165541159175d313dabf',
+       i686: '12408a157c8b17f0d32a2166ed9ae6de560985bce948d8da0ad4ad9be895fbf9',
+     x86_64: 'c59be078d6b5120a57ee6a0ee21caea62e9f6a227855e014a3b661c3400e50f0'
   })
 
   depends_on 'libsm'
   depends_on 'libx11'
+  patchelf
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
-    system "make"
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/parted.rb
+++ b/packages/parted.rb
@@ -3,38 +3,35 @@ require 'package'
 class Parted < Package
   description 'Create, destroy, resize, check, copy partitions and file systems.'
   homepage 'https://www.gnu.org/software/parted'
-  @_ver = '3.4'
+  @_ver = '3.5'
   version @_ver
   license 'GPL-3'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/parted/parted-#{@_ver}.tar.xz"
-  source_sha256 'e1298022472da5589b7f2be1d5ee3c1b66ec3d96dfbad03dc642afd009da5342'
+  source_sha256 '4938dd5c1c125f6c78b1f4b3e297526f18ee74aa43d45c248578b1d2470c05a2'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/parted/3.4_armv7l/parted-3.4-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/parted/3.4_armv7l/parted-3.4-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/parted/3.4_i686/parted-3.4-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/parted/3.4_x86_64/parted-3.4-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/parted/3.5_armv7l/parted-3.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/parted/3.5_armv7l/parted-3.5-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/parted/3.5_x86_64/parted-3.5-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-     aarch64: 'ede8edf189c6a15f7f73c5473230e183e658515392727cf263bcec6f6e7a3145',
-      armv7l: 'ede8edf189c6a15f7f73c5473230e183e658515392727cf263bcec6f6e7a3145',
-        i686: '4df150824d0b15cbbd57e3d053dfdb7ae636165e61082ec294981abf96dacf58',
-      x86_64: 'c5dbafb2ff514b1eec1f9cdb5cffae0659120151ecb6d3552230a2a5054c95dc',
+  binary_sha256({
+    aarch64: 'd5a0356c1b50d3b96d40816186f53b26230db7642cf2a8efc86e3388c35bdf34',
+     armv7l: 'd5a0356c1b50d3b96d40816186f53b26230db7642cf2a8efc86e3388c35bdf34',
+     x86_64: '7ff57d716c7c5c5e7a640c57b584bead70e4e853dc0937c501ba95e4a33cfe8a'
   })
 
   depends_on 'lvm2'
   depends_on 'ncurses'
   depends_on 'readline'
+  patchelf
 
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS}"
-    system "make"
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
-
 end

--- a/packages/xhost.rb
+++ b/packages/xhost.rb
@@ -3,35 +3,38 @@ require 'package'
 class Xhost < Package
   description 'Server access control program for X'
   homepage 'https://github.com/freedesktop/xorg-xhost'
-  version '1.0.7'
+  version '1.0.8'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.x.org/releases/individual/app/xhost-1.0.7.tar.bz2'
-  source_sha256 '93e619ee15471f576cfb30c663e18f5bc70aca577a63d2c2c03f006a7837c29a'
+  source_url 'https://www.x.org/releases/individual/app/xhost-1.0.8.tar.bz2'
+  source_sha256 'a2dc3c579e13674947395ef8ccc1b3763f89012a216c2cc6277096489aadc396'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xhost/1.0.7_armv7l/xhost-1.0.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xhost/1.0.7_armv7l/xhost-1.0.7-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xhost/1.0.7_i686/xhost-1.0.7-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xhost/1.0.7_x86_64/xhost-1.0.7-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xhost/1.0.8_armv7l/xhost-1.0.8-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xhost/1.0.8_armv7l/xhost-1.0.8-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xhost/1.0.8_i686/xhost-1.0.8-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xhost/1.0.8_x86_64/xhost-1.0.8-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '6bc7b1b1ac3da2a29d255dc12116d8fb7558b7a951c39694e793a17de3118f0f',
-     armv7l: '6bc7b1b1ac3da2a29d255dc12116d8fb7558b7a951c39694e793a17de3118f0f',
-       i686: '6b52588ce97148da0b44ca76a7934b9f921834fe3d3bc3165c9085a46fb20d87',
-     x86_64: '81710af7e1d0a9193739e8fd4f87b469be75ceadf364f5628504927a7f715ab2',
+  binary_sha256({
+    aarch64: '314e4cf5b09e6e4517639c6904efd5e7cb1336536524f102c210e9e5c4388b5b',
+     armv7l: '314e4cf5b09e6e4517639c6904efd5e7cb1336536524f102c210e9e5c4388b5b',
+       i686: 'd2fb32097557b95a2c824a1c5cdd3b3fd515ef99c5294350e6c6443ee0190cb0',
+     x86_64: '8e108d51711153c01c45343af91d6b1c7bd493e4da823ebe85209eb5278ee25a'
   })
 
   depends_on 'xorg_lib'
+  depends_on 'libx11' # R
+  depends_on 'libxmu' # R
+
+  patchelf
 
   def self.build
-    system './configure',
-           '--enable-ipv6',
-           '--enable-tcp-transport',
-           '--enable-unix-transport',
-           "--prefix=#{CREW_PREFIX}",
-           '--enable-local-transport',
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system "./configure \
+           --enable-ipv6 \
+           --enable-tcp-transport \
+           --enable-unix-transport \
+           --enable-local-transport \
+           #{CREW_OPTIONS}"
     system 'make'
   end
 


### PR DESCRIPTION
Fixes #6999 

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

Works properly:
- [x] `x86_64`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gparted_1.4.0  CREW_TESTING=1 crew update
```
