### PR TITLE
Fix crew files command

### DIFF
--- a/commands/help.rb
+++ b/commands/help.rb
@@ -50,9 +50,8 @@ class Command
       EOT
     when 'files'
       puts <<~EOT
-        Display installed files of package(s).
-        Usage: crew files <package1> [<package2> ...]
-        The package(s) must be currently installed.
+        Display files of package(s).
+        Usage: crew files [-v|--verbose] <package1> [<package2> ...]
       EOT
     when 'install'
       puts <<~EOT

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.68.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.68.9' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]
@@ -497,7 +497,7 @@ CREW_DOCOPT = <<~DOCOPT
     crew deps [options] [--deep] [-t|--tree] [-b|--include-build-deps] [--exclude-buildessential] [-v|--verbose] <name> ...
     crew diskstat [options] [-a|--all] [<count>]
     crew download [options] [-s|--source] [-v|--verbose] <name> ...
-    crew files [options] <name> ...
+    crew files [options] [-v|--verbose] <name> ...
     crew help [options] [<command>] [-v|--verbose] [<subcommand>]
     crew install [options] [-f|--force] [-k|--keep] [--regenerate-filelist] [-s|--source] [-S|--recursive-build] [-v|--verbose] <name> ...
     crew list [options] [-v|--verbose] (available|compatible|incompatible|essential|installed)

--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -64,10 +64,8 @@ class ConvenienceFunctions
 
   def self.read_filelist(path, always_calcuate_from_disk: false)
     filelist = File.readlines(path, chomp: true)
-
     if filelist.first&.start_with?('# Total size') && !always_calcuate_from_disk
-      total_size, *contents = filelist
-      return [total_size[/Total size: (\d+)/, 1].to_i, contents]
+      return [filelist.first[/Total size: (\d+)/, 1].to_i, filelist]
     else
       return [get_package_disk_size(filelist), filelist]
     end


### PR DESCRIPTION
This update fixes the following:
1. The file count was always one extra since it included the `# Total size: ...` line from the filelist
2. Previously, only installed packages would return file results.  Now it will return results even if the package is not installed since it looks in the manifest directory for the filelist.
3. The file size calculation was always adding up the files since `always_calcuate_from_disk: true` but that is unnecessary extra processing because `# Total size: ...` is already available in the filelist.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=fix-crew-files-command crew update \
&& yes | crew upgrade
```