### PR TITLE
Detox 2.0.0 => 3.0.1

### DIFF
--- a/manifest/armv7l/d/detox.filelist
+++ b/manifest/armv7l/d/detox.filelist
@@ -1,12 +1,15 @@
-# Total size: 480730
+# Total size: 495126
 /usr/local/bin/detox
 /usr/local/bin/inline-detox
 /usr/local/etc/detoxrc
 /usr/local/share/detox/cp1252.tbl
 /usr/local/share/detox/iso8859_1.tbl
+/usr/local/share/detox/legacy/cp1252.tbl
+/usr/local/share/detox/legacy/iso8859_1.tbl
+/usr/local/share/detox/legacy/unicode.tbl
+/usr/local/share/detox/legacy/unidecode.tbl
 /usr/local/share/detox/safe.tbl
 /usr/local/share/detox/unicode.tbl
-/usr/local/share/detox/unidecode.tbl
 /usr/local/share/doc/detox/BUILD.md
 /usr/local/share/doc/detox/CHANGELOG.md
 /usr/local/share/doc/detox/LICENSE

--- a/manifest/i686/d/detox.filelist
+++ b/manifest/i686/d/detox.filelist
@@ -1,12 +1,15 @@
-# Total size: 439386
+# Total size: 500798
 /usr/local/bin/detox
 /usr/local/bin/inline-detox
 /usr/local/etc/detoxrc
 /usr/local/share/detox/cp1252.tbl
 /usr/local/share/detox/iso8859_1.tbl
+/usr/local/share/detox/legacy/cp1252.tbl
+/usr/local/share/detox/legacy/iso8859_1.tbl
+/usr/local/share/detox/legacy/unicode.tbl
+/usr/local/share/detox/legacy/unidecode.tbl
 /usr/local/share/detox/safe.tbl
 /usr/local/share/detox/unicode.tbl
-/usr/local/share/detox/unidecode.tbl
 /usr/local/share/doc/detox/BUILD.md
 /usr/local/share/doc/detox/CHANGELOG.md
 /usr/local/share/doc/detox/LICENSE

--- a/manifest/x86_64/d/detox.filelist
+++ b/manifest/x86_64/d/detox.filelist
@@ -1,12 +1,15 @@
-# Total size: 534258
+# Total size: 518310
 /usr/local/bin/detox
 /usr/local/bin/inline-detox
 /usr/local/etc/detoxrc
 /usr/local/share/detox/cp1252.tbl
 /usr/local/share/detox/iso8859_1.tbl
+/usr/local/share/detox/legacy/cp1252.tbl
+/usr/local/share/detox/legacy/iso8859_1.tbl
+/usr/local/share/detox/legacy/unicode.tbl
+/usr/local/share/detox/legacy/unidecode.tbl
 /usr/local/share/detox/safe.tbl
 /usr/local/share/detox/unicode.tbl
-/usr/local/share/detox/unidecode.tbl
 /usr/local/share/doc/detox/BUILD.md
 /usr/local/share/doc/detox/CHANGELOG.md
 /usr/local/share/doc/detox/LICENSE

--- a/packages/detox.rb
+++ b/packages/detox.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Detox < Autotools
   description 'detox is a program that renames files to make them easier to work with under Linux and other Unix-like operating systems.'
   homepage 'https://github.com/dharple/detox'
-  version '2.0.0'
+  version '3.0.1'
   license 'BSD-3 Clause'
   compatibility 'all'
   source_url 'https://github.com/dharple/detox.git'
@@ -11,9 +11,11 @@ class Detox < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '997436983cee04e7d368d74709b77ded41959793c0c9536aedb6d065517d6856',
-     armv7l: '997436983cee04e7d368d74709b77ded41959793c0c9536aedb6d065517d6856',
-       i686: 'e8db275366a3402c1f293a2de4ae2734438e606cbe7e807144d581c9cb1a3b30',
-     x86_64: 'c6841edbd7daf7c0fda861de3d30546f2108f5207bc1b8dab6529095c5fb3724'
+    aarch64: '63b3f1aed4cca8017ea6ff5c7188c9ea1ad30627debbe0825220a9ce1ecb0c12',
+     armv7l: '63b3f1aed4cca8017ea6ff5c7188c9ea1ad30627debbe0825220a9ce1ecb0c12',
+       i686: 'bbc10e0d040d9cab86b60cfdb7514f71f33084d44e37a7a72faf2433bac50049',
+     x86_64: 'f6075327c543f7896d7747f42c45e7c043ade6d4628b80f56daaccdae594297b'
   })
+
+  depends_on 'glibc' # R
 end

--- a/tests/package/d/detox
+++ b/tests/package/d/detox
@@ -1,0 +1,3 @@
+#!/bin/bash
+detox --help
+detox -V

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -27,6 +27,7 @@ codex
 dart
 dbeaver
 delve
+detox
 f2fs_tools
 faad2
 fastfetch


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-detox crew update \
&& yes | crew upgrade

$ crew check detox -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/detox.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/detox.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/d/detox to /usr/local/lib/crew/tests/package/d
Checking detox package ...
Property tests for detox passed.
Checking detox package ...
Buildsystem test for detox passed.
Checking detox package ...
usage: detox [-hLnrvV] [-f configfile] [-s sequence] [--dry-run] [--help] [--inline] [--recursive] [--special] [--verbose]
	  file [file ...]

	-f configfile	choose which config file to use
	-h --help	this message
	--inline	run inline mode
	-L		list available sequences and exit
			with -v ... dump sequence contents
	-n --dry-run	do a dry run (don't actually do anything)
	-r --recursive	be recursive (descend into subdirectories)
	-s sequence	choose which sequence to detox with
	--special	work on links and special files
	-v --verbose 	be verbose
	-V 		show the current version
detox 3.0.1
Package tests for detox passed.
```