### PR TITLE
Add navi package and tealdeer dependency

### DIFF
--- a/manifest/armv7l/n/navi.filelist
+++ b/manifest/armv7l/n/navi.filelist
@@ -1,0 +1,2 @@
+# Total size: 3220136
+/usr/local/bin/navi

--- a/manifest/armv7l/t/tealdeer.filelist
+++ b/manifest/armv7l/t/tealdeer.filelist
@@ -1,0 +1,2 @@
+# Total size: 2649588
+/usr/local/bin/tldr

--- a/manifest/i686/n/navi.filelist
+++ b/manifest/i686/n/navi.filelist
@@ -1,0 +1,2 @@
+# Total size: 4176988
+/usr/local/bin/navi

--- a/manifest/i686/t/tealdeer.filelist
+++ b/manifest/i686/t/tealdeer.filelist
@@ -1,0 +1,2 @@
+# Total size: 3097228
+/usr/local/bin/tldr

--- a/manifest/x86_64/n/navi.filelist
+++ b/manifest/x86_64/n/navi.filelist
@@ -1,0 +1,2 @@
+# Total size: 4264224
+/usr/local/bin/navi

--- a/manifest/x86_64/t/tealdeer.filelist
+++ b/manifest/x86_64/t/tealdeer.filelist
@@ -1,0 +1,2 @@
+# Total size: 3426392
+/usr/local/bin/tldr

--- a/manifest/x86_64/t/tldr.filelist
+++ b/manifest/x86_64/t/tldr.filelist
@@ -1,1 +1,2 @@
+# Total size: 14139
 /usr/local/bin/tldr

--- a/packages/navi.rb
+++ b/packages/navi.rb
@@ -1,0 +1,25 @@
+require 'buildsystems/rust'
+
+class Navi < RUST
+  description 'An interactive cheatsheet tool for the command-line'
+  homepage 'https://github.com/denisidoro/navi'
+  version '2.24.0'
+  license 'Apache-2.0'
+  compatibility 'all'
+  source_url 'https://github.com/denisidoro/navi.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '3d38b2e94028057c3e82a65ce1c442c33909f09e2dc19d343d0184ef74200801',
+     armv7l: '3d38b2e94028057c3e82a65ce1c442c33909f09e2dc19d343d0184ef74200801',
+       i686: 'cd09c6f3aba3d702ea648b78701a8947b48cf214bc4a836bac3d46820309124e',
+     x86_64: 'd0ac52a0b7969f49c2a9a11e70b7a988c7a01a71beda2f69f5ba78d88d41c01a'
+  })
+
+  depends_on 'fzf' # R
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc' # R
+  depends_on 'rust' => :build
+  depends_on 'tealdeer' # R
+end

--- a/packages/tealdeer.rb
+++ b/packages/tealdeer.rb
@@ -1,0 +1,33 @@
+require 'buildsystems/rust'
+
+class Tealdeer < RUST
+  description 'A very fast implementation of tldr in Rust.'
+  homepage 'https://tealdeer-rs.github.io/tealdeer/'
+  version '1.8.0'
+  license 'Apache-2.0, MIT'
+  compatibility 'all'
+  source_url 'https://github.com/tealdeer-rs/tealdeer.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '814f8deaec35a3c0947f320d9db6835cba9a189da48fc55db0201c0186d31ca8',
+     armv7l: '814f8deaec35a3c0947f320d9db6835cba9a189da48fc55db0201c0186d31ca8',
+       i686: '8f0b10662ebd2fcebb3d1ca3650ef5dc3299eb35b18e9d8c04a599139a6d332e',
+     x86_64: '8f116680132091b4a84646214cc639b28038c52dd9c2f79341f9b742abb5e812'
+  })
+
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc' # R
+  depends_on 'rust' => :build
+
+  def self.preflight
+    if Package.installed('tldr')
+      abort <<~EOM.orange
+
+        tldr is installed. To install this package, execute:
+        crew remove tldr && crew install tealdeer
+      EOM
+    end
+  end
+end

--- a/packages/tldr.rb
+++ b/packages/tldr.rb
@@ -11,6 +11,16 @@ class Tldr < Package
 
   no_compile_needed
 
+  def self.preflight
+    if Package.installed('tealdeer')
+      abort <<~EOM.orange
+
+        tealdeer is installed. To install this package, execute:
+        crew remove tealdeer && crew install tldr
+      EOM
+    end
+  end
+
   def self.patch
     # Fix /usr/local/bin/tldr: 97: /usr/local/bin/tldr: cannot create /dev/stderr: Permission denied
     system "sed -i 's, > /dev/stderr,,g' tldr"

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6325,6 +6325,11 @@ url: https://gitlab.gnome.org/GNOME/nautilus/-/tags
 activity: high
 ---
 kind: url
+name: navi
+url: https://github.com/denisidoro/navi/releases
+activity: low
+---
+kind: url
 name: ncat
 url: https://nmap.org/dist/
 activity: low
@@ -9253,6 +9258,11 @@ kind: url
 name: tdb
 url: https://www.samba.org/ftp/tdb/
 activity: medium
+---
+kind: url
+name: tealdeer
+url: https://github.com/tealdeer-rs/tealdeer/releases
+activity: low
 ---
 kind: url
 name: teams


### PR DESCRIPTION
Requires #13120 to be merged before the i686 tests will pass.

## Description
navi: An interactive cheatsheet tool for the command-line.  See https://github.com/denisidoro/navi.
tealdeer: A very fast implementation of tldr in Rust.   See https://tealdeer-rs.github.io/tealdeer/.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-navi-package crew update \
&& yes | crew upgrade
```