### PR TITLE
Add ironclad package

### DIFF
--- a/manifest/armv7l/i/ironclad.filelist
+++ b/manifest/armv7l/i/ironclad.filelist
@@ -1,0 +1,2 @@
+# Total size: 6357392
+/usr/local/bin/ironclad

--- a/manifest/i686/i/ironclad.filelist
+++ b/manifest/i686/i/ironclad.filelist
@@ -1,0 +1,2 @@
+# Total size: 6344848
+/usr/local/bin/ironclad

--- a/manifest/x86_64/i/ironclad.filelist
+++ b/manifest/x86_64/i/ironclad.filelist
@@ -1,0 +1,2 @@
+# Total size: 6517640
+/usr/local/bin/ironclad

--- a/packages/ironclad.rb
+++ b/packages/ironclad.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Ironclad < Package
+  description 'A command line password manager.'
+  homepage 'https://www.dmulholl.com/docs/ironclad/master/'
+  version '2.7.0'
+  license '0BSD'
+  compatibility 'all'
+  source_url 'https://github.com/dmulholl/ironclad.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: 'd71c5253d76d64b58a2d32732745e658d66f0cc430dad5513e52910e8bde3b51',
+     armv7l: 'd71c5253d76d64b58a2d32732745e658d66f0cc430dad5513e52910e8bde3b51',
+       i686: '17e304fd45ac30488bd57856c50135da1638c2cb060da2401ed694db9d569d4d',
+     x86_64: '764b3f9256a2ad15879341e7b1949d7b8b15a2524cc75ebb05310a6443fcc2e5'
+  })
+
+  depends_on 'glibc' # R
+  depends_on 'go' => :build
+
+  def self.build
+    system 'make build'
+  end
+
+  def self.install
+    FileUtils.install 'build/ironclad', "#{CREW_DEST_PREFIX}/bin/ironclad", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -3525,6 +3525,11 @@ url: https://github.com/iputils/iputils/releases
 activity: low
 ---
 kind: url
+name: ironclad
+url: https://github.com/dmulholl/ironclad/releases
+activity: none
+---
+kind: url
 name: irrlicht
 url: https://sourceforge.net/projects/irrlicht/files/Irrlicht%20SDK/
 activity: none


### PR DESCRIPTION
## Description
A command line password manager.  See https://www.dmulholl.com/docs/ironclad/master/.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-ironclad-package crew update \
&& yes | crew upgrade
```