### PR TITLE
Opera 125.0.5729.49 => 126.0.5750.18

### DIFF
--- a/manifest/x86_64/o/opera.filelist
+++ b/manifest/x86_64/o/opera.filelist
@@ -1,4 +1,4 @@
-# Total size: 361935634
+# Total size: 359096836
 /usr/local/bin/opera
 /usr/local/share/applications/opera.desktop
 /usr/local/share/doc/opera-stable/changelog.gz

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,12 +3,12 @@ require 'package'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '125.0.5729.49'
+  version '126.0.5750.18'
   license 'OPERA-2018'
   compatibility 'x86_64'
 
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 'badc645bfe6130b9b4d4341a0a4c82c5ac5f115f4daf5203b90c66d072fa40b7'
+  source_sha256 'f31c35821eef95b746f4c6bca37fd4a3b2276d953602cd2bc4e6b2f3ec5cfcc5'
 
   no_compile_needed
   no_shrink

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -92,6 +92,7 @@ libxfce4ui
 nano
 ocaml
 opencode
+opera
 rqlite
 sphinx
 usql


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade

$ crew check opera
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/opera.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking opera package ...
Property tests for opera passed.
Checking opera package ...
Buildsystem test for opera passed.
Checking opera package ...
Library test for opera passed.
Checking opera package ...
/usr/local/share/x86_64-linux-gnu/opera-stable/opera: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory
Package tests for opera failed.
```