### PR TITLE
Add hyperfine package

### DIFF
--- a/manifest/armv7l/h/hyperfine.filelist
+++ b/manifest/armv7l/h/hyperfine.filelist
@@ -1,0 +1,8 @@
+# Total size: 1243026
+/usr/local/bin/hyperfine
+/usr/local/etc/bash.d/10-hyperfine
+/usr/local/share/hyperfine/CHANGELOG.md
+/usr/local/share/hyperfine/LICENSE-APACHE
+/usr/local/share/hyperfine/LICENSE-MIT
+/usr/local/share/hyperfine/README.md
+/usr/local/share/man/man1/hyperfine.1.zst

--- a/manifest/i686/h/hyperfine.filelist
+++ b/manifest/i686/h/hyperfine.filelist
@@ -1,0 +1,8 @@
+# Total size: 1402674
+/usr/local/bin/hyperfine
+/usr/local/etc/bash.d/10-hyperfine
+/usr/local/share/hyperfine/CHANGELOG.md
+/usr/local/share/hyperfine/LICENSE-APACHE
+/usr/local/share/hyperfine/LICENSE-MIT
+/usr/local/share/hyperfine/README.md
+/usr/local/share/man/man1/hyperfine.1.zst

--- a/manifest/x86_64/h/hyperfine.filelist
+++ b/manifest/x86_64/h/hyperfine.filelist
@@ -1,0 +1,8 @@
+# Total size: 1425054
+/usr/local/bin/hyperfine
+/usr/local/etc/bash.d/10-hyperfine
+/usr/local/share/hyperfine/CHANGELOG.md
+/usr/local/share/hyperfine/LICENSE-APACHE
+/usr/local/share/hyperfine/LICENSE-MIT
+/usr/local/share/hyperfine/README.md
+/usr/local/share/man/man1/hyperfine.1.zst

--- a/packages/hyperfine.rb
+++ b/packages/hyperfine.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Hyperfine < Package
+  description 'A command-line benchmarking tool'
+  homepage 'https://github.com/sharkdp/hyperfine'
+  version '1.20.0'
+  license 'Apache-2.0, MIT'
+  compatibility 'all'
+  source_url({
+    aarch64: "https://github.com/sharkdp/hyperfine/releases/download/v#{version}/hyperfine-v#{version}-arm-unknown-linux-gnueabihf.tar.gz",
+     armv7l: "https://github.com/sharkdp/hyperfine/releases/download/v#{version}/hyperfine-v#{version}-arm-unknown-linux-gnueabihf.tar.gz",
+       i686: "https://github.com/sharkdp/hyperfine/releases/download/v#{version}/hyperfine-v#{version}-i686-unknown-linux-gnu.tar.gz",
+     x86_64: "https://github.com/sharkdp/hyperfine/releases/download/v#{version}/hyperfine-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+  })
+  source_sha256({
+    aarch64: 'f13c6ae21380d90b03310bd74a672db579a6a45d1b5df91bf2e06baf8f1cf4fd',
+     armv7l: 'f13c6ae21380d90b03310bd74a672db579a6a45d1b5df91bf2e06baf8f1cf4fd',
+       i686: 'a5209e023c9396a94251614218ece32c0c0ae219fb159245d53c8cee5f9d9eeb',
+     x86_64: '63ad53934062118f5b0be11785e0bb1603d4b91667d1921f2fd8df9a8712040a'
+  })
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man1"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/hyperfine"
+    FileUtils.mv 'hyperfine', "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mv 'hyperfine.1', "#{CREW_DEST_MAN_PREFIX}/man1"
+    FileUtils.mv 'autocomplete/hyperfine.bash', "#{CREW_DEST_PREFIX}/etc/bash.d/10-hyperfine"
+    FileUtils.rm_rf 'autocomplete'
+    FileUtils.mv Dir['*'], "#{CREW_DEST_PREFIX}/share/hyperfine"
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'hyperfine -h' to get started.\n"
+  end
+end

--- a/tests/package/h/hyperfine
+++ b/tests/package/h/hyperfine
@@ -1,0 +1,3 @@
+#!/bin/bash
+hyperfine -h | head
+hyperfine -V

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -3380,6 +3380,11 @@ url: https://github.com/open-mpi/hwloc/tags
 activity: medium
 ---
 kind: url
+name: hyperfine
+url: https://github.com/sharkdp/hyperfine/releases
+activity: medium
+---
+kind: url
 name: hyphen
 url: https://github.com/hunspell/hyphen/
 activity: none


### PR DESCRIPTION
## Description
A command-line benchmarking tool.  See https://github.com/sharkdp/hyperfine.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-hyperfine-package crew update \
&& yes | crew upgrade

$ crew check hyperfine -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/hyperfine.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/hyperfine.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/h/hyperfine to /usr/local/lib/crew/tests/package/h
Checking hyperfine package ...
Property tests for hyperfine passed.
Checking hyperfine package ...
Buildsystem test for hyperfine passed.
Checking hyperfine package ...
A command-line benchmarking tool.

Usage: hyperfine [OPTIONS] <command>...

Arguments:
  <command>...
          The command to benchmark. This can be the name of an executable, a
          command line like "grep -i todo" or a shell command like "sleep 0.5 &&
          echo test". The latter is only available if the shell is not
          explicitly disabled via '--shell=none'. If multiple commands are
hyperfine 1.20.0
Package tests for hyperfine passed.
```