### PR TITLE
Terraform 1.13.3 => 1.13.5

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.13.3'
+  version '1.13.5'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: 'cb4a434b83a11d159c8c172b08e9b11b47458befb4e021f5ce20a894dd50c777',
-     armv7l: 'cb4a434b83a11d159c8c172b08e9b11b47458befb4e021f5ce20a894dd50c777',
-       i686: '68444c089d3c467b524c994f039f8b3bfa3362bef0dcf0105d2e2c3099752434',
-     x86_64: '71fc43d92ea09907be5d416d2405a6a9c2d1ceaed633f5e175c0af26e8c4b365'
+    aarch64: '33ced3ed54c828ece06a9e84f43a8737686640208c0c1d36be830c34012714f0',
+     armv7l: '33ced3ed54c828ece06a9e84f43a8737686640208c0c1d36be830c34012714f0',
+       i686: '3369e665e1de0d43b59ea79e9ca96432e91b5fc4c734d5f0ce8c214e03a6c989',
+     x86_64: '0dbe3fcc268eb670801af6a6456799d1ae26e72e73797f6c6167e18aafd1fd9a'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.13.3 to version 1.13.5.

## Additional information
Tested & Working properly:
- [X] `x86_64`
- [X] `i686`
- [X] `armv7l`
##
- [X] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##