### PR TITLE
Ollama 0.12.10 => 0.13.5

### DIFF
--- a/manifest/x86_64/o/ollama.filelist
+++ b/manifest/x86_64/o/ollama.filelist
@@ -1,2 +1,2 @@
-# Total size: 32258144
+# Total size: 35632896
 /usr/local/bin/ollama

--- a/packages/ollama.rb
+++ b/packages/ollama.rb
@@ -4,11 +4,11 @@ require 'misc_functions'
 class Ollama < Package
   description 'Get up and running with large language models.'
   homepage 'https://ollama.com/'
-  version '0.12.10'
+  version '0.13.5'
   license 'MIT'
   compatibility 'x86_64'
   source_url "https://github.com/ollama/ollama/releases/download/v#{version}/ollama-linux-amd64.tgz"
-  source_sha256 '8f4bf70a9856a34ba71355745c2189a472e2691a020ebd2e242a58e4d2094722'
+  source_sha256 '41fb93ff8be35e4d2d22bafd1c42b487efb15b766076d976766bd1ee4db3f8e2'
 
   no_compile_needed
   no_shrink

--- a/tests/package/o/ollama
+++ b/tests/package/o/ollama
@@ -1,0 +1,3 @@
+#!/bin/bash
+ollama -h
+ollama -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-ollama crew update \
&& yes | crew upgrade

$ crew check ollama -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/ollama.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/ollama.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/o/ollama to /usr/local/lib/crew/tests/package/o
Checking ollama package ...
Property tests for ollama passed.
Checking ollama package ...
Buildsystem test for ollama passed.
Checking ollama package ...
Large language model runner

Usage:
  ollama [flags]
  ollama [command]

Available Commands:
  serve       Start ollama
  create      Create a model
  show        Show information for a model
  run         Run a model
  stop        Stop a running model
  pull        Pull a model from a registry
  push        Push a model to a registry
  signin      Sign in to ollama.com
  signout     Sign out from ollama.com
  list        List models
  ps          List running models
  cp          Copy a model
  rm          Remove a model
  help        Help about any command

Flags:
  -h, --help      help for ollama
  -v, --version   Show version information

Use "ollama [command] --help" for more information about a command.
Warning: could not connect to a running Ollama instance
Warning: client version is 0.13.5
Package tests for ollama passed.
```