### PR TITLE
Add missing dependencies to awscli

### DIFF
--- a/packages/awscli.rb
+++ b/packages/awscli.rb
@@ -26,6 +26,9 @@ class Awscli < Pip
   depends_on 'groff' # R
   depends_on 'py3_botocore' # R
   depends_on 'py3_docutils' # R
+  depends_on 'py3_jmespath' # R
+  depends_on 'py3_pyasn1' # R
+  depends_on 'py3_python_dateutil' # R
   depends_on 'py3_rsa' # R
   depends_on 'py3_s3transfer' # R
   depends_on 'python3' => :build


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`

Before:
```
$ aws
Traceback (most recent call last):
  File "/usr/local/bin/aws", line 19, in <module>
    import awscli.clidriver
  File "/usr/local/lib/python3.14/site-packages/awscli/clidriver.py", line 17, in <module>
    import botocore.session
  File "/usr/local/lib/python3.14/site-packages/botocore/session.py", line 26, in <module>
    import botocore.client
  File "/usr/local/lib/python3.14/site-packages/botocore/client.py", line 15, in <module>
    from botocore import (
    ...<3 lines>...
    )
  File "/usr/local/lib/python3.14/site-packages/botocore/waiter.py", line 17, in <module>
    import jmespath
ModuleNotFoundError: No module named 'jmespath'
```
After:
```
$ aws
Note: AWS CLI version 2, the latest major version of the AWS CLI, is now stable and recommended for general use. For more information, see the AWS CLI version 2 installation instructions at: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
```
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-awscli crew update \
&& yes | crew upgrade

$ crew check awscli
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/awscli.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking awscli package ...
Property tests for awscli passed.
Checking awscli package ...
Buildsystem test for awscli passed.
Checking awscli package ...
Library test for awscli passed.
Checking awscli package ...
aws()                                                                    aws()

Name
       aws -

Description
       The  AWS  Command  Line  Interface is a unified tool to manage your AWS
       services.

Synopsis
aws-cli/1.44.15 Python/3.14.2 Linux/6.4.0-1mx-ahs-amd64 botocore/1.42.25
Package tests for awscli passed.
```