### PR TITLE
Vivaldi 7.7.3851.48-1 => 7.7.3851.52-1

### DIFF
--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -1,4 +1,4 @@
-# Total size: 437023806
+# Total size: 436899237
 /usr/local/bin/vivaldi
 /usr/local/bin/vivaldi-stable
 /usr/local/etc/cron.daily/vivaldi
@@ -444,7 +444,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-99342bc30d810da1f42f87c66fad928b.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-508d5eeab1c1fda26c0f3c6f8e6bd8e5.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -5,7 +5,7 @@ class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
   # The project stopped supporting armv7l after the 7.5 release.
-  version ARCH.eql?('x86_64') ? '7.7.3851.48-1' : '7.5.3735.74-1'
+  version ARCH.eql?('x86_64') ? '7.7.3851.52-1' : '7.5.3735.74-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -28,7 +28,7 @@ class Vivaldi < Package
     source_sha256 '9017e6327c140ad9a9e1f0ce450681a729a15ea764337c30226f51c042ff7e62'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 'f70f801c26665a42fd7d260835a38561da778f6d2559850152a77d422cf24498'
+    source_sha256 '75f28318f0a48dbc394b2c505f0a256e36e6f95017b0b9ce9423125687b11657'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m141 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```