### PR TITLE
Vivaldi 7.6.3797.63-1 => 7.7.3851.48-1

### DIFF
--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -1,4 +1,4 @@
-# Total size: 440847548
+# Total size: 437023806
 /usr/local/bin/vivaldi
 /usr/local/bin/vivaldi-stable
 /usr/local/etc/cron.daily/vivaldi
@@ -7,13 +7,11 @@
 /usr/local/share/doc/vivaldi-stable/changelog.gz
 /usr/local/share/icons/hicolor/128x128/apps/vivaldi.png
 /usr/local/share/icons/hicolor/16x16/apps/vivaldi.png
-/usr/local/share/icons/hicolor/22x22/apps/vivaldi.png
 /usr/local/share/icons/hicolor/24x24/apps/vivaldi.png
 /usr/local/share/icons/hicolor/256x256/apps/vivaldi.png
 /usr/local/share/icons/hicolor/32x32/apps/vivaldi.png
 /usr/local/share/icons/hicolor/48x48/apps/vivaldi.png
 /usr/local/share/icons/hicolor/64x64/apps/vivaldi.png
-/usr/local/share/menu/vivaldi.menu
 /usr/local/share/vivaldi/LICENSE.html
 /usr/local/share/vivaldi/MEIPreload/manifest.json
 /usr/local/share/vivaldi/MEIPreload/preloaded_data.pb
@@ -345,7 +343,6 @@
 /usr/local/share/vivaldi/locales/zh-TW_FEMININE.pak
 /usr/local/share/vivaldi/locales/zh-TW_MASCULINE.pak
 /usr/local/share/vivaldi/locales/zh-TW_NEUTER.pak
-/usr/local/share/vivaldi/product_logo_32.xpm
 /usr/local/share/vivaldi/resources.pak
 /usr/local/share/vivaldi/resources/vivaldi/_locales/af/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/am/messages.json
@@ -447,7 +444,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-961d098457d963e453bffb7538a6c892.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-99342bc30d810da1f42f87c66fad928b.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html
@@ -585,6 +582,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/americanas_com_br.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/ap.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/aversi.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/aviasales.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/bbc.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/berlingske_dk.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/bild.png
@@ -721,6 +719,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/tidal.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/trademe.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/trip.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/tripadvisor.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/twitch.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/unext_jp.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/vedur.png
@@ -799,6 +798,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ar_tu_babnet.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_arstechnica.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_at_kronen_zeitung.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_aviasales.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_az_oxu.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ben_prothomalo.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_bestbuy.png

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -5,7 +5,7 @@ class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
   # The project stopped supporting armv7l after the 7.5 release.
-  version ARCH.eql?('x86_64') ? '7.6.3797.63-1' : '7.5.3735.74-1'
+  version ARCH.eql?('x86_64') ? '7.7.3851.48-1' : '7.5.3735.74-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -28,7 +28,7 @@ class Vivaldi < Package
     source_sha256 '9017e6327c140ad9a9e1f0ce450681a729a15ea764337c30226f51c042ff7e62'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 'e9eae79e65c883e87c94e628e0c4c34ee083b9327ced5211f14343af61072090'
+    source_sha256 'f70f801c26665a42fd7d260835a38561da778f6d2559850152a77d422cf24498'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m141 container
- [x] `armv7l` Unable to launch in strongbad m141 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```