### PR TITLE
cpio -> 2.13

### DIFF
--- a/packages/cpio.rb
+++ b/packages/cpio.rb
@@ -3,34 +3,35 @@ require 'package'
 class Cpio < Package
   description 'GNU cpio copies files into or out of a cpio or tar archive. The archive can be another file on the disk, a magnetic tape, or a pipe.'
   homepage 'https://www.gnu.org/software/cpio/'
-  version '2.12'
+  version '2.13'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'http://ftp.gnu.org/gnu/cpio/cpio-2.12.tar.gz'
-  source_sha256 '08a35e92deb3c85d269a0059a27d4140a9667a6369459299d08c17f713a92e73'
+  source_url 'https://ftpmirror.gnu.org/cpio/cpio-2.13.tar.bz2'
+  source_sha256 'eab5bdc5ae1df285c59f2a4f140a98fc33678a0bf61bdba67d9436ae26b46f6d'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.12_armv7l/cpio-2.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.12_armv7l/cpio-2.12-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.12_i686/cpio-2.12-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.12_x86_64/cpio-2.12-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: 'ce329d2fa0fc9f708af6992a72335ed787e2c6753ed745149f3b343e5d237f0d',
-     armv7l: 'ce329d2fa0fc9f708af6992a72335ed787e2c6753ed745149f3b343e5d237f0d',
-       i686: '9240db94042983365a1c70b762dfee9870ee75697e13b88ae33b86b94d2a7d50',
-     x86_64: '492cb4051825b4de2393229e82ace30f19cd43794f0828d76d0466e97c88916d',
-  })
-
-  depends_on 'binutils'
-  depends_on 'gawk'
+  def self.patch
+    # these patches allow -flto to work
+    _url = "https://github.com/alpinelinux/aports/raw/dfc99097d6372098d36f33a1c80961d3639293f2/community/cpio"
+    downloader "#{_url}/CVE-2021-38185.patch", "a92b9b3367a90cb66e08674df9b62dfacafa85885bfe5b16de0517e1694a2502"
+    downloader "#{_url}/CVE-2021-38185-2.patch", "2a2b3564d3910dfa7b0f595af6a69ed5a664443e786fc770a9a51d453b7af6d1"
+    downloader "#{_url}/CVE-2021-38185-3.patch", "3b337b844cc37043cb49b115fcf0efa0bc6a042eee7ef7a074c74b56d3978156"
+    downloader "#{_url}/gcc-10.patch", "68181f05736e9165493320f5213f76410c496a04ca03a3a7da3eb6f8d0c4e4c1"
+    Dir['*.patch'].each do |filename|
+      system "patch -Np1 -i #{filename} || true" # some patch hunks fail
+    end
+  end
 
   def self.build
-    system './configure'
+    system "./configure #{CREW_OPTIONS} \
+              --enable-mt" # magnetic tape, not manifest tool
     system 'make'
   end
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/cpio.rb
+++ b/packages/cpio.rb
@@ -4,18 +4,22 @@ class Cpio < Package
   description 'GNU cpio copies files into or out of a cpio or tar archive. The archive can be another file on the disk, a magnetic tape, or a pipe.'
   homepage 'https://www.gnu.org/software/cpio/'
   version '2.13'
-  license 'GPL-3'
   compatibility 'all'
+  license 'GPL-3'
   source_url 'https://ftpmirror.gnu.org/cpio/cpio-2.13.tar.bz2'
   source_sha256 'eab5bdc5ae1df285c59f2a4f140a98fc33678a0bf61bdba67d9436ae26b46f6d'
 
   binary_url({
     i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.13_i686/cpio-2.13-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.13_x86_64/cpio-2.13-chromeos-x86_64.tar.zst'
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.13_x86_64/cpio-2.13-chromeos-x86_64.tar.zst',
+ aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.13_armv7l/cpio-2.13-chromeos-armv7l.tar.zst',
+  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.13_armv7l/cpio-2.13-chromeos-armv7l.tar.zst'
   })
   binary_sha256({
     i686: 'af635bbef1f4b56a2ad457e97f0a4794e3b854784f4e86375fe3dea6905e0407',
-  x86_64: '11265e9d8eb7760d0d9e98e80860056793243e622cdf82d4ed2a2ef51722f8ee'
+  x86_64: '11265e9d8eb7760d0d9e98e80860056793243e622cdf82d4ed2a2ef51722f8ee',
+ aarch64: '61e781fe2ff468ae371bc7058f0d970a299d763012bb285895826b099ace958a',
+  armv7l: '61e781fe2ff468ae371bc7058f0d970a299d763012bb285895826b099ace958a'
   })
 
   def self.patch

--- a/packages/cpio.rb
+++ b/packages/cpio.rb
@@ -9,13 +9,22 @@ class Cpio < Package
   source_url 'https://ftpmirror.gnu.org/cpio/cpio-2.13.tar.bz2'
   source_sha256 'eab5bdc5ae1df285c59f2a4f140a98fc33678a0bf61bdba67d9436ae26b46f6d'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.13_i686/cpio-2.13-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cpio/2.13_x86_64/cpio-2.13-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: 'af635bbef1f4b56a2ad457e97f0a4794e3b854784f4e86375fe3dea6905e0407',
+  x86_64: '11265e9d8eb7760d0d9e98e80860056793243e622cdf82d4ed2a2ef51722f8ee'
+  })
+
   def self.patch
     # these patches allow -flto to work
-    _url = "https://github.com/alpinelinux/aports/raw/dfc99097d6372098d36f33a1c80961d3639293f2/community/cpio"
-    downloader "#{_url}/CVE-2021-38185.patch", "a92b9b3367a90cb66e08674df9b62dfacafa85885bfe5b16de0517e1694a2502"
-    downloader "#{_url}/CVE-2021-38185-2.patch", "2a2b3564d3910dfa7b0f595af6a69ed5a664443e786fc770a9a51d453b7af6d1"
-    downloader "#{_url}/CVE-2021-38185-3.patch", "3b337b844cc37043cb49b115fcf0efa0bc6a042eee7ef7a074c74b56d3978156"
-    downloader "#{_url}/gcc-10.patch", "68181f05736e9165493320f5213f76410c496a04ca03a3a7da3eb6f8d0c4e4c1"
+    _url = 'https://github.com/alpinelinux/aports/raw/dfc99097d6372098d36f33a1c80961d3639293f2/community/cpio'
+    downloader "#{_url}/CVE-2021-38185.patch", 'a92b9b3367a90cb66e08674df9b62dfacafa85885bfe5b16de0517e1694a2502'
+    downloader "#{_url}/CVE-2021-38185-2.patch", '2a2b3564d3910dfa7b0f595af6a69ed5a664443e786fc770a9a51d453b7af6d1'
+    downloader "#{_url}/CVE-2021-38185-3.patch", '3b337b844cc37043cb49b115fcf0efa0bc6a042eee7ef7a074c74b56d3978156'
+    downloader "#{_url}/gcc-10.patch", '68181f05736e9165493320f5213f76410c496a04ca03a3a7da3eb6f8d0c4e4c1'
     Dir['CVE-2021-38185.patch', 'CVE-2021-38185-2.patch', 'CVE-2021-38185-3.patch', 'gcc-10.patch'].each do |filename|
       system "patch -Np1 -i #{filename}"
     end
@@ -28,7 +37,7 @@ class Cpio < Package
   end
 
   def self.install
-    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check

--- a/packages/cpio.rb
+++ b/packages/cpio.rb
@@ -16,8 +16,8 @@ class Cpio < Package
     downloader "#{_url}/CVE-2021-38185-2.patch", "2a2b3564d3910dfa7b0f595af6a69ed5a664443e786fc770a9a51d453b7af6d1"
     downloader "#{_url}/CVE-2021-38185-3.patch", "3b337b844cc37043cb49b115fcf0efa0bc6a042eee7ef7a074c74b56d3978156"
     downloader "#{_url}/gcc-10.patch", "68181f05736e9165493320f5213f76410c496a04ca03a3a7da3eb6f8d0c4e4c1"
-    Dir['*.patch'].each do |filename|
-      system "patch -Np1 -i #{filename} || true" # some patch hunks fail
+    Dir['CVE-2021-38185.patch', 'CVE-2021-38185-2.patch', 'CVE-2021-38185-3.patch', 'gcc-10.patch'].each do |filename|
+      system "patch -Np1 -i #{filename}"
     end
   end
 


### PR DESCRIPTION
Needs armv7l binaires. 

#### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING=1 CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew CREW_TESTING_BRANCH=cpio_2.13 crew update
```
