### PR TITLE
Add unbuilt glib to updater-glib-2.86.1 — glib → 2.86.1,gobject_introspection → 1.86.0

### DIFF
--- a/manifest/armv7l/g/glib.filelist
+++ b/manifest/armv7l/g/glib.filelist
@@ -1,4 +1,4 @@
-# Total size: 29285797
+# Total size: 29412625
 /usr/local/bin/gapplication
 /usr/local/bin/gdbus
 /usr/local/bin/gdbus-codegen
@@ -332,22 +332,22 @@
 /usr/local/lib/glib-2.0/include/glibconfig.h
 /usr/local/lib/libgio-2.0.so
 /usr/local/lib/libgio-2.0.so.0
-/usr/local/lib/libgio-2.0.so.0.8600.0
+/usr/local/lib/libgio-2.0.so.0.8600.1
 /usr/local/lib/libgirepository-2.0.so
 /usr/local/lib/libgirepository-2.0.so.0
-/usr/local/lib/libgirepository-2.0.so.0.8600.0
+/usr/local/lib/libgirepository-2.0.so.0.8600.1
 /usr/local/lib/libglib-2.0.so
 /usr/local/lib/libglib-2.0.so.0
-/usr/local/lib/libglib-2.0.so.0.8600.0
+/usr/local/lib/libglib-2.0.so.0.8600.1
 /usr/local/lib/libgmodule-2.0.so
 /usr/local/lib/libgmodule-2.0.so.0
-/usr/local/lib/libgmodule-2.0.so.0.8600.0
+/usr/local/lib/libgmodule-2.0.so.0.8600.1
 /usr/local/lib/libgobject-2.0.so
 /usr/local/lib/libgobject-2.0.so.0
-/usr/local/lib/libgobject-2.0.so.0.8600.0
+/usr/local/lib/libgobject-2.0.so.0.8600.1
 /usr/local/lib/libgthread-2.0.so
 /usr/local/lib/libgthread-2.0.so.0
-/usr/local/lib/libgthread-2.0.so.0.8600.0
+/usr/local/lib/libgthread-2.0.so.0.8600.1
 /usr/local/lib/pkgconfig/gio-2.0.pc
 /usr/local/lib/pkgconfig/gio-unix-2.0.pc
 /usr/local/lib/pkgconfig/girepository-2.0.pc
@@ -366,8 +366,8 @@
 /usr/local/share/bash-completion/completions/gio
 /usr/local/share/bash-completion/completions/gresource
 /usr/local/share/bash-completion/completions/gsettings
-/usr/local/share/gdb/auto-load/usr/local/lib/libglib-2.0.so.0.8600.0-gdb.py
-/usr/local/share/gdb/auto-load/usr/local/lib/libgobject-2.0.so.0.8600.0-gdb.py
+/usr/local/share/gdb/auto-load/usr/local/lib/libglib-2.0.so.0.8600.1-gdb.py
+/usr/local/share/gdb/auto-load/usr/local/lib/libgobject-2.0.so.0.8600.1-gdb.py
 /usr/local/share/gettext/its/gschema.its
 /usr/local/share/gettext/its/gschema.loc
 /usr/local/share/gir-1.0/GIRepository-3.0.gir

--- a/manifest/i686/g/glib.filelist
+++ b/manifest/i686/g/glib.filelist
@@ -1,4 +1,4 @@
-# Total size: 18186759
+# Total size: 18312325
 /usr/local/bin/gapplication
 /usr/local/bin/gdbus
 /usr/local/bin/gdbus-codegen
@@ -325,22 +325,22 @@
 /usr/local/lib/glib-2.0/include/glibconfig.h
 /usr/local/lib/libgio-2.0.so
 /usr/local/lib/libgio-2.0.so.0
-/usr/local/lib/libgio-2.0.so.0.8600.0
+/usr/local/lib/libgio-2.0.so.0.8600.1
 /usr/local/lib/libgirepository-2.0.so
 /usr/local/lib/libgirepository-2.0.so.0
-/usr/local/lib/libgirepository-2.0.so.0.8600.0
+/usr/local/lib/libgirepository-2.0.so.0.8600.1
 /usr/local/lib/libglib-2.0.so
 /usr/local/lib/libglib-2.0.so.0
-/usr/local/lib/libglib-2.0.so.0.8600.0
+/usr/local/lib/libglib-2.0.so.0.8600.1
 /usr/local/lib/libgmodule-2.0.so
 /usr/local/lib/libgmodule-2.0.so.0
-/usr/local/lib/libgmodule-2.0.so.0.8600.0
+/usr/local/lib/libgmodule-2.0.so.0.8600.1
 /usr/local/lib/libgobject-2.0.so
 /usr/local/lib/libgobject-2.0.so.0
-/usr/local/lib/libgobject-2.0.so.0.8600.0
+/usr/local/lib/libgobject-2.0.so.0.8600.1
 /usr/local/lib/libgthread-2.0.so
 /usr/local/lib/libgthread-2.0.so.0
-/usr/local/lib/libgthread-2.0.so.0.8600.0
+/usr/local/lib/libgthread-2.0.so.0.8600.1
 /usr/local/lib/pkgconfig/gio-2.0.pc
 /usr/local/lib/pkgconfig/gio-unix-2.0.pc
 /usr/local/lib/pkgconfig/girepository-2.0.pc
@@ -359,8 +359,8 @@
 /usr/local/share/bash-completion/completions/gio
 /usr/local/share/bash-completion/completions/gresource
 /usr/local/share/bash-completion/completions/gsettings
-/usr/local/share/gdb/auto-load/usr/local/lib/libglib-2.0.so.0.8600.0-gdb.py
-/usr/local/share/gdb/auto-load/usr/local/lib/libgobject-2.0.so.0.8600.0-gdb.py
+/usr/local/share/gdb/auto-load/usr/local/lib/libglib-2.0.so.0.8600.1-gdb.py
+/usr/local/share/gdb/auto-load/usr/local/lib/libgobject-2.0.so.0.8600.1-gdb.py
 /usr/local/share/gettext/its/gschema.its
 /usr/local/share/gettext/its/gschema.loc
 /usr/local/share/glib-2.0/codegen/__init__.py

--- a/manifest/x86_64/g/glib.filelist
+++ b/manifest/x86_64/g/glib.filelist
@@ -1,4 +1,4 @@
-# Total size: 30554471
+# Total size: 30684483
 /usr/local/bin/gapplication
 /usr/local/bin/gdbus
 /usr/local/bin/gdbus-codegen
@@ -332,22 +332,22 @@
 /usr/local/lib64/glib-2.0/include/glibconfig.h
 /usr/local/lib64/libgio-2.0.so
 /usr/local/lib64/libgio-2.0.so.0
-/usr/local/lib64/libgio-2.0.so.0.8600.0
+/usr/local/lib64/libgio-2.0.so.0.8600.1
 /usr/local/lib64/libgirepository-2.0.so
 /usr/local/lib64/libgirepository-2.0.so.0
-/usr/local/lib64/libgirepository-2.0.so.0.8600.0
+/usr/local/lib64/libgirepository-2.0.so.0.8600.1
 /usr/local/lib64/libglib-2.0.so
 /usr/local/lib64/libglib-2.0.so.0
-/usr/local/lib64/libglib-2.0.so.0.8600.0
+/usr/local/lib64/libglib-2.0.so.0.8600.1
 /usr/local/lib64/libgmodule-2.0.so
 /usr/local/lib64/libgmodule-2.0.so.0
-/usr/local/lib64/libgmodule-2.0.so.0.8600.0
+/usr/local/lib64/libgmodule-2.0.so.0.8600.1
 /usr/local/lib64/libgobject-2.0.so
 /usr/local/lib64/libgobject-2.0.so.0
-/usr/local/lib64/libgobject-2.0.so.0.8600.0
+/usr/local/lib64/libgobject-2.0.so.0.8600.1
 /usr/local/lib64/libgthread-2.0.so
 /usr/local/lib64/libgthread-2.0.so.0
-/usr/local/lib64/libgthread-2.0.so.0.8600.0
+/usr/local/lib64/libgthread-2.0.so.0.8600.1
 /usr/local/lib64/pkgconfig/gio-2.0.pc
 /usr/local/lib64/pkgconfig/gio-unix-2.0.pc
 /usr/local/lib64/pkgconfig/girepository-2.0.pc
@@ -366,8 +366,8 @@
 /usr/local/share/bash-completion/completions/gio
 /usr/local/share/bash-completion/completions/gresource
 /usr/local/share/bash-completion/completions/gsettings
-/usr/local/share/gdb/auto-load/usr/local/lib64/libglib-2.0.so.0.8600.0-gdb.py
-/usr/local/share/gdb/auto-load/usr/local/lib64/libgobject-2.0.so.0.8600.0-gdb.py
+/usr/local/share/gdb/auto-load/usr/local/lib64/libglib-2.0.so.0.8600.1-gdb.py
+/usr/local/share/gdb/auto-load/usr/local/lib64/libgobject-2.0.so.0.8600.1-gdb.py
 /usr/local/share/gettext/its/gschema.its
 /usr/local/share/gettext/its/gschema.loc
 /usr/local/share/gir-1.0/GIRepository-3.0.gir

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -11,10 +11,10 @@ class Glib < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '9dd914a165ec477952974197531ef5a3163a93a60f19478b1691050070eb6afc',
-     armv7l: '9dd914a165ec477952974197531ef5a3163a93a60f19478b1691050070eb6afc',
-       i686: '8d6728712ffc56e8d9496c9dba31175a0dab3cb4c9fa1b920b3c08046d305640',
-     x86_64: '1e0210b3446d17767b9b88e66fd0b3e8c449790529d3221727c4f7832e38c62a'
+    aarch64: '078fc2e0cbec6f2a3ffabc7983decbd531fb2e89f15d89fedbd83a455573a19d',
+     armv7l: '078fc2e0cbec6f2a3ffabc7983decbd531fb2e89f15d89fedbd83a455573a19d',
+       i686: 'ea903993830032fc0afe98fe320e75fd5abb4d423f7d1a9e19d31db6301ec233',
+     x86_64: '6fc27c85d461d1d1481b5ffcb0ea8157b83c396b8f69475eaa0a872a8e865883'
   })
 
   depends_on 'elfutils' # R
@@ -30,9 +30,6 @@ class Glib < Meson
   gnome
   no_strip if %w[aarch64 armv7l].include? ARCH
 
-  def self.prebuild
-    system 'PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --upgrade --force-reinstall pip setuptools'
-  end
   meson_options '-Dselinux=disabled \
     -Dsysprof=disabled \
     -Dman-pages=disabled \

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -118,7 +118,7 @@ class Python3 < Package
   def self.postinstall
     # First force pip upgrade to make sure we are past the problematic pip 23.2.1
     # See https://github.com/pypa/pip/issues/12357 and https://github.com/pypa/pip/issues/12428
-    system 'PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --upgrade --force-reinstall pip setuptools'
+    # system 'PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --upgrade --force-reinstall pip'
     # Pip is installed inside Python 3. The following steps ensure that
     # pip can properly build other packages from buildsystems/pip.
     # @required_pip_modules = %w[build installer setuptools wheel pyproject_hooks]


### PR DESCRIPTION
## Description
#### Commits:
-  69fb382df Add binaries.
-  42b1392e3 Adjust glib build settings.
-  9accf23d3 Add unbuilt glib to updater-glib-2.86.1
### Packages with Updated versions or Changed package files:
- `glib` &rarr; 2.86.1
- `gobject_introspection` &rarr; 1.86.0
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=updater-glib-2.86.1 crew update \
&& yes | crew upgrade
```
