### PR TITLE
Signal_desktop 7.80.1 => 7.82.0

### DIFF
--- a/manifest/x86_64/s/signal_desktop.filelist
+++ b/manifest/x86_64/s/signal_desktop.filelist
@@ -1,4 +1,4 @@
-# Total size: 460927149
+# Total size: 465348041
 /usr/local/bin/signal-desktop
 /usr/local/share/Signal/LICENSE.electron.txt
 /usr/local/share/Signal/LICENSES.chromium.html
@@ -113,6 +113,7 @@
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/fs-xattr/build/Release/xattr.node
 /usr/local/share/Signal/resources/apparmor-profile
 /usr/local/share/Signal/resources/org.signalapp.enable-backups.policy
+/usr/local/share/Signal/resources/org.signalapp.plaintext-export.policy
 /usr/local/share/Signal/resources/org.signalapp.view-aep.policy
 /usr/local/share/Signal/resources/package-type
 /usr/local/share/Signal/signal-desktop

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.80.1'
+  version '7.82.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 'f50cfcaf6e823eeecaf4ddf84159cbadd5fa07b8816ce788b782e0a532bad647'
+  source_sha256 '1a8e0ccb5e846ce0e5feba75adfbdeba31f96df94621b6ff3bc00b757de5ddf9'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
