### PR TITLE
[`llvm`] [`gcc`]: Correct variable name

### DIFF
--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -32,7 +32,7 @@ class Gcc < Package
   depends_on 'libssp' # L
   depends_on 'zstd' # R
 
-  provides 'libs', 'GCC runtime libraries', "#{LIB_SUFFIX}/*.so*"
+  provides 'libs', 'GCC runtime libraries', "#{ARCH_LIB}/*.so*"
 
   no_env_options
   no_patchelf

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -32,7 +32,7 @@ class Llvm < Package
   no_patchelf
 
   provides 'libs', 'LLVM runtime libraries',
-           lambda {|f| File.fnmatch("#{LIB_SUFFIX}/*.so*", f) and f !~ /(clang|lldb)/ }
+           lambda {|f| File.fnmatch("#{ARCH_LIB}/*.so*", f) and f !~ /(clang|lldb)/ }
 
   case ARCH
   when 'aarch64', 'armv7l'


### PR DESCRIPTION
I haven't tested the latest changes in #7018 before this moment...

Fully tested on `x86_64`