### PR TITLE
Google_chrome 143.0.7499.146-1 => 143.0.7499.192-1

### DIFF
--- a/manifest/x86_64/g/google_chrome.filelist
+++ b/manifest/x86_64/g/google_chrome.filelist
@@ -1,4 +1,4 @@
-# Total size: 391356415
+# Total size: 391544649
 /usr/local/bin/google-chrome
 /usr/local/share/appdata/google-chrome.appdata.xml
 /usr/local/share/applications/com.google.Chrome.desktop

--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -3,12 +3,12 @@ require 'package'
 class Google_chrome < Package
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '143.0.7499.146-1'
+  version '143.0.7499.192-1'
   license 'google-chrome'
   compatibility 'x86_64'
 
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_#{version}_amd64.deb"
-  source_sha256 '1a110f0e8968aa59c4619fe569569074da25c675bd0c1571d84b5ef4c8f41834'
+  source_sha256 '6484c286dc8089f0eb41d124b96e3ef4c4cb0ff289dc0f8698e1f1b851fbc834'
 
   no_compile_needed
   no_shrink

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -84,6 +84,7 @@ freerdp
 freetds
 fribidi
 gambit
+google_chrome
 libcdr
 libvisio
 libxfce4ui


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade

$ crew check google_chrome 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/google_chrome.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking google_chrome package ...
Property tests for google_chrome passed.
Checking google_chrome package ...
Buildsystem test for google_chrome passed.
Checking google_chrome package ...
Library test for google_chrome passed.
Checking google_chrome package ...
Google Chrome 143.0.7499.192 
Package tests for google_chrome passed.
```