### PR TITLE
Vscodium 1.106.37943 => 1.107.18605

### DIFF
--- a/manifest/armv7l/v/vscodium.filelist
+++ b/manifest/armv7l/v/vscodium.filelist
@@ -1,4 +1,4 @@
-# Total size: 358354510
+# Total size: 365032153
 /usr/local/VSCodium-linux-arm/LICENSES.chromium.html
 /usr/local/VSCodium-linux-arm/bin/codium
 /usr/local/VSCodium-linux-arm/bin/codium-tunnel
@@ -112,7 +112,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/schemas/package.schema.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/.npmrc
-/usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/dist/node/85.cssServerMain.js
+/usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/dist/node/533.cssServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/dist/node/920.cssServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/dist/node/cssServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/css-language-features/server/package.json
@@ -259,8 +259,8 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/schemas/package.schema.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/.npmrc
-/usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/dist/node/421.htmlServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/dist/node/490.htmlServerMain.js
+/usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/dist/node/573.htmlServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/dist/node/769.htmlServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/dist/node/htmlServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/html-language-features/server/lib/jquery.d.ts
@@ -308,8 +308,8 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/.npmrc
-/usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/774.jsonServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/962.jsonServerMain.js
+/usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/990.jsonServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/dist/node/jsonServerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json-language-features/server/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/json/language-configuration.json
@@ -435,6 +435,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/README.md
 /usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/dist/extension.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/dist/extension.js.LICENSE.txt
+/usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/dist/libmsalruntime.so
 /usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/media/auth.css
 /usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/media/favicon.ico
 /usr/local/VSCodium-linux-arm/resources/app/extensions/microsoft-authentication/media/icon.png
@@ -1118,6 +1119,13 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/vscode-languagedetection/model/model.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/vscode-languagedetection/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscode/windows-mutex/LICENSE
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/native-keymap/LICENSE
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/native-keymap/ThirdPartyNotices.txt
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/native-keymap/build/Release/keymapping.node
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/native-keymap/checksum.txt
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/native-keymap/index.js
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/native-keymap/install.js
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/native-keymap/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/policy-watcher/LICENSE
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/policy-watcher/build/Release/vscodium-policy-watcher.node
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/@vscodium/policy-watcher/index.js
@@ -1744,13 +1752,6 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/native-is-elevated/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/native-is-elevated/tst/elevated.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/native-is-elevated/tst/normal.js
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/native-keymap/License.txt
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/native-keymap/PoliCheckExclusions.xml
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/native-keymap/SECURITY.md
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/native-keymap/ThirdPartyNotices.txt
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/native-keymap/build/Release/keymapping.node
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/native-keymap/index.js
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/native-keymap/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/native-watchdog/LICENSE
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/native-watchdog/SECURITY.md
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/native-watchdog/build/Release/watchdog.node
@@ -2012,9 +2013,9 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/tar/node_modules/yallist/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/tar/node_modules/yallist/yallist.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/tar/package.json
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/tas-client-umd/LICENSE
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/tas-client-umd/lib/tas-client-umd.js
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/tas-client-umd/package.json
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/tas-client/LICENSE.txt
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/tas-client/dist/tas-client.min.js
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/tas-client/package.json
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/tiny-inflate/LICENSE
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/tiny-inflate/index.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/tiny-inflate/package.json
@@ -2384,6 +2385,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/workbench.desktop.main.js
 /usr/local/VSCodium-linux-arm/resources/app/out/vscode-dts/vscode.d.ts
 /usr/local/VSCodium-linux-arm/resources/app/package.json
+/usr/local/VSCodium-linux-arm/resources/app/policies/policy.json
 /usr/local/VSCodium-linux-arm/resources/app/product.json
 /usr/local/VSCodium-linux-arm/resources/app/resources/linux/code.png
 /usr/local/VSCodium-linux-arm/resources/completions/bash/codium

--- a/manifest/x86_64/v/vscodium.filelist
+++ b/manifest/x86_64/v/vscodium.filelist
@@ -1,4 +1,4 @@
-# Total size: 440466715
+# Total size: 447188259
 /usr/local/VSCodium-linux-x64/LICENSES.chromium.html
 /usr/local/VSCodium-linux-x64/bin/codium
 /usr/local/VSCodium-linux-x64/bin/codium-tunnel
@@ -112,7 +112,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/schemas/package.schema.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/.npmrc
-/usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/dist/node/85.cssServerMain.js
+/usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/dist/node/533.cssServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/dist/node/920.cssServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/dist/node/cssServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/css-language-features/server/package.json
@@ -259,8 +259,8 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/schemas/package.schema.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/.npmrc
-/usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/dist/node/421.htmlServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/dist/node/490.htmlServerMain.js
+/usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/dist/node/573.htmlServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/dist/node/769.htmlServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/dist/node/htmlServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/html-language-features/server/lib/jquery.d.ts
@@ -308,8 +308,8 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/.npmrc
-/usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/774.jsonServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/962.jsonServerMain.js
+/usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/990.jsonServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/dist/node/jsonServerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json-language-features/server/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/json/language-configuration.json
@@ -435,6 +435,8 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/README.md
 /usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/dist/extension.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/dist/extension.js.LICENSE.txt
+/usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/dist/libmsalruntime.so
+/usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/dist/msal-node-runtime.node
 /usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/media/auth.css
 /usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/media/favicon.ico
 /usr/local/VSCodium-linux-x64/resources/app/extensions/microsoft-authentication/media/icon.png
@@ -1118,6 +1120,13 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/vscode-languagedetection/model/model.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/vscode-languagedetection/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscode/windows-mutex/LICENSE
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/native-keymap/LICENSE
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/native-keymap/ThirdPartyNotices.txt
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/native-keymap/build/Release/keymapping.node
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/native-keymap/checksum.txt
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/native-keymap/index.js
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/native-keymap/install.js
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/native-keymap/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/policy-watcher/LICENSE
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/policy-watcher/build/Release/vscodium-policy-watcher.node
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/@vscodium/policy-watcher/index.js
@@ -1744,13 +1753,6 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/native-is-elevated/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/native-is-elevated/tst/elevated.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/native-is-elevated/tst/normal.js
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/native-keymap/License.txt
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/native-keymap/PoliCheckExclusions.xml
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/native-keymap/SECURITY.md
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/native-keymap/ThirdPartyNotices.txt
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/native-keymap/build/Release/keymapping.node
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/native-keymap/index.js
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/native-keymap/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/native-watchdog/LICENSE
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/native-watchdog/SECURITY.md
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/native-watchdog/build/Release/watchdog.node
@@ -2012,9 +2014,9 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/tar/node_modules/yallist/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/tar/node_modules/yallist/yallist.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/tar/package.json
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/tas-client-umd/LICENSE
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/tas-client-umd/lib/tas-client-umd.js
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/tas-client-umd/package.json
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/tas-client/LICENSE.txt
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/tas-client/dist/tas-client.min.js
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/tas-client/package.json
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/tiny-inflate/LICENSE
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/tiny-inflate/index.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/tiny-inflate/package.json
@@ -2384,6 +2386,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/workbench.desktop.main.js
 /usr/local/VSCodium-linux-x64/resources/app/out/vscode-dts/vscode.d.ts
 /usr/local/VSCodium-linux-x64/resources/app/package.json
+/usr/local/VSCodium-linux-x64/resources/app/policies/policy.json
 /usr/local/VSCodium-linux-x64/resources/app/product.json
 /usr/local/VSCodium-linux-x64/resources/app/resources/linux/code.png
 /usr/local/VSCodium-linux-x64/resources/completions/bash/codium

--- a/packages/vscodium.rb
+++ b/packages/vscodium.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vscodium < Package
   description 'VSCodium is Open Source Software Binaries of VSCode with a community-driven default configuration.'
   homepage 'https://vscodium.com/'
-  version '1.106.37943'
+  version '1.107.18605'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.28'
@@ -13,9 +13,9 @@ class Vscodium < Package
      x86_64: "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-x64-#{version}.tar.gz"
   })
   source_sha256({
-    aarch64: '09dfd3e98a3a8cba9058d42655670d53c799840cba2745721181539e514e8f72',
-     armv7l: '09dfd3e98a3a8cba9058d42655670d53c799840cba2745721181539e514e8f72',
-     x86_64: '3fbd5a7885626aa4a83297e0b4a3d902c725b1674122f33d0ef02863c726e4ec'
+    aarch64: '1aa286260582156b3b2313fcd7d92a35041eb223d6980ecc6a3711e2c85a4163',
+     armv7l: '1aa286260582156b3b2313fcd7d92a35041eb223d6980ecc6a3711e2c85a4163',
+     x86_64: '6eb0b68cdae20aa5cca73fb4e2c0cc58459e02b484aeb57d7edfe2bc21d32abd'
   })
 
   depends_on 'alsa_lib' # R

--- a/tests/package/v/vscodium
+++ b/tests/package/v/vscodium
@@ -1,0 +1,3 @@
+#!/bin/bash
+codium -h | head
+codium -v

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -68,3 +68,4 @@ libxfce4ui
 nano
 ocaml
 opencode
+vscodium


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vscodium crew update \
&& yes | crew upgrade

$ crew check vscodium -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/vscodium.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/vscodium.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/v/vscodium to /usr/local/lib/crew/tests/package/v
Checking vscodium package ...
Property tests for vscodium passed.
Checking vscodium package ...
Buildsystem test for vscodium passed.
Checking vscodium package ...
VSCodium 1.107.18605

Usage: codium [options] [paths...]

To read from stdin, append '-' (e.g. 'ps aux | grep code | codium -')

Options
  -d --diff <file> <file>                    Compare two files with each
                                             other.
  -m --merge <path1> <path2> <base> <result> Perform a three-way merge by
1.107.18605
96f34f074874df5b33628814dc2e9ef019c4cbfa
arm
Package tests for vscodium passed.
```