### PR TITLE
Use patchelf function by default when building packages

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1059,7 +1059,7 @@ def prepare_package(destdir)
 end
 
 def patchelf_set_need_paths(dir)
-  return if @pkg.no_patchelf? || !@pkg.patchelf?
+  return if @pkg.no_patchelf?
 
   Dir.chdir dir do
     puts 'Running patchelf'.lightblue

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.13'
+CREW_VERSION = '1.23.14'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -13,6 +13,7 @@ class Glibc < Package
 
   no_env_options
   conflicts_ok
+  no_patchelf
 
   @libc_version = LIBC_VERSION
   # Uncomment following line to build a version of glibc different


### PR DESCRIPTION
- Use `patchelf` by default when building packages. This lets binaries work without hacks when run as root, since LD_LIBRARY_PATH doesn't have to be manually set.
- `glibc` is excluded from this process to avoid breakage
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=patchelf_default CREW_TESTING=1 crew update
```
