### PR TITLE
Doctl 1.100.0 => 1.148.0

### DIFF
--- a/manifest/armv7l/d/doctl.filelist
+++ b/manifest/armv7l/d/doctl.filelist
@@ -1,2 +1,2 @@
-# Total size: 4599352
+# Total size: 25179328
 /usr/local/bin/doctl

--- a/manifest/i686/d/doctl.filelist
+++ b/manifest/i686/d/doctl.filelist
@@ -1,2 +1,2 @@
-# Total size: 5297560
+# Total size: 25132080
 /usr/local/bin/doctl

--- a/manifest/x86_64/d/doctl.filelist
+++ b/manifest/x86_64/d/doctl.filelist
@@ -1,2 +1,2 @@
-# Total size: 5872788
+# Total size: 26438760
 /usr/local/bin/doctl

--- a/packages/doctl.rb
+++ b/packages/doctl.rb
@@ -3,20 +3,23 @@ require 'package'
 class Doctl < Package
   description 'The official command line interface for the DigitalOcean API.'
   homepage 'https://github.com/digitalocean/doctl'
-  version '1.100.0'
+  version '1.148.0'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'SKIP'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '9de72297695d143c82386eb728114e2169fc384922ce67fa4565050228f6a8ec',
-     armv7l: '9de72297695d143c82386eb728114e2169fc384922ce67fa4565050228f6a8ec',
-       i686: 'f568369579923bb53c52e628dad85904314a0d6e579c14ca004de298acf7a95d',
-     x86_64: '87919f94bf861fc6b7f5c3320b75fff075553729774d4fc0afe4e6a2878ebc78'
+    aarch64: 'f8c20f273b7a8e7bdb6b3d9907bf987325023bdeba5acc8cbd38e77edd55b07f',
+     armv7l: 'f8c20f273b7a8e7bdb6b3d9907bf987325023bdeba5acc8cbd38e77edd55b07f',
+       i686: '1f6e651d0e733bd1e56eaf474b055934920808d7aed1ba2f61ddd49c3cb579ac',
+     x86_64: 'a6d80d75f25048da7c546d656dc32eef2fcade30c6a0df46781cc92eaae9677e'
   })
 
+  depends_on 'glibc' # R
   depends_on 'go' => :build
+
+  no_source_build
 
   def self.install
     system "GOBIN=#{CREW_DEST_PREFIX}/bin go install github.com/digitalocean/doctl/cmd/doctl@v#{version}"

--- a/tests/package/d/doctl
+++ b/tests/package/d/doctl
@@ -1,0 +1,3 @@
+#!/bin/bash
+doctl -h | head
+doctl version

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -29,6 +29,7 @@ dbeaver
 delve
 detox
 difftastic
+doctl
 f2fs_tools
 faad2
 fastfetch


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-doctl crew update \
&& yes | crew upgrade

$ crew check doctl -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/doctl.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/doctl.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/d/doctl to /usr/local/lib/crew/tests/package/d
Checking doctl package ...
Property tests for doctl passed.
Checking doctl package ...
Buildsystem test for doctl passed.
Checking doctl package ...
doctl is a command line interface (CLI) for the DigitalOcean API.

Usage:
  doctl [command]

Manage DigitalOcean Resources:
  1-click         Display commands that pertain to 1-click applications
  account         Display commands that retrieve account details
  apps            Displays commands for working with apps
  compute         Display commands that manage infrastructure
doctl version 0.0.0-dev
release 1.148.0 is available, check it out! 
Package tests for doctl passed.
```