### PR TITLE
Vivaldi 7.6.3797.55-1 => 7.6.3797.56-1

### DIFF
--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -1,4 +1,4 @@
-# Total size: 442134123
+# Total size: 441177061
 /usr/local/bin/vivaldi
 /usr/local/bin/vivaldi-stable
 /usr/local/etc/cron.daily/vivaldi
@@ -447,7 +447,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-0f39a78aaad5e83752201c6758cfe13f.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-bc9bc33e534baec2b3177308f294c870.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html
@@ -705,6 +705,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/seznam.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/shein.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/shopee_pl.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/skyscanner.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/spiegel_de.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/spotify.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/start_me.png
@@ -1011,6 +1012,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_si_lankanews.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_simplygames.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_sk_auktality.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_skyscanner.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_sl_zurnal.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_spyr.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_sq_express.png

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -5,7 +5,7 @@ class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
   # The project stopped supporting armv7l after the 7.5 release.
-  version ARCH.eql?('x86_64') ? '7.6.3797.55-1' : '7.5.3735.74-1'
+  version ARCH.eql?('x86_64') ? '7.6.3797.56-1' : '7.5.3735.74-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -28,7 +28,7 @@ class Vivaldi < Package
     source_sha256 '9017e6327c140ad9a9e1f0ce450681a729a15ea764337c30226f51c042ff7e62'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 '94fddd42f4981ae30e11dbe7ba522be83e8211727ed9c8944a884c6455233f2b'
+    source_sha256 '6a2292270278564ad452728e7f9a026a8bcc03e0ce77d563055c90cf18161ca5'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m139 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```