### PR TITLE
Run rubocop 1.79.2 on tree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # These pre-commit hooks mirror the Github CI, so running them locally will catch errors earlier.
 repos:
   - repo: https://github.com/rubocop/rubocop
-    rev: v1.77.0
+    rev: v1.79.2
     hooks:
       - id: rubocop
   - repo: https://github.com/syntaqx/git-hooks

--- a/lib/crew_lockfile.rb
+++ b/lib/crew_lockfile.rb
@@ -416,13 +416,13 @@ unless defined?($__crew_lockfile__) || defined?(CrewLockfile)
           nil
         end
         begin
-          return((Time.now - File.stat(@path).mtime) < @max_age)
+          return ((Time.now - File.stat(@path).mtime) < @max_age)
         rescue Errno::ENOENT
           return false
         end
       else
         exist = File.exist?(@path)
-        return(exist ? true : nil)
+        return (exist ? true : nil)
       end
     end
 
@@ -518,7 +518,7 @@ unless defined?($__crew_lockfile__) || defined?(CrewLockfile)
       ensure
         File.umask umask if umask
       end
-      return(block_given? ? begin; yield f; ensure; f.close; end : f)
+      return (block_given? ? begin; yield f; ensure; f.close; end : f)
     end
 
     def touch(path)


### PR DESCRIPTION
Not a ton going on here, just some new `Layout/SpaceAroundKeyword` offenses.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=unwise crew update \
&& yes | crew upgrade
```
