### PR TITLE
Opera 124.0.5705.65 => 125.0.5729.15

### DIFF
--- a/manifest/x86_64/o/opera.filelist
+++ b/manifest/x86_64/o/opera.filelist
@@ -1,4 +1,4 @@
-# Total size: 360843462
+# Total size: 360451552
 /usr/local/bin/opera
 /usr/local/share/applications/opera.desktop
 /usr/local/share/doc/opera-stable/changelog.gz
@@ -113,7 +113,6 @@
 /usr/local/share/x86_64-linux-gnu/opera-stable/resources/browser.js
 /usr/local/share/x86_64-linux-gnu/opera-stable/resources/continue_shopping.json
 /usr/local/share/x86_64-linux-gnu/opera-stable/resources/default_partner_content.json
-/usr/local/share/x86_64-linux-gnu/opera-stable/resources/destination_travel_intent_keywords.json
 /usr/local/share/x86_64-linux-gnu/opera-stable/resources/doh_providers.json
 /usr/local/share/x86_64-linux-gnu/opera-stable/resources/domain_suggestions.json
 /usr/local/share/x86_64-linux-gnu/opera-stable/resources/ffmpeg_preload_config.json
@@ -179,7 +178,6 @@
 /usr/local/share/x86_64-linux-gnu/opera-stable/resources/specific_keywords.json
 /usr/local/share/x86_64-linux-gnu/opera-stable/resources/standard_themes/default_dark_theme.zip
 /usr/local/share/x86_64-linux-gnu/opera-stable/resources/standard_themes/default_theme.zip
-/usr/local/share/x86_64-linux-gnu/opera-stable/resources/travel_intent_keywords.json
 /usr/local/share/x86_64-linux-gnu/opera-stable/snapshot_blob.bin
 /usr/local/share/x86_64-linux-gnu/opera-stable/v8_context_snapshot.bin
 /usr/local/share/x86_64-linux-gnu/opera-stable/vk_swiftshader_icd.json

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,12 +3,12 @@ require 'package'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '124.0.5705.65'
+  version '125.0.5729.15'
   license 'OPERA-2018'
   compatibility 'x86_64'
 
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '002567e1c9d8c08b0422f94d805c35b32a5c9e9fc18bd386daed75e8a2f1b37d'
+  source_sha256 'aa82b1ac72ec4aa07108f17568267fe7ad266e1ee8dbac66f2c15f255952d073'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
``