### PR TITLE
gcc -> 12.1, update mold as per upstream issue fix

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -14,7 +14,7 @@ class Buildessential < Package
 
   # install first to get ldconfig
   depends_on 'glibc'
-  # depends_on 'gcc11'
+  depends_on 'gcc'
   depends_on 'gmp'
   depends_on 'mpfr'
   depends_on 'mpc'

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -25,7 +25,7 @@ class Freetype < Package
   depends_on 'brotli'
   depends_on 'bz2'
   depends_on 'expat'
-  depends_on 'gcc11'
+  depends_on 'gcc'
   depends_on 'glib'
   depends_on 'graphite'
   depends_on 'harfbuzz'

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -4,7 +4,7 @@ require 'open3'
 class Gcc < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '11.2.0'
+  version '12.1.0'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   compatibility 'all'
 
@@ -15,9 +15,9 @@ class Gcc < Package
   rescue StandardError
   end
   begin
-    depends_on status.exitstatus.zero? ? "gcc#{@gcc_ver.chomp}" : 'gcc11'
+    depends_on status.exitstatus.zero? ? "gcc#{@gcc_ver.chomp}" : 'gcc12'
   rescue
-    depends_on 'gcc11'
+    depends_on 'gcc12'
   end
 
   def self.postinstall

--- a/packages/gcc12.rb
+++ b/packages/gcc12.rb
@@ -1,0 +1,415 @@
+require 'package'
+require 'open3'
+
+class Gcc12 < Package
+  description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
+  homepage 'https://www.gnu.org/software/gcc/'
+  version '12.1'
+  license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
+  compatibility 'all'
+  source_url 'https://gcc.gnu.org/pub/gcc/releases/gcc-12.1.0/gcc-12.1.0.tar.xz'
+  source_sha256 '62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc12/12.1_armv7l/gcc12-12.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc12/12.1_armv7l/gcc12-12.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc12/12.1_i686/gcc12-12.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc12/12.1_x86_64/gcc12-12.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'c3507c61d1f9e245ca66ea11f3091785287697eed1a0deba9c769ac443426494',
+     armv7l: 'c3507c61d1f9e245ca66ea11f3091785287697eed1a0deba9c769ac443426494',
+       i686: 'bd0a415636e7602320b0daca9ef545fac326396ddf52baa2fe385af752f47452',
+     x86_64: 'e48ecf0106f6a6a01cb3d80327e14ca302f96d7b5c79f44c781a483d2f5ad066'
+  })
+
+  depends_on 'ccache' => :build
+  depends_on 'dejagnu' => :build # for test
+  depends_on 'glibc' # R
+  depends_on 'gmp' # R
+  depends_on 'isl' # R
+  depends_on 'mpc' # R
+  depends_on 'mpfr' # R
+  depends_on 'libssp' # L
+  depends_on 'zstd' # R
+  no_env_options
+  no_patchelf
+  conflicts_ok
+
+  @gcc_version = version.split('-')[0].partition('.')[0]
+
+  # Reimplement gcc preflight section during gcc12 release cycle.
+  # def self.preflight
+  #   # Use full gcc path to bypass ccache
+  #   stdout_and_stderr, status = Open3.capture2e('bash', '-c',
+  #                                               "#{CREW_PREFIX}/bin/gcc -dumpversion 2>&1 | tail -1 | cut -d' ' -f1")
+  #   if status.success?
+  #     installed_gccver = stdout_and_stderr.chomp
+  #     # One gets "-dumpversion" or "bash:" with no gcc installed.
+  #     unless installed_gccver.to_s == '-dumpversion' ||
+  #       installed_gccver.to_s == 'bash:' ||
+  #       installed_gccver.to_s == @gcc_version.to_s ||
+  #       installed_gccver.partition('.')[0].to_s == @gcc_version.partition('.')[0].to_s
+  #       warn "GCC version #{installed_gccver} is currently installed.".lightred
+  #       warn "To use #{to_s.downcase} please run:".lightgreen
+  #       warn "crew remove gcc#{installed_gccver} && crew install #{to_s.downcase}".lightgreen
+  #       exit 1
+  #     end
+  #   end
+  # end
+
+  def self.patch
+    # This fixes a PATH_MAX undefined error which breaks libsanitizer
+    # "libsanitizer/asan/asan_linux.cpp:217:21: error: ‘PATH_MAX’ was not declared in this scope"
+    # This is defined in https://chromium.googlesource.com/chromiumos/third_party/kernel/+/refs/heads/chromeos-5.4/include/uapi/linux/limits.h
+    # and is defined as per suggested method here: https://github.com/ZefengWang/cross-tool-chain-build
+    # The following is due to sed not passing newlines right.
+    system "grep  -q 4096 libsanitizer/asan/asan_linux.cpp || (sed -i '77a #endif' libsanitizer/asan/asan_linux.cpp &&
+    sed -i '77a #define PATH_MAX 4096' libsanitizer/asan/asan_linux.cpp &&
+    sed -i '77a #ifndef PATH_MAX' libsanitizer/asan/asan_linux.cpp)"
+  end
+
+  def self.prebuild
+    @C99 = <<~EOF
+      #!/usr/bin/env sh
+      fl="-std=c99"
+      for opt; do
+        case "$opt" in
+          -std=c99|-std=iso9899:1999) fl="";;
+          -std=*) echo "`basename $0` called with non ISO C99 option $opt" >&2
+              exit 1;;
+        esac
+      done
+      exec gcc $fl ${1+"$@"}
+    EOF
+
+    @C89 = <<~EOF
+      #!/usr/bin/env sh
+      fl="-std=c89"
+      for opt; do
+        case "$opt" in
+          -ansi|-std=c89|-std=iso9899:1990) fl="";;
+          -std=*) echo "`basename $0` called with non ANSI/ISO C option $opt" >&2
+                exit 1;;
+        esac
+      done
+      exec gcc $fl ${1+"$@"}
+    EOF
+    File.write 'c99', @C99
+    File.write 'c89', @C89
+  end
+
+  def self.build
+    @gcc_global_opts = '--disable-bootstrap \
+      --disable-install-libiberty \
+      --disable-libmpx \
+      --disable-libssp \
+      --disable-multilib \
+      --disable-werror \
+      --enable-cet=auto \
+      --enable-checking=release \
+      --enable-clocale=gnu \
+      --enable-default-pie \
+      --enable-default-ssp \
+      --enable-gnu-indirect-function \
+      --enable-gnu-unique-object \
+      --enable-host-shared \
+      --enable-lto \
+      --enable-plugin \
+      --enable-shared \
+      --enable-symvers \
+      --enable-static \
+      --enable-threads=posix \
+      --with-gcc-major-version-only \
+      --with-gmp \
+      --with-isl \
+      --with-mpc \
+      --with-mpfr \
+      --with-pic \
+      --with-system-libunwind \
+      --with-system-zlib'
+
+    @cflags = '-fPIC -pipe'
+    @cxxflags = '-fPIC -pipe'
+    # @languages = 'c,c++,jit,objc,fortran,go'
+    # go build fails on 20220305 snapshot
+    @languages = 'c,c++,jit,objc,fortran'
+    case ARCH
+    when 'armv7l', 'aarch64'
+      @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-fpu=neon --with-tune=cortex-a15'
+    when 'x86_64'
+      @archflags = '--with-arch-64=x86-64'
+    when 'i686'
+      @archflags = '--with-arch-32=i686'
+    end
+
+    # Set ccache sloppiness as per
+    # https://wiki.archlinux.org/index.php/Ccache#Sloppiness
+    system 'ccache --set-config=sloppiness=file_macro,locale,time_macros'
+    # Prefix ccache to path.
+    @path = "#{CREW_LIB_PREFIX}/ccache/bin:#{CREW_PREFIX}/bin:/usr/bin:/bin"
+
+    # Install prereqs using the standard gcc method so they can be
+    # linked statically.
+    # system './contrib/download_prerequisites'
+
+    ## Install newer version of gmp
+    # gmp_url = "https://gmplib.org/download/gmp/gmp-#{@gmp_ver}.tar.lz"
+    # gmp_sha256 = '2c7f4f0d370801b2849c48c9ef3f59553b5f1d3791d070cffb04599f9fc67b41'
+    # system "curl -Ls #{gmp_url} | hashpipe sha256 #{gmp_sha256} | tar --lzip -x"
+    # system "ln -sf ../gmp-#{@gmp_ver} gmp"
+
+    ## Install newer version of isl
+    # isl_url = "http://isl.gforge.inria.fr/isl-#{@isl_ver}.tar.bz2"
+    # isl_sha256 = 'c58922c14ae7d0791a77932f377840890f19bc486b653fa64eba7f1026fb214d'
+    # system "curl -Ls #{isl_url} | hashpipe sha256 #{isl_sha256} | tar xj"
+    # system "ln -sf ../isl-#{@isl_ver} isl"
+
+    ## Install newer version of mpc
+    # mpc_url = "https://ftp.gnu.org/gnu/mpc/mpc-#{@mpc_ver}.tar.gz"
+    # mpc_sha256 = '17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459'
+    # system "curl -Ls #{mpc_url} | hashpipe sha256 #{mpc_sha256} | tar xz"
+    # system "ln -sf ../mpc-#{@mpc_ver} mpc"
+
+    ## Install newer version of mpfr
+    # mpfr_url = "https://www.mpfr.org/mpfr-current/mpfr-#{@mpfr_ver}.tar.xz"
+    # mpfr_sha256 = '0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f'
+    # system "curl -Ls #{mpfr_url} | hashpipe sha256 #{mpfr_sha256} | tar xJ"
+    # Dir.chdir "mpfr-#{@mpfr_ver}" do
+    #  system 'curl -Ls "https://gforge.inria.fr/scm/viewvc.php/mpfr/misc/www/mpfr-4.1.0/allpatches?revision=14491&view=co" | \
+    #    hashpipe sha256 dfa7d8a14ec7cb3b344cb81cfd7bd7e22aba62379941cc9110759f11172ac013 | patch -NZp1 --binary'
+    # end
+    # system "ln -sf ../mpfr-#{@mpfr_ver} mpfr"
+
+    FileUtils.mkdir_p 'objdir/gcc/.deps'
+
+    Dir.chdir('objdir') do
+      system "env NM=gcc-nm AR=gcc-ar RANLIB=gcc-ranlib \
+        CFLAGS='#{@cflags}' CXXFLAGS='#{@cxxflags}' \
+        LDFLAGS='-L#{CREW_LIB_PREFIX}/lib -Wl,-rpath=#{CREW_LIB_PREFIX}' \
+        LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        ../configure #{CREW_OPTIONS} \
+        #{@gcc_global_opts} \
+        #{@archflags} \
+        --with-native-system-header-dir=#{CREW_PREFIX}/include \
+        --enable-languages=#{@languages} \
+        --program-suffix=-#{@gcc_version}"
+      # LIBRARY_PATH=#{CREW_LIB_PREFIX} needed for x86_64 to avoid:
+      # /usr/local/bin/ld: cannot find crti.o: No such file or directory
+      # /usr/local/bin/ld: cannot find /usr/lib64/libc_nonshared.a
+      system "env PATH=#{@path} \
+        LIBRARY_PATH=#{CREW_LIB_PREFIX} \
+        make || make -j1"
+    end
+  end
+
+  # preserve for check, skip check for current version
+  def self.check
+    # Dir.chdir('objdir') do
+    #  system "make -k check -j#{CREW_NPROC} || true"
+    #  system '../contrib/test_summary'
+    # end
+  end
+
+  def self.install
+    gcc_arch = `objdir/gcc/xgcc -dumpmachine`.chomp
+    gcc_dir = "gcc/#{gcc_arch}/#{@gcc_version}"
+    gcc_libdir = "#{CREW_DEST_LIB_PREFIX}/#{gcc_dir}"
+    Dir.chdir('objdir') do
+      # gcc-libs install
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+          make -C #{CREW_TGT}/libgcc DESTDIR=#{CREW_DEST_DIR} install-shared"
+
+      @gcc_libs = %w[libatomic libgfortran libgo libgomp libitm
+                     libquadmath libsanitizer/asan libsanitizer/lsan libsanitizer/ubsan
+                     libsanitizer/tsan libstdc++-v3/src libvtv]
+      @gcc_libs.each do |lib|
+        system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+          make -C #{CREW_TGT}/#{lib} \
+          DESTDIR=#{CREW_DEST_DIR} install-toolexeclibLTLIBRARIES || true"
+      end
+
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libobjc DESTDIR=#{CREW_DEST_DIR} install-libs || true"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libstdc++-v3/po DESTDIR=#{CREW_DEST_DIR} install || true"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libphobos DESTDIR=#{CREW_DEST_DIR} install || true"
+
+      @gcc_libs_info = %w[libgomp libitm libquadmath]
+      @gcc_libs_info.each do |lib|
+        system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+          make -C #{CREW_TGT}/#{lib} DESTDIR=#{CREW_DEST_DIR} install-info || true"
+      end
+
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+          make DESTDIR=#{CREW_DEST_DIR} install-strip"
+
+      # gcc-non-lib install
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C gcc DESTDIR=#{CREW_DEST_DIR} install-driver install-cpp install-gcc-ar \
+        c++.install-common install-headers install-plugin install-lto-wrapper"
+
+      @gcov_install = %w[gcov gcov-tool]
+      @gcov_install.each do |gcov_bin|
+        FileUtils.install "gcc/#{gcov_bin}", "#{CREW_DEST_PREFIX}/bin/#{gcov_bin}-#{@gcc_version}", mode: 0o755
+      end
+
+      FileUtils.mkdir_p gcc_libdir
+      @gcc_libdir_install = %w[cc1 cc1plus collect2 lto1]
+      @gcc_libdir_install.each do |lib|
+        FileUtils.install "gcc/#{lib}", "#{gcc_libdir}/", mode: 0o755
+      end
+
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libgcc DESTDIR=#{CREW_DEST_DIR} install"
+
+      @libstdc_install = %w[src include libsupc++]
+      @libstdc_install.each do |lib|
+        system "env LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} \
+      LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+      make -C #{CREW_TGT}/libstdc++-v3/#{lib} DESTDIR=#{CREW_DEST_DIR} install"
+      end
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libstdc++-v3/python DESTDIR=#{CREW_DEST_DIR} install"
+
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make DESTDIR=#{CREW_DEST_DIR} install-libcc1"
+
+      # http://www.linuxfromscratch.org/lfs/view/development/chapter06/gcc.html#contents-gcc
+      # move a misplaced file
+      # The installation stage puts some files used by gdb under the /usr/local/lib(64) directory.
+      # This generates spurious error messages when performing ldconfig. This command moves the files to another location.
+      FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib"
+      FileUtils.mv Dir.glob("#{CREW_DEST_LIB_PREFIX}/*gdb.py"),
+                   "#{CREW_DEST_PREFIX}/share/gdb/auto-load/usr/lib/"
+
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make DESTDIR=#{CREW_DEST_DIR} install-fixincludes"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C gcc DESTDIR=#{CREW_DEST_DIR} install-mkheaders"
+
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C lto-plugin DESTDIR=#{CREW_DEST_DIR} install"
+
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libgomp DESTDIR=#{CREW_DEST_DIR} install-nodist_libsubincludeHEADERS || true"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libgomp DESTDIR=#{CREW_DEST_DIR} install-nodist_toolexeclibHEADERS || true"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libitm DESTDIR=#{CREW_DEST_DIR} install-nodist_toolexeclibHEADERS || true"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libquadmath DESTDIR=#{CREW_DEST_DIR} install-nodist_libsubincludeHEADERS || true"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libsanitizer DESTDIR=#{CREW_DEST_DIR} install-nodist_sanincludeHEADERS || true"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libsanitizer DESTDIR=#{CREW_DEST_DIR} install-nodist_toolexeclibHEADERS || true"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libsanitizer/asan DESTDIR=#{CREW_DEST_DIR} install-nodist_toolexeclibHEADERS || true"
+      # This failed on i686
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libsanitizer/tsan DESTDIR=#{CREW_DEST_DIR} install-nodist_toolexeclibHEADERS || true"
+      # This might fail on i686
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libsanitizer/lsan DESTDIR=#{CREW_DEST_DIR} install-nodist_toolexeclibHEADERS || true"
+
+      # libiberty is installed from binutils
+      # system "env LD_LIBRARY_PATH=#{CREW_LIB_PREFIX} \
+      #      LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+      #      make -C libiberty DESTDIR=#{CREW_DEST_DIR} install"
+      # install -m644 libiberty/pic/libiberty.a "#{CREW_DEST_PREFIX}/lib"
+
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C gcc DESTDIR=#{CREW_DEST_DIR} install-man install-info"
+
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C libcpp DESTDIR=#{CREW_DEST_DIR} install"
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C gcc DESTDIR=#{CREW_DEST_DIR} install-po"
+
+      # install the libstdc++ man pages
+      system "env LIBRARY_PATH=#{CREW_LIB_PREFIX} PATH=#{@path} \
+        make -C #{CREW_TGT}/libstdc++-v3/doc DESTDIR=#{CREW_DEST_DIR} doc-install-man"
+
+      # byte-compile python libraries
+      system "python -m compileall #{CREW_DEST_PREFIX}/share/gcc-#{@gcc_version}/"
+      system "python -O -m compileall #{CREW_DEST_PREFIX}/share/gcc-#{@gcc_version}"
+    end
+
+    Dir.chdir "#{CREW_DEST_MAN_PREFIX}/man1" do
+      Dir.glob("*-#{@gcc_version}.1*").each do |f|
+        @basefile = f.gsub("-#{@gcc_version}", '')
+        FileUtils.ln_sf f, @basefile
+      end
+    end
+
+    Dir.chdir "#{CREW_DEST_PREFIX}/bin/" do
+      Dir.glob("#{gcc_arch}-*-#{@gcc_version}").each do |f|
+        @basefile_nover = f.split(/-#{@gcc_version}/, 2).first
+        puts "Symlinking #{f} to #{@basefile_nover}"
+        FileUtils.ln_sf f, @basefile_nover
+        @basefile_noarch = f.split(/#{gcc_arch}-/, 2).last
+        puts "Symlinking #{f} to #{@basefile_noarch}"
+        FileUtils.ln_sf f, @basefile_noarch
+        @basefile_noarch_nover = @basefile_nover.split(/#{gcc_arch}-/, 2).last
+        puts "Symlinking #{f} to #{@basefile_noarch_nover}"
+        FileUtils.ln_sf f, @basefile_noarch_nover
+        @basefile_noarch_nover_nogcc = @basefile_noarch_nover.split(/gcc-/, 2).last
+        puts "Symlinking #{f} to #{gcc_arch}-#{@basefile_noarch_nover_nogcc}"
+        FileUtils.ln_sf f, "#{gcc_arch}-#{@basefile_noarch_nover_nogcc}"
+      end
+      Dir.glob("*-#{@gcc_version}").each do |f|
+        @basefile_nover = f.split(/-#{@gcc_version}/, 2).first
+        puts "Symlinking #{f} to #{@basefile_nover}"
+        FileUtils.ln_sf f, @basefile_nover
+      end
+      # many packages expect this symlink
+      puts "Symlinking gcc-#{@gcc_version} to cc"
+      FileUtils.ln_sf "gcc-#{@gcc_version}", 'cc'
+    end
+    # libgomp.so conflicts with llvm
+    @deletefiles = %W[#{CREW_DEST_LIB_PREFIX}/libgomp.so]
+    @deletefiles.each do |f|
+      FileUtils.rm f if File.exist?(f)
+    end
+    # make sure current version of gcc LTO plugin for Gold linker is installed.
+    FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
+    puts "Symlinking #{CREW_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so to #{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
+    FileUtils.ln_sf "#{CREW_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so", "#{CREW_DEST_LIB_PREFIX}/bfd-plugins/"
+    # binutils makes a symlink here, but just in case it isn't there.
+    if ARCH == 'x86_64'
+      FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/lib/bfd-plugins/"
+      puts "Symlinking #{CREW_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so to #{CREW_DEST_PREFIX}/lib/bfd-plugins/"
+      FileUtils.ln_sf "#{CREW_PREFIX}/libexec/#{gcc_dir}/liblto_plugin.so", "#{CREW_DEST_PREFIX}/lib/bfd-plugins/"
+    end
+    FileUtils.install 'c99', "#{CREW_DEST_PREFIX}/bin/c99", mode: 0o755
+    FileUtils.install 'c89', "#{CREW_DEST_PREFIX}/bin/c89", mode: 0o755
+  end
+
+  def self.postinstall
+    # check for conflicts with other installed files
+    @override_allowed = %w[gcc11 gcc10]
+    puts 'Checking for conflicts with files from installed packages...'
+    conflicts = []
+    conflictscmd = `grep --exclude #{CREW_META_PATH}#{name}.filelist -Fxf #{CREW_META_PATH}#{name}.filelist #{CREW_META_PATH}*.filelist`
+    conflicts << conflictscmd.gsub(/(\.filelist|#{CREW_META_PATH})/, '').split("\n")
+    conflicts.reject!(&:empty?)
+    unless conflicts.empty?
+      if conflicts_ok?
+        puts 'Handling conflicts with identically named files in other packages. This may take some time...'.orange
+      else
+        puts 'Error: There is a conflict with the same file in another package.'.lightred
+        @_errors = 1
+      end
+      conflicts.each do |conflict|
+        conflict.each do |thisconflict|
+          singleconflict = thisconflict.split(':', -1)
+          if @override_allowed.include?(singleconflict[0])
+            puts "Overriding conflicting file in #{singleconflict[1]} from #{singleconflict[0]}." if @opt_verbose
+            system "sed -i '\\\?^#{singleconflict[1]}?d'  #{CREW_META_PATH}/#{singleconflict[0]}.filelist"
+          end
+        end
+      end
+    end
+  end
+end

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -27,7 +27,7 @@ class Harfbuzz < Package
   depends_on 'brotli'
   depends_on 'bz2'
   depends_on 'chafa'
-  depends_on 'gcc11'
+  depends_on 'gcc'
   depends_on 'glib'
   depends_on 'gobject_introspection' => :build
   depends_on 'fontconfig'

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -3,28 +3,29 @@ require 'package'
 class Libssp < Package
   description 'Libssp is a part of the GCC toolkit.'
   homepage 'https://gcc.gnu.org/'
-  version '11.3'
+  version '12.1'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   compatibility 'all'
-  source_url 'https://gcc.gnu.org/pub/gcc/releases/gcc-11.3.0/gcc-11.3.0.tar.xz'
-  source_sha256 'b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39'
+  source_url 'https://gcc.gnu.org/pub/gcc/releases/gcc-12.1.0/gcc-12.1.0.tar.xz'
+  source_sha256 '62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.3_armv7l/libssp-11.3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.3_armv7l/libssp-11.3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.3_i686/libssp-11.3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/11.3_x86_64/libssp-11.3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.1_armv7l/libssp-12.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.1_armv7l/libssp-12.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.1_i686/libssp-12.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.1_x86_64/libssp-12.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd8a38e46e54f5967b13a2f10fc64ed96ed97c24bc86fc7be6ca2e44a0978205a',
-     armv7l: 'd8a38e46e54f5967b13a2f10fc64ed96ed97c24bc86fc7be6ca2e44a0978205a',
-       i686: '0e3977ade0372d3884fbfcf2118cfcad9e978e7f728295f5fee27ffeec70a247',
-     x86_64: 'd741ef80b07f006decc798ffce3dbb8fb860e7ef46a3a9524f09f6d4649a5743'
+    aarch64: '065f8dd669e4caef511f947239c045a2c95a3fecf445deb7d96eda51d3386aa0',
+     armv7l: '065f8dd669e4caef511f947239c045a2c95a3fecf445deb7d96eda51d3386aa0',
+       i686: '50e28f45d8f31bedc6b39696135e25e50200bf706ce6d63598ddfc60b5b764cb',
+     x86_64: '86846d918f1bfb80b414c3e0074aed9316930b924ea3e6e278d35c8d1b160081'
   })
 
   depends_on 'ccache' => :build
   depends_on 'dejagnu' => :build # for test
   depends_on 'glibc' # R
+  patchelf
 
   @gcc_name = 'libssp'
 

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -6,24 +6,29 @@ require 'package'
 class Mold < Package
   description 'A Modern Linker'
   homepage 'https://github.com/rui314/mold'
-  version '1.2.1'
+  version '1.2.1-d8a8877'
   compatibility 'all'
   source_url 'https://github.com/rui314/mold.git'
-  git_hashtag "v#{version}"
+  git_hashtag 'd8a8877875d96d0efdb727b4ba600ee3910a333f'
+
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1_armv7l/mold-1.2.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1_armv7l/mold-1.2.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1_i686/mold-1.2.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1_x86_64/mold-1.2.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1-d8a8877_armv7l/mold-1.2.1-d8a8877-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1-d8a8877_armv7l/mold-1.2.1-d8a8877-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1-d8a8877_i686/mold-1.2.1-d8a8877-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.2.1-d8a8877_x86_64/mold-1.2.1-d8a8877-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c5d2cb41de614fd6348195619e6f6132e1382ab08a3ef914b90b640fab48d2ac',
-     armv7l: 'c5d2cb41de614fd6348195619e6f6132e1382ab08a3ef914b90b640fab48d2ac',
-       i686: '659f6da41b604fcc900c70e5805209b1ac0b3b8d3e026c719f0d57f222944e8d',
-     x86_64: '7cd47648337aacc6f8b137693b2626bff44649b5ba4c0422f9a9fadc27504150'
+    aarch64: '3d79cc7d4283e165e469b5e9f3c38ce7528e6f0e04c5a3cddc6443ea32c41fd4',
+     armv7l: '3d79cc7d4283e165e469b5e9f3c38ce7528e6f0e04c5a3cddc6443ea32c41fd4',
+       i686: '6acb72f499175a5a42f9ff14df89631009277de3fcfdaebb62a22b3d338a2c9e',
+     x86_64: 'a6beb44615308b7747999fc7856e30c493c4c4faadf5d25b03bd5cb32852fddb'
   })
 
+  depends_on 'zlibpkg' # R
+  depends_on 'glibc' # R
+  depends_on 'openssl' # R
+  depends_on 'gcc12' # R
   depends_on 'xxhash' => :build
   no_env_options
 

--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -25,7 +25,7 @@ class Wayland < Package
 
   depends_on 'expat'
   depends_on 'libxml2'
-  depends_on 'gcc11'
+  depends_on 'gcc'
   depends_on 'icu4c'
   depends_on 'zlibpkg'
   depends_on 'libffi'


### PR DESCRIPTION
- Update gcc12 and libssp to 12.1.0
- Update mold (built with gcc12 as per upstream patch to [fix chromebrew build issue.](https://github.com/rui314/mold/issues/410))

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gcc12 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
