### PR TITLE
openldap -> 2.61, curl rebuild, alpine -> 2.25

### DIFF
--- a/packages/alpine.rb
+++ b/packages/alpine.rb
@@ -3,51 +3,52 @@ require 'package'
 class Alpine < Package
   description 'The continuation of the Alpine email client from University of Washington.'
   homepage 'http://alpine.x10host.com/alpine'
-  version '2.22'
+  version '2.25'
   license 'Apache-2.0'
   compatibility 'all'
-  source_url 'http://alpine.x10host.com/alpine/release/src/alpine-2.22.tar.xz'
-  source_sha256 '849567c1b6f71fde3aaa1c97cf0577b12a525d9e22c0ea47797c4bf1cd2bbfdb'
+  source_url 'http://alpine.x10host.com/alpine/release/src/alpine-2.25.tar.xz'
+  source_sha256 '658a150982f6740bb4128e6dd81188eaa1212ca0bf689b83c2093bb518ecf776'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/alpine/2.22_armv7l/alpine-2.22-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/alpine/2.22_armv7l/alpine-2.22-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/alpine/2.22_i686/alpine-2.22-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/alpine/2.22_x86_64/alpine-2.22-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/alpine/2.25_armv7l/alpine-2.25-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/alpine/2.25_armv7l/alpine-2.25-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/alpine/2.25_i686/alpine-2.25-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/alpine/2.25_x86_64/alpine-2.25-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '3856cd6cb2d2073b4cf022e5d2db54ed65ba2f7ab53545c4cd476d894a343d89',
-     armv7l: '3856cd6cb2d2073b4cf022e5d2db54ed65ba2f7ab53545c4cd476d894a343d89',
-       i686: '32701e3edcc3cab4a409d66cb9747c799b1265b46cb531e093b2472660f34f48',
-     x86_64: '4277b6583b8e753da09a95ea7912d69666d45dae5a9db91b18abf1a7bbcca155',
+  binary_sha256({
+    aarch64: '6c919cb0d6fad903fc0e0cb96f1d8bff6030181a9e871b38ccd59a121f342dfe',
+     armv7l: '6c919cb0d6fad903fc0e0cb96f1d8bff6030181a9e871b38ccd59a121f342dfe',
+       i686: '453a722ceefb5749a215e76599133686011b51c9b45a4747d5c95faf7f94f799',
+     x86_64: '31d6176774aee2a53e8fd784816c7daaa361cf80c8ea8fa11f99c3fe22c3bfef'
   })
 
+  depends_on 'e2fsprogs'
   depends_on 'hunspell_en_us'
   depends_on 'openldap'
-  depends_on 'tcl'
+  depends_on 'tcl' # R
+  no_fhs # complains about /usr/local/tmp
 
   def self.patch
-    # Fixes ./configure: line 8156: /usr/bin/file: No such file or directory
     system 'filefix'
   end
 
   def self.build
-    system "./configure",
-    "--prefix=#{CREW_PREFIX}",
-    "--libdir=#{CREW_LIB_PREFIX}",
-    "--with-ssl-dir=/etc/ssl",
-    "--with-ssl-include-dir=#{CREW_PREFIX}/include",
-    "--with-ssl-lib-dir=#{CREW_LIB_PREFIX}", "--disable-nls",
-    "--with-system-pinerc=#{CREW_PREFIX}/etc/alpine.d/pine.conf",
-    "--with-system-fixed-pinerc=#{CREW_PREFIX}/etc/alpine/pine.conf.fixed"
-    system "make"
+    system "./configure \
+           #{CREW_OPTIONS} \
+           --with-ssl-dir=#{CREW_PREFIX}/etc/ssl \
+           --with-ssl-include-dir=#{CREW_PREFIX}/include \
+           --with-ssl-lib-dir=#{CREW_LIB_PREFIX} \
+           --disable-nls \
+           --with-system-pinerc=#{CREW_PREFIX}/etc/alpine.d/pine.conf \
+           --with-system-fixed-pinerc=#{CREW_PREFIX}/etc/alpine/pine.conf.fixed"
+    system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
-    system "make", "check"
+    system 'make', 'check'
   end
 end

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -4,28 +4,29 @@ class Libcurl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
   @_ver = '7.82.0'
-  version @_ver
+  version "#{@_ver}-1"
   license 'curl'
   compatibility 'all'
   source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
   source_sha256 '0aaa12d7bd04b0966254f2703ce80dd5c38dbbd76af0297d3d690cdce58a583c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0_armv7l/libcurl-7.82.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0_armv7l/libcurl-7.82.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0_i686/libcurl-7.82.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0_x86_64/libcurl-7.82.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0-1_armv7l/libcurl-7.82.0-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0-1_armv7l/libcurl-7.82.0-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0-1_i686/libcurl-7.82.0-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.82.0-1_x86_64/libcurl-7.82.0-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4c93987529a02ef14f2febd2554ad0f8720605a12d4d3ed76c904b2386b2cc5a',
-     armv7l: '4c93987529a02ef14f2febd2554ad0f8720605a12d4d3ed76c904b2386b2cc5a',
-       i686: '4bf55e9a5cfd3eaf2114198969a5a536f74dd348c4398968128b36c52153b588',
-     x86_64: 'b43580537b314e0aad5aa99de45928618b302c9879c89cd18d13165a22fd6c96'
+    aarch64: '99cb07b00694c2adce9a43517597c979bcad6cf7d6622d6cb8000a5da5ceee32',
+     armv7l: '99cb07b00694c2adce9a43517597c979bcad6cf7d6622d6cb8000a5da5ceee32',
+       i686: 'c1e5c9d7d7b2d8e22367c71de6ca7aef6ffd3e52d201c998488ca6c12b71ddae',
+     x86_64: '88504cec88c61e0a7c95a8fb370078848825fa2349436525f3d6b53c7f1eeede'
   })
 
-  depends_on 'brotli' => :build
+  depends_on 'brotli' # R
   depends_on 'ca_certificates' => :build
   depends_on 'c_ares' # R
+  depends_on 'glibc' # R
   depends_on 'libcyrussasl' # R
   depends_on 'libidn2' # R
   depends_on 'libnghttp2' # R
@@ -39,6 +40,7 @@ class Libcurl < Package
   depends_on 'valgrind' => :build
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
+
 
   def self.build
     @libssh = '--with-libssh'

--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -3,27 +3,32 @@ require 'package'
 class Openldap < Package
   description 'OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.'
   homepage 'https://www.openldap.org/'
-  @_ver = '2.5.5'
-  version "#{@_ver}-1"
+  @_ver = '2.6.1'
+  version @_ver
   license 'OpenLDAP and GPL-2'
   compatibility 'all'
   source_url "https://openldap.org/software/download/OpenLDAP/openldap-release/openldap-#{@_ver}.tgz"
-  source_sha256 '74ecefda2afc0e054d2c7dc29166be6587fa9de7a4087a80183bc9c719dbf6b3'
+  source_sha256 '9d576ea6962d7db8a2e2808574e8c257c15aef55f403a1fb5a0faf35de70e6f3'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5-1_armv7l/openldap-2.5.5-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5-1_armv7l/openldap-2.5.5-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5-1_i686/openldap-2.5.5-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.5.5-1_x86_64/openldap-2.5.5-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.1_armv7l/openldap-2.6.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.1_armv7l/openldap-2.6.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.1_i686/openldap-2.6.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.1_x86_64/openldap-2.6.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'fb6fd0f0690103b39b71bce3a71426feb41ac8f0de03466a2a5985dcd82a4fdd',
-     armv7l: 'fb6fd0f0690103b39b71bce3a71426feb41ac8f0de03466a2a5985dcd82a4fdd',
-       i686: '409d75a7523e4de951285a5f9daf0d14166467242ce37cf85b5718a85e63cc88',
-     x86_64: 'a79aa7779fe182d0e529099f704a7c3d9e590b103d33e2f35779e59c4b582e06'
+    aarch64: '6b3a8709e772c271933bfe76cc79aa7c6a73319358c48857dc4d3a53d1cabd7d',
+     armv7l: '6b3a8709e772c271933bfe76cc79aa7c6a73319358c48857dc4d3a53d1cabd7d',
+       i686: '25415a5c55504a205f7c1768d5e12b5c7278c70e56f3bd77c3e5d103f8da6517',
+     x86_64: '4549a1d764ad469b8bffaba66bb291d68ba7bd20deeb8b8b286bc65f825d71a9'
   })
 
-  depends_on 'libcyrussasl'
+  depends_on 'glibc' # R
+  depends_on 'libcyrussasl' # R
+  depends_on 'krb5' # R
+  depends_on 'e2fsprogs' # R
+  depends_on 'openssl' # R
+  depends_on 'util_linux' # R
 
   def self.patch
     system 'filefix'


### PR DESCRIPTION
- OpenLDAP -> 2.61
- This also requires curl to be rebuilt
- This also requires alpine to be rebuilt, so it is updated to 2.25.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=openldap  CREW_TESTING=1 crew update
```