### PR TITLE
Telegram 6.3.4 => 6.4.1

### DIFF
--- a/manifest/x86_64/t/telegram.filelist
+++ b/manifest/x86_64/t/telegram.filelist
@@ -1,3 +1,3 @@
-# Total size: 196767061
+# Total size: 198848789
 /usr/local/bin/Telegram
 /usr/local/bin/telegram

--- a/packages/telegram.rb
+++ b/packages/telegram.rb
@@ -3,12 +3,12 @@ require 'package'
 class Telegram < Package
   description "Telegram is a messaging app with a focus on speed and security, it's super-fast, simple and free."
   homepage 'https://telegram.org/'
-  version '6.3.4'
+  version '6.4.1'
   license 'BSD, LGPL-2+ and GPL-3-with-openssl-exception'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.tdesktop.com/tlinux/tsetup.#{version}.tar.xz"
-  source_sha256 '362c9daf5234a4f753328565d475db0ac329eadf139a9c39c8eb2347135fbf82'
+  source_sha256 '12ba5a5cb970e022e32639dbfa86d38d3a16caaf098499eee7f217096882e2f6'
 
   depends_on 'mesa'
 

--- a/tests/package/t/telegram
+++ b/tests/package/t/telegram
@@ -1,0 +1,2 @@
+#!/bin/bash
+telegram --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-telegram crew update \
&& yes | crew upgrade

$ crew check telegram
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/telegram.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking telegram package ...
Property tests for telegram passed.
Checking telegram package ...
Buildsystem test for telegram passed.
Checking telegram package ...
Library test for telegram passed.
Checking telegram package ...
qt.qpa.xcb: could not connect to display 
qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
Failed to create wl_display (No such file or directory)
qt.qpa.plugin: Could not load the Qt platform plugin "wayland" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: wayland-brcm, wayland-egl, wayland, xcb.

/usr/local/bin/telegram: line 6: 20437 Aborted                 Telegram "$@"
Package tests for telegram failed.
```