### PR TITLE
Lazygit 0.55.0 => 0.56.0

### DIFF
--- a/manifest/armv7l/l/lazygit.filelist
+++ b/manifest/armv7l/l/lazygit.filelist
@@ -1,2 +1,2 @@
-# Total size: 20512952
+# Total size: 20578488
 /usr/local/bin/lazygit

--- a/manifest/i686/l/lazygit.filelist
+++ b/manifest/i686/l/lazygit.filelist
@@ -1,2 +1,2 @@
-# Total size: 20357304
+# Total size: 20443320
 /usr/local/bin/lazygit

--- a/manifest/x86_64/l/lazygit.filelist
+++ b/manifest/x86_64/l/lazygit.filelist
@@ -1,2 +1,2 @@
-# Total size: 21999800
+# Total size: 21852344
 /usr/local/bin/lazygit

--- a/packages/lazygit.rb
+++ b/packages/lazygit.rb
@@ -3,7 +3,7 @@ require 'package'
 class Lazygit < Package
   description 'A simple terminal UI for git commands'
   homepage 'https://github.com/jesseduffield/lazygit'
-  version '0.55.0'
+  version '0.56.0'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Lazygit < Package
      x86_64: "https://github.com/jesseduffield/lazygit/releases/download/v#{version}/lazygit_#{version}_linux_x86_64.tar.gz"
   })
   source_sha256({
-    aarch64: '063948635231925b3877eaa19eda0d31fa51ad143e53feef653487030c6f2ed8',
-     armv7l: '063948635231925b3877eaa19eda0d31fa51ad143e53feef653487030c6f2ed8',
-       i686: '5c1383a58683df66ea8a5521893d0bf9a0f5f9f4593a13d2a4738d3af987b4be',
-     x86_64: 'e7c1c2d127ebdb241398f3daf05907a71a0c977ff12beba6b8ebdb069f9dba6a'
+    aarch64: '7fc078e735fd08a8ba7dd514025432443c8f3b576220be8873c661d173fe86df',
+     armv7l: '7fc078e735fd08a8ba7dd514025432443c8f3b576220be8873c661d173fe86df',
+       i686: '9c5d5920a4deb8ba5735f2a3df7627a03926d637609e74c57595a3ee38750a5f',
+     x86_64: 'ced13c2ae074bbf6c201bc700ee2971e193b811c3b2ae0ed4d00d6225c6c9ab7'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-lazygit crew update \
&& yes | crew upgrade
```