### PR TITLE
Fastfetch 2.42.0 => 2.56.1

### DIFF
--- a/manifest/armv7l/f/fastfetch.filelist
+++ b/manifest/armv7l/f/fastfetch.filelist
@@ -1,4 +1,4 @@
-# Total size: 2258714
+# Total size: 1918320
 /usr/local/bin/fastfetch
 /usr/local/bin/flashfetch
 /usr/local/share/bash-completion/completions/fastfetch
@@ -23,7 +23,11 @@
 /usr/local/share/fastfetch/presets/examples/24.jsonc
 /usr/local/share/fastfetch/presets/examples/25.jsonc
 /usr/local/share/fastfetch/presets/examples/26.jsonc
+/usr/local/share/fastfetch/presets/examples/27.jsonc
+/usr/local/share/fastfetch/presets/examples/28.jsonc
+/usr/local/share/fastfetch/presets/examples/29.jsonc
 /usr/local/share/fastfetch/presets/examples/3.jsonc
+/usr/local/share/fastfetch/presets/examples/30.jsonc
 /usr/local/share/fastfetch/presets/examples/4.jsonc
 /usr/local/share/fastfetch/presets/examples/5.jsonc
 /usr/local/share/fastfetch/presets/examples/6.jsonc

--- a/manifest/x86_64/f/fastfetch.filelist
+++ b/manifest/x86_64/f/fastfetch.filelist
@@ -1,4 +1,4 @@
-# Total size: 2981326
+# Total size: 2511916
 /usr/local/bin/fastfetch
 /usr/local/bin/flashfetch
 /usr/local/share/bash-completion/completions/fastfetch
@@ -23,7 +23,11 @@
 /usr/local/share/fastfetch/presets/examples/24.jsonc
 /usr/local/share/fastfetch/presets/examples/25.jsonc
 /usr/local/share/fastfetch/presets/examples/26.jsonc
+/usr/local/share/fastfetch/presets/examples/27.jsonc
+/usr/local/share/fastfetch/presets/examples/28.jsonc
+/usr/local/share/fastfetch/presets/examples/29.jsonc
 /usr/local/share/fastfetch/presets/examples/3.jsonc
+/usr/local/share/fastfetch/presets/examples/30.jsonc
 /usr/local/share/fastfetch/presets/examples/4.jsonc
 /usr/local/share/fastfetch/presets/examples/5.jsonc
 /usr/local/share/fastfetch/presets/examples/6.jsonc

--- a/packages/fastfetch.rb
+++ b/packages/fastfetch.rb
@@ -6,7 +6,7 @@ require 'buildsystems/cmake'
 class Fastfetch < CMake
   description 'Like Neofetch, but much faster because written in C'
   homepage 'https://github.com/fastfetch-cli/fastfetch'
-  version '2.42.0'
+  version '2.56.1'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/fastfetch-cli/fastfetch.git'
@@ -14,9 +14,9 @@ class Fastfetch < CMake
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e2c6084fd2dc22ea43e2aa9ca2745b8dee94349d02bedeb35bb7e7050ad5d58d',
-     armv7l: 'e2c6084fd2dc22ea43e2aa9ca2745b8dee94349d02bedeb35bb7e7050ad5d58d',
-     x86_64: '2b05cd0d4030300b5e110f63f1466c6ac4c4a0ba1bca6be46b48325051d5a118'
+    aarch64: 'a53400daace622eb3d0248cc82841976f1fa0c59aaa8e0c7ce9e30cd665bf1ce',
+     armv7l: 'a53400daace622eb3d0248cc82841976f1fa0c59aaa8e0c7ce9e30cd665bf1ce',
+     x86_64: '869df9d3a665d335af89fbf3ded81ecb2ca0d8088ca0199ce855236f6770193e'
   })
 
   depends_on 'chafa' => :build

--- a/tests/package/f/fastfetch
+++ b/tests/package/f/fastfetch
@@ -1,0 +1,3 @@
+#!/bin/bash
+fastfetch -h | head
+fastfetch -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-fastfetch crew update \
&& yes | crew upgrade

$ crew check fastfetch 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/fastfetch.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking fastfetch package ...
Property tests for fastfetch passed.
Checking fastfetch package ...
Buildsystem test for fastfetch passed.
Checking fastfetch package ...
Library test for fastfetch passed.
Checking fastfetch package ...
Fastfetch is a neofetch-like tool for fetching system information and displaying them in a pretty way

Usage: fastfetch <?options>

Informative options:
  -h, --help <?command>: Display this help message or help for a specific command
  -v, --version: Show the full version of fastfetch
      --version-raw: Display the raw version string (major.minor.patch)
      --list-config-paths: List search paths for config files
      --list-data-paths: List search paths for presets and logos
fastfetch 2.56.1 (x86_64)
Package tests for fastfetch passed.
```