### PR TITLE
Codex 0.64.0 => 0.73.0

### DIFF
--- a/manifest/x86_64/c/codex.filelist
+++ b/manifest/x86_64/c/codex.filelist
@@ -1,2 +1,2 @@
-# Total size: 47023400
+# Total size: 52030208
 /usr/local/bin/codex

--- a/packages/codex.rb
+++ b/packages/codex.rb
@@ -3,12 +3,12 @@ require 'package'
 class Codex < Package
   description 'Lightweight coding agent that runs in your terminal'
   homepage 'https://github.com/openai/codex'
-  version '0.64.0'
+  version '0.73.0'
   license 'Apache-2.0'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-x86_64-unknown-linux-gnu.zst"
-  source_sha256 'd13fc4ea818b9bb5c2d590ebd4f20abc5d26efd5bd8aa8a477a6271fd0814c9a'
+  source_sha256 '14b7f0462e3b95da9e12ff0fafc4f05499f58a4e307d540641c1edca80964462'
 
   depends_on 'zstd'
 

--- a/tests/package/c/codex
+++ b/tests/package/c/codex
@@ -1,0 +1,3 @@
+#!/bin/bash
+codex -h
+codex --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-codex crew update \
&& yes | crew upgrade

$ crew check codex -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/codex.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/codex.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/c/codex to /usr/local/lib/crew/tests/package/c
Checking codex package ...
Property tests for codex passed.
Checking codex package ...
Buildsystem test for codex passed.
Checking codex package ...
Codex CLI

Usage: codex [OPTIONS] [PROMPT]
       codex [OPTIONS] <COMMAND> [ARGS]

Commands:
  exec        Run Codex non-interactively [aliases: e]
  review      Run a code review non-interactively
  login       Manage login
  logout      Remove stored authentication credentials
  mcp         [experimental] Run Codex as an MCP server and manage MCP servers
  mcp-server  [experimental] Run the Codex MCP server (stdio transport)
  app-server  [experimental] Run the app server or related tooling
  completion  Generate shell completion scripts
  sandbox     Run commands within a Codex-provided sandbox [aliases: debug]
  apply       Apply the latest diff produced by Codex agent as a `git apply` to your local working tree [aliases: a]
  resume      Resume a previous interactive session (picker by default; use --last to continue the most recent)
  cloud       [EXPERIMENTAL] Browse tasks from Codex Cloud and apply changes locally
  features    Inspect feature flags
  help        Print this message or the help of the given subcommand(s)

Arguments:
  [PROMPT]  Optional user prompt to start the session

Options:
  -c, --config <key=value>                        Override a configuration value that would otherwise be loaded from `~/.codex/config.toml`. Use a dotted path (`foo.bar.baz`) to override nested values. The
                                                  `value` portion is parsed as TOML. If it fails to parse as TOML, the raw string is used as a literal
      --enable <FEATURE>                          Enable a feature (repeatable). Equivalent to `-c features.<name>=true`
      --disable <FEATURE>                         Disable a feature (repeatable). Equivalent to `-c features.<name>=false`
  -i, --image <FILE>...                           Optional image(s) to attach to the initial prompt
  -m, --model <MODEL>                             Model the agent should use
      --oss                                       Convenience flag to select the local open source model provider. Equivalent to -c model_provider=oss; verifies a local LM Studio or Ollama server is running
      --local-provider <OSS_PROVIDER>             Specify which local provider to use (lmstudio or ollama). If not specified with --oss, will use config default or show selection
  -p, --profile <CONFIG_PROFILE>                  Configuration profile from config.toml to specify default options
  -s, --sandbox <SANDBOX_MODE>                    Select the sandbox policy to use when executing model-generated shell commands [possible values: read-only, workspace-write, danger-full-access]
  -a, --ask-for-approval <APPROVAL_POLICY>        Configure when the model requires human approval before executing a command [possible values: untrusted, on-failure, on-request, never]
      --full-auto                                 Convenience alias for low-friction sandboxed automatic execution (-a on-request, --sandbox workspace-write)
      --dangerously-bypass-approvals-and-sandbox  Skip all confirmation prompts and execute commands without sandboxing. EXTREMELY DANGEROUS. Intended solely for running in environments that are externally
                                                  sandboxed
  -C, --cd <DIR>                                  Tell the agent to use the specified directory as its working root
      --search                                    Enable web search (off by default). When enabled, the native Responses `web_search` tool is available to the model (no per‑call approval)
      --add-dir <DIR>                             Additional directories that should be writable alongside the primary workspace
  -h, --help                                      Print help (see more with '--help')
  -V, --version                                   Print version
codex-cli 0.73.0
Package tests for codex passed.
```