### PR TITLE
Frp 0.65.0 => 0.66.0

### DIFF
--- a/manifest/armv7l/f/frp.filelist
+++ b/manifest/armv7l/f/frp.filelist
@@ -1,4 +1,4 @@
-# Total size: 33566470
+# Total size: 33959686
 /usr/local/bin/frpc
 /usr/local/bin/frps
 /usr/local/share/frp/LICENSE

--- a/manifest/x86_64/f/frp.filelist
+++ b/manifest/x86_64/f/frp.filelist
@@ -1,4 +1,4 @@
-# Total size: 36970246
+# Total size: 37293830
 /usr/local/bin/frpc
 /usr/local/bin/frps
 /usr/local/share/frp/LICENSE

--- a/packages/frp.rb
+++ b/packages/frp.rb
@@ -3,7 +3,7 @@ require 'package'
 class Frp < Package
   description 'A fast reverse proxy'
   homepage 'https://github.com/fatedier/frp'
-  version '0.65.0'
+  version '0.66.0'
   license 'Apache-2.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url({
@@ -12,9 +12,9 @@ class Frp < Package
      x86_64: "https://github.com/fatedier/frp/releases/download/v#{version}/frp_#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'd4ffa465e038439eb165195c5e6b875bf712010cfe266761417025b416ed5118',
-     armv7l: 'd4ffa465e038439eb165195c5e6b875bf712010cfe266761417025b416ed5118',
-     x86_64: '52ced8c5fdf772f48a9909da4c10c7568c061861946ac9af7a86eeaf14b7e6d5'
+    aarch64: '85f2fc1b2c4eee11d0c2990cc3176d127dc021beebbf46e2c8d67fd14c5c9024',
+     armv7l: '85f2fc1b2c4eee11d0c2990cc3176d127dc021beebbf46e2c8d67fd14c5c9024',
+     x86_64: '317a17a7adac2e6bed2d7a83dc077da91ced0d110e1636373ece8ae5ac8b578b'
   })
 
   no_compile_needed

--- a/tests/package/f/frp
+++ b/tests/package/f/frp
@@ -1,0 +1,3 @@
+#!/bin/bash
+frpc -v
+frps -v

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -91,6 +91,7 @@ freeglut
 freerdp
 freetds
 fribidi
+frp
 gambit
 google_chrome
 libcdr


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-frp crew update \
&& yes | crew upgrade

$ crew check frp
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/frp.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking frp package ...
Property tests for frp passed.
Checking frp package ...
Buildsystem test for frp passed.
Checking frp package ...
Library test for frp passed.
Checking frp package ...
0.66.0
0.66.0
Package tests for frp passed.
```