### PR TITLE
Edge 143.0.3650.80-1 => 143.0.3650.96-1

### DIFF
--- a/manifest/x86_64/e/edge.filelist
+++ b/manifest/x86_64/e/edge.filelist
@@ -1,4 +1,4 @@
-# Total size: 635953395
+# Total size: 635987846
 /usr/local/bin/edge
 /usr/local/bin/microsoft-edge
 /usr/local/bin/microsoft-edge-stable

--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -3,12 +3,12 @@ require 'package'
 class Edge < Package
   description 'Microsoft Edge is the fast and secure browser'
   homepage 'https://www.microsoft.com/en-us/edge'
-  version '143.0.3650.80-1'
+  version '143.0.3650.96-1'
   license 'MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_#{version}_amd64.deb"
-  source_sha256 '528877731d82c3b01fe1f3622b7b0fdefa69a633f4bc7b8c1582bc9e07d08f00'
+  source_sha256 'c1a394bb565d7132785c4dabaf50a1333021997c5350370f2a2927cb897a396a'
 
   depends_on 'at_spi2_core'
   depends_on 'libcom_err'

--- a/tests/package/e/edge
+++ b/tests/package/e/edge
@@ -1,0 +1,2 @@
+#!/bin/bash
+msedge --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-edge crew update \
&& yes | crew upgrade

$ crew check edge -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/edge.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/edge.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/e/edge to /usr/local/lib/crew/tests/package/e
Checking edge package ...
Property tests for edge passed.
Checking edge package ...
Buildsystem test for edge passed.
Checking edge package ...
Microsoft Edge 143.0.3650.96 unknown
Package tests for edge passed.
```