### PR TITLE
Revamp python3 postinstall to handle setuptools. — python3 → 3.13.9-2

### DIFF
--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -3,7 +3,7 @@ require 'package'
 class Python3 < Package
   description 'Python is a programming language that lets you work quickly and integrate systems more effectively.'
   homepage 'https://www.python.org/'
-  version '3.13.9-1'
+  version '3.13.9-2'
   license 'PSF-2.0'
   compatibility 'all'
   source_url "https://www.python.org/ftp/python/#{version.split('-').first}/Python-#{version.split('-').first}.tar.xz"
@@ -116,9 +116,8 @@ class Python3 < Package
   end
 
   def self.postinstall
-    # First force pip upgrade to make sure we are past the problematic pip 23.2.1
-    # See https://github.com/pypa/pip/issues/12357 and https://github.com/pypa/pip/issues/12428
-    # system 'PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --upgrade --force-reinstall pip'
+    # Fix issues with newer setuptools breaking existing python3 installs.
+    system 'PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --upgrade --force-reinstall pip setuptools'
     # Pip is installed inside Python 3. The following steps ensure that
     # pip can properly build other packages from buildsystems/pip.
     # @required_pip_modules = %w[build installer setuptools wheel pyproject_hooks]


### PR DESCRIPTION
## Description
#### Commits:
-  92e223b53 Revamp python3 postinstall to handle setuptools.
### Packages with Updated versions or Changed package files:
- `python3` &rarr; 3.13.9-2 (current version is 3.13.9)
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=python3_rebuild crew update \
&& yes | crew upgrade
```
