### PR TITLE
Google_chrome 142.0.7444.134-1 => 142.0.7444.162-1

### DIFF
--- a/manifest/x86_64/g/google_chrome.filelist
+++ b/manifest/x86_64/g/google_chrome.filelist
@@ -1,4 +1,4 @@
-# Total size: 390696286
+# Total size: 390715825
 /usr/local/bin/google-chrome
 /usr/local/share/appdata/google-chrome.appdata.xml
 /usr/local/share/applications/com.google.Chrome.desktop

--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -3,12 +3,12 @@ require 'package'
 class Google_chrome < Package
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '142.0.7444.134-1'
+  version '142.0.7444.162-1'
   license 'google-chrome'
   compatibility 'x86_64'
 
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_#{version}_amd64.deb"
-  source_sha256 '7b14e3bafc2ffd6da77a6bc11f29620fbe00b7b8ba65c2b2a53f716953f37001'
+  source_sha256 'ddf2a6fea0910c44b5a9e11ffc3d6d94d31748cb8e94a98ca622958879c4eb4e'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m141 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```