### PR TITLE
Update unset_default_browser function to handle alternate binary location

### DIFF
--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -138,7 +138,8 @@ class ConvenienceFunctions
   def self.unset_default_browser(browser_name, browser_binary)
     Dir.chdir("#{CREW_PREFIX}/bin") do
       if File.exist?('x-www-browser') && File.symlink?('x-www-browser') &&
-         File.realpath('x-www-browser') == "#{CREW_PREFIX}/share/#{browser_name.downcase}/#{browser_binary}"
+         ["#{CREW_PREFIX}/share/#{browser_name.downcase}/#{browser_binary}",
+          "#{CREW_PREFIX}/bin/#{browser_binary}"].include?(File.realpath('x-www-browser'))
         FileUtils.rm "#{CREW_PREFIX}/bin/x-www-browser"
       end
     end


### PR DESCRIPTION
Required for #12022 update.

Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-unset_default_browser crew update \
&& yes | crew upgrade
```