### PR TITLE
Add ruby/setup-ruby@v1 to Generate-PR workflow.

### DIFF
--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -453,6 +453,9 @@ jobs:
             else
               echo "No Changed Files."
             fi
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0.0'
       - name: Create Pull Request
         env:
           CHANGED_GITHUB_CONFIG_FILES: ${{ steps.changed-files.outputs.github_all_changed_files }}


### PR DESCRIPTION
- This might be why the Generated PRs have the wrong ruby version suffixes in them.