### PR TITLE
Dav1d 1.5.2 => 1.5.3

### DIFF
--- a/manifest/armv7l/d/dav1d.filelist
+++ b/manifest/armv7l/d/dav1d.filelist
@@ -1,4 +1,4 @@
-# Total size: 853518
+# Total size: 853454
 /usr/local/bin/dav1d
 /usr/local/include/dav1d/common.h
 /usr/local/include/dav1d/data.h

--- a/manifest/i686/d/dav1d.filelist
+++ b/manifest/i686/d/dav1d.filelist
@@ -1,4 +1,4 @@
-# Total size: 1514638
+# Total size: 1514414
 /usr/local/bin/dav1d
 /usr/local/include/dav1d/common.h
 /usr/local/include/dav1d/data.h

--- a/manifest/x86_64/d/dav1d.filelist
+++ b/manifest/x86_64/d/dav1d.filelist
@@ -1,4 +1,4 @@
-# Total size: 2167372
+# Total size: 2167052
 /usr/local/bin/dav1d
 /usr/local/include/dav1d/common.h
 /usr/local/include/dav1d/data.h

--- a/packages/dav1d.rb
+++ b/packages/dav1d.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Dav1d < Meson
   description 'dav1d is a new AV1 cross-platform decoder, open-source, and focused on speed and correctness.'
   homepage 'https://code.videolan.org/videolan/dav1d'
-  version '1.5.2'
+  version '1.5.3'
   license 'BSD-2'
   compatibility 'all'
   source_url 'https://code.videolan.org/videolan/dav1d.git'
@@ -11,10 +11,10 @@ class Dav1d < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e5fc00913117a06424326c6803e9d8ebcca07db9164f734c9b383b4f0d8e456d',
-     armv7l: 'e5fc00913117a06424326c6803e9d8ebcca07db9164f734c9b383b4f0d8e456d',
-       i686: '4c402d4771a7ebef6b38a8d55d737ae87ca2906acc807b0127ec21c7662e63b9',
-     x86_64: '691d00f59ff04c670f19c800e62d02a3a52c5bff947c43535c54ba8f8068877f'
+    aarch64: '96852f722190552c9362c8cacc0450ed6e983d31f049f413191fabea83579b3e',
+     armv7l: '96852f722190552c9362c8cacc0450ed6e983d31f049f413191fabea83579b3e',
+       i686: 'bb2b93f8b16cb3c3e4f0f13152b55b9f0215be2ee3c58cf35f068dffb2cc8f54',
+     x86_64: '422fe62bb8f9dd287e1b03a96f19d788ecd868b30e535b4d1f693aee0c1066f0'
   })
 
   depends_on 'gcc_lib' # R

--- a/tests/package/d/dav1d
+++ b/tests/package/d/dav1d
@@ -1,0 +1,3 @@
+#!/bin/bash
+dav1d 2>&1 | head
+dav1d -v 2>&1

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -25,6 +25,7 @@ bmon
 cargo_c
 codex
 dart
+dav1d
 dbeaver
 delve
 detox


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-dav1d crew update \
&& yes | crew upgrade

$ crew check dav1d -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/dav1d.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/dav1d.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/d/dav1d to /usr/local/lib/crew/tests/package/d
Checking dav1d package ...
Property tests for dav1d passed.
Checking dav1d package ...
Buildsystem test for dav1d passed.
Checking dav1d package ...
Input file (-i/--input) is required

Usage: dav1d [options]

Supported options:
 --input/-i $file:     input file
 --output/-o $file:    output file (%n, %w or %h will be filled in for per-frame files)
 --demuxer $name:      force demuxer type ('ivf', 'section5' or 'annexb'; default: detect from content)
 --muxer $name:        force muxer type ('md5', 'xxh3', 'yuv', 'yuv4mpeg2' or 'null'; default: detect from extension)
                       use 'frame' as prefix to write per-frame files; if filename contains %n, will default to writing per-frame files
b546257
Package tests for dav1d passed.
```