### PR TITLE
Difftastic 0.62.0 => 0.67.0

### DIFF
--- a/manifest/armv7l/d/difftastic.filelist
+++ b/manifest/armv7l/d/difftastic.filelist
@@ -1,2 +1,2 @@
-# Total size: 5499468
+# Total size: 109091364
 /usr/local/bin/difft

--- a/manifest/i686/d/difftastic.filelist
+++ b/manifest/i686/d/difftastic.filelist
@@ -1,2 +1,2 @@
-# Total size: 5823672
+# Total size: 108990664
 /usr/local/bin/difft

--- a/manifest/x86_64/d/difftastic.filelist
+++ b/manifest/x86_64/d/difftastic.filelist
@@ -1,2 +1,2 @@
-# Total size: 5812972
+# Total size: 109710600
 /usr/local/bin/difft

--- a/packages/difftastic.rb
+++ b/packages/difftastic.rb
@@ -3,7 +3,7 @@ require 'package'
 class Difftastic < Package
   description 'Difftastic is a structural diff tool that compares files based on their syntax.'
   homepage 'https://github.com/Wilfred/difftastic'
-  version '0.62.0'
+  version '0.67.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/Wilfred/difftastic.git'
@@ -11,12 +11,14 @@ class Difftastic < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '67cd66a4e4c1e96f16819b75b20ffabd43f0586fe3057b2a99a1df59df63e1a0',
-     armv7l: '67cd66a4e4c1e96f16819b75b20ffabd43f0586fe3057b2a99a1df59df63e1a0',
-       i686: '0202aa02d6bc115f10480901bdc53cf7dfec9130f6873859b035bcb2feae2481',
-     x86_64: 'f2706ced7fc57e3b311e449a2db4bfe86489b58d53071ea9e94d2436c9adf954'
+    aarch64: '915b7280bb0469681495323cc5d460311f26515f34ae8437fe73479c93c65ab9',
+     armv7l: '915b7280bb0469681495323cc5d460311f26515f34ae8437fe73479c93c65ab9',
+       i686: 'f156ba2709bc1b846595135057fb8140d4d773c6daaf9b8a3948f3765235b415',
+     x86_64: '18c72ff3d4d5be9a742ea860b13f8009fdb629587de86490e7b9dab0c965176b'
   })
 
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc' # R
   depends_on 'rust' => :build
 
   def self.install

--- a/tests/package/d/difftastic
+++ b/tests/package/d/difftastic
@@ -1,0 +1,3 @@
+#!/bin/bash
+difft -h | head
+difft -V

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -28,6 +28,7 @@ dart
 dbeaver
 delve
 detox
+difftastic
 f2fs_tools
 faad2
 fastfetch


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-difftastic crew update \
&& yes | crew upgrade

$ crew check difftastic -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/difftastic.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/difftastic.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/d/difftastic to /usr/local/lib/crew/tests/package/d
Checking difftastic package ...
Property tests for difftastic passed.
Checking difftastic package ...
Buildsystem test for difftastic passed.
Checking difftastic package ...
A structural diff that understands syntax.

Usage: difft [OPTIONS] OLD-PATH NEW-PATH

Options:
      --context <LINES>            The number of contextual lines to show around changed lines. [env: DFT_CONTEXT=] [default: 3]
      --width <COLUMNS>            Use this many columns when calculating line wrapping. If not specified, difftastic will detect the terminal width. [env: DFT_WIDTH=]
      --tab-width <NUM_SPACES>     Treat a tab as this many spaces. [env: DFT_TAB_WIDTH=] [default: 4]
      --display <MODE>             Display mode for showing results.
                                   
Difftastic 0.67.0
Package tests for difftastic passed.
```