### PR TITLE
Adjust libxcrypt install in install.sh. 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CREW_INSTALLER_VERSION=2025111401
+CREW_INSTALLER_VERSION=2025112401
 # Exit on fail.
 set -eE
 
@@ -280,6 +280,8 @@ if [[ -n "${CREW_PRE_GLIBC_STANDALONE}" ]]; then
   [[ "$LIBC_VERSION" == "2.27" ]] && BOOTSTRAP_PACKAGES='zstd_static glibc_build227'
 
   [[ -n "${PREFIX_CMD}" ]] && BOOTSTRAP_PACKAGES+=' util_linux'
+  # Overwrite the glibc libcrypt.so.1.1.0 with the one from libxcrypt.
+  BOOTSTRAP_PACKAGES+=' libxcrypt '
   BOOTSTRAP_PACKAGES+=' upx patchelf lz4 zlib xzutils zlib_ng gcc_lib crew_mvdir ca_certificates libyaml openssl findutils ncurses readline bash psmisc'
 else
   # Ruby wants gcc_lib, so install our version build against our glibc


### PR DESCRIPTION
## Description
- This is needed for these older milestone-based containers so that the (older) glibc version gets overwritten.
- (The older glibc libcrypt libraries were causing issues during builds of packages like `shadow`.)
- Already tested and used to build today's container images.
#### Commits:
-  dd39a4ce0 Adjust libxcrypt install in install.sh.
### Other changed files:
- install.sh
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=installer_libxcrypt crew update \
&& yes | crew upgrade
```
