### PR TITLE
Exfatprogs 1.3.0 => 1.3.1

### DIFF
--- a/manifest/armv7l/e/exfatprogs.filelist
+++ b/manifest/armv7l/e/exfatprogs.filelist
@@ -1,12 +1,10 @@
-# Total size: 249399
-/usr/local/sbin/defrag.exfat
+# Total size: 215661
 /usr/local/sbin/dump.exfat
 /usr/local/sbin/exfat2img
 /usr/local/sbin/exfatlabel
 /usr/local/sbin/fsck.exfat
 /usr/local/sbin/mkfs.exfat
 /usr/local/sbin/tune.exfat
-/usr/local/share/man/man8/defrag.exfat.8.zst
 /usr/local/share/man/man8/dump.exfat.8.zst
 /usr/local/share/man/man8/exfat2img.8.zst
 /usr/local/share/man/man8/exfatlabel.8.zst

--- a/manifest/i686/e/exfatprogs.filelist
+++ b/manifest/i686/e/exfatprogs.filelist
@@ -1,12 +1,10 @@
-# Total size: 276751
-/usr/local/sbin/defrag.exfat
+# Total size: 237361
 /usr/local/sbin/dump.exfat
 /usr/local/sbin/exfat2img
 /usr/local/sbin/exfatlabel
 /usr/local/sbin/fsck.exfat
 /usr/local/sbin/mkfs.exfat
 /usr/local/sbin/tune.exfat
-/usr/local/share/man/man8/defrag.exfat.8.zst
 /usr/local/share/man/man8/dump.exfat.8.zst
 /usr/local/share/man/man8/exfat2img.8.zst
 /usr/local/share/man/man8/exfatlabel.8.zst

--- a/manifest/x86_64/e/exfatprogs.filelist
+++ b/manifest/x86_64/e/exfatprogs.filelist
@@ -1,12 +1,10 @@
-# Total size: 245907
-/usr/local/sbin/defrag.exfat
+# Total size: 210237
 /usr/local/sbin/dump.exfat
 /usr/local/sbin/exfat2img
 /usr/local/sbin/exfatlabel
 /usr/local/sbin/fsck.exfat
 /usr/local/sbin/mkfs.exfat
 /usr/local/sbin/tune.exfat
-/usr/local/share/man/man8/defrag.exfat.8.zst
 /usr/local/share/man/man8/dump.exfat.8.zst
 /usr/local/share/man/man8/exfat2img.8.zst
 /usr/local/share/man/man8/exfatlabel.8.zst

--- a/packages/exfatprogs.rb
+++ b/packages/exfatprogs.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Exfatprogs < Autotools
   description 'exFAT filesystem userspace utilities for the Linux Kernel exfat driver.'
   homepage 'https://github.com/exfatprogs/exfatprogs'
-  version '1.3.0'
+  version '1.3.1'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/exfatprogs/exfatprogs.git'
@@ -11,10 +11,10 @@ class Exfatprogs < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '353b01f8d423aa4580e5ec6f5ea56664c91a3ede89125686866b256f4e0d3013',
-     armv7l: '353b01f8d423aa4580e5ec6f5ea56664c91a3ede89125686866b256f4e0d3013',
-       i686: 'b8386e36d404726675ca078f71cb308a3be271d391c438086c09704c5efe4c82',
-     x86_64: 'b5b0df3a389481dbec05bad847970979f45ee9275d6bbb3ba864276c3a5084f4'
+    aarch64: 'd8f7504081e2f18f00bfddc3420b1de84d189628994e61847840c76b76698fbe',
+     armv7l: 'd8f7504081e2f18f00bfddc3420b1de84d189628994e61847840c76b76698fbe',
+       i686: 'cd409f831c754d9f6dedd9736a5df6bf9db317f678447dd136c21207208fcdb3',
+     x86_64: 'c2b37dbe978808a8b0d12f9392c13e4f72c76a1141ca6d9d0b4324e5f2c89be3'
   })
 
   depends_on 'glibc' # R

--- a/tests/package/e/exfatprogs
+++ b/tests/package/e/exfatprogs
@@ -1,0 +1,2 @@
+#!/bin/bash
+for b in $(crew files exfatprogs | grep /usr/local/sbin); do $b -V 2>&1; done

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -35,6 +35,7 @@ enchant
 enet
 epiphany
 evince
+exfatprogs
 exo
 extra_cmake_modules
 f2fs_tools


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-exfatprogs crew update \
&& yes | crew upgrade

$ crew check exfatprogs 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/exfatprogs.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking exfatprogs package ...
Property tests for exfatprogs passed.
Checking exfatprogs package ...
Buildsystem test for exfatprogs passed.
Checking exfatprogs package ...
Library test for exfatprogs passed.
Checking exfatprogs package ...
exfatprogs version : 1.3.1
exfatprogs version : 1.3.1
exfatprogs version : 1.3.1
Usage: /usr/local/sbin/fsck.exfat
	-r | --repair        Repair interactively
	-y | --repair-yes    Repair without ask
	-n | --repair-no     No repair
	-p | --repair-auto   Repair automatically
	-a                   Repair automatically
	-b | --ignore-bad-fs Try to recover even if exfat is not found
	-s | --rescue        Assign orphaned clusters to files
	-V | --version       Show version
	-v | --verbose       Print debug
	-h | --help          Show help
exfatprogs version : 1.3.1
exfatprogs version : 1.3.1
exfatprogs version : 1.3.1
Package tests for exfatprogs passed.
```