### PR TITLE
Google_chrome 141.0.7390.76-1 => 141.0.7390.107-1

### DIFF
--- a/manifest/x86_64/g/google_chrome.filelist
+++ b/manifest/x86_64/g/google_chrome.filelist
@@ -1,4 +1,4 @@
-# Total size: 396755778
+# Total size: 396776230
 /usr/local/bin/google-chrome
 /usr/local/share/appdata/google-chrome.appdata.xml
 /usr/local/share/applications/com.google.Chrome.desktop

--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -3,12 +3,12 @@ require 'package'
 class Google_chrome < Package
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '141.0.7390.76-1'
+  version '141.0.7390.107-1'
   license 'google-chrome'
   compatibility 'x86_64'
 
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_#{version}_amd64.deb"
-  source_sha256 '612bc3748d538dd567f0480a529538716a451210731c4d30e04abbc5905e05c7'
+  source_sha256 '74d738a546aa82180cc626cea479f7a761fff39072aa93c3458a545975fb6735'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m140 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```