### PR TITLE
rebuild of musl_openssl with rand-seed, and also rebuild git, musl_curl

### DIFF
--- a/packages/git.rb
+++ b/packages/git.rb
@@ -4,23 +4,23 @@ class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
   @_ver = '2.36.1'
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.36.1.tar.xz'
   source_sha256 '405d4a0ff6e818d1f12b3e92e1ac060f612adcb454f6299f70583058cb508370'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.36.1_armv7l/git-2.36.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.36.1_armv7l/git-2.36.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.36.1_i686/git-2.36.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.36.1_x86_64/git-2.36.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.36.1-1_armv7l/git-2.36.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.36.1-1_armv7l/git-2.36.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.36.1-1_i686/git-2.36.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.36.1-1_x86_64/git-2.36.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3604d08ece40aa20e8c6164bce16f07616f732392a5e46acc4de110f19f713d0',
-     armv7l: '3604d08ece40aa20e8c6164bce16f07616f732392a5e46acc4de110f19f713d0',
-       i686: '48ecfadf2d2b32eed81668a21a680ae62f22e038f813f48d47720909ade19dab',
-     x86_64: '7485285cca0f607c8be984a7295f0a9813e8e0ff44d74e75c85acea292a2b4f8'
+    aarch64: '1d95807cebb27dc40f9ae0aa6740cb944b9f54fa6b435bcd70a3fbecd1420d00',
+     armv7l: '1d95807cebb27dc40f9ae0aa6740cb944b9f54fa6b435bcd70a3fbecd1420d00',
+       i686: 'e963a67154ca6b70c8cdff85ba601cbfec8417708f44b22afc9964b93674a989',
+     x86_64: '89bb1db2cc774b8716e308db91e5c9a1a1712a9bf9da238ce36f308ef6308e39'
   })
 
   depends_on 'ca_certificates' => :build

--- a/packages/musl_curl.rb
+++ b/packages/musl_curl.rb
@@ -4,23 +4,23 @@ class Musl_curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
   @_ver = '7.83.1'
-  version @_ver.to_s
+  version "#{@_ver}-1"
   license 'curl'
   compatibility 'all'
   source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
   source_sha256 '2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_curl/7.83.1_armv7l/musl_curl-7.83.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_curl/7.83.1_armv7l/musl_curl-7.83.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_curl/7.83.1_i686/musl_curl-7.83.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_curl/7.83.1_x86_64/musl_curl-7.83.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_curl/7.83.1-1_armv7l/musl_curl-7.83.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_curl/7.83.1-1_armv7l/musl_curl-7.83.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_curl/7.83.1-1_i686/musl_curl-7.83.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_curl/7.83.1-1_x86_64/musl_curl-7.83.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e761eea6a6880d8553c13085cb7864ec7576571b38504bf0b5b63357290bbbd4',
-     armv7l: 'e761eea6a6880d8553c13085cb7864ec7576571b38504bf0b5b63357290bbbd4',
-       i686: '67a1d55db6b522fa2139ca5cba47717ea1ddc1ff611f80f946dbb2454a260299',
-     x86_64: 'd723d24bc53e0a083002c6ad409eef7be8c2eda5b16190061bf4e7faf39275f2'
+    aarch64: '47fe9daa31bc359467cb02c5a300267511fe9cad1a96fb8456ae006bd8ce998e',
+     armv7l: '47fe9daa31bc359467cb02c5a300267511fe9cad1a96fb8456ae006bd8ce998e',
+       i686: 'e360541229fcd5b7efa2486225f43936ea71986cd755b80287bd35462b571fc9',
+     x86_64: '5379bafb00482c6406b9daa17eb5dee87b6ecb718d54ccf3ac5b918298003678'
   })
 
   depends_on 'ca_certificates' => :build

--- a/packages/musl_openssl.rb
+++ b/packages/musl_openssl.rb
@@ -4,23 +4,23 @@ class Musl_openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
   @_ver = '3.0.3'
-  version @_ver
+  version "#{@_ver}-1"
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
   source_sha256 'ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.3_armv7l/musl_openssl-3.0.3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.3_armv7l/musl_openssl-3.0.3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.3_i686/musl_openssl-3.0.3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.3_x86_64/musl_openssl-3.0.3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.3-1_armv7l/musl_openssl-3.0.3-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.3-1_armv7l/musl_openssl-3.0.3-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.3-1_i686/musl_openssl-3.0.3-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.3-1_x86_64/musl_openssl-3.0.3-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'b5e5e2ee3f997a5c4b0ed556c9910152620cdb6077a35cdc3618ffbc3ae19783',
-     armv7l: 'b5e5e2ee3f997a5c4b0ed556c9910152620cdb6077a35cdc3618ffbc3ae19783',
-       i686: 'd05edf1e5a84af558c55b8370164dcb7b00c9b3ef05491102c0d4ae7a716e768',
-     x86_64: 'bc294a522e698f72afba02f6b1e1b757fca513c0d082cbfef6096b89cd122bd4'
+    aarch64: '4fef0865c1fbe05a53c9f5b780dcaa057d9a9392850f0f49cd5ad4e61c557bb5',
+     armv7l: '4fef0865c1fbe05a53c9f5b780dcaa057d9a9392850f0f49cd5ad4e61c557bb5',
+       i686: '5be37951d05b99439b34f8964435f9b60a9b35a8b2ee2aae7ae617b6ab70f47f',
+     x86_64: '2359bf9d949a73617bae01b42368af122541f2464d56964acd47ccb31201f8c3'
   })
 
   depends_on 'musl_native_toolchain' => :build
@@ -33,13 +33,19 @@ class Musl_openssl < Package
   is_static
 
   def self.build
+    # rand-seed is needed to keep git from breaking with an error about
+    # insufficient randomness being available.
     case ARCH
     when 'aarch64', 'armv7l'
       @openssl_configure_target = 'linux-generic32'
+      # rdcpu breaks armv7l builds with OpenSSL 3.0.3
+      @rand_seed = 'os,getrandom'
     when 'i686'
       @openssl_configure_target = 'linux-elf'
+      @rand_seed = 'os,getrandom,rdcpu'
     when 'x86_64'
       @openssl_configure_target = 'linux-x86_64'
+      @rand_seed = 'os,getrandom,rdcpu'
     end
     # Use debian build options to work around problem building on armv7l.
     # Disable cast because it breaks i686 builds.
@@ -58,6 +64,7 @@ class Musl_openssl < Package
         no-ssl3-method \
         no-tests \
         no-zlib \
+        --with-rand-seed=#{@rand_seed} \
         -static --static \
         -Wl,-rpath=#{CREW_MUSL_PREFIX}/lib -Wl,--enable-new-dtags \
         -Wl,-Bsymbolic \


### PR DESCRIPTION
- The last update to musl_openssl worked around a bug in 3.0.3 on armv7l where rand-seed=rdcpu breaks, but I forgot that we need to still have rand-seed set in OpenSSL, **otherwise git complains of insufficient randomness**.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=openssl_git CREW_TESTING=1 crew update
```
