### PR TITLE
Work around tar install issue on aarch64 machines

### DIFF
--- a/packages/core.rb
+++ b/packages/core.rb
@@ -116,7 +116,7 @@ class Core < Package
   depends_on 'sed'
   depends_on 'slang'
   depends_on 'sqlite'
-  depends_on 'tar'
+  depends_on 'tar' unless KERN_ARCH == 'aarch64' # our tar is currently broken on aarch64 machines
   depends_on 'uchardet'
   depends_on 'unzip'
   depends_on 'upx'


### PR DESCRIPTION
Possible workaround for #13463 based on the fix from #13492.

If the system tar works and ours doesn't, just don't install ours on aarch64.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=earthy crew update \
&& yes | crew upgrade
```