### PR TITLE
Joplin 3.5.6 => 3.5.7

### DIFF
--- a/manifest/x86_64/j/joplin.filelist
+++ b/manifest/x86_64/j/joplin.filelist
@@ -1,4 +1,4 @@
-# Total size: 418695966
+# Total size: 420681819
 /usr/local/bin/joplin
 /usr/local/share/icons/hicolor/1024x1024/apps/joplin.png
 /usr/local/share/icons/hicolor/128x128/apps/joplin.png

--- a/packages/joplin.rb
+++ b/packages/joplin.rb
@@ -3,12 +3,12 @@ require 'package'
 class Joplin < Package
   description 'Open source note-taking app'
   homepage 'https://joplinapp.org/'
-  version '3.5.6'
+  version '3.5.7'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://objects.joplinusercontent.com/v#{version}/Joplin-#{version}.AppImage"
-  source_sha256 '000cc739fa7d7f6d9e71fe02d0e7c910ffac13a216c6ec7e92cf791019dda8c0'
+  source_sha256 'b874d9319c3f46d060c088eff99e462ad79e6c2bf90b789a1078f4a6eec43fe7'
 
   depends_on 'gtk3'
   depends_on 'gdk_base'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-joplin crew update \
&& yes | crew upgrade
```