### PR TITLE
Revert problematic ruby_ruby_libversion update

### DIFF
--- a/packages/ruby_ruby_libversion.rb
+++ b/packages/ruby_ruby_libversion.rb
@@ -3,7 +3,7 @@ require 'buildsystems/ruby'
 class Ruby_ruby_libversion < RUBY
   description 'Ruby bindings for libversion.'
   homepage 'https://github.com/Zopolis4/ruby-libversion'
-  version "1.1.0-#{CREW_RUBY_VER}"
+  version "1.0.0-2-#{CREW_RUBY_VER}"
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'


### PR DESCRIPTION
Reverts https://github.com/chromebrew/chromebrew/pull/13759.

Given that this is currently breaking CI, installs, and containers, it might make sense to just deal with it now and then properly fix it later.