### PR TITLE
Updates to imagemagick 7, ffmpeg, openjpeg

### DIFF
--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -3,24 +3,24 @@ require 'package'
 class Ffmpeg < Package
   description 'Complete solution to record, convert and stream audio and video'
   homepage 'https://ffmpeg.org/'
-  @_ver = '5.0'
-  version "#{@_ver}-1"
+  @_ver = '5.0.1'
+  version @_ver.to_s
   license 'LGPL-2,1, GPL-2, GPL-3, and LGPL-3' # When changing ffmpeg's configure options, make sure this variable is still accurate.
   compatibility 'all'
   source_url 'https://git.ffmpeg.org/ffmpeg.git'
   git_hashtag "n#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_armv7l/ffmpeg-5.0-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_armv7l/ffmpeg-5.0-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_i686/ffmpeg-5.0-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_x86_64/ffmpeg-5.0-1-chromeos-x86_64.tar.zst'
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_i686/ffmpeg-5.0-1-chromeos-i686.tar.zst',
+ aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0.1_armv7l/ffmpeg-5.0.1-chromeos-armv7l.tar.zst',
+  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0.1_armv7l/ffmpeg-5.0.1-chromeos-armv7l.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0.1_x86_64/ffmpeg-5.0.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'b55ea0c0549d576e0c946180d0b0a3c560aae01d9074ad8b0c5bee2045a3955e',
-     armv7l: 'b55ea0c0549d576e0c946180d0b0a3c560aae01d9074ad8b0c5bee2045a3955e',
-       i686: '91e328f13cdaa3e433ed1a3ebe862b2b81e1c689ba5babc6e7787ba688bfb1b6',
-     x86_64: '7eeca38e7677f959d8516faf79019b2502e578b9aee41ad075d2157aae55c667'
+    i686: '91e328f13cdaa3e433ed1a3ebe862b2b81e1c689ba5babc6e7787ba688bfb1b6',
+ aarch64: '94ab8e4974898ccfbc1cc59104de69014faee16e7b42777f20466fe43c2ece33',
+  armv7l: '94ab8e4974898ccfbc1cc59104de69014faee16e7b42777f20466fe43c2ece33',
+  x86_64: 'bc52e2af52e1158a2b9c86efc992bbd098745b7ab7b34bd9136dcb6a16fab26c'
   })
 
   depends_on 'avisynthplus' # ?

--- a/packages/imagemagick7.rb
+++ b/packages/imagemagick7.rb
@@ -3,7 +3,7 @@ require 'package'
 class Imagemagick7 < Package
   description 'Use ImageMagick to create, edit, compose, or convert bitmap images.'
   homepage 'http://www.imagemagick.org/script/index.php'
-  @_ver = '7.1.0-19'
+  @_ver = '7.1.0-37'
   version @_ver
   license 'imagemagick'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Imagemagick7 < Package
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-19_armv7l/imagemagick7-7.1.0-19-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-19_armv7l/imagemagick7-7.1.0-19-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-19_i686/imagemagick7-7.1.0-19-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-19_x86_64/imagemagick7-7.1.0-19-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-37_armv7l/imagemagick7-7.1.0-37-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-37_armv7l/imagemagick7-7.1.0-37-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-37_i686/imagemagick7-7.1.0-37-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/imagemagick7/7.1.0-37_x86_64/imagemagick7-7.1.0-37-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e4ab61bc827580630719cdcd95036bff97375f7626deaea8a22e2cb8ffdde9a1',
-     armv7l: 'e4ab61bc827580630719cdcd95036bff97375f7626deaea8a22e2cb8ffdde9a1',
-       i686: 'f112987ecd6c6c5be4632ae7f3b953a30d2a4ad1ebeeb92d51d006a300a887cb',
-     x86_64: 'f3f60b31f682ce39b3fc56bb7a3f44d5fd0fcb87c37e0951080fc57dbc852757'
+    aarch64: '734c1dde282b695f90ad9a7af940a088ff91eefcb30189fbcb0b89d5eb14bd3a',
+     armv7l: '734c1dde282b695f90ad9a7af940a088ff91eefcb30189fbcb0b89d5eb14bd3a',
+       i686: '1f0490156c755f3328b6881641251292332ca527bd5fdfa757bf3190f1982dc8',
+     x86_64: '7f9e553d8b73ba2339a800d8668f80d9518879dbf3c2296e55e14f4ebd190edb'
   })
 
   depends_on 'flif'

--- a/packages/openjpeg.rb
+++ b/packages/openjpeg.rb
@@ -3,32 +3,29 @@ require 'package'
 class Openjpeg < Package
   description 'An open source JPEG 2000 codec, written in C.'
   homepage 'https://github.com/uclouvain/openjpeg'
-  version '2.4.0'
+  version '2.5.0'
   license 'BSD-2'
   compatibility 'all'
-  source_url 'https://github.com/uclouvain/openjpeg/archive/v2.4.0.tar.gz'
-  source_sha256 '8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d'
+  source_url 'https://github.com/uclouvain/openjpeg/archive/v2.5.0.tar.gz'
+  source_sha256 '0333806d6adecc6f7a91243b2b839ff4d2053823634d4f6ed7a59bc87409122a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openjpeg/2.4.0_armv7l/openjpeg-2.4.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openjpeg/2.4.0_armv7l/openjpeg-2.4.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openjpeg/2.4.0_i686/openjpeg-2.4.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openjpeg/2.4.0_x86_64/openjpeg-2.4.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openjpeg/2.5.0_armv7l/openjpeg-2.5.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openjpeg/2.5.0_armv7l/openjpeg-2.5.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openjpeg/2.5.0_i686/openjpeg-2.5.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openjpeg/2.5.0_x86_64/openjpeg-2.5.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '595710bad9c20bb9cf549c4ac128c38a7b95d765482a4686f92e9a7c2436492c',
-     armv7l: '595710bad9c20bb9cf549c4ac128c38a7b95d765482a4686f92e9a7c2436492c',
-       i686: 'bab4acb957c546518cff701f1c004778351c7d973bb0c3f42bd4c5e89fd37f87',
-     x86_64: '490073608d724068424b594ef15e77bdef75bcb44beebe6c8fe09eb99f06bd0a'
+    aarch64: 'e8f47ab6ee2e585d41a40def616a99e8c38855cb286a687c264bddc62666f41b',
+     armv7l: 'e8f47ab6ee2e585d41a40def616a99e8c38855cb286a687c264bddc62666f41b',
+       i686: '3cea296254991ddd62be39c5ec3cc901343ec4e06cc5896146780b14fb270cd6',
+     x86_64: '47261041b12e3bb63bc2cd47d285afcc8fabdcd1075b80db0c1a35bf3267a826'
   })
 
   def self.build
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      cmake \
+      system "cmake \
         -G Ninja \
         #{CREW_CMAKE_OPTIONS} \
         -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
Fixes #7129 (Maybe?)

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=imagemagick7_openjpeg_ffmpeg CREW_TESTING=1 crew update
```
