### PR TITLE
`lib/downloader`: Add an option for disabling progress bar

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.23.18'
+CREW_VERSION = '1.23.19'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -81,7 +81,7 @@ else
 end
 
 # If CREW_USE_CURL environment variable exists use curl in lieu of net/http.
-CREW_USE_CURL = ENV['CREW_USE_CURL'] == '1'
+CREW_USE_CURL = ENV['CREW_USE_CURL'].eql?('1')
 
 # Use an external downloader instead of net/http if CREW_DOWNLOADER is set, see lib/downloader.rb for more info
 # About the format of the CREW_DOWNLOADER variable, see line 130-133 in lib/downloader.rb
@@ -89,8 +89,8 @@ CREW_DOWNLOADER = ( ENV['CREW_DOWNLOADER'].to_s.empty? ) ? nil : ENV['CREW_DOWNL
 
 # Downloader maximum retry count
 CREW_DOWNLOADER_RETRY = ( ENV['CREW_DOWNLOADER_RETRY'].to_s.empty? ) ? 3 : ENV['CREW_DOWNLOADER_RETRY'].to_i
-# Downloader show progress bar or not
-CREW_DOWNLOADER_SHOW_PROGBAR = ENV.fetch('CREW_DOWNLOADER_SHOW_PROGBAR', '1').eql?('1')
+# show download progress bar or not (only applied when using the default ruby downloader)
+CREW_HIDE_PROGBAR = ENV['CREW_HIDE_PROGBAR'].eql?('1')
 
 # set certificate file location for lib/downloader.rb
 SSL_CERT_FILE = if ENV['SSL_CERT_FILE'].to_s.empty? || !File.exist?(ENV['SSL_CERT_FILE'])

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -89,6 +89,8 @@ CREW_DOWNLOADER = ( ENV['CREW_DOWNLOADER'].to_s.empty? ) ? nil : ENV['CREW_DOWNL
 
 # Downloader maximum retry count
 CREW_DOWNLOADER_RETRY = ( ENV['CREW_DOWNLOADER_RETRY'].to_s.empty? ) ? 3 : ENV['CREW_DOWNLOADER_RETRY'].to_i
+# Downloader show progress bar or not
+CREW_DOWNLOADER_SHOW_PROGBAR = ENV.fetch('CREW_DOWNLOADER_SHOW_PROGBAR', '1').eql?('1')
 
 # set certificate file location for lib/downloader.rb
 SSL_CERT_FILE = if ENV['SSL_CERT_FILE'].to_s.empty? || !File.exist?(ENV['SSL_CERT_FILE'])

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -133,7 +133,7 @@ def http_downloader (url, filename = File.basename(url), verbose = false)
       # read file chunks from server, write it to filesystem
       File.open(filename, 'wb') do |io|
         response.read_body do |chunk|
-          if CREW_DOWNLOADER_SHOW_PROGBAR
+          unless CREW_HIDE_PROGBAR
             downloaded_size += chunk.size # record downloaded size, used for showing progress bar
             if file_size.positive?
               # calculate downloading progress percentage with the given file size

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -133,15 +133,17 @@ def http_downloader (url, filename = File.basename(url), verbose = false)
       # read file chunks from server, write it to filesystem
       File.open(filename, 'wb') do |io|
         response.read_body do |chunk|
-          downloaded_size += chunk.size # record downloaded size, used for showing progress bar
-          if file_size.positive?
-            # calculate downloading progress percentage with the given file size
-            percentage = (downloaded_size / file_size) * 100
-            # show progress bar, file size and progress percentage
-            printf "\r""[%-#{@progBarW}.#{@progBarW}s] %9.9s %3d%%",
-                   '#' * ( @progBarW * (percentage / 100) ),
-                   human_size(file_size),
-                   percentage
+          if CREW_DOWNLOADER_SHOW_PROGBAR
+            downloaded_size += chunk.size # record downloaded size, used for showing progress bar
+            if file_size.positive?
+              # calculate downloading progress percentage with the given file size
+              percentage = (downloaded_size / file_size) * 100
+              # show progress bar, file size and progress percentage
+              printf "\r""[%-#{@progBarW}.#{@progBarW}s] %9.9s %3d%%",
+                     '#' * ( @progBarW * (percentage / 100) ),
+                     human_size(file_size),
+                     percentage
+            end
           end
           io.write(chunk) # write to file
         end


### PR DESCRIPTION
This allows the user to hide the download progress bar by setting `CREW_DOWNLOADER_SHOW_PROGBAR` to `0`, which is useful when redirecting output to log files (when outputting to log files, the `\r` control char will be ignored by text editors and show many lines of progress bar)

Tested on `x86_64`