### PR TITLE
Xercesc 3.2.5 => 3.3.0

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.67.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.67.9' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -424,6 +424,7 @@ unless defined?(CREW_ANITYA_PACKAGE_NAME_MAPPINGS)
     { pkg_name: 'vim_runtime', anitya_pkg: 'vim', comments: '' },
     { pkg_name: 'webkitgtk_6', anitya_pkg: 'webkitgtk~stable', comments: '' },
     { pkg_name: 'xauth', anitya_pkg: 'xorg-x11-xauth', comments: '' },
+    { pkg_name: 'xercesc', anitya_pkg: 'xerces-c', comments: 'Prefer to GitHub' },
     { pkg_name: 'yad', anitya_pkg: 'yad', comments: 'Prefer to GitHub' },
     { pkg_name: 'zimg', anitya_pkg: 'zimg', comments: 'Prefer to GitHub' },
     { pkg_name: 'zoneinfo', anitya_pkg: 'tzdata', comments: '' }

--- a/manifest/armv7l/x/xercesc.filelist
+++ b/manifest/armv7l/x/xercesc.filelist
@@ -1,4 +1,4 @@
-# Total size: 8725179
+# Total size: 9635670
 /usr/local/bin/CreateDOMDocument
 /usr/local/bin/DOMCount
 /usr/local/bin/DOMPrint
@@ -483,7 +483,7 @@
 /usr/local/include/xercesc/xinclude/XIncludeDOMDocumentProcessor.hpp
 /usr/local/include/xercesc/xinclude/XIncludeLocation.hpp
 /usr/local/include/xercesc/xinclude/XIncludeUtils.hpp
-/usr/local/lib/libxerces-c-3.2.so
+/usr/local/lib/libxerces-c-3.3.so
 /usr/local/lib/libxerces-c.la
 /usr/local/lib/libxerces-c.so
 /usr/local/lib/pkgconfig/xerces-c.pc

--- a/manifest/i686/x/xercesc.filelist
+++ b/manifest/i686/x/xercesc.filelist
@@ -1,4 +1,4 @@
-# Total size: 9407682
+# Total size: 10091993
 /usr/local/bin/CreateDOMDocument
 /usr/local/bin/DOMCount
 /usr/local/bin/DOMPrint
@@ -483,7 +483,7 @@
 /usr/local/include/xercesc/xinclude/XIncludeDOMDocumentProcessor.hpp
 /usr/local/include/xercesc/xinclude/XIncludeLocation.hpp
 /usr/local/include/xercesc/xinclude/XIncludeUtils.hpp
-/usr/local/lib/libxerces-c-3.2.so
+/usr/local/lib/libxerces-c-3.3.so
 /usr/local/lib/libxerces-c.la
 /usr/local/lib/libxerces-c.so
 /usr/local/lib/pkgconfig/xerces-c.pc

--- a/manifest/x86_64/x/xercesc.filelist
+++ b/manifest/x86_64/x/xercesc.filelist
@@ -1,4 +1,4 @@
-# Total size: 9594773
+# Total size: 10346572
 /usr/local/bin/CreateDOMDocument
 /usr/local/bin/DOMCount
 /usr/local/bin/DOMPrint
@@ -483,7 +483,7 @@
 /usr/local/include/xercesc/xinclude/XIncludeDOMDocumentProcessor.hpp
 /usr/local/include/xercesc/xinclude/XIncludeLocation.hpp
 /usr/local/include/xercesc/xinclude/XIncludeUtils.hpp
-/usr/local/lib64/libxerces-c-3.2.so
+/usr/local/lib64/libxerces-c-3.3.so
 /usr/local/lib64/libxerces-c.la
 /usr/local/lib64/libxerces-c.so
 /usr/local/lib64/pkgconfig/xerces-c.pc

--- a/packages/xercesc.rb
+++ b/packages/xercesc.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Xercesc < Autotools
   description 'Xerces-C++ is a validating XML parser written in a portable subset of C++.'
   homepage 'https://xerces.apache.org/xerces-c/'
-  version '3.2.5'
+  version '3.3.0'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/apache/xerces-c.git'
@@ -11,10 +11,10 @@ class Xercesc < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f8b2b89232b64109e16cb378545adbc29d60a80ac141dc58ee303a83c5f5db4e',
-     armv7l: 'f8b2b89232b64109e16cb378545adbc29d60a80ac141dc58ee303a83c5f5db4e',
-       i686: '1573698c5fa1871953d6fe90bfa4cc613a71dde7bd1a63c36d83c184e5911ca5',
-     x86_64: 'f1a1409f5fdcb3670d4f05c6fb500c554a871c073c478f51283de0d0ef993b8a'
+    aarch64: '08c39e12821035988630c10496a85173743089f88661352dff107458c8462121',
+     armv7l: '08c39e12821035988630c10496a85173743089f88661352dff107458c8462121',
+       i686: 'c1ffc9af8cd5af9e72e51d2015e2a3ab64b87334fc96a1ef962d489f3c803432',
+     x86_64: '9e59c9d153c5d78fb15127ba1940fd12dba45835d696dd7d721aa5af0d6e5c74'
   })
 
   depends_on 'brotli' # R


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-xercesc crew update \
&& yes | crew upgrade
```