### PR TITLE
Dehtml 1.8 => 2.0

### DIFF
--- a/manifest/armv7l/d/dehtml.filelist
+++ b/manifest/armv7l/d/dehtml.filelist
@@ -1,4 +1,4 @@
-# Total size: 26141
+# Total size: 26250
 /usr/local/bin/dehtml
 /usr/local/share/locale/de/LC_MESSAGES/dehtml.mo
 /usr/local/share/locale/nl/LC_MESSAGES/dehtml.mo

--- a/manifest/i686/d/dehtml.filelist
+++ b/manifest/i686/d/dehtml.filelist
@@ -1,4 +1,4 @@
-# Total size: 30233
+# Total size: 26626
 /usr/local/bin/dehtml
 /usr/local/share/locale/de/LC_MESSAGES/dehtml.mo
 /usr/local/share/locale/nl/LC_MESSAGES/dehtml.mo

--- a/manifest/x86_64/d/dehtml.filelist
+++ b/manifest/x86_64/d/dehtml.filelist
@@ -1,4 +1,4 @@
-# Total size: 35693
+# Total size: 28598
 /usr/local/bin/dehtml
 /usr/local/share/locale/de/LC_MESSAGES/dehtml.mo
 /usr/local/share/locale/nl/LC_MESSAGES/dehtml.mo

--- a/packages/dehtml.rb
+++ b/packages/dehtml.rb
@@ -3,23 +3,30 @@ require 'buildsystems/autotools'
 class Dehtml < Autotools
   description 'Dehtml removes HTML constructs from documents for indexing, spell checking and so on.'
   homepage 'http://www.moria.de/~michael/dehtml/'
-  version '1.8'
+  version '2.0'
   license 'GPL-2+'
   compatibility 'all'
   source_url "http://www.moria.de/~michael/dehtml/dehtml-#{version}.tar.gz"
-  source_sha256 'a00e86643b0aa73861e9d8d619a80370f0f99519d34ce12459fab77f5f6b5bde'
+  source_sha256 '838d2a3c892eab8f26a29c94732b8eff2ce5594014ea1da09e3a532d5149b2db'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd443a2fbbc3d16fdcefce0e8910bd20a230ecce4aeea3cf4aa6a811cd76c3ed1',
-     armv7l: 'd443a2fbbc3d16fdcefce0e8910bd20a230ecce4aeea3cf4aa6a811cd76c3ed1',
-       i686: 'ead0e0cc2d7a9486ccb8d7a0a0f4b19cdb71f3081df2e7d0d8402aa93ef539de',
-     x86_64: 'ac7002d89ff6d5537cd22b350d7b86c46424b7c8f918533b5d06239490727aae'
+    aarch64: '649cb05f43386af89a6717b45e40cca2d83bfbdd804688dd7d9ae82519de3139',
+     armv7l: '649cb05f43386af89a6717b45e40cca2d83bfbdd804688dd7d9ae82519de3139',
+       i686: '3dd3356aca416e5cbcbb4d351bc045ab3e8bf7180103aa1667f2b148a3c9c0de',
+     x86_64: '67800096fda44e8685c9a74d785c35b070be22b5ca1de16f7d1cbda33e9b8a59'
   })
 
   depends_on 'glibc' # R
 
   autotools_build_relative_dir '.'
+
+  def self.patch
+    # Fix config.status: error: cannot find input file: `test/run.in'.
+    system "sed -i 's, test/run,,' configure"
+    # Fix chmod: missing operand after '755'.
+    system "sed -i 's,chmod 755,,' configure"
+  end
 
   # The Makefile.in does not respect DESTDIR, so we override the buildsystem and append the explicit paths here.
   def self.build

--- a/tests/package/d/dehtml
+++ b/tests/package/d/dehtml
@@ -1,0 +1,3 @@
+#!/bin/bash
+dehtml --help 2>&1
+dehtml --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-dehtml crew update \
&& yes | crew upgrade

$ crew check dehtml -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/dehtml.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/dehtml.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/d/dehtml to /usr/local/lib/crew/tests/package/d
Checking dehtml package ...
Property tests for dehtml passed.
Checking dehtml package ...
Buildsystem test for dehtml passed.
Checking dehtml package ...
Usage: dehtml [-w] [-s] [-l] [-p] [-u] [file ...]

Remove HTML constructs from documents.

-w, --word-list     output a word list
-s, --skip-headers  do not output headers
-l, --skip-lists    do not output lists
-p, --pretty-print  pretty printed output
-u, --skip-urls     Do not include indexed URLs
-h, --help          display this help and exit
    --version       display version and exit

Report bugs to <michael@moria.de>.
dehtml 2.0
Package tests for dehtml passed.
```