### PR TITLE
Add usql package

### DIFF
--- a/manifest/x86_64/u/usql.filelist
+++ b/manifest/x86_64/u/usql.filelist
@@ -1,0 +1,2 @@
+# Total size: 216520488
+/usr/local/bin/usql

--- a/packages/usql.rb
+++ b/packages/usql.rb
@@ -1,0 +1,25 @@
+require 'package'
+
+class Usql < Package
+  description 'Universal command-line interface for SQL databases'
+  homepage 'https://github.com/xo/usql'
+  version '0.20.0'
+  license 'MIT'
+  compatibility 'x86_64'
+  source_url 'SKIP'
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+     x86_64: 'aebb1e0fb75dab1b1627c2e315b2b7810f7fac636efb4d2b7acb74252bd1a571'
+  })
+
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc' # R
+  depends_on 'go' => :build
+
+  no_source_build
+
+  def self.install
+    system "GOBIN=#{CREW_DEST_PREFIX}/bin go install -tags most github.com/xo/usql@v#{version}"
+  end
+end

--- a/tests/package/u/usql
+++ b/tests/package/u/usql
@@ -1,0 +1,3 @@
+#!/bin/bash
+usql --help | head
+usql -V

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -79,6 +79,7 @@ nano
 ocaml
 opencode
 rqlite
+usql
 vscodium
 xdpyinfo
 yyjson

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -9835,6 +9835,11 @@ url: https://www.kernel.org/pub/linux/utils/usb/usbutils/
 activity: low
 ---
 kind: url
+name: usql
+url: https://github.com/xo/usql/releases
+activity: medium
+---
+kind: url
 name: utf8proc
 url: https://github.com/JuliaLang/utf8proc/releases
 activity: low


### PR DESCRIPTION
## Description
Universal command-line interface for SQL databases.  See https://github.com/xo/usql.
##
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-usql-package crew update \
&& yes | crew upgrade

$ crew check usql -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/usql.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/usql.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/u/usql to /usr/local/lib/crew/tests/package/u
Copied /home/chronos/user/chromebrew/manifest/x86_64/u/usql.filelist to /usr/local/lib/crew/manifest/x86_64/u/usql.filelist
Checking usql package ...
Property tests for usql passed.
Checking usql package ...
Buildsystem test for usql passed.
Checking usql package ...
Library test for usql passed.
Checking usql package ...
usql, the universal command-line interface for SQL databases

Usage:
  usql [flags]... [DSN]

Arguments:
  DSN   database url or connection name

Flags:
  -c, --command COMMAND                     run only single command (SQL or internal) and exit
usql 0.0.0-dev
Package tests for usql passed.
```