### PR TITLE
Glab 1.77.0 => 1.78.2

### DIFF
--- a/manifest/i686/g/glab.filelist
+++ b/manifest/i686/g/glab.filelist
@@ -1,2 +1,2 @@
-# Total size: 43835576
+# Total size: 43905208
 /usr/local/bin/glab

--- a/manifest/x86_64/g/glab.filelist
+++ b/manifest/x86_64/g/glab.filelist
@@ -1,2 +1,2 @@
-# Total size: 46039224
+# Total size: 46112952
 /usr/local/bin/glab

--- a/packages/glab.rb
+++ b/packages/glab.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glab < Package
   description 'A GitLab CLI tool bringing GitLab to your command line'
   homepage 'https://gitlab.com/gitlab-org/cli'
-  version '1.77.0'
+  version '1.78.2'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Glab < Package
      x86_64: "https://gitlab.com/gitlab-org/cli/-/releases/v#{version}/downloads/glab_#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: '1f7555f0abaecceea571990ceadccd00949dd9f576322a30d3952e703d765fe5',
-     armv7l: '1f7555f0abaecceea571990ceadccd00949dd9f576322a30d3952e703d765fe5',
-       i686: '8dd165624d2cafd0e0387f67a30be9663f129a3ce3feb3423da54f0d8a662112',
-     x86_64: '15c71384585092d7ad28b96914bb780f0be75c1074f7de83d63937bd96ea2eb2'
+    aarch64: 'b46edab6e8b1ffaa16b13762cc28080d8d7e4d97fedf21978069d9806c315de1',
+     armv7l: 'b46edab6e8b1ffaa16b13762cc28080d8d7e4d97fedf21978069d9806c315de1',
+       i686: '0f6d78806f7d24c96c985fb80c15a1ed0b610d56cd021d818e98568642314612',
+     x86_64: '64071cae1b6ff7881b022910752d734b6b6e44dcf8d67304cac7a3c64ce4e939'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-glab crew update \
&& yes | crew upgrade
```
No changes in armv7l filelist.