### PR TITLE
Add mcfly package

### DIFF
--- a/manifest/armv7l/m/mcfly.filelist
+++ b/manifest/armv7l/m/mcfly.filelist
@@ -1,0 +1,3 @@
+# Total size: 4299886
+/usr/local/bin/mcfly
+/usr/local/etc/bash.d/10-mcfly

--- a/manifest/i686/m/mcfly.filelist
+++ b/manifest/i686/m/mcfly.filelist
@@ -1,0 +1,3 @@
+# Total size: 5229726
+/usr/local/bin/mcfly
+/usr/local/etc/bash.d/10-mcfly

--- a/manifest/x86_64/m/mcfly.filelist
+++ b/manifest/x86_64/m/mcfly.filelist
@@ -1,0 +1,3 @@
+# Total size: 5552742
+/usr/local/bin/mcfly
+/usr/local/etc/bash.d/10-mcfly

--- a/packages/mcfly.rb
+++ b/packages/mcfly.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Mcfly < Package
+  description 'fly through your shell history'
+  homepage 'https://github.com/cantino/mcfly'
+  version '0.9.3'
+  license 'MIT'
+  compatibility 'all'
+  source_url({
+    aarch64: "https://github.com/cantino/mcfly/releases/download/v#{version}/mcfly-v#{version}-armv7-unknown-linux-gnueabihf.tar.gz",
+     armv7l: "https://github.com/cantino/mcfly/releases/download/v#{version}/mcfly-v#{version}-armv7-unknown-linux-gnueabihf.tar.gz",
+       i686: "https://github.com/cantino/mcfly/releases/download/v#{version}/mcfly-v#{version}-i686-unknown-linux-musl.tar.gz",
+     x86_64: "https://github.com/cantino/mcfly/releases/download/v#{version}/mcfly-v#{version}-x86_64-unknown-linux-musl.tar.gz"
+  })
+  source_sha256({
+    aarch64: 'f8b960a5c9b7634637b40cd6823458d8e39eb3c0bfecaa540dd7a4d446f01771',
+     armv7l: 'f8b960a5c9b7634637b40cd6823458d8e39eb3c0bfecaa540dd7a4d446f01771',
+       i686: 'd3a1f513e5dead8400a1bd431fb1b579ad7ace8bcd6a27610eb4d2fa2982afc1',
+     x86_64: 'be0d3c1e0253189a5d834767231c2a4d206f077f4184699ac7069482ed9c6453'
+  })
+
+  no_compile_needed
+  no_shrink
+  print_source_bashrc
+
+  def self.build
+    File.write '10-mcfly', <<~EOF
+      #!/bin/bash
+      eval "$(mcfly init bash)"
+    EOF
+  end
+
+  def self.install
+    FileUtils.install '10-mcfly', "#{CREW_DEST_PREFIX}/etc/bash.d/10-mcfly", mode: 0o644
+    FileUtils.install 'mcfly', "#{CREW_DEST_PREFIX}/bin/mcfly", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'mcfly' to get started.\n"
+  end
+end

--- a/tests/package/m/mcfly
+++ b/tests/package/m/mcfly
@@ -1,0 +1,3 @@
+#!/bin/bash
+mcfly 2>&1
+mcfly -V

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6015,6 +6015,11 @@ url: https://git.kernel.org/pub/scm/utils/cpu/mce/mcelog.git/
 activity: medium
 ---
 kind: url
+name: mcfly
+url: https://github.com/cantino/mcfly/releases
+activity: low
+---
+kind: url
 name: mdp
 url: https://github.com/visit1985/mdp/releases
 activity: low


### PR DESCRIPTION
## Description
McFly replaces your default ctrl-r shell history search with an intelligent search engine that takes into account your working directory and the context of recently executed commands. McFly's suggestions are prioritized in real time with a small neural network.

TL;DR: an upgraded ctrl-r where history results make sense for what you're working on right now.

See https://github.com/cantino/mcfly.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-mcfly-package crew update \
&& yes | crew upgrade

$ crew check mcfly -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/mcfly.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/mcfly.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/m/mcfly to /usr/local/lib/crew/tests/package/m
Checking mcfly package ...
Property tests for mcfly passed.
Checking mcfly package ...
Buildsystem test for mcfly passed.
Checking mcfly package ...
Fly through your shell history

Usage: mcfly [OPTIONS] <COMMAND>

Commands:
  add     Add commands to the history
  search  Search the history
  move    Record a directory having been moved; moves command records from the old path to the new one
  train   Train the suggestion engine (developer tool)
  init    Prints the shell code used to execute mcfly
  dump    Dump history into stdout; the results are sorted by timestamp
  stats   Prints stats
  help    Print this message or the help of the given subcommand(s)

Options:
  -d, --debug                          Debug
      --session_id <SESSION_ID>        Session ID to record or search under (defaults to $`MCFLY_SESSION_ID`)
      --mcfly_history <MCFLY_HISTORY>  Shell history file to read from when adding or searching (defaults to $`MCFLY_HISTORY`)
      --history_format <FORMAT>        Shell history file format [default: bash] [possible values: bash, zsh, zsh-extended, fish]
  -h, --help                           Print help
  -V, --version                        Print version
mcfly 0.9.3
Package tests for mcfly passed.
```