### PR TITLE
Tauri_cli 2.9.4 => 2.9.6

### DIFF
--- a/manifest/x86_64/t/tauri_cli.filelist
+++ b/manifest/x86_64/t/tauri_cli.filelist
@@ -1,2 +1,2 @@
-# Total size: 19000992
+# Total size: 19005856
 /usr/local/bin/tauri

--- a/packages/tauri_cli.rb
+++ b/packages/tauri_cli.rb
@@ -3,12 +3,12 @@ require 'package'
 class Tauri_cli < Package
   description 'Build smaller, faster, and more secure desktop and mobile applications with a web frontend.'
   homepage 'https://tauri.app/'
-  version '2.9.4'
+  version '2.9.6'
   license 'Apache-2.0, MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v#{version}/cargo-tauri-x86_64-unknown-linux-gnu.tgz"
-  source_sha256 '7889c6722ff7caa8dac0a0acaae505561df4a93e12e8985feea7ccaf3fc2b221'
+  source_sha256 '17909a3eb6d8037c1b5d284d69ba0950cd450bae63ce94351f03a020c2f34610'
 
   no_compile_needed
 

--- a/tests/package/t/tauri_cli
+++ b/tests/package/t/tauri_cli
@@ -1,0 +1,3 @@
+#!/bin/bash
+tauri -h
+tauri -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-tauri_cli crew update \
&& yes | crew upgrade

$ crew check tauri_cli -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/tauri_cli.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/tauri_cli.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/t/tauri_cli to /usr/local/lib/crew/tests/package/t
Checking tauri_cli package ...
Property tests for tauri_cli passed.
Checking tauri_cli package ...
Buildsystem test for tauri_cli passed.
Checking tauri_cli package ...
Command line interface for building Tauri apps

Usage: tauri [OPTIONS] <COMMAND>

Commands:
  init         Initialize a Tauri project in an existing directory
  dev          Run your app in development mode
  build        Build your app in release mode and generate bundles and installers
  bundle       Generate bundles and installers for your app (already built by `tauri build`)
  android      Android commands
  migrate      Migrate from v1 to v2
  info         Show a concise list of information about the environment, Rust, Node.js and their versions as well as a few relevant project configurations
  add          Add a tauri plugin to the project
  remove       Remove a tauri plugin from the project
  plugin       Manage or create Tauri plugins
  icon         Generate various icons for all major platforms
  signer       Generate signing keys for Tauri updater or sign files
  completions  Generate Tauri CLI shell completions for Bash, Zsh, PowerShell or Fish
  permission   Manage or create permissions for your app or plugin
  capability   Manage or create capabilities for your app
  inspect      Manage or create permissions for your app or plugin
  help         Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose...  Enables verbose logging
  -h, --help        Print help
  -V, --version     Print version
tauri-cli 2.9.6
Package tests for tauri_cli passed.
```