### PR TITLE
Awscli 1.43.15-py3.14 => 1.44.7-py3.14

### DIFF
--- a/manifest/armv7l/a/awscli.filelist
+++ b/manifest/armv7l/a/awscli.filelist
@@ -1,4 +1,4 @@
-# Total size: 12000481
+# Total size: 12083986
 /usr/local/bin/aws
 /usr/local/bin/aws.cmd
 /usr/local/bin/aws_bash_completer
@@ -6,13 +6,13 @@
 /usr/local/bin/aws_zsh_completer.sh
 /usr/local/etc/bash.d/aws
 /usr/local/etc/zsh.d/aws
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/INSTALLER
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/LICENSE.txt
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/METADATA
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/RECORD
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/REQUESTED
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/WHEEL
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/top_level.txt
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/INSTALLER
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/LICENSE.txt
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/METADATA
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/RECORD
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/REQUESTED
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/WHEEL
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/top_level.txt
 /usr/local/lib/python3.14/site-packages/awscli/__init__.py
 /usr/local/lib/python3.14/site-packages/awscli/__main__.py
 /usr/local/lib/python3.14/site-packages/awscli/__pycache__/__init__.cpython-314.pyc
@@ -391,11 +391,13 @@
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__init__.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/__init__.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/base.cpython-314.pyc
+/usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/caseconflict.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/delete.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/exacttimestamps.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/register.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/sizeonly.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/base.py
+/usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/caseconflict.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/delete.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/exacttimestamps.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/register.py
@@ -980,11 +982,14 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/cancel-update-stack.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/continue-update-rollback.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-generated-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack-instances.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack-refactor.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack-set.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/deactivate-type.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-generated-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-stack-instances.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-stack-set.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-stack.rst
@@ -992,10 +997,13 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/deregister-type.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-account-limits.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-generated-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-publisher.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-resource-scan.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-drift-detection-status.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-events.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-instance.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-refactor.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-resource-drifts.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-resource.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-resources.rst
@@ -1009,13 +1017,18 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/detect-stack-set-drift.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/estimate-template-cost.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/execute-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/execute-stack-refactor.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/get-stack-policy.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/get-template-summary.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/get-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-change-sets.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-exports.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-generated-templates.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-imports.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-resource-scan-related-resources.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-resource-scan-resources.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-instances.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-refactor-actions.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-resources.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-set-operation-results.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-set-operations.rst
@@ -1032,6 +1045,7 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/set-type-configuration.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/set-type-default-version.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/signal-resource.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/start-resource-scan.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/stop-stack-set-operation.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/test-type.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/update-stack-instances.rst
@@ -6287,6 +6301,7 @@
 /usr/local/lib/python3.14/site-packages/awscli/text.py
 /usr/local/lib/python3.14/site-packages/awscli/topics/config-vars.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/return-codes.rst
+/usr/local/lib/python3.14/site-packages/awscli/topics/s3-case-insensitivity.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/s3-config.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/s3-faq.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/topic-tags.json

--- a/manifest/i686/a/awscli.filelist
+++ b/manifest/i686/a/awscli.filelist
@@ -1,4 +1,4 @@
-# Total size: 12000481
+# Total size: 12083986
 /usr/local/bin/aws
 /usr/local/bin/aws.cmd
 /usr/local/bin/aws_bash_completer
@@ -6,13 +6,13 @@
 /usr/local/bin/aws_zsh_completer.sh
 /usr/local/etc/bash.d/aws
 /usr/local/etc/zsh.d/aws
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/INSTALLER
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/LICENSE.txt
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/METADATA
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/RECORD
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/REQUESTED
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/WHEEL
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/top_level.txt
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/INSTALLER
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/LICENSE.txt
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/METADATA
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/RECORD
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/REQUESTED
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/WHEEL
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/top_level.txt
 /usr/local/lib/python3.14/site-packages/awscli/__init__.py
 /usr/local/lib/python3.14/site-packages/awscli/__main__.py
 /usr/local/lib/python3.14/site-packages/awscli/__pycache__/__init__.cpython-314.pyc
@@ -391,11 +391,13 @@
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__init__.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/__init__.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/base.cpython-314.pyc
+/usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/caseconflict.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/delete.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/exacttimestamps.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/register.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/sizeonly.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/base.py
+/usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/caseconflict.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/delete.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/exacttimestamps.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/register.py
@@ -980,11 +982,14 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/cancel-update-stack.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/continue-update-rollback.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-generated-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack-instances.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack-refactor.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack-set.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/deactivate-type.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-generated-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-stack-instances.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-stack-set.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-stack.rst
@@ -992,10 +997,13 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/deregister-type.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-account-limits.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-generated-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-publisher.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-resource-scan.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-drift-detection-status.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-events.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-instance.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-refactor.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-resource-drifts.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-resource.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-resources.rst
@@ -1009,13 +1017,18 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/detect-stack-set-drift.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/estimate-template-cost.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/execute-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/execute-stack-refactor.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/get-stack-policy.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/get-template-summary.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/get-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-change-sets.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-exports.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-generated-templates.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-imports.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-resource-scan-related-resources.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-resource-scan-resources.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-instances.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-refactor-actions.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-resources.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-set-operation-results.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-set-operations.rst
@@ -1032,6 +1045,7 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/set-type-configuration.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/set-type-default-version.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/signal-resource.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/start-resource-scan.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/stop-stack-set-operation.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/test-type.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/update-stack-instances.rst
@@ -6287,6 +6301,7 @@
 /usr/local/lib/python3.14/site-packages/awscli/text.py
 /usr/local/lib/python3.14/site-packages/awscli/topics/config-vars.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/return-codes.rst
+/usr/local/lib/python3.14/site-packages/awscli/topics/s3-case-insensitivity.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/s3-config.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/s3-faq.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/topic-tags.json

--- a/manifest/x86_64/a/awscli.filelist
+++ b/manifest/x86_64/a/awscli.filelist
@@ -1,4 +1,4 @@
-# Total size: 12000481
+# Total size: 12083986
 /usr/local/bin/aws
 /usr/local/bin/aws.cmd
 /usr/local/bin/aws_bash_completer
@@ -6,13 +6,13 @@
 /usr/local/bin/aws_zsh_completer.sh
 /usr/local/etc/bash.d/aws
 /usr/local/etc/zsh.d/aws
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/INSTALLER
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/LICENSE.txt
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/METADATA
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/RECORD
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/REQUESTED
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/WHEEL
-/usr/local/lib/python3.14/site-packages/awscli-1.43.15.dist-info/top_level.txt
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/INSTALLER
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/LICENSE.txt
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/METADATA
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/RECORD
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/REQUESTED
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/WHEEL
+/usr/local/lib/python3.14/site-packages/awscli-1.44.7.dist-info/top_level.txt
 /usr/local/lib/python3.14/site-packages/awscli/__init__.py
 /usr/local/lib/python3.14/site-packages/awscli/__main__.py
 /usr/local/lib/python3.14/site-packages/awscli/__pycache__/__init__.cpython-314.pyc
@@ -391,11 +391,13 @@
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__init__.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/__init__.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/base.cpython-314.pyc
+/usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/caseconflict.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/delete.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/exacttimestamps.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/register.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/__pycache__/sizeonly.cpython-314.pyc
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/base.py
+/usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/caseconflict.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/delete.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/exacttimestamps.py
 /usr/local/lib/python3.14/site-packages/awscli/customizations/s3/syncstrategy/register.py
@@ -980,11 +982,14 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/cancel-update-stack.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/continue-update-rollback.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-generated-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack-instances.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack-refactor.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack-set.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/create-stack.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/deactivate-type.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-generated-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-stack-instances.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-stack-set.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/delete-stack.rst
@@ -992,10 +997,13 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/deregister-type.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-account-limits.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-generated-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-publisher.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-resource-scan.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-drift-detection-status.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-events.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-instance.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-refactor.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-resource-drifts.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-resource.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/describe-stack-resources.rst
@@ -1009,13 +1017,18 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/detect-stack-set-drift.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/estimate-template-cost.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/execute-change-set.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/execute-stack-refactor.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/get-stack-policy.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/get-template-summary.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/get-template.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-change-sets.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-exports.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-generated-templates.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-imports.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-resource-scan-related-resources.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-resource-scan-resources.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-instances.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-refactor-actions.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-resources.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-set-operation-results.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/list-stack-set-operations.rst
@@ -1032,6 +1045,7 @@
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/set-type-configuration.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/set-type-default-version.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/signal-resource.rst
+/usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/start-resource-scan.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/stop-stack-set-operation.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/test-type.rst
 /usr/local/lib/python3.14/site-packages/awscli/examples/cloudformation/update-stack-instances.rst
@@ -6287,6 +6301,7 @@
 /usr/local/lib/python3.14/site-packages/awscli/text.py
 /usr/local/lib/python3.14/site-packages/awscli/topics/config-vars.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/return-codes.rst
+/usr/local/lib/python3.14/site-packages/awscli/topics/s3-case-insensitivity.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/s3-config.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/s3-faq.rst
 /usr/local/lib/python3.14/site-packages/awscli/topics/topic-tags.json

--- a/packages/awscli.rb
+++ b/packages/awscli.rb
@@ -3,7 +3,7 @@ require 'buildsystems/pip'
 class Awscli < Pip
   description 'Universal Command Line Interface for Amazon Web Services'
   homepage 'https://github.com/aws/aws-cli'
-  version "1.43.15-#{CREW_PY_VER}"
+  version "1.44.7-#{CREW_PY_VER}"
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'SKIP'
@@ -17,10 +17,10 @@ class Awscli < Pip
   })
 
   binary_sha256({
-    aarch64: '095f3b78c4e5d912aaacc96bb810c0d51469ac8045215ac978782c29e92c79bd',
-     armv7l: '095f3b78c4e5d912aaacc96bb810c0d51469ac8045215ac978782c29e92c79bd',
-       i686: 'eee692f47632f781a3c8331aebee9c391deca277306cd3a13870b50ee747374c',
-     x86_64: '30e9c8d00f6bab741aaa3c817fca51ed1509f2e000e82ec3db5014b901294dd1'
+    aarch64: '63a379ce87cbdd8a8f1742b63f579deeddbda0a2ce9e4ae8cdf13ad47147d38e',
+     armv7l: '63a379ce87cbdd8a8f1742b63f579deeddbda0a2ce9e4ae8cdf13ad47147d38e',
+       i686: 'f4b4e2e26a56138f3c33694f600a3a383280c33ebaee453f2051cbe602808b85',
+     x86_64: '219d299655d0e5b2518e1575487f2c3803658df754dd389fb3a091a9ec03e03f'
   })
 
   depends_on 'groff'

--- a/tests/package/a/awscli
+++ b/tests/package/a/awscli
@@ -1,0 +1,3 @@
+#!/bin/bash
+aws help | head
+aws --version

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -13,6 +13,7 @@ arp_scan
 asunder
 augeas
 autoconf_archive
+awscli
 axel
 b2
 bc


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-awscli crew update \
&& yes | crew upgrade

$ crew check awscli -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/awscli.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/awscli.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/a/awscli to /usr/local/lib/crew/tests/package/a
Checking awscli package ...
Property tests for awscli passed.
Checking awscli package ...
Buildsystem test for awscli passed.
Checking awscli package ...
AWS()                                                                    AWS()

NAME
       aws -

DESCRIPTION
       The  AWS  Command  Line  Interface is a unified tool to manage your AWS
       services.

SYNOPSIS
aws-cli/1.44.7 Python/3.14.2 Linux/6.4.0-1mx-ahs-amd64 botocore/1.42.17
Package tests for awscli passed.
```