### PR TITLE
Coreutils 9.1 => 9.2

### DIFF
--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -3,24 +3,23 @@ require 'package'
 class Coreutils < Package
   description 'The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system.'
   homepage 'https://www.gnu.org/software/coreutils/coreutils.html'
-  @_ver = '9.1'
-  version @_ver
+  version '9.2'
   license 'GPL-3'
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/gnu/coreutils/coreutils-#{@_ver}.tar.xz"
-  source_sha256 '61a1f410d78ba7e7f37a5a4f50e6d1320aca33375484a3255eddf17a38580423'
+  source_url 'https://ftpmirror.gnu.org/gnu/coreutils/coreutils-9.2.tar.xz'
+  source_sha256 '6885ff47b9cdb211de47d368c17853f406daaf98b148aaecdf10de29cc04b0b3'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/coreutils/9.1_armv7l/coreutils-9.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/coreutils/9.1_armv7l/coreutils-9.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/coreutils/9.1_i686/coreutils-9.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/coreutils/9.1_x86_64/coreutils-9.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/coreutils/9.2_armv7l/coreutils-9.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/coreutils/9.2_armv7l/coreutils-9.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/coreutils/9.2_i686/coreutils-9.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/coreutils/9.2_x86_64/coreutils-9.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '384491c5353bab5d14d731699c5d262947d20dfaa6485eeccb610e566b831b0c',
-     armv7l: '384491c5353bab5d14d731699c5d262947d20dfaa6485eeccb610e566b831b0c',
-       i686: 'd65d86505f3cb596e9ff3190caace4d6f1d8e01a8aa8424e15a398d47b1e275b',
-     x86_64: '0857a1e3af002c5cf70e5ed1d3f6af033c7fcd4e37fbebb6ce01c6730151686d'
+    aarch64: '39540783dbce98b48122fdba187de6a14622fdeec7bc6ceffe399e280379ec4f',
+     armv7l: '39540783dbce98b48122fdba187de6a14622fdeec7bc6ceffe399e280379ec4f',
+       i686: '0745b0227a7f39f3958403cb116974a11189dccc6953a23e2919768e83f769ee',
+     x86_64: '354fc8cfaba39b4bc37cde938ea8bea330d242c3e51cad2835f78d1d4834a829'
   })
 
   depends_on 'libcap' # R
@@ -30,54 +29,29 @@ class Coreutils < Package
     %w[uutils_coreutils].each do |cutils|
       next unless File.exist? "#{CREW_PREFIX}/etc/crew/meta/#{cutils}.filelist"
 
-      puts "#{cutils} installed and conflicts with this version.".orange
+      puts "#{cutils} is installed and conflicts with this version.".orange
       puts 'To install this version, execute the following:'.lightblue
       abort "crew remove #{cutils} && crew install coreutils".lightblue
     end
   end
 
-  def self.patch
-    # Patch from https://git.savannah.gnu.org/cgit/gnulib.git/diff/?id=84863a1c4dc8cca8fb0f6f670f67779cdd2d543b
-    @gnulibpatch = <<~'PATCH_EOF'
-      diff --git a/lib/string.in.h b/lib/string.in.h
-      index b6840fa..33160b2 100644
-      --- a/lib/string.in.h
-      +++ b/lib/string.in.h
-      @@ -583,7 +583,7 @@ _GL_FUNCDECL_RPL (strndup, char *,
-                         _GL_ATTRIBUTE_MALLOC _GL_ATTRIBUTE_DEALLOC_FREE);
-       _GL_CXXALIAS_RPL (strndup, char *, (char const *__s, size_t __n));
-       # else
-      -#  if !@HAVE_DECL_STRNDUP@ || __GNUC__ >= 11
-      +#  if !@HAVE_DECL_STRNDUP@ || (__GNUC__ >= 11 && !defined strndup)
-       _GL_FUNCDECL_SYS (strndup, char *,
-                         (char const *__s, size_t __n)
-                         _GL_ARG_NONNULL ((1))
-      @@ -593,7 +593,7 @@ _GL_CXXALIAS_SYS (strndup, char *, (char const *__s, size_t __n));
-       # endif
-       _GL_CXXALIASWARN (strndup);
-       #else
-      -# if __GNUC__ >= 11
-      +# if __GNUC__ >= 11 && !defined strndup
-       /* For -Wmismatched-dealloc: Associate strndup with free or rpl_free.  */
-       _GL_FUNCDECL_SYS (strndup, char *,
-                         (char const *__s, size_t __n)
-    PATCH_EOF
-    File.write('gnulib.patch', @gnulibpatch)
-    system 'patch -p 1 -i gnulib.patch' if ARCH == 'i686'
-  end
-
   def self.build
     system "./configure #{CREW_OPTIONS}"
     system 'make'
+    arch = <<~EOF
+      #!/bin/bash
+      echo #{ARCH}
+    EOF
+    File.write 'arch', arch
   end
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    system "cat <<'EOF'> #{CREW_DEST_PREFIX}/bin/arch
-#!/bin/bash
-echo \"#{ARCH}\"
-EOF"
-    system "chmod +x #{CREW_DEST_PREFIX}/bin/arch"
+    FileUtils.install 'arch', "#{CREW_DEST_PREFIX}/bin/arch", mode: 0o755
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    # Remove conflicts with psmisc package.
+    Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
+      FileUtils.rm %w[kill uptime]
+    end
   end
 end


### PR DESCRIPTION
Tested binaries on all architectures with `for b in $(crew files coreutils|grep /usr/local/bin); do $b --version; done`.