### PR TITLE
Alacritty 0.15.1 => 0.16.0

### DIFF
--- a/manifest/armv7l/a/alacritty.filelist
+++ b/manifest/armv7l/a/alacritty.filelist
@@ -1,4 +1,4 @@
-# Total size: 7866587
+# Total size: 7795862
 /usr/local/bin/alacritty
 /usr/local/share/applications/Alacritty.desktop
 /usr/local/share/bash-completion/completions/alacritty

--- a/manifest/x86_64/a/alacritty.filelist
+++ b/manifest/x86_64/a/alacritty.filelist
@@ -1,4 +1,4 @@
-# Total size: 9233099
+# Total size: 9178262
 /usr/local/bin/alacritty
 /usr/local/share/applications/Alacritty.desktop
 /usr/local/share/bash-completion/completions/alacritty

--- a/packages/alacritty.rb
+++ b/packages/alacritty.rb
@@ -6,7 +6,7 @@ require 'package'
 class Alacritty < Package
   description 'A cross-platform, GPU-accelerated terminal emulator'
   homepage 'https://github.com/alacritty/alacritty'
-  version '0.15.1'
+  version '0.16.0'
   license 'Apache'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/alacritty/alacritty.git'
@@ -14,21 +14,22 @@ class Alacritty < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '110e93dfcb455ada8777a38c1874f670b03a02e32d756faa3d8bd877e8131e93',
-     armv7l: '110e93dfcb455ada8777a38c1874f670b03a02e32d756faa3d8bd877e8131e93',
-     x86_64: 'd6db5d3bebc9807b2b8dc476ca83668c92f3e4d6e6d0f8734d2c5e55e84dddc2'
+    aarch64: 'e5a1d61d4ee4ceccc36fe873f4742664f1fa6a0c240a9f35e66b3817c54f5a08',
+     armv7l: 'e5a1d61d4ee4ceccc36fe873f4742664f1fa6a0c240a9f35e66b3817c54f5a08',
+     x86_64: '91a290725efad5d27126a338e445e31cd44d399889e8a130d0d01197d655b392'
   })
 
-  depends_on 'fontconfig'
-  depends_on 'ncurses'
-  depends_on 'libxcb'
-  depends_on 'rust' => :build
+  depends_on 'fontconfig' # R
   depends_on 'freetype' # R
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'harfbuzz' # R
+  depends_on 'libxcb' # R
   depends_on 'libxcursor' # R
   depends_on 'libxi' # R
+  depends_on 'libxkbcommon' # R
+  depends_on 'ncurses' # R
+  depends_on 'rust' => :build
 
   def self.build
     system 'CARGO_INCREMENTAL=0 cargo build --release'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in nocturne m90 container
- [x] `armv7l` Unable to launch in fievel m91 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-alacritty crew update \
&& yes | crew upgrade
```