### PR TITLE
Signal_desktop 7.83.0 => 7.84.0

### DIFF
--- a/manifest/x86_64/s/signal_desktop.filelist
+++ b/manifest/x86_64/s/signal_desktop.filelist
@@ -1,4 +1,4 @@
-# Total size: 465623452
+# Total size: 455998013
 /usr/local/bin/signal-desktop
 /usr/local/share/Signal/LICENSE.electron.txt
 /usr/local/share/Signal/LICENSES.chromium.html

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.83.0'
+  version '7.84.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '5d7021d466be03af5fba597ac5b6c0e5d66f1e45ed2de3de979ca061661c57c2'
+  source_sha256 '8bd783ced8f3b4edba064586f46f52892687d8d2f36b6cdd4cedb98dfffc8eed'
 
   no_compile_needed
   no_shrink

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -93,6 +93,7 @@ nano
 ocaml
 opencode
 rqlite
+signal_desktop
 sphinx
 usql
 vivaldi


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade

$ crew check signal_desktop
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/signal_desktop.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking signal_desktop package ...
Property tests for signal_desktop passed.
Checking signal_desktop package ...
Buildsystem test for signal_desktop passed.
Checking signal_desktop package ...
Library test for signal_desktop passed.
Checking signal_desktop package ...
[18791:0109/084948.252563:FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /usr/local/share/Signal/chrome-sandbox is owned by root and has mode 4755.
/usr/local/bin/signal-desktop: line 3: 18791 Trace/breakpoint trap   /usr/local/share/Signal/signal-desktop "$@"
[18793:0100/000000.276628:ERROR:content/zygote/zygote_linux.cc:672] write: Broken pipe (32)
Package tests for signal_desktop failed.
```