### PR TITLE
Add penguins_eggs package

### DIFF
--- a/packages/penguins_eggs.rb
+++ b/packages/penguins_eggs.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Penguins_eggs < Package
+  description 'A professional and universal remastering tool for all major distributions'
+  homepage 'https://penguins-eggs.net/'
+  version '25.12.16'
+  license 'GPL-2, MIT'
+  compatibility 'x86_64'
+  min_glibc '2.28'
+  source_url "https://github.com/pieroproietti/penguins-eggs/releases/download/v#{version}/penguins-eggs-#{version}-5-x86_64.AppImage"
+  source_sha256 '07dadbaff5422a96f93eed2b28f1f82b296c33c92dcd80a56a9d915e4e120d24'
+
+  depends_on 'gtk3'
+
+  no_compile_needed
+  no_shrink
+
+  def self.preflight
+    # Need at least 1 gb of free disk space to install.
+    MiscFunctions.check_free_disk_space(1073741824)
+  end
+
+  def self.build
+    File.write 'eggs.sh', <<~EOF
+      #!/bin/bash
+      cd #{CREW_PREFIX}/share/eggs
+      ./AppRun "$@"
+    EOF
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/eggs"
+    FileUtils.install 'eggs.sh', "#{CREW_DEST_PREFIX}/bin/eggs", mode: 0o755
+    FileUtils.mv Dir['usr/share/*'], "#{CREW_DEST_PREFIX}/share"
+    FileUtils.mv Dir['*'], "#{CREW_DEST_PREFIX}/share/eggs"
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'eggs' to get started.\n"
+  end
+end

--- a/tests/package/p/penguins_eggs
+++ b/tests/package/p/penguins_eggs
@@ -1,0 +1,3 @@
+#!/bin/bash
+eggs help
+eggs version

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -7115,6 +7115,11 @@ url: https://www.piumarta.com/software/peg/
 activity: none
 ---
 kind: url
+name: penguins_eggs
+url: https://github.com/pieroproietti/penguins-eggs/releases
+activity: high
+---
+kind: url
 name: perf
 url: https://www.kernel.org/pub/linux/kernel/v4.x/
 activity: medium


### PR DESCRIPTION
## Description
A professional and universal remastering tool for all major distributions.  See https://penguins-eggs.net/.
##
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-penguin_eggs-package crew update \
&& yes | crew upgrade

$ crew check penguins_eggs -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/penguins_eggs.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/penguins_eggs.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/p/penguins_eggs to /usr/local/lib/crew/tests/package/p
Checking penguins_eggs package ...
Property tests for penguins_eggs passed.
Checking penguins_eggs package ...
Buildsystem test for penguins_eggs passed.
Checking penguins_eggs package ...
A remaster system tool, compatible with Almalinux, Alpine, Arch, Debian, Devuan, Fedora, Manjaro, Opensuse, Ubuntu and derivatives

VERSION
  penguins-eggs/25.12.16 linux-x64 node-v22.21.0

USAGE
  $ eggs [COMMAND]

TOPICS
  export    export penguins-eggs AppImage to the destination host
  setup     Automatically check and install system prerequisites
  tools     clean system log, apt, etc
  wardrobe  get warorobe

COMMANDS
  adapt         adapt monitor resolution for VM only
  autocomplete  Display autocomplete installation instructions.
  calamares     a GUI system installer - install and configure calamares
  config        Configure eggs to run it
  cuckoo        PXE start with proxy-dhcp
  dad           ask help from daddy - TUI configuration helper
  help          Display help for eggs.
  kill          kill the eggs/free the nest
  krill         a TUI system installer - install the system
  love          the simplest way to get an egg!
  mom           ask help from mommy - TUI helper
  produce       produce a live image from your system
  status        informations about eggs status
  update        update the Penguins' eggs tool
  version

penguins-eggs/25.12.16 linux-x64 node-v22.21.0
Package tests for penguins_eggs passed.
```