### PR TITLE
openssl rebuilds, add gcc12 to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 ARCH="${ARCH/armv8l/armv7l}"
 
 # BOOTSTRAP_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
-BOOTSTRAP_PACKAGES="musl_zstd pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd rsync ruby"
+BOOTSTRAP_PACKAGES="musl_zstd pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd gcc12 rsync ruby"
 
 # Add musl bin to path
 PATH=/usr/local/share/musl/bin:$PATH

--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -23,7 +23,7 @@ class Popt < Package
   })
 
   depends_on 'glibc' # R
-  depends_on 'gcc12' if ARCH == 'i686' # R
+  depends_on 'gcc12' unless ARCH == 'x86_64' # R
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'

--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -3,24 +3,27 @@ require 'package'
 class Popt < Package
   description 'Library for parsing command line options'
   homepage 'https://directory.fsf.org/wiki/Popt'
-  version '78ebda3'
+  version '1.18-7182e46'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/rpm-software-management/popt.git'
-  git_hashtag '78ebda342ca9bec60e4dd5f1d5b720dade3ab4b2'
+  git_hashtag '7182e4618ad5a0186145fc2aa4a98c2229afdfa8'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_armv7l/popt-78ebda3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_armv7l/popt-78ebda3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_i686/popt-78ebda3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/78ebda3_x86_64/popt-78ebda3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46_armv7l/popt-1.18-7182e46-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46_armv7l/popt-1.18-7182e46-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46_i686/popt-1.18-7182e46-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46_x86_64/popt-1.18-7182e46-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2ba47ce5e9cf8493c82d371da80dc4e5a0e0d7bc0cf36996781b089d01e3b8d1',
-     armv7l: '2ba47ce5e9cf8493c82d371da80dc4e5a0e0d7bc0cf36996781b089d01e3b8d1',
-       i686: '611be7ffbadab77c9da3492f13fbc8860522ec01adefbfbb462fb9c1afc76530',
-     x86_64: '591ff491561a48dc2a993b718a554dc303fab823929dc622963d6144db6e5fe1'
+    aarch64: '5bc51a9e367fac643a4c39acf250d8989c606c3d49c5ee41a662911acfc6863d',
+     armv7l: '5bc51a9e367fac643a4c39acf250d8989c606c3d49c5ee41a662911acfc6863d',
+       i686: '3ef4682d25a75e2d3464a5479744d9bd57473e9e303d1161fa4a2945752d3eb5',
+     x86_64: '93a2f1c02bda8ceee0c4cec070eab58bb997ba1a80e5cd0c37d4052464da4ce2'
   })
+
+  depends_on 'glibc' # R
+  depends_on 'gcc12' if ARCH == 'i686' # R
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'

--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -3,30 +3,34 @@ require 'package'
 class Rsync < Package
   description 'rsync is an open source utility that provides fast incremental file transfer.'
   homepage 'https://rsync.samba.org/'
-  @_ver = '3.2.3'
-  version "#{@_ver}-2"
+  @_ver = '3.2.4'
+  version @_ver.to_s
   license 'GPL-3'
   compatibility 'all'
   source_url "http://rsync.samba.org/ftp/rsync/src/rsync-#{@_ver}.tar.gz"
-  source_sha256 'becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e'
+  source_sha256 '6f761838d08052b0b6579cf7f6737d93e47f01f4da04c5d24d3447b7f2a5fad1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_armv7l/rsync-3.2.3-2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_armv7l/rsync-3.2.3-2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_i686/rsync-3.2.3-2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.3-2_x86_64/rsync-3.2.3-2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.4_armv7l/rsync-3.2.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.4_armv7l/rsync-3.2.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.4_i686/rsync-3.2.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.4_x86_64/rsync-3.2.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ba288d6e49f3bef27932e810d58206b1c3c8c60bfb5ef3168bbded428ee89a0b',
-     armv7l: 'ba288d6e49f3bef27932e810d58206b1c3c8c60bfb5ef3168bbded428ee89a0b',
-       i686: '6eb5c8f79b5e29ad461f833738db4251bfbadb037ab2ea8030ed3516e709c1a4',
-     x86_64: '7f8006dc3358106d7f949b8a344746cc7b445c03bb9640238b1d48322f5c07ae'
+    aarch64: 'a2a22a25d50fe400ddb6cd525abbfea05f82fb36e2da0dd6550402b8a0529327',
+     armv7l: 'a2a22a25d50fe400ddb6cd525abbfea05f82fb36e2da0dd6550402b8a0529327',
+       i686: 'f78152b34b3ccfb798f890ac78a8174f03bf27fe750fb747576e5274f3f3045f',
+     x86_64: '78d02794bbea0bfc750a4f216eb855b43179b22d0c0366119544692c0881b160'
   })
 
-  depends_on 'xxhash'
-  depends_on 'lz4'
-  depends_on 'popt'
-  depends_on 'zstd'
+  depends_on 'acl' # R
+  depends_on 'attr' # R
+  depends_on 'glibc' # R
+  depends_on 'lz4' # R
+  depends_on 'openssl' # R
+  depends_on 'popt' # R
+  depends_on 'xxhash' # R
+  depends_on 'zstd' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS} --disable-maintainer-mode"

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -3,28 +3,38 @@ require 'package'
 class Ruby < Package
   description 'Ruby is a dynamic, open source programming language with a focus on simplicity and productivity.'
   homepage 'https://www.ruby-lang.org/en/'
-  version '3.1.2'
+  @_ver = '3.1.2'
+  version "#{@_ver}-1"
   license 'Ruby-BSD and BSD-2'
   compatibility 'all'
   source_url 'https://github.com/ruby/ruby.git'
-  git_hashtag "v#{version.tr('.', '_')}"
+  git_hashtag "v#{@_ver.tr('.', '_')}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2_armv7l/ruby-3.1.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2_armv7l/ruby-3.1.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2_i686/ruby-3.1.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2_x86_64/ruby-3.1.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-1_armv7l/ruby-3.1.2-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-1_armv7l/ruby-3.1.2-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-1_i686/ruby-3.1.2-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-1_x86_64/ruby-3.1.2-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ecdc85c4e4e790de310c8fcc8550ea29f8c842e782e5fc6abb6ef516b89c066f',
-     armv7l: 'ecdc85c4e4e790de310c8fcc8550ea29f8c842e782e5fc6abb6ef516b89c066f',
-       i686: '60c190389e21bdffb689ddb62220dcc96a94c9200428124dd2e0303d09954252',
-     x86_64: 'b4b9564d4c67ad01096e401bf654535025cd9c274b0faeedc8a4d53906046f47'
+    aarch64: '83fe8527ef252f66e831b2ac4941722076567e11d89245e0a128cac82d8e3e80',
+     armv7l: '83fe8527ef252f66e831b2ac4941722076567e11d89245e0a128cac82d8e3e80',
+       i686: 'b730c0bf7e18b8a37e23004a29f2cbd0e6f6aa01e368a5993cb93f0d26a49816',
+     x86_64: 'a54b69a20abf4608f6431b762d6ddb0c5cd4a4d0e91bdcb0aedb7dcc0e9175bd'
   })
 
+  depends_on 'zlibpkg' # R
+  depends_on 'glibc' # R
+  depends_on 'gmp' # R
+  depends_on 'gcc12' # R
+  depends_on 'libffi' # R
+  depends_on 'openssl' # R
+  depends_on 'libyaml' # R
+  depends_on 'readline' # R
   depends_on 'ca_certificates'
   depends_on 'libyaml' # This is needed to install gems
-  # at run-time, system's gmp, openssl, readline and zlibpkg are possible to use
+  # at run-time, system's gmp, openssl, readline and zlibpkg can be used
+
   no_env_options
 
   def self.build


### PR DESCRIPTION
- Install is currently broken due to rsync and ruby complaining about the just rebuilt openssl, so `rsync`, `ruby`, and `popt` (dep of rsync) are rebuilt in this PR. (rsync and popt are actually updated.)
- Also, `gcc12` is added to `install.sh` since gcc12's libgcc may be needed for ruby at install time.
- (This can hopefully be adjusted to just have gcc12::libs once we port that function to work in `install.sh` @supechicken 

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=openssl_rebuilds  CREW_TESTING=1 crew update
```
