### PR TITLE
Go 1.25.1 => 1.25.3

### DIFF
--- a/manifest/armv7l/g/go.filelist
+++ b/manifest/armv7l/g/go.filelist
@@ -1,4 +1,4 @@
-# Total size: 203298839
+# Total size: 203574970
 /usr/local/bin/go
 /usr/local/bin/gofmt
 /usr/local/share/go/CONTRIBUTING.md
@@ -57,7 +57,8 @@
 /usr/local/share/go/lib/fips140/README.md
 /usr/local/share/go/lib/fips140/fips140.sum
 /usr/local/share/go/lib/fips140/inprocess.txt
-/usr/local/share/go/lib/fips140/v1.0.0.zip
+/usr/local/share/go/lib/fips140/v1.0.0-c2097c7c.zip
+/usr/local/share/go/lib/fips140/v1.0.0.txt
 /usr/local/share/go/lib/time/README
 /usr/local/share/go/lib/time/mkzip.go
 /usr/local/share/go/lib/time/update.bash
@@ -124,6 +125,7 @@
 /usr/local/share/go/src/archive/tar/testdata/gnu-nil-sparse-hole.tar
 /usr/local/share/go/src/archive/tar/testdata/gnu-not-utf8.tar
 /usr/local/share/go/src/archive/tar/testdata/gnu-sparse-big.tar
+/usr/local/share/go/src/archive/tar/testdata/gnu-sparse-many-zeros.tar.bz2
 /usr/local/share/go/src/archive/tar/testdata/gnu-utf8.tar
 /usr/local/share/go/src/archive/tar/testdata/gnu.tar
 /usr/local/share/go/src/archive/tar/testdata/hardlink.tar
@@ -1644,6 +1646,7 @@
 /usr/local/share/go/src/cmd/go/internal/imports/scan.go
 /usr/local/share/go/src/cmd/go/internal/imports/scan_test.go
 /usr/local/share/go/src/cmd/go/internal/imports/tags.go
+/usr/local/share/go/src/cmd/go/internal/imports/testdata/android/.h.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/a_android.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/b_android_arm64.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/c_linux.go
@@ -1653,6 +1656,7 @@
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/g.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/tags.txt
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/want.txt
+/usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/.h.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/a_illumos.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/b_illumos_amd64.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/c_solaris.go
@@ -3698,6 +3702,7 @@
 /usr/local/share/go/src/cmd/vendor/github.com/google/pprof/third_party/svgpan/LICENSE
 /usr/local/share/go/src/cmd/vendor/github.com/google/pprof/third_party/svgpan/svgpan.go
 /usr/local/share/go/src/cmd/vendor/github.com/google/pprof/third_party/svgpan/svgpan.js
+/usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/.gitignore
 /usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/LICENSE
 /usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/README.md
 /usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/SECURITY.md
@@ -3808,6 +3813,7 @@
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/plan9/zsyscall_plan9_amd64.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/plan9/zsyscall_plan9_arm.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/plan9/zsysnum_plan9.go
+/usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/.gitignore
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/README.md
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/affinity_linux.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/aliases.go
@@ -4151,6 +4157,12 @@
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/windows/zerrors_windows.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/windows/zknownfolderids_windows.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.dockerignore
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.eslintrc.json
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.gitattributes
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.gitignore
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.prettierrc.json
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.stylelintrc.json
 /usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/CONTRIBUTING.md
 /usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/LICENSE
 /usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/PATENTS
@@ -5854,7 +5866,10 @@
 /usr/local/share/go/src/embed/internal/embedtest/embed_test.go
 /usr/local/share/go/src/embed/internal/embedtest/embedx_test.go
 /usr/local/share/go/src/embed/internal/embedtest/testdata/-not-hidden/fortune.txt
+/usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/.more/tip.txt
+/usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/_more/tip.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/fortune.txt
+/usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/more/tip.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/_hidden/fortune.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/ascii.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/glass.txt
@@ -9399,6 +9414,7 @@
 /usr/local/share/go/src/runtime/debuglog_off.go
 /usr/local/share/go/src/runtime/debuglog_on.go
 /usr/local/share/go/src/runtime/debuglog_test.go
+/usr/local/share/go/src/runtime/decoratemappings_test.go
 /usr/local/share/go/src/runtime/defer_test.go
 /usr/local/share/go/src/runtime/defs1_linux.go
 /usr/local/share/go/src/runtime/defs1_netbsd_386.go
@@ -13568,6 +13584,7 @@
 /usr/local/share/go/test/fixedbugs/issue7538b.go
 /usr/local/share/go/test/fixedbugs/issue7547.go
 /usr/local/share/go/test/fixedbugs/issue7550.go
+/usr/local/share/go/test/fixedbugs/issue75569.go
 /usr/local/share/go/test/fixedbugs/issue7590.go
 /usr/local/share/go/test/fixedbugs/issue7648.dir/a.go
 /usr/local/share/go/test/fixedbugs/issue7648.dir/b.go

--- a/manifest/i686/g/go.filelist
+++ b/manifest/i686/g/go.filelist
@@ -1,4 +1,4 @@
-# Total size: 201512160
+# Total size: 201870137
 /usr/local/bin/go
 /usr/local/bin/gofmt
 /usr/local/share/go/CONTRIBUTING.md
@@ -57,7 +57,8 @@
 /usr/local/share/go/lib/fips140/README.md
 /usr/local/share/go/lib/fips140/fips140.sum
 /usr/local/share/go/lib/fips140/inprocess.txt
-/usr/local/share/go/lib/fips140/v1.0.0.zip
+/usr/local/share/go/lib/fips140/v1.0.0-c2097c7c.zip
+/usr/local/share/go/lib/fips140/v1.0.0.txt
 /usr/local/share/go/lib/time/README
 /usr/local/share/go/lib/time/mkzip.go
 /usr/local/share/go/lib/time/update.bash
@@ -124,6 +125,7 @@
 /usr/local/share/go/src/archive/tar/testdata/gnu-nil-sparse-hole.tar
 /usr/local/share/go/src/archive/tar/testdata/gnu-not-utf8.tar
 /usr/local/share/go/src/archive/tar/testdata/gnu-sparse-big.tar
+/usr/local/share/go/src/archive/tar/testdata/gnu-sparse-many-zeros.tar.bz2
 /usr/local/share/go/src/archive/tar/testdata/gnu-utf8.tar
 /usr/local/share/go/src/archive/tar/testdata/gnu.tar
 /usr/local/share/go/src/archive/tar/testdata/hardlink.tar
@@ -1644,6 +1646,7 @@
 /usr/local/share/go/src/cmd/go/internal/imports/scan.go
 /usr/local/share/go/src/cmd/go/internal/imports/scan_test.go
 /usr/local/share/go/src/cmd/go/internal/imports/tags.go
+/usr/local/share/go/src/cmd/go/internal/imports/testdata/android/.h.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/a_android.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/b_android_arm64.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/c_linux.go
@@ -1653,6 +1656,7 @@
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/g.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/tags.txt
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/want.txt
+/usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/.h.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/a_illumos.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/b_illumos_amd64.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/c_solaris.go
@@ -3698,6 +3702,7 @@
 /usr/local/share/go/src/cmd/vendor/github.com/google/pprof/third_party/svgpan/LICENSE
 /usr/local/share/go/src/cmd/vendor/github.com/google/pprof/third_party/svgpan/svgpan.go
 /usr/local/share/go/src/cmd/vendor/github.com/google/pprof/third_party/svgpan/svgpan.js
+/usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/.gitignore
 /usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/LICENSE
 /usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/README.md
 /usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/SECURITY.md
@@ -3808,6 +3813,7 @@
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/plan9/zsyscall_plan9_amd64.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/plan9/zsyscall_plan9_arm.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/plan9/zsysnum_plan9.go
+/usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/.gitignore
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/README.md
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/affinity_linux.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/aliases.go
@@ -4151,6 +4157,12 @@
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/windows/zerrors_windows.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/windows/zknownfolderids_windows.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.dockerignore
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.eslintrc.json
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.gitattributes
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.gitignore
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.prettierrc.json
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.stylelintrc.json
 /usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/CONTRIBUTING.md
 /usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/LICENSE
 /usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/PATENTS
@@ -5854,7 +5866,10 @@
 /usr/local/share/go/src/embed/internal/embedtest/embed_test.go
 /usr/local/share/go/src/embed/internal/embedtest/embedx_test.go
 /usr/local/share/go/src/embed/internal/embedtest/testdata/-not-hidden/fortune.txt
+/usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/.more/tip.txt
+/usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/_more/tip.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/fortune.txt
+/usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/more/tip.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/_hidden/fortune.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/ascii.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/glass.txt
@@ -9399,6 +9414,7 @@
 /usr/local/share/go/src/runtime/debuglog_off.go
 /usr/local/share/go/src/runtime/debuglog_on.go
 /usr/local/share/go/src/runtime/debuglog_test.go
+/usr/local/share/go/src/runtime/decoratemappings_test.go
 /usr/local/share/go/src/runtime/defer_test.go
 /usr/local/share/go/src/runtime/defs1_linux.go
 /usr/local/share/go/src/runtime/defs1_netbsd_386.go
@@ -13568,6 +13584,7 @@
 /usr/local/share/go/test/fixedbugs/issue7538b.go
 /usr/local/share/go/test/fixedbugs/issue7547.go
 /usr/local/share/go/test/fixedbugs/issue7550.go
+/usr/local/share/go/test/fixedbugs/issue75569.go
 /usr/local/share/go/test/fixedbugs/issue7590.go
 /usr/local/share/go/test/fixedbugs/issue7648.dir/a.go
 /usr/local/share/go/test/fixedbugs/issue7648.dir/b.go

--- a/manifest/x86_64/g/go.filelist
+++ b/manifest/x86_64/g/go.filelist
@@ -1,4 +1,4 @@
-# Total size: 205621443
+# Total size: 206005230
 /usr/local/bin/go
 /usr/local/bin/gofmt
 /usr/local/share/go/CONTRIBUTING.md
@@ -57,7 +57,8 @@
 /usr/local/share/go/lib/fips140/README.md
 /usr/local/share/go/lib/fips140/fips140.sum
 /usr/local/share/go/lib/fips140/inprocess.txt
-/usr/local/share/go/lib/fips140/v1.0.0.zip
+/usr/local/share/go/lib/fips140/v1.0.0-c2097c7c.zip
+/usr/local/share/go/lib/fips140/v1.0.0.txt
 /usr/local/share/go/lib/time/README
 /usr/local/share/go/lib/time/mkzip.go
 /usr/local/share/go/lib/time/update.bash
@@ -124,6 +125,7 @@
 /usr/local/share/go/src/archive/tar/testdata/gnu-nil-sparse-hole.tar
 /usr/local/share/go/src/archive/tar/testdata/gnu-not-utf8.tar
 /usr/local/share/go/src/archive/tar/testdata/gnu-sparse-big.tar
+/usr/local/share/go/src/archive/tar/testdata/gnu-sparse-many-zeros.tar.bz2
 /usr/local/share/go/src/archive/tar/testdata/gnu-utf8.tar
 /usr/local/share/go/src/archive/tar/testdata/gnu.tar
 /usr/local/share/go/src/archive/tar/testdata/hardlink.tar
@@ -1644,6 +1646,7 @@
 /usr/local/share/go/src/cmd/go/internal/imports/scan.go
 /usr/local/share/go/src/cmd/go/internal/imports/scan_test.go
 /usr/local/share/go/src/cmd/go/internal/imports/tags.go
+/usr/local/share/go/src/cmd/go/internal/imports/testdata/android/.h.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/a_android.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/b_android_arm64.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/c_linux.go
@@ -1653,6 +1656,7 @@
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/g.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/tags.txt
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/android/want.txt
+/usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/.h.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/a_illumos.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/b_illumos_amd64.go
 /usr/local/share/go/src/cmd/go/internal/imports/testdata/illumos/c_solaris.go
@@ -3698,6 +3702,7 @@
 /usr/local/share/go/src/cmd/vendor/github.com/google/pprof/third_party/svgpan/LICENSE
 /usr/local/share/go/src/cmd/vendor/github.com/google/pprof/third_party/svgpan/svgpan.go
 /usr/local/share/go/src/cmd/vendor/github.com/google/pprof/third_party/svgpan/svgpan.js
+/usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/.gitignore
 /usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/LICENSE
 /usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/README.md
 /usr/local/share/go/src/cmd/vendor/github.com/ianlancetaylor/demangle/SECURITY.md
@@ -3808,6 +3813,7 @@
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/plan9/zsyscall_plan9_amd64.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/plan9/zsyscall_plan9_arm.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/plan9/zsysnum_plan9.go
+/usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/.gitignore
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/README.md
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/affinity_linux.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/unix/aliases.go
@@ -4151,6 +4157,12 @@
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/windows/zerrors_windows.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/windows/zknownfolderids_windows.go
 /usr/local/share/go/src/cmd/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.dockerignore
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.eslintrc.json
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.gitattributes
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.gitignore
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.prettierrc.json
+/usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/.stylelintrc.json
 /usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/CONTRIBUTING.md
 /usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/LICENSE
 /usr/local/share/go/src/cmd/vendor/golang.org/x/telemetry/PATENTS
@@ -5854,7 +5866,10 @@
 /usr/local/share/go/src/embed/internal/embedtest/embed_test.go
 /usr/local/share/go/src/embed/internal/embedtest/embedx_test.go
 /usr/local/share/go/src/embed/internal/embedtest/testdata/-not-hidden/fortune.txt
+/usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/.more/tip.txt
+/usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/_more/tip.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/fortune.txt
+/usr/local/share/go/src/embed/internal/embedtest/testdata/.hidden/more/tip.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/_hidden/fortune.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/ascii.txt
 /usr/local/share/go/src/embed/internal/embedtest/testdata/glass.txt
@@ -9399,6 +9414,7 @@
 /usr/local/share/go/src/runtime/debuglog_off.go
 /usr/local/share/go/src/runtime/debuglog_on.go
 /usr/local/share/go/src/runtime/debuglog_test.go
+/usr/local/share/go/src/runtime/decoratemappings_test.go
 /usr/local/share/go/src/runtime/defer_test.go
 /usr/local/share/go/src/runtime/defs1_linux.go
 /usr/local/share/go/src/runtime/defs1_netbsd_386.go
@@ -13568,6 +13584,7 @@
 /usr/local/share/go/test/fixedbugs/issue7538b.go
 /usr/local/share/go/test/fixedbugs/issue7547.go
 /usr/local/share/go/test/fixedbugs/issue7550.go
+/usr/local/share/go/test/fixedbugs/issue75569.go
 /usr/local/share/go/test/fixedbugs/issue7590.go
 /usr/local/share/go/test/fixedbugs/issue7648.dir/a.go
 /usr/local/share/go/test/fixedbugs/issue7648.dir/b.go

--- a/packages/go.rb
+++ b/packages/go.rb
@@ -3,7 +3,7 @@ require 'package'
 class Go < Package
   description 'Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.'
   homepage 'https://go.dev'
-  version '1.25.1'
+  version '1.25.3'
   license 'BSD'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Go < Package
      x86_64: "https://go.dev/dl/go#{version}.linux-amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'eb949be683e82a99e9861dafd7057e31ea40b161eae6c4cd18fdc0e8c4ae6225',
-     armv7l: 'eb949be683e82a99e9861dafd7057e31ea40b161eae6c4cd18fdc0e8c4ae6225',
-       i686: 'd03cdcbc9bd8baf5cf028de390478e9e2b3e4d0afe5a6582dedc19bfe6a263b2',
-     x86_64: '7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd171254312c41ca12e'
+    aarch64: '3992bd28316484be0af36494124588581aa27e0659a436d607b11d534045bc1f',
+     armv7l: '3992bd28316484be0af36494124588581aa27e0659a436d607b11d534045bc1f',
+       i686: 'acb585c13e7acb10e3b53743c39a7996640c745dffd7d828758786bde92f44ca',
+     x86_64: '0335f314b6e7bfe08c3d0cfaa7c19db961b7b99fb20be62b0a826c992ad14e0f'
   })
 
   conflicts_ok # FIXME: Remove this when file conflicts between go and gcc are fixed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-go crew update \
&& yes | crew upgrade
```