### PR TITLE
Packer 1.14.2 => 1.14.3

### DIFF
--- a/manifest/armv7l/p/packer.filelist
+++ b/manifest/armv7l/p/packer.filelist
@@ -1,2 +1,2 @@
-# Total size: 39649451
+# Total size: 40763576
 /usr/local/bin/packer

--- a/manifest/i686/p/packer.filelist
+++ b/manifest/i686/p/packer.filelist
@@ -1,2 +1,2 @@
-# Total size: 39661739
+# Total size: 40722616
 /usr/local/bin/packer

--- a/manifest/x86_64/p/packer.filelist
+++ b/manifest/x86_64/p/packer.filelist
@@ -1,2 +1,2 @@
-# Total size: 42037419
+# Total size: 43012280
 /usr/local/bin/packer

--- a/packages/packer.rb
+++ b/packages/packer.rb
@@ -3,7 +3,7 @@ require 'package'
 class Packer < Package
   description 'Packer is an open source tool for creating identical machine images for multiple platforms from a single source configuration.'
   homepage 'https://www.packer.io/'
-  version '1.14.2'
+  version '1.14.3'
   license 'Apache-2.0, BSD-2, BSD-4, MIT, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Packer < Package
      x86_64: "https://releases.hashicorp.com/packer/#{version}/packer_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '1bca6b645d2f4e5968b77f6b2ccc06e9ab4f38eb1453116ee6542402068bdb0c',
-     armv7l: '1bca6b645d2f4e5968b77f6b2ccc06e9ab4f38eb1453116ee6542402068bdb0c',
-       i686: '52c6bc04da164dbba135aa974f3a36bb662091187bc39997b1e548f589854d04',
-     x86_64: 'cfefdea4ac580eba7b254ef34d25b756d4961741004e3e701a1476594d13e64a'
+    aarch64: '0676cbfb8f3a666c8b3c38e4f5d58db54e5ee70ebd7baf725df7f0cea2bb6fd9',
+     armv7l: '0676cbfb8f3a666c8b3c38e4f5d58db54e5ee70ebd7baf725df7f0cea2bb6fd9',
+       i686: 'b9f3e49aa5a31a4fe0cab45d284e05b7a7b9d5532400d6cd6e5ad604f814649f',
+     x86_64: '95041cc0a30f05d5583be26a7c0b715f488e461418ce0c5d88ba204cb092bef1'
   })
 
   no_compile_needed

--- a/tests/package/p/packer
+++ b/tests/package/p/packer
@@ -1,0 +1,3 @@
+#!/bin/bash
+packer
+packer --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-packer crew update \
&& yes | crew upgrade

$ crew check packer -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/packer.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/packer.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/p/packer to /usr/local/lib/crew/tests/package/p
Checking packer package ...
Property tests for packer passed.
Checking packer package ...
Buildsystem test for packer passed.
Checking packer package ...
Usage: packer [--version] [--help] <command> [<args>]

Available commands are:
    build           build image(s) from template
    console         creates a console for testing variable interpolation
    fix             fixes templates from old versions of packer
    fmt             Rewrites HCL2 config files to canonical format
    hcl2_upgrade    transform a JSON template into an HCL2 configuration
    init            Install missing plugins or upgrade plugins
    inspect         see components of a template
    plugins         Interact with Packer plugins and catalog
    validate        check that a template is valid
    version         Prints the Packer version

Packer v1.14.3
Package tests for packer passed.
```