### PR TITLE
Glab 1.78.2 => 1.80.4

### DIFF
--- a/manifest/armv7l/g/glab.filelist
+++ b/manifest/armv7l/g/glab.filelist
@@ -1,2 +1,2 @@
-# Total size: 44105912
+# Total size: 44171448
 /usr/local/bin/glab

--- a/manifest/i686/g/glab.filelist
+++ b/manifest/i686/g/glab.filelist
@@ -1,2 +1,2 @@
-# Total size: 43905208
+# Total size: 43843768
 /usr/local/bin/glab

--- a/manifest/x86_64/g/glab.filelist
+++ b/manifest/x86_64/g/glab.filelist
@@ -1,2 +1,2 @@
-# Total size: 46112952
+# Total size: 46162104
 /usr/local/bin/glab

--- a/packages/glab.rb
+++ b/packages/glab.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glab < Package
   description 'A GitLab CLI tool bringing GitLab to your command line'
   homepage 'https://gitlab.com/gitlab-org/cli'
-  version '1.78.2'
+  version '1.80.4'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Glab < Package
      x86_64: "https://gitlab.com/gitlab-org/cli/-/releases/v#{version}/downloads/glab_#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'b46edab6e8b1ffaa16b13762cc28080d8d7e4d97fedf21978069d9806c315de1',
-     armv7l: 'b46edab6e8b1ffaa16b13762cc28080d8d7e4d97fedf21978069d9806c315de1',
-       i686: '0f6d78806f7d24c96c985fb80c15a1ed0b610d56cd021d818e98568642314612',
-     x86_64: '64071cae1b6ff7881b022910752d734b6b6e44dcf8d67304cac7a3c64ce4e939'
+    aarch64: '1e9477b10295ea375e9cc460d7caa81991782125f06769798cb63ddaa130fdaa',
+     armv7l: '1e9477b10295ea375e9cc460d7caa81991782125f06769798cb63ddaa130fdaa',
+       i686: '7b24ebf2cc25981b1dba18d7349de8f7aa892ea66fa2be1e35dde4c9ce4d8e28',
+     x86_64: '1675ca17511d67042f3ec20a383b9395da8e1b68d18d4f7eb038043c19ce0a91'
   })
 
   no_compile_needed

--- a/tests/package/g/glab
+++ b/tests/package/g/glab
@@ -1,0 +1,3 @@
+#!/bin/bash
+glab -h
+glab -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-glab crew update \
&& yes | crew upgrade

$ crew check glab
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/glab.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking glab package ...
Property tests for glab passed.
Checking glab package ...
Buildsystem test for glab passed.
Checking glab package ...

  GLab is an open source GitLab CLI tool that brings GitLab to your command line.                                       
         
  USAGE  
         
    glab <command> <subcommand> [command] [--flags]  
            
  COMMANDS  
            
    alias [command] [--flags]                 Create, list, and delete aliases.
    api <endpoint> [--flags]                  Make an authenticated request to the GitLab API.
    auth <command> [command]                  Manage glab's authentication state.
    changelog <command> [command] [--flags]   Interact with the changelog API.
    check-update                              Check for latest glab releases.
    ci <command> [command] [--flags]          Work with GitLab CI/CD pipelines and jobs.
    cluster <command> [command] [--flags]     Manage GitLab Agents for Kubernetes and their clusters.
    completion [--flags]                      Generate shell completion scripts.
    config [command] [--flags]                Manage glab settings.
    deploy-key <command> [command] [--flags]  Manage deploy keys.
    duo <command> prompt [command]            Work with GitLab Duo
    gpg-key <command> [command] [--flags]     Manage GPG keys registered with your GitLab account.
    help [command]                            Help about any command
    incident [command] [--flags]              Work with GitLab incidents.
    issue [command] [--flags]                 Work with GitLab issues.
    iteration <command> [command] [--flags]   Retrieve iteration information.
    job <command> [command] [--flags]         Work with GitLab CI/CD jobs.
    label <command> [command] [--flags]       Manage labels on remote.
    mcp <command> [command]                   Work with a Model Context Protocol (MCP) server. (EXPERIMENTAL)
    milestone <command> [command] [--flags]   Manage group or project milestones.
    mr <command> [command] [--flags]          Create, view, and manage merge requests.
    opentofu <command> [command] [--flags]    Work with the OpenTofu or Terraform integration.
    release <command> [command] [--flags]     Manage GitLab releases.
    repo <command> [command] [--flags]        Work with GitLab repositories and projects.
    schedule <command> [command] [--flags]    Work with GitLab CI/CD schedules.
    securefile <command> [command] [--flags]  Manage secure files for a project.
    snippet <command> [command] [--flags]     Create, view and manage snippets.
    ssh-key <command> [command] [--flags]     Manage SSH keys registered with your GitLab account.
    stack <command> [command] [--flags]       Create, manage, and work with stacked diffs. (EXPERIMENTAL)
    token [command] [--flags]                 Manage personal, project, or group tokens
    user <command> [command] [--flags]        Interact with a GitLab user account.
    variable [command] [--flags]              Manage variables for a GitLab project or group.
    version                                   Show version information for glab.
         
  FLAGS  
         
    -h --help                                 Show help for this command.
    -v --version                              Show glab version information

glab 1.80.4 (f4b518e9)
Package tests for glab passed.
```