### PR TITLE
Signal_desktop 7.73.0 => 7.74.0

### DIFF
--- a/manifest/x86_64/s/signal_desktop.filelist
+++ b/manifest/x86_64/s/signal_desktop.filelist
@@ -1,4 +1,4 @@
-# Total size: 452161453
+# Total size: 452725844
 /usr/local/bin/signal-desktop
 /usr/local/share/Signal/LICENSE.electron.txt
 /usr/local/share/Signal/LICENSES.chromium.html

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.73.0'
+  version '7.74.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '9ebeb0167f1defd61410b025521f543ff6b3bf8d3f53a5c6a4791fb50a4d21b0'
+  source_sha256 'f7f185df8c9ac6da154fec1c31aafae6127b7f100c62d3f7750ed7ac079169a2'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m140 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```