### PR TITLE
Remove installation of libversion in CI

### DIFF
--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -389,17 +389,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
           ref: ${{ inputs.branch || github.ref_name }}
-      - name: Install ruby-libversion  # Hopefully this will get added as an Ubuntu/Debian package. https://github.com/repology/libversion/issues/35
-        working-directory: ${{ runner.temp }}
-        run: |
-          git clone --depth 1 -b 3.0.4 https://github.com/repology/libversion
-          cd libversion
-          mkdir build
-          cd build
-          cmake ..
-          make -j "$(nproc)"
-          sudo make install
-          sudo gem install --no-update-sources -N ruby-libversion --conservative
       - name: Get GH Token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v4

--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -38,17 +38,6 @@ jobs:
           git config --global push.autoSetupRemote true
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-      - name: Install ruby-libversion  # Hopefully this will get added as an Ubuntu/Debian package. https://github.com/repology/libversion/issues/35
-        working-directory: ${{ runner.temp }}
-        run: |
-          git clone --depth 1 -b 3.0.4 https://github.com/repology/libversion
-          cd libversion
-          mkdir build
-          cd build
-          cmake ..
-          make -j "$(nproc)"
-          sudo make install
-          sudo gem install --no-update-sources -N ruby-libversion --conservative
       - name: Check for updates.
         id: update-checks
         run: |


### PR DESCRIPTION
## Description
I implemented a pure ruby fallback and released it in ruby-libversion 1.1.0.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=fruits crew update \
&& yes | crew upgrade
```