### PR TITLE
Exo 4.19.0 => 4.20.0

### DIFF
--- a/manifest/armv7l/e/exo.filelist
+++ b/manifest/armv7l/e/exo.filelist
@@ -1,4 +1,4 @@
-# Total size: 2229753
+# Total size: 2310630
 /usr/local/bin/exo-desktop-item-edit
 /usr/local/bin/exo-open
 /usr/local/include/exo-2/exo/exo-binding.h
@@ -122,6 +122,7 @@
 /usr/local/share/locale/uk/LC_MESSAGES/exo.mo
 /usr/local/share/locale/ur/LC_MESSAGES/exo.mo
 /usr/local/share/locale/ur_PK/LC_MESSAGES/exo.mo
+/usr/local/share/locale/uz/LC_MESSAGES/exo.mo
 /usr/local/share/locale/vi/LC_MESSAGES/exo.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/exo.mo
 /usr/local/share/locale/zh_HK/LC_MESSAGES/exo.mo

--- a/manifest/x86_64/e/exo.filelist
+++ b/manifest/x86_64/e/exo.filelist
@@ -1,4 +1,4 @@
-# Total size: 2290761
+# Total size: 2357622
 /usr/local/bin/exo-desktop-item-edit
 /usr/local/bin/exo-open
 /usr/local/include/exo-2/exo/exo-binding.h
@@ -122,6 +122,7 @@
 /usr/local/share/locale/uk/LC_MESSAGES/exo.mo
 /usr/local/share/locale/ur/LC_MESSAGES/exo.mo
 /usr/local/share/locale/ur_PK/LC_MESSAGES/exo.mo
+/usr/local/share/locale/uz/LC_MESSAGES/exo.mo
 /usr/local/share/locale/vi/LC_MESSAGES/exo.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/exo.mo
 /usr/local/share/locale/zh_HK/LC_MESSAGES/exo.mo

--- a/packages/exo.rb
+++ b/packages/exo.rb
@@ -3,22 +3,36 @@ require 'buildsystems/autotools'
 class Exo < Autotools
   description 'Extension library for the Xfce desktop environment'
   homepage 'https://xfce.org/'
-  version '4.19.0'
+  version '4.20.0'
   license 'Apache-2.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://archive.xfce.org/src/xfce/exo/#{version.rpartition('.')[0]}/exo-#{version}.tar.bz2"
-  source_sha256 'a0124108c197efcc576a6deeface381416dc7137b6a7e7dfa3060fad62509fb7'
+  source_sha256 '4277f799245f1efde01cd917fd538ba6b12cf91c9f8a73fe2035fd5456ec078d'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '89e5a94b33a630e03eeb5d9e748f71b9ee27001b7b749b2cc765b441ff48f999',
-     armv7l: '89e5a94b33a630e03eeb5d9e748f71b9ee27001b7b749b2cc765b441ff48f999',
-     x86_64: '4aa61da36edd80c5d36e94c34b610b9dcd41747acfca85d6834041c84eb04c9b'
+    aarch64: '29c6db515960f02636859f30c0cd983d90bae54239be751edad658eae5eb56cf',
+     armv7l: '29c6db515960f02636859f30c0cd983d90bae54239be751edad658eae5eb56cf',
+     x86_64: '2c61c320e8c783cabdd17ea803e1d0e6e4317df5a03120073fd717eaf04c7b59'
   })
 
-  depends_on 'libxfce4ui'
-  depends_on 'xfce4_dev_tools'
+  depends_on 'at_spi2_core' # R
+  depends_on 'cairo' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
+  depends_on 'glibc' # R
+  depends_on 'gtk3' # R
+  depends_on 'harfbuzz' # R
+  depends_on 'libxfce4ui' # R
+  depends_on 'libxfce4util' # R
+  depends_on 'pango' # R
   depends_on 'valgrind' => :build
+  depends_on 'xfce4_dev_tools' # R
+  depends_on 'zlib' # R
+
+  def self.prebuild
+    ConvenienceFunctions.libtoolize('glib-2.0', 'glib')
+  end
 
   run_tests
 end

--- a/tests/package/e/exo
+++ b/tests/package/e/exo
@@ -1,0 +1,3 @@
+#!/bin/bash
+exo-desktop-item-edit --version 2>&1
+exo-open --version 2>&1

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -35,6 +35,7 @@ enchant
 enet
 epiphany
 evince
+exo
 f2fs_tools
 faad2
 fastfetch


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-exo crew update \
&& yes | crew upgrade

$ crew check exo
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/exo.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking exo package ...
Property tests for exo passed.
Checking exo package ...
Buildsystem test for exo passed.
Checking exo package ...
Library test for exo passed.
Checking exo package ...
exo-desktop-item-edit: /usr/local/lib64/libuuid.so.1: no version information available (required by /usr/local/lib64/libSM.so.6)

(exo-desktop-item-edit:35041): dbind-WARNING **: 23:53:40.126: Couldn't connect to accessibility bus: Failed to connect to socket /run/user/1000/at-spi/bus_0: No such file or directory
exo-desktop-item-edit 4.20.0

Copyright (c) 2005-2007
	os-cillation e.K. All rights reserved.

Copyright (c) 2008-2024
	The Xfce development team. All rights reserved.

Written by Benedikt Meurer <benny@xfce.org>.

exo-desktop-item-edit comes with ABSOLUTELY NO WARRANTY,
You may redistribute copies of exo-desktop-item-edit under the terms of
the GNU Lesser General Public License which can be found in the
exo source package.

Please report bugs to <https://gitlab.xfce.org/xfce/exo>.

(exo-open:35043): dbind-WARNING **: 23:53:40.137: Couldn't connect to accessibility bus: Failed to connect to socket /run/user/1000/at-spi/bus_0: No such file or directory
exo-open 4.20.0

Copyright (c) 2005-2007
	os-cillation e.K. All rights reserved.

Copyright (c) 2009-2024
	The Xfce development team. All rights reserved.

Written by Benedikt Meurer <benny@xfce.org>.

exo-open comes with ABSOLUTELY NO WARRANTY,
You may redistribute copies of exo-open under the terms of
the GNU Lesser General Public License which can be found in the
exo source package.

Please report bugs to <https://gitlab.xfce.org/xfce/exo>.
Package tests for exo passed.
```