### PR TITLE
Cursor 2.1.48 => 2.2.17

### DIFF
--- a/manifest/x86_64/c/cursor.filelist
+++ b/manifest/x86_64/c/cursor.filelist
@@ -1,4 +1,4 @@
-# Total size: 1257125536
+# Total size: 1267060112
 /usr/local/bin/cursor
 /usr/local/share/appdata/cursor.appdata.xml
 /usr/local/share/applications/cursor-url-handler.desktop
@@ -8505,6 +8505,7 @@
 /usr/local/share/cursor/resources/app/out/vscode-dts/vscode.d.ts
 /usr/local/share/cursor/resources/app/package.json
 /usr/local/share/cursor/resources/app/product.json
+/usr/local/share/cursor/resources/app/resources/helpers/cursor-sandbox
 /usr/local/share/cursor/resources/app/resources/helpers/cursor-terminal-wrapper
 /usr/local/share/cursor/resources/app/resources/helpers/node
 /usr/local/share/cursor/resources/app/resources/linux/code.png
@@ -17039,6 +17040,7 @@
 /usr/local/share/cursor/usr/share/cursor/resources/app/out/vscode-dts/vscode.d.ts
 /usr/local/share/cursor/usr/share/cursor/resources/app/package.json
 /usr/local/share/cursor/usr/share/cursor/resources/app/product.json
+/usr/local/share/cursor/usr/share/cursor/resources/app/resources/helpers/cursor-sandbox
 /usr/local/share/cursor/usr/share/cursor/resources/app/resources/helpers/cursor-terminal-wrapper
 /usr/local/share/cursor/usr/share/cursor/resources/app/resources/helpers/node
 /usr/local/share/cursor/usr/share/cursor/resources/app/resources/linux/code.png

--- a/packages/cursor.rb
+++ b/packages/cursor.rb
@@ -3,12 +3,12 @@ require 'package'
 class Cursor < Package
   description 'The AI Code Editor'
   homepage 'https://www.cursor.com/'
-  version '2.1.48'
+  version '2.2.17'
   license 'Cursor EULA'
   compatibility 'x86_64'
   # Download links can be found at https://cursor.uuid.site/
-  source_url 'https://downloads.cursor.com/production/ce371ffbf5e240ca47f4b5f3f20efed084991120/linux/x64/Cursor-2.1.48-x86_64.AppImage'
-  source_sha256 '52aeb5659673951c83a8f68d9c96ed785438282f6eb03e437544931a0be8db02'
+  source_url 'https://downloads.cursor.com/production/cf858ca030e9c9a99ea444ec6efcbcfc40bfda75/linux/x64/Cursor-2.2.17-x86_64.AppImage'
+  source_sha256 'f134cd20695ab641c4f0ef3b87c5467af8da8b258347caaaf0f03b97ae018a3b'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in nocturne m90 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-cursor crew update \
&& yes | crew upgrade
```