### PR TITLE
Fix undefined method 'gsub' for nil (NoMethodError) in ConvenienceFunctions.libtoolize

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.68.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.68.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -97,8 +97,8 @@ class ConvenienceFunctions
       s.gsub!("#{CREW_LIB_PREFIX}/", '')
     end
     return if libnames.empty?
-    dlname = libnames.grep(/.so./).first
-    libname = dlname.gsub(/.so.\d+/, '')
+    dlname = libnames.grep(/.so(.)?/).first
+    libname = dlname.gsub(/.so(.\d+)?/, '')
     longest_libname = libnames.max_by(&:length)
     libvars = longest_libname.rpartition('.so.')[2].split('.')
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=fix-libtoolize-undefined-method-gsub-for-nil crew update \
&& yes | crew upgrade
```