### PR TITLE
Add mp3cat package

### DIFF
--- a/manifest/armv7l/m/mp3cat.filelist
+++ b/manifest/armv7l/m/mp3cat.filelist
@@ -1,0 +1,2 @@
+# Total size: 1810196
+/usr/local/bin/mp3cat

--- a/manifest/i686/m/mp3cat.filelist
+++ b/manifest/i686/m/mp3cat.filelist
@@ -1,0 +1,2 @@
+# Total size: 1708836
+/usr/local/bin/mp3cat

--- a/manifest/x86_64/m/mp3cat.filelist
+++ b/manifest/x86_64/m/mp3cat.filelist
@@ -1,0 +1,2 @@
+# Total size: 1791688
+/usr/local/bin/mp3cat

--- a/packages/mp3cat.rb
+++ b/packages/mp3cat.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Mp3cat < Package
+  description 'A command line utility for joining MP3 files.'
+  homepage 'https://www.dmulholl.com/dev/mp3cat.html'
+  version '4.2.2'
+  license 'Public domain'
+  compatibility 'all'
+  source_url 'https://github.com/dmulholl/mp3cat.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: 'aaec98bd300b98172ec9d55136179fdff99bf267c5544d572b762ff6bd2e79bd',
+     armv7l: 'aaec98bd300b98172ec9d55136179fdff99bf267c5544d572b762ff6bd2e79bd',
+       i686: 'd998ee175531335ee0d5b3b76b6d9658d753a7983675cf46867d2fc4321f3d5d',
+     x86_64: 'ba456930bc94cd13952f6769a55bd4ec4514a78bab5e105dd1625d70429ed95d'
+  })
+
+  depends_on 'glibc' # R
+  depends_on 'go' => :build
+
+  def self.build
+    system 'go build -o bin/mp3cat'
+  end
+
+  def self.install
+    FileUtils.install 'bin/mp3cat', "#{CREW_DEST_PREFIX}/bin/mp3cat", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6170,6 +6170,11 @@ url: https://sourceforge.net/projects/motif/files/
 activity: none
 ---
 kind: url
+name: mp3cat
+url: https://github.com/dmulholl/mp3cat/releases
+activity: none
+---
+kind: url
 name: mp4v2
 url: https://code.google.com/archive/p/mp4v2/downloads
 activity: none


### PR DESCRIPTION
A command line utility for joining MP3 files. See https://www.dmulholl.com/dev/mp3cat.html.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-mp3cat-package crew update \
&& yes | crew upgrade
```