### PR TITLE
Deno 2.5.2 => 2.6.3

### DIFF
--- a/manifest/x86_64/d/deno.filelist
+++ b/manifest/x86_64/d/deno.filelist
@@ -1,3 +1,3 @@
-# Total size: 139592839
+# Total size: 141282226
 /usr/local/bin/deno
 /usr/local/share/bash-completion/completions/deno

--- a/packages/deno.rb
+++ b/packages/deno.rb
@@ -6,15 +6,15 @@ require 'buildsystems/rust'
 class Deno < RUST
   description 'A secure runtime for JavaScript and TypeScript'
   homepage 'https://deno.land'
-  version '2.5.2'
+  version '2.6.3'
   license 'MIT'
-  compatibility 'aarch64 x86_64'
+  compatibility 'x86_64'
   source_url 'https://github.com/denoland/deno.git'
   git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-     x86_64: '0cad3fd862366c2da84a7edff54c6af5bd75b69207f6b293db2dfc1b11341124'
+     x86_64: '0271b20a6910910741593a169e2dc9cd909b211ad53a24315dfb5382e44fe53c'
   })
 
   depends_on 'gcc_lib' # R

--- a/tests/package/d/deno
+++ b/tests/package/d/deno
@@ -1,0 +1,3 @@
+#!/bin/bash
+deno -h | head
+deno -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-deno crew update \
&& yes | crew upgrade

$ crew check deno -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/deno.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/deno.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/d/deno to /usr/local/lib/crew/tests/package/d
Checking deno package ...
Property tests for deno passed.
Checking deno package ...
Buildsystem test for deno passed.
Checking deno package ...
Deno: A modern JavaScript and TypeScript runtime

Usage: deno [OPTIONS] [COMMAND]

Commands:
  Execution:
    run          Run a JavaScript or TypeScript program, or a task
                  deno run main.ts  |  deno run --allow-net=google.com main.ts  |  deno main.ts
    serve        Run a server
                  deno serve main.ts
deno 2.6.3
Package tests for deno passed.
```