### PR TITLE
Go 1.25.4 => 1.25.5

### DIFF
--- a/manifest/armv7l/g/go.filelist
+++ b/manifest/armv7l/g/go.filelist
@@ -1,4 +1,4 @@
-# Total size: 203577059
+# Total size: 203580368
 /usr/local/bin/go
 /usr/local/bin/gofmt
 /usr/local/share/go/CONTRIBUTING.md

--- a/manifest/i686/g/go.filelist
+++ b/manifest/i686/g/go.filelist
@@ -1,4 +1,4 @@
-# Total size: 201868130
+# Total size: 201871439
 /usr/local/bin/go
 /usr/local/bin/gofmt
 /usr/local/share/go/CONTRIBUTING.md

--- a/manifest/x86_64/g/go.filelist
+++ b/manifest/x86_64/g/go.filelist
@@ -1,4 +1,4 @@
-# Total size: 206003223
+# Total size: 206006532
 /usr/local/bin/go
 /usr/local/bin/gofmt
 /usr/local/share/go/CONTRIBUTING.md

--- a/packages/go.rb
+++ b/packages/go.rb
@@ -3,7 +3,7 @@ require 'package'
 class Go < Package
   description 'Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.'
   homepage 'https://go.dev'
-  version '1.25.4'
+  version '1.25.5'
   license 'BSD'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Go < Package
      x86_64: "https://go.dev/dl/go#{version}.linux-amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'ff86a6406310d840edb170f539a51a7efac0ac2b2f84527b1b2bf5935fc4ab6d',
-     armv7l: 'ff86a6406310d840edb170f539a51a7efac0ac2b2f84527b1b2bf5935fc4ab6d',
-       i686: '0cf5f721ab7c5e7a170dedb2b51d9b1fedfe6ef1b2c626bf7a47fb9a613c5d96',
-     x86_64: '9fa5ffeda4170de60f67f3aa0f824e426421ba724c21e133c1e35d6159ca1bec'
+    aarch64: '0b27e3dec8d04899d6941586d2aa2721c3dee67c739c1fc1b528188f3f6e8ab5',
+     armv7l: '0b27e3dec8d04899d6941586d2aa2721c3dee67c739c1fc1b528188f3f6e8ab5',
+       i686: 'db908a86e888574ed3432355ba5372ad3ef2c0821ba9b91ceaa0f6634620c40c',
+     x86_64: '9e9b755d63b36acf30c12a9a3fc379243714c1c6d3dd72861da637f336ebb35b'
   })
 
   conflicts_ok # FIXME: Remove this when file conflicts between go and gcc are fixed

--- a/tests/package/g/go
+++ b/tests/package/g/go
@@ -1,0 +1,3 @@
+#!/bin/bash
+go 2>&1 | head
+go version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-go crew update \
&& yes | crew upgrade

$ crew  check go -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/go.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/go.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/g/go to /usr/local/lib/crew/tests/package/g
Checking go package ...
Property tests for go passed.
Checking go package ...
Buildsystem test for go passed.
Checking go package ...
Go is a tool for managing Go source code.

Usage:

	go <command> [arguments]

The commands are:

	bug         start a bug report
	build       compile packages and dependencies
go version go1.25.5 linux/amd64
Package tests for go passed.
```