### PR TITLE
Php82 8.2.29 => 8.2.30

### DIFF
--- a/manifest/armv7l/p/php82.filelist
+++ b/manifest/armv7l/p/php82.filelist
@@ -1,4 +1,4 @@
-# Total size: 82805412
+# Total size: 82980271
 /usr/local/bin/pear
 /usr/local/bin/peardev
 /usr/local/bin/pecl
@@ -369,10 +369,22 @@
 /usr/local/lib/build/shtool
 /usr/local/lib/extensions/no-debug-non-zts-20220829/dba.so
 /usr/local/lib/extensions/no-debug-non-zts-20220829/opcache.so
+/usr/local/lib/php/.channels/.alias/pear.txt
+/usr/local/lib/php/.channels/.alias/pecl.txt
+/usr/local/lib/php/.channels/.alias/phpdocs.txt
+/usr/local/lib/php/.channels/__uri.reg
+/usr/local/lib/php/.channels/doc.php.net.reg
+/usr/local/lib/php/.channels/pear.php.net.reg
+/usr/local/lib/php/.channels/pecl.php.net.reg
 /usr/local/lib/php/.depdb
 /usr/local/lib/php/.depdblock
 /usr/local/lib/php/.filemap
 /usr/local/lib/php/.lock
+/usr/local/lib/php/.registry/archive_tar.reg
+/usr/local/lib/php/.registry/console_getopt.reg
+/usr/local/lib/php/.registry/pear.reg
+/usr/local/lib/php/.registry/structures_graph.reg
+/usr/local/lib/php/.registry/xml_util.reg
 /usr/local/lib/php/Archive/Tar.php
 /usr/local/lib/php/Console/Getopt.php
 /usr/local/lib/php/OS/Guess.php

--- a/manifest/x86_64/p/php82.filelist
+++ b/manifest/x86_64/p/php82.filelist
@@ -1,4 +1,4 @@
-# Total size: 90460253
+# Total size: 90639853
 /usr/local/bin/pear
 /usr/local/bin/peardev
 /usr/local/bin/pecl
@@ -369,10 +369,22 @@
 /usr/local/lib64/build/shtool
 /usr/local/lib64/extensions/no-debug-non-zts-20220829/dba.so
 /usr/local/lib64/extensions/no-debug-non-zts-20220829/opcache.so
+/usr/local/lib64/php/.channels/.alias/pear.txt
+/usr/local/lib64/php/.channels/.alias/pecl.txt
+/usr/local/lib64/php/.channels/.alias/phpdocs.txt
+/usr/local/lib64/php/.channels/__uri.reg
+/usr/local/lib64/php/.channels/doc.php.net.reg
+/usr/local/lib64/php/.channels/pear.php.net.reg
+/usr/local/lib64/php/.channels/pecl.php.net.reg
 /usr/local/lib64/php/.depdb
 /usr/local/lib64/php/.depdblock
 /usr/local/lib64/php/.filemap
 /usr/local/lib64/php/.lock
+/usr/local/lib64/php/.registry/archive_tar.reg
+/usr/local/lib64/php/.registry/console_getopt.reg
+/usr/local/lib64/php/.registry/pear.reg
+/usr/local/lib64/php/.registry/structures_graph.reg
+/usr/local/lib64/php/.registry/xml_util.reg
 /usr/local/lib64/php/Archive/Tar.php
 /usr/local/lib64/php/Console/Getopt.php
 /usr/local/lib64/php/OS/Guess.php

--- a/packages/php82.rb
+++ b/packages/php82.rb
@@ -3,21 +3,21 @@ require 'package'
 class Php82 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'https://www.php.net/'
-  version '8.2.29'
+  version '8.2.30'
   license 'PHP-3.01'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://www.php.net/distributions/php-#{version}.tar.xz"
-  source_sha256 '475f991afd2d5b901fb410be407d929bc00c46285d3f439a02c59e8b6fe3589c'
+  source_sha256 'bc90523e17af4db46157e75d0c9ef0b9d0030b0514e62c26ba7b513b8c4eb015'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'ad7b0b63ad9e987a9e096b623406044e50e37d238ae2402411b979338ad10540',
-     armv7l: 'ad7b0b63ad9e987a9e096b623406044e50e37d238ae2402411b979338ad10540',
-     x86_64: '6d58d8f67ac65cb073f32a4382578b156c9046ce41fdbbd767e1392873496959'
+    aarch64: '639c5dd59218e2b1f400c2c1416eda6d0e6907c569fbd471986c4863c9270015',
+     armv7l: '639c5dd59218e2b1f400c2c1416eda6d0e6907c569fbd471986c4863c9270015',
+     x86_64: '5de61d89f6627c0b1e16c72127af514281521fbc9e0cb40c8ca202678e2044b0'
   })
 
-  depends_on 'aspell_en' => :build
   depends_on 'aspell' # R
+  depends_on 'aspell_en' => :build
   depends_on 'brotli' # R
   depends_on 'bzip2' # R
   depends_on 'c_ares' # R
@@ -37,6 +37,8 @@ class Php82 < Package
   depends_on 'libidn2' # R
   depends_on 'libjpeg_turbo' # R
   depends_on 'libnghttp2' # R
+  depends_on 'libnghttp3' # R
+  depends_on 'libngtcp2' # R
   depends_on 'libpng' # R
   depends_on 'libpsl' # R
   depends_on 'libsodium' # R

--- a/tests/package/p/php82
+++ b/tests/package/p/php82
@@ -1,0 +1,3 @@
+#!/bin/bash
+php -h | head
+php -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-php82 crew update \
&& yes | crew upgrade

$ crew check php82 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/php82.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking php82 package ...
Property tests for php82 passed.
Checking php82 package ...
Buildsystem test for php82 passed.
Checking php82 package ...
Library test for php82 passed.
Checking php82 package ...
Usage: php [options] [-f] <file> [--] [args...]
   php [options] -r <code> [--] [args...]
   php [options] [-B <begin_code>] -R <code> [-E <end_code>] [--] [args...]
   php [options] [-B <begin_code>] -F <file> [-E <end_code>] [--] [args...]
   php [options] -S <addr>:<port> [-t docroot] [router]
   php [options] -- [args...]
   php [options] -a

  -a               Run as interactive shell (requires readline extension)
  -c <path>|<file> Look for php.ini file in this directory
PHP 8.2.30 (cli) (built: Jan  7 2026 10:17:28) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.30, Copyright (c) Zend Technologies
Package tests for php82 passed.
```