### PR TITLE
Termius 9.34.7 => 9.34.8

### DIFF
--- a/manifest/x86_64/t/termius.filelist
+++ b/manifest/x86_64/t/termius.filelist
@@ -1,4 +1,4 @@
-# Total size: 382233723
+# Total size: 408527020
 /usr/local/bin/termius
 /usr/local/share/Termius/LICENSE.electron.txt
 /usr/local/share/Termius/LICENSES.chromium.html

--- a/packages/termius.rb
+++ b/packages/termius.rb
@@ -3,12 +3,12 @@ require 'package'
 class Termius < Package
   description 'Modern SSH Client'
   homepage 'https://termius.com/'
-  version '9.34.7'
+  version '9.34.8'
   license 'Apache-2.0, LGPL-2.1, MIT'
   compatibility 'x86_64'
   min_glibc '2.33'
   source_url 'https://www.termius.com/download/linux/Termius.deb'
-  source_sha256 'e04a338aa08086a95ecf3051c158e01d6253e00bf4e56d7d7f9828352604ee18'
+  source_sha256 '5f383906fd20a910e73148a98f6c71e12fe58f921994c8ddda5842d182c01f24'
 
   depends_on 'sommelier'
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m142 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-termius crew update \
&& yes | crew upgrade

$ crew check termius -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/termius.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/termius.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/t/termius to /usr/local/lib/crew/tests/package/t
Checking termius package ...
Property tests for termius passed.
Checking termius package ...
Buildsystem test for termius passed.
Checking termius package ...
[13992:1223/004734.841790:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /usr/local/share/Termius/chrome-sandbox is owned by root and has mode 4755.
/usr/local/lib/crew/tests/package/t/termius: line 2: 13992 Trace/breakpoint trap      termius --version
[13994:0100/000000.859735:ERROR:zygote_linux.cc(649)] write: Broken pipe (32)
Package tests for termius failed.
```