### PR TITLE
Php85 8.5.0 => 8.5.1

### DIFF
--- a/manifest/armv7l/p/php85.filelist
+++ b/manifest/armv7l/p/php85.filelist
@@ -1,4 +1,4 @@
-# Total size: 115181669
+# Total size: 115186736
 /usr/local/bin/pear
 /usr/local/bin/peardev
 /usr/local/bin/pecl

--- a/manifest/x86_64/p/php85.filelist
+++ b/manifest/x86_64/p/php85.filelist
@@ -1,4 +1,4 @@
-# Total size: 128743481
+# Total size: 128733816
 /usr/local/bin/pear
 /usr/local/bin/peardev
 /usr/local/bin/pecl

--- a/packages/php85.rb
+++ b/packages/php85.rb
@@ -3,7 +3,7 @@ require 'package'
 class Php85 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'https://www.php.net/'
-  version '8.5.0'
+  version '8.5.1'
   license 'PHP-3.01'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://www.php.net/distributions/php-#{version}.tar.xz"
@@ -11,9 +11,9 @@ class Php85 < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'c2787c9323651af3d0a56d0f7ddb70d86e623aa841087c5e219f13ddb0abb763',
-     armv7l: 'c2787c9323651af3d0a56d0f7ddb70d86e623aa841087c5e219f13ddb0abb763',
-     x86_64: 'd86d051c8ef1bde112d102e4085ff704b911335b82707f15ca6f9679e303c74c'
+    aarch64: '1f76317922a018ba7004b2e97d74022f39b13fcfa217fbe1c028a525425ee30e',
+     armv7l: '1f76317922a018ba7004b2e97d74022f39b13fcfa217fbe1c028a525425ee30e',
+     x86_64: '3c6088a4b86cb769c7248660b89c2ed6c99fee83797cd6f7c5d204f5f31dc19b'
   })
 
   depends_on 'aspell_en' => :build

--- a/tests/package/p/php85
+++ b/tests/package/p/php85
@@ -1,0 +1,3 @@
+#!/bin/bash
+php -h | head
+php -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-php85 crew update \
&& yes | crew upgrade

$ crew check php85 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/php85.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking php85 package ...
Property tests for php85 passed.
Checking php85 package ...
Buildsystem test for php85 passed.
Checking php85 package ...
Library test for php85 passed.
Checking php85 package ...
Usage: php [options] [-f] <file> [--] [args...]
   php [options] -r <code> [--] [args...]
   php [options] [-B <begin_code>] -R <code> [-E <end_code>] [--] [args...]
   php [options] [-B <begin_code>] -F <file> [-E <end_code>] [--] [args...]
   php [options] -S <addr>:<port> [-t docroot] [router]
   php [options] -- [args...]
   php [options] -a

  -a               Run as interactive shell (requires readline extension)
  -c <path>|<file> Look for php.ini file in this directory
PHP 8.5.1 (cli) (built: Jan  7 2026 10:14:27) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.5.1, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.1, Copyright (c), by Zend Technologies
Package tests for php85 passed.
```