### PR TITLE
Add `conflicts_with` property and use it for `coreutils`, `tealdeer` and `tldr`

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.67.11' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.67.12' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -71,7 +71,8 @@ class Package
            :git_branch,
            :git_hashtag,
            :max_glibc,
-           :min_glibc
+           :min_glibc,
+           :conflicts_with
 
   create_placeholder :preflight,       # Function for checks to see if install should occur.
                      :patch,           # Function to perform patch operations prior to build from source.
@@ -132,11 +133,6 @@ class Package
     else
       puts "#{config_object} saved.".lightgreen
     end
-  end
-
-  def self.installed(pkg)
-    # Returns true if the package is installed, false otherwise.
-    return File.file? "#{CREW_META_PATH}/#{pkg}.filelist"
   end
 
   def self.load_package(pkg_file, reload = nil)

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -11,7 +11,7 @@ class PackageUtils
   end
 
   def self.compatible?(pkg)
-    return (pkg.compatibility.casecmp?('all') || pkg.compatibility.include?(ARCH)) && (pkg.min_glibc.nil? || (pkg.min_glibc <= LIBC_VERSION)) && (pkg.max_glibc.nil? || (pkg.max_glibc >= LIBC_VERSION))
+    return (pkg.compatibility.casecmp?('all') || pkg.compatibility.include?(ARCH)) && (pkg.min_glibc.nil? || (pkg.min_glibc <= LIBC_VERSION)) && (pkg.max_glibc.nil? || (pkg.max_glibc >= LIBC_VERSION)) && !installed?(pkg.conflicts_with)
   end
 
   def self.incompatible_reason(pkg)
@@ -19,6 +19,7 @@ class PackageUtils
     reason.push "#{pkg.name.capitalize} is not compatible with #{ARCH}." if !pkg.compatibility.casecmp?('all') && !pkg.compatibility.include?(ARCH)
     reason.push "ChromeOS is currently running glibc #{LIBC_VERSION}, but the minimum version for #{pkg.name} is #{pkg.min_glibc}." if !pkg.min_glibc.nil? && (pkg.min_glibc >= LIBC_VERSION)
     reason.push "ChromeOS is currently running glibc #{LIBC_VERSION}, but the maximum version for #{pkg.name} is #{pkg.min_glibc}." if !pkg.max_glibc.nil? && (pkg.max_glibc.to_s <= LIBC_VERSION)
+    reason.push "#{pkg.name.capitalize} conflicts with #{pkg.conflicts_with.capitalize}, which is currently installed." if installed?(pkg.conflicts_with)
     return reason
   end
 

--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -24,15 +24,7 @@ class Coreutils < Autotools
   depends_on 'libcap' # R
   depends_on 'openssl' # R
 
-  def self.preflight
-    %w[uutils_coreutils].each do |cutils|
-      next unless File.exist? "#{CREW_PREFIX}/etc/crew/meta/#{cutils}.filelist"
-
-      puts "#{cutils} is installed and conflicts with this version.".orange
-      puts 'To install this version, execute the following:'.lightblue
-      abort "crew remove #{cutils} && crew install coreutils".lightblue
-    end
-  end
+  conflicts_with 'uutils_coreutils'
 
   def self.prebuild
     File.write 'arch', <<~EOF

--- a/packages/tealdeer.rb
+++ b/packages/tealdeer.rb
@@ -21,13 +21,5 @@ class Tealdeer < RUST
   depends_on 'glibc' # R
   depends_on 'rust' => :build
 
-  def self.preflight
-    if Package.installed('tldr')
-      abort <<~EOM.orange
-
-        tldr is installed. To install this package, execute:
-        crew remove tldr && crew install tealdeer
-      EOM
-    end
-  end
+  conflicts_with 'tldr'
 end

--- a/packages/tldr.rb
+++ b/packages/tldr.rb
@@ -11,15 +11,7 @@ class Tldr < Package
 
   no_compile_needed
 
-  def self.preflight
-    if Package.installed('tealdeer')
-      abort <<~EOM.orange
-
-        tealdeer is installed. To install this package, execute:
-        crew remove tealdeer && crew install tldr
-      EOM
-    end
-  end
+  conflicts_with 'tealdeer'
 
   def self.patch
     # Fix /usr/local/bin/tldr: 97: /usr/local/bin/tldr: cannot create /dev/stderr: Permission denied

--- a/tests/lib/package_utils.rb
+++ b/tests/lib/package_utils.rb
@@ -90,6 +90,26 @@ class PackageUtilsTest < Minitest::Test
     refute(PackageUtils.compatible?(pkg))
   end
 
+  def test_compatible_conflicts_with
+    # A package that conflicts with a package that is not installed is compatible.
+    pkg = Class.new(Package)
+    pkg.instance_eval do
+      compatibility 'all'
+      conflicts_with '99notinstalled'
+    end
+    assert(PackageUtils.compatible?(pkg))
+  end
+
+  def test_not_compatible_conflicts_with
+    # A package that conflicts with a package that is not installed is compatible.
+    pkg = Class.new(Package)
+    pkg.instance_eval do
+      compatibility 'all'
+      conflicts_with 'ruby'
+    end
+    refute(PackageUtils.compatible?(pkg))
+  end
+
   def test_get_binary_url_old_hash
     pkg = Class.new(Package)
     pkg.name = 'hello_world_chromebrew'


### PR DESCRIPTION
## Description
This unifies and simplifies the logic for determining if a package conflicts with another package in an unacceptable way prior to installation. 

Right now I've added it for `tealdeer` and `tldr`, as well as `coreutils` (`uutils_coreutils` didn't have any logic to complain in the other direction, so I haven't added any)

I've only applied this to the simplest instances where one package conflicts with another-- there are all sorts of cases with openjdk or php versions, or vim binaries that I haven't touched.

I also added tests for `PackageUtils.compatible?` on `max_glibc` and `min_glibc`, because tests are good (and also to confirm the functionality of a refactor I was planning that didn't end up working)

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=crust crew update \
&& yes | crew upgrade
```
