### PR TITLE
Prioritise runtime dependencies over build dependencies in tools/getrealdeps.rb

### DIFF
--- a/tests/tools/getrealdeps.rb
+++ b/tests/tools/getrealdeps.rb
@@ -102,6 +102,30 @@ class GetRealDepsTest < Minitest::Test
     test_wrapper(input_file, expected_pkg_file, deps)
   end
 
+  def test_replace_build_dependency
+    deps = ['json_c']
+    input_file = <<~EOF
+      class Example < Package
+        binary_sha256({})
+
+        depends_on 'a2png'
+        depends_on 'json_c' => :build
+        depends_on 'lzlib'
+      end
+    EOF
+    expected_pkg_file = <<~EOF
+      class Example < Package
+        binary_sha256({})
+
+        depends_on 'a2png'
+        depends_on 'json_c' # R
+        depends_on 'lzlib'
+      end
+    EOF
+
+    test_wrapper(input_file, expected_pkg_file, deps)
+  end
+
   def test_add_special_dependency_to_empty
     deps = []
     input_file = <<~EOF
@@ -266,6 +290,29 @@ class GetRealDepsTest < Minitest::Test
         depends_on 'libmms'
         depends_on 'libspng' # R
         depends_on 'ruby' # R
+      end
+    EOF
+
+    test_wrapper(input_file, expected_pkg_file, deps)
+  end
+
+  def test_does_not_remove_build_dependency
+    deps = ['libspng']
+    input_file = <<~EOF
+      class Example < Package
+        binary_sha256({})
+
+        depends_on 'libmatroska'
+        depends_on 'ninja' => :build
+      end
+    EOF
+    expected_pkg_file = <<~EOF
+      class Example < Package
+        binary_sha256({})
+
+        depends_on 'libmatroska'
+        depends_on 'libspng' # R
+        depends_on 'ninja' => :build
       end
     EOF
 


### PR DESCRIPTION
## Description
As decided in https://github.com/chromebrew/chromebrew/pull/12791#discussion_r2352463165.

Tested and working locally.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=bananna crew update \
&& yes | crew upgrade
```
