### PR TITLE
Audacity 3.7.5 => 3.7.6

### DIFF
--- a/packages/audacity.rb
+++ b/packages/audacity.rb
@@ -3,12 +3,12 @@ require 'package'
 class Audacity < Package
   description "Audacity is the world's most popular audio editing and recording app"
   homepage 'https://www.audacityteam.org/'
-  version '3.7.5'
+  version '3.7.6'
   license 'GPL-3'
   compatibility 'x86_64'
   min_glibc '2.30'
   source_url "https://github.com/audacity/audacity/releases/download/Audacity-#{version}/audacity-linux-#{version}-x64-22.04.AppImage"
-  source_sha256 'aa092571e6447b3e82d8cf6b9e31ee4907581e4925b791f49c8563e1cfa93716'
+  source_sha256 'b82b080504d62f7bd2a13a386385dd1bc76a97c32f353a77da41586e0d5f4669'
 
   depends_on 'gtk3'
   depends_on 'libthai'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
```
$ audacity
/usr/local/share/audacity/lib/libatk-1.0.so.0
/usr/local/share/audacity/lib/libatk-bridge-2.0.so.0
/usr/local/share/audacity/lib/libcairo-gobject.so.2
/usr/local/share/audacity/lib/libcairo.so.2
/usr/local/share/audacity/lib/libgio-2.0.so.0
/usr/local/share/audacity/lib/libglib-2.0.so.0
/usr/local/share/audacity/lib/libgmodule-2.0.so.0
/usr/local/share/audacity/lib/libgobject-2.0.so.0
/usr/local/share/audacity/lib/libgthread-2.0.so.0
/usr/local/share/audacity/lib/libjack.so.0
findlib: /usr/local/lib64/libpango-1.0.so.0: undefined symbol: g_once_init_leave_pointer
/usr/local/share/audacity/AppRun.wrapped: Using fallback for library 'libpango-1.0.so.0'
/usr/local/share/audacity/lib/libpixman-1.so.0
/usr/local/share/audacity/lib/libportaudio.so
findlib: /usr/local/lib64/libpango-1.0.so.0: undefined symbol: g_once_init_leave_pointer
/usr/local/share/audacity/AppRun.wrapped: Using fallback for library 'librsvg-2.so.2'
/usr/local/share/audacity/bin/audacity: /usr/local/lib64/libuuid.so.1: no version information available (required by /usr/local/share/audacity/lib/lib-uuid.so)
/usr/local/share/audacity/bin/audacity: symbol lookup error: /usr/local/lib64/libpango-1.0.so.0: undefined symbol: g_once_init_leave_pointer
```
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-audacity crew update \
&& yes | crew upgrade
```