### PR TITLE
Remove remaining uses of @_ver in git_hashtag

### DIFF
--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -3,12 +3,11 @@ require 'package'
 class Aria2 < Package
   description 'aria2 is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.'
   homepage 'https://aria2.github.io/'
-  @_ver = '1.36.0'
-  version @_ver
+  version '1.36.0'
   license 'GPL-2+-with-openssl-exception'
   compatibility 'all'
   source_url 'https://github.com/aria2/aria2.git'
-  git_hashtag "release-#{@_ver}"
+  git_hashtag "release-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/aria2/1.36.0_armv7l/aria2-1.36.0-chromeos-armv7l.tar.zst',

--- a/packages/bind.rb
+++ b/packages/bind.rb
@@ -3,12 +3,11 @@ require 'package'
 class Bind < Package
   description 'BIND is open source software that enables you to publish your Domain Name System (DNS) information on the Internet, and to resolve DNS queries for your users.'
   homepage 'https://www.isc.org/downloads/bind/'
-  @_ver = '9.19.9'
-  version @_ver
+  version '9.19.9'
   license 'Apache-2.0, BSD, BSD-2, GPL-2, HPND, ISC and MPL-2.0'
   compatibility 'all'
   source_url 'https://gitlab.isc.org/isc-projects/bind9.git'
-  git_hashtag "v#{@_ver.gsub('.', '_')}"
+  git_hashtag "v#{version.gsub('.', '_')}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bind/9.19.9_armv7l/bind-9.19.9-chromeos-armv7l.tar.zst',

--- a/packages/fuse3.rb
+++ b/packages/fuse3.rb
@@ -3,12 +3,11 @@ require 'package'
 class Fuse3 < Package
   description 'The reference implementation of the Linux FUSE (Filesystem in Userspace) interface.'
   homepage 'https://github.com/libfuse/libfuse/'
-  @_ver = '3.14.0'
-  version @_ver
+  version '3.14.0'
   license 'GPL-2+'
   compatibility 'all'
   source_url 'https://github.com/libfuse/libfuse.git'
-  git_hashtag "fuse-#{@_ver}"
+  git_hashtag "fuse-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.14.0_armv7l/fuse3-3.14.0-chromeos-armv7l.tar.zst',

--- a/packages/gmmlib.rb
+++ b/packages/gmmlib.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gmmlib < Package
   description 'The Intel(R) Graphics Memory Management Library provides device specific and buffer management for the Intel(R) Graphics Compute Runtime for OpenCL(TM) and the Intel(R) Media Driver for VAAPI.'
   homepage 'https://github.com/intel/gmmlib/'
-  @_ver = '22.3.3'
-  version @_ver
+  version '22.3.3'
   license 'MIT'
   compatibility 'x86_64'
   source_url 'https://github.com/intel/gmmlib.git'
-  git_hashtag "intel-gmmlib-#{@_ver}"
+  git_hashtag "intel-gmmlib-#{version}"
 
   binary_url({
     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gmmlib/22.3.3_x86_64/gmmlib-22.3.3-chromeos-x86_64.tar.zst'

--- a/packages/gtest.rb
+++ b/packages/gtest.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gtest < Package
   description 'Google Test - C++ testing utility'
   homepage 'https://opensource.google/projects/googletest'
-  @_ver = '1.11.0'
-  version @_ver
+  version '1.11.0'
   license 'BSD-3'
   compatibility 'all'
   source_url 'https://github.com/google/googletest.git'
-  git_hashtag "release-#{@_ver}"
+  git_hashtag "release-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtest/1.11.0_armv7l/gtest-1.11.0-chromeos-armv7l.tar.xz',

--- a/packages/info2man.rb
+++ b/packages/info2man.rb
@@ -3,12 +3,11 @@ require 'package'
 class Info2man < Package
   description 'Convert GNU info files to POD or man pages.'
   homepage 'https://www.cskk.ezoshosting.com/cs/css/info2pod.html'
-  @_ver = '1.1-10'
-  version @_ver
+  version '1.1-10'
   license 'unknown'
   compatibility 'all'
   source_url 'https://salsa.debian.org/debian/info2man.git'
-  git_hashtag "debian/#{@_ver}"
+  git_hashtag "debian/#{version}"
 
   def self.patch
     system "sed -i 's:#!/usr/bin/perl:#!#{CREW_PREFIX}/bin/perl:g' 0README.txt info2pod"

--- a/packages/intel_media_driver.rb
+++ b/packages/intel_media_driver.rb
@@ -3,12 +3,11 @@ require 'package'
 class Intel_media_driver < Package
   description 'The Intel(R) Media Driver for VAAPI is a new VA-API (Video Acceleration API) user mode driver supporting hardware accelerated decoding, encoding, and video post processing for GEN based graphics hardware.'
   homepage 'https://github.com/intel/media-driver'
-  @_ver = '22.6.6'
-  version @_ver
+  version '22.6.6'
   license 'BSD-3, and MIT'
   compatibility 'x86_64'
   source_url 'https://github.com/intel/media-driver.git'
-  git_hashtag "intel-media-#{@_ver}"
+  git_hashtag "intel-media-#{version}"
 
   binary_url({
     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/intel_media_driver/22.6.6_x86_64/intel_media_driver-22.6.6-chromeos-x86_64.tar.zst'

--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libdrm < Package
   description 'Cross-driver middleware for DRI protocol.'
   homepage 'https://dri.freedesktop.org'
-  @_ver = '2.4.114'
-  version @_ver
+  version '2.4.114'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/mesa/drm.git'
-  git_hashtag "libdrm-#{@_ver}"
+  git_hashtag "libdrm-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.114_armv7l/libdrm-2.4.114-chromeos-armv7l.tar.zst',

--- a/packages/libebml.rb
+++ b/packages/libebml.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libebml < Package
   description 'libEBML is a C++ library to parse EBML files.'
   homepage 'https://matroska.org/downloads/libraries.html'
-  @_ver = '1.4.2'
-  version @_ver
+  version '1.4.2'
   compatibility 'all'
   license 'BSD'
   source_url 'https://github.com/Matroska-Org/libebml.git'
-  git_hashtag "release-#{@_ver}"
+  git_hashtag "release-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libebml/1.4.2_armv7l/libebml-1.4.2-chromeos-armv7l.tpxz',

--- a/packages/libmatroska.rb
+++ b/packages/libmatroska.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libmatroska < Package
   description 'libmatroska is a C++ library to parse Matroska files, i.e., .mkv and .mka.'
   homepage 'https://matroska.org/downloads/libraries.html'
-  @_ver = '1.6.3'
-  version @_ver
+  version '1.6.3'
   compatibility 'all'
   license 'BSD'
   source_url 'https://github.com/Matroska-Org/libmatroska.git'
-  git_hashtag "release-#{@_ver}"
+  git_hashtag "release-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmatroska/1.6.3_armv7l/libmatroska-1.6.3-chromeos-armv7l.tpxz',

--- a/packages/libmpc.rb
+++ b/packages/libmpc.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libmpc < Package
   description 'Musepack is an audio compression format with a strong emphasis on high quality.'
   homepage 'https://www.musepack.net/'
-  @_ver = 'r495'
-  version @_ver
+  version 'r495'
   compatibility 'all'
   license 'BSD and LGPL-2+'
   source_url 'https://salsa.debian.org/multimedia-team/libmpc.git'
-  git_hashtag "debian/2%0.1_#{@_ver}-2"
+  git_hashtag "debian/2%0.1_#{version}-2"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmpc/r495_armv7l/libmpc-r495-chromeos-armv7l.tpxz',

--- a/packages/libnl3.rb
+++ b/packages/libnl3.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libnl3 < Package
   description 'libnl is a library for applications dealing with netlink sockets.'
   homepage 'http://www.infradead.org/~tgr/libnl/'
-  @_ver = '3.7.0'
-  version @_ver
+  version '3.7.0'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://github.com/thom311/libnl.git'
-  git_hashtag "libnl#{@_ver.gsub('.', '_')}"
+  git_hashtag "libnl#{version.gsub('.', '_')}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnl3/3.7.0_armv7l/libnl3-3.7.0-chromeos-armv7l.tar.zst',

--- a/packages/libsdl2.rb
+++ b/packages/libsdl2.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libsdl2 < Package
   description 'Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.'
   homepage 'http://www.libsdl.org'
-  @_ver = '2.26.4'
-  version @_ver
+  version '2.26.4'
   license 'ZLIB'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/libsdl-org/SDL.git'
-  git_hashtag "release-#{@_ver}"
+  git_hashtag "release-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsdl2/2.26.4_armv7l/libsdl2-2.26.4-chromeos-armv7l.tar.zst',

--- a/packages/libspatialaudio.rb
+++ b/packages/libspatialaudio.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libspatialaudio < Package
   description 'libspatialaudio is a library for Ambisonic encoding and decoding, filtering and binaural rendering.'
   homepage 'https://github.com/videolabs/libspatialaudio/'
-  @_ver = '0.3.0+git20180730'
-  version @_ver
+  version '0.3.0+git20180730'
   compatibility 'all'
   license 'LGPL-2.1'
   source_url 'https://salsa.debian.org/multimedia-team/libspatialaudio.git'
-  git_hashtag "debian/#{@_ver}+dfsg1-2"
+  git_hashtag "debian/#{version}+dfsg1-2"
 
   depends_on 'libmysofa'
 

--- a/packages/libwacom.rb
+++ b/packages/libwacom.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libwacom < Package
   description 'libwacom is a wrapper library for evdev devices.'
   homepage 'https://github.com/linuxwacom/libwacom'
-  @_ver = '1.12'
-  version @_ver
+  version '1.12'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/linuxwacom/libwacom.git'
-  git_hashtag "libwacom-#{@_ver}"
+  git_hashtag "libwacom-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwacom/1.12_armv7l/libwacom-1.12-chromeos-armv7l.tpxz',

--- a/packages/llvm_build16.rb
+++ b/packages/llvm_build16.rb
@@ -3,12 +3,11 @@ require 'package'
 class Llvm_build16 < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'
   homepage 'http://llvm.org/'
-  @_ver = '16.0.5'
-  version @_ver
+  version '16.0.5'
   license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'https://github.com/llvm/llvm-project.git'
-  git_hashtag "llvmorg-#{@_ver}"
+  git_hashtag "llvmorg-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm_build16/16.0.5_armv7l/llvm_build16-16.0.5-chromeos-armv7l.tar.zst',

--- a/packages/musl_libssh.rb
+++ b/packages/musl_libssh.rb
@@ -3,12 +3,11 @@ require 'package'
 class Musl_libssh < Package
   description 'libssh is a multiplatform C library implementing the SSHv2 and SSHv1 protocol on client and server side.'
   homepage 'https://www.libssh.org/'
-  @_ver = '0.9.6'
-  version @_ver
+  version '0.9.6'
   compatibility 'all'
   license 'LGPL-2.1'
   source_url 'https://git.libssh.org/projects/libssh.git'
-  git_hashtag "libssh-#{@_ver}"
+  git_hashtag "libssh-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libssh/0.9.6_armv7l/musl_libssh-0.9.6-chromeos-armv7l.tpxz',

--- a/packages/musl_libucontext.rb
+++ b/packages/musl_libucontext.rb
@@ -3,12 +3,11 @@ require 'package'
 class Musl_libucontext < Package
   description 'Library which provides the ucontext.h C API'
   homepage 'https://github.com/kaniini/libucontext'
-  @_ver = '1.1'
-  version @_ver
+  version '1.1'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/kaniini/libucontext.git'
-  git_hashtag "libucontext-#{@_ver}"
+  git_hashtag "libucontext-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libucontext/1.1_armv7l/musl_libucontext-1.1-chromeos-armv7l.tpxz',

--- a/packages/pcsc_lite.rb
+++ b/packages/pcsc_lite.rb
@@ -3,12 +3,11 @@ require 'package'
 class Pcsc_lite < Package
   description 'PCSC is middleware to access a smart card using SCard API (PC/SC).'
   homepage 'https://pcsclite.apdu.fr/'
-  @_ver = '1.9.5'
-  version @_ver
+  version '1.9.5'
   compatibility 'all'
   license 'BSD, ISC, MIT, GPL-3+ and GPL-2'
   source_url 'https://salsa.debian.org/debian/pcsc-lite.git'
-  git_hashtag "debian/#{@_ver}-1"
+  git_hashtag "debian/#{version}-1"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pcsc_lite/1.9.5_armv7l/pcsc_lite-1.9.5-chromeos-armv7l.tpxz',

--- a/packages/pupnp.rb
+++ b/packages/pupnp.rb
@@ -3,12 +3,11 @@ require 'package'
 class Pupnp < Package
   description 'PUPnP is the Portable SDK for UPnP devices.'
   homepage 'https://pupnp.github.io/pupnp/'
-  @_ver = '1.14.12'
-  version @_ver
+  version '1.14.12'
   compatibility 'all'
   license 'BSD-3'
   source_url 'https://github.com/pupnp/pupnp.git'
-  git_hashtag "release-#{@_ver}"
+  git_hashtag "release-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pupnp/1.14.12_armv7l/pupnp-1.14.12-chromeos-armv7l.tpxz',

--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -3,12 +3,11 @@ require 'package'
 class Xorg_server < Package
   description 'The Xorg Server is the core of the X Window system.'
   homepage 'https://www.x.org'
-  @_ver = '21.1.7'
-  version @_ver
+  version '21.1.7'
   license 'BSD-3, MIT, BSD-4, MIT-with-advertising, ISC and custom'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/xorg/xserver.git'
-  git_hashtag "xorg-server-#{@_ver}"
+  git_hashtag "xorg-server-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.7_armv7l/xorg_server-21.1.7-chromeos-armv7l.tar.zst',

--- a/packages/xrdb.rb
+++ b/packages/xrdb.rb
@@ -3,12 +3,11 @@ require 'package'
 class Xrdb < Package
   description 'xrdb - X server resource database utility'
   homepage 'https://x.org'
-  @_ver = '1.2.1'
-  version @_ver
+  version '1.2.1'
   license 'custom'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/xorg/app/xrdb.git'
-  git_hashtag "xrdb-#{@_ver}"
+  git_hashtag "xrdb-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xrdb/1.2.1_armv7l/xrdb-1.2.1-chromeos-armv7l.tar.zst',

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -3,12 +3,11 @@ require 'package'
 class Xwayland < Package
   description 'X server configured to work with weston or sommelier'
   homepage 'https://x.org'
-  @_ver = '23.1.0'
-  version @_ver
+  version '23.1.0'
   license 'MIT-with-advertising, ISC, BSD-3, BSD and custom'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.freedesktop.org/xorg/xserver.git'
-  git_hashtag "xwayland-#{@_ver}"
+  git_hashtag "xwayland-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/23.1.0_armv7l/xwayland-23.1.0-chromeos-armv7l.tar.zst',

--- a/packages/zopfli.rb
+++ b/packages/zopfli.rb
@@ -3,12 +3,11 @@ require 'package'
 class Zopfli < Package
   description 'A very good, but slow, deflate or zlib compression.'
   homepage 'https://github.com/google/zopfli/'
-  @_ver = '1.0.3'
-  version @_ver
+  version '1.0.3'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/google/zopfli.git'
-  git_hashtag "zopfli-#{@_ver}"
+  git_hashtag "zopfli-#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zopfli/1.0.3_armv7l/zopfli-1.0.3-chromeos-armv7l.tar.xz',


### PR DESCRIPTION
Following on from #8371, I am removing 24 uses of @_ver from packages that use it like this: 
```
@_ver = '1.2.3'
version @_ver
...
git_hashtag "llvmorg-#{@_ver}"
```
which now becomes:
```
version '1.2.3'
...
git_hashtag "llvmorg-#{version}"
```

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=laver3 CREW_TESTING=1 crew update
```
