### PR TITLE
rust -> 1.60.0

### DIFF
--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -3,23 +3,23 @@ require 'package'
 class Rust < Package
   description 'Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.'
   homepage 'https://www.rust-lang.org/'
-  @_ver = '1.59.0'
+  @_ver = '1.60.0'
   version @_ver
   license 'Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'SKIP'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.59.0_armv7l/rust-1.59.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.59.0_armv7l/rust-1.59.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.59.0_i686/rust-1.59.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.59.0_x86_64/rust-1.59.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.60.0_armv7l/rust-1.60.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.60.0_armv7l/rust-1.60.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.60.0_i686/rust-1.60.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.60.0_x86_64/rust-1.60.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dbf49ca3d439fdf5c88e11925d71af44454f11690ffa53276140ce8721d460bd',
-     armv7l: 'dbf49ca3d439fdf5c88e11925d71af44454f11690ffa53276140ce8721d460bd',
-       i686: 'dce519b03936ae60d9aea5630549a3d079193dd5da2217e2af2377b0259aff9a',
-     x86_64: 'ec32f15f83ca611963f96cf76a59692d074a34f9c48b86544e81d77b50ae5db6'
+    aarch64: 'a038eb7a729cd34f293c2d95bc1b26b9ce55b0dd59fd7184cde7f8ae1e9b9c14',
+     armv7l: 'a038eb7a729cd34f293c2d95bc1b26b9ce55b0dd59fd7184cde7f8ae1e9b9c14',
+       i686: 'dda0048df85b2d29885216dd5b715ea0cd1bbcdc10960d51de8919d0e7709ab8',
+     x86_64: '91963df0606c683bead339d9b52cad631bdf1a99e6345a0d8fac31387bf87f1e'
   })
 
   def self.install


### PR DESCRIPTION


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rust CREW_TESTING=1 crew update
```