### PR TITLE
Go_containerregistry 0.20.6 => 0.20.7

### DIFF
--- a/manifest/armv7l/g/go_containerregistry.filelist
+++ b/manifest/armv7l/g/go_containerregistry.filelist
@@ -1,4 +1,4 @@
-# Total size: 39060008
+# Total size: 39780904
 /usr/local/bin/crane
 /usr/local/bin/gcrane
 /usr/local/bin/krane

--- a/manifest/i686/g/go_containerregistry.filelist
+++ b/manifest/i686/g/go_containerregistry.filelist
@@ -1,4 +1,4 @@
-# Total size: 39195176
+# Total size: 39698984
 /usr/local/bin/crane
 /usr/local/bin/gcrane
 /usr/local/bin/krane

--- a/manifest/x86_64/g/go_containerregistry.filelist
+++ b/manifest/x86_64/g/go_containerregistry.filelist
@@ -1,4 +1,4 @@
-# Total size: 41153064
+# Total size: 41763368
 /usr/local/bin/crane
 /usr/local/bin/gcrane
 /usr/local/bin/krane

--- a/packages/go_containerregistry.rb
+++ b/packages/go_containerregistry.rb
@@ -3,7 +3,7 @@ require 'package'
 class Go_containerregistry < Package
   description 'Go library and CLIs for working with container registries'
   homepage 'https://github.com/google/go-containerregistry'
-  version '0.20.6'
+  version '0.20.7'
   license 'Apache-2.0'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Go_containerregistry < Package
      x86_64: "https://github.com/google/go-containerregistry/releases/download/v#{version}/go-containerregistry_Linux_x86_64.tar.gz"
   })
   source_sha256({
-    aarch64: '6c7c80b4e9d7ea683b0b6267776d094d24ce7ec3dca3e0f43ce18a80a1b84e86',
-     armv7l: '6c7c80b4e9d7ea683b0b6267776d094d24ce7ec3dca3e0f43ce18a80a1b84e86',
-       i686: 'efca5a8d3d59a9a58fc91bafa26921c2f90dc0e26a88428807fe237eb85ec448',
-     x86_64: 'c1d593d01551f2c9a3df5ca0a0be4385a839bd9b86d4a76e18d7b17d16559127'
+    aarch64: 'd8d6c91f6b0c4475406b12050b6a70841ad330af9f339945027147e99126baea',
+     armv7l: 'd8d6c91f6b0c4475406b12050b6a70841ad330af9f339945027147e99126baea',
+       i686: '9c8865fc6af4a4be62a64093ae9c2f6ed05f73ec32ed29cffa0bcd3ec0002986',
+     x86_64: '8ef3564d264e6b5ca93f7b7f5652704c4dd29d33935aff6947dd5adefd05953e'
   })
 
   no_compile_needed

--- a/tests/package/g/go_containerregistry
+++ b/tests/package/g/go_containerregistry
@@ -1,0 +1,2 @@
+#!/bin/bash
+for b in crane gcrane krane; do $b version; done


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-go_containerregistry crew update \
&& yes | crew upgrade

$ crew check go_containerregistry -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/go_containerregistry.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/go_containerregistry.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/g/go_containerregistry to /usr/local/lib/crew/tests/package/g
Checking go_containerregistry package ...
Property tests for go_containerregistry passed.
Checking go_containerregistry package ...
Buildsystem test for go_containerregistry passed.
Checking go_containerregistry package ...
0.20.7
0.20.7
0.20.7
Package tests for go_containerregistry passed.
```