### PR TITLE
Fix gem installs incorrectly reporting gem name and version. 

### DIFF
--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -189,6 +189,7 @@ class RUBY < Package
   def self.install
     # @install_gem will always be true during upgrades since we remove
     # the old gem during the upgrade.
+    set_vars(name, version) if @ruby_gem_name.blank? || @gem_installed_version.blank?
     unless @install_gem
       puts "#{@ruby_gem_name} #{@gem_installed_version} is properly installed.".lightgreen
       return

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.67.19' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.67.20' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
## Description
#### Commits:
-  a60b7bd17 Fix gem installs incorrectly reporting gem name and version.
### Other changed files:
- lib/buildsystems/ruby.rb
- lib/const.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=install crew update \
&& yes | crew upgrade
```
