### PR TITLE
Termius 9.32.2 => 9.32.3

### DIFF
--- a/manifest/x86_64/t/termius.filelist
+++ b/manifest/x86_64/t/termius.filelist
@@ -1,4 +1,4 @@
-# Total size: 382521190
+# Total size: 382535554
 /usr/local/bin/termius
 /usr/local/share/Termius/LICENSE.electron.txt
 /usr/local/share/Termius/LICENSES.chromium.html
@@ -126,9 +126,14 @@
 /usr/local/share/Termius/resources/app.asar.unpacked/node_modules/@termius/windows-iap-bridge/build/Release/binding.node/index.js
 /usr/local/share/Termius/resources/app.asar.unpacked/node_modules/@termius/windows-iap-bridge/lib/main.js
 /usr/local/share/Termius/resources/app.asar.unpacked/node_modules/@termius/windows-iap-bridge/package.json
+/usr/local/share/Termius/resources/app.asar.unpacked/out/shell-integration/.tcshrc
 /usr/local/share/Termius/resources/app.asar.unpacked/out/shell-integration/bashrc.sh
 /usr/local/share/Termius/resources/app.asar.unpacked/out/shell-integration/shrc.sh
 /usr/local/share/Termius/resources/app.asar.unpacked/out/shell-integration/xdg_data/fish/vendor_conf.d/termius.fish
+/usr/local/share/Termius/resources/app.asar.unpacked/out/shell-integration/zdotdir/.zlogin
+/usr/local/share/Termius/resources/app.asar.unpacked/out/shell-integration/zdotdir/.zprofile
+/usr/local/share/Termius/resources/app.asar.unpacked/out/shell-integration/zdotdir/.zshenv
+/usr/local/share/Termius/resources/app.asar.unpacked/out/shell-integration/zdotdir/.zshrc
 /usr/local/share/Termius/resources/package-type
 /usr/local/share/Termius/resources/termius.apparmor
 /usr/local/share/Termius/snapshot_blob.bin

--- a/packages/termius.rb
+++ b/packages/termius.rb
@@ -3,12 +3,12 @@ require 'package'
 class Termius < Package
   description 'Modern SSH Client'
   homepage 'https://termius.com/'
-  version '9.32.2'
+  version '9.32.3'
   license 'Apache-2.0, LGPL-2.1, MIT'
   compatibility 'x86_64'
   min_glibc '2.33'
   source_url 'https://www.termius.com/download/linux/Termius.deb'
-  source_sha256 '3150665cfa1fd2fd3538fa43ab92f04e81934e015bb75d33c7dba24b6aa12f57'
+  source_sha256 'b90cb78260afa5a8950934b00ab35ff8dd090290b497523b65d28566eb5dfc97'
 
   depends_on 'sommelier'
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m140 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-termius crew update \
&& yes | crew upgrade
```