### PR TITLE
rfkill -> 1.0

### DIFF
--- a/packages/rfkill.rb
+++ b/packages/rfkill.rb
@@ -3,26 +3,11 @@ require 'package'
 class Rfkill < Package
   description 'Tool for enabling and disabling wireless devices.'
   homepage 'http://linuxwireless.org/en/users/Documentation/rfkill'
-  version '0.5'
+  version '1.0'
   license 'ISC'
   compatibility 'all'
-  source_url 'https://www.kernel.org/pub/software/network/rfkill/rfkill-0.5.tar.xz'
-  source_sha256 'e0ae3004215e39a6c5c36e0726558740728d16f67ebdb8bea621250f6091d86a'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rfkill/0.5_armv7l/rfkill-0.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rfkill/0.5_armv7l/rfkill-0.5-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rfkill/0.5_i686/rfkill-0.5-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rfkill/0.5_x86_64/rfkill-0.5-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '23aa25afb00546a728082d06d0b1e4f55a98c684d1bc43003f935efb661dced6',
-     armv7l: '23aa25afb00546a728082d06d0b1e4f55a98c684d1bc43003f935efb661dced6',
-       i686: '38e7c40f7206437a02e33a7219f08d1c47578bb254be0959dc7abbaf073ca1a3',
-     x86_64: 'b491bd154ece2066272972c2110f8bc5d6c9a3ce4a0189fda5825d3cbddb0d71',
-  })
-
-  depends_on 'buildessential' => :build
+  source_url 'https://www.kernel.org/pub/software/network/rfkill/rfkill-1.0.tar.xz'
+  source_sha256 'dffc631c611520478b8a286f57c67a35e8cb5802d376c6ca13b057365432389c'
 
   def self.build
     system "make"
@@ -30,6 +15,8 @@ class Rfkill < Package
 
   def self.install
     system "make", "DESTDIR=#{CREW_DEST_DIR}", "SBINDIR=#{CREW_PREFIX}/sbin", "MANDIR=#{CREW_PREFIX}/share/man", "install"
+    # Manpage is automatically gzipped. Chromebrew double-gzips it when packaging.
+    system "gunzip #{CREW_DEST_MAN_PREFIX}/man8/rfkill.8.gz"
   end
 
   def self.check


### PR DESCRIPTION
needs binaries.
NOTE: rfkill is also provided by util-linux, and that seems to be the standard binary throughout Linux distros, notably, Debian, Fedora and Arch Linux. Should we make this package fake and redirect it to util-linux?

#### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=rfkill_1.0 CREW_TESTING=1 crew update
```