### PR TITLE
Monero_gui 0.18.4.3 => 0.18.4.4

### DIFF
--- a/manifest/x86_64/m/monero_gui.filelist
+++ b/manifest/x86_64/m/monero_gui.filelist
@@ -1,4 +1,4 @@
-# Total size: 124058067
+# Total size: 124849171
 /usr/local/bin/monero
 /usr/local/bin/monero-wallet-gui
 /usr/local/share/monero/monero-gui-wallet-guide.pdf

--- a/packages/monero_gui.rb
+++ b/packages/monero_gui.rb
@@ -4,11 +4,11 @@ require 'misc_functions'
 class Monero_gui < Package
   description 'Private, decentralized cryptocurrency that keeps your finances confidential and secure.'
   homepage 'https://www.getmonero.org/'
-  version '0.18.4.3'
+  version '0.18.4.4'
   license 'The Cryptonote developers,The Boolberry developers,MIT'
   compatibility 'x86_64'
   source_url "https://downloads.getmonero.org/gui/monero-gui-linux-x64-v#{version}.tar.bz2"
-  source_sha256 '0bd84de0a7c18b2a3ea8e8eff2194ae000cf1060045badfd4ab48674bc1b9325'
+  source_sha256 'e45cb3fa9d972d67628cfed6463fb7604ae1414a11ba449f5e2f901c769ac788'
 
   depends_on 'monero' # R
   depends_on 'xcb_util' # R

--- a/tests/package/m/monero_gui
+++ b/tests/package/m/monero_gui
@@ -1,0 +1,2 @@
+#!/bin/bash
+monero -h


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-monero_gui crew update \
&& yes | crew upgrade

$ crew check monero_gui -f

Using rubocop to sanitize /home/chronos/user/chromebrew/packages/monero_gui.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/monero_gui.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/m/monero_gui to /usr/local/lib/crew/tests/package/m
Checking monero_gui package ...
Property tests for monero_gui passed.
Checking monero_gui package ...
Buildsystem test for monero_gui passed.
Checking monero_gui package ...
Usage: /usr/local/bin/monero-wallet-gui [options]

Options:
  --verify-update <update-binary>  Verify update binary using
                                   'shasum'-compatible (SHA256 algo) output
                                   signed by two maintainers.
                                   * Requires 'hashes.txt' - signed 'shasum'
                                   output (i.e. 'gpg -o hashes.txt --clear-sign
                                   <shasum_output>') generated by a maintainer.
                                   * Requires 'hashes.txt.sig' - detached
                                   signature of 'hashes.txt' (i.e. 'gpg -b
                                   hashes.txt') generated by another maintainer.
  --disable-check-updates          Disable automatic check for updates.
  --socks5-proxy <address:port>    Enable socks5 proxy. Used for remote node
                                   connection (advanced mode), updates
                                   downloading and fetching price sources.
  -l, --log-file <file>            Log to specified file
  -h, --help                       Displays help on commandline options.
  --help-all                       Displays help including Qt specific options.
Package tests for monero_gui passed.
```