### PR TITLE
Test out the GitHub arm64 arm runners for unit tests.

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -20,12 +20,12 @@ jobs:
         arch: [x86_64, armv7l, i686]
         runner:
           - ubuntu-24.04
-          - [self-hosted, ARM]
+          - ubuntu-24.04-arm
         exclude:
           - arch: x86_64
-            runner: [self-hosted, ARM]
+            runner: ubuntu-24.04-arm
           - arch: i686
-            runner: [self-hosted, ARM]
+            runner: ubuntu-24.04-arm
           - arch: armv7l
             runner: ubuntu-24.04
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
- It's possible that the default GitHub arm64 runners may work for our unit tests, so see if they do...