### PR TITLE
Terraform 1.11.4 => 1.12.1

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.11.4'
+  version '1.12.1'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '3cf072a049ab0178e9cbec47a14712ba7f38cc8ef061f3a7c0ff57b83d320edd',
-     armv7l: '3cf072a049ab0178e9cbec47a14712ba7f38cc8ef061f3a7c0ff57b83d320edd',
-       i686: '8e4bd232ce8b0cde2a90132a9c4d25665791c7a48bbb159f5cd4988265d10372',
-     x86_64: '1ce994251c00281d6845f0f268637ba50c0005657eb3cf096b92f753b42ef4dc'
+    aarch64: '552a2dba27b8da9c0f59342a854c5b0e77250362c83964b84a8d0e2defb59ef2',
+     armv7l: '552a2dba27b8da9c0f59342a854c5b0e77250362c83964b84a8d0e2defb59ef2',
+       i686: '044a4e8591d95d711d3918956c7d267060131e526d6da93f5d62099d8714b1d3',
+     x86_64: 'dcaf8ba801660a431a6769ec44ba53b66c1ad44637512ef3961f7ffe4397ef7c'
   })
 
   def self.install


### PR DESCRIPTION
## Description
This commit updates the Terraform CLI from version 1.11.4 to version 1.12.1.

## Additional information
Tested & Working properly:
- [X] `x86_64`
- [X] `i686`
- [X] `armv7l`
##
- [X] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##