### PR TITLE
Add z package

### DIFF
--- a/manifest/armv7l/z/z.filelist
+++ b/manifest/armv7l/z/z.filelist
@@ -1,0 +1,3 @@
+# Total size: 11690
+/usr/local/bin/z
+/usr/local/share/man/man1/z.1.zst

--- a/manifest/i686/z/z.filelist
+++ b/manifest/i686/z/z.filelist
@@ -1,0 +1,3 @@
+# Total size: 11690
+/usr/local/bin/z
+/usr/local/share/man/man1/z.1.zst

--- a/manifest/x86_64/z/z.filelist
+++ b/manifest/x86_64/z/z.filelist
@@ -1,0 +1,3 @@
+# Total size: 11690
+/usr/local/bin/z
+/usr/local/share/man/man1/z.1.zst

--- a/packages/z.rb
+++ b/packages/z.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Z < Package
+  description 'jump around'
+  homepage 'https://github.com/rupa/z'
+  version '1.12'
+  license 'WTFPL'
+  compatibility 'all'
+  source_url 'https://github.com/rupa/z.git'
+  git_hashtag "v#{version}"
+
+  no_compile_needed
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    FileUtils.install 'z.sh', "#{CREW_DEST_PREFIX}/bin/z", mode: 0o755
+    FileUtils.install 'z.1', "#{CREW_DEST_MAN_PREFIX}/man1/z.1", mode: 0o644
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'man z' to get started.\n"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -10590,6 +10590,11 @@ url: https://github.com/ibireme/yyjson/releases
 activity: medium
 ---
 kind: url
+name: z
+url: https://github.com/rupa/z/releases
+activity: none
+---
+kind: url
 name: z_library
 url: https://z-lib.fm/z-access#desktop_app_tab
 activity: low


### PR DESCRIPTION
## Description
       Tracks your most used directories, based on 'frecency'.

       After  a  short  learning  phase, z will take you to the most 'frecent'
       directory that matches ALL of the regexes given on the command line, in
       order.

       For example, z foo bar would match /foo/bar but not /bar/foo.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-z-package crew update \
&& yes | crew upgrade
```