### PR TITLE
Hugo 0.132.1 => 0.153.1

### DIFF
--- a/manifest/armv7l/h/hugo.filelist
+++ b/manifest/armv7l/h/hugo.filelist
@@ -1,0 +1,2 @@
+# Total size: 50023508
+/usr/local/bin/hugo

--- a/manifest/i686/h/hugo.filelist
+++ b/manifest/i686/h/hugo.filelist
@@ -1,0 +1,2 @@
+# Total size: 47227696
+/usr/local/bin/hugo

--- a/manifest/x86_64/h/hugo.filelist
+++ b/manifest/x86_64/h/hugo.filelist
@@ -1,1 +1,2 @@
+# Total size: 56703208
 /usr/local/bin/hugo

--- a/packages/hugo.rb
+++ b/packages/hugo.rb
@@ -3,24 +3,26 @@ require 'package'
 class Hugo < Package
   description 'Hugo is one of the most popular open-source static site generators.'
   homepage 'https://gohugo.io'
-  version ARCH.eql?('i686') ? '0.101.0' : '0.132.1'
+  version ARCH.eql?('i686') ? '0.101.0' : '0.153.1'
   license 'Apache-2.0, Unlicense, BSD, BSD-2 and MPL-2.0'
   compatibility 'all'
+  min_glibc '2.29' if ARCH.eql?('x86_64')
   source_url({
-    aarch64: 'https://github.com/gohugoio/hugo/releases/download/v0.132.1/hugo_0.132.1_linux-arm.tar.gz',
-     armv7l: 'https://github.com/gohugoio/hugo/releases/download/v0.132.1/hugo_0.132.1_linux-arm.tar.gz',
-       i686: 'https://github.com/gohugoio/hugo/releases/download/v0.101.0/hugo_0.101.0_Linux-32bit.tar.gz', # 0.101.0 is the latest version available
-     x86_64: 'https://github.com/gohugoio/hugo/releases/download/v0.132.1/hugo_extended_0.132.1_linux-amd64.tar.gz'
+    aarch64: "https://github.com/gohugoio/hugo/releases/download/v#{version}/hugo_#{version}_linux-arm.tar.gz",
+     armv7l: "https://github.com/gohugoio/hugo/releases/download/v#{version}/hugo_#{version}_linux-arm.tar.gz",
+       i686: "https://github.com/gohugoio/hugo/releases/download/v#{version}/hugo_#{version}_Linux-32bit.tar.gz", # 0.101.0 is the latest version available
+     x86_64: "https://github.com/gohugoio/hugo/releases/download/v#{version}/hugo_extended_#{version}_linux-amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'b96d769b94477b75d50cab0e6b548c3b896a991692d000d9481b636e6fe6fdba',
-     armv7l: 'b96d769b94477b75d50cab0e6b548c3b896a991692d000d9481b636e6fe6fdba',
+    aarch64: 'a26f56c368dd7077560d7e9ba57e6d95e5f143e1d0347a3a346c2715920fb658',
+     armv7l: 'a26f56c368dd7077560d7e9ba57e6d95e5f143e1d0347a3a346c2715920fb658',
        i686: '9ae794edd86415a611cae15fc72382ee6f2b729754e15319c144057a5457eaed',
-     x86_64: '4280ee4823e8035ef83d1e1948184b3e1fa44f2280ea7bb64be60818e2b6ff14'
+     x86_64: 'e5806957b8696d10a713199503b21b577abf92e1bcb85730124269479e7f5fc6'
   })
 
+  no_compile_needed
+
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.install 'hugo', "#{CREW_DEST_PREFIX}/bin/hugo", mode: 0o755
   end
 end

--- a/tests/package/h/hugo
+++ b/tests/package/h/hugo
@@ -1,0 +1,3 @@
+#!/bin/bash
+hugo -h | head
+hugo version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-hugo crew update \
&& yes | crew upgrade

$ crew check hugo -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/hugo.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/hugo.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/h/hugo to /usr/local/lib/crew/tests/package/h
Checking hugo package ...
Property tests for hugo passed.
Checking hugo package ...
Buildsystem test for hugo passed.
Checking hugo package ...
hugo is the main command, used to build your Hugo site.

Hugo is a Fast and Flexible Static Site Generator
built with love by spf13 and friends in Go.

Complete documentation is available at https://gohugo.io/.

Usage:
  hugo [flags]
  hugo [command]
hugo v0.153.1-8e6cac8462d210f611154068eaa24c4461357653+extended linux/amd64 BuildDate=2025-12-20T15:15:53Z VendorInfo=gohugoio
Package tests for hugo passed.
```