### PR TITLE
Keep mandb postinstall from killing installs. — man_db → 2.13.1-2

### DIFF
--- a/packages/man_db.rb
+++ b/packages/man_db.rb
@@ -67,6 +67,6 @@ class Man_db < Package
     # See https://gitlab.com/man-db/man-db/-/issues/4
     # Also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003089
     FileUtils.mkdir_p "#{CREW_PREFIX}/var/log"
-    system "MANPATH='' MAN_DISABLE_SECCOMP=1 nice -n 20 mandb -C #{CREW_PREFIX}/etc/man_db.conf -psc &> #{CREW_PREFIX}/var/log/man-db-rebuild.log &"
+    system "MANPATH='' MAN_DISABLE_SECCOMP=1 nice -n 20 mandb -C #{CREW_PREFIX}/etc/man_db.conf -psc &> #{CREW_PREFIX}/var/log/man-db-rebuild.log &", exception: false
   end
 end


### PR DESCRIPTION
## Description
#### Commits:
-  6d671babb Keep mandb postinstall from killing installs.
### Packages with Updated versions or Changed package files:
- `man_db` &rarr; 2.13.1-2 (current version is 2.13.1)
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=mandb crew update \
&& yes | crew upgrade
```
