### PR TITLE
pax_utils -> 1.3.4 and updated deps, add gnulib_git

### DIFF
--- a/packages/gnulib_git.rb
+++ b/packages/gnulib_git.rb
@@ -1,0 +1,42 @@
+# Adapted from Arch Linux gnulib-git PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=gnulib-git
+
+require 'package'
+
+class Gnulib_git < Package
+  description 'GNU Portability Library'
+  homepage 'http://www.gnu.org/software/gnulib'
+  version 'v0.1-d6a07b4'
+  license 'custom'
+  compatibility 'all'
+  source_url 'https://git.savannah.gnu.org/git/gnulib.git'
+  git_hashtag 'd6a07b4dc21b3118727743142c678858df442853'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnulib_git/v0.1-d6a07b4_armv7l/gnulib_git-v0.1-d6a07b4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnulib_git/v0.1-d6a07b4_armv7l/gnulib_git-v0.1-d6a07b4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnulib_git/v0.1-d6a07b4_i686/gnulib_git-v0.1-d6a07b4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnulib_git/v0.1-d6a07b4_x86_64/gnulib_git-v0.1-d6a07b4-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '14dc5ef4dae60f1d48ea49849f66cacda35c901f57cd401f780715517286acf6',
+     armv7l: '14dc5ef4dae60f1d48ea49849f66cacda35c901f57cd401f780715517286acf6',
+       i686: '26cd24849f625113a04995fcc4923710a3e54102368770e6678bcfdb3d3bc040',
+     x86_64: '3215f4e675b309772d8d4b334e8ec5de4a94a463054aa7262b85adb1ef9d359f'
+  })
+
+  def self.patch
+    system "sed -i \"/^[ ]*gnulib_dir=/s,\\`[^\\`]*\\`,#{CREW_PREFIX}/share/gnulib-git,\" gnulib-tool"
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/gnulib-git"
+    FileUtils.install %w[check-module gnulib-tool], "#{CREW_DEST_PREFIX}/share/gnulib-git/", mode: 0o755
+    FileUtils.cp_r %w[build-aux lib m4 modules top], "#{CREW_DEST_PREFIX}/share/gnulib-git"
+
+    FileUtils.cp_r %w[doc tests], "#{CREW_DEST_PREFIX}/share/gnulib-git/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.ln "#{CREW_DEST_PREFIX}/share/gnulib-git/gnulib-tool", "#{CREW_DEST_PREFIX}/bin/"
+    FileUtils.ln "#{CREW_DEST_PREFIX}/share/gnulib-git/check-module", "#{CREW_DEST_PREFIX}/bin/"
+  end
+end

--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libcap < Package
   description 'Libcap implements the user-space interfaces to the POSIX 1003.1e capabilities available in Linux kernels.'
   homepage 'https://directory.fsf.org/wiki/Libcap/'
-  @_ver = '2.63'
+  @_ver = '2.64'
   version @_ver
   license 'GPL-2 or BSD'
   compatibility 'all'
@@ -11,22 +11,23 @@ class Libcap < Package
   git_hashtag "libcap-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.63_armv7l/libcap-2.63-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.63_armv7l/libcap-2.63-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.63_i686/libcap-2.63-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.63_x86_64/libcap-2.63-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.64_armv7l/libcap-2.64-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.64_armv7l/libcap-2.64-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.64_i686/libcap-2.64-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.64_x86_64/libcap-2.64-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'b090422c28aa929a2a585c73739eda6c8c953379ecb0b90f1f596ad5e37706de',
-     armv7l: 'b090422c28aa929a2a585c73739eda6c8c953379ecb0b90f1f596ad5e37706de',
-       i686: '235e7deaec2896dd3db2af3b851699c1fd4dd680b6e2e02d91b895d54ca6d01b',
-     x86_64: '2e306e64bf4f170ad232ab0a64de65a5c4dbbb877ce6f5d7e7ebaa57c39acdde'
+    aarch64: '03701822e8ae9cfee9ea023b377499797b037372c204f27c755bf68a01dddd4c',
+     armv7l: '03701822e8ae9cfee9ea023b377499797b037372c204f27c755bf68a01dddd4c',
+       i686: '4032d0a74b1b6a23da3d97643f14c830d7499c7b3d8677715bb369e77054a655',
+     x86_64: 'cc6593f845dfc3adc63cfd5dadaf23117c646ae5d37442961380fe0f82295fe3'
   })
 
+  depends_on 'glibc' # R
   depends_on 'gperf' => :build
   depends_on 'linux_pam'
 
-  def self.build
+  def self.patch
     # add includes option to make it work with gperf-3.1
     system 'sed -e "/gperf --/s/gperf --/gperf --includes --/" -e "/gperf --/s/cap_lookup_name(/cap_dummy(/" -i libcap/Makefile'
     # change the path to ld
@@ -36,9 +37,15 @@ class Libcap < Package
     # set exec_prefix
     system "sed -i 's,^exec_prefix=,exec_prefix=\$(prefix),g' Make.Rules"
     # use system libdir
-    system "sed -i 's,^lib_prefix=\$(exec_prefix),lib_prefix=#{CREW_LIB_PREFIX},g' Make.Rules"
+    case ARCH
+    when 'armv7l', 'aarch64'
+      system "sed -i 's,^lib_prefix=\$(exec_prefix),lib_prefix=#{CREW_LIB_PREFIX},g' Make.Rules"
+    end
     # http://git.yoctoproject.org/cgit.cgi/poky/plain/meta/recipes-support/libcap/files/0001-ensure-the-XATTR_NAME_CAPS-is-defined-when-it-is-use.patch
     system 'sed -i "s,^\#ifdef VFS_CAP_U32,\#if defined (VFS_CAP_U32) \&\& defined (XATTR_NAME_CAPS),g" libcap/cap_file.c'
+  end
+
+  def self.build
     system "#{CREW_ENV_OPTIONS} make"
   end
 

--- a/packages/libseccomp.rb
+++ b/packages/libseccomp.rb
@@ -3,31 +3,32 @@ require 'package'
 class Libseccomp < Package
   description 'The libseccomp library provides an easy to use, platform independent, interface to the Linux Kernel\'s syscall filtering mechanism.'
   homepage 'https://github.com/seccomp/libseccomp'
-  @_ver = '2.5.1'
+  @_ver = '2.5.4'
   version @_ver
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://github.com/seccomp/libseccomp/archive/v#{@_ver}.tar.gz"
-  source_sha256 '76ad54e31d143b39a99083564045212a965e026a1010a742edd793d26d699829'
+  source_sha256 '96bbadb4384716272a6d2be82801dc564f7aab345febfe9b698b70fc606e3f75'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libseccomp/2.5.1_armv7l/libseccomp-2.5.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libseccomp/2.5.1_armv7l/libseccomp-2.5.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libseccomp/2.5.1_i686/libseccomp-2.5.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libseccomp/2.5.1_x86_64/libseccomp-2.5.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libseccomp/2.5.4_armv7l/libseccomp-2.5.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libseccomp/2.5.4_armv7l/libseccomp-2.5.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libseccomp/2.5.4_i686/libseccomp-2.5.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libseccomp/2.5.4_x86_64/libseccomp-2.5.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a5fb74e92c03f02a6079796234e0c3c192ec689d71bc5b5dd104c0decdd747b1',
-     armv7l: 'a5fb74e92c03f02a6079796234e0c3c192ec689d71bc5b5dd104c0decdd747b1',
-       i686: '4d9b966795112a9bf8a6d3da564345998ee007400c9720b4d86b58e79c7c65ea',
-     x86_64: 'dc052c6c4962cc1f5b30c1a73f0ab397abd15406d808a18f96ed8ff095a62e25'
+    aarch64: 'd4aafa04c27719b2d5d5be94a89846d0a118710effd5f1144e2139a0b8f9c09d',
+     armv7l: 'd4aafa04c27719b2d5d5be94a89846d0a118710effd5f1144e2139a0b8f9c09d',
+       i686: '96743fd080af70581781c4e0b17bdb3f5c91b765c1355803193527984176f5f9',
+     x86_64: '1097b0549a2f0210fa15ca54f7916b9927363534913dbc3030270c39c2559d3d'
   })
+
+  depends_on 'glibc' # R
+  depends_on 'gperf' => :build
 
   def self.build
     system './autogen.sh'
-    system "env CFLAGS='-flto=auto' \
-      CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS}"
     system 'make'
   end

--- a/packages/linux_pam.rb
+++ b/packages/linux_pam.rb
@@ -3,34 +3,38 @@ require 'package'
 class Linux_pam < Package
   description 'Linux PAM (Pluggable Authentication Modules for Linux) project'
   homepage 'https://github.com/linux-pam/linux-pam'
-  version '1.5.1'
+  version '1.5.2'
   license 'BSD-3'
   compatibility 'all'
-  source_url 'https://github.com/linux-pam/linux-pam/releases/download/v1.5.1/Linux-PAM-1.5.1.tar.xz'
-  source_sha256 '201d40730b1135b1b3cdea09f2c28ac634d73181ccd0172ceddee3649c5792fc'
+  source_url 'https://github.com/linux-pam/linux-pam/releases/download/v1.5.2/Linux-PAM-1.5.2.tar.xz'
+  source_sha256 'e4ec7131a91da44512574268f493c6d8ca105c87091691b8e9b56ca685d4f94d'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_pam/1.5.1_armv7l/linux_pam-1.5.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_pam/1.5.1_armv7l/linux_pam-1.5.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_pam/1.5.1_i686/linux_pam-1.5.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_pam/1.5.1_x86_64/linux_pam-1.5.1-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_pam/1.5.2_armv7l/linux_pam-1.5.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_pam/1.5.2_armv7l/linux_pam-1.5.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_pam/1.5.2_i686/linux_pam-1.5.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linux_pam/1.5.2_x86_64/linux_pam-1.5.2-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '50f55a3858081ca4748fba9f731310b81c9ed6ed85597c1fd715a5c2ae1f56d4',
-     armv7l: '50f55a3858081ca4748fba9f731310b81c9ed6ed85597c1fd715a5c2ae1f56d4',
-       i686: '5017e846407cb9692a915b1b513616515a45a6143303904125d29f0a43348ab6',
-     x86_64: 'af1b7e6212444ba310b0441a5f32697f6478a1b62f79b78153fd49718a4e8465',
+  binary_sha256({
+    aarch64: 'fdf87dc40abeb0525e3026d68979b17210cc5a991fe9056e83f9c6b5c8ea3ba9',
+     armv7l: 'fdf87dc40abeb0525e3026d68979b17210cc5a991fe9056e83f9c6b5c8ea3ba9',
+       i686: '74f51ebb2dfddf54317bb2fab540688373f62dcb334cf3e3a30de0b323cd79db',
+     x86_64: '81a43a40a39d742a56fc74716e91098f4497c5f1b1f702de0791bdf6fe5e95aa'
   })
 
+  depends_on 'glibc' # R
   depends_on 'libdb' # libdb needs to be built with "--enable-dbm"
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-static --disable-nis"
+    system "./configure #{CREW_OPTIONS} \
+      --disable-selinux \
+      --enable-static \
+      --disable-nis"
     system 'make'
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include/security"
     Dir.chdir "#{CREW_DEST_PREFIX}/include" do
       system "find . -type f -exec ln -s #{CREW_PREFIX}/include/{} #{CREW_DEST_PREFIX}/include/security/{} \\;"

--- a/packages/pax_utils.rb
+++ b/packages/pax_utils.rb
@@ -3,38 +3,61 @@ require 'package'
 class Pax_utils < Package
   description 'ELF utils that can check files for security relevant properties'
   homepage 'https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities'
-  version '1.2.5'
+  version '1.3.4'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://dev.gentoo.org/~slyfox/distfiles/pax-utils-1.2.5.tar.xz'
-  source_sha256 '7ce7170ceed255bb47cac03b88bcbc636b0e412cac974e213e8017a1dae292ec'
+  source_url 'https://dev.gentoo.org/~xen0n/distfiles/pax-utils-1.3.4.tar.xz'
+  source_sha256 '8baed2f9c5ae8e0cda1b9c75990864101afc64fad0a4616e10f3ff8ef891040b'
 
-  binary_url ({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pax_utils/1.2.5_armv7l/pax_utils-1.2.5-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pax_utils/1.2.5_armv7l/pax_utils-1.2.5-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pax_utils/1.2.5_i686/pax_utils-1.2.5-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pax_utils/1.2.5_x86_64/pax_utils-1.2.5-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pax_utils/1.3.4_armv7l/pax_utils-1.3.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pax_utils/1.3.4_armv7l/pax_utils-1.3.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pax_utils/1.3.4_i686/pax_utils-1.3.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pax_utils/1.3.4_x86_64/pax_utils-1.3.4-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-     aarch64: 'edc856ff6cc451358da1fb46a2a1023594f3d243cb1c30e5aa67c9ee9ed4dac6',
-      armv7l: 'edc856ff6cc451358da1fb46a2a1023594f3d243cb1c30e5aa67c9ee9ed4dac6',
-        i686: '9254843237e4bba47da7c4ec63ca7109e32ad7fee5822a1862fdddc789c280bb',
-      x86_64: '836d8627d96ed61608cb7bee423db753fc00c67600c62386e1df98d4529c35c9',
+  binary_sha256({
+    aarch64: '54b27eaf90d7d9f0ec2852986c5549939ddba12b5232313996330ee0d9f4bdda',
+     armv7l: '54b27eaf90d7d9f0ec2852986c5549939ddba12b5232313996330ee0d9f4bdda',
+       i686: '05b1cd3d421d12e40ae555cb0b4422e332386d3ff5a6e0ee874ec9dfc94392eb',
+     x86_64: '427a8ce76e866049a418d8f727de81a9a76e3cb30f5021ef5b079ed9a3c4cacb'
   })
-
+  # The following two are only needed for build with autogen.sh
+  # depends_on 'gnulib_git' => :build
+  # depends_on 'xmlto' => :build
+  depends_on 'glibc' # R
   depends_on 'py3_pyelftools'
   depends_on 'libcap' => :build
   depends_on 'libseccomp' => :build
 
-  def self.build
+  def self.patch
+    # https://lists.gnu.org/archive/html/bug-gnulib/2022-04/msg00075.html
+    @gnulib_patch = <<~'PATCHEOF'
+      diff --git a/gnulib/import/string.in.h b/gnulib/import/string.in.h
+      index b6840fa9121..cb344ed0498 100644
+      --- a/autotools/gnulib/string.in.h
+      +++ b/autotools/gnulib/string.in.h
+      @@ -594,6 +594,7 @@ _GL_CXXALIAS_SYS (strndup, char *, (char const *__s, size_t __n));
+       _GL_CXXALIASWARN (strndup);
+       #else
+       # if __GNUC__ >= 11
+      +#undef strndup
+       /* For -Wmismatched-dealloc: Associate strndup with free or rpl_free.  */
+       _GL_FUNCDECL_SYS (strndup, char *,
+                         (char const *__s, size_t __n)
+    PATCHEOF
+    File.write('gnulib.patch', @gnulib_patch)
+    system 'patch -Np1 -i gnulib.patch'
     system "sed -i 's|/usr/bin/env python|/usr/bin/env python3|g' lddtree.py"
-    system "env #{CREW_ENV_OPTIONS} \
-    ./configure \
-    #{CREW_OPTIONS} \
-    --with-caps \
-    --with-seccomp \
-    --with-python"
-    system "make"
+  end
+
+  def self.build
+    # system './autogen.sh'
+    system "./configure \
+      #{CREW_OPTIONS} \
+      --with-caps \
+      --with-seccomp \
+      --with-python"
+    system 'make'
   end
 
   def self.install

--- a/packages/py3_pyelftools.rb
+++ b/packages/py3_pyelftools.rb
@@ -3,26 +3,28 @@ require 'package'
 class Py3_pyelftools < Package
   description 'Pure-Python library for parsing and analyzing ELF files and DWARF debugging information.'
   homepage 'https://github.com/eliben/pyelftools/'
-  @_ver = '0.27'
-  version "#{@_ver}-1"
+  @_ver = '0.28'
+  version @_ver
   license 'public-domain'
   compatibility 'all'
   source_url 'https://github.com/eliben/pyelftools.git'
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyelftools/0.27-1_armv7l/py3_pyelftools-0.27-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyelftools/0.27-1_armv7l/py3_pyelftools-0.27-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyelftools/0.27-1_i686/py3_pyelftools-0.27-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyelftools/0.27-1_x86_64/py3_pyelftools-0.27-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyelftools/0.28_armv7l/py3_pyelftools-0.28-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyelftools/0.28_armv7l/py3_pyelftools-0.28-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyelftools/0.28_i686/py3_pyelftools-0.28-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyelftools/0.28_x86_64/py3_pyelftools-0.28-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'cee59c129fbccd6f72d2ea45ba82cc0d986bcf8c42ed4813a473781d8a73538a',
-     armv7l: 'cee59c129fbccd6f72d2ea45ba82cc0d986bcf8c42ed4813a473781d8a73538a',
-       i686: '9105d58b8bbf878aa48c558dbcf11394b24272610ebfdc5ad4b0185023daa0f6',
-     x86_64: '5c2a2b09a2a480f4be521ac6075d14c7ed07bce390603370c76c4c23e08666ef'
+    aarch64: '969669befcac95f56ea469f66cced8d37728d89c92b87c6e11fa9b12943d0482',
+     armv7l: '969669befcac95f56ea469f66cced8d37728d89c92b87c6e11fa9b12943d0482',
+       i686: 'c6112ede652cbcb1f46efcdab9c5d66e73ab9483b9615a2d50ef2a00ba7bc735',
+     x86_64: 'a43b98cb137c5c8093a497a39ae63d79d9c2ad0ef4ec08391392e099a962f5a4'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'python3' # R
   depends_on 'py3_setuptools' => :build
 
   def self.build


### PR DESCRIPTION
- Update pax_utils, and update depends
- `libcap` -> 2.64
- `libseccomp` -> 2.5.4
- `linux_pam` -> 1.5.2
- `py3_pyelftools` -> 0.28
- Add `gnulib_git`

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/<satmandu/chromebrew.git CREW_TESTING_BRANCH=pax  CREW_TESTING=1 crew update
```
