### PR TITLE
A New Python Buildsystem: build, flit and installer

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.16'
+CREW_VERSION = '1.23.17'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -235,6 +235,8 @@ PY3_SETUP_BUILD_OPTIONS = "--executable=#{CREW_PREFIX}/bin/python3"
 PY2_SETUP_BUILD_OPTIONS = "--executable=#{CREW_PREFIX}/bin/python2"
 PY_SETUP_INSTALL_OPTIONS_NO_SVEM = "--root=#{CREW_DEST_DIR} --prefix=#{CREW_PREFIX} -O2 --compile"
 PY_SETUP_INSTALL_OPTIONS = "#{PY_SETUP_INSTALL_OPTIONS_NO_SVEM} --single-version-externally-managed"
+PY3_BUILD_OPTIONS = "--wheel --no-isolation"
+PY3_INSTALLER_OPTIONS = "--destdir=#{CREW_DEST_DIR} --compile-bytecode 2 dist/*.whl"
 
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
                        `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.18'
+  version '1.19'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -110,6 +110,10 @@ class Buildessential < Package
   # Python
   depends_on 'python2'
   depends_on 'python3'
+  depends_on 'py3_setuptools'
+  depends_on 'py3_build'
+  depends_on 'py3_installer'
+  depends_on 'py3_flit_core'
 
   # Qt
   #depends_on 'qtcreator'

--- a/packages/py3_build.rb
+++ b/packages/py3_build.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Py3_build < Package
+  description 'Python build is a simple, correct PEP 517 build frontend.'
+  homepage 'https://pypa-build.readthedocs.io/'
+  @_ver = '0.8.0'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/pypa/build.git'
+  git_hashtag @_ver
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.8.0_armv7l/py3_build-0.8.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.8.0_armv7l/py3_build-0.8.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.8.0_i686/py3_build-0.8.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.8.0_x86_64/py3_build-0.8.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '82001da40e13f38282b18237fb19ae2acaa5f618b1bea546705ec81fe66a10e1',
+     armv7l: '82001da40e13f38282b18237fb19ae2acaa5f618b1bea546705ec81fe66a10e1',
+       i686: 'b3979f3a2c4f020dc76a2b1517591af73476e4c03b3c3be4255d689e1c00fe46',
+     x86_64: 'e1c0a3053b017e58ce6bfd2e1b24b5cff11488516d585389640d023e1f7e8c6f'
+  })
+
+  depends_on 'py3_packaging'
+  depends_on 'py3_pep517'
+  depends_on 'py3_tomli'
+
+  def self.build
+    system "python3 -m build #{PY3_BUILD_OPTIONS}"
+  end
+
+  def self.install
+    system "python3 -m installer #{PY3_INSTALLER_OPTIONS}"
+  end
+end

--- a/packages/py3_flit.rb
+++ b/packages/py3_flit.rb
@@ -1,0 +1,38 @@
+require 'package'
+
+class Py3_flit < Package
+  description 'Flit provides simplified packaging of Python modules.'
+  homepage 'https://flit.pypa.io/'
+  @_ver = '3.7.1'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/pypa/flit.git'
+  git_hashtag @_ver
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_flit/3.7.1_armv7l/py3_flit-3.7.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_flit/3.7.1_armv7l/py3_flit-3.7.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_flit/3.7.1_i686/py3_flit-3.7.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_flit/3.7.1_x86_64/py3_flit-3.7.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '0d3d6d84c6086b31bd4e1aadcb507c5492ab87e64dc866e1064343c6fa1e82ec',
+     armv7l: '0d3d6d84c6086b31bd4e1aadcb507c5492ab87e64dc866e1064343c6fa1e82ec',
+       i686: '33b26c11c228eea59b6723633f057171930731b3cc653f864eea093ebd79732f',
+     x86_64: 'ca2b38b085a2bb35d5a42daa20209c15cf94b613eea6ecadd2f4c78afc1ee655'
+  })
+
+  depends_on 'py3_docutils'
+  depends_on 'py3_flit_core'
+  depends_on 'py3_tomli'
+  depends_on 'py3_tomli_w'
+
+  def self.build
+    system "python3 -m build #{PY3_BUILD_OPTIONS}"
+  end
+
+  def self.install
+    system "python3 -m installer #{PY3_INSTALLER_OPTIONS}"
+  end
+end

--- a/packages/py3_flit_core.rb
+++ b/packages/py3_flit_core.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Py3_flit_core < Package
+  description 'Flit provides simplified packaging of Python modules—core portions.'
+  homepage 'https://flit.pypa.io/'
+  @_ver = '3.7.1'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/pypa/flit.git'
+  git_hashtag @_ver
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_flit_core/3.7.1_armv7l/py3_flit_core-3.7.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_flit_core/3.7.1_armv7l/py3_flit_core-3.7.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_flit_core/3.7.1_i686/py3_flit_core-3.7.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_flit_core/3.7.1_x86_64/py3_flit_core-3.7.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '6cd60febd51da85301f56efe8dd2cecb1e9538d39a9b73051fae4e5bcf5ebd38',
+     armv7l: '6cd60febd51da85301f56efe8dd2cecb1e9538d39a9b73051fae4e5bcf5ebd38',
+       i686: 'd0e8c456b76858a20919059f5b9ea450215ed7eaffa9b240c71fc169b99e6b18',
+     x86_64: '02cdf0552501cd995130a2f48d38329beda696c45b7cb20a9224128845d354cb'
+  })
+
+  def self.build
+    Dir.chdir 'flit_core' do
+      system "python3 -m build #{PY3_BUILD_OPTIONS}"
+    end
+  end
+
+  def self.install
+    Dir.chdir 'flit_core' do
+      system "python3 -m installer #{PY3_INSTALLER_OPTIONS}"
+    end
+  end
+end

--- a/packages/py3_installer.rb
+++ b/packages/py3_installer.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Py3_installer < Package
+  description 'Python build is a simple, correct PEP 517 build frontend.'
+  homepage 'https://installer.readthedocs.io/'
+  @_ver = '0.5.1'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/pypa/installer.git'
+  git_hashtag @_ver
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_installer/0.5.1_armv7l/py3_installer-0.5.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_installer/0.5.1_armv7l/py3_installer-0.5.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_installer/0.5.1_i686/py3_installer-0.5.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_installer/0.5.1_x86_64/py3_installer-0.5.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '5e74ca2aacdd953fd8d404394cd184a9c5fdab5b5cd9604285a1c0d60710d305',
+     armv7l: '5e74ca2aacdd953fd8d404394cd184a9c5fdab5b5cd9604285a1c0d60710d305',
+       i686: '2a7eb4c4e3fc39a9f36f50e3d0b30429cc16a327322f35b6a031b76aa10df811',
+     x86_64: 'c4d852d89c1d5ebaa3dc92b96ad2645f4813a04e8982eca6bddcdf14ef90761b'
+  })
+
+  def self.build
+    system "python3 -m build #{PY3_BUILD_OPTIONS}"
+  end
+
+  def self.install
+    system "python3 -m installer #{PY3_INSTALLER_OPTIONS}"
+  end
+end

--- a/packages/py3_packaging.rb
+++ b/packages/py3_packaging.rb
@@ -4,32 +4,32 @@ class Py3_packaging < Package
   description 'Packaging provides core utilities for Python packages'
   homepage 'https://packaging.pypa.io/'
   @_ver = '21.3'
-  version @_ver
+  version "#{@_ver}-1"
   license 'BSD-2 or Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/pypa/packaging.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_packaging/21.3_armv7l/py3_packaging-21.3-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_packaging/21.3_armv7l/py3_packaging-21.3-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_packaging/21.3_i686/py3_packaging-21.3-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_packaging/21.3_x86_64/py3_packaging-21.3-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_packaging/21.3-1_armv7l/py3_packaging-21.3-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_packaging/21.3-1_armv7l/py3_packaging-21.3-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_packaging/21.3-1_i686/py3_packaging-21.3-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_packaging/21.3-1_x86_64/py3_packaging-21.3-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '469e4712247c92fac3ffd8d494fc729e25d434ac9fc6a8fe36b781a4da6e5b37',
-     armv7l: '469e4712247c92fac3ffd8d494fc729e25d434ac9fc6a8fe36b781a4da6e5b37',
-       i686: '5c9b22be25b6e750af2e79f107243c0ce4aaa01fdeb031650602152bb920b3bf',
-     x86_64: 'c18e092f10ce84cb715fa94b38ee38af4c99ddeeaeb6bfc5a5c4b5408b44135d'
+    aarch64: 'bda279e8aee2afcabbf2fe1991a91480254f8d1bc660f4756a05a6c2fd976c2c',
+     armv7l: 'bda279e8aee2afcabbf2fe1991a91480254f8d1bc660f4756a05a6c2fd976c2c',
+       i686: '01428054eeae4807ad922c8c3c61ccae181418ff740553ffd40e88235b5400a7',
+     x86_64: 'a73d7698a0828726649302974e125cb512de29ffd4364aa9a983f365b6cb2ec9'
   })
 
-  depends_on 'py3_setuptools' => :build
+  depends_on 'py3_pyparsing'
 
   def self.build
-    system "python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS}"
+    system "python3 -m build #{PY3_BUILD_OPTIONS}"
   end
 
   def self.install
-    system "python3 setup.py install #{PY_SETUP_INSTALL_OPTIONS}"
+    system "python3 -m installer #{PY3_INSTALLER_OPTIONS}"
   end
 end

--- a/packages/py3_pep517.rb
+++ b/packages/py3_pep517.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Py3_pep517 < Package
+  description 'Python PEP517 is an API to call PEP 517 hooks for building Python packages '
+  homepage 'https://pep517.readthedocs.io/'
+  @_ver = '0.12.0'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/pypa/pep517.git'
+  git_hashtag "v#{@_ver}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pep517/0.12.0_armv7l/py3_pep517-0.12.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pep517/0.12.0_armv7l/py3_pep517-0.12.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pep517/0.12.0_i686/py3_pep517-0.12.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pep517/0.12.0_x86_64/py3_pep517-0.12.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '3859ce14eaff1b97a1e16dcdf742c039d1c8e76e36616a7b2482ec83df10de54',
+     armv7l: '3859ce14eaff1b97a1e16dcdf742c039d1c8e76e36616a7b2482ec83df10de54',
+       i686: '8bd85456f842b652281dec2adf8535fde039c08ab045496ba03107b62b0a26aa',
+     x86_64: '3449cac3f9fde2537161811473c50566d823c8dd5e423db4cc64bf1538d0ef46'
+  })
+
+  depends_on 'py3_tomli'
+
+  def self.build
+    system "python3 -m build #{PY3_BUILD_OPTIONS}"
+  end
+
+  def self.install
+    system "python3 -m installer #{PY3_INSTALLER_OPTIONS}"
+  end
+end

--- a/packages/py3_pyparsing.rb
+++ b/packages/py3_pyparsing.rb
@@ -3,33 +3,31 @@ require 'package'
 class Py3_pyparsing < Package
   description 'The pyparsing module is an alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions.'
   homepage 'https://github.com/pyparsing/pyparsing/'
-  @_ver = '2.4.7'
-  version "#{@_ver}-1"
+  @_ver = '3.0.9'
+  version @_ver
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/pyparsing/pyparsing.git'
   git_hashtag "pyparsing_#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/2.4.7-1_armv7l/py3_pyparsing-2.4.7-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/2.4.7-1_armv7l/py3_pyparsing-2.4.7-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/2.4.7-1_i686/py3_pyparsing-2.4.7-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/2.4.7-1_x86_64/py3_pyparsing-2.4.7-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9_armv7l/py3_pyparsing-3.0.9-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9_armv7l/py3_pyparsing-3.0.9-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9_i686/py3_pyparsing-3.0.9-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9_x86_64/py3_pyparsing-3.0.9-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5c84dec013f9409d5ddad79f5c4034c10541926dde48d5848d946284b2aacb12',
-     armv7l: '5c84dec013f9409d5ddad79f5c4034c10541926dde48d5848d946284b2aacb12',
-       i686: 'c084beab43308489cdc1f2814776354e5d2b94c680e7c75ceccf330945747659',
-     x86_64: '10addc1059f3399f556b9ee9b6b2206abf8c0131ec74ec853465032274acbce9'
+    aarch64: '260491f085b29afd3337a19ed3b6799f209e8ef902a0dc378524617518b50432',
+     armv7l: '260491f085b29afd3337a19ed3b6799f209e8ef902a0dc378524617518b50432',
+       i686: 'c0b44b7b246de089e25f55dbea208910a4489565af2f0d694435fdd49aad647a',
+     x86_64: 'a198eb924014106ccb4577cd3bb4d55be6123c303eb4a445535d2cde488ea694'
   })
 
-  depends_on 'py3_setuptools' => :build
-
   def self.build
-    system "python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS}"
+    system "python3 -m build #{PY3_BUILD_OPTIONS}"
   end
 
   def self.install
-    system "python3 setup.py install #{PY_SETUP_INSTALL_OPTIONS}"
+    system "python3 -m installer #{PY3_INSTALLER_OPTIONS}"
   end
 end

--- a/packages/py3_tomli.rb
+++ b/packages/py3_tomli.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Py3_tomli < Package
+  description "Tomli is a lil' TOML parser."
+  homepage 'https://github.com/hukkin/tomli/'
+  @_ver = '2.0.1'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/hukkin/tomli.git'
+  git_hashtag @_ver
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_tomli/2.0.1_armv7l/py3_tomli-2.0.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_tomli/2.0.1_armv7l/py3_tomli-2.0.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_tomli/2.0.1_i686/py3_tomli-2.0.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_tomli/2.0.1_x86_64/py3_tomli-2.0.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'de41b0810b3aebabd707fbabab530c47baaf08322a11966981a3db1ac2944fc8',
+     armv7l: 'de41b0810b3aebabd707fbabab530c47baaf08322a11966981a3db1ac2944fc8',
+       i686: '0309b9967791f8d04b021437270b4232d2f8365e7668e88b57b144a012a77be2',
+     x86_64: 'edafb58e7d166f341ae3c0d47871b4804c8503cd72069a344584ed7fee7b226f'
+  })
+
+  def self.build
+    system "python3 -m build #{PY3_BUILD_OPTIONS}"
+  end
+
+  def self.install
+    system "python3 -m installer #{PY3_INSTALLER_OPTIONS}"
+  end
+end

--- a/packages/py3_tomli_w.rb
+++ b/packages/py3_tomli_w.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Py3_tomli_w < Package
+  description "Tomli-w is a lil' TOML writer."
+  homepage 'https://github.com/hukkin/tomli-w/'
+  @_ver = '1.0.0'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/hukkin/tomli-w.git'
+  git_hashtag @_ver
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_tomli_w/1.0.0_armv7l/py3_tomli_w-1.0.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_tomli_w/1.0.0_armv7l/py3_tomli_w-1.0.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_tomli_w/1.0.0_i686/py3_tomli_w-1.0.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_tomli_w/1.0.0_x86_64/py3_tomli_w-1.0.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '446079f23706d1e23af65ff654b8e373aec8c3202c99978faea6accc9d7c706b',
+     armv7l: '446079f23706d1e23af65ff654b8e373aec8c3202c99978faea6accc9d7c706b',
+       i686: '1f7ab0a43dd6168dee084f3f293cbcf405c060331bb819cdfac867dd654001c2',
+     x86_64: '6a386b76da03628b1a46f24996370e0a8a9eb6c9c35d0952c9bd63c122e316dc'
+  })
+
+  def self.build
+    system "python3 -m build #{PY3_BUILD_OPTIONS}"
+  end
+
+  def self.install
+    system "python3 -m installer #{PY3_INSTALLER_OPTIONS}"
+  end
+end


### PR DESCRIPTION
The Python Package Authority (PYPA) has decided to make yet another python build system. The idea of this build system is to make packing python packages easier, especially where pip is unnecessary/unwanted such as in linux package management systems (that's us!). After using it, I will have to say it's much easier to figure out and use than `setuptools` so I'm hoping more python packagers will adopt it. The new buildsystem consists of a few packages and their dependencies, and this PR adds them.

![standards](https://user-images.githubusercontent.com/55339220/171071365-d202f131-0cb9-4716-92d6-8e7651164cbe.png)

#### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=new_python_buildsystem CREW_TESTING=1 crew update
```

### Building
Unfortunately, I can't build ARM binaries, and building these is a bit weird, just for the first time. The buildsystem can piggyback off a previous binary, so this is just a one-time thing. In the armv7l container, run:
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=new_python_buildsystem CREW_TESTING=1 crew update
pip install flit-core build installer
/output/crewb py3_{tomli,tomli_w,pep517,installer,build,flit_core,flit}
```

I also modified buildessential to include these packages, because many python packages are already starting to use this system, and they are small.