### PR TITLE
Add opencode package

### DIFF
--- a/manifest/x86_64/o/opencode.filelist
+++ b/manifest/x86_64/o/opencode.filelist
@@ -1,0 +1,2 @@
+# Total size: 142858528
+/usr/local/bin/opencode

--- a/packages/opencode.rb
+++ b/packages/opencode.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Opencode < Package
+  description 'The open source coding agent.'
+  homepage 'https://opencode.ai/'
+  version '1.0.193'
+  license 'MIT'
+  compatibility 'x86_64'
+  source_url "https://github.com/sst/opencode/releases/download/v#{version}/opencode-linux-x64.tar.gz"
+  source_sha256 'aa2dc94fbecdabbe20846a6d2fe8348d7a3f0c134508ff8a6aaed0be0615233c'
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.install 'opencode', "#{CREW_DEST_PREFIX}/bin/opencode", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'opencode' to get started.\n"
+  end
+end

--- a/tests/package/o/opencode
+++ b/tests/package/o/opencode
@@ -1,0 +1,3 @@
+#!/bin/bash
+opencode -h | head
+opencode -v

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -67,3 +67,4 @@ libvisio
 libxfce4ui
 nano
 ocaml
+opencode

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6790,6 +6790,11 @@ url: https://github.com/KhronosGroup/OpenCL-ICD-Loader/releases
 activity: medium
 ---
 kind: url
+name: opencode
+url: https://github.com/sst/opencode/releases
+activity: high
+---
+kind: url
 name: openconnect
 url: ftp://ftp.infradead.org/pub/openconnect/
 activity: none


### PR DESCRIPTION
## Description
The open source coding agent.  See https://opencode.ai/.
##
Tested & Working properly:
- [x] `x86_64`  Works in both nocturne m90 and hatch m142 containers.
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-opencode-package crew update \
&& yes | crew upgrade

$ crew check opencode -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/opencode.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/opencode.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/o/opencode to /usr/local/lib/crew/tests/package/o
Checking opencode package ...
Property tests for opencode passed.
Checking opencode package ...
Buildsystem test for opencode passed.
Checking opencode package ...

                                 ▄
█▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
█░░█ █░░█ █▀▀▀ █░░█ █░░░ █░░█ █░░█ █▀▀▀
▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀

Commands:
  opencode acp                 start ACP (Agent Client Protocol) server
  opencode [project]           start opencode tui                                          [default]
  opencode attach <url>        attach to a running opencode server
1.0.193
Package tests for opencode passed.
```