### PR TITLE
Rustdesk 1.4.0 => 1.4.4

### DIFF
--- a/manifest/armv7l/r/rustdesk.filelist
+++ b/manifest/armv7l/r/rustdesk.filelist
@@ -1,3 +1,4 @@
+# Total size: 37306333
 /usr/local/bin/rustdesk
 /usr/local/share/applications/rustdesk-link.desktop
 /usr/local/share/applications/rustdesk.desktop

--- a/manifest/x86_64/r/rustdesk.filelist
+++ b/manifest/x86_64/r/rustdesk.filelist
@@ -1,3 +1,4 @@
+# Total size: 79665099
 /usr/local/bin/rustdesk
 /usr/local/share/applications/rustdesk-link.desktop
 /usr/local/share/applications/rustdesk.desktop

--- a/packages/rustdesk.rb
+++ b/packages/rustdesk.rb
@@ -3,7 +3,7 @@ require 'package'
 class Rustdesk < Package
   description 'An open-source remote desktop application designed for self-hosting, as an alternative to TeamViewer.'
   homepage 'https://rustdesk.com/'
-  version '1.4.0'
+  version '1.4.4'
   license 'AGPL-3.0'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -13,9 +13,9 @@ class Rustdesk < Package
      x86_64: "https://github.com/rustdesk/rustdesk/releases/download/#{version}/rustdesk-#{version}-x86_64.deb"
   })
   source_sha256({
-    aarch64: 'f80a3b7bfd4bd040f8f3421d455e12d984c2638606a385e201d992a941c3a536',
-     armv7l: 'f80a3b7bfd4bd040f8f3421d455e12d984c2638606a385e201d992a941c3a536',
-     x86_64: '64a5b1929dbd819adc373a9396ad2a162ca94de1cf895efcad6d2750f317998e'
+    aarch64: '037d7a8387b162973228d07377fe366fd6e7388f293d1cb5f7f8f5f879644560',
+     armv7l: '037d7a8387b162973228d07377fe366fd6e7388f293d1cb5f7f8f5f879644560',
+     x86_64: 'db722ef63ee3e1e410ab34aba7b6dd3b416a61516f3b744f9b9707ee9639e46c'
   })
 
   depends_on 'gtk3'

--- a/tests/package/r/rustdesk
+++ b/tests/package/r/rustdesk
@@ -1,0 +1,2 @@
+#!/bin/bash
+rustdesk --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l` Unable to launch in strongbad m142 container
```
$ rustdesk
thread 'main' panicked at /root/.cargo/git/checkouts/rust-sciter-7f05b555a89dd1b0/5322f3a/src/lib.rs:365:21:
error: 'libsciter-gtk.so' was not found neither in PATH nor near the current executable.
  Please verify that Sciter SDK is installed and its binaries (from bin.lnx) are available in PATH.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
qemu: uncaught target signal 6 (Aborted) - core dumped
Aborted                    rustdesk
```
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-rustdesk crew update \
&& yes | crew upgrade

$ crew check rustdesk -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/rustdesk.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/rustdesk.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/r/rustdesk to /usr/local/lib/crew/tests/package/r
Checking rustdesk package ...
Property tests for rustdesk passed.
Checking rustdesk package ...
Buildsystem test for rustdesk passed.
Checking rustdesk package ...
1.4.4
Package tests for rustdesk passed.
```