### PR TITLE
Add claude package

### DIFF
--- a/manifest/x86_64/c/claude.filelist
+++ b/manifest/x86_64/c/claude.filelist
@@ -1,0 +1,2 @@
+# Total size: 211323904
+/usr/local/bin/claude

--- a/packages/claude.rb
+++ b/packages/claude.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Claude < Package
+  description 'Claude Code, Anthropic’s agentic coding tool that lives in your terminal'
+  homepage 'https://claude.com/product/claude-code'
+  version '2.0.61'
+  license 'Claude/Antropic Terms and Conditions'
+  compatibility 'x86_64'
+  source_url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/linux-x64/claude"
+  source_sha256 '5c5686e99180eb0bd0498564e1fa991aa05c4199a08222a15c1563626332e8fc'
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.install 'claude', "#{CREW_DEST_PREFIX}/bin/claude", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'claude -h' to get started.\n"
+  end
+
+  def self.postremove
+    Package.agree_to_remove("#{HOME}/.claude")
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1005,6 +1005,11 @@ url: https://gitlab.com/dave_m/clamtk/-/tags
 activity: none
 ---
 kind: url
+name: claude
+url: https://claude.com/product/claude-code
+activity: medium
+---
+kind: url
 name: clean
 url: https://sourceforge.net/projects/clean/files/clean/
 activity: none


### PR DESCRIPTION
## Description
Claude Code, Anthropic’s agentic coding tool that lives in your terminal and helps you turn ideas into code faster than ever before.  See https://claude.com/product/claude-code.
##
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-claude-package crew update \
&& yes | crew upgrade
```