### PR TITLE
Deno 2.6.3 => 2.6.4

### DIFF
--- a/manifest/x86_64/d/deno.filelist
+++ b/manifest/x86_64/d/deno.filelist
@@ -1,3 +1,3 @@
-# Total size: 141282226
+# Total size: 142941106
 /usr/local/bin/deno
 /usr/local/share/bash-completion/completions/deno

--- a/packages/deno.rb
+++ b/packages/deno.rb
@@ -6,7 +6,7 @@ require 'buildsystems/rust'
 class Deno < RUST
   description 'A secure runtime for JavaScript and TypeScript'
   homepage 'https://deno.land'
-  version '2.6.3'
+  version '2.6.4'
   license 'MIT'
   compatibility 'x86_64'
   source_url 'https://github.com/denoland/deno.git'
@@ -14,7 +14,7 @@ class Deno < RUST
   binary_compression 'tar.zst'
 
   binary_sha256({
-     x86_64: '0271b20a6910910741593a169e2dc9cd909b211ad53a24315dfb5382e44fe53c'
+     x86_64: '6fe7ac7078a117e5d10a9ba54eebea0463b45d94c0771022102a98c650267292'
   })
 
   depends_on 'gcc_lib' # R

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -33,6 +33,7 @@ dart
 dav1d
 dbeaver
 delve
+deno
 detox
 difftastic
 doctl


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-deno crew update \
&& yes | crew upgrade

$ crew check deno
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/deno.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking deno package ...
Property tests for deno passed.
Checking deno package ...
Buildsystem test for deno passed.
Checking deno package ...
Library test for deno passed.
Checking deno package ...
Deno: A modern JavaScript and TypeScript runtime

Usage: deno [OPTIONS] [COMMAND]

Commands:
  Execution:
    run          Run a JavaScript or TypeScript program, or a task
                  deno run main.ts  |  deno run --allow-net=google.com main.ts  |  deno main.ts
    serve        Run a server
                  deno serve main.ts
deno 2.6.4
Package tests for deno passed.
```