### PR TITLE
Symfony 5.16.0 => 5.16.1

### DIFF
--- a/manifest/x86_64/s/symfony.filelist
+++ b/manifest/x86_64/s/symfony.filelist
@@ -1,2 +1,2 @@
-# Total size: 15679672
+# Total size: 15683768
 /usr/local/bin/symfony

--- a/packages/symfony.rb
+++ b/packages/symfony.rb
@@ -3,7 +3,7 @@ require 'package'
 class Symfony < Package
   description 'Symfony is a set of PHP Components, a Web Application framework'
   homepage 'https://symfony.com/'
-  version '5.16.0'
+  version '5.16.1'
   license 'AGPL-3.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url({
@@ -12,9 +12,9 @@ class Symfony < Package
      x86_64: "https://github.com/symfony-cli/symfony-cli/releases/download/v#{version}/symfony-cli_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'a863020fd0408dc58a8618a06244953e7d717a4ecdeae0352c8291bd598374f1',
-     armv7l: 'a863020fd0408dc58a8618a06244953e7d717a4ecdeae0352c8291bd598374f1',
-     x86_64: '944c08b63f3e083302863e3e28d19867400990d88706ff560cff8db2359096fd'
+    aarch64: '174306b9db01d79085015fad3db3978fb8c2b85acdb7e0b139ffbd46ddca8d14',
+     armv7l: '174306b9db01d79085015fad3db3978fb8c2b85acdb7e0b139ffbd46ddca8d14',
+     x86_64: 'a059047854004c1e6993256dcc18d7adcc6247c79363f09ec913815523cfb6cb'
   })
 
   depends_on 'php83' unless File.exist? "#{CREW_PREFIX}/bin/php"

--- a/tests/package/s/symfony
+++ b/tests/package/s/symfony
@@ -1,0 +1,2 @@
+#!/bin/bash
+symfony -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-symfony crew update \
&& yes | crew upgrade

$ crew check symfony -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/symfony.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/symfony.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/s/symfony to /usr/local/lib/crew/tests/package/s
Checking symfony package ...
Property tests for symfony passed.
Checking symfony package ...
Buildsystem test for symfony passed.
Checking symfony package ...
Symfony CLI version 5.16.1 (c) 2021-2025 Fabien Potencier (2025-11-25T07:30:20Z - stable)
Package tests for symfony passed.
```
