### PR TITLE
Act 0.2.83 => 0.2.84

### DIFF
--- a/manifest/armv7l/a/act.filelist
+++ b/manifest/armv7l/a/act.filelist
@@ -1,2 +1,2 @@
-# Total size: 19202232
+# Total size: 19267768
 /usr/local/bin/act

--- a/manifest/i686/a/act.filelist
+++ b/manifest/i686/a/act.filelist
@@ -1,2 +1,2 @@
-# Total size: 19218616
+# Total size: 19263672
 /usr/local/bin/act

--- a/manifest/x86_64/a/act.filelist
+++ b/manifest/x86_64/a/act.filelist
@@ -1,2 +1,2 @@
-# Total size: 20340920
+# Total size: 20390072
 /usr/local/bin/act

--- a/packages/act.rb
+++ b/packages/act.rb
@@ -3,7 +3,7 @@ require 'package'
 class Act < Package
   description 'Run your GitHub Actions locally'
   homepage 'https://github.com/nektos/act'
-  version '0.2.83'
+  version '0.2.84'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Act < Package
      x86_64: "https://github.com/nektos/act/releases/download/v#{version}/act_Linux_x86_64.tar.gz"
   })
   source_sha256({
-    aarch64: 'f25ab2e2285ad049b285465e82c76549839e7729f43cda6a317e70b48cbf387f',
-     armv7l: 'f25ab2e2285ad049b285465e82c76549839e7729f43cda6a317e70b48cbf387f',
-       i686: '0f1b3f9b41c8a37310925fb162a1234fbfdc465a3302eb2bfc3de63657fa28dd',
-     x86_64: 'ed37d29fc117b3075cf586bb9323ec6c16320a5a3c5c0df9f1859d271d303f0d'
+    aarch64: '6d4a5886b76fe030ac0fbf3d69f4ff8d06f8d6cd0dc4ea8d02edb459ede301a4',
+     armv7l: '6d4a5886b76fe030ac0fbf3d69f4ff8d06f8d6cd0dc4ea8d02edb459ede301a4',
+       i686: '979350138ee837892de07108fca73638da5be0e0fbbe6f089e42c44d417f2140',
+     x86_64: '19d4525fb0d80ff50bd3252d3fa47ee1265a331fe4c39249ac65347e527e16e2'
   })
 
   no_compile_needed

--- a/tests/package/a/act
+++ b/tests/package/a/act
@@ -1,0 +1,2 @@
+#!/bin/bash
+act --version

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -1,6 +1,7 @@
 acl
 acpi
 acpica
+act
 aliyun_cli
 alsa_lib
 alsa_plugins


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-act crew update \
&& yes | crew upgrade

$ crew check act 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/act.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking act package ...
Property tests for act passed.
Checking act package ...
Buildsystem test for act passed.
Checking act package ...
Library test for act passed.
Checking act package ...
act version 0.2.84
Package tests for act passed.
```