### PR TITLE
Crew_profile_base 0.0.32 => 0.0.33

### DIFF
--- a/manifest/armv7l/c/crew_profile_base.filelist
+++ b/manifest/armv7l/c/crew_profile_base.filelist
@@ -1,4 +1,4 @@
-# Total size: 6798
+# Total size: 6800
 /usr/local/etc/bash.d/0-stub
 /usr/local/etc/bash.d/01-crew
 /usr/local/etc/bash.d/02-history

--- a/manifest/i686/c/crew_profile_base.filelist
+++ b/manifest/i686/c/crew_profile_base.filelist
@@ -1,4 +1,4 @@
-# Total size: 6798
+# Total size: 6800
 /usr/local/etc/bash.d/0-stub
 /usr/local/etc/bash.d/01-crew
 /usr/local/etc/bash.d/02-history

--- a/manifest/x86_64/c/crew_profile_base.filelist
+++ b/manifest/x86_64/c/crew_profile_base.filelist
@@ -1,4 +1,4 @@
-# Total size: 6798
+# Total size: 6800
 /usr/local/etc/bash.d/0-stub
 /usr/local/etc/bash.d/01-crew
 /usr/local/etc/bash.d/02-history

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,11 +3,11 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  version '0.0.32'
+  version '0.0.33'
   license 'GPL-3+'
   compatibility 'all'
-  source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 'f9f0705fb68fa69372c0f730af398029704be9b15d8781230ded67cc459a0bdd'
+  source_url 'https://github.com/chromebrew/crew-profile-base.git'
+  git_hashtag version
 
   no_compile_needed
   print_source_bashrc


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-crew_profile_base crew update \
&& yes | crew upgrade
```