### PR TITLE
Rqlite 9.3.1 => 9.3.5

### DIFF
--- a/manifest/armv7l/r/rqlite.filelist
+++ b/manifest/armv7l/r/rqlite.filelist
@@ -1,0 +1,8 @@
+# Total size: 44002296
+/usr/local/bin/rqbench
+/usr/local/bin/rqlite
+/usr/local/bin/rqlited
+/usr/local/bin/startrqlited
+/usr/local/bin/stoprqlited
+/usr/local/etc/bash.d/10-rqlited
+/usr/local/lib/ld-linux.so.3

--- a/packages/rqlite.rb
+++ b/packages/rqlite.rb
@@ -3,12 +3,20 @@ require 'package'
 class Rqlite < Package
   description 'The lightweight, user-friendly, distributed relational database built on SQLite.'
   homepage 'https://rqlite.io/'
-  version '9.3.1'
+  version '9.3.5'
   license 'MIT'
-  compatibility 'x86_64'
+  compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.29'
-  source_url "https://github.com/rqlite/rqlite/releases/download/v#{version}/rqlite-v#{version}-linux-amd64.tar.gz"
-  source_sha256 '84fed36b27c336632c76463981ebf4e44811eb57efe31c35d1d6c160556c7b98'
+  source_url({
+    aarch64: "https://github.com/rqlite/rqlite/releases/download/v#{version}/rqlite-v#{version}-linux-arm.tar.gz",
+     armv7l: "https://github.com/rqlite/rqlite/releases/download/v#{version}/rqlite-v#{version}-linux-arm.tar.gz",
+     x86_64: "https://github.com/rqlite/rqlite/releases/download/v#{version}/rqlite-v#{version}-linux-amd64.tar.gz"
+  })
+  source_sha256({
+    aarch64: '1f9bcc18d232de5a00bb7559de94d8104f26a72c220ddc6d29c0c1f2c808911f',
+     armv7l: '1f9bcc18d232de5a00bb7559de94d8104f26a72c220ddc6d29c0c1f2c808911f',
+     x86_64: '24ed2ce052c9ed8e6f6261810062f88632f810f0d0e6887860758d376df85a5a'
+  })
 
   depends_on 'psmisc'
 
@@ -33,6 +41,10 @@ class Rqlite < Package
   def self.install
     FileUtils.install %w[rqbench rqlite rqlited startrqlited stoprqlited], "#{CREW_DEST_PREFIX}/bin", mode: 0o755
     FileUtils.install 'rqlited.sh', "#{CREW_DEST_PREFIX}/etc/bash.d/10-rqlited"
+    if File.exist?("#{CREW_PREFIX}/opt/glibc-libs/ld-linux-armhf.so.3") && !File.exist?("#{CREW_LIB_PREFIX}/ld-linux.so.3")
+      FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
+      FileUtils.ln_s "#{CREW_PREFIX}/opt/glibc-libs/ld-linux-armhf.so.3", "#{CREW_DEST_LIB_PREFIX}/ld-linux.so.3"
+    end
   end
 
   def self.postinstall
@@ -41,7 +53,6 @@ class Rqlite < Package
       Run 'startrqlited' to start the rqlite daemon.
       Run 'stoprqlited' to stop the rqlite daemon.
       Run 'rqlite' to start the cli.
-
     EOM
   end
 

--- a/tests/package/r/rqlite
+++ b/tests/package/r/rqlite
@@ -1,0 +1,4 @@
+#!/bin/bash
+rqbench -h 2>&1
+rqlite -h | head
+rqlite -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l` Unable to launch in strongbad m142 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-rqlite crew update \
&& yes | crew upgrade

$ crew check rqlite -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/rqlite.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/rqlite.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/r/rqlite to /usr/local/lib/crew/tests/package/r
Checking rqlite package ...
Property tests for rqlite passed.
Checking rqlite package ...
Buildsystem test for rqlite passed.
Checking rqlite package ...

rqbench is a simple load testing utility for rqlite.

Usage: rqbench [arguments] <SQL statement>
  -a string
    	Node address (default "localhost:4001")
  -b int
    	Statements per request (default 1)
  -m int
    	Print progress every m requests
  -n int
    	Number of requests (default 100)
  -o string
    	One-shot execute statement to preload
  -p string
    	Endpoint to use (default "/db/execute")
  -q	Use queued writes
  -t string
    	Transport to use (default "http")
  -x	Use explicit transaction per request
Options:

  -h, --help
      display help information

  -a, --alternatives
      comma separated list of 'host:port' pairs to use as fallback

  -s, --scheme[=http]
      protocol scheme (http or https)
Version v9.3.5, commit 8fe936ac406b803c5ee8215763a685af6672df0f, branch master, built on 2025-12-08T03:01:30+0000
Package tests for rqlite passed.
```