### PR TITLE
Dart 3.10.4 => 3.10.6

### DIFF
--- a/manifest/armv7l/d/dart.filelist
+++ b/manifest/armv7l/d/dart.filelist
@@ -1,4 +1,4 @@
-# Total size: 418307507
+# Total size: 418328393
 /usr/local/bin/dart
 /usr/local/lib/dart/LICENSE
 /usr/local/lib/dart/README

--- a/manifest/x86_64/d/dart.filelist
+++ b/manifest/x86_64/d/dart.filelist
@@ -1,10 +1,11 @@
-# Total size: 598398547
+# Total size: 587619377
 /usr/local/bin/dart
 /usr/local/lib64/dart/LICENSE
 /usr/local/lib64/dart/README
 /usr/local/lib64/dart/bin/dart
-/usr/local/lib64/dart/bin/dart.sym
 /usr/local/lib64/dart/bin/dartaotruntime
+/usr/local/lib64/dart/bin/dartvm
+/usr/local/lib64/dart/bin/dartvm.sym
 /usr/local/lib64/dart/bin/resources/dartdoc/resources/blank.txt
 /usr/local/lib64/dart/bin/resources/dartdoc/resources/docs.dart.js
 /usr/local/lib64/dart/bin/resources/dartdoc/resources/docs.dart.js.map
@@ -32,7 +33,6 @@
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_documentation.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_extension.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_extension_type.html
-/usr/local/lib64/dart/bin/resources/dartdoc/templates/_feature_set.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_footer.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_head.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_instance_fields.html
@@ -54,6 +54,7 @@
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_static_methods.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_static_properties.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_super_chain.html
+/usr/local/lib64/dart/bin/resources/dartdoc/templates/_tags.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_type.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_type_multiline.html
 /usr/local/lib64/dart/bin/resources/dartdoc/templates/_typedef.html
@@ -78,7 +79,6 @@
 /usr/local/lib64/dart/bin/resources/devtools/.last_build_id
 /usr/local/lib64/dart/bin/resources/devtools/assets/AssetManifest.bin
 /usr/local/lib64/dart/bin/resources/devtools/assets/AssetManifest.bin.json
-/usr/local/lib64/dart/bin/resources/devtools/assets/AssetManifest.json
 /usr/local/lib64/dart/bin/resources/devtools/assets/FontManifest.json
 /usr/local/lib64/dart/bin/resources/devtools/assets/NOTICES
 /usr/local/lib64/dart/bin/resources/devtools/assets/assets/dart_syntax.json
@@ -511,9 +511,8 @@
 /usr/local/lib64/dart/bin/snapshots/dart2js_aot.dart.snapshot
 /usr/local/lib64/dart/bin/snapshots/dart2wasm_product.snapshot
 /usr/local/lib64/dart/bin/snapshots/dart_mcp_server_aot.dart.snapshot
-/usr/local/lib64/dart/bin/snapshots/dart_tooling_daemon.dart.snapshot
 /usr/local/lib64/dart/bin/snapshots/dart_tooling_daemon_aot.dart.snapshot
-/usr/local/lib64/dart/bin/snapshots/dartdev.dart.snapshot
+/usr/local/lib64/dart/bin/snapshots/dartdev_aot.dart.snapshot
 /usr/local/lib64/dart/bin/snapshots/dartdevc.dart.snapshot
 /usr/local/lib64/dart/bin/snapshots/dartdevc_aot.dart.snapshot
 /usr/local/lib64/dart/bin/snapshots/dds_aot.dart.snapshot
@@ -791,7 +790,6 @@
 /usr/local/lib64/dart/lib/_internal/wasm/lib/simd_patch.dart
 /usr/local/lib64/dart/lib/_internal/wasm/lib/stack_trace_patch.dart
 /usr/local/lib64/dart/lib/_internal/wasm/lib/stopwatch_patch.dart
-/usr/local/lib64/dart/lib/_internal/wasm/lib/string.dart
 /usr/local/lib64/dart/lib/_internal/wasm/lib/string_buffer_patch.dart
 /usr/local/lib64/dart/lib/_internal/wasm/lib/string_helper.dart
 /usr/local/lib64/dart/lib/_internal/wasm/lib/string_patch.dart

--- a/packages/dart.rb
+++ b/packages/dart.rb
@@ -3,7 +3,7 @@ require 'package'
 class Dart < Package
   description 'The Dart SDK is a set of tools and libraries for the Dart programming language.  You can find information about Dart online at dartlang.org.'
   homepage 'https://dart.dev'
-  version '3.10.4'
+  version '3.10.6'
   license 'BSD-3'
   compatibility 'aarch64 armv7l x86_64'
 
@@ -13,9 +13,9 @@ class Dart < Package
      x86_64: "https://storage.googleapis.com/dart-archive/channels/stable/release/#{version}/sdk/dartsdk-linux-x64-release.zip"
   })
   source_sha256({
-    aarch64: '2dd412046e8d9fbe429c6fb5f1c042b27f081720c1f1e36a25cc367b7bbe7c52',
-     armv7l: '2dd412046e8d9fbe429c6fb5f1c042b27f081720c1f1e36a25cc367b7bbe7c52',
-     x86_64: '60a9a34eb1165d331d776dc89fb4fd43b9d8bdaf2ca137c1fdcf98d6c89abeec'
+    aarch64: '2bd447cb87dec1584432968b2d1637b466960bd367528287fe907a73854c8c95',
+     armv7l: '2bd447cb87dec1584432968b2d1637b466960bd367528287fe907a73854c8c95',
+     x86_64: '6c2ec3ec17956bf868255fb30c8f9330dc7615dcbd5df252cc1ceba87aa22735'
   })
 
   conflicts_with 'flutter'

--- a/tests/package/d/dart
+++ b/tests/package/d/dart
@@ -1,0 +1,3 @@
+#!/bin/bash
+dart -h
+dart --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-dart crew update \
&& yes | crew upgrade

$ crew check dart -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/dart.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/dart.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/d/dart to /usr/local/lib/crew/tests/package/d
Checking dart package ...
Property tests for dart passed.
Checking dart package ...
Buildsystem test for dart passed.
Checking dart package ...
A command-line utility for Dart development.

Usage: dart <command|dart-file> [arguments]

Global options:
-v, --verbose               Show additional command output.
    --version               Print the Dart SDK version.
    --enable-analytics      Enable analytics.
    --disable-analytics     Disable analytics.
    --suppress-analytics    Disallow analytics for this `dart *` run without changing the analytics configuration.
-h, --help                  Print this usage information.

Available commands:

Global
  install     Install or upgrade a Dart CLI tool for global use.
  installed   List globally installed Dart CLI tools.
  uninstall   Remove a globally installed Dart CLI tool.

Project
  build       Build a Dart application including code assets.
  compile     Compile Dart to various formats.
  create      Create a new Dart project.
  pub         Work with packages.
  run         Run a Dart program.
  test        Run tests for a project.

Source code
  analyze     Analyze Dart code in a directory.
  doc         Generate API documentation for Dart projects.
  fix         Apply automated fixes to Dart source code.
  format      Idiomatically format Dart source code.

Tools
  devtools    Open DevTools (optionally connecting to an existing application).
  info        Show diagnostic information about the installed tooling.

Run "dart help <command>" for more information about a command.
See https://dart.dev/tools/dart-tool for detailed documentation.
Dart SDK version: 3.10.6 (stable) (Tue Dec 16 06:05:04 2025 -0800) on "linux_x64"
Package tests for dart passed.
```