### PR TITLE
Joplin 3.5.7 => 3.5.9

### DIFF
--- a/manifest/x86_64/j/joplin.filelist
+++ b/manifest/x86_64/j/joplin.filelist
@@ -1,4 +1,4 @@
-# Total size: 420681819
+# Total size: 421032502
 /usr/local/bin/joplin
 /usr/local/share/icons/hicolor/1024x1024/apps/joplin.png
 /usr/local/share/icons/hicolor/128x128/apps/joplin.png

--- a/packages/joplin.rb
+++ b/packages/joplin.rb
@@ -3,12 +3,12 @@ require 'package'
 class Joplin < Package
   description 'Open source note-taking app'
   homepage 'https://joplinapp.org/'
-  version '3.5.7'
+  version '3.5.9'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://objects.joplinusercontent.com/v#{version}/Joplin-#{version}.AppImage"
-  source_sha256 'b874d9319c3f46d060c088eff99e462ad79e6c2bf90b789a1078f4a6eec43fe7'
+  source_sha256 'eb0a27fa5777077c23b290f829812bab3941b8ce04717d8ead75edceaa8e8ece'
 
   depends_on 'gtk3'
   depends_on 'gdk_base'

--- a/tests/package/j/joplin
+++ b/tests/package/j/joplin
@@ -1,0 +1,2 @@
+#!/bin/bash
+joplin


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-joplin crew update \
&& yes | crew upgrade

$ crew check joplin -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/joplin.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/joplin.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/j/joplin to /usr/local/lib/crew/tests/package/j
Checking joplin package ...
Property tests for joplin passed.
Checking joplin package ...
Buildsystem test for joplin passed.
Checking joplin package ...
[18790:1219/223010.542388:FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /usr/local/share/joplin/chrome-sandbox is owned by root and has mode 4755.
/usr/local/bin/joplin: line 3: 18790 Trace/breakpoint trap      ./AppRun "$@"
[18794:0100/000000.561334:ERROR:content/zygote/zygote_linux.cc:672] write: Broken pipe (32)
Package tests for joplin failed.
```