### PR TITLE
Signal_desktop 7.19.0 => 7.19.1

### DIFF
--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.19.0'
+  version '7.19.1'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '94ef0638273f2f858ef9a3d1eaa4a7dc7425a9e081eade6958010d45739385d2'
+  source_sha256 '6d5b9dc2c53673b4c5f65cd478a92674827ffb20832bbf815f5be3f9e924ccca'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
##
Tested & (not) Working properly:
- [x] `x86_64` (fails in the hatch m126 container)
- [ ] `i686`
- [ ] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```
