### PR TITLE
Revert "updater-zlib_ng-2.2.5 — zlib_ng => 2.2.5"

### DIFF
--- a/manifest/armv7l/z/zlib_ng.filelist
+++ b/manifest/armv7l/z/zlib_ng.filelist
@@ -7,5 +7,5 @@
 /usr/local/lib/cmake/zlib-ng/zlib-ng.cmake
 /usr/local/lib/libz-ng.so
 /usr/local/lib/libz-ng.so.2
-/usr/local/lib/libz-ng.so.2.2.5
+/usr/local/lib/libz-ng.so.2.2.4
 /usr/local/lib/pkgconfig/zlib-ng.pc

--- a/manifest/i686/z/zlib_ng.filelist
+++ b/manifest/i686/z/zlib_ng.filelist
@@ -7,5 +7,5 @@
 /usr/local/lib/cmake/zlib-ng/zlib-ng.cmake
 /usr/local/lib/libz-ng.so
 /usr/local/lib/libz-ng.so.2
-/usr/local/lib/libz-ng.so.2.2.5
+/usr/local/lib/libz-ng.so.2.2.4
 /usr/local/lib/pkgconfig/zlib-ng.pc

--- a/manifest/x86_64/z/zlib_ng.filelist
+++ b/manifest/x86_64/z/zlib_ng.filelist
@@ -7,5 +7,5 @@
 /usr/local/lib64/cmake/zlib-ng/zlib-ng.cmake
 /usr/local/lib64/libz-ng.so
 /usr/local/lib64/libz-ng.so.2
-/usr/local/lib64/libz-ng.so.2.2.5
+/usr/local/lib64/libz-ng.so.2.2.4
 /usr/local/lib64/pkgconfig/zlib-ng.pc

--- a/packages/zlib_ng.rb
+++ b/packages/zlib_ng.rb
@@ -6,7 +6,7 @@ require 'buildsystems/cmake'
 class Zlib_ng < CMake
   description 'zlib replacement with optimizations for next generation systems'
   homepage 'https://github.com/zlib-ng/zlib-ng'
-  version '2.2.5'
+  version '2.2.4'
   license 'Zlib'
   compatibility 'all'
   source_url 'https://github.com/zlib-ng/zlib-ng.git'
@@ -14,10 +14,10 @@ class Zlib_ng < CMake
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e6c7492e99d6be7e3833df41c126f8db5c8d76d4106cc757b3b19d5893c267a2',
-     armv7l: 'e6c7492e99d6be7e3833df41c126f8db5c8d76d4106cc757b3b19d5893c267a2',
-       i686: 'c65538e6450c3cdeb322fe7e450fde7668a501b2a4d3b02b1823371ff3f7d548',
-     x86_64: '014b332e175cca9c4aae66b4c993a2a5d5c5f7031f1b0c8df5be98ea1d2a1abb'
+    aarch64: '6f70e2c3a18e809cfc0bd92059170e9ae938416847e2c91b2549800fc6e2c387',
+     armv7l: '6f70e2c3a18e809cfc0bd92059170e9ae938416847e2c91b2549800fc6e2c387',
+       i686: '67cc7fbd92642298fc6bca2a20c50f648095a42482b5ebe7a0e02657a238a317',
+     x86_64: 'baf51c97c8244097c847dcd5645d21feb65631b20e1cc3fb70c24455bacaf0c3'
   })
 
   depends_on 'glibc'


### PR DESCRIPTION
Reverts chromebrew/chromebrew#12444

Looks like this failed the unit tests.