### PR TITLE
Vscodium 1.105.17075 => 1.106.27818

### DIFF
--- a/manifest/armv7l/v/vscodium.filelist
+++ b/manifest/armv7l/v/vscodium.filelist
@@ -1,4 +1,4 @@
-# Total size: 356681030
+# Total size: 358353907
 /usr/local/VSCodium-linux-arm/LICENSES.chromium.html
 /usr/local/VSCodium-linux-arm/bin/codium
 /usr/local/VSCodium-linux-arm/bin/codium-tunnel
@@ -141,6 +141,10 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/docker/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/docker/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/docker/syntaxes/docker.tmLanguage.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/dotenv/language-configuration.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/dotenv/package.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/dotenv/package.nls.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/dotenv/syntaxes/dotenv.tmLanguage.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/emmet/README.md
 /usr/local/VSCodium-linux-arm/resources/app/extensions/emmet/dist/node/emmetNodeMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/emmet/images/icon.png
@@ -305,7 +309,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/.npmrc
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/774.jsonServerMain.js
-/usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/875.jsonServerMain.js
+/usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/962.jsonServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/jsonServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json/language-configuration.json
@@ -1055,6 +1059,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/deviceid/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/iconv-lite-umd/LICENSE
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/iconv-lite-umd/lib/iconv-lite-umd.js
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/iconv-lite-umd/lib/iconv-lite-umd.js.LICENSE.txt
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/iconv-lite-umd/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/proxy-agent/LICENSE.md
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/proxy-agent/SECURITY.md
@@ -1096,8 +1101,10 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/SECURITY.md
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/cgmanifest.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/package.json
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-bash.wasm
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-css.wasm
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-ini.wasm
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-powershell.wasm
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-regex.wasm
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-typescript.wasm
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter.js

--- a/manifest/x86_64/v/vscodium.filelist
+++ b/manifest/x86_64/v/vscodium.filelist
@@ -1,4 +1,4 @@
-# Total size: 438623891
+# Total size: 440466112
 /usr/local/VSCodium-linux-x64/LICENSES.chromium.html
 /usr/local/VSCodium-linux-x64/bin/codium
 /usr/local/VSCodium-linux-x64/bin/codium-tunnel
@@ -141,6 +141,10 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/docker/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/docker/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/docker/syntaxes/docker.tmLanguage.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/dotenv/language-configuration.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/dotenv/package.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/dotenv/package.nls.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/dotenv/syntaxes/dotenv.tmLanguage.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/emmet/README.md
 /usr/local/VSCodium-linux-x64/resources/app/extensions/emmet/dist/node/emmetNodeMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/emmet/images/icon.png
@@ -305,7 +309,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/.npmrc
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/774.jsonServerMain.js
-/usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/875.jsonServerMain.js
+/usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/962.jsonServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/jsonServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json/language-configuration.json
@@ -1055,6 +1059,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/deviceid/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/iconv-lite-umd/LICENSE
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/iconv-lite-umd/lib/iconv-lite-umd.js
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/iconv-lite-umd/lib/iconv-lite-umd.js.LICENSE.txt
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/iconv-lite-umd/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/proxy-agent/LICENSE.md
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/proxy-agent/SECURITY.md
@@ -1096,8 +1101,10 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/SECURITY.md
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/cgmanifest.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/package.json
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-bash.wasm
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-css.wasm
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-ini.wasm
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-powershell.wasm
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-regex.wasm
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-typescript.wasm
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter.js

--- a/packages/vscodium.rb
+++ b/packages/vscodium.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vscodium < Package
   description 'VSCodium is Open Source Software Binaries of VSCode with a community-driven default configuration.'
   homepage 'https://vscodium.com/'
-  version '1.105.17075'
+  version '1.106.27818'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.28'
@@ -13,9 +13,9 @@ class Vscodium < Package
      x86_64: "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-x64-#{version}.tar.gz"
   })
   source_sha256({
-    aarch64: '325376daf5a1d058aa81842a67562384012d3d119a1afe11cf72772c5eae76db',
-     armv7l: '325376daf5a1d058aa81842a67562384012d3d119a1afe11cf72772c5eae76db',
-     x86_64: 'f9a31c44033598ebb6acb0951ad93280680cffc54d7ad78ceba04e9664022290'
+    aarch64: '999a1fde6f4542b072668532ed5b52e7a78f4f36d25e6bb6528d500b4032fa73',
+     armv7l: '999a1fde6f4542b072668532ed5b52e7a78f4f36d25e6bb6528d500b4032fa73',
+     x86_64: '96d78e0514660106d8d7394f68153cc0a766b6908fe2f924e7e62e4340794578'
   })
 
   depends_on 'alsa_lib' # R


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
- [x] `armv7l` Unable to launch in strongbad m142 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vscodium crew update \
&& yes | crew upgrade
```