### PR TITLE
Dust 1.2.3 => 1.2.4

### DIFF
--- a/manifest/armv7l/d/dust.filelist
+++ b/manifest/armv7l/d/dust.filelist
@@ -1,2 +1,2 @@
-# Total size: 2432032
+# Total size: 2423944
 /usr/local/bin/dust

--- a/manifest/i686/d/dust.filelist
+++ b/manifest/i686/d/dust.filelist
@@ -1,2 +1,2 @@
-# Total size: 2677696
+# Total size: 2690084
 /usr/local/bin/dust

--- a/manifest/x86_64/d/dust.filelist
+++ b/manifest/x86_64/d/dust.filelist
@@ -1,2 +1,2 @@
-# Total size: 3122040
+# Total size: 3064728
 /usr/local/bin/dust

--- a/packages/dust.rb
+++ b/packages/dust.rb
@@ -3,7 +3,7 @@ require 'package'
 class Dust < Package
   description 'A more intuitive version of du in rust'
   homepage 'https://github.com/bootandy/dust'
-  version '1.2.3'
+  version '1.2.4'
   license 'Apache-2.0'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Dust < Package
      x86_64: "https://github.com/bootandy/dust/releases/download/v#{version}/dust-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
   })
   source_sha256({
-    aarch64: 'df8f5cc6d6c4cdcef8598c700b7f3aa6a211e1c106f09cbae88d7336fb9fa544',
-     armv7l: 'df8f5cc6d6c4cdcef8598c700b7f3aa6a211e1c106f09cbae88d7336fb9fa544',
-       i686: '6f8e930f6d2be139dc80b49aba5d32dd18b8327508adf662caa456fb8b1e21b0',
-     x86_64: 'f6a590a958a7fd1529fea7ae99b36be10158aa3a0ec0d686d83cc0ee89e9a142'
+    aarch64: '6418bb07a767c3cc37cd5730c308e62f780d82a2adff3ec1f3469c5cf032b084',
+     armv7l: '6418bb07a767c3cc37cd5730c308e62f780d82a2adff3ec1f3469c5cf032b084',
+       i686: 'a8387c884b1a7785cc0c5ebe03407389e00a393c16b46e3fac860e9a70707d34',
+     x86_64: '707cfdbfb9d2dc536f8c3853815bbe98a01012f2772463835edae06816551160'
   })
 
   no_compile_needed

--- a/tests/package/d/dust
+++ b/tests/package/d/dust
@@ -1,0 +1,3 @@
+#!/bin/bash
+dust -h | head
+dust -V

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -36,6 +36,7 @@ delve
 detox
 difftastic
 doctl
+dust
 enchant
 enet
 epiphany


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-dust crew update \
&& yes | crew upgrade

$ crew check dust 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/dust.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking dust package ...
Property tests for dust passed.
Checking dust package ...
Buildsystem test for dust passed.
Checking dust package ...
Library test for dust passed.
Checking dust package ...
Like du but more intuitive

Usage: dust [OPTIONS] [PATH]...

Arguments:
  [PATH]...  Input files or directories

Options:
  -d, --depth <DEPTH>              Depth to show
  -T, --threads <THREADS>          Number of threads to use
Dust 1.2.4
Package tests for dust passed.
```