### PR TITLE
libtool -> 2.4.7

### DIFF
--- a/packages/libtool.rb
+++ b/packages/libtool.rb
@@ -9,6 +9,15 @@ class Libtool < Package
   source_url 'https://ftpmirror.gnu.org/libtool/libtool-2.4.7.tar.xz'
   source_sha256 '4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d'
 
+  binary_url({
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.7_i686/libtool-2.4.7-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.7_x86_64/libtool-2.4.7-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    i686: '1b07197ea6683afa881e858adddb9909a52759af6a80a1bfe14a1cd185c58424',
+  x86_64: '2d23028648189ae30acb1a18b758aeb9ca3146b29bef4cf1758ab4cfc678c490'
+  })
+
   depends_on 'm4'
 
   def self.build
@@ -22,7 +31,6 @@ class Libtool < Package
   end
 
   def self.check
-    puts 'Notice: Libtool checks take a very long time.'.yellow
     system 'make', 'check'
   end
 end

--- a/packages/libtool.rb
+++ b/packages/libtool.rb
@@ -3,35 +3,25 @@ require 'package'
 class Libtool < Package
   description 'GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries behind a consistent, portable interface.'
   homepage 'https://www.gnu.org/software/libtool/'
-  version '2.4.6-4'
+  version '2.4.7'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz'
-  source_sha256 'e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.6-4_armv7l/libtool-2.4.6-4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.6-4_armv7l/libtool-2.4.6-4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.6-4_i686/libtool-2.4.6-4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.6-4_x86_64/libtool-2.4.6-4-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '4d83d3c0d26b8aef3fba0d0d42feaa3fda736652a82ecfd24f4cdce384dc2b0c',
-     armv7l: '4d83d3c0d26b8aef3fba0d0d42feaa3fda736652a82ecfd24f4cdce384dc2b0c',
-       i686: '6eb2da330f7d23c34f41f5f7d94e1abc2f4b4feeb59d4c3886bfb00c8d34b4fb',
-     x86_64: 'c0de77f4eeee3d662c9575b69125fa2778fe623ffad54de5ed296a01622e3724',
-  })
+  source_url 'https://ftpmirror.gnu.org/libtool/libtool-2.4.7.tar.xz'
+  source_sha256 '4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d'
 
   depends_on 'm4'
 
   def self.build
-    system "./configure",
-             "--prefix=#{CREW_PREFIX}",
-             "--libdir=#{CREW_LIB_PREFIX}"
+    system "./configure #{CREW_OPTIONS} \
+            --enable-ltdl-install"
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.check
+    system 'make', 'check'
   end
 end

--- a/packages/libtool.rb
+++ b/packages/libtool.rb
@@ -22,6 +22,7 @@ class Libtool < Package
   end
 
   def self.check
+    puts 'Notice: Libtool checks take a very long time.'.yellow
     system 'make', 'check'
   end
 end

--- a/packages/libtool.rb
+++ b/packages/libtool.rb
@@ -10,12 +10,16 @@ class Libtool < Package
   source_sha256 '4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.7_i686/libtool-2.4.7-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.7_x86_64/libtool-2.4.7-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.7_armv7l/libtool-2.4.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.7_armv7l/libtool-2.4.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.7_i686/libtool-2.4.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtool/2.4.7_x86_64/libtool-2.4.7-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '1b07197ea6683afa881e858adddb9909a52759af6a80a1bfe14a1cd185c58424',
-  x86_64: '2d23028648189ae30acb1a18b758aeb9ca3146b29bef4cf1758ab4cfc678c490'
+    aarch64: '5b4596b096e34beaabac8011062b977b15fc20da158c9a12288a453c310fdc48',
+     armv7l: '5b4596b096e34beaabac8011062b977b15fc20da158c9a12288a453c310fdc48',
+       i686: '1b07197ea6683afa881e858adddb9909a52759af6a80a1bfe14a1cd185c58424',
+     x86_64: '2d23028648189ae30acb1a18b758aeb9ca3146b29bef4cf1758ab4cfc678c490'
   })
 
   depends_on 'm4'
@@ -31,6 +35,10 @@ class Libtool < Package
   end
 
   def self.check
+    # Some tests fail on arm builds.
+    # Link order of deplibs             FAILED (link-order2.at:126)
+    # static linking flags for programs FAILED (static.at:177)
+    # Run tests with low max_cmd_len    FAILED (cmdline_wrap.at:48)
     system 'make', 'check'
   end
 end


### PR DESCRIPTION
needs armv7l binaries. This version of libtool finally finally finally fixes our issue with no file command at `/usr/bin/file`

#### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING=1 CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew CREW_TESTING_BRANCH=libtool_2.4.7 crew update
```
