### PR TITLE
Antigravity 1.11.14 => 1.11.17

### DIFF
--- a/manifest/x86_64/a/antigravity.filelist
+++ b/manifest/x86_64/a/antigravity.filelist
@@ -1,4 +1,4 @@
-# Total size: 730962110
+# Total size: 730990227
 /usr/local/bin/antigravity
 /usr/local/share/antigravity/LICENSES.chromium.html
 /usr/local/share/antigravity/antigravity

--- a/packages/antigravity.rb
+++ b/packages/antigravity.rb
@@ -3,12 +3,13 @@ require 'package'
 class Antigravity < Package
   description 'Next-generation IDE from Google'
   homepage 'https://antigravity.google/'
-  version '1.11.14'
+  version '1.11.17'
   license 'Google Terms of Service'
   compatibility 'x86_64'
   min_glibc '2.28'
-  source_url 'https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_1.11.14-1764918088_amd64_acf73c2fd8e096dca6a2d5535d58efc5.deb'
-  source_sha256 '67138611cf331f8186b1a013856a9823a7a9bfd2b1243290103f2b66917ae49c'
+  # To display this url, the latest Debian package must be installed and then run 'apt download --print-uris antigravity'
+  source_url 'https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_1.11.17-1765244408_amd64_9df0712156d4f7f37ea353feaa9633ca.deb'
+  source_sha256 'f5b61a4d00354f846e8850a2da9e87b7e204298f0f5cfa0365ede7207c7fc897'
 
   no_compile_needed
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-antigravity crew update \
&& yes | crew upgrade
```