### PR TITLE
Opera 120.0.5543.38 => 120.0.5543.61

### DIFF
--- a/manifest/x86_64/o/opera.filelist
+++ b/manifest/x86_64/o/opera.filelist
@@ -113,6 +113,7 @@
 /usr/local/share/x86_64-linux-gnu/opera/resources/browser.js
 /usr/local/share/x86_64-linux-gnu/opera/resources/continue_shopping.json
 /usr/local/share/x86_64-linux-gnu/opera/resources/default_partner_content.json
+/usr/local/share/x86_64-linux-gnu/opera/resources/destination_travel_intent_keywords.json
 /usr/local/share/x86_64-linux-gnu/opera/resources/doh_providers.json
 /usr/local/share/x86_64-linux-gnu/opera/resources/domain_suggestions.json
 /usr/local/share/x86_64-linux-gnu/opera/resources/ffmpeg_preload_config.json

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '120.0.5543.38'
+  version '120.0.5543.61'
   license 'OPERA-2018'
   compatibility 'x86_64'
   min_glibc '2.29'
@@ -12,7 +12,7 @@ class Opera < Package
   # faster apt mirror, but only works when downloading latest version of opera
   # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '7aef364964a4ff7727c82dcb5a057e70b4622ba8a4e0141af64cddb47e010843'
+  source_sha256 'f8b5abc9a2a58c379538d408097baadac68509bad5c334c087476d0a9cc7a0a8'
 
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m137 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```