### PR TITLE
crew: Don't use patchelf if a package specifies no_compile_needed

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1059,7 +1059,7 @@ def prepare_package(destdir)
 end
 
 def patchelf_set_need_paths(dir)
-  return if @pkg.no_patchelf?
+  return if @pkg.no_patchelf? or @pkg.no_compile_needed?
 
   Dir.chdir dir do
     puts 'Running patchelf'.lightblue

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.15'
+CREW_VERSION = '1.23.16'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
- This speeds up firefox installs.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=nocompilenopatchelf CREW_TESTING=1 crew update
```
