### PR TITLE
Caprine 2.60.3 => 2.61.0

### DIFF
--- a/manifest/x86_64/c/caprine.filelist
+++ b/manifest/x86_64/c/caprine.filelist
@@ -1,3 +1,4 @@
+# Total size: 297963888
 /usr/local/bin/caprine
 /usr/local/share/applications/caprine.desktop
 /usr/local/share/caprine/AppRun

--- a/packages/caprine.rb
+++ b/packages/caprine.rb
@@ -3,11 +3,11 @@ require 'package'
 class Caprine < Package
   description 'An elegant Facebook Messenger desktop app'
   homepage 'https://sindresorhus.com/caprine/'
-  version '2.60.3'
+  version '2.61.0'
   license 'MIT'
   compatibility 'x86_64'
   source_url "https://github.com/sindresorhus/caprine/releases/download/v#{version}/Caprine-#{version}.AppImage"
-  source_sha256 '3fc8f57fcff84638d81679846ee9241091f71e914be7657787218f96985a73ce'
+  source_sha256 '1372b67a2de8fd9c9d3f0178557c3ac67add86f270d6b4c3073b06d38751980b'
 
   depends_on 'gtk3'
   depends_on 'sommelier'

--- a/tests/package/c/caprine
+++ b/tests/package/c/caprine
@@ -1,0 +1,2 @@
+#!/bin/bash
+caprine

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -23,6 +23,7 @@ bind
 bison
 bitmap
 bmon
+caprine
 cargo_c
 codex
 dart


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-caprine crew update \
&& yes | crew upgrade
```