### PR TITLE
Signal_desktop 7.80.0 => 7.80.1

### DIFF
--- a/manifest/x86_64/s/signal_desktop.filelist
+++ b/manifest/x86_64/s/signal_desktop.filelist
@@ -1,4 +1,4 @@
-# Total size: 460866201
+# Total size: 460927149
 /usr/local/bin/signal-desktop
 /usr/local/share/Signal/LICENSE.electron.txt
 /usr/local/share/Signal/LICENSES.chromium.html

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.80.0'
+  version '7.80.1'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '0aea2b87b608781caaee0774cb54daa477e447c6c2ebe59046cd2d246b4ba6b4'
+  source_sha256 'f50cfcaf6e823eeecaf4ddf84159cbadd5fa07b8816ce788b782e0a532bad647'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
```
[17558:1125/233704.438426:FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /usr/local/share/Signal/chrome-sandbox is owned by root and has mode 4755.
/usr/local/bin/signal-desktop: line 3: 17558 Trace/breakpoint trap      /usr/local/share/Signal/signal-desktop "$@"
[17560:0100/000000.459958:ERROR:content/zygote/zygote_linux.cc:672] write: Broken pipe (32)
```
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```