### PR TITLE
Refactor and add tests for get_anitya_id in tools/version.rb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,12 @@ task :lib_test do
   ruby 'tests/lib/package_utils.rb'
 end
 
+# Tool tests
+task :tool_test do
+  ruby 'tests/tool/getrealdeps.rb'
+  ruby 'tests/tool/version.rb'
+end
+
 # Package tests
 task :package_test do
   ruby 'tests/dep_test'

--- a/tests/tools/version.rb
+++ b/tests/tools/version.rb
@@ -1,0 +1,53 @@
+require 'minitest/autorun'
+require_relative '../../tools/version'
+
+class VersionMonitorTest < Minitest::Test
+  def test_get_simple_anitya_id
+    assert_equal(15222, get_anitya_id('audaspace', 'https://github.com/audaspace/audaspace', 'CMake'))
+  end
+
+  def test_get_nonexistent_anitya_id
+    assert_nil(get_anitya_id('99notreal', 'ftp://com.ruby', 'Package'))
+  end
+
+  def test_get_pip_gem_anitya_id
+    # We shoudn't be attempting to check versions of Pip or Ruby packages, so we just return nil.
+    assert_nil(get_anitya_id('py3_unsupported_python', 'https://github.com/ntessore/unsupported-python', 'Pip'))
+    assert_nil(get_anitya_id('ruby_typeprof', 'https://github.com/ruby/typeprof', 'RUBY'))
+  end
+
+  def test_get_dashed_anitya_id
+    # If we weren't able to find an anitya package using the package name, we try again using dashes instead of underscores.
+    assert_equal(115295, get_anitya_id('abseil_cpp', 'https://abseil.io/', 'CMake'))
+    assert_equal(13117, get_anitya_id('adwaita_icon_theme', 'https://wiki.gnome.org/Design', 'Meson'))
+  end
+
+  def test_get_nonexistent_dashed_anitya_id
+    assert_nil(get_anitya_id('99_still_notreal', 'ftp://com.crystal', 'Package'))
+  end
+
+  def test_get_multi_ecosystem_anitya_id
+    # This should eliminate all the other candidates due to their ecosystems, so the homepage isn't even checked.
+    assert_equal(217, get_anitya_id('bridge_utils', 'https://wiki.linuxfoundation.org/networking/bridge', 'Package'))
+    assert_equal(217, get_anitya_id('bridge_utils', 'example.com', 'Package'))
+    # If we pretend we're a Python package, the other candidates should still get eliminated by homepage checking.
+    assert_equal(217, get_anitya_id('bridge_utils', 'https://wiki.linuxfoundation.org/networking/bridge', 'Python'))
+    # If we pretend we're a Python package and give a dummy homepage, we shouldn't be able to choose and will return nil.
+    assert_nil(get_anitya_id('bridge_utils', 'example.com', 'Python'))
+  end
+
+  def test_get_multi_homepage_anitya_id
+    # Both candidates for check will pass the ecosystem check, so the differentiation will be done by homepage checking.
+    assert_equal(7593, get_anitya_id('check', 'https://libcheck.github.io/check/', 'CMake'))
+    # Test that our fuzzy homepage matching properly ignores the scheme and www subdomain when checking homepage equality.
+    assert_equal(7593, get_anitya_id('check', 'http://libcheck.github.io/check/', 'CMake'))
+    assert_equal(7593, get_anitya_id('check', 'https://www.libcheck.github.io/check/', 'CMake'))
+    # If we aren't able to match by homepage, we should return nil.
+    assert_nil(get_anitya_id('check', 'example.com', 'CMake'))
+  end
+
+  def test_get_multi_homepage_ecosystem_anitya_id
+    # There should be multiple candidates that survive the ecosystem check, but only one will pass the homepage check.
+    assert_equal(247, get_anitya_id('cairo', 'https://www.cairographics.org', 'Meson'))
+  end
+end


### PR DESCRIPTION
## Description
The usual, a refactor and tests to make sure it didn't break anything.

Notable aspects of the refactor:
- Pass in the buildsystem/superclass of the package as a string instead of relying on the `@pkg` instance variable.
  - This is just nicer overall, and makes it possible to actually test the thing.
- Use recursion to handle the `name_candidate` stuff, as this lets us deduplicate a whole bunch of code.
- Handle multiple candidates better:
  - Make an array out of the existing candidate data in the json response and deal with that instead of all the array index nonsense I was doing previously.
  - Remove invalid candidates from the array rather than checking for valid ones and adding them to a new array.
  - Check ecosystems by just using the known list of every true Anitya ecosystem instead of the ecosystem == homepage check, as this doesn't work if the homepage is edited after entry creation (as per https://github.com/fedora-infra/anitya/issues/1978#issuecomment-3563048326)  

Tested and working outside of container.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=homage crew update \
&& yes | crew upgrade
```