### PR TITLE
gcc -> 11.3, llvm -> 14.0.1

### DIFF
--- a/packages/gcc11.rb
+++ b/packages/gcc11.rb
@@ -4,23 +4,23 @@ require 'open3'
 class Gcc11 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '11.2.1-20220305'
+  version '11.3'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   compatibility 'all'
-  source_url 'https://gcc.gnu.org/pub/gcc/snapshots/11-20220305/gcc-11-20220305.tar.xz'
-  source_sha256 '097a4369fb148044ee82fba5fa15f2224dee01218e0ca997ffcc99dd66eb71b6'
+  source_url 'https://gcc.gnu.org/pub/gcc/releases/gcc-11.3.0/gcc-11.3.0.tar.xz'
+  source_sha256 'b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220305_armv7l/gcc11-11.2.1-20220305-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220305_armv7l/gcc11-11.2.1-20220305-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220305_i686/gcc11-11.2.1-20220305-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.2.1-20220305_x86_64/gcc11-11.2.1-20220305-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.3_armv7l/gcc11-11.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.3_armv7l/gcc11-11.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.3_i686/gcc11-11.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc11/11.3_x86_64/gcc11-11.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1bd3f9ff1a404c1af0dac747766a617d5110375e69f5e81661bb86743b42ac82',
-     armv7l: '1bd3f9ff1a404c1af0dac747766a617d5110375e69f5e81661bb86743b42ac82',
-       i686: '28c70e51a3c97078167f340df22ced293d752b8b166bbf5d914b9a5951d2f9e9',
-     x86_64: '5e8c934ccb5a4a18d7395904f81efbdc8376993f3b83228ebcaa373023ad561a'
+    aarch64: 'fe81d80adeb677f352531308e2ccc9b5bce8d7bffe827c136440b7cc03da57fd',
+     armv7l: 'fe81d80adeb677f352531308e2ccc9b5bce8d7bffe827c136440b7cc03da57fd',
+       i686: 'afab8f5dff70482762fbc77d6e663b2dfd20498f5eb68d3d0f3b96b45659df03',
+     x86_64: 'ed75e74c102547f84c73ae97e96604fedb06710a95390d1df0c74987caad9109'
   })
 
   depends_on 'ccache' => :build
@@ -33,6 +33,7 @@ class Gcc11 < Package
   depends_on 'libssp' # L
   depends_on 'zstd' # R
   no_env_options
+  no_patchelf
 
   @gcc_version = version.split('-')[0].partition('.')[0]
 

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libssp < Package
   description 'Libssp is a part of the GCC toolkit.'
   homepage 'https://gcc.gnu.org/'
-  version '11.2.1-20220108'
+  version '11.3'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   compatibility 'all'
-  source_url 'https://gcc.gnu.org/pub/gcc/snapshots/11-20220108/gcc-11-20220108.tar.xz'
-  source_sha256 'a433837a85087c2357a456145ae140bd588e75d44a90031ed57c29de66e46468'
+  source_url 'https://gcc.gnu.org/pub/gcc/releases/gcc-11.3.0/gcc-11.3.0.tar.xz'
+  source_sha256 'b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39'
 
   binary_url({
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.1-20220108_i686/libssp-11.2.1-20220108-chromeos-i686.tar.xz',
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.1-20220108_armv7l/libssp-11.2.1-20220108-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.1-20220108_armv7l/libssp-11.2.1-20220108-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.2.1-20220108_x86_64/libssp-11.2.1-20220108-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.3_armv7l/libssp-11.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.3_armv7l/libssp-11.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.3_i686/libssp-11.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.3_x86_64/libssp-11.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-       i686: 'a8459db3bf278ca9cd120d3d7b166def4816fc112a42869968a2801eb4ceca81',
-    aarch64: 'b7bdc82eca1ade26a484837a9b544852b9c3e5e5f4cbe571213e35e9c417398d',
-     armv7l: 'b7bdc82eca1ade26a484837a9b544852b9c3e5e5f4cbe571213e35e9c417398d',
-     x86_64: 'b443fabf868ac235e2b7e621c9eeec34389e469a87f180a9aaccaa01256b8038'
+    aarch64: 'd8a38e46e54f5967b13a2f10fc64ed96ed97c24bc86fc7be6ca2e44a0978205a',
+     armv7l: 'd8a38e46e54f5967b13a2f10fc64ed96ed97c24bc86fc7be6ca2e44a0978205a',
+       i686: '0e3977ade0372d3884fbfcf2118cfcad9e978e7f728295f5fee27ffeec70a247',
+     x86_64: 'd741ef80b07f006decc798ffce3dbb8fb860e7ef46a3a9524f09f6d4649a5743'
   })
 
   depends_on 'ccache' => :build

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -3,25 +3,24 @@ require 'package'
 class Llvm < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, libcxxabi, and openmp are included.'
   homepage 'http://llvm.org/'
-  @_ver = '13.0.1-19b8'
+  @_ver = '14.0.1'
   version @_ver
-  license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   compatibility 'all'
+  license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   source_url 'https://github.com/llvm/llvm-project.git'
-  git_branch 'release/13.x'
-  git_hashtag '19b8368225dc9ec5a0da547eae48c10dae13522d'
+  git_hashtag 'llvmorg-14.0.1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/13.0.1-19b8_armv7l/llvm-13.0.1-19b8-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/13.0.1-19b8_armv7l/llvm-13.0.1-19b8-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/13.0.1-19b8_i686/llvm-13.0.1-19b8-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/13.0.1-19b8_x86_64/llvm-13.0.1-19b8-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1_armv7l/llvm-14.0.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1_armv7l/llvm-14.0.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1_i686/llvm-14.0.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm/14.0.1_x86_64/llvm-14.0.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '02c756bc93eb4e9754dad06734abca94abf0bec54ca76147c8e12650a32fb83e',
-     armv7l: '02c756bc93eb4e9754dad06734abca94abf0bec54ca76147c8e12650a32fb83e',
-       i686: 'fee0d7cb0d862fdccb4efd180f17d102a970d7308c69839097303745297b4b0a',
-     x86_64: '83d5df5b4b1febe0b4c6805ab346231e46083ab9b0f516a02dd5d7eea2990852'
+    aarch64: '1fb330a76b8465c50786afc60a04f04ca2e57dfec5b02b1e18982311a26b4f95',
+     armv7l: '1fb330a76b8465c50786afc60a04f04ca2e57dfec5b02b1e18982311a26b4f95',
+       i686: '5ed6ca9e6cd709df0135b24dcb683b393294e18d861b43bdb4cad6f3084a483b',
+     x86_64: 'ce24efa733bfbd3fc826155b098e1bd7a3bab31ab81f7a53c62d0a41cfb8bd4f'
   })
 
   depends_on 'ocaml' => :build
@@ -29,12 +28,14 @@ class Llvm < Package
   depends_on 'ccache' => :build
   depends_on 'elfutils' # R
   depends_on 'gcc' # R
+  no_env_options
+  no_patchelf
 
   case ARCH
   when 'aarch64', 'armv7l'
     # LLVM_TARGETS_TO_BUILD = 'ARM;AArch64;AMDGPU'
     # LLVM_TARGETS_TO_BUILD = 'all'.freeze
-    @ARCH_C_FLAGS = "-ltinfow -fPIC -march=armv7-a -mfloat-abi=hard -ccc-gcc-name #{CREW_BUILD}"
+    @ARCH_C_FLAGS = "-fPIC -march=armv7-a -mfloat-abi=hard -ccc-gcc-name #{CREW_BUILD}"
     @ARCH_CXX_FLAGS = "-fPIC -march=armv7-a -mfloat-abi=hard -ccc-gcc-name #{CREW_BUILD}"
     @ARCH_LDFLAGS = ''
     @ARCH_LTO_LDFLAGS = "#{@ARCH_LDFLAGS} -flto=thin"
@@ -52,7 +53,7 @@ class Llvm < Package
     # LLVM_TARGETS_TO_BUILD = 'X86'.freeze
     # Because ld.lld: error: undefined symbol: __atomic_store
     # Polly demands fPIC
-    @ARCH_C_FLAGS = '-ltinfow -latomic -fPIC'
+    @ARCH_C_FLAGS = '-latomic -fPIC'
     @ARCH_CXX_FLAGS = '-latomic -fPIC'
     # Because getting this error:
     # ld.lld: error: relocation R_386_PC32 cannot be used against symbol isl_map_fix_si; recompile with -fPIC
@@ -63,7 +64,7 @@ class Llvm < Package
   when 'x86_64'
     # LLVM_TARGETS_TO_BUILD = 'X86;AMDGPU'
     # LLVM_TARGETS_TO_BUILD = 'all'.freeze
-    @ARCH_C_FLAGS = '-ltinfow -fPIC'
+    @ARCH_C_FLAGS = '-fPIC'
     @ARCH_CXX_FLAGS = '-fPIC'
     @ARCH_LDFLAGS = ''
     @ARCH_LTO_LDFLAGS = "#{@ARCH_LDFLAGS} -flto=thin"
@@ -85,29 +86,6 @@ class Llvm < Package
     # system "sudo rm /usr/lib#{CREW_LIB_SUFFIX}/libform.so || true"
     # system "sudo ln -s #{CREW_LIB_PREFIX}/libncurses.so.6 /lib#{CREW_LIB_SUFFIX}/libncurses.so.5 || true"
     # system "sudo ln -s #{CREW_LIB_PREFIX}/libform.so /usr/lib#{CREW_LIB_SUFFIX}/libform.so || true"
-
-    # Patch for i686 in llvm 13 via https://bugs.llvm.org/show_bug.cgi?id=51917
-    @llvm13_i686_patch = <<~LLVM_HEREDOC
-      --- a/lldb/source/Plugins/Process/Linux/IntelPTManager.cpp
-      +++ b/lldb/source/Plugins/Process/Linux/IntelPTManager.cpp
-      @@ -145,7 +145,11 @@ static Error CheckPsbPeriod(size_t psb_period) {
-       }
-
-       size_t IntelPTThreadTrace::GetTraceBufferSize() const {
-      +#ifndef PERF_ATTR_SIZE_VER5
-      +  llvm_unreachable("Intel PT Linux perf event not supported");
-      +#else
-         return m_mmap_meta->aux_size;
-      +#endif
-       }
-
-       static Expected<uint64_t>
-    LLVM_HEREDOC
-    case ARCH
-    when 'i686'
-      File.write('llvm13_i686.patch', @llvm13_i686_patch)
-      system 'patch -Np1 -i llvm13_i686.patch'
-    end
   end
 
   def self.build
@@ -203,9 +181,9 @@ clang++ -fPIC  -rtlib=compiler-rt -stdlib=libc++ -cxx-isystem \${cxx_sys} -I \${
 
   def self.check
     Dir.chdir('builddir') do
-      # system "samu check-llvm || true"
-      # system "samu check-clang || true"
-      # system "samu check-lld || true"
+      system 'samu check-llvm || true'
+      system 'samu check-clang || true'
+      system 'samu check-lld || true'
     end
   end
 


### PR DESCRIPTION
- This has no magic to reduce package sizes. Just straight updates.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=compilers  CREW_TESTING=1 crew update
```
