### PR TITLE
Antigravity 1.12.4 => 1.13.3

### DIFF
--- a/manifest/x86_64/a/antigravity.filelist
+++ b/manifest/x86_64/a/antigravity.filelist
@@ -1,4 +1,4 @@
-# Total size: 731993805
+# Total size: 733706599
 /usr/local/bin/antigravity
 /usr/local/share/antigravity/LICENSES.chromium.html
 /usr/local/share/antigravity/antigravity

--- a/packages/antigravity.rb
+++ b/packages/antigravity.rb
@@ -3,13 +3,13 @@ require 'package'
 class Antigravity < Package
   description 'Next-generation IDE from Google'
   homepage 'https://antigravity.google/'
-  version '1.12.4'
+  version '1.13.3'
   license 'Google Terms of Service'
   compatibility 'x86_64'
   min_glibc '2.28'
   # To display this url, the latest Debian package must be installed and then run 'apt download --print-uris antigravity'
-  source_url 'https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_1.12.4-1765945650_amd64_2e1596b9e78009717589d375637bab9f.deb'
-  source_sha256 'b19ba8495542ae75152df7c111330a36c6f7ba8358c015734418ad2f2847ae4d'
+  source_url 'https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_1.13.3-1766182170_amd64_365061c50063f9bd47a9ff88432261b8.deb'
+  source_sha256 'd9920f9e0788245b1dab0f73a607b4eea00605bfb70e16795da1c1ac89eabd4b'
 
   no_compile_needed
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-antigravity crew update \
&& yes | crew upgrade

$ crew check antigravity -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/antigravity.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/antigravity.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/a/antigravity to /usr/local/lib/crew/tests/package/a
Checking antigravity package ...
Property tests for antigravity passed.
Checking antigravity package ...
Buildsystem test for antigravity passed.
Checking antigravity package ...
1.104.0
94f91bc110994badc7c086033db813077a5226af
x64
Package tests for antigravity passed.
```