### PR TITLE
B2 5.3.3 => 5.4.2

### DIFF
--- a/manifest/armv7l/b/b2.filelist
+++ b/manifest/armv7l/b/b2.filelist
@@ -1,4 +1,4 @@
-# Total size: 2411899
+# Total size: 2438724
 /usr/local/bin/b2
 /usr/local/share/b2/src/build-system.jam
 /usr/local/share/b2/src/build/ac.jam
@@ -66,6 +66,7 @@
 /usr/local/share/b2/src/tools/features/cflags-feature.jam
 /usr/local/share/b2/src/tools/features/compileflags-feature.jam
 /usr/local/share/b2/src/tools/features/conditional-feature.jam
+/usr/local/share/b2/src/tools/features/contracts-feature.jam
 /usr/local/share/b2/src/tools/features/coverage-feature.jam
 /usr/local/share/b2/src/tools/features/cxx-template-depth-feature.jam
 /usr/local/share/b2/src/tools/features/cxxabi-feature.jam
@@ -198,6 +199,7 @@
 /usr/local/share/b2/src/tools/types/sass-type.jam
 /usr/local/share/b2/src/tools/types/xml.jam
 /usr/local/share/b2/src/tools/unix.jam
+/usr/local/share/b2/src/tools/vcpkg.jam
 /usr/local/share/b2/src/tools/vmsdecc.jam
 /usr/local/share/b2/src/tools/whale.jam
 /usr/local/share/b2/src/tools/xlf.jam

--- a/manifest/i686/b/b2.filelist
+++ b/manifest/i686/b/b2.filelist
@@ -1,4 +1,4 @@
-# Total size: 2555907
+# Total size: 2582316
 /usr/local/bin/b2
 /usr/local/share/b2/src/build-system.jam
 /usr/local/share/b2/src/build/ac.jam
@@ -66,6 +66,7 @@
 /usr/local/share/b2/src/tools/features/cflags-feature.jam
 /usr/local/share/b2/src/tools/features/compileflags-feature.jam
 /usr/local/share/b2/src/tools/features/conditional-feature.jam
+/usr/local/share/b2/src/tools/features/contracts-feature.jam
 /usr/local/share/b2/src/tools/features/coverage-feature.jam
 /usr/local/share/b2/src/tools/features/cxx-template-depth-feature.jam
 /usr/local/share/b2/src/tools/features/cxxabi-feature.jam
@@ -198,6 +199,7 @@
 /usr/local/share/b2/src/tools/types/sass-type.jam
 /usr/local/share/b2/src/tools/types/xml.jam
 /usr/local/share/b2/src/tools/unix.jam
+/usr/local/share/b2/src/tools/vcpkg.jam
 /usr/local/share/b2/src/tools/vmsdecc.jam
 /usr/local/share/b2/src/tools/whale.jam
 /usr/local/share/b2/src/tools/xlf.jam

--- a/manifest/x86_64/b/b2.filelist
+++ b/manifest/x86_64/b/b2.filelist
@@ -1,4 +1,4 @@
-# Total size: 2498783
+# Total size: 2525512
 /usr/local/bin/b2
 /usr/local/share/b2/src/build-system.jam
 /usr/local/share/b2/src/build/ac.jam
@@ -66,6 +66,7 @@
 /usr/local/share/b2/src/tools/features/cflags-feature.jam
 /usr/local/share/b2/src/tools/features/compileflags-feature.jam
 /usr/local/share/b2/src/tools/features/conditional-feature.jam
+/usr/local/share/b2/src/tools/features/contracts-feature.jam
 /usr/local/share/b2/src/tools/features/coverage-feature.jam
 /usr/local/share/b2/src/tools/features/cxx-template-depth-feature.jam
 /usr/local/share/b2/src/tools/features/cxxabi-feature.jam
@@ -198,6 +199,7 @@
 /usr/local/share/b2/src/tools/types/sass-type.jam
 /usr/local/share/b2/src/tools/types/xml.jam
 /usr/local/share/b2/src/tools/unix.jam
+/usr/local/share/b2/src/tools/vcpkg.jam
 /usr/local/share/b2/src/tools/vmsdecc.jam
 /usr/local/share/b2/src/tools/whale.jam
 /usr/local/share/b2/src/tools/xlf.jam

--- a/packages/b2.rb
+++ b/packages/b2.rb
@@ -3,7 +3,7 @@ require 'package'
 class B2 < Package
   description 'B2 makes it easy to build C++ projects, everywhere.'
   homepage 'https://www.bfgroup.xyz/b2/'
-  version '5.3.3'
+  version '5.4.2'
   license 'BSL 1.0'
   compatibility 'all'
   source_url 'https://github.com/bfgroup/b2.git'
@@ -11,10 +11,10 @@ class B2 < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b943e619859f8b7208f62237f540fd722198c538241e7e515333f5149ad0316d',
-     armv7l: 'b943e619859f8b7208f62237f540fd722198c538241e7e515333f5149ad0316d',
-       i686: '9c2cfa45722d75f4b1d35a0e7899ae9ffe845a33a706a0d891a6bd2d6b810edc',
-     x86_64: '0a51077f71a657c5cd9d4aa950acc26e622eec16d2fddeb98ee4a26d56ac1edf'
+    aarch64: '4fb0969ed19d32d7a5ff4aa17818a6520c8b07be012b68158996e05d77658829',
+     armv7l: '4fb0969ed19d32d7a5ff4aa17818a6520c8b07be012b68158996e05d77658829',
+       i686: 'b64616fd92e5930cec29d16a045618ad81a768b47d398c3501b176590783023c',
+     x86_64: 'e25331d87cd4b8c738c372b8cd8bd1750885fc33208bf2d87416a595ae56e51f'
   })
 
   depends_on 'gcc_lib' # R

--- a/tests/package/b/b2
+++ b/tests/package/b/b2
@@ -1,0 +1,3 @@
+#!/bin/bash
+b2 --help
+b2 --version

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -12,6 +12,7 @@ asunder
 augeas
 autoconf_archive
 axel
+b2
 bc
 bdftopcf
 bind


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-b2 crew update \
&& yes | crew upgrade

$ crew check b2 -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/b2.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/b2.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/b/b2 to /usr/local/lib/crew/tests/package/b
Checking b2 package ...
Property tests for b2 passed.
Checking b2 package ...
Buildsystem test for b2 passed.
Checking b2 package ...
B2 5.4.2 (OS=LINUX, jobs=12)

General command line usage:

    b2 [options] [properties] [targets]

  Options, properties and targets can be specified in any order.
      
Important Options:

  * --clean Remove targets instead of building
  * -a Rebuild everything
  * -n Don't execute the commands, only print them
  * -d+2 Show commands as they are executed
  * -d0 Suppress all informational messages
  * -q Stop at first error
  * --reconfigure Rerun all configuration checks
  * --durations[=N] Report top N targets by execution time
  * --debug-configuration Diagnose configuration
  * --debug-building Report which targets are built with what properties
  * --debug-generator Diagnose generator search/execution

Further Help:

   The following options can be used to obtain additional documentation.

  * --help-options Print more obscure command line options.
  * --help-internal B2 implementation details.
  * --help-doc-options Implementation details doc formatting.

...found 1 target...
B2 5.4.2 (OS=LINUX, jobs=12)

Package tests for b2 passed.
```