### PR TITLE
Joplin 3.4.6 => 3.5.6

### DIFF
--- a/manifest/x86_64/j/joplin.filelist
+++ b/manifest/x86_64/j/joplin.filelist
@@ -1,3 +1,4 @@
+# Total size: 418695966
 /usr/local/bin/joplin
 /usr/local/share/icons/hicolor/1024x1024/apps/joplin.png
 /usr/local/share/icons/hicolor/128x128/apps/joplin.png

--- a/packages/joplin.rb
+++ b/packages/joplin.rb
@@ -3,12 +3,12 @@ require 'package'
 class Joplin < Package
   description 'Open source note-taking app'
   homepage 'https://joplinapp.org/'
-  version '3.4.6'
+  version '3.5.6'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://objects.joplinusercontent.com/v#{version}/Joplin-#{version}.AppImage"
-  source_sha256 '573c09aefef5635ee2fdc7c761d9cf4841f83f75cddfcfec2a3827b265a5c575'
+  source_sha256 '000cc739fa7d7f6d9e71fe02d0e7c910ffac13a216c6ec7e92cf791019dda8c0'
 
   depends_on 'gtk3'
   depends_on 'gdk_base'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m141 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-joplin crew update \
&& yes | crew upgrade
```