### PR TITLE
Rclone 1.71.2 => 1.72.1

### DIFF
--- a/manifest/armv7l/r/rclone.filelist
+++ b/manifest/armv7l/r/rclone.filelist
@@ -1,3 +1,3 @@
-# Total size: 64149787
+# Total size: 68104909
 /usr/local/bin/rclone
 /usr/local/share/man/man1/rclone.1.zst

--- a/manifest/i686/r/rclone.filelist
+++ b/manifest/i686/r/rclone.filelist
@@ -1,3 +1,3 @@
-# Total size: 64858395
+# Total size: 69055181
 /usr/local/bin/rclone
 /usr/local/share/man/man1/rclone.1.zst

--- a/manifest/x86_64/r/rclone.filelist
+++ b/manifest/x86_64/r/rclone.filelist
@@ -1,3 +1,3 @@
-# Total size: 69749019
+# Total size: 74101453
 /usr/local/bin/rclone
 /usr/local/share/man/man1/rclone.1.zst

--- a/packages/rclone.rb
+++ b/packages/rclone.rb
@@ -3,7 +3,7 @@ require 'package'
 class Rclone < Package
   description 'Rclone is a command-line program to manage files on cloud storage.'
   homepage 'https://rclone.org/'
-  version '1.71.2'
+  version '1.72.1'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Rclone < Package
      x86_64: "https://github.com/rclone/rclone/releases/download/v#{version}/rclone-v#{version}-linux-amd64.zip"
   })
   source_sha256({
-    aarch64: 'bd89eb49aff89be4f9d73455885283a825d356e795424e39edb39134d397325b',
-     armv7l: 'bd89eb49aff89be4f9d73455885283a825d356e795424e39edb39134d397325b',
-       i686: '809df9d197f0fa070f13aa5a94a2155f68e5f2dea18db9aa3967922ed04efc31',
-     x86_64: 'ab9fa5877cee91c64fdfd61a27028a458cf618b39259e5c371dc2ec34a12e415'
+    aarch64: 'cbff78f41ad97b5eedab77f42a2e8ef609a776901c849089a75c7fa35f43142e',
+     armv7l: 'cbff78f41ad97b5eedab77f42a2e8ef609a776901c849089a75c7fa35f43142e',
+       i686: 'd9bcc34e25b64f639a51e7be77549b2ec20eae70ba9c768104490b17952081d8',
+     x86_64: 'b5c9b2fb6ada8a400c5fc5d48cd112dc1adea21a3b73b03857059374dd8a78d0'
   })
 
   no_compile_needed

--- a/tests/package/r/rclone
+++ b/tests/package/r/rclone
@@ -1,0 +1,3 @@
+#!/bin/bash
+rclone help | head
+rclone version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-rclone crew update \
&& yes | crew upgrade

$ crew check rclone -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/rclone.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/rclone.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/r/rclone to /usr/local/lib/crew/tests/package/r
Checking rclone package ...
Property tests for rclone passed.
Checking rclone package ...
Buildsystem test for rclone passed.
Checking rclone package ...
Usage:
  rclone [flags]
  rclone [command]

Available commands:
  about       Get quota information from the remote.
  archive     Perform an action on an archive.
  authorize   Remote authorization.
  backend     Run a backend-specific command.
  bisync      Perform bidirectional synchronization between two paths.
rclone v1.72.1
- os/version: chromeos 90 (64 bit)
- os/kernel: 6.4.0-1mx-ahs-amd64 (x86_64)
- os/type: linux
- os/arch: amd64
- go/version: go1.25.5
- go/linking: static
- go/tags: none
Package tests for rclone passed.
```