### PR TITLE
Vivaldi 7.5.3735.64-1 => 7.5.3735.66-1

### DIFF
--- a/manifest/armv7l/v/vivaldi.filelist
+++ b/manifest/armv7l/v/vivaldi.filelist
@@ -1,4 +1,4 @@
-# Total size: 343614736
+# Total size: 343615105
 /usr/local/bin/vivaldi
 /usr/local/bin/vivaldi-stable
 /usr/local/etc/cron.daily/vivaldi
@@ -210,7 +210,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-eefb8fe444d0a58e376f861136bd427b.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-100a787a065fb032edd706d8678be20c.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -1,4 +1,4 @@
-# Total size: 437527497
+# Total size: 437527494
 /usr/local/bin/vivaldi
 /usr/local/bin/vivaldi-stable
 /usr/local/etc/cron.daily/vivaldi
@@ -210,7 +210,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-68b28ab0a6d989fd6757429c3b465feb.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-44f35fc00393a2f46f75c53ff0ff646f.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
-  version '7.5.3735.64-1'
+  version '7.5.3735.66-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -24,10 +24,10 @@ class Vivaldi < Package
   case ARCH
   when 'aarch64', 'armv7l'
     arch = 'armhf'
-    source_sha256 'e67872a811d955b662b0e620e87b53a9f591564e9adc80c3b447edffcf4317aa'
+    source_sha256 'd2ca9c354056ba16ca254f55f16f95ee5a78eaea5abab84c55b9cb03f0cb1aff'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 '7085508a8c3f9b610ca24d4239eca8f6fff51c2292b539c3b7f4ad95d5e4fe8a'
+    source_sha256 '1138fdd7e013fdf17c50186ab233894384a76ca205e896ff4f85e6b7732eb663'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m138 container
- [x] `armv7l` Unable to launch in strongbad m138 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```