### PR TITLE
Php83 8.3.28-1 => 8.3.29

### DIFF
--- a/manifest/armv7l/p/php83.filelist
+++ b/manifest/armv7l/p/php83.filelist
@@ -1,4 +1,4 @@
-# Total size: 87639833
+# Total size: 87650837
 /usr/local/bin/pear
 /usr/local/bin/peardev
 /usr/local/bin/pecl

--- a/manifest/x86_64/p/php83.filelist
+++ b/manifest/x86_64/p/php83.filelist
@@ -1,4 +1,4 @@
-# Total size: 95264796
+# Total size: 95274331
 /usr/local/bin/pear
 /usr/local/bin/peardev
 /usr/local/bin/pecl

--- a/packages/php83.rb
+++ b/packages/php83.rb
@@ -3,17 +3,17 @@ require 'package'
 class Php83 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'https://www.php.net/'
-  version '8.3.28-1'
+  version '8.3.29'
   license 'PHP-3.01'
   compatibility 'aarch64 armv7l x86_64'
-  source_url "https://www.php.net/distributions/php-#{version.split('-').first}.tar.xz"
+  source_url "https://www.php.net/distributions/php-#{version}.tar.xz"
   source_sha256 '25e3860f30198a386242891c0bf9e2955931f7b666b96c3e3103d36a2a322326'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1f3bffdbeff97dc0cdbcedc007db65272d583e012106fe9fd2581027fe7c1b8a',
-     armv7l: '1f3bffdbeff97dc0cdbcedc007db65272d583e012106fe9fd2581027fe7c1b8a',
-     x86_64: '8f735b1cfd7837d3b3b87f590fd8a4c31076c89bab3501f1819dcbf942483577'
+    aarch64: 'a6019251691b872cc827632760087158599546e5a4ffc60c51657199b3d1284f',
+     armv7l: 'a6019251691b872cc827632760087158599546e5a4ffc60c51657199b3d1284f',
+     x86_64: '87b5ff84593b7209b55cfbb512b673c4f4fe4c2e413dbfb6d4984a553e34c9dc'
   })
 
   depends_on 'aspell' # R

--- a/tests/package/p/php83
+++ b/tests/package/p/php83
@@ -1,0 +1,3 @@
+#!/bin/bash
+php -h | head
+php -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-php83 crew update \
&& yes | crew upgrade

$ crew check php83
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/php83.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking php83 package ...
Property tests for php83 passed.
Checking php83 package ...
Buildsystem test for php83 passed.
Checking php83 package ...
Library test for php83 passed.
Checking php83 package ...
Usage: php [options] [-f] <file> [--] [args...]
   php [options] -r <code> [--] [args...]
   php [options] [-B <begin_code>] -R <code> [-E <end_code>] [--] [args...]
   php [options] [-B <begin_code>] -F <file> [-E <end_code>] [--] [args...]
   php [options] -S <addr>:<port> [-t docroot] [router]
   php [options] -- [args...]
   php [options] -a

  -a               Run as interactive shell (requires readline extension)
  -c <path>|<file> Look for php.ini file in this directory
PHP 8.3.29 (cli) (built: Jan  7 2026 10:20:28) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.3.29, Copyright (c) Zend Technologies
Package tests for php83 passed.
```