### PR TITLE
Cargo_c 0.10.18 => 0.10.19

### DIFF
--- a/manifest/armv7l/c/cargo_c.filelist
+++ b/manifest/armv7l/c/cargo_c.filelist
@@ -1,4 +1,4 @@
-# Total size: 91774656
+# Total size: 92801792
 /usr/local/bin/cargo-capi
 /usr/local/bin/cargo-cbuild
 /usr/local/bin/cargo-cinstall

--- a/manifest/i686/c/cargo_c.filelist
+++ b/manifest/i686/c/cargo_c.filelist
@@ -1,4 +1,4 @@
-# Total size: 125352960
+# Total size: 126214144
 /usr/local/bin/cargo-capi
 /usr/local/bin/cargo-cbuild
 /usr/local/bin/cargo-cinstall

--- a/manifest/x86_64/c/cargo_c.filelist
+++ b/manifest/x86_64/c/cargo_c.filelist
@@ -1,4 +1,4 @@
-# Total size: 111980496
+# Total size: 113179856
 /usr/local/bin/cargo-capi
 /usr/local/bin/cargo-cbuild
 /usr/local/bin/cargo-cinstall

--- a/packages/cargo_c.rb
+++ b/packages/cargo_c.rb
@@ -7,7 +7,7 @@ require 'buildsystems/rust'
 class Cargo_c < RUST
   description 'A cargo subcommand to build and install C-ABI compatible dynamic and static libraries'
   homepage 'https://github.com/lu-zero/cargo-c/'
-  version '0.10.18'
+  version '0.10.19'
   license 'LGPL-2.1 and MPL-1.1'
   compatibility 'all'
   source_url 'https://github.com/lu-zero/cargo-c.git'
@@ -15,10 +15,10 @@ class Cargo_c < RUST
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '3d72a64b0bb32cefe89565acffb4f87b95b6685ba8e7df1e8d6e496785a45c80',
-     armv7l: '3d72a64b0bb32cefe89565acffb4f87b95b6685ba8e7df1e8d6e496785a45c80',
-       i686: '066c9375c62f0c7a55dec648e1299b5a6b180ac6faa5ac59972f34c0766ed8ba',
-     x86_64: 'fa3dfadca2c4465983550b3f52cc36018eb68b9125f1870cc9e3ed68ffd81d1f'
+    aarch64: '508bd6cd29beb51a6031077fc797ceb14de2b54aaaef3aabcd2009467ef51c14',
+     armv7l: '508bd6cd29beb51a6031077fc797ceb14de2b54aaaef3aabcd2009467ef51c14',
+       i686: '79a4f693895c39f8beffbf6425aa6467a59aaedcab04163793d48d5d937d1c43',
+     x86_64: '1f193eca5b477ebd37e6250a623560b9b232e9f5832659df13dd8a3cf5bc72fc'
   })
 
   depends_on 'curl' # R

--- a/tests/package/c/cargo_c
+++ b/tests/package/c/cargo_c
@@ -1,0 +1,2 @@
+#!/bin/bash
+for b in $(crew files cargo_c | grep /usr/local/bin); do $b --version; done

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -19,6 +19,7 @@ bind
 bison
 bitmap
 bmon
+cargo_c
 codex
 dbeaver
 f2fs_tools


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-cargo_c crew update \
&& yes | crew upgrade

$ crew check cargo_c -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/cargo_c.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/cargo_c.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/c/cargo_c to /usr/local/lib/crew/tests/package/c
Checking cargo_c package ...
Property tests for cargo_c passed.
Checking cargo_c package ...
Buildsystem test for cargo_c passed.
Checking cargo_c package ...
cargo-c 0.10.19+cargo-0.93.0
cargo-c 0.10.19+cargo-0.93.0
cargo-c 0.10.19+cargo-0.93.0
cargo-c 0.10.19+cargo-0.93.0
Package tests for cargo_c passed.
```