### PR TITLE
Fonts package updates (w/o reworking crew) + qemu -> 7.0 (also update qemu deps)

### DIFF
--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -3,23 +3,23 @@ require 'package'
 class Cairo < Package
   description 'Cairo is a 2D graphics library with support for multiple output devices.'
   homepage 'https://www.cairographics.org'
-  version '1.17.5-ec54603'
+  version '1.17.5-521a3a7'
   license 'LGPL-2.1 or MPL-1.1'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/cairo/cairo.git'
-  git_hashtag 'ec54603366a39a5ad12c489aaf0bbb85859fa7a9'
+  git_hashtag '521a3a7bdb9299d511dcb1e4f243670141e53847'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_armv7l/cairo-1.17.5-ec54603-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_armv7l/cairo-1.17.5-ec54603-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_i686/cairo-1.17.5-ec54603-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-ec54603_x86_64/cairo-1.17.5-ec54603-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-521a3a7_armv7l/cairo-1.17.5-521a3a7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-521a3a7_armv7l/cairo-1.17.5-521a3a7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-521a3a7_i686/cairo-1.17.5-521a3a7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cairo/1.17.5-521a3a7_x86_64/cairo-1.17.5-521a3a7-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1afe2c4afb826e35c549f786db7983a961a7cb1ca14d079ee448463949ad4626',
-     armv7l: '1afe2c4afb826e35c549f786db7983a961a7cb1ca14d079ee448463949ad4626',
-       i686: 'cbd2b8faf20bbc08751be0e2e37d38d8df6007b93b46ec82c06a8878c730a06e',
-     x86_64: 'bf0cf34ce1bced53bb91aa0d43c0769c436afea02c78773d2ccdb1ad40c4f105'
+    aarch64: 'b25dd9988c79c6aec537112453482669e16cf3d213d3570cc74c5c36699e7bcc',
+     armv7l: 'b25dd9988c79c6aec537112453482669e16cf3d213d3570cc74c5c36699e7bcc',
+       i686: '22ae49c94736cb58b748a7808b61a3e76c6b759fba2cf0e4af5520a57fe18a62',
+     x86_64: '9d185159bee32c5600571ee922ce105558700c5c1c0c6057e19ea724fd9f3573'
   })
 
   depends_on 'fontconfig'
@@ -32,6 +32,7 @@ class Cairo < Package
   depends_on 'lzo'
   depends_on 'mesa'
   depends_on 'pixman'
+  conflicts_ok # because this overwrites the limited cairo from harfbuzz
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -3,7 +3,7 @@ require 'package'
 class Fontconfig < Package
   description 'Fontconfig is a library for configuring and customizing font access.'
   homepage 'https://www.freedesktop.org/software/fontconfig/front.html'
-  @_ver = '2.13.96'
+  @_ver = '2.14.0'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,20 +11,21 @@ class Fontconfig < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_armv7l/fontconfig-2.13.96-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_armv7l/fontconfig-2.13.96-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_i686/fontconfig-2.13.96-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.13.96_x86_64/fontconfig-2.13.96-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_armv7l/fontconfig-2.14.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_armv7l/fontconfig-2.14.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_i686/fontconfig-2.14.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fontconfig/2.14.0_x86_64/fontconfig-2.14.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ee7900160a576c6402191b39c4a1764691d1eb97f18c19e0117bf2fd9fc0435c',
-     armv7l: 'ee7900160a576c6402191b39c4a1764691d1eb97f18c19e0117bf2fd9fc0435c',
-       i686: '5dc551362bc72fdcbd7734812e62d5035a97fee9b733b6690cae2286e6d4d69d',
-     x86_64: '0c0f777ba5352f92851c70a010b25824fa269dab2b389b95f823e03d890f4b15'
+    aarch64: '73da87e4645d2fb31682be0d4d58ba7dfab33bf5e7eebb3725b64dac9bbe0482',
+     armv7l: '73da87e4645d2fb31682be0d4d58ba7dfab33bf5e7eebb3725b64dac9bbe0482',
+       i686: '47f744211b28c0a5f44ec9f02a629310dc8952607d7481fb2c7a96374b16e4ad',
+     x86_64: 'bb28212f219e29c3bfd670189813e46f8d46ba79cd88259004dd4b6ad5f1f411'
   })
 
+
+
   depends_on 'gperf'
-  depends_on 'harfbuzz' => :build
   depends_on 'jsonc'
   depends_on 'util_linux'
   depends_on 'graphite'
@@ -44,7 +45,7 @@ class Fontconfig < Package
     --localstatedir=#{CREW_PREFIX}/cache \
     --default-library=both \
     -Ddoc=disabled \
-    -Dfreetype2:harfbuzz=enabled \
+    -Dfreetype2:harfbuzz=disabled \
     -Dfreetype2:default_library=both \
     builddir"
     system 'meson configure builddir'
@@ -78,9 +79,15 @@ class Fontconfig < Package
     File.write("#{CREW_DEST_PREFIX}/etc/env.d/fontconfig", @env)
   end
 
+  def self.preinstall
+    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+    if @device[:installed_packages].any? { |elem| elem[:name] == 'freetype' }
+      system "sed -i '/freetype2/d;/libfreetype/d' filelist"
+      system "sed -i '/freetype2/d;/libfreetype/d' dlist"
+    end
+  end
+
   def self.postinstall
-    # The following postinstall fails if graphite isn't installed when fontconfig
-    # is being installed.
-    system "env FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts fc-cache -fv || true"
+    system "FONTCONFIG_PATH=#{CREW_PREFIX}/etc/fonts fc-cache -fv || true"
   end
 end

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -3,23 +3,23 @@ require 'package'
 class Freetype < Package
   description 'FreeType is a freely available software library to render fonts.'
   homepage 'https://www.freetype.org/'
-  version '2.11.1' # Update freetype in harfbuzz when updating freetype
+  version '2.12.0' # Update freetype in harfbuzz when updating freetype
   license 'FTL or GPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/freetype/freetype.git'
   git_hashtag "VER-#{version.tr('.', '-')}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_armv7l/freetype-2.11.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_armv7l/freetype-2.11.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_i686/freetype-2.11.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.11.1_x86_64/freetype-2.11.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_armv7l/freetype-2.12.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_armv7l/freetype-2.12.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_i686/freetype-2.12.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freetype/2.12.0_x86_64/freetype-2.12.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5fb990e84010805de92eda4efac6b0cf183c8dee02eda7b2d1ed183028d0e857',
-     armv7l: '5fb990e84010805de92eda4efac6b0cf183c8dee02eda7b2d1ed183028d0e857',
-       i686: '2961cc77104f9a1eccd75905e957644ef1b21ef93fab368cbd1ed31c022dc43c',
-     x86_64: '3c2492c222856b9a45bc8eaec55398f59e49062f8b3c9e45edc8b129d38c641b'
+    aarch64: '7ff2e02d08ead4e7b5fb1a16d4e8f5551a4420a51a8b0dae8f12d33d308d469a',
+     armv7l: '7ff2e02d08ead4e7b5fb1a16d4e8f5551a4420a51a8b0dae8f12d33d308d469a',
+       i686: 'b2c34d291f9324105f712434274c4d360c3e98b8b567162d44b54ff74b22b3ba',
+     x86_64: 'a49bad49bfc204855936a8124229f1e8b21cb11e719981dd925c76edfecea0de'
   })
 
   depends_on 'brotli'
@@ -29,6 +29,7 @@ class Freetype < Package
   depends_on 'glib'
   depends_on 'graphite'
   depends_on 'harfbuzz'
+  depends_on 'librsvg'
   depends_on 'pcre'
   depends_on 'zlibpkg'
   # to avoid resetting mold usage
@@ -38,15 +39,8 @@ class Freetype < Package
   conflicts_ok
 
   def self.build
-    case ARCH
-    when 'aarch64', 'armv7l'
-      @meson_options = CREW_MESON_OPTIONS
-    when 'i686', 'x86_64'
-      @meson_options = CREW_MESON_OPTIONS.gsub('-Dc_args=\'-O2', '-Dc_args=\'-O2 -fuse-ld=mold').gsub('-Dcpp_args=\'-O2',
-                                                                                                      '-Dcpp_args=\'-O2 -fuse-ld=mold')
-    end
     system 'pip3 install docwriter'
-    system "meson #{@meson_options} \
+    system "meson #{CREW_MESON_OPTIONS} \
       -Dharfbuzz=enabled \
       builddir"
     system 'meson configure builddir'
@@ -62,5 +56,29 @@ class Freetype < Package
   def self.postinstall
     # make sure to delete downloaded files
     system "find #{CREW_BREW_DIR}/* -name freetype*.tar -exec rm -rf {} \+"
+    # This should become a function.
+    # check for conflicts with other installed files
+    @override_allowed = %w[fontconfig harfbuzz]
+    puts "Checking for conflicts with files from installed packages..."
+    conflicts = []
+    conflictscmd = %x[grep --exclude #{CREW_META_PATH}#{self.name}.filelist -Fxf #{CREW_META_PATH}#{self.name}.filelist #{CREW_META_PATH}*.filelist]
+    conflicts << conflictscmd.gsub(/(\.filelist|#{CREW_META_PATH})/, '').split("\n")
+    conflicts.reject!(&:empty?)
+    unless conflicts.empty?
+      if self.conflicts_ok?
+        puts "Handling conflict with the same file in another package.".orange
+      else
+        puts "Error: There is a conflict with the same file in another package.".lightred
+        @_errors = 1
+      end
+      conflicts.each do |conflict|
+        conflict.each do |thisconflict|
+          singleconflict = thisconflict.split(':',-1)
+          if @override_allowed.include?(singleconflict[0])
+            system "sed -i '\\\?^#{singleconflict[1]}?d'  #{CREW_META_PATH}/#{singleconflict[0]}.filelist"
+          end
+        end
+      end
+    end
   end
 end

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.71.3'
+  @_ver = '2.72.0'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
@@ -12,16 +12,16 @@ class Glib < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_armv7l/glib-2.71.3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_armv7l/glib-2.71.3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_i686/glib-2.71.3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.71.3_x86_64/glib-2.71.3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_armv7l/glib-2.72.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_armv7l/glib-2.72.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_i686/glib-2.72.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_x86_64/glib-2.72.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'f790de63e82f702d061f2de152025f3f76294165c11b1412b914ef197876eed8',
-     armv7l: 'f790de63e82f702d061f2de152025f3f76294165c11b1412b914ef197876eed8',
-       i686: '9113fd3b36bbeba475fe1d02c30e3e5da480c1c0de9808a3ad3f0d4f4c2fe890',
-     x86_64: 'd2fc753604c45fc397ebceadefca2b9db3aea42384c70237688df6d33e5b60d8'
+    aarch64: '916c00b3ac163e3a526a2329eea9d0ef3008f72980208087741d9efc80418b00',
+     armv7l: '916c00b3ac163e3a526a2329eea9d0ef3008f72980208087741d9efc80418b00',
+       i686: 'ad226ebbe63163ec517a3340e7b7d658c8bdf5cf751533b189b784eea833a5fb',
+     x86_64: 'b8ba6860034f65920bab6a302f237196058e394ea696835cb97f8a9e2af340f8'
   })
 
   depends_on 'elfutils' # R
@@ -33,6 +33,7 @@ class Glib < Package
   depends_on 'util_linux' # R
   depends_on 'zlibpkg' # R
   no_env_options
+  gnome
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
@@ -46,9 +47,5 @@ class Glib < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
   end
 end

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.72.0'
+  @_ver = '2.72.1'
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   version @_ver
   license 'LGPL-2.1'
@@ -12,16 +12,16 @@ class Glib < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_armv7l/glib-2.72.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_armv7l/glib-2.72.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_i686/glib-2.72.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.0_x86_64/glib-2.72.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.1_armv7l/glib-2.72.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.1_armv7l/glib-2.72.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.1_i686/glib-2.72.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.72.1_x86_64/glib-2.72.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '916c00b3ac163e3a526a2329eea9d0ef3008f72980208087741d9efc80418b00',
-     armv7l: '916c00b3ac163e3a526a2329eea9d0ef3008f72980208087741d9efc80418b00',
-       i686: 'ad226ebbe63163ec517a3340e7b7d658c8bdf5cf751533b189b784eea833a5fb',
-     x86_64: 'b8ba6860034f65920bab6a302f237196058e394ea696835cb97f8a9e2af340f8'
+    aarch64: '2c56eed09d770f2dcf68f47bdd26923ae00306cb3b8c0cbed41f0f819d582d35',
+     armv7l: '2c56eed09d770f2dcf68f47bdd26923ae00306cb3b8c0cbed41f0f819d582d35',
+       i686: '8b73a5befbfc7b7c2e2e88a18f684ae9c5005182aff3f19ec05e1cc491a7f65e',
+     x86_64: 'e26b9b49b5bfcbfc0188fd32c69d02ed9345633011b3ed56fa803d55ea5a65b1'
   })
 
   depends_on 'elfutils' # R
@@ -33,6 +33,7 @@ class Glib < Package
   depends_on 'util_linux' # R
   depends_on 'zlibpkg' # R
   no_env_options
+  patchelf
   gnome
 
   def self.build

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -3,45 +3,48 @@ require 'package'
 class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
-  @_ver = '4.0.0'
-  version "#{@_ver}-1"
+  @_ver = '4.2.0'
+  version @_ver
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
-  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_armv7l/harfbuzz-4.0.0-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_i686/harfbuzz-4.0.0-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.0.0-1_x86_64/harfbuzz-4.0.0-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_armv7l/harfbuzz-4.2.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_armv7l/harfbuzz-4.2.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_i686/harfbuzz-4.2.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/4.2.0_x86_64/harfbuzz-4.2.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
-     armv7l: '45c23425ee8a671df2f26dd8db51962b5a9de734042ae54431a6504339ffc049',
-       i686: 'fe23c57f63f0fd9d03cd8679076d0aa6aeb0db9880efd1099814385fe53c878f',
-     x86_64: 'c9ad1d2c137cfa65efcfbc855fc6b2a616130653d18ff730b53ece6676513a44'
+    aarch64: '0e2f9f45e620ec75db77481292a90273ad79b5afeca3c07afb24568917cef9c9',
+     armv7l: '0e2f9f45e620ec75db77481292a90273ad79b5afeca3c07afb24568917cef9c9',
+       i686: '14c173bb67126e2b0a862dd61b1071a7e3520d3235b923c9c95dd33a0564ac2d',
+     x86_64: 'ae8e1ceb094880512c493f8a8559ec1162393a06756b8363517d39343086c684'
   })
+  git_hashtag @_ver
 
-  # provides libpng, freetype (sans harfbuzz), and ragel
-  # depends_on 'cairo' => :build (cairo is only needed for tests and tools)
+  # provides libpng, freetype (sans harfbuzz), ragel, and a non-x11 cairo stub
   depends_on 'brotli'
   depends_on 'bz2'
   depends_on 'chafa'
   depends_on 'gcc11'
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build
+  depends_on 'fontconfig'
   depends_on 'graphite'
   depends_on 'icu4c'
   depends_on 'libffi'
+  depends_on 'pixman' # Needed for cairo subproject
   depends_on 'pcre'
   depends_on 'py3_six' => :build
   depends_on 'zlibpkg'
   no_env_options
+  conflicts_ok
 
   def self.patch
     # Update to new versions of freetype as they come out.
-    system "sed -i 's,revision=VER-2-11-0,revision=VER-2-11-1,g' subprojects/freetype2.wrap"
+    system "sed -i 's,revision=VER-2-11-0,revision=VER-2-12-0,g' subprojects/freetype2.wrap"
+    system "sed -i 's,revision=c90faeb7492b1b778d18a796afe5c2e4b32a6356,revision=521a3a7bdb9299d511dcb1e4f243670141e53847,g' subprojects/cairo.wrap"
   end
 
   def self.build
@@ -49,7 +52,7 @@ class Harfbuzz < Package
       --wrap-mode=default \
       --default-library=both \
       -Dbenchmark=disabled \
-      -Dcairo=disabled \
+      -Dcairo=enabled \
       -Ddocs=disabled \
       -Dfreetype=enabled \
       -Dgraphite2=enabled \
@@ -63,5 +66,40 @@ class Harfbuzz < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja install -C builddir"
+  end
+
+  def self.preinstall
+    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+    if @device[:installed_packages].any? { |elem| elem[:name] == 'freetype' }
+      system "sed -i '/freetype2/d;/libfreetype/d' filelist"
+      system "sed -i '/freetype2/d;/libfreetype/d' dlist"
+    end
+  end
+
+  def self.postinstall
+    # This should become a function.
+    # check for conflicts with other installed files
+    @override_allowed = %w[fontconfig cairo]
+    puts "Checking for conflicts with files from installed packages..."
+    conflicts = []
+    conflictscmd = %x[grep --exclude #{CREW_META_PATH}#{self.name}.filelist -Fxf #{CREW_META_PATH}#{self.name}.filelist #{CREW_META_PATH}*.filelist]
+    conflicts << conflictscmd.gsub(/(\.filelist|#{CREW_META_PATH})/, '').split("\n")
+    conflicts.reject!(&:empty?)
+    unless conflicts.empty?
+      if self.conflicts_ok?
+        puts "Warning: There is a conflict with the same file in another package.".orange
+      else
+        puts "Error: There is a conflict with the same file in another package.".lightred
+        @_errors = 1
+      end
+      conflicts.each do |conflict|
+        conflict.each do |thisconflict|
+          singleconflict = thisconflict.split(':',-1)
+          if @override_allowed.include?(singleconflict[0])
+            system "sed -i '\\\?^#{singleconflict[1]}?d'  #{CREW_META_PATH}/#{singleconflict[0]}.filelist"
+          end
+        end
+      end
+    end
   end
 end

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -3,29 +3,27 @@ require 'package'
 class Librsvg < Package
   description 'SVG library for GNOME'
   homepage 'https://wiki.gnome.org/Projects/LibRsvg'
-  version '2.50.3-1'
+  version '2.52.8'
   license 'LGPL-2+'
   compatibility 'all'
-  source_url 'https://download.gnome.org/sources/librsvg/2.50/librsvg-2.50.3.tar.xz'
-  source_sha256 'a4298a98e3a95fdd73c858c17d4dd018525fb09dbb13bbd668a0c2243989e958'
+  source_url 'https://gitlab.gnome.org/GNOME/librsvg.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_armv7l/librsvg-2.50.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_armv7l/librsvg-2.50.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_i686/librsvg-2.50.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.50.3-1_x86_64/librsvg-2.50.3-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_armv7l/librsvg-2.52.8-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_armv7l/librsvg-2.52.8-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_i686/librsvg-2.52.8-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_x86_64/librsvg-2.52.8-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '40d0ff493b29670a4375a7fc35c236cdc44c249a6658bbc49ea54a435868d729',
-     armv7l: '40d0ff493b29670a4375a7fc35c236cdc44c249a6658bbc49ea54a435868d729',
-       i686: 'c3f61459db1d6007d9a17537ec9297967b176e7cca3ddb711113253bf731b24f',
-     x86_64: 'dccf2e623cfb6da4c6995a3b0ad0fe8563a0126ed1e6fd4ecd8764ce15101245'
+    aarch64: '3445bbd63ea8dd5c37285cb822cedaf9eb48fe040bbf40f46dbbb8e59c336d81',
+     armv7l: '3445bbd63ea8dd5c37285cb822cedaf9eb48fe040bbf40f46dbbb8e59c336d81',
+       i686: '50eef90138769cda46c1ab822bc756aa877f548026050e629d2654964060215b',
+     x86_64: 'f84307e2d4c55dbd92d11e0b9184918304733b4c70ef7ffe09b183258de91bdf'
   })
 
-  depends_on 'cairo'
   depends_on 'fontconfig'
-  depends_on 'freetype'
-  depends_on 'harfbuzz' => :build
+  depends_on 'harfbuzz'
   depends_on 'fribidi'
   depends_on 'gdk_pixbuf'
   depends_on 'glib'
@@ -33,29 +31,21 @@ class Librsvg < Package
   depends_on 'harfbuzz'
   depends_on 'libcroco'
   depends_on 'libjpeg'
-  depends_on 'libpng'
   depends_on 'pango'
   depends_on 'rust' => :build
   depends_on 'py3_six' => :build
   depends_on 'vala' => :build
+  gnome
 
   def self.build
     # Following rustup modification as per https://github.com/rust-lang/rustup/issues/1167#issuecomment-367061388
     system 'rustup install stable --profile minimal || (rm -frv ~/.rustup/toolchains/* && rustup install stable --profile minimal)'
     system 'rustup default stable'
-    system "env CFLAGS='-pipe -flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto' \
-      ./configure \
-      --prefix=#{CREW_PREFIX} \
-      --libdir=#{CREW_LIB_PREFIX} \
-      --mandir=#{CREW_MAN_PREFIX} \
-      --build=#{CREW_BUILD} \
-      --host=#{CREW_BUILD} \
-      --target=#{CREW_BUILD} \
+    system 'NOCONFIGURE=1 ./autogen.sh'
+    system "./configure \
+      #{CREW_OPTIONS} \
       --enable-introspection=yes \
       --enable-vala=yes \
-      --disable-static \
       --enable-pixbuf-loader \
       --disable-tools"
     system 'make'

--- a/packages/libsdl2.rb
+++ b/packages/libsdl2.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libsdl2 < Package
   description 'Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.'
   homepage 'http://www.libsdl.org'
-  @_ver = '2.0.18'
+  @_ver = '2.0.20'
   version @_ver
   license 'ZLIB'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Libsdl2 < Package
   git_hashtag "release-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsdl2/2.0.18_armv7l/libsdl2-2.0.18-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsdl2/2.0.18_armv7l/libsdl2-2.0.18-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsdl2/2.0.18_i686/libsdl2-2.0.18-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsdl2/2.0.18_x86_64/libsdl2-2.0.18-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsdl2/2.0.20_armv7l/libsdl2-2.0.20-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsdl2/2.0.20_armv7l/libsdl2-2.0.20-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsdl2/2.0.20_i686/libsdl2-2.0.20-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsdl2/2.0.20_x86_64/libsdl2-2.0.20-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5c40b35e64e22d0f394f0324ea93f77a06c9359aff1b620109ebb96e03b74880',
-     armv7l: '5c40b35e64e22d0f394f0324ea93f77a06c9359aff1b620109ebb96e03b74880',
-       i686: '3089c520dfce88e2c878bbc28135feb39af7fd05e681772011fd429137ff9d07',
-     x86_64: '8c3d271c3440af75ea3cbefa84508878808177090683acd1d07e38d54d56e987'
+    aarch64: 'd52290a1e8cc8c7922ca91a9d95df39b6ab65f4a0eca007347b7205203530337',
+     armv7l: 'd52290a1e8cc8c7922ca91a9d95df39b6ab65f4a0eca007347b7205203530337',
+       i686: '61782729b7ceec09e2239aabbdcde7ea1dc3d7f47332db3cdd20fca815cac2b0',
+     x86_64: '3ab3b5cd9beeb10b10e2216f937a5e31405599ff134ceffa6619a33fe9636c8e'
   })
 
   depends_on 'xorg_server'
@@ -28,14 +28,14 @@ class Libsdl2 < Package
   depends_on 'ibus'
   depends_on 'pulseaudio'
   depends_on 'nasm' => :build
+  patchelf
 
   def self.patch
     system 'filefix'
   end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS}"
     system 'make'
   end

--- a/packages/libusb.rb
+++ b/packages/libusb.rb
@@ -3,32 +3,30 @@ require 'package'
 class Libusb < Package
   description 'A cross-platform library that gives apps easy access to USB devices'
   homepage 'https://sourceforge.net/projects/libusb/'
-  @_ver = '1.0.24'
+  @_ver = '1.0.26'
   version @_ver
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://github.com/libusb/libusb/releases/download/v#{@_ver}/libusb-#{@_ver}.tar.bz2"
-  source_sha256 '7efd2685f7b327326dcfb85cee426d9b871fd70e22caa15bb68d595ce2a2b12a'
+  source_sha256 '12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libusb/1.0.24_armv7l/libusb-1.0.24-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libusb/1.0.24_armv7l/libusb-1.0.24-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libusb/1.0.24_i686/libusb-1.0.24-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libusb/1.0.24_x86_64/libusb-1.0.24-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libusb/1.0.26_armv7l/libusb-1.0.26-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libusb/1.0.26_armv7l/libusb-1.0.26-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libusb/1.0.26_i686/libusb-1.0.26-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libusb/1.0.26_x86_64/libusb-1.0.26-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ded8613e843afa15f3cee5cebfd443b46cd628184de64564df93104ceff11de2',
-     armv7l: 'ded8613e843afa15f3cee5cebfd443b46cd628184de64564df93104ceff11de2',
-       i686: '492b39ccfc194a917db879576b50d0b888c9036c70e7f0f15c39c7b427a75d4f',
-     x86_64: 'ceb4addc8cbb3e1e6a72549ef699514ed20ecb2b40d4277a42702b2c13f24491'
+    aarch64: 'b1ec533b10ebaca34474b8876e26b2ad9dfda3dab193e71a4caeddb4db3a6f38',
+     armv7l: 'b1ec533b10ebaca34474b8876e26b2ad9dfda3dab193e71a4caeddb4db3a6f38',
+       i686: 'f7b9cba3d12a9e999228b0143a617a768f2f90f897ee06588d581313c92f0e5c',
+     x86_64: '5517a4b11a9cd8789f32f700942c6627f872b4e742b6175dcb9746fc3795963f'
   })
 
   depends_on 'eudev'
 
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS}"
     system 'make'
   end

--- a/packages/libxdmcp.rb
+++ b/packages/libxdmcp.rb
@@ -23,6 +23,8 @@ class Libxdmcp < Package
      x86_64: '553304325808a09bc564a989a1e727046000b892ce75d1dec437df7d67ade648'
   })
 
+  depends_on 'libbsd' # R
+  depends_on 'libmd' # R
   depends_on 'xorg_proto'
 
   def self.build

--- a/packages/pixman.rb
+++ b/packages/pixman.rb
@@ -3,26 +3,24 @@ require 'package'
 class Pixman < Package
   description 'Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.'
   homepage 'http://www.pixman.org/'
-  version '285b9a9'
+  version '285b9a9-1'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/pixman/pixman.git'
   git_hashtag '285b9a907caffeb979322e629d4e57aa42061b5a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_armv7l/pixman-285b9a9-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_armv7l/pixman-285b9a9-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_i686/pixman-285b9a9-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9_x86_64/pixman-285b9a9-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_armv7l/pixman-285b9a9-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_armv7l/pixman-285b9a9-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_i686/pixman-285b9a9-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pixman/285b9a9-1_x86_64/pixman-285b9a9-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dc326a21317a03af7349f4b8f77210b027ab779e77021cff0a93036b7d341b5a',
-     armv7l: 'dc326a21317a03af7349f4b8f77210b027ab779e77021cff0a93036b7d341b5a',
-       i686: 'd14290d99d729a89764f39ac004486df18402954af13b0e672b88834ed39e04b',
-     x86_64: '7e281e451c1ab1a4dcd4b15f5b7ecd29205786126488c3fdf355d520a0df75ff'
+    aarch64: 'a7ec280be6f2dfab3576a91dcd9ea44c62bed128606bf9cae996f7035201f255',
+     armv7l: 'a7ec280be6f2dfab3576a91dcd9ea44c62bed128606bf9cae996f7035201f255',
+       i686: '8d8363d7502f4207f3f093e10a4853bd2cec872d084ea019cbd2b5a91294e9bd',
+     x86_64: '6f9d90580d13341db34078d1d3c4d03f2f746c471bb9a8aa35679663cf5a26b9'
   })
-
-  depends_on 'harfbuzz'
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -34,12 +34,15 @@ class Qemu < Package
   depends_on 'hicolor_icon_theme'
   patchelf
 
-  def self.build
+  def self.patch
     # Avoid linux/usbdevice_fs.h:88:9: error: unknown type name ‘u8’ error
-    system "sed -i 's,<linux/usbdevice_fs.h>,\"linux/usbdevice_fs.h\",g' hw/usb/host-libusb.c"
     FileUtils.mkdir_p 'linux'
     FileUtils.cp "#{CREW_PREFIX}/include/linux/usbdevice_fs.h",'linux/usbdevice_fs.h'
     system "sed -i 's,^\([[:blank:]]*\)u8,\1__u8,g' linux/usbdevice_fs.h"
+    system "sed -i 's,<linux/usbdevice_fs.h>,\"linux/usbdevice_fs.h\",g' hw/usb/host-libusb.c"
+  end
+
+  def self.build
     FileUtils.mkdir_p 'build'
     Dir.chdir 'build' do
       system "../configure #{CREW_OPTIONS.sub(/--target.*/, '')} \

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -10,34 +10,52 @@ class Qemu < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/6.2.0_armv7l/qemu-6.2.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/6.2.0_armv7l/qemu-6.2.0-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/6.2.0_x86_64/qemu-6.2.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/7.0.0_armv7l/qemu-7.0.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/7.0.0_armv7l/qemu-7.0.0-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/7.0.0_x86_64/qemu-7.0.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c3446bacc562d8ca3320d20d48922270dfc7300c64d29031a440c19a032c5880',
-     armv7l: 'c3446bacc562d8ca3320d20d48922270dfc7300c64d29031a440c19a032c5880',
-     x86_64: 'b51aab47f59c927803b2c25313a326f7539d2d0a984094389abea78d8366b624'
+    aarch64: '5c628a3b1106b46ce76bc46bfe31b929210dc4ace9b343582d331b7191cf9281',
+     armv7l: '5c628a3b1106b46ce76bc46bfe31b929210dc4ace9b343582d331b7191cf9281',
+     x86_64: 'a0130ee4038e2c28eff096a362dcb4d33413c7d06be4fb613d56e3f6a5500089'
   })
 
-  depends_on 'glib'
-  depends_on 'gtk3'
-  depends_on 'jemalloc'
-  depends_on 'libaio'
-  depends_on 'libcap_ng'
-  depends_on 'libgcrypt'
-  depends_on 'fontconfig'
-  depends_on 'libsdl2'
-  depends_on 'libusb'
-  depends_on 'lzo'
-  depends_on 'pixman'
+  depends_on 'alsa_lib' # R
+  depends_on 'atk' # R
+  depends_on 'cairo' # R
+  depends_on 'eudev' # R
+  depends_on 'fontconfig' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
+  depends_on 'gtk3' # R
+  depends_on 'harfbuzz' # R
   depends_on 'hicolor_icon_theme'
+  depends_on 'jack' # R
+  depends_on 'jemalloc'
+  depends_on 'libaio' # R
+  depends_on 'libcap_ng' # R
+  depends_on 'libepoxy' # R
+  depends_on 'libgcrypt'
+  depends_on 'libjpeg' # R
+  depends_on 'libsdl2' # R
+  depends_on 'libusb' # R
+  depends_on 'libx11' # R
+  depends_on 'libxkbcommon' # R
+  depends_on 'linux_pam' # R
+  depends_on 'lzo' # R
+  depends_on 'mesa' # R
+  depends_on 'pango' # R
+  depends_on 'pipewire' # R
+  depends_on 'pixman' # R
+  depends_on 'pulseaudio' # R
+  depends_on 'sdl2_image' # R
+  depends_on 'snappy' # R
   patchelf
 
   def self.patch
     # Avoid linux/usbdevice_fs.h:88:9: error: unknown type name ‘u8’ error
     FileUtils.mkdir_p 'linux'
-    FileUtils.cp "#{CREW_PREFIX}/include/linux/usbdevice_fs.h",'linux/usbdevice_fs.h'
+    FileUtils.cp "#{CREW_PREFIX}/include/linux/usbdevice_fs.h", 'linux/usbdevice_fs.h'
     system "sed -i 's,^\\\([[:blank:]]*\\\)u8,\\1__u8,g' linux/usbdevice_fs.h"
     system "sed -i 's,<linux/usbdevice_fs.h>,\"linux/usbdevice_fs.h\",g' hw/usb/host-libusb.c"
   end
@@ -48,7 +66,7 @@ class Qemu < Package
       system "../configure #{CREW_OPTIONS.sub(/--target.*/, '')} \
         --disable-stack-protector \
         --enable-lto"
-      system 'make'
+      system 'make || make -j1'
     end
   end
 

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -38,7 +38,7 @@ class Qemu < Package
     # Avoid linux/usbdevice_fs.h:88:9: error: unknown type name ‘u8’ error
     FileUtils.mkdir_p 'linux'
     FileUtils.cp "#{CREW_PREFIX}/include/linux/usbdevice_fs.h",'linux/usbdevice_fs.h'
-    system "sed -i 's,^\([[:blank:]]*\)u8,\1__u8,g' linux/usbdevice_fs.h"
+    system "sed -i 's,^\\\([[:blank:]]*\\\)u8,\\1__u8,g' linux/usbdevice_fs.h"
     system "sed -i 's,<linux/usbdevice_fs.h>,\"linux/usbdevice_fs.h\",g' hw/usb/host-libusb.c"
   end
 


### PR DESCRIPTION
Fixes #6959 

- Also `qemu`->7.0

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fonts3 CREW_TESTING=1 crew update
crew upgrade pixman fontconfig harfbuzz librsvg freetype cairo glib libxdmcp
```