### PR TITLE
Antigravity 1.11.17 => 1.12.4

### DIFF
--- a/manifest/x86_64/a/antigravity.filelist
+++ b/manifest/x86_64/a/antigravity.filelist
@@ -1,4 +1,4 @@
-# Total size: 730990227
+# Total size: 731993805
 /usr/local/bin/antigravity
 /usr/local/share/antigravity/LICENSES.chromium.html
 /usr/local/share/antigravity/antigravity

--- a/packages/antigravity.rb
+++ b/packages/antigravity.rb
@@ -3,13 +3,13 @@ require 'package'
 class Antigravity < Package
   description 'Next-generation IDE from Google'
   homepage 'https://antigravity.google/'
-  version '1.11.17'
+  version '1.12.4'
   license 'Google Terms of Service'
   compatibility 'x86_64'
   min_glibc '2.28'
   # To display this url, the latest Debian package must be installed and then run 'apt download --print-uris antigravity'
-  source_url 'https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_1.11.17-1765244408_amd64_9df0712156d4f7f37ea353feaa9633ca.deb'
-  source_sha256 'f5b61a4d00354f846e8850a2da9e87b7e204298f0f5cfa0365ede7207c7fc897'
+  source_url 'https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_1.12.4-1765945650_amd64_2e1596b9e78009717589d375637bab9f.deb'
+  source_sha256 'b19ba8495542ae75152df7c111330a36c6f7ba8358c015734418ad2f2847ae4d'
 
   no_compile_needed
 

--- a/tests/package/a/antigravity
+++ b/tests/package/a/antigravity
@@ -1,0 +1,2 @@
+#!/bin/bash
+antigravity -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-antigravity crew update \
&& yes | crew upgrade

$ crew check antigravity -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/antigravity.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/antigravity.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/a/antigravity to /usr/local/lib/crew/tests/package/a
Checking antigravity package ...
Property tests for antigravity passed.
Checking antigravity package ...
Buildsystem test for antigravity passed.
Checking antigravity package ...
1.104.0
da3eb231fb10e6dc27750aa465b8582265c907d9
x64
Package tests for antigravity passed.
```