### PR TITLE
Google_chrome 143.0.7499.40-1 => 143.0.7499.109-1

### DIFF
--- a/manifest/x86_64/g/google_chrome.filelist
+++ b/manifest/x86_64/g/google_chrome.filelist
@@ -1,4 +1,4 @@
-# Total size: 391706257
+# Total size: 391551132
 /usr/local/bin/google-chrome
 /usr/local/share/appdata/google-chrome.appdata.xml
 /usr/local/share/applications/com.google.Chrome.desktop

--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -3,12 +3,12 @@ require 'package'
 class Google_chrome < Package
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '143.0.7499.40-1'
+  version '143.0.7499.109-1'
   license 'google-chrome'
   compatibility 'x86_64'
 
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_#{version}_amd64.deb"
-  source_sha256 'af1e727cdf1f0f86ecd92440489eb96058a37eaf71927503c1989776001a8085'
+  source_sha256 'dfa61e3934e17c5ccc42cfb0c7114bc30526a74b8f05bd3e6fc4c3ecb1b57bed'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```