### PR TITLE
ninja -> 1.11.0

### DIFF
--- a/packages/ninja.rb
+++ b/packages/ninja.rb
@@ -8,7 +8,16 @@ class Ninja < Package
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/ninja-build/ninja.git'
-  git_hashtag 'v' + @_ver
+  git_hashtag "v#{@_ver}"
+
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.0_i686/ninja-1.11.0-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.0_x86_64/ninja-1.11.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'd6d082ec9df9d956812f82734ef7551d484a209487eef2f4fee8c96d7a37365c',
+  x86_64: '389f237b9bbf6869288131087a6a7b62ee3889ba173b2a9e0bd455ebef98f96c'
+  })
 
   depends_on 're2c' => :build
   depends_on 'emacs' => :build
@@ -18,7 +27,7 @@ class Ninja < Package
   end
 
   def self.build
-    system "python3 configure.py --bootstrap"
+    system 'python3 configure.py --bootstrap'
     system 'emacs -Q --batch -f batch-byte-compile misc/ninja-mode.el'
   end
 

--- a/packages/ninja.rb
+++ b/packages/ninja.rb
@@ -3,39 +3,45 @@ require 'package'
 class Ninja < Package
   description 'a small build system with a focus on speed'
   homepage 'https://ninja-build.org'
-  version '1.10.2'
+  @_ver = '1.11.0'
+  version @_ver
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://github.com/ninja-build/ninja/archive/v1.10.2.tar.gz'
-  source_sha256 'ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed'
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.10.2_armv7l/ninja-1.10.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.10.2_armv7l/ninja-1.10.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.10.2_i686/ninja-1.10.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.10.2_x86_64/ninja-1.10.2-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'd6fe1cfab1c8c0c9a4865fcc1918ebe86a4effd17a28d9fc7b90401e550e2b90',
-     armv7l: 'd6fe1cfab1c8c0c9a4865fcc1918ebe86a4effd17a28d9fc7b90401e550e2b90',
-       i686: '36f809229fd7779f0783742a579043c9b8a69ec9454efcb1ff7655fd621d5e45',
-     x86_64: '40ee7476d70e15874acb59b43e4e379c67cc65793ead2af6fbd67331f06193ff'
-  })
+  source_url 'https://github.com/ninja-build/ninja.git'
+  git_hashtag 'v' + @_ver
 
   depends_on 're2c' => :build
+  depends_on 'emacs' => :build
 
   def self.patch
     system 'filefix'
   end
 
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      AR=gcc-ar \
-      python3 configure.py --bootstrap"
+    system "python3 configure.py --bootstrap"
+    system 'emacs -Q --batch -f batch-byte-compile misc/ninja-mode.el'
   end
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/doc/ninja/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/emacs/site-lisp/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/vim/vimfiles/syntax/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/bash-completion/completions/"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/zsh/site-functions/"
+
     FileUtils.install 'ninja', "#{CREW_DEST_PREFIX}/bin/ninja", mode: 0o755
+    FileUtils.install 'doc/manual.asciidoc', "#{CREW_DEST_PREFIX}/share/doc/ninja/manual.asciidoc"
+    FileUtils.install 'misc/ninja-mode.el', "#{CREW_DEST_PREFIX}/share/emacs/site-lisp/ninja-mode.el"
+    FileUtils.install 'misc/ninja-mode.elc', "#{CREW_DEST_PREFIX}/share/emacs/site-lisp/ninja-mode.elc"
+    FileUtils.install 'misc/ninja.vim', "#{CREW_DEST_PREFIX}/share/vim/vimfiles/syntax/ninja.vim"
+    FileUtils.install 'misc/bash-completion', "#{CREW_DEST_PREFIX}/share/bash-completion/completions/ninja"
+    FileUtils.install 'misc/zsh-completion', "#{CREW_DEST_PREFIX}/share/zsh/site-functions/_ninja"
+  end
+
+  def self.check
+    system 'python3 configure.py'
+    system './ninja ninja_test'
+    system './ninja_test'
   end
 end

--- a/packages/ninja.rb
+++ b/packages/ninja.rb
@@ -11,12 +11,16 @@ class Ninja < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.0_i686/ninja-1.11.0-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.0_x86_64/ninja-1.11.0-chromeos-x86_64.tar.zst'
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.0_x86_64/ninja-1.11.0-chromeos-x86_64.tar.zst',
+   aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.0_armv7l/ninja-1.11.0-chromeos-armv7l.tar.zst',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.0_armv7l/ninja-1.11.0-chromeos-armv7l.tar.zst',
+      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.0_i686/ninja-1.11.0-chromeos-i686.tar.zst'
   })
   binary_sha256({
-    i686: 'd6d082ec9df9d956812f82734ef7551d484a209487eef2f4fee8c96d7a37365c',
-  x86_64: '389f237b9bbf6869288131087a6a7b62ee3889ba173b2a9e0bd455ebef98f96c'
+    x86_64: '40ee7476d70e15874acb59b43e4e379c67cc65793ead2af6fbd67331f06193ff',
+   aarch64: '7b87e31690157dc58eb495a8e6daf2f334866a8f5aa0dda171cb6cad1f19cf4d',
+    armv7l: '7b87e31690157dc58eb495a8e6daf2f334866a8f5aa0dda171cb6cad1f19cf4d',
+      i686: 'c34abd516d109070b2c57976f5cb7821b67fe65d5dcd1a010b3e3f3d31f94178'
   })
 
   depends_on 're2c' => :build


### PR DESCRIPTION
Needs armv7l binaries. Added emacs, vim, bash and zsh support. Added asciidoc documentation.

#### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING=1 CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew CREW_TESTING_BRANCH=ninja_1.11.0 crew update
```
