### PR TITLE
Termius 9.33.0 => 9.34.4

### DIFF
--- a/manifest/x86_64/t/termius.filelist
+++ b/manifest/x86_64/t/termius.filelist
@@ -1,4 +1,4 @@
-# Total size: 382723328
+# Total size: 382233723
 /usr/local/bin/termius
 /usr/local/share/Termius/LICENSE.electron.txt
 /usr/local/share/Termius/LICENSES.chromium.html

--- a/packages/termius.rb
+++ b/packages/termius.rb
@@ -3,12 +3,12 @@ require 'package'
 class Termius < Package
   description 'Modern SSH Client'
   homepage 'https://termius.com/'
-  version '9.33.0'
+  version '9.34.4'
   license 'Apache-2.0, LGPL-2.1, MIT'
   compatibility 'x86_64'
   min_glibc '2.33'
   source_url 'https://www.termius.com/download/linux/Termius.deb'
-  source_sha256 '0120b5e957648d520beecfa2f93a1756cd1e903b5fcf084c592f261619961844'
+  source_sha256 'e04a338aa08086a95ecf3051c158e01d6253e00bf4e56d7d7f9828352604ee18'
 
   depends_on 'sommelier'
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
```
[18390:1125/234117.474723:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /usr/local/share/Termius/chrome-sandbox is owned by root and has mode 4755.
Trace/breakpoint trap      termius
[18392:0100/000000.493478:ERROR:zygote_linux.cc(649)] write: Broken pipe (32)
```
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-termius crew update \
&& yes | crew upgrade
```