### PR TITLE
Scbi 9.9 => 12.1

### DIFF
--- a/manifest/armv7l/s/scbi.filelist
+++ b/manifest/armv7l/s/scbi.filelist
@@ -1,8 +1,11 @@
+# Total size: 689359
 /usr/local/.config/scbi/.core.plugins
 /usr/local/.config/scbi/.env
 /usr/local/.config/scbi/.pkgs-cos
 /usr/local/.config/scbi/.pkgs-deb
+/usr/local/.config/scbi/.pkgs-deb~12
 /usr/local/.config/scbi/.pkgs-fed
+/usr/local/.config/scbi/.pkgs-mingw
 /usr/local/.config/scbi/.pkgs-rhl
 /usr/local/.config/scbi/.pkgs-ubt
 /usr/local/.config/scbi/.plan-default
@@ -28,6 +31,8 @@
 /usr/local/.config/scbi/c-alt-ergo
 /usr/local/.config/scbi/c-aunit
 /usr/local/.config/scbi/c-aws
+/usr/local/.config/scbi/c-aws-lib
+/usr/local/.config/scbi/c-aws-tools
 /usr/local/.config/scbi/c-ayacc
 /usr/local/.config/scbi/c-binutils
 /usr/local/.config/scbi/c-blaslapack
@@ -40,10 +45,12 @@
 /usr/local/.config/scbi/c-e3-core
 /usr/local/.config/scbi/c-e3-testsuite
 /usr/local/.config/scbi/c-exiv2
+/usr/local/.config/scbi/c-garlic
 /usr/local/.config/scbi/c-gcc
 /usr/local/.config/scbi/c-gdb
 /usr/local/.config/scbi/c-gimp
 /usr/local/.config/scbi/c-git
+/usr/local/.config/scbi/c-glade
 /usr/local/.config/scbi/c-gmp
 /usr/local/.config/scbi/c-gnadelite
 /usr/local/.config/scbi/c-gnatcoll
@@ -58,6 +65,7 @@
 /usr/local/.config/scbi/c-gnatcoll-db-libs-sql
 /usr/local/.config/scbi/c-gnatcoll-db-libs-sqlite
 /usr/local/.config/scbi/c-gnatcoll-db-tools
+/usr/local/.config/scbi/c-gnatdist
 /usr/local/.config/scbi/c-gnatdoc4
 /usr/local/.config/scbi/c-gpmdp
 /usr/local/.config/scbi/c-gpr2
@@ -73,6 +81,7 @@
 /usr/local/.config/scbi/c-hubicfuse
 /usr/local/.config/scbi/c-imagemagick
 /usr/local/.config/scbi/c-langkit
+/usr/local/.config/scbi/c-langkit-support
 /usr/local/.config/scbi/c-lcms2
 /usr/local/.config/scbi/c-lensfun
 /usr/local/.config/scbi/c-libadalang
@@ -83,7 +92,9 @@
 /usr/local/.config/scbi/c-libgegl
 /usr/local/.config/scbi/c-libgpr
 /usr/local/.config/scbi/c-libiconv
+/usr/local/.config/scbi/c-liblktlang
 /usr/local/.config/scbi/c-libmypaint
+/usr/local/.config/scbi/c-libopenjpeg
 /usr/local/.config/scbi/c-librest
 /usr/local/.config/scbi/c-llvm
 /usr/local/.config/scbi/c-markdown
@@ -97,6 +108,7 @@
 /usr/local/.config/scbi/c-pixelsaver
 /usr/local/.config/scbi/c-polyorb
 /usr/local/.config/scbi/c-prettier-ada
+/usr/local/.config/scbi/c-python-post-install-dist-packages
 /usr/local/.config/scbi/c-python3-modules
 /usr/local/.config/scbi/c-readline
 /usr/local/.config/scbi/c-sandbox
@@ -105,6 +117,7 @@
 /usr/local/.config/scbi/c-templates-parser
 /usr/local/.config/scbi/c-v2p
 /usr/local/.config/scbi/c-vss
+/usr/local/.config/scbi/c-vss-text
 /usr/local/.config/scbi/c-win32ada
 /usr/local/.config/scbi/c-wisi-token
 /usr/local/.config/scbi/c-wposix
@@ -112,7 +125,9 @@
 /usr/local/.config/scbi/patches/0001-fix-mpris-support-in-gnome.patch
 /usr/local/.config/scbi/patches/gps-css-gtk3.36.patch
 /usr/local/.config/scbi/patches/libfswatch.patch
+/usr/local/.config/scbi/patches/wisi-adb.patch
 /usr/local/bin/scbi
+/usr/local/bin/scbi-format
 /usr/local/bin/scbi-lint
 /usr/local/bin/scbi-shell
 /usr/local/bin/scbi-show

--- a/manifest/i686/s/scbi.filelist
+++ b/manifest/i686/s/scbi.filelist
@@ -1,8 +1,11 @@
+# Total size: 689359
 /usr/local/.config/scbi/.core.plugins
 /usr/local/.config/scbi/.env
 /usr/local/.config/scbi/.pkgs-cos
 /usr/local/.config/scbi/.pkgs-deb
+/usr/local/.config/scbi/.pkgs-deb~12
 /usr/local/.config/scbi/.pkgs-fed
+/usr/local/.config/scbi/.pkgs-mingw
 /usr/local/.config/scbi/.pkgs-rhl
 /usr/local/.config/scbi/.pkgs-ubt
 /usr/local/.config/scbi/.plan-default
@@ -28,6 +31,8 @@
 /usr/local/.config/scbi/c-alt-ergo
 /usr/local/.config/scbi/c-aunit
 /usr/local/.config/scbi/c-aws
+/usr/local/.config/scbi/c-aws-lib
+/usr/local/.config/scbi/c-aws-tools
 /usr/local/.config/scbi/c-ayacc
 /usr/local/.config/scbi/c-binutils
 /usr/local/.config/scbi/c-blaslapack
@@ -40,10 +45,12 @@
 /usr/local/.config/scbi/c-e3-core
 /usr/local/.config/scbi/c-e3-testsuite
 /usr/local/.config/scbi/c-exiv2
+/usr/local/.config/scbi/c-garlic
 /usr/local/.config/scbi/c-gcc
 /usr/local/.config/scbi/c-gdb
 /usr/local/.config/scbi/c-gimp
 /usr/local/.config/scbi/c-git
+/usr/local/.config/scbi/c-glade
 /usr/local/.config/scbi/c-gmp
 /usr/local/.config/scbi/c-gnadelite
 /usr/local/.config/scbi/c-gnatcoll
@@ -58,6 +65,7 @@
 /usr/local/.config/scbi/c-gnatcoll-db-libs-sql
 /usr/local/.config/scbi/c-gnatcoll-db-libs-sqlite
 /usr/local/.config/scbi/c-gnatcoll-db-tools
+/usr/local/.config/scbi/c-gnatdist
 /usr/local/.config/scbi/c-gnatdoc4
 /usr/local/.config/scbi/c-gpmdp
 /usr/local/.config/scbi/c-gpr2
@@ -73,6 +81,7 @@
 /usr/local/.config/scbi/c-hubicfuse
 /usr/local/.config/scbi/c-imagemagick
 /usr/local/.config/scbi/c-langkit
+/usr/local/.config/scbi/c-langkit-support
 /usr/local/.config/scbi/c-lcms2
 /usr/local/.config/scbi/c-lensfun
 /usr/local/.config/scbi/c-libadalang
@@ -83,7 +92,9 @@
 /usr/local/.config/scbi/c-libgegl
 /usr/local/.config/scbi/c-libgpr
 /usr/local/.config/scbi/c-libiconv
+/usr/local/.config/scbi/c-liblktlang
 /usr/local/.config/scbi/c-libmypaint
+/usr/local/.config/scbi/c-libopenjpeg
 /usr/local/.config/scbi/c-librest
 /usr/local/.config/scbi/c-llvm
 /usr/local/.config/scbi/c-markdown
@@ -97,6 +108,7 @@
 /usr/local/.config/scbi/c-pixelsaver
 /usr/local/.config/scbi/c-polyorb
 /usr/local/.config/scbi/c-prettier-ada
+/usr/local/.config/scbi/c-python-post-install-dist-packages
 /usr/local/.config/scbi/c-python3-modules
 /usr/local/.config/scbi/c-readline
 /usr/local/.config/scbi/c-sandbox
@@ -105,6 +117,7 @@
 /usr/local/.config/scbi/c-templates-parser
 /usr/local/.config/scbi/c-v2p
 /usr/local/.config/scbi/c-vss
+/usr/local/.config/scbi/c-vss-text
 /usr/local/.config/scbi/c-win32ada
 /usr/local/.config/scbi/c-wisi-token
 /usr/local/.config/scbi/c-wposix
@@ -112,7 +125,9 @@
 /usr/local/.config/scbi/patches/0001-fix-mpris-support-in-gnome.patch
 /usr/local/.config/scbi/patches/gps-css-gtk3.36.patch
 /usr/local/.config/scbi/patches/libfswatch.patch
+/usr/local/.config/scbi/patches/wisi-adb.patch
 /usr/local/bin/scbi
+/usr/local/bin/scbi-format
 /usr/local/bin/scbi-lint
 /usr/local/bin/scbi-shell
 /usr/local/bin/scbi-show

--- a/manifest/x86_64/s/scbi.filelist
+++ b/manifest/x86_64/s/scbi.filelist
@@ -1,8 +1,11 @@
+# Total size: 689359
 /usr/local/.config/scbi/.core.plugins
 /usr/local/.config/scbi/.env
 /usr/local/.config/scbi/.pkgs-cos
 /usr/local/.config/scbi/.pkgs-deb
+/usr/local/.config/scbi/.pkgs-deb~12
 /usr/local/.config/scbi/.pkgs-fed
+/usr/local/.config/scbi/.pkgs-mingw
 /usr/local/.config/scbi/.pkgs-rhl
 /usr/local/.config/scbi/.pkgs-ubt
 /usr/local/.config/scbi/.plan-default
@@ -28,6 +31,8 @@
 /usr/local/.config/scbi/c-alt-ergo
 /usr/local/.config/scbi/c-aunit
 /usr/local/.config/scbi/c-aws
+/usr/local/.config/scbi/c-aws-lib
+/usr/local/.config/scbi/c-aws-tools
 /usr/local/.config/scbi/c-ayacc
 /usr/local/.config/scbi/c-binutils
 /usr/local/.config/scbi/c-blaslapack
@@ -40,10 +45,12 @@
 /usr/local/.config/scbi/c-e3-core
 /usr/local/.config/scbi/c-e3-testsuite
 /usr/local/.config/scbi/c-exiv2
+/usr/local/.config/scbi/c-garlic
 /usr/local/.config/scbi/c-gcc
 /usr/local/.config/scbi/c-gdb
 /usr/local/.config/scbi/c-gimp
 /usr/local/.config/scbi/c-git
+/usr/local/.config/scbi/c-glade
 /usr/local/.config/scbi/c-gmp
 /usr/local/.config/scbi/c-gnadelite
 /usr/local/.config/scbi/c-gnatcoll
@@ -58,6 +65,7 @@
 /usr/local/.config/scbi/c-gnatcoll-db-libs-sql
 /usr/local/.config/scbi/c-gnatcoll-db-libs-sqlite
 /usr/local/.config/scbi/c-gnatcoll-db-tools
+/usr/local/.config/scbi/c-gnatdist
 /usr/local/.config/scbi/c-gnatdoc4
 /usr/local/.config/scbi/c-gpmdp
 /usr/local/.config/scbi/c-gpr2
@@ -73,6 +81,7 @@
 /usr/local/.config/scbi/c-hubicfuse
 /usr/local/.config/scbi/c-imagemagick
 /usr/local/.config/scbi/c-langkit
+/usr/local/.config/scbi/c-langkit-support
 /usr/local/.config/scbi/c-lcms2
 /usr/local/.config/scbi/c-lensfun
 /usr/local/.config/scbi/c-libadalang
@@ -83,7 +92,9 @@
 /usr/local/.config/scbi/c-libgegl
 /usr/local/.config/scbi/c-libgpr
 /usr/local/.config/scbi/c-libiconv
+/usr/local/.config/scbi/c-liblktlang
 /usr/local/.config/scbi/c-libmypaint
+/usr/local/.config/scbi/c-libopenjpeg
 /usr/local/.config/scbi/c-librest
 /usr/local/.config/scbi/c-llvm
 /usr/local/.config/scbi/c-markdown
@@ -97,6 +108,7 @@
 /usr/local/.config/scbi/c-pixelsaver
 /usr/local/.config/scbi/c-polyorb
 /usr/local/.config/scbi/c-prettier-ada
+/usr/local/.config/scbi/c-python-post-install-dist-packages
 /usr/local/.config/scbi/c-python3-modules
 /usr/local/.config/scbi/c-readline
 /usr/local/.config/scbi/c-sandbox
@@ -105,6 +117,7 @@
 /usr/local/.config/scbi/c-templates-parser
 /usr/local/.config/scbi/c-v2p
 /usr/local/.config/scbi/c-vss
+/usr/local/.config/scbi/c-vss-text
 /usr/local/.config/scbi/c-win32ada
 /usr/local/.config/scbi/c-wisi-token
 /usr/local/.config/scbi/c-wposix
@@ -112,7 +125,9 @@
 /usr/local/.config/scbi/patches/0001-fix-mpris-support-in-gnome.patch
 /usr/local/.config/scbi/patches/gps-css-gtk3.36.patch
 /usr/local/.config/scbi/patches/libfswatch.patch
+/usr/local/.config/scbi/patches/wisi-adb.patch
 /usr/local/bin/scbi
+/usr/local/bin/scbi-format
 /usr/local/bin/scbi-lint
 /usr/local/bin/scbi-shell
 /usr/local/bin/scbi-show

--- a/packages/scbi.rb
+++ b/packages/scbi.rb
@@ -3,7 +3,7 @@ require 'package'
 class Scbi < Package
   description 'Setup Configure Build Install - Tool to build from sources with local developers checkout support'
   homepage 'https://github.com/TurboGit/scbi'
-  version '9.9'
+  version '12.1'
   license 'Copyright (C) Pascal Obry'
   compatibility 'all'
   source_url 'https://github.com/TurboGit/scbi.git'
@@ -32,7 +32,7 @@ class Scbi < Package
     system "sed -i 's,hostname --short,hostname,' #{CREW_DEST_PREFIX}/.config/scbi/6_distpkg"
     # Download and install User Guide.
     downloader "https://github.com/TurboGit/scbi/releases/download/v#{version}/scbi.pdf",
-               'e63b75682501bb04fbf16a5bcd3a23e788ddec92fadf577975ed83b72d03d7e0'
+               '9d085ede42b538a5ffc555da0d9a18619b00e094d7fdc538b1077fcac657aef5'
     FileUtils.install 'scbi.pdf', "#{CREW_DEST_PREFIX}/share/scbi/scbi.pdf", mode: 0o644
   end
 

--- a/tests/package/s/scbi
+++ b/tests/package/s/scbi
@@ -1,0 +1,2 @@
+#!/bin/bash
+scbi -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-scbi crew update \
&& yes | crew upgrade

$ crew check scbi -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/scbi.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/scbi.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/s/scbi to /usr/local/lib/crew/tests/package/s
Checking scbi package ...
Property tests for scbi passed.
Checking scbi package ...
Buildsystem test for scbi passed.
Checking scbi package ...
Unsupported Linux distribution, external lib support disabled

SCBI : 
CORE plugins : 
Package tests for scbi passed.
```