### PR TITLE
Vscodium 1.104.26450 => 1.105.17075

### DIFF
--- a/manifest/armv7l/v/vscodium.filelist
+++ b/manifest/armv7l/v/vscodium.filelist
@@ -1,4 +1,4 @@
-# Total size: 354956310
+# Total size: 356681030
 /usr/local/VSCodium-linux-arm/LICENSES.chromium.html
 /usr/local/VSCodium-linux-arm/bin/codium
 /usr/local/VSCodium-linux-arm/bin/codium-tunnel
@@ -111,6 +111,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/schemas/package.schema.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/.npmrc
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/dist/node/85.cssServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/dist/node/920.cssServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/dist/node/cssServerMain.js
@@ -253,6 +254,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/schemas/package.schema.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/.npmrc
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/dist/node/421.htmlServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/dist/node/490.htmlServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/dist/node/769.htmlServerMain.js
@@ -301,6 +303,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/icons/json.png
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/package.nls.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/.npmrc
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/774.jsonServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/875.jsonServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/jsonServerMain.js
@@ -416,6 +419,15 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/merge-conflict/media/icon.png
 /usr/local/VSCodium-linux-arm/resources/app/extensions/merge-conflict/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/merge-conflict/package.nls.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/mermaid-chat-features/README.md
+/usr/local/VSCodium-linux-arm/resources/app/extensions/mermaid-chat-features/chat-webview-out/index.js
+/usr/local/VSCodium-linux-arm/resources/app/extensions/mermaid-chat-features/chat-webview-src/index.ts
+/usr/local/VSCodium-linux-arm/resources/app/extensions/mermaid-chat-features/chat-webview-src/tsconfig.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/mermaid-chat-features/dist/extension.js
+/usr/local/VSCodium-linux-arm/resources/app/extensions/mermaid-chat-features/esbuild-chat-webview.mjs
+/usr/local/VSCodium-linux-arm/resources/app/extensions/mermaid-chat-features/extension-browser.webpack.config.js
+/usr/local/VSCodium-linux-arm/resources/app/extensions/mermaid-chat-features/package.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/mermaid-chat-features/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/README.md
 /usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/dist/extension.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/dist/extension.js.LICENSE.txt
@@ -748,6 +760,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/swift/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/swift/snippets/swift.code-snippets
 /usr/local/VSCodium-linux-arm/resources/app/extensions/swift/syntaxes/swift.tmLanguage.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/terminal-suggest/.gitignore
 /usr/local/VSCodium-linux-arm/resources/app/extensions/terminal-suggest/README.md
 /usr/local/VSCodium-linux-arm/resources/app/extensions/terminal-suggest/ThirdPartyNotices.txt
 /usr/local/VSCodium-linux-arm/resources/app/extensions/terminal-suggest/dist/fig/README.md
@@ -1020,10 +1033,6 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/build/Release/watcher.node
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/index.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/index.js.flow
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/node_modules/detect-libc/LICENSE
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/node_modules/detect-libc/bin/detect-libc.js
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/node_modules/detect-libc/lib/detect-libc.js
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/node_modules/detect-libc/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/scripts/build-from-source.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@parcel/watcher/wrapper.js
@@ -1266,6 +1275,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/define-lazy-prop/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/detect-libc/LICENSE
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/detect-libc/lib/detect-libc.js
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/detect-libc/lib/filesystem.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/detect-libc/lib/process.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/detect-libc/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/end-of-stream/LICENSE

--- a/manifest/x86_64/v/vscodium.filelist
+++ b/manifest/x86_64/v/vscodium.filelist
@@ -1,4 +1,4 @@
-# Total size: 436993799
+# Total size: 438623891
 /usr/local/VSCodium-linux-x64/LICENSES.chromium.html
 /usr/local/VSCodium-linux-x64/bin/codium
 /usr/local/VSCodium-linux-x64/bin/codium-tunnel
@@ -111,6 +111,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/schemas/package.schema.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/.npmrc
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/dist/node/85.cssServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/dist/node/920.cssServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/dist/node/cssServerMain.js
@@ -253,6 +254,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/schemas/package.schema.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/.npmrc
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/dist/node/421.htmlServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/dist/node/490.htmlServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/dist/node/769.htmlServerMain.js
@@ -301,6 +303,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/icons/json.png
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/package.nls.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/.npmrc
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/774.jsonServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/875.jsonServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/jsonServerMain.js
@@ -416,6 +419,15 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/merge-conflict/media/icon.png
 /usr/local/VSCodium-linux-x64/resources/app/extensions/merge-conflict/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/merge-conflict/package.nls.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/mermaid-chat-features/README.md
+/usr/local/VSCodium-linux-x64/resources/app/extensions/mermaid-chat-features/chat-webview-out/index.js
+/usr/local/VSCodium-linux-x64/resources/app/extensions/mermaid-chat-features/chat-webview-src/index.ts
+/usr/local/VSCodium-linux-x64/resources/app/extensions/mermaid-chat-features/chat-webview-src/tsconfig.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/mermaid-chat-features/dist/extension.js
+/usr/local/VSCodium-linux-x64/resources/app/extensions/mermaid-chat-features/esbuild-chat-webview.mjs
+/usr/local/VSCodium-linux-x64/resources/app/extensions/mermaid-chat-features/extension-browser.webpack.config.js
+/usr/local/VSCodium-linux-x64/resources/app/extensions/mermaid-chat-features/package.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/mermaid-chat-features/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/README.md
 /usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/dist/extension.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/dist/extension.js.LICENSE.txt
@@ -748,6 +760,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/swift/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/swift/snippets/swift.code-snippets
 /usr/local/VSCodium-linux-x64/resources/app/extensions/swift/syntaxes/swift.tmLanguage.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/terminal-suggest/.gitignore
 /usr/local/VSCodium-linux-x64/resources/app/extensions/terminal-suggest/README.md
 /usr/local/VSCodium-linux-x64/resources/app/extensions/terminal-suggest/ThirdPartyNotices.txt
 /usr/local/VSCodium-linux-x64/resources/app/extensions/terminal-suggest/dist/fig/README.md
@@ -1020,10 +1033,6 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/build/Release/watcher.node
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/index.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/index.js.flow
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/node_modules/detect-libc/LICENSE
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/node_modules/detect-libc/bin/detect-libc.js
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/node_modules/detect-libc/lib/detect-libc.js
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/node_modules/detect-libc/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/scripts/build-from-source.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@parcel/watcher/wrapper.js
@@ -1266,6 +1275,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/define-lazy-prop/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/detect-libc/LICENSE
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/detect-libc/lib/detect-libc.js
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/detect-libc/lib/filesystem.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/detect-libc/lib/process.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/detect-libc/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/end-of-stream/LICENSE

--- a/packages/vscodium.rb
+++ b/packages/vscodium.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vscodium < Package
   description 'VSCodium is Open Source Software Binaries of VSCode with a community-driven default configuration.'
   homepage 'https://vscodium.com/'
-  version '1.104.26450'
+  version '1.105.17075'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.28'
@@ -13,9 +13,9 @@ class Vscodium < Package
      x86_64: "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-x64-#{version}.tar.gz"
   })
   source_sha256({
-    aarch64: '436ada470dd2b77be765ac32e6f3bd6f7f830af9cc20c1443042b118e497933f',
-     armv7l: '436ada470dd2b77be765ac32e6f3bd6f7f830af9cc20c1443042b118e497933f',
-     x86_64: 'bfa70638a038c1ec077e15635d65e44019afe7a8923026b1728d86f44432d632'
+    aarch64: '325376daf5a1d058aa81842a67562384012d3d119a1afe11cf72772c5eae76db',
+     armv7l: '325376daf5a1d058aa81842a67562384012d3d119a1afe11cf72772c5eae76db',
+     x86_64: 'f9a31c44033598ebb6acb0951ad93280680cffc54d7ad78ceba04e9664022290'
   })
 
   depends_on 'alsa_lib' # R


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m141 container
- [x] `armv7l` Unable to launch in strongbad m141 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vscodium crew update \
&& yes | crew upgrade
```