### PR TITLE
Signal_desktop 7.79.0 => 7.80.0

### DIFF
--- a/manifest/x86_64/s/signal_desktop.filelist
+++ b/manifest/x86_64/s/signal_desktop.filelist
@@ -1,4 +1,4 @@
-# Total size: 459997871
+# Total size: 460866201
 /usr/local/bin/signal-desktop
 /usr/local/share/Signal/LICENSE.electron.txt
 /usr/local/share/Signal/LICENSES.chromium.html

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.79.0'
+  version '7.80.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '11326da1ea532b7933c5a4328da58a4bcc911ed58cf4a16d8bc32bf392d856d1'
+  source_sha256 '0aea2b87b608781caaee0774cb54daa477e447c6c2ebe59046cd2d246b4ba6b4'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m141 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```