### PR TITLE
Rebuild openssl & popt w/o patchelf, add no_patchelf to other bootstrap packages

### DIFF
--- a/packages/ca_certificates.rb
+++ b/packages/ca_certificates.rb
@@ -23,6 +23,8 @@ class Ca_certificates < Package
      x86_64: '4f3ef9802940646facd1408b34b378ef866829d1c60b3b23560465afff5b97c3'
   })
 
+  no_patchelf
+
   def self.patch
     # Patch from:
     # https://gitweb.gentoo.org/repo/gentoo.git/plain/app-misc/ca-certificates/files/ca-certificates-20150426-root.patch

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -39,6 +39,7 @@ class Git < Package
 
   is_musl
   is_static
+  no_patchelf
 
   def self.patch
     # Patch to prevent error function conflict with libidn2

--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -22,6 +22,8 @@ class Gmp < Package
      x86_64: '50847bd14c11de841c7c74696e2ff4503253bbaacd38e9ffb31814d6ccfb76f3'
   })
 
+  no_patchelf
+
   def self.build
     system 'filefix'
     system "./configure \

--- a/packages/libyaml.rb
+++ b/packages/libyaml.rb
@@ -22,6 +22,8 @@ class Libyaml < Package
      x86_64: '157e3e7c7dad0cea905a78944270b7b1fdd58bd363eeb167784a6d90a8c362b8',
   })
 
+  no_patchelf
+
   def self.build
     system "./configure #{CREW_OPTIONS}"
     system 'make'

--- a/packages/lz4.rb
+++ b/packages/lz4.rb
@@ -22,6 +22,8 @@ class Lz4 < Package
      x86_64: '6042be5675f4a8d7deb51f595bb97fcd4932be5ffcd8ffbc3d2e8c9de03d55ba',
   })
 
+  no_patchelf
+
   def self.build
     system 'make', "PREFIX=#{CREW_PREFIX}"
   end

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -22,6 +22,8 @@ class Ncurses < Package
      x86_64: '567cf7a40682009b0b817795e62e248374e87896ab76e5bd5fc69f98d252bf31'
   })
 
+  no_patchelf
+
   def self.build
     # build libncurses
     Dir.mkdir 'ncurses_build'

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -4,26 +4,27 @@ class Openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
   @_ver = '1.1.1o'
-  version @_ver
+  version "#{@_ver}-1"
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
   source_sha256 '9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1o_armv7l/openssl-1.1.1o-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1o_armv7l/openssl-1.1.1o-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1o_i686/openssl-1.1.1o-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1o_x86_64/openssl-1.1.1o-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1o-1_armv7l/openssl-1.1.1o-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1o-1_armv7l/openssl-1.1.1o-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1o-1_i686/openssl-1.1.1o-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1o-1_x86_64/openssl-1.1.1o-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'fd3e9dea038b65e611bc0668b4f2532525fdacee4146c57881efd9e64f87691f',
-     armv7l: 'fd3e9dea038b65e611bc0668b4f2532525fdacee4146c57881efd9e64f87691f',
-       i686: '7ba7e3a6071faa345a30755f5a9f836298964240fd9f6da75b24963426470fb1',
-     x86_64: '169a7333e640476541d9f11c7c49953942a0162272bd749a942f4a72326577fd'
+    aarch64: '8d3aebd58570d123e253ca53516012d907ae0ae908dd1c0dc45e65b782f2d927',
+     armv7l: '8d3aebd58570d123e253ca53516012d907ae0ae908dd1c0dc45e65b782f2d927',
+       i686: '43831e6753b8598462c6759b337d722c374632075de3e737f0a42231508167ec',
+     x86_64: '4d52d5fa7c5950d4bee7cde519346b267bfcd725b725d6ba8325b92a84cc551c'
   })
 
   depends_on 'ccache' => :build
+  no_patchelf
 
   case ARCH
   when 'aarch64', 'armv7l'
@@ -60,7 +61,8 @@ class Openssl < Package
   end
 
   def self.check
-    system 'make test'
+    # Don't run tests if we are just rebuilding the same version of openssl.
+    system 'make test' unless `openssl version | awk '{print $2}'`.chomp == @_ver
   end
 
   def self.install

--- a/packages/pixz.rb
+++ b/packages/pixz.rb
@@ -28,6 +28,7 @@ class Pixz < Package
   depends_on 'asciidoc' => :build
   depends_on 'libarchive'
   depends_on 'xzutils'
+  no_patchelf
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'

--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -23,6 +23,7 @@ class Popt < Package
   })
 
   depends_on 'glibc' # R
+  depends_on 'gcc12' unless ARCH == 'x86_64' # R
   no_patchelf
 
   def self.build

--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -3,27 +3,27 @@ require 'package'
 class Popt < Package
   description 'Library for parsing command line options'
   homepage 'https://directory.fsf.org/wiki/Popt'
-  version '1.18-7182e46'
+  version '1.18-7182e46-1'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/rpm-software-management/popt.git'
   git_hashtag '7182e4618ad5a0186145fc2aa4a98c2229afdfa8'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46_armv7l/popt-1.18-7182e46-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46_armv7l/popt-1.18-7182e46-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46_i686/popt-1.18-7182e46-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46_x86_64/popt-1.18-7182e46-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_armv7l/popt-1.18-7182e46-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_armv7l/popt-1.18-7182e46-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_i686/popt-1.18-7182e46-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_x86_64/popt-1.18-7182e46-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5bc51a9e367fac643a4c39acf250d8989c606c3d49c5ee41a662911acfc6863d',
-     armv7l: '5bc51a9e367fac643a4c39acf250d8989c606c3d49c5ee41a662911acfc6863d',
-       i686: '3ef4682d25a75e2d3464a5479744d9bd57473e9e303d1161fa4a2945752d3eb5',
-     x86_64: '93a2f1c02bda8ceee0c4cec070eab58bb997ba1a80e5cd0c37d4052464da4ce2'
+    aarch64: '7f4e3731424ab89c32d4d492715b421f7a2e08ff3722f42db56c116abed0afde',
+     armv7l: '7f4e3731424ab89c32d4d492715b421f7a2e08ff3722f42db56c116abed0afde',
+       i686: '1d7715334c368c049386f977c50a234f1f9204c829301b1a5482740d526acefe',
+     x86_64: 'f97c13e9e22bda93cc219dd899947f2269c2a2e997e713810e9603ad8ba69d6b'
   })
 
   depends_on 'glibc' # R
-  depends_on 'gcc12' unless ARCH == 'x86_64' # R
+  no_patchelf
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'

--- a/packages/xxhash.rb
+++ b/packages/xxhash.rb
@@ -22,6 +22,8 @@ class Xxhash < Package
      x86_64: 'a6d0d300a1e11a255d545f759598c35b280083055954765c4f68e5c733e74ecc',
   })
 
+  no_patchelf
+
   def self.build
     system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}"
   end

--- a/packages/zstd.rb
+++ b/packages/zstd.rb
@@ -24,6 +24,7 @@ class Zstd < Package
   })
 
   depends_on 'musl_zstd'
+  no_patchelf
 
   def self.build
     Dir.chdir 'build/cmake' do


### PR DESCRIPTION
- All `BOOTSTRAP_PACKAGES` used in install.sh need to be built w/o patchelf, otherwise they can't use system libraries before Chromebrew libraries are installed.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=openssl_nopatchelf CREW_TESTING=1 crew update
```
