### PR TITLE
Fix install issue on total_size 0 for glibc_fallthrough

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -963,7 +963,7 @@ def prepare_package(destdir)
 
     # If the package is completely empty, something has probably gone wrong.
     total_size = filelist.values.sum
-    abort 'total_size is 0. It seems that no files were installed.'.lightred if total_size.zero?
+    abort 'total_size is 0. It seems that no files were installed.'.lightred if total_size.zero? && @pkg.name != 'glibc_fallthrough'
 
     File.write 'filelist', <<~EOF
       # Total size: #{total_size}


### PR DESCRIPTION
## Description
this should fix it, but someone should probably test to double check

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=misguided crew update \
&& yes | crew upgrade
```
