### PR TITLE
Fix up licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ License
 Copyright 2013-2022 Michal Siwek and [all the awesome contributors](https://github.com/skycocker/chromebrew/graphs/contributors).
 
 This project including all of its source files is released under the terms of [GNU General Public License (version 3 or later)](http://www.gnu.org/licenses/gpl.txt).
-<a rel="license-software" href="https://www.gnu.org/licenses/gpl-3.0.en.html"><img alt="GNU General Public License" style="border-width:0" src="https://www.gnu.org/graphics/gplv3-127x51.png" height="31" />
 
 This project embeds [docopt.rb](https://github.com/docopt/docopt.rb) at lib/docopt.rb. We retain its [MIT license](https://github.com/skycocker/chromebrew/blob/master/lib/docopt.LICENSE).
-<a rel="license-docopt" href="hhttps://mit-license.org/"><img alt="MIT License" style="border-width:0" src="https://upload.wikimedia.org/wikipedia/commons/0/0c/MIT_logo.svg" height="31" />
+
+<a rel="license-software" href="https://www.gnu.org/licenses/gpl-3.0.en.html"><img alt="GNU General Public License" style="border-width:0" src="https://www.gnu.org/graphics/gplv3-127x51.png" height="31" /></a>
+<a rel="license-docopt" href="https://mit-license.org/"><img alt="MIT License" style="border-width:0" src="https://upload.wikimedia.org/wikipedia/commons/0/0c/MIT_logo.svg" height="31" /></a>

--- a/README.md
+++ b/README.md
@@ -154,3 +154,7 @@ License
 Copyright 2013-2022 Michal Siwek and [all the awesome contributors](https://github.com/skycocker/chromebrew/graphs/contributors).
 
 This project including all of its source files is released under the terms of [GNU General Public License (version 3 or later)](http://www.gnu.org/licenses/gpl.txt).
+<a rel="license-software" href="https://www.gnu.org/licenses/gpl-3.0.en.html"><img alt="GNU General Public License" style="border-width:0" src="https://www.gnu.org/graphics/gplv3-127x51.png" height="31" />
+
+This project embeds [docopt.rb](https://github.com/docopt/docopt.rb) at lib/docopt.rb. We retain its [MIT license](https://github.com/skycocker/chromebrew/blob/master/lib/docopt.LICENSE).
+<a rel="license-docopt" href="hhttps://mit-license.org/"><img alt="MIT License" style="border-width:0" src="https://upload.wikimedia.org/wikipedia/commons/0/0c/MIT_logo.svg" height="31" />

--- a/bin/crew
+++ b/bin/crew
@@ -56,11 +56,12 @@ version #{CREW_VERSION}
 DOCOPT
 
 CREW_LICENSE = <<~LICENSESTRING
-  Copyright (C) 2021 Chromebrew Authors
+  Copyright (C) 2022 Chromebrew Authors
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, version 3 of the License.
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -69,6 +70,10 @@ CREW_LICENSE = <<~LICENSESTRING
 
   You should have received a copy of the GNU General Public License
   along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html.
+
+  Chromebrew embeds lib/docopt.rb from another project under the MIT License.
+  You should have received a copy of the license along with this program.
+  If not, see https://github.com/docopt/docopt.rb/blob/master/LICENSE
 LICENSESTRING
 
 # All available crew commands.

--- a/bin/crew
+++ b/bin/crew
@@ -56,7 +56,7 @@ version #{CREW_VERSION}
 DOCOPT
 
 CREW_LICENSE = <<~LICENSESTRING
-  Copyright (C) 2022 Chromebrew Authors
+  Copyright (C) 2013-2022 Chromebrew Authors
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Waiting on a response from skycocker in #7126

Also changed:
- Added GPLv3 and MIT license images
- Clarified attribution for docopt (MIT license attribution clause) in LICENSESTRING and README
- Updated year in LICENSESTRING (use year range from README)