### PR TITLE
Tree 2.1.0 => 2.2.1

### DIFF
--- a/manifest/armv7l/t/tree.filelist
+++ b/manifest/armv7l/t/tree.filelist
@@ -1,3 +1,3 @@
-# Total size: 73525
+# Total size: 90073
 /usr/local/bin/tree
 /usr/local/share/man/man1/tree.1.zst

--- a/manifest/i686/t/tree.filelist
+++ b/manifest/i686/t/tree.filelist
@@ -1,3 +1,3 @@
-# Total size: 98053
+# Total size: 99205
 /usr/local/bin/tree
 /usr/local/share/man/man1/tree.1.zst

--- a/manifest/x86_64/t/tree.filelist
+++ b/manifest/x86_64/t/tree.filelist
@@ -1,3 +1,3 @@
-# Total size: 91685
+# Total size: 97365
 /usr/local/bin/tree
 /usr/local/share/man/man1/tree.1.zst

--- a/packages/tree.rb
+++ b/packages/tree.rb
@@ -2,26 +2,28 @@ require 'package'
 
 class Tree < Package
   description 'Tree is a recursive directory listing command that produces a depth indented listing of files, which is colorized ala dircolors if the LS_COLORS environment variable is set and output is to tty.'
-  homepage 'http://mama.indstate.edu/users/ice/tree/'
-  version '2.1.0'
+  homepage 'https://github.com/Old-Man-Programmer/tree'
+  version '2.2.1'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'http://mama.indstate.edu/users/ice/tree/src/tree-2.1.0.tgz'
-  source_sha256 '0160c535bff2b0dc6a830b9944e981e3427380f63e748da96ced7071faebabf6'
+  source_url 'https://github.com/Old-Man-Programmer/tree.git'
+  git_hashtag version
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '3bcf4c520da9ece2bfafe91dc60a3aef3d082748bb97831b6dc11435d5bb3a9d',
-     armv7l: '3bcf4c520da9ece2bfafe91dc60a3aef3d082748bb97831b6dc11435d5bb3a9d',
-       i686: 'ed51e27c703299efd1b73221c6c5226d2b0d10c629dac2326d1edc6a9258867f',
-     x86_64: 'a99cb6010fc11eb1802b1307b9e486104f74745baed92b8764b7f2055ea908f6'
+    aarch64: 'ee1ffe8304e20d04ab323c44c85956438d2478be886734bac9e3a90800cf0f1b',
+     armv7l: 'ee1ffe8304e20d04ab323c44c85956438d2478be886734bac9e3a90800cf0f1b',
+       i686: '61479f4b2831ec6927c4c81352988b2c0d20b1923667e605cb08bb41d6b98dd9',
+     x86_64: '1f1de80fc668ace74490a1a2ec74c6408de42223feb3ba7afbb11b4f0f6dc621'
   })
+
+  depends_on 'glibc' # R
 
   def self.build
     system 'make'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_PREFIX}/bin", "MANDIR=#{CREW_DEST_MAN_PREFIX}", 'install'
+    system 'make', "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_PREFIX}/bin", "MANDIR=#{CREW_DEST_MAN_PREFIX}", 'install'
   end
 end


### PR DESCRIPTION
Source url changed to match the official project at https://release-monitoring.org/project/372543/.

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-tree crew update \
&& yes | crew upgrade
```