### PR TITLE
Have version.rb use anitya match if a single package matches when the underscore in the name is toggled to a dash. 

### DIFF
--- a/tools/version.rb
+++ b/tools/version.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# version.rb version 3.8 (for Chromebrew)
+# version.rb version 3.9 (for Chromebrew)
 
 OPTIONS = %w[-h --help -j --json -u --update-package-files -v --verbose -vv]
 
@@ -175,18 +175,19 @@ def get_anitya_id(name, homepage)
       if number_of_packages.zero?
         puts "No Anitya package found with #{name_candidate}." if VERY_VERBOSE
         return
-      end
-
-      puts "number_of_packages = #{number_of_packages}" if VERY_VERBOSE
-      (0..(number_of_packages - 1)).each do |i|
-        next if json['items'][i].nil?
-        homepage_domain = homepage.gsub(%r{http(s)?://(www\.)?}, '').chomp('/')
-        puts "homepage_domain = #{homepage.gsub(%r{http(s)?://(www\.)?}, '').chomp('/')}" if VERY_VERBOSE
-        candidate_homepage_domain = json['items'][i]['homepage'].gsub(%r{http(s)?://(www\.)?}, '').chomp('/')
-        puts "candidate_homepage_domain = #{json['items'][i]['homepage'].gsub(%r{http(s)?://(www\.)?}, '').chomp('/')}" if VERY_VERBOSE
-        if homepage_domain == candidate_homepage_domain
-          @new_anitya_name = name_candidate
-          return json['items'][i]['id']
+      elsif number_of_packages == 1 # We assume we have the right package, take the ID and move on.
+        return json['items'][0]['id']
+      else
+        (0..(number_of_packages - 1)).each do |i|
+          next if json['items'][i].nil?
+          homepage_domain = homepage.gsub(%r{http(s)?://(www\.)?}, '').chomp('/')
+          puts "homepage_domain = #{homepage.gsub(%r{http(s)?://(www\.)?}, '').chomp('/')}" if VERY_VERBOSE
+          candidate_homepage_domain = json['items'][i]['homepage'].gsub(%r{http(s)?://(www\.)?}, '').chomp('/')
+          puts "candidate_homepage_domain = #{json['items'][i]['homepage'].gsub(%r{http(s)?://(www\.)?}, '').chomp('/')}" if VERY_VERBOSE
+          if homepage_domain == candidate_homepage_domain
+            @new_anitya_name = name_candidate
+            return json['items'][i]['id']
+          end
         end
       end
     end


### PR DESCRIPTION
## Description
```
tools/version.rb -vv xorg_xset
Package   Status           Current      Upstream     Updatable?   Compile?
-------   ------           -------      --------     ----------   --------
url is https://release-monitoring.org/api/v2/projects/?name=xorg_xset
{"items"=>[], "items_per_page"=>25, "page"=>1, "total_items"=>0}
number_of_packages = 0
No Anitya package found with xorg_xset. Attempting a new search with xorg-xset.
url is https://release-monitoring.org/api/v2/projects/?name=xorg-xset
anitya_name: xorg_xset anitya_id: 14954
{"latest_version"=>"1.2.5", "stable_versions"=>["1.2.5", "1.2.4", "1.2.3", "1.2.2", "1.2.1", "1.2.0", "1.1.0", "1.0.4", "1.0.3", "1.0.2", "1.0.1", "0.99.1"], "versions"=>["1.2.5", "1.2.4", "1.2.3", "1.2.2", "1.2.1", "1.2.0", "1.1.0", "1.0.4", "1.0.3", "1.0.2", "1.0.1", "0.99.1"]}
xorg_xset Up to date.      1.2.5        1.2.5        Yes          Yes
```
#### Commits:
-  0ad3cbd94 Have version.rb use anitya match if a single package matches when the underscore in the name is toggled to a dash.
### Other changed files:
- tools/version.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=anitya_version crew update \
&& yes | crew upgrade
```
