### PR TITLE
Monero and Monero_gui 0.18.4.1 => 0.18.4.3

### DIFF
--- a/manifest/armv7l/m/monero.filelist
+++ b/manifest/armv7l/m/monero.filelist
@@ -1,3 +1,4 @@
+# Total size: 165877598
 /usr/local/bin/monero-blockchain-ancestry
 /usr/local/bin/monero-blockchain-depth
 /usr/local/bin/monero-blockchain-export

--- a/manifest/x86_64/m/monero.filelist
+++ b/manifest/x86_64/m/monero.filelist
@@ -1,3 +1,4 @@
+# Total size: 235859610
 /usr/local/bin/monero-blockchain-ancestry
 /usr/local/bin/monero-blockchain-depth
 /usr/local/bin/monero-blockchain-export

--- a/manifest/x86_64/m/monero_gui.filelist
+++ b/manifest/x86_64/m/monero_gui.filelist
@@ -1,3 +1,4 @@
+# Total size: 124058067
 /usr/local/bin/monero
 /usr/local/bin/monero-wallet-gui
 /usr/local/share/monero/monero-gui-wallet-guide.pdf

--- a/packages/monero.rb
+++ b/packages/monero.rb
@@ -3,7 +3,7 @@ require 'package'
 class Monero < Package
   description 'Private, decentralized cryptocurrency that keeps your finances confidential and secure.'
   homepage 'https://www.getmonero.org/'
-  version '0.18.4.1'
+  version '0.18.4.3'
   license 'The Cryptonote developers,The Boolberry developers,MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.27'
@@ -14,9 +14,9 @@ class Monero < Package
      x86_64: "https://downloads.getmonero.org/cli/monero-linux-x64-v#{version}.tar.bz2"
   })
   source_sha256({
-    aarch64: 'a080b9f703c9b09cb3713376d7679cda089e6772794bd0bfa994cb256b6f3535',
-     armv7l: 'a080b9f703c9b09cb3713376d7679cda089e6772794bd0bfa994cb256b6f3535',
-     x86_64: '702ccb799c24160c0c76676d7a5b21a7e3432be47294d20e0a75451592f591b2'
+    aarch64: '3ac83049bc565fb5238501f0fa629cdd473bbe94d5fb815088af8e6ff1d761cd',
+     armv7l: '3ac83049bc565fb5238501f0fa629cdd473bbe94d5fb815088af8e6ff1d761cd',
+     x86_64: '3a7b36ae4da831a4e9913e0a891728f4c43cd320f9b136cdb6686b1d0a33fafa'
   })
 
   no_compile_needed

--- a/packages/monero_gui.rb
+++ b/packages/monero_gui.rb
@@ -4,18 +4,19 @@ require 'misc_functions'
 class Monero_gui < Package
   description 'Private, decentralized cryptocurrency that keeps your finances confidential and secure.'
   homepage 'https://www.getmonero.org/'
-  version '0.18.4.1'
+  version '0.18.4.3'
   license 'The Cryptonote developers,The Boolberry developers,MIT'
   compatibility 'x86_64'
   source_url "https://downloads.getmonero.org/gui/monero-gui-linux-x64-v#{version}.tar.bz2"
-  source_sha256 '60cbd662ccf1fdaf8732a21b6e505b806c6a4f62492c975fb1a13fd820dc8495'
+  source_sha256 '0bd84de0a7c18b2a3ea8e8eff2194ae000cf1060045badfd4ab48674bc1b9325'
 
-  depends_on 'monero'
-  depends_on 'xcb_util_image'
-  depends_on 'xcb_util_keysyms'
-  depends_on 'xcb_util_renderutil'
-  depends_on 'xcb_util_wm'
-  depends_on 'sommelier'
+  depends_on 'monero' # R
+  depends_on 'xcb_util' # R
+  depends_on 'xcb_util_image' # R
+  depends_on 'xcb_util_keysyms' # R
+  depends_on 'xcb_util_renderutil' # R
+  depends_on 'xcb_util_wm' # R
+  depends_on 'sommelier' # R
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l` Only monero, not monero_gui
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-monero-packages crew update \
&& yes | crew upgrade
```
