### PR TITLE
Move install.sh to using Python 3.14 by default. 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CREW_INSTALLER_VERSION=2025112401
+CREW_INSTALLER_VERSION=2025120401
 # Exit on fail.
 set -eE
 
@@ -178,7 +178,7 @@ aarch64|armv7l|armv8l)
   ;;
 esac
 
-: "${CREW_PY_VER:=3.13}"
+: "${CREW_PY_VER:=3.14}"
 CREW_NPROC="$(nproc)"
 export CREW_NPROC
 


### PR DESCRIPTION
## Description
#### Commits:
-  348cc9242 Move install.sh to using Python 3.14 by default.
### Other changed files:
- install.sh
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=installer_python crew update \
&& yes | crew upgrade
```
