### PR TITLE
Add no_patchelf to crew_profile_base, add patchelf to core

### DIFF
--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/skycocker/chromebrew'
-  version '1.4'
+  version '1.5'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -59,6 +59,7 @@ class Core < Package
   depends_on 'nettle'
   depends_on 'openldap'
   depends_on 'openssl'
+  depends_on 'patchelf'
   depends_on 'p11kit'
   depends_on 'pcre'
   depends_on 'pcre2'

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -9,6 +9,7 @@ class Crew_profile_base < Package
   source_url 'SKIP'
 
   no_compile_needed
+  no_patchelf
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d"


### PR DESCRIPTION
- The addition of automatic patchelf appears to break installs by crashing on install of `crew_profile_base`.
  - Resolve this by adding `patchelf` to core, which adds 512kb to the default install (just to be safe).
  - Add `no_patchelf` to `crew_profile_base`

Works properly: (This should work and be harmless... but only a container install can truly test this)
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_profile_base_fix  CREW_TESTING=1 crew update
```