### PR TITLE
Opera 123.0.5669.23 => 123.0.5669.47

### DIFF
--- a/manifest/x86_64/o/opera.filelist
+++ b/manifest/x86_64/o/opera.filelist
@@ -1,4 +1,4 @@
-# Total size: 360300535
+# Total size: 360457765
 /usr/local/bin/opera
 /usr/local/share/applications/opera.desktop
 /usr/local/share/doc/opera-stable/changelog.gz

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,12 +3,12 @@ require 'package'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '123.0.5669.23'
+  version '123.0.5669.47'
   license 'OPERA-2018'
   compatibility 'x86_64'
 
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '8f6907760f1deb44bd8f76cbc9c863987fdc4405c71888ce8062aa98d2219c75'
+  source_sha256 '052ef36d02210f937586167b8f25bcd940c0a2d0123f1d3842c1c4d4c6c42973'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m141 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```