### PR TITLE
Etcd 3.6.6 => 3.6.7

### DIFF
--- a/manifest/x86_64/e/etcd.filelist
+++ b/manifest/x86_64/e/etcd.filelist
@@ -1,4 +1,4 @@
-# Total size: 60535336
+# Total size: 60539432
 /usr/local/bin/etcd
 /usr/local/bin/etcdctl
 /usr/local/bin/etcdutl

--- a/packages/etcd.rb
+++ b/packages/etcd.rb
@@ -3,11 +3,11 @@ require 'package'
 class Etcd < Package
   description 'Distributed reliable key-value store for the most critical data of a distributed system'
   homepage 'https://etcd.io/'
-  version '3.6.6'
+  version '3.6.7'
   license 'Apache-2.0'
   compatibility 'x86_64'
   source_url "https://github.com/etcd-io/etcd/releases/download/v#{version}/etcd-v#{version}-linux-amd64.tar.gz"
-  source_sha256 '887afaa4a99f22d802ccdfbe65730a5e79aa5c9ce2c8799c67e9d804c50ecedb'
+  source_sha256 'cf8af880c5a01ee5363cefa14a3e0cb7e5308dcf4ed17a6973099c9a7aee5a9a'
 
   no_compile_needed
   no_shrink

--- a/tests/package/e/etcd
+++ b/tests/package/e/etcd
@@ -1,0 +1,2 @@
+#!/bin/bash
+etcd --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-etcd crew update \
&& yes | crew upgrade

$ crew check etcd -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/etcd.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/etcd.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/e/etcd to /usr/local/lib/crew/tests/package/e
Checking etcd package ...
Property tests for etcd passed.
Checking etcd package ...
Buildsystem test for etcd passed.
Checking etcd package ...
etcd Version: 3.6.7
Git SHA: e838ef1
Go Version: go1.24.11
Go OS/Arch: linux/amd64
Package tests for etcd passed.
```