### PR TITLE
Edge 140.0.3485.94-1 => 141.0.3537.57-1

### DIFF
--- a/manifest/x86_64/e/edge.filelist
+++ b/manifest/x86_64/e/edge.filelist
@@ -1,4 +1,4 @@
-# Total size: 632284848
+# Total size: 634207543
 /usr/local/bin/edge
 /usr/local/bin/microsoft-edge
 /usr/local/bin/microsoft-edge-stable
@@ -13,7 +13,6 @@
 /usr/local/share/man/man1/microsoft-edge-stable.1.zst
 /usr/local/share/man/man1/microsoft-edge.1.zst
 /usr/local/share/man/man1/msedge.1.zst
-/usr/local/share/menu/microsoft-edge.menu
 /usr/local/share/msedge/AdSelectionAttestationsPreloaded/ad-selection-attestations.dat
 /usr/local/share/msedge/AdSelectionAttestationsPreloaded/manifest.json
 /usr/local/share/msedge/MEIPreload/manifest.json
@@ -132,7 +131,6 @@
 /usr/local/share/msedge/product_logo_24.png
 /usr/local/share/msedge/product_logo_256.png
 /usr/local/share/msedge/product_logo_32.png
-/usr/local/share/msedge/product_logo_32.xpm
 /usr/local/share/msedge/product_logo_48.png
 /usr/local/share/msedge/product_logo_64.png
 /usr/local/share/msedge/resources.pak

--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -4,12 +4,12 @@ require 'convenience_functions'
 class Edge < Package
   description 'Microsoft Edge is the fast and secure browser'
   homepage 'https://www.microsoft.com/en-us/edge'
-  version '140.0.3485.94-1'
+  version '141.0.3537.57-1'
   license 'MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_#{version}_amd64.deb"
-  source_sha256 '52f9c04fced7f58325c85d62f73edb0425a9cf7094d9959ef61a000601925d8f'
+  source_sha256 'c6a1eee8e741e81149562f9899026332387b09b2f69bd76b50782d4551c186b9'
 
   depends_on 'at_spi2_core'
   depends_on 'libcom_err'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m140 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-edge crew update \
&& yes | crew upgrade
```