### PR TITLE
Add update exclusion for util_linux due to broken build. See https://github.com/util-linux/util-linux/issues/3763 

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -361,6 +361,7 @@ unless defined?(CREW_UPDATER_EXCLUDED_PKGS)
     { pkg_name: 'linuxheaders', comments: 'Requires manual update.' },
     { pkg_name: 'py3_ldapdomaindump', comments: 'Build is broken.' },
     { pkg_name: 'ruby', comments: 'i686 needs building with GCC 14.' },
+    { pkg_name: 'util_linux', comments: '2.41.2 build broken. See https://github.com/util-linux/util-linux/issues/3763' },
     { pkg_name: 'xdg_base', comments: 'Internal Chromebrew Package.' }
   ].to_h { |h| [h[:pkg_name], h[:comments]] }
 end


### PR DESCRIPTION
## Description
#### Commits:
-  2d6ae1faf Add update exclusion for util_linux due to broken build. See https://github.com/util-linux/util-linux/issues/3763
### Other changed files:
- lib/const.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=version_check crew update \
&& yes | crew upgrade
```
