### PR TITLE
Lego 4.28.1 => 4.30.1

### DIFF
--- a/manifest/armv7l/l/lego.filelist
+++ b/manifest/armv7l/l/lego.filelist
@@ -1,1 +1,2 @@
+# Total size: 58851512
 /usr/local/bin/lego

--- a/manifest/i686/l/lego.filelist
+++ b/manifest/i686/l/lego.filelist
@@ -1,1 +1,2 @@
+# Total size: 59437240
 /usr/local/bin/lego

--- a/manifest/x86_64/l/lego.filelist
+++ b/manifest/x86_64/l/lego.filelist
@@ -1,1 +1,2 @@
+# Total size: 63991992
 /usr/local/bin/lego

--- a/packages/lego.rb
+++ b/packages/lego.rb
@@ -3,7 +3,7 @@ require 'package'
 class Lego < Package
   description "Let's Encrypt/ACME client and library written in Go"
   homepage 'https://go-acme.github.io/lego/'
-  version '4.28.1'
+  version '4.30.1'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Lego < Package
      x86_64: "https://github.com/go-acme/lego/releases/download/v#{version}/lego_v#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'a3d6bfbb9a2e477b0ed0dbfd260052ed941a613bc4dd2a70301281f4fc6bda81',
-     armv7l: 'a3d6bfbb9a2e477b0ed0dbfd260052ed941a613bc4dd2a70301281f4fc6bda81',
-       i686: '8e23581a5e17dad9adc96e9f7974227b543f99ef772b9e4fca7735559659dc77',
-     x86_64: '592f26b00837fbc3f05698761130ced2468eac0de924e9e3d5d55bd5560e4b6b'
+    aarch64: '42d11acb8954c4cf3d8a7b87dbc3fa720264bd2afc17a0ae6559a534be0744ca',
+     armv7l: '42d11acb8954c4cf3d8a7b87dbc3fa720264bd2afc17a0ae6559a534be0744ca',
+       i686: '691d8db514c9c7b08cb2f7f169b155b7b349315e8bea3d86615f7d889f4d6a7c',
+     x86_64: '39fa1c929feb16d34a2673a6df80e17feddd1060122efd7fd41f9eb7d3f0fc28'
   })
 
   no_compile_needed

--- a/tests/package/l/lego
+++ b/tests/package/l/lego
@@ -1,0 +1,3 @@
+#!/bin/bash
+lego -h | head
+lego -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-lego crew update \
&& yes | crew upgrade

$ crew check lego -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/lego.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/lego.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/l/lego to /usr/local/lib/crew/tests/package/l
Checking lego package ...
Property tests for lego passed.
Checking lego package ...
Buildsystem test for lego passed.
Checking lego package ...
NAME:
   lego - Let's Encrypt client written in Go

USAGE:
   lego [global options] command [command options]

VERSION:
   4.30.1

COMMANDS:
lego version 4.30.1 linux/amd64
Package tests for lego passed.
```