### PR TITLE
Properly use reusable workflows via uses: instead of gh workflow -R for simple cases

### DIFF
--- a/.github/workflows/Container-Package-Updater.yml
+++ b/.github/workflows/Container-Package-Updater.yml
@@ -14,13 +14,7 @@ permissions:                    # Global permissions configuration starts here
 jobs:
   update-check:
     if: ${{ github.repository_owner == 'chromebrew' }}
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: true
-      - name: Check for updates in core and buildessential packages.
-        id: trigger-update-checks
-        run: |
-          # shellcheck disable=SC2116
-          gh workflow -R chromebrew/chromebrew run Package-Dependencies-Updater.yml -f version_cmd_input="core buildessential"
+    uses: ./.github/workflows/Package-Dependencies-Updater.yml
+    secrets: inherit
+    with:
+      version_cmd_input: "core buildessential*"

--- a/.github/workflows/Package-Dependencies-Updater.yml
+++ b/.github/workflows/Package-Dependencies-Updater.yml
@@ -6,6 +6,11 @@ on:
       version_cmd_input:
         description: "Packages to check for dependency tree updates."
         required: true
+  workflow_call:
+    inputs:
+      version_cmd_input:
+        type: string
+        required: true
 env:
   GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}  # setting GH_TOKEN for the entire workflow
 permissions:                    # Global permissions configuration starts here

--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -7,6 +7,11 @@ on:
       version_cmd_input:
         description: "Input to version.rb command"
         required: true
+  workflow_call:
+    inputs:
+      version_cmd_input:
+        type: string
+        required: true
 env:
   GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}  # setting GH_TOKEN for the entire workflow
 permissions:                    # Global permissions configuration starts here

--- a/.github/workflows/Updater.yml
+++ b/.github/workflows/Updater.yml
@@ -12,15 +12,15 @@ permissions:                    # Global permissions configuration starts here
   packages: write
   pull-requests: write          # 'write' access to pull requests
 jobs:
-  update-check:
+  pip-update-checks:
     if: ${{ github.repository_owner == 'chromebrew' }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check for updates in pip packages.
-        id: pip-update-checks
-        run: |
-          gh workflow -R chromebrew/chromebrew run Updater-on-Demand.yml -f version_cmd_input="py3_*"
-      - name: Check for updates in ruby gem packages.
-        id: gem-update-checks
-        run: |
-          gh workflow -R chromebrew/chromebrew run Updater-on-Demand.yml -f version_cmd_input="ruby_*"
+    uses: ./.github/workflows/Updater-on-Demand.yml
+    secrets: inherit
+    with:
+      version_cmd_input: "py3_*"
+  gem-update-checks:
+    if: ${{ github.repository_owner == 'chromebrew' }}
+    uses: ./.github/workflows/Updater-on-Demand.yml
+    secrets: inherit
+    with:
+      version_cmd_input: "ruby_*"


### PR DESCRIPTION
## Description
This handles the simple cases, more as a proof of concept before I tackle the more complex cases. 

Tested and working.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=realign crew update \
&& yes | crew upgrade
```