### PR TITLE
Vivaldi 7.7.3851.66-1 => 7.7.3851.67-1

### DIFF
--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -1,4 +1,4 @@
-# Total size: 436921000
+# Total size: 436925686
 /usr/local/bin/vivaldi
 /usr/local/bin/vivaldi-stable
 /usr/local/etc/cron.daily/vivaldi
@@ -444,7 +444,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-1b706cd0189c526deabe85aeef4da297.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-0fe36b1b818f562085b49c433b0a1d84.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -5,7 +5,7 @@ class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
   # The project stopped supporting armv7l after the 7.5 release.
-  version ARCH.eql?('x86_64') ? '7.7.3851.66-1' : '7.5.3735.74-1'
+  version ARCH.eql?('x86_64') ? '7.7.3851.67-1' : '7.5.3735.74-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -28,7 +28,7 @@ class Vivaldi < Package
     source_sha256 '9017e6327c140ad9a9e1f0ce450681a729a15ea764337c30226f51c042ff7e62'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 '9150f46957e1a8cd5984587255c67ab5e17748cd8695e63805db115ddc6ed6be'
+    source_sha256 '6ef739415b7e41c6b0f596b7e92e93ba07d72c08fbe5bbbc17bda74ba174a6f1'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -93,6 +93,7 @@ opencode
 rqlite
 sphinx
 usql
+vivaldi
 vscodium
 xdpyinfo
 yyjson


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade

$ crew check vivaldi 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/vivaldi.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking vivaldi package ...
Property tests for vivaldi passed.
Checking vivaldi package ...
Buildsystem test for vivaldi passed.
Checking vivaldi package ...
Library test for vivaldi passed.
Checking vivaldi package ...
Vivaldi 7.7.3851.67 stable
Package tests for vivaldi passed.
```