### PR TITLE
Opera 124.0.5705.42 => 124.0.5705.65

### DIFF
--- a/manifest/x86_64/o/opera.filelist
+++ b/manifest/x86_64/o/opera.filelist
@@ -1,4 +1,4 @@
-# Total size: 360840161
+# Total size: 360843462
 /usr/local/bin/opera
 /usr/local/share/applications/opera.desktop
 /usr/local/share/doc/opera-stable/changelog.gz

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,12 +3,12 @@ require 'package'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '124.0.5705.42'
+  version '124.0.5705.65'
   license 'OPERA-2018'
   compatibility 'x86_64'
 
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 'd165fb2c41531574f350aeb547bf74a746c9b85bb59813101c312d97c40dd75e'
+  source_sha256 '002567e1c9d8c08b0422f94d805c35b32a5c9e9fc18bd386daed75e8a2f1b37d'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
```
/usr/local/share/x86_64-linux-gnu/opera-stable/opera: symbol lookup error: /usr/local/lib64/libatk-1.0.so.0: undefined symbol: g_once_init_leave_pointer
```
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```