### PR TITLE
Firejail 0.9.76 => 0.9.78

### DIFF
--- a/manifest/armv7l/f/firejail.filelist
+++ b/manifest/armv7l/f/firejail.filelist
@@ -1,4 +1,4 @@
-# Total size: 2397556
+# Total size: 2525176
 /usr/local/bin/firecfg
 /usr/local/bin/firejail
 /usr/local/bin/firemon
@@ -439,6 +439,7 @@
 /usr/local/etc/firejail/ghostwriter.profile
 /usr/local/etc/firejail/gimp-2.10.profile
 /usr/local/etc/firejail/gimp-2.8.profile
+/usr/local/etc/firejail/gimp-3.0.profile
 /usr/local/etc/firejail/gimp.profile
 /usr/local/etc/firejail/gist-paste.profile
 /usr/local/etc/firejail/gist.profile
@@ -496,6 +497,7 @@
 /usr/local/etc/firejail/gnome-system-log.profile
 /usr/local/etc/firejail/gnome-taquin.profile
 /usr/local/etc/firejail/gnome-tetravex.profile
+/usr/local/etc/firejail/gnome-text-editor.profile
 /usr/local/etc/firejail/gnome-todo.profile
 /usr/local/etc/firejail/gnome-twitch.profile
 /usr/local/etc/firejail/gnome-weather.profile
@@ -544,6 +546,8 @@
 /usr/local/etc/firejail/gunzip.profile
 /usr/local/etc/firejail/guvcview.profile
 /usr/local/etc/firejail/gwenview.profile
+/usr/local/etc/firejail/gzdoom-common.profile
+/usr/local/etc/firejail/gzdoom.profile
 /usr/local/etc/firejail/gzexe.profile
 /usr/local/etc/firejail/gzip.profile
 /usr/local/etc/firejail/handbrake-gtk.profile
@@ -698,6 +702,7 @@
 /usr/local/etc/firejail/lzcat.profile
 /usr/local/etc/firejail/lzcmp.profile
 /usr/local/etc/firejail/lzdiff.profile
+/usr/local/etc/firejail/lzdoom.profile
 /usr/local/etc/firejail/lzegrep.profile
 /usr/local/etc/firejail/lzfgrep.profile
 /usr/local/etc/firejail/lzgrep.profile
@@ -809,6 +814,7 @@
 /usr/local/etc/firejail/ncdu.profile
 /usr/local/etc/firejail/ncdu2.profile
 /usr/local/etc/firejail/ncmpcpp.profile
+/usr/local/etc/firejail/ne.profile
 /usr/local/etc/firejail/nemo.profile
 /usr/local/etc/firejail/neochat.profile
 /usr/local/etc/firejail/neomutt.profile
@@ -871,6 +877,7 @@
 /usr/local/etc/firejail/openmw-launcher.profile
 /usr/local/etc/firejail/openmw.profile
 /usr/local/etc/firejail/openoffice.org.profile
+/usr/local/etc/firejail/openra.profile
 /usr/local/etc/firejail/openshot-qt.profile
 /usr/local/etc/firejail/openshot.profile
 /usr/local/etc/firejail/openstego.profile
@@ -960,6 +967,7 @@
 /usr/local/etc/firejail/qt6ct.profile
 /usr/local/etc/firejail/qtox.profile
 /usr/local/etc/firejail/quadrapassel.profile
+/usr/local/etc/firejail/quakespasm.profile
 /usr/local/etc/firejail/quassel.profile
 /usr/local/etc/firejail/quaternion.profile
 /usr/local/etc/firejail/quiterss.profile
@@ -1199,6 +1207,7 @@
 /usr/local/etc/firejail/transmission-show.profile
 /usr/local/etc/firejail/tremc.profile
 /usr/local/etc/firejail/tremulous.profile
+/usr/local/etc/firejail/trivalent.profile
 /usr/local/etc/firejail/trojita.profile
 /usr/local/etc/firejail/truecraft.profile
 /usr/local/etc/firejail/ts3client_runscript.sh.profile
@@ -1229,6 +1238,7 @@
 /usr/local/etc/firejail/utox.profile
 /usr/local/etc/firejail/uudeview.profile
 /usr/local/etc/firejail/uzbl-browser.profile
+/usr/local/etc/firejail/uzdoom.profile
 /usr/local/etc/firejail/vesktop.profile
 /usr/local/etc/firejail/viewnior.profile
 /usr/local/etc/firejail/viking.profile
@@ -1257,6 +1267,7 @@
 /usr/local/etc/firejail/warmux.profile
 /usr/local/etc/firejail/warsow.profile
 /usr/local/etc/firejail/warzone2100.profile
+/usr/local/etc/firejail/warzone2100.real.profile
 /usr/local/etc/firejail/waterfox-classic.profile
 /usr/local/etc/firejail/waterfox-current.profile
 /usr/local/etc/firejail/waterfox.profile
@@ -1369,8 +1380,8 @@
 /usr/local/etc/firejail/zulip.profile
 /usr/local/lib/firejail/etc-cleanup
 /usr/local/lib/firejail/fbuilder
+/usr/local/lib/firejail/fbwrap
 /usr/local/lib/firejail/fcopy
-/usr/local/lib/firejail/fids
 /usr/local/lib/firejail/firejail-welcome.sh
 /usr/local/lib/firejail/fix_private-bin.py
 /usr/local/lib/firejail/fj-mkdeb.py
@@ -1415,6 +1426,7 @@
 /usr/local/share/doc/firejail/COPYING
 /usr/local/share/doc/firejail/README
 /usr/local/share/doc/firejail/RELNOTES
+/usr/local/share/doc/firejail/new_syscalls.txt
 /usr/local/share/doc/firejail/profile.template
 /usr/local/share/doc/firejail/redirect_alias-profile.template
 /usr/local/share/doc/firejail/syscalls.txt

--- a/manifest/i686/f/firejail.filelist
+++ b/manifest/i686/f/firejail.filelist
@@ -1,4 +1,4 @@
-# Total size: 2414715
+# Total size: 2541430
 /usr/local/bin/firecfg
 /usr/local/bin/firejail
 /usr/local/bin/firemon
@@ -439,6 +439,7 @@
 /usr/local/etc/firejail/ghostwriter.profile
 /usr/local/etc/firejail/gimp-2.10.profile
 /usr/local/etc/firejail/gimp-2.8.profile
+/usr/local/etc/firejail/gimp-3.0.profile
 /usr/local/etc/firejail/gimp.profile
 /usr/local/etc/firejail/gist-paste.profile
 /usr/local/etc/firejail/gist.profile
@@ -496,6 +497,7 @@
 /usr/local/etc/firejail/gnome-system-log.profile
 /usr/local/etc/firejail/gnome-taquin.profile
 /usr/local/etc/firejail/gnome-tetravex.profile
+/usr/local/etc/firejail/gnome-text-editor.profile
 /usr/local/etc/firejail/gnome-todo.profile
 /usr/local/etc/firejail/gnome-twitch.profile
 /usr/local/etc/firejail/gnome-weather.profile
@@ -544,6 +546,8 @@
 /usr/local/etc/firejail/gunzip.profile
 /usr/local/etc/firejail/guvcview.profile
 /usr/local/etc/firejail/gwenview.profile
+/usr/local/etc/firejail/gzdoom-common.profile
+/usr/local/etc/firejail/gzdoom.profile
 /usr/local/etc/firejail/gzexe.profile
 /usr/local/etc/firejail/gzip.profile
 /usr/local/etc/firejail/handbrake-gtk.profile
@@ -698,6 +702,7 @@
 /usr/local/etc/firejail/lzcat.profile
 /usr/local/etc/firejail/lzcmp.profile
 /usr/local/etc/firejail/lzdiff.profile
+/usr/local/etc/firejail/lzdoom.profile
 /usr/local/etc/firejail/lzegrep.profile
 /usr/local/etc/firejail/lzfgrep.profile
 /usr/local/etc/firejail/lzgrep.profile
@@ -809,6 +814,7 @@
 /usr/local/etc/firejail/ncdu.profile
 /usr/local/etc/firejail/ncdu2.profile
 /usr/local/etc/firejail/ncmpcpp.profile
+/usr/local/etc/firejail/ne.profile
 /usr/local/etc/firejail/nemo.profile
 /usr/local/etc/firejail/neochat.profile
 /usr/local/etc/firejail/neomutt.profile
@@ -871,6 +877,7 @@
 /usr/local/etc/firejail/openmw-launcher.profile
 /usr/local/etc/firejail/openmw.profile
 /usr/local/etc/firejail/openoffice.org.profile
+/usr/local/etc/firejail/openra.profile
 /usr/local/etc/firejail/openshot-qt.profile
 /usr/local/etc/firejail/openshot.profile
 /usr/local/etc/firejail/openstego.profile
@@ -960,6 +967,7 @@
 /usr/local/etc/firejail/qt6ct.profile
 /usr/local/etc/firejail/qtox.profile
 /usr/local/etc/firejail/quadrapassel.profile
+/usr/local/etc/firejail/quakespasm.profile
 /usr/local/etc/firejail/quassel.profile
 /usr/local/etc/firejail/quaternion.profile
 /usr/local/etc/firejail/quiterss.profile
@@ -1199,6 +1207,7 @@
 /usr/local/etc/firejail/transmission-show.profile
 /usr/local/etc/firejail/tremc.profile
 /usr/local/etc/firejail/tremulous.profile
+/usr/local/etc/firejail/trivalent.profile
 /usr/local/etc/firejail/trojita.profile
 /usr/local/etc/firejail/truecraft.profile
 /usr/local/etc/firejail/ts3client_runscript.sh.profile
@@ -1229,6 +1238,7 @@
 /usr/local/etc/firejail/utox.profile
 /usr/local/etc/firejail/uudeview.profile
 /usr/local/etc/firejail/uzbl-browser.profile
+/usr/local/etc/firejail/uzdoom.profile
 /usr/local/etc/firejail/vesktop.profile
 /usr/local/etc/firejail/viewnior.profile
 /usr/local/etc/firejail/viking.profile
@@ -1257,6 +1267,7 @@
 /usr/local/etc/firejail/warmux.profile
 /usr/local/etc/firejail/warsow.profile
 /usr/local/etc/firejail/warzone2100.profile
+/usr/local/etc/firejail/warzone2100.real.profile
 /usr/local/etc/firejail/waterfox-classic.profile
 /usr/local/etc/firejail/waterfox-current.profile
 /usr/local/etc/firejail/waterfox.profile
@@ -1369,8 +1380,8 @@
 /usr/local/etc/firejail/zulip.profile
 /usr/local/lib/firejail/etc-cleanup
 /usr/local/lib/firejail/fbuilder
+/usr/local/lib/firejail/fbwrap
 /usr/local/lib/firejail/fcopy
-/usr/local/lib/firejail/fids
 /usr/local/lib/firejail/firejail-welcome.sh
 /usr/local/lib/firejail/fix_private-bin.py
 /usr/local/lib/firejail/fj-mkdeb.py
@@ -1415,6 +1426,7 @@
 /usr/local/share/doc/firejail/COPYING
 /usr/local/share/doc/firejail/README
 /usr/local/share/doc/firejail/RELNOTES
+/usr/local/share/doc/firejail/new_syscalls.txt
 /usr/local/share/doc/firejail/profile.template
 /usr/local/share/doc/firejail/redirect_alias-profile.template
 /usr/local/share/doc/firejail/syscalls.txt

--- a/manifest/x86_64/f/firejail.filelist
+++ b/manifest/x86_64/f/firejail.filelist
@@ -1,4 +1,4 @@
-# Total size: 2470260
+# Total size: 2604312
 /usr/local/bin/firecfg
 /usr/local/bin/firejail
 /usr/local/bin/firemon
@@ -439,6 +439,7 @@
 /usr/local/etc/firejail/ghostwriter.profile
 /usr/local/etc/firejail/gimp-2.10.profile
 /usr/local/etc/firejail/gimp-2.8.profile
+/usr/local/etc/firejail/gimp-3.0.profile
 /usr/local/etc/firejail/gimp.profile
 /usr/local/etc/firejail/gist-paste.profile
 /usr/local/etc/firejail/gist.profile
@@ -496,6 +497,7 @@
 /usr/local/etc/firejail/gnome-system-log.profile
 /usr/local/etc/firejail/gnome-taquin.profile
 /usr/local/etc/firejail/gnome-tetravex.profile
+/usr/local/etc/firejail/gnome-text-editor.profile
 /usr/local/etc/firejail/gnome-todo.profile
 /usr/local/etc/firejail/gnome-twitch.profile
 /usr/local/etc/firejail/gnome-weather.profile
@@ -544,6 +546,8 @@
 /usr/local/etc/firejail/gunzip.profile
 /usr/local/etc/firejail/guvcview.profile
 /usr/local/etc/firejail/gwenview.profile
+/usr/local/etc/firejail/gzdoom-common.profile
+/usr/local/etc/firejail/gzdoom.profile
 /usr/local/etc/firejail/gzexe.profile
 /usr/local/etc/firejail/gzip.profile
 /usr/local/etc/firejail/handbrake-gtk.profile
@@ -698,6 +702,7 @@
 /usr/local/etc/firejail/lzcat.profile
 /usr/local/etc/firejail/lzcmp.profile
 /usr/local/etc/firejail/lzdiff.profile
+/usr/local/etc/firejail/lzdoom.profile
 /usr/local/etc/firejail/lzegrep.profile
 /usr/local/etc/firejail/lzfgrep.profile
 /usr/local/etc/firejail/lzgrep.profile
@@ -809,6 +814,7 @@
 /usr/local/etc/firejail/ncdu.profile
 /usr/local/etc/firejail/ncdu2.profile
 /usr/local/etc/firejail/ncmpcpp.profile
+/usr/local/etc/firejail/ne.profile
 /usr/local/etc/firejail/nemo.profile
 /usr/local/etc/firejail/neochat.profile
 /usr/local/etc/firejail/neomutt.profile
@@ -871,6 +877,7 @@
 /usr/local/etc/firejail/openmw-launcher.profile
 /usr/local/etc/firejail/openmw.profile
 /usr/local/etc/firejail/openoffice.org.profile
+/usr/local/etc/firejail/openra.profile
 /usr/local/etc/firejail/openshot-qt.profile
 /usr/local/etc/firejail/openshot.profile
 /usr/local/etc/firejail/openstego.profile
@@ -960,6 +967,7 @@
 /usr/local/etc/firejail/qt6ct.profile
 /usr/local/etc/firejail/qtox.profile
 /usr/local/etc/firejail/quadrapassel.profile
+/usr/local/etc/firejail/quakespasm.profile
 /usr/local/etc/firejail/quassel.profile
 /usr/local/etc/firejail/quaternion.profile
 /usr/local/etc/firejail/quiterss.profile
@@ -1199,6 +1207,7 @@
 /usr/local/etc/firejail/transmission-show.profile
 /usr/local/etc/firejail/tremc.profile
 /usr/local/etc/firejail/tremulous.profile
+/usr/local/etc/firejail/trivalent.profile
 /usr/local/etc/firejail/trojita.profile
 /usr/local/etc/firejail/truecraft.profile
 /usr/local/etc/firejail/ts3client_runscript.sh.profile
@@ -1229,6 +1238,7 @@
 /usr/local/etc/firejail/utox.profile
 /usr/local/etc/firejail/uudeview.profile
 /usr/local/etc/firejail/uzbl-browser.profile
+/usr/local/etc/firejail/uzdoom.profile
 /usr/local/etc/firejail/vesktop.profile
 /usr/local/etc/firejail/viewnior.profile
 /usr/local/etc/firejail/viking.profile
@@ -1257,6 +1267,7 @@
 /usr/local/etc/firejail/warmux.profile
 /usr/local/etc/firejail/warsow.profile
 /usr/local/etc/firejail/warzone2100.profile
+/usr/local/etc/firejail/warzone2100.real.profile
 /usr/local/etc/firejail/waterfox-classic.profile
 /usr/local/etc/firejail/waterfox-current.profile
 /usr/local/etc/firejail/waterfox.profile
@@ -1369,8 +1380,8 @@
 /usr/local/etc/firejail/zulip.profile
 /usr/local/lib64/firejail/etc-cleanup
 /usr/local/lib64/firejail/fbuilder
+/usr/local/lib64/firejail/fbwrap
 /usr/local/lib64/firejail/fcopy
-/usr/local/lib64/firejail/fids
 /usr/local/lib64/firejail/firejail-welcome.sh
 /usr/local/lib64/firejail/fix_private-bin.py
 /usr/local/lib64/firejail/fj-mkdeb.py
@@ -1415,6 +1426,7 @@
 /usr/local/share/doc/firejail/COPYING
 /usr/local/share/doc/firejail/README
 /usr/local/share/doc/firejail/RELNOTES
+/usr/local/share/doc/firejail/new_syscalls.txt
 /usr/local/share/doc/firejail/profile.template
 /usr/local/share/doc/firejail/redirect_alias-profile.template
 /usr/local/share/doc/firejail/syscalls.txt

--- a/packages/firejail.rb
+++ b/packages/firejail.rb
@@ -4,7 +4,7 @@ class Firejail < Autotools
   description 'Firejail is a SUID program that reduces the risk of security breaches by restricting the running environment of untrusted applications
   by using Linux namespaces and seccomp-bpf.'
   homepage 'https://firejail.wordpress.com'
-  version '0.9.76'
+  version '0.9.78'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/netblue30/firejail.git'
@@ -12,10 +12,10 @@ class Firejail < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'bff33bf236831eb1ca5c0ba2064733cca9c422811ebbea36f082ebcaca0df080',
-     armv7l: 'bff33bf236831eb1ca5c0ba2064733cca9c422811ebbea36f082ebcaca0df080',
-       i686: 'f5873641f744bc3177d4df5cad0bf34d86ad96c74e47eb3792506f216880b915',
-     x86_64: '9e100ef06b2fdda9994c6c134b2dd3a2b21e0ea5699bb278ee986903d8db6f35'
+    aarch64: '31b144e9c5bd0a2595c8f00743fbc52304d428d10f9025f1653d7584d92ddb69',
+     armv7l: '31b144e9c5bd0a2595c8f00743fbc52304d428d10f9025f1653d7584d92ddb69',
+       i686: '4cc0204abcc35d160c87aa5e6184ad2d9981ead98003ff0cb1e0027e80ccc32f',
+     x86_64: '3894ac400e6f178405b03de5af04876ef73986fbe36b68e3bb0996e98ece6e43'
   })
 
   depends_on 'glibc' # R

--- a/tests/package/f/firejail
+++ b/tests/package/f/firejail
@@ -1,0 +1,2 @@
+#!/bin/bash
+for b in $(crew files firejail | grep /usr/local/bin); do $b --version; done


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-firejail crew update \
&& yes | crew upgrade

$ crew check firejail
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/firejail.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking firejail package ...
Property tests for firejail passed.
Checking firejail package ...
Buildsystem test for firejail passed.
Checking firejail package ...
Library test for firejail passed.
Checking firejail package ...
firecfg version 0.9.78

firejail version 0.9.78

Compile time support:
	- always force nonewprivs support is disabled
	- AppArmor support is disabled
	- AppImage support is enabled
	- chroot support is enabled
	- D-BUS proxy support is enabled
	- file transfer support is enabled
	- Landlock support is enabled
	- networking support is enabled
	- output logging is enabled
	- private-home support is enabled
	- private-lib support is disabled
	- private-cache and tmpfs as user enabled
	- sandbox check is enabled
	- SELinux support is disabled
	- user namespace support is enabled
	- X11 sandboxing support is enabled

firemon version 0.9.78

jailcheck version 0.9.78

Package tests for firejail passed.
```