### PR TITLE
Delve 1.24.1 => 1.26.0

### DIFF
--- a/manifest/i686/d/delve.filelist
+++ b/manifest/i686/d/delve.filelist
@@ -1,2 +1,2 @@
-# Total size: 4176072
+# Total size: 14228048
 /usr/local/bin/dlv

--- a/manifest/x86_64/d/delve.filelist
+++ b/manifest/x86_64/d/delve.filelist
@@ -1,2 +1,2 @@
-# Total size: 4734932
+# Total size: 16084104
 /usr/local/bin/dlv

--- a/packages/delve.rb
+++ b/packages/delve.rb
@@ -3,15 +3,15 @@ require 'package'
 class Delve < Package
   description 'Debugger for the Go programming language'
   homepage 'https://github.com/go-delve/delve'
-  version '1.24.1'
+  version '1.26.0'
   license 'MIT'
   compatibility 'i686 x86_64'
   source_url 'SKIP'
   binary_compression 'tar.zst'
 
   binary_sha256({
-       i686: '6951f4ce2b6bbf8a5246b67bfb04a4515e16a860bf9be44f0235f2d205fc3685',
-     x86_64: 'cf071e94d9d66c7d072350e29e0bc6b02ac0c1913b750d7f8619ebfaeb3735f8'
+       i686: '01fc97ecd71ac31986917c4cd43d09c4ee37b6d9366d9871e4363de644b0c3c0',
+     x86_64: '2a695c0ed83bd4760efb5de5f2b2308dcfd45416f2c94d488c63e90fcb885c4d'
   })
 
   depends_on 'glibc' # R

--- a/tests/package/d/delve
+++ b/tests/package/d/delve
@@ -1,0 +1,3 @@
+#!/bin/bash
+dlv help | head
+dlv version

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -23,6 +23,7 @@ cargo_c
 codex
 dart
 dbeaver
+delve
 f2fs_tools
 faad2
 fastfetch


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-delve crew update \
&& yes | crew upgrade

$ crew check delve -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/delve.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/delve.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/d/delve to /usr/local/lib/crew/tests/package/d
Checking delve package ...
Property tests for delve passed.
Checking delve package ...
Buildsystem test for delve passed.
Checking delve package ...
Delve is a source level debugger for Go programs.

Delve enables you to interact with your program by controlling the execution of the process,
evaluating variables, and providing information of thread / goroutine state, CPU register state and more.

The goal of this tool is to provide a simple yet powerful interface for debugging Go programs.

Pass flags to the program you are debugging using `--`, for example:

`dlv exec ./hello -- server --config conf/config.toml`
Delve Debugger
Version: 1.26.0
Build: $Id: 7fd7302eab8b16d715a94af1b5dfbffc2e1359bc $
Package tests for delve passed.
```