### PR TITLE
Monero 0.18.4.3 => 0.18.4.4

### DIFF
--- a/manifest/armv7l/m/monero.filelist
+++ b/manifest/armv7l/m/monero.filelist
@@ -1,4 +1,4 @@
-# Total size: 165877598
+# Total size: 169439486
 /usr/local/bin/monero-blockchain-ancestry
 /usr/local/bin/monero-blockchain-depth
 /usr/local/bin/monero-blockchain-export

--- a/manifest/x86_64/m/monero.filelist
+++ b/manifest/x86_64/m/monero.filelist
@@ -1,4 +1,4 @@
-# Total size: 235859610
+# Total size: 242914410
 /usr/local/bin/monero-blockchain-ancestry
 /usr/local/bin/monero-blockchain-depth
 /usr/local/bin/monero-blockchain-export

--- a/packages/monero.rb
+++ b/packages/monero.rb
@@ -3,7 +3,7 @@ require 'package'
 class Monero < Package
   description 'Private, decentralized cryptocurrency that keeps your finances confidential and secure.'
   homepage 'https://www.getmonero.org/'
-  version '0.18.4.3'
+  version '0.18.4.4'
   license 'The Cryptonote developers,The Boolberry developers,MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.27'
@@ -14,9 +14,9 @@ class Monero < Package
      x86_64: "https://downloads.getmonero.org/cli/monero-linux-x64-v#{version}.tar.bz2"
   })
   source_sha256({
-    aarch64: '3ac83049bc565fb5238501f0fa629cdd473bbe94d5fb815088af8e6ff1d761cd',
-     armv7l: '3ac83049bc565fb5238501f0fa629cdd473bbe94d5fb815088af8e6ff1d761cd',
-     x86_64: '3a7b36ae4da831a4e9913e0a891728f4c43cd320f9b136cdb6686b1d0a33fafa'
+    aarch64: '2040dc22748ef39ed8a755324d2515261b65315c67b91f449fa1617c5978910b',
+     armv7l: '2040dc22748ef39ed8a755324d2515261b65315c67b91f449fa1617c5978910b',
+     x86_64: '7fe45ee9aade429ccdcfcad93b905ba45da5d3b46d2dc8c6d5afc48bd9e7f108'
   })
 
   no_compile_needed

--- a/tests/package/m/monero
+++ b/tests/package/m/monero
@@ -1,0 +1,3 @@
+#!/bin/bash
+monero-wallet-cli --help 2>&1 | head
+monero-wallet-cli --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-monero crew update \
&& yes | crew upgrade

$ crew check monero -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/monero.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/monero.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/m/monero to /usr/local/lib/crew/tests/package/m
Checking monero package ...
Property tests for monero passed.
Checking monero package ...
Buildsystem test for monero passed.
Checking monero package ...
Monero 'Fluorine Fermi' (v0.18.4.4-release)

This is the command line monero wallet. It needs to connect to a monero
daemon to work correctly.

Usage:
  monero-wallet-cli [--wallet-file=<filename>|--generate-new-wallet=<filename>] [<COMMAND>]

General options:
  --help                                Produce help message
Monero 'Fluorine Fermi' (v0.18.4.4-release)
Package tests for monero passed.
```