### PR TITLE
Php84 8.4.15 => 8.4.16

### DIFF
--- a/manifest/armv7l/p/php84.filelist
+++ b/manifest/armv7l/p/php84.filelist
@@ -1,4 +1,4 @@
-# Total size: 98652298
+# Total size: 98662130
 /usr/local/bin/pear
 /usr/local/bin/peardev
 /usr/local/bin/pecl

--- a/manifest/x86_64/p/php84.filelist
+++ b/manifest/x86_64/p/php84.filelist
@@ -1,4 +1,4 @@
-# Total size: 108100563
+# Total size: 108102566
 /usr/local/bin/pear
 /usr/local/bin/peardev
 /usr/local/bin/pecl

--- a/packages/php84.rb
+++ b/packages/php84.rb
@@ -3,7 +3,7 @@ require 'package'
 class Php84 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'https://www.php.net/'
-  version '8.4.15'
+  version '8.4.16'
   license 'PHP-3.01'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://www.php.net/distributions/php-#{version}.tar.xz"
@@ -11,9 +11,9 @@ class Php84 < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f6098d38c69fd32c0cc841f2183b37d5a07750f64d1a0985e37215f1df5d89e2',
-     armv7l: 'f6098d38c69fd32c0cc841f2183b37d5a07750f64d1a0985e37215f1df5d89e2',
-     x86_64: '3dbbedc64c100a30b876c0d038f9e6f60a9707037e48805abf9b5db355784c2a'
+    aarch64: '8e2797c4e06c1849edb715f166d4a32e15416c4a36fc962ddf7ddb8b4611bc68',
+     armv7l: '8e2797c4e06c1849edb715f166d4a32e15416c4a36fc962ddf7ddb8b4611bc68',
+     x86_64: '7bb3185ab336a31784b547f1e3fc0209e4571340481d6796a7d150895b435e8c'
   })
 
   depends_on 'aspell_en' => :build

--- a/tests/package/p/php84
+++ b/tests/package/p/php84
@@ -1,0 +1,3 @@
+#!/bin/bash
+php -h | head
+php -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-php84 crew update \
&& yes | crew upgrade

$ crew check php84
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/php84.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking php84 package ...
Property tests for php84 passed.
Checking php84 package ...
Buildsystem test for php84 passed.
Checking php84 package ...
Library test for php84 passed.
Checking php84 package ...
Usage: php [options] [-f] <file> [--] [args...]
   php [options] -r <code> [--] [args...]
   php [options] [-B <begin_code>] -R <code> [-E <end_code>] [--] [args...]
   php [options] [-B <begin_code>] -F <file> [-E <end_code>] [--] [args...]
   php [options] -S <addr>:<port> [-t docroot] [router]
   php [options] -- [args...]
   php [options] -a

  -a               Run as interactive shell (requires readline extension)
  -c <path>|<file> Look for php.ini file in this directory
PHP 8.4.16 (cli) (built: Jan  9 2026 01:23:48) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.4.16, Copyright (c) Zend Technologies
Package tests for php84 passed.
```