### PR TITLE
Revert "updater-python3-3.13.9 — python3 → 3.13.9"

### DIFF
--- a/manifest/armv7l/p/python3.filelist
+++ b/manifest/armv7l/p/python3.filelist
@@ -1,4 +1,4 @@
-# Total size: 264530569
+# Total size: 264524190
 /usr/local/bin/idle3
 /usr/local/bin/idle3.13
 /usr/local/bin/pip

--- a/manifest/i686/p/python3.filelist
+++ b/manifest/i686/p/python3.filelist
@@ -1,4 +1,4 @@
-# Total size: 257890268
+# Total size: 257885203
 /usr/local/bin/idle3
 /usr/local/bin/idle3.13
 /usr/local/bin/pip

--- a/manifest/x86_64/p/python3.filelist
+++ b/manifest/x86_64/p/python3.filelist
@@ -1,4 +1,4 @@
-# Total size: 271581874
+# Total size: 271575635
 /usr/local/bin/idle3
 /usr/local/bin/idle3.13
 /usr/local/bin/pip

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -3,18 +3,18 @@ require 'package'
 class Python3 < Package
   description 'Python is a programming language that lets you work quickly and integrate systems more effectively.'
   homepage 'https://www.python.org/'
-  version '3.13.9'
+  version '3.13.8'
   license 'PSF-2.0'
   compatibility 'all'
   source_url "https://www.python.org/ftp/python/#{version}/Python-#{version}.tar.xz"
-  source_sha256 'ed5ef34cda36cfa2f3a340f07cac7e7814f91c7f3c411f6d3562323a866c5c66'
+  source_sha256 'b9910730526b298299b46b35595ced9055722df60c06ad6301f6a4e2c728a252'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '7af0359c8da2b5989cae41c41aa951e10034942939ef343db7ac71d529c7e179',
-     armv7l: '7af0359c8da2b5989cae41c41aa951e10034942939ef343db7ac71d529c7e179',
-       i686: 'f2902d97778b0505ffdace819a9f46533de9bf71f41e97519f87e2e04df9a106',
-     x86_64: '703c494ee1b53ace9ecf452870f08f1656b5e26a37045b994af8a622a981b955'
+    aarch64: 'f4e06c87d8c7e263ca81f8ab9bbd1887161f04382270da99e03768c9072de14a',
+     armv7l: 'f4e06c87d8c7e263ca81f8ab9bbd1887161f04382270da99e03768c9072de14a',
+       i686: 'f17bf7ec21f498585fee3a3c5b5da9da9b8d4cf581d69e00cef932f9bd8342c7',
+     x86_64: '210ad397fbc3f61b6ac712cd79305dc34768c8ae9adce9448d76c18d25755a54'
   })
 
   depends_on 'autoconf_archive' => :build


### PR DESCRIPTION
Reverts chromebrew/chromebrew#13139 and moves us back to Python 3.13.8.

x86_64 builds appear to have been replaced by arm builds!

```
chronos@buppie-x86_64:2.27 M90 /usr/local/tmp/crew/dest $ file usr/local/bin/python3.13
usr/local/bin/python3.13: ELF 32-bit LSB pie executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, stripped
```