### PR TITLE
Acpica 20250807 => 20251212

### DIFF
--- a/manifest/x86_64/a/acpica.filelist
+++ b/manifest/x86_64/a/acpica.filelist
@@ -1,4 +1,4 @@
-# Total size: 2479224
+# Total size: 2490448
 /usr/local/bin/acpibin
 /usr/local/bin/acpidump
 /usr/local/bin/acpiexamples

--- a/packages/acpica.rb
+++ b/packages/acpica.rb
@@ -3,7 +3,7 @@ require 'package'
 class Acpica < Package
   description 'ACPI tools, including Intel ACPI Source Language compiler'
   homepage 'https://www.intel.com/content/www/us/en/developer/topic-technology/open/acpica/overview.html'
-  version '20250807'
+  version '20251212'
   license 'GPL-2'
   compatibility 'x86_64'
   source_url 'https://github.com/acpica/acpica.git'
@@ -11,7 +11,7 @@ class Acpica < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-     x86_64: '2ed7312f5e2787c778c5157c16dadfa4aadb5afb88cfd0a44657318c5aaadf4d'
+     x86_64: '9c27c344d60ac98dbea070d64945c7b2cafa030f4e643648fca2e63715248d59'
   })
 
   depends_on 'glibc' # R

--- a/tests/package/a/acpica
+++ b/tests/package/a/acpica
@@ -1,0 +1,2 @@
+#!/bin/bash
+for b in $(crew files acpica | grep /usr/local/bin); do $b -v 2>&1; done

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -1,5 +1,6 @@
 acl
 acpi
+acpica
 alsa_lib
 alsa_plugins
 alsa_utils


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-acpica crew update \
&& yes | crew upgrade

$ crew check acpica -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/acpica.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/acpica.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/a/acpica to /usr/local/lib/crew/tests/package/a
Checking acpica package ...
Property tests for acpica passed.
Checking acpica package ...
Buildsystem test for acpica passed.
Checking acpica package ...

Intel ACPI Component Architecture
ACPI Binary Table Dump Utility version 20251212
Copyright (c) 2000 - 2025 Intel Corporation


Intel ACPI Component Architecture
ACPI Binary Table Dump Utility version 20251212
Copyright (c) 2000 - 2025 Intel Corporation


Intel ACPI Component Architecture
ACPI Example Code version 20251212
Copyright (c) 2000 - 2025 Intel Corporation

ACPI: Loading ACPI tables
ACPI: RSDP 0x000055C7ADD25540 000024 (v02 INTEL )
ACPI: XSDT 0x000055C7ADD254C0 00002C (v01 INTEL  TEMPLATE 00000001 INTL 20131115)
ACPI: FACP 0x000055C7ADD253A0 00010C (v05 INTEL  TEMPLATE 00000000 INTL 20131115)
ACPI: DSDT 0x000055C7ADD252C0 00008C (v02 Intel  Template 00000001 INTL 20140424)
ACPI: FACS 0x000055C7ADD25360 000040
ACPI: 1 ACPI AML tables successfully acquired and loaded
ACPI: Example ACPICA info message
ACPI Warning: Example ACPICA warning message (20251212/examples-258)
ACPI Error: Example ACPICA error message (20251212/examples-259)
ACPI Error: AE_AML_OPERAND_TYPE, Example ACPICA exception message (20251212/examples-260)
ACPI: Executing _OSI reserved method
ACPI: _OSI returned 0xFFFFFFFF
ACPI: Executing MAIN method
ACPI Debug:  "Main/Arg0: Method [MAIN] is executing"
ACPI: Received a region access
ACPI: Received a notify 0x0
Method [MAIN] returned: "Main successfully completed execution"

Intel ACPI Component Architecture
AML Execution/Debug Utility version 20251212
Copyright (c) 2000 - 2025 Intel Corporation


ACPI: No outstanding allocations

Intel ACPI Component Architecture
ACPI Help Utility version 20251212
Copyright (c) 2000 - 2025 Intel Corporation


Intel ACPI Component Architecture
ACPI Source Code Conversion Utility version 20251212
Copyright (c) 2000 - 2025 Intel Corporation


Intel ACPI Component Architecture
ACPI Binary Table Extraction Utility version 20251212
Copyright (c) 2000 - 2025 Intel Corporation


Intel ACPI Component Architecture
ASL+ Optimizing Compiler/Disassembler version 20251212
Copyright (c) 2000 - 2025 Intel Corporation

Package tests for acpica passed.
```