### PR TITLE
lib/const: Wrap all constant definitions with a function

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -6,7 +6,6 @@ require 'open3'
 def crew_const(const_name, default_value = nil) = (Object.const_set(const_name, default_value) unless Object.const_defined?(const_name))
 
 crew_const :CREW_VERSION, '1.61.10'
-crew_const :OLD_CREW_VERSION, CREW_VERSION
 
 # Kernel architecture.
 crew_const :KERN_ARCH, Etc.uname[:machine]


### PR DESCRIPTION
This PR simplifies all `CONST = ... unless defined?(...)` syntax into `crew_const :CONST, ...` for convenience:
 
```ruby
# before
CREW_CONST ||= '1.0' unless defined?(CREW_CONST)

# after
crew_const :CREW_CONST, '1.0'
```

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/supechicken/chromebrew.git CREW_BRANCH=wrap_const crew update \
&& yes | crew upgrade
```
