### PR TITLE
Lazygit 0.56.0 => 0.57.0

### DIFF
--- a/manifest/armv7l/l/lazygit.filelist
+++ b/manifest/armv7l/l/lazygit.filelist
@@ -1,2 +1,2 @@
-# Total size: 20578488
+# Total size: 20512952
 /usr/local/bin/lazygit

--- a/manifest/i686/l/lazygit.filelist
+++ b/manifest/i686/l/lazygit.filelist
@@ -1,2 +1,2 @@
-# Total size: 20443320
+# Total size: 20361400
 /usr/local/bin/lazygit

--- a/manifest/x86_64/l/lazygit.filelist
+++ b/manifest/x86_64/l/lazygit.filelist
@@ -1,2 +1,2 @@
-# Total size: 21852344
+# Total size: 21762232
 /usr/local/bin/lazygit

--- a/packages/lazygit.rb
+++ b/packages/lazygit.rb
@@ -3,7 +3,7 @@ require 'package'
 class Lazygit < Package
   description 'A simple terminal UI for git commands'
   homepage 'https://github.com/jesseduffield/lazygit'
-  version '0.56.0'
+  version '0.57.0'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Lazygit < Package
      x86_64: "https://github.com/jesseduffield/lazygit/releases/download/v#{version}/lazygit_#{version}_linux_x86_64.tar.gz"
   })
   source_sha256({
-    aarch64: '7fc078e735fd08a8ba7dd514025432443c8f3b576220be8873c661d173fe86df',
-     armv7l: '7fc078e735fd08a8ba7dd514025432443c8f3b576220be8873c661d173fe86df',
-       i686: '9c5d5920a4deb8ba5735f2a3df7627a03926d637609e74c57595a3ee38750a5f',
-     x86_64: 'ced13c2ae074bbf6c201bc700ee2971e193b811c3b2ae0ed4d00d6225c6c9ab7'
+    aarch64: '2984e480923f8685b5184f497c14e5fe9d4b7890e70ef50fdead3d5846212ae6',
+     armv7l: '2984e480923f8685b5184f497c14e5fe9d4b7890e70ef50fdead3d5846212ae6',
+       i686: 'cd5c17dab07b0db999ab4691f5e6bcdd700b3402d30d3f447ba1e88f84f2de49',
+     x86_64: 'ced011ecd1459d069c66128fbf172b7248c8b99d8983fa17d84a247a98146d5e'
   })
 
   no_compile_needed

--- a/tests/package/l/lazygit
+++ b/tests/package/l/lazygit
@@ -1,0 +1,3 @@
+#!/bin/bash
+lazygit -h 2>&1
+lazygit -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-lazygit crew update \
&& yes | crew upgrade

$ crew check lazygit -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/lazygit.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/lazygit.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/l/lazygit to /usr/local/lib/crew/tests/package/l
Checking lazygit package ...
Property tests for lazygit passed.
Checking lazygit package ...
Buildsystem test for lazygit passed.
Checking lazygit package ...
lazygit

  Usage:
    lazygit [git-arg]

  Positional Variables: 
    git-arg   Panel to focus upon opening lazygit. Accepted values (based on git terminology): status, branch, log, stash. Ignored if --filter arg is passed.
  Flags: 
    -h --help               Displays help with available flag, subcommand, and positional value parameters.
    -p --path               Path of git repo. (equivalent to --work-tree=<path> --git-dir=<path>/.git/)
    -f --filter             Path to filter on in `git log -- <path>`. When in filter mode, the commits, reflog, and stash are filtered based on the given path, and some operations are restricted
    -v --version            Print the current version
    -d --debug              Run in debug mode with logging (see --logs flag below). Use the LOG_LEVEL env var to set the log level (debug/info/warn/error)
    -l --logs               Tail lazygit logs (intended to be used when `lazygit --debug` is called in a separate terminal tab)
       --profile            Start the profiler and serve it on http port 6060. See CONTRIBUTING.md for more info.
    -c --config             Print the default config
    -cd --print-config-dir   Print the config directory
    -ucd --use-config-dir     override default config directory with provided directory
    -w --work-tree          equivalent of the --work-tree git argument
    -g --git-dir            equivalent of the --git-dir git argument
    -ucf --use-config-file    Comma separated list to custom config file(s)
    -sm --screen-mode        The initial screen-mode, which determines the size of the focused panel. Valid options: 'normal' (default), 'half', 'full'

commit=17d03ec8cb89d4c65fd129228164562a220abefb, build date=2025-12-06T13:01:50Z, build source=binaryRelease, version=0.57.0, os=linux, arch=amd64, git version=2.52.0
Package tests for lazygit passed.
```