### PR TITLE
Refactor tools/version.rb fallbacks

### DIFF
--- a/tests/tools/version.rb
+++ b/tests/tools/version.rb
@@ -2,6 +2,12 @@ require 'minitest/autorun'
 require_relative '../../tools/version'
 
 class VersionMonitorTest < Minitest::Test
+  def test_gitlab_fallback
+    assert_equal('1.0.0', gitlab_fallback(URI.parse('https://gitlab.com/caseif/fs2sbc.git')))
+    assert_nil(gitlab_fallback(URI.parse('https://gitlab.com/erikschull/Simple-Camera-Abandoned.git')))
+    assert_nil(gitlab_fallback(URI.parse('https://gitlab.com/99notreal/99notreal.git')))
+  end
+
   def test_sourceforge_fallback
     # This repo has been archived for 7 years, so hopefully there won't be any new releases.
     assert_equal('0.7.1', sourceforge_fallback(URI.parse('http://downloads.sourceforge.net/project/netcat/netcat/0.7.1/netcat-0.7.1.tar.gz')))


### PR DESCRIPTION
## Description
Everything except the github one, because that's a little more involved.

Split into functions, refactor, add tests, the usual.

Behavior is the same except error messages are slightly more specific.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=recover crew update \
&& yes | crew upgrade
```