### PR TITLE
Evince 45.0 => 48.1

### DIFF
--- a/manifest/armv7l/e/evince.filelist
+++ b/manifest/armv7l/e/evince.filelist
@@ -1,4 +1,4 @@
-# Total size: 10800343
+# Total size: 10503863
 /usr/local/bin/evince
 /usr/local/bin/evince-previewer
 /usr/local/bin/evince-thumbnailer
@@ -2869,6 +2869,7 @@
 /usr/local/share/locale/it/LC_MESSAGES/evince.mo
 /usr/local/share/locale/ja/LC_MESSAGES/evince.mo
 /usr/local/share/locale/ka/LC_MESSAGES/evince.mo
+/usr/local/share/locale/kab/LC_MESSAGES/evince.mo
 /usr/local/share/locale/kk/LC_MESSAGES/evince.mo
 /usr/local/share/locale/km/LC_MESSAGES/evince.mo
 /usr/local/share/locale/kn/LC_MESSAGES/evince.mo

--- a/manifest/x86_64/e/evince.filelist
+++ b/manifest/x86_64/e/evince.filelist
@@ -1,4 +1,4 @@
-# Total size: 11098727
+# Total size: 10946923
 /usr/local/bin/evince
 /usr/local/bin/evince-previewer
 /usr/local/bin/evince-thumbnailer
@@ -2869,6 +2869,7 @@
 /usr/local/share/locale/it/LC_MESSAGES/evince.mo
 /usr/local/share/locale/ja/LC_MESSAGES/evince.mo
 /usr/local/share/locale/ka/LC_MESSAGES/evince.mo
+/usr/local/share/locale/kab/LC_MESSAGES/evince.mo
 /usr/local/share/locale/kk/LC_MESSAGES/evince.mo
 /usr/local/share/locale/km/LC_MESSAGES/evince.mo
 /usr/local/share/locale/kn/LC_MESSAGES/evince.mo

--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -6,7 +6,7 @@ require 'buildsystems/meson'
 class Evince < Meson
   description 'Document viewer PDF, PostScript, XPS, djvu, dvi, tiff, cbr, cbz, cb7, cbt'
   homepage 'https://wiki.gnome.org/Apps/Evince'
-  version '45.0'
+  version '48.1'
   license 'GPL'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/evince.git'
@@ -14,9 +14,9 @@ class Evince < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '25eb43693a5ca3fc77814f63d91a5dd07382f9e73f4bd10d689751485395519d',
-     armv7l: '25eb43693a5ca3fc77814f63d91a5dd07382f9e73f4bd10d689751485395519d',
-     x86_64: 'b18d1011d5dcf0718034146d0f93ede644b15111e005167391c7c52e057d5288'
+    aarch64: '74d656129feb4be560d3f0796238c9436f610f63fd2df7b78422cae392cd88d7',
+     armv7l: '74d656129feb4be560d3f0796238c9436f610f63fd2df7b78422cae392cd88d7',
+     x86_64: '305b088604804d6e8da83e1f8936610199aab024a8de87d39ada08f59b9026e6'
   })
 
   depends_on 'at_spi2_core' # R
@@ -25,9 +25,10 @@ class Evince < Meson
   depends_on 'docbook_xsl' => :build
   depends_on 'gcc_lib' # R
   depends_on 'gdk_pixbuf' # R
-  depends_on 'glibc' # R
   depends_on 'glib' # R
+  depends_on 'glibc' # R
   depends_on 'gnome_desktop' # R
+  depends_on 'gspell' # R
   depends_on 'gstreamer' # R
   depends_on 'gtk3' # R
   depends_on 'gtk_doc' => :build

--- a/tests/package/e/evince
+++ b/tests/package/e/evince
@@ -1,0 +1,5 @@
+#!/bin/bash
+evince --help | head
+evince --version
+evince-previewer -h | head
+evince-thumbnailer -h | head

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -34,6 +34,7 @@ doctl
 enchant
 enet
 epiphany
+evince
 f2fs_tools
 faad2
 fastfetch


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-evince crew update \
&& yes | crew upgrade

$ crew check evince -f
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/evince.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Copied /home/chronos/user/chromebrew/packages/evince.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/e/evince to /usr/local/lib/crew/tests/package/e
Checking evince package ...
Property tests for evince passed.
Checking evince package ...
Buildsystem test for evince passed.
Checking evince package ...
Usage:
  evince [OPTION…] [FILE…] GNOME Document Viewer

Help Options:
  -h, --help                  Show help options
  --help-all                  Show all help options
  --help-gtk                  Show GTK+ Options

Application Options:
  -o, --new-window            Open a new window.
GNOME Document Viewer 48.1
Usage:
  evince-previewer [OPTION…] GNOME Document Previewer

Help Options:
  -h, --help                    Show help options
  --help-all                    Show all help options
  --help-gtk                    Show GTK+ Options

Application Options:
  -u, --unlink-tempfile         Delete the temporary file
Usage:
  evince-thumbnailer [OPTION…] <input> <output> - GNOME Document Thumbnailer

Help Options:
  -h, --help              Show help options

Application Options:
  -s, --size=SIZE         
  -l, --no-limit          Don't limit the thumbnailing time to 15 seconds

Package tests for evince passed.
```