### PR TITLE
Nushell 0.108.0 => 0.109.1

### DIFF
--- a/manifest/armv7l/n/nushell.filelist
+++ b/manifest/armv7l/n/nushell.filelist
@@ -1,4 +1,4 @@
-# Total size: 190345176
+# Total size: 204577300
 /usr/local/bin/nu
 /usr/local/bin/nu_plugin_custom_values
 /usr/local/bin/nu_plugin_example

--- a/manifest/x86_64/n/nushell.filelist
+++ b/manifest/x86_64/n/nushell.filelist
@@ -1,4 +1,4 @@
-# Total size: 207510280
+# Total size: 221686624
 /usr/local/bin/nu
 /usr/local/bin/nu_plugin_custom_values
 /usr/local/bin/nu_plugin_example

--- a/packages/nushell.rb
+++ b/packages/nushell.rb
@@ -3,7 +3,7 @@ require 'package'
 class Nushell < Package
   description 'A new type of shell'
   homepage 'https://www.nushell.sh/'
-  version '0.108.0'
+  version '0.109.1'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.28'
@@ -13,9 +13,9 @@ class Nushell < Package
      x86_64: "https://github.com/nushell/nushell/releases/download/#{version}/nu-#{version}-x86_64-unknown-linux-gnu.tar.gz"
   })
   source_sha256({
-    aarch64: '5823f3b115fd4fd303cc5dcc316d07e7afeee74b0d9937ee380d40b97c3d13d9',
-     armv7l: '5823f3b115fd4fd303cc5dcc316d07e7afeee74b0d9937ee380d40b97c3d13d9',
-     x86_64: 'f0daaa0256b0f7dd5f4d9925b4d5522d8de5e947ed9ad64a43526e5cffeb05df'
+    aarch64: 'd326d4763ddb4ae2b3a5542f1a6f67d4c578575a9ec69e00bbc892d60b2b1232',
+     armv7l: 'd326d4763ddb4ae2b3a5542f1a6f67d4c578575a9ec69e00bbc892d60b2b1232',
+     x86_64: '0fa23b828ac610e3ee7798b25e38cef5cfdc47503326236d27cd57d1c959190e'
   })
 
   no_compile_needed

--- a/tests/package/n/nushell
+++ b/tests/package/n/nushell
@@ -1,0 +1,3 @@
+#!/bin/bash
+nu -h | head
+nu --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-nushell crew update \
&& yes | crew upgrade

$ crew check nushell -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/nushell.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/nushell.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/n/nushell to /usr/local/lib/crew/tests/package/n
Checking nushell package ...
Property tests for nushell passed.
Checking nushell package ...
Buildsystem test for nushell passed.
Checking nushell package ...
The nushell language and shell.

Usage:
  > nu {flags} (script file) ...(script args) 

Flags:
  -h, --help: Display the help message for this command
  -c, --commands <string>: run the given commands and then exit
  -e, --execute <string>: run the given commands and then enter an interactive shell
  -I, --include-path <string>: set the NU_LIB_DIRS for the given script (delimited by char record_sep (''))
0.109.1
Package tests for nushell passed.
```