### PR TITLE
Gedit 48.2 => 49.0, Libgedit_gtksourcevew 299.5.0 => 299.6.0, Tepl_66.13.0-icu77.1 => 6.14.0-icu77.1

### DIFF
--- a/manifest/armv7l/g/gedit.filelist
+++ b/manifest/armv7l/g/gedit.filelist
@@ -1,26 +1,27 @@
-# Total size: 10586111
+# Total size: 10674626
 /usr/local/bin/gedit
-/usr/local/include/gedit-48.2/gedit/gedit-app-activatable.h
-/usr/local/include/gedit-48.2/gedit/gedit-app.h
-/usr/local/include/gedit-48.2/gedit/gedit-commands.h
-/usr/local/include/gedit-48.2/gedit/gedit-debug.h
-/usr/local/include/gedit-48.2/gedit/gedit-document.h
-/usr/local/include/gedit-48.2/gedit/gedit-encodings-combo-box.h
-/usr/local/include/gedit-48.2/gedit/gedit-enum-types.h
-/usr/local/include/gedit-48.2/gedit/gedit-menu-extension.h
-/usr/local/include/gedit-48.2/gedit/gedit-message-bus.h
-/usr/local/include/gedit-48.2/gedit/gedit-message.h
-/usr/local/include/gedit-48.2/gedit/gedit-statusbar.h
-/usr/local/include/gedit-48.2/gedit/gedit-tab.h
-/usr/local/include/gedit-48.2/gedit/gedit-utils.h
-/usr/local/include/gedit-48.2/gedit/gedit-view-activatable.h
-/usr/local/include/gedit-48.2/gedit/gedit-view.h
-/usr/local/include/gedit-48.2/gedit/gedit-window-activatable.h
-/usr/local/include/gedit-48.2/gedit/gedit-window.h
+/usr/local/include/gedit-49/gedit/gedit-app-activatable.h
+/usr/local/include/gedit-49/gedit/gedit-app.h
+/usr/local/include/gedit-49/gedit/gedit-commands.h
+/usr/local/include/gedit-49/gedit/gedit-debug.h
+/usr/local/include/gedit-49/gedit/gedit-document.h
+/usr/local/include/gedit-49/gedit/gedit-encodings-combo-box.h
+/usr/local/include/gedit-49/gedit/gedit-enum-types.h
+/usr/local/include/gedit-49/gedit/gedit-menu-extension.h
+/usr/local/include/gedit-49/gedit/gedit-message-bus.h
+/usr/local/include/gedit-49/gedit/gedit-message.h
+/usr/local/include/gedit-49/gedit/gedit-tab.h
+/usr/local/include/gedit-49/gedit/gedit-utils.h
+/usr/local/include/gedit-49/gedit/gedit-view-activatable.h
+/usr/local/include/gedit-49/gedit/gedit-view.h
+/usr/local/include/gedit-49/gedit/gedit-window-activatable.h
+/usr/local/include/gedit-49/gedit/gedit-window.h
 /usr/local/lib/gedit/girepository-1.0/Gedit-3.0.typelib
-/usr/local/lib/gedit/libgedit-48.2.so
+/usr/local/lib/gedit/libgedit-49.so
+/usr/local/lib/gedit/plugins/codecomment.plugin
 /usr/local/lib/gedit/plugins/docinfo.plugin
 /usr/local/lib/gedit/plugins/filebrowser.plugin
+/usr/local/lib/gedit/plugins/libcodecomment.so
 /usr/local/lib/gedit/plugins/libdocinfo.so
 /usr/local/lib/gedit/plugins/libfilebrowser.so
 /usr/local/lib/gedit/plugins/libmodelines.so
@@ -63,6 +64,7 @@
 /usr/local/share/help/C/gedit/gedit-open-on-server.page
 /usr/local/share/help/C/gedit/gedit-open-recent.page
 /usr/local/share/help/C/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/C/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/C/gedit/gedit-plugin-guide.page
 /usr/local/share/help/C/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/C/gedit/gedit-plugins-file-browser.page
@@ -97,6 +99,7 @@
 /usr/local/share/help/ar/gedit/gedit-open-on-server.page
 /usr/local/share/help/ar/gedit/gedit-open-recent.page
 /usr/local/share/help/ar/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ar/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ar/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ar/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ar/gedit/gedit-plugins-file-browser.page
@@ -131,6 +134,7 @@
 /usr/local/share/help/bg/gedit/gedit-open-on-server.page
 /usr/local/share/help/bg/gedit/gedit-open-recent.page
 /usr/local/share/help/bg/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/bg/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/bg/gedit/gedit-plugin-guide.page
 /usr/local/share/help/bg/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/bg/gedit/gedit-plugins-file-browser.page
@@ -165,6 +169,7 @@
 /usr/local/share/help/ca/gedit/gedit-open-on-server.page
 /usr/local/share/help/ca/gedit/gedit-open-recent.page
 /usr/local/share/help/ca/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ca/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ca/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ca/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ca/gedit/gedit-plugins-file-browser.page
@@ -199,6 +204,7 @@
 /usr/local/share/help/cs/gedit/gedit-open-on-server.page
 /usr/local/share/help/cs/gedit/gedit-open-recent.page
 /usr/local/share/help/cs/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/cs/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/cs/gedit/gedit-plugin-guide.page
 /usr/local/share/help/cs/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/cs/gedit/gedit-plugins-file-browser.page
@@ -233,6 +239,7 @@
 /usr/local/share/help/da/gedit/gedit-open-on-server.page
 /usr/local/share/help/da/gedit/gedit-open-recent.page
 /usr/local/share/help/da/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/da/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/da/gedit/gedit-plugin-guide.page
 /usr/local/share/help/da/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/da/gedit/gedit-plugins-file-browser.page
@@ -267,6 +274,7 @@
 /usr/local/share/help/de/gedit/gedit-open-on-server.page
 /usr/local/share/help/de/gedit/gedit-open-recent.page
 /usr/local/share/help/de/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/de/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/de/gedit/gedit-plugin-guide.page
 /usr/local/share/help/de/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/de/gedit/gedit-plugins-file-browser.page
@@ -301,6 +309,7 @@
 /usr/local/share/help/el/gedit/gedit-open-on-server.page
 /usr/local/share/help/el/gedit/gedit-open-recent.page
 /usr/local/share/help/el/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/el/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/el/gedit/gedit-plugin-guide.page
 /usr/local/share/help/el/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/el/gedit/gedit-plugins-file-browser.page
@@ -335,6 +344,7 @@
 /usr/local/share/help/en_GB/gedit/gedit-open-on-server.page
 /usr/local/share/help/en_GB/gedit/gedit-open-recent.page
 /usr/local/share/help/en_GB/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/en_GB/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/en_GB/gedit/gedit-plugin-guide.page
 /usr/local/share/help/en_GB/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/en_GB/gedit/gedit-plugins-file-browser.page
@@ -369,6 +379,7 @@
 /usr/local/share/help/es/gedit/gedit-open-on-server.page
 /usr/local/share/help/es/gedit/gedit-open-recent.page
 /usr/local/share/help/es/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/es/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/es/gedit/gedit-plugin-guide.page
 /usr/local/share/help/es/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/es/gedit/gedit-plugins-file-browser.page
@@ -403,6 +414,7 @@
 /usr/local/share/help/eu/gedit/gedit-open-on-server.page
 /usr/local/share/help/eu/gedit/gedit-open-recent.page
 /usr/local/share/help/eu/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/eu/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/eu/gedit/gedit-plugin-guide.page
 /usr/local/share/help/eu/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/eu/gedit/gedit-plugins-file-browser.page
@@ -437,6 +449,7 @@
 /usr/local/share/help/fi/gedit/gedit-open-on-server.page
 /usr/local/share/help/fi/gedit/gedit-open-recent.page
 /usr/local/share/help/fi/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/fi/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/fi/gedit/gedit-plugin-guide.page
 /usr/local/share/help/fi/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/fi/gedit/gedit-plugins-file-browser.page
@@ -471,6 +484,7 @@
 /usr/local/share/help/fr/gedit/gedit-open-on-server.page
 /usr/local/share/help/fr/gedit/gedit-open-recent.page
 /usr/local/share/help/fr/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/fr/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/fr/gedit/gedit-plugin-guide.page
 /usr/local/share/help/fr/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/fr/gedit/gedit-plugins-file-browser.page
@@ -505,6 +519,7 @@
 /usr/local/share/help/gl/gedit/gedit-open-on-server.page
 /usr/local/share/help/gl/gedit/gedit-open-recent.page
 /usr/local/share/help/gl/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/gl/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/gl/gedit/gedit-plugin-guide.page
 /usr/local/share/help/gl/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/gl/gedit/gedit-plugins-file-browser.page
@@ -539,6 +554,7 @@
 /usr/local/share/help/hu/gedit/gedit-open-on-server.page
 /usr/local/share/help/hu/gedit/gedit-open-recent.page
 /usr/local/share/help/hu/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/hu/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/hu/gedit/gedit-plugin-guide.page
 /usr/local/share/help/hu/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/hu/gedit/gedit-plugins-file-browser.page
@@ -573,6 +589,7 @@
 /usr/local/share/help/id/gedit/gedit-open-on-server.page
 /usr/local/share/help/id/gedit/gedit-open-recent.page
 /usr/local/share/help/id/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/id/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/id/gedit/gedit-plugin-guide.page
 /usr/local/share/help/id/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/id/gedit/gedit-plugins-file-browser.page
@@ -607,6 +624,7 @@
 /usr/local/share/help/it/gedit/gedit-open-on-server.page
 /usr/local/share/help/it/gedit/gedit-open-recent.page
 /usr/local/share/help/it/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/it/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/it/gedit/gedit-plugin-guide.page
 /usr/local/share/help/it/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/it/gedit/gedit-plugins-file-browser.page
@@ -641,6 +659,7 @@
 /usr/local/share/help/ja/gedit/gedit-open-on-server.page
 /usr/local/share/help/ja/gedit/gedit-open-recent.page
 /usr/local/share/help/ja/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ja/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ja/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ja/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ja/gedit/gedit-plugins-file-browser.page
@@ -675,6 +694,7 @@
 /usr/local/share/help/ko/gedit/gedit-open-on-server.page
 /usr/local/share/help/ko/gedit/gedit-open-recent.page
 /usr/local/share/help/ko/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ko/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ko/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ko/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ko/gedit/gedit-plugins-file-browser.page
@@ -709,6 +729,7 @@
 /usr/local/share/help/lv/gedit/gedit-open-on-server.page
 /usr/local/share/help/lv/gedit/gedit-open-recent.page
 /usr/local/share/help/lv/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/lv/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/lv/gedit/gedit-plugin-guide.page
 /usr/local/share/help/lv/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/lv/gedit/gedit-plugins-file-browser.page
@@ -743,6 +764,7 @@
 /usr/local/share/help/oc/gedit/gedit-open-on-server.page
 /usr/local/share/help/oc/gedit/gedit-open-recent.page
 /usr/local/share/help/oc/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/oc/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/oc/gedit/gedit-plugin-guide.page
 /usr/local/share/help/oc/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/oc/gedit/gedit-plugins-file-browser.page
@@ -777,6 +799,7 @@
 /usr/local/share/help/pl/gedit/gedit-open-on-server.page
 /usr/local/share/help/pl/gedit/gedit-open-recent.page
 /usr/local/share/help/pl/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/pl/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/pl/gedit/gedit-plugin-guide.page
 /usr/local/share/help/pl/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/pl/gedit/gedit-plugins-file-browser.page
@@ -811,6 +834,7 @@
 /usr/local/share/help/pt_BR/gedit/gedit-open-on-server.page
 /usr/local/share/help/pt_BR/gedit/gedit-open-recent.page
 /usr/local/share/help/pt_BR/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/pt_BR/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/pt_BR/gedit/gedit-plugin-guide.page
 /usr/local/share/help/pt_BR/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/pt_BR/gedit/gedit-plugins-file-browser.page
@@ -845,6 +869,7 @@
 /usr/local/share/help/ro/gedit/gedit-open-on-server.page
 /usr/local/share/help/ro/gedit/gedit-open-recent.page
 /usr/local/share/help/ro/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ro/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ro/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ro/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ro/gedit/gedit-plugins-file-browser.page
@@ -879,6 +904,7 @@
 /usr/local/share/help/ru/gedit/gedit-open-on-server.page
 /usr/local/share/help/ru/gedit/gedit-open-recent.page
 /usr/local/share/help/ru/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ru/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ru/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ru/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ru/gedit/gedit-plugins-file-browser.page
@@ -913,6 +939,7 @@
 /usr/local/share/help/sl/gedit/gedit-open-on-server.page
 /usr/local/share/help/sl/gedit/gedit-open-recent.page
 /usr/local/share/help/sl/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/sl/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/sl/gedit/gedit-plugin-guide.page
 /usr/local/share/help/sl/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/sl/gedit/gedit-plugins-file-browser.page
@@ -947,6 +974,7 @@
 /usr/local/share/help/sv/gedit/gedit-open-on-server.page
 /usr/local/share/help/sv/gedit/gedit-open-recent.page
 /usr/local/share/help/sv/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/sv/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/sv/gedit/gedit-plugin-guide.page
 /usr/local/share/help/sv/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/sv/gedit/gedit-plugins-file-browser.page
@@ -981,6 +1009,7 @@
 /usr/local/share/help/te/gedit/gedit-open-on-server.page
 /usr/local/share/help/te/gedit/gedit-open-recent.page
 /usr/local/share/help/te/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/te/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/te/gedit/gedit-plugin-guide.page
 /usr/local/share/help/te/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/te/gedit/gedit-plugins-file-browser.page
@@ -1015,6 +1044,7 @@
 /usr/local/share/help/th/gedit/gedit-open-on-server.page
 /usr/local/share/help/th/gedit/gedit-open-recent.page
 /usr/local/share/help/th/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/th/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/th/gedit/gedit-plugin-guide.page
 /usr/local/share/help/th/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/th/gedit/gedit-plugins-file-browser.page
@@ -1049,6 +1079,7 @@
 /usr/local/share/help/uk/gedit/gedit-open-on-server.page
 /usr/local/share/help/uk/gedit/gedit-open-recent.page
 /usr/local/share/help/uk/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/uk/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/uk/gedit/gedit-plugin-guide.page
 /usr/local/share/help/uk/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/uk/gedit/gedit-plugins-file-browser.page
@@ -1083,6 +1114,7 @@
 /usr/local/share/help/zh_CN/gedit/gedit-open-on-server.page
 /usr/local/share/help/zh_CN/gedit/gedit-open-recent.page
 /usr/local/share/help/zh_CN/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/zh_CN/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/zh_CN/gedit/gedit-plugin-guide.page
 /usr/local/share/help/zh_CN/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/zh_CN/gedit/gedit-plugins-file-browser.page
@@ -1117,6 +1149,7 @@
 /usr/local/share/help/zh_HK/gedit/gedit-open-on-server.page
 /usr/local/share/help/zh_HK/gedit/gedit-open-recent.page
 /usr/local/share/help/zh_HK/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/zh_HK/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/zh_HK/gedit/gedit-plugin-guide.page
 /usr/local/share/help/zh_HK/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/zh_HK/gedit/gedit-plugins-file-browser.page
@@ -1151,6 +1184,7 @@
 /usr/local/share/help/zh_TW/gedit/gedit-open-on-server.page
 /usr/local/share/help/zh_TW/gedit/gedit-open-recent.page
 /usr/local/share/help/zh_TW/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/zh_TW/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/zh_TW/gedit/gedit-plugin-guide.page
 /usr/local/share/help/zh_TW/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/zh_TW/gedit/gedit-plugins-file-browser.page

--- a/manifest/armv7l/l/libgedit_gtksourceview.filelist
+++ b/manifest/armv7l/l/libgedit_gtksourceview.filelist
@@ -1,5 +1,7 @@
-# Total size: 3687430
+# Total size: 3697761
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/completion-providers/words/gtksourcecompletionwords.h
+/usr/local/include/libgedit-gtksourceview-300/gtksourceview/file-loading-and-saving/gtksourceiconv.h
+/usr/local/include/libgedit-gtksourceview-300/gtksourceview/file-loading-and-saving/gtksourceinputstream.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksource-enumtypes.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksource.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourceautocleanups.h
@@ -19,6 +21,7 @@
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcegutterrendererpixbuf.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcegutterrenderertext.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourceinit.h
+/usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourceiter.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcelanguage.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcelanguagemanager.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcemark.h
@@ -38,7 +41,7 @@
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourceview.h
 /usr/local/lib/girepository-1.0/GtkSource-300.typelib
 /usr/local/lib/libgedit-gtksourceview-300.so
-/usr/local/lib/libgedit-gtksourceview-300.so.3
+/usr/local/lib/libgedit-gtksourceview-300.so.4
 /usr/local/lib/pkgconfig/libgedit-gtksourceview-300.pc
 /usr/local/share/gir-1.0/GtkSource-300.gir
 /usr/local/share/libgedit-gtksourceview-300/language-specs/R.lang

--- a/manifest/armv7l/t/tepl_6.filelist
+++ b/manifest/armv7l/t/tepl_6.filelist
@@ -1,4 +1,6 @@
-# Total size: 1123567
+# Total size: 1152015
+/usr/local/include/libgedit-tepl-6/tepl/code-comment/tepl-code-comment-view.h
+/usr/local/include/libgedit-tepl-6/tepl/code-comment/tepl-code-comment.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-abstract-factory.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-application-window.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-application.h
@@ -14,7 +16,6 @@
 /usr/local/include/libgedit-tepl-6/tepl/tepl-info-bar.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-init.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-io-error-info-bars.h
-/usr/local/include/libgedit-tepl-6/tepl/tepl-iter.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-language-chooser-dialog.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-language-chooser-widget.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-language-chooser.h
@@ -41,6 +42,7 @@
 /usr/local/include/libgedit-tepl-6/tepl/tepl-signal-group.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-space-drawer-prefs.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-status-menu-button.h
+/usr/local/include/libgedit-tepl-6/tepl/tepl-statusbar.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-style-scheme-chooser-full.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-style-scheme-chooser-simple.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-tab-group.h
@@ -54,7 +56,7 @@
 /usr/local/include/libgedit-tepl-6/tepl/tepl.h
 /usr/local/lib/girepository-1.0/Tepl-6.typelib
 /usr/local/lib/libgedit-tepl-6.so
-/usr/local/lib/libgedit-tepl-6.so.3
+/usr/local/lib/libgedit-tepl-6.so.4
 /usr/local/lib/pkgconfig/libgedit-tepl-6.pc
 /usr/local/share/gir-1.0/Tepl-6.gir
 /usr/local/share/locale/be/LC_MESSAGES/libgedit-tepl-6.mo

--- a/manifest/x86_64/g/gedit.filelist
+++ b/manifest/x86_64/g/gedit.filelist
@@ -1,26 +1,27 @@
-# Total size: 10820347
+# Total size: 10914810
 /usr/local/bin/gedit
-/usr/local/include/gedit-48.2/gedit/gedit-app-activatable.h
-/usr/local/include/gedit-48.2/gedit/gedit-app.h
-/usr/local/include/gedit-48.2/gedit/gedit-commands.h
-/usr/local/include/gedit-48.2/gedit/gedit-debug.h
-/usr/local/include/gedit-48.2/gedit/gedit-document.h
-/usr/local/include/gedit-48.2/gedit/gedit-encodings-combo-box.h
-/usr/local/include/gedit-48.2/gedit/gedit-enum-types.h
-/usr/local/include/gedit-48.2/gedit/gedit-menu-extension.h
-/usr/local/include/gedit-48.2/gedit/gedit-message-bus.h
-/usr/local/include/gedit-48.2/gedit/gedit-message.h
-/usr/local/include/gedit-48.2/gedit/gedit-statusbar.h
-/usr/local/include/gedit-48.2/gedit/gedit-tab.h
-/usr/local/include/gedit-48.2/gedit/gedit-utils.h
-/usr/local/include/gedit-48.2/gedit/gedit-view-activatable.h
-/usr/local/include/gedit-48.2/gedit/gedit-view.h
-/usr/local/include/gedit-48.2/gedit/gedit-window-activatable.h
-/usr/local/include/gedit-48.2/gedit/gedit-window.h
+/usr/local/include/gedit-49/gedit/gedit-app-activatable.h
+/usr/local/include/gedit-49/gedit/gedit-app.h
+/usr/local/include/gedit-49/gedit/gedit-commands.h
+/usr/local/include/gedit-49/gedit/gedit-debug.h
+/usr/local/include/gedit-49/gedit/gedit-document.h
+/usr/local/include/gedit-49/gedit/gedit-encodings-combo-box.h
+/usr/local/include/gedit-49/gedit/gedit-enum-types.h
+/usr/local/include/gedit-49/gedit/gedit-menu-extension.h
+/usr/local/include/gedit-49/gedit/gedit-message-bus.h
+/usr/local/include/gedit-49/gedit/gedit-message.h
+/usr/local/include/gedit-49/gedit/gedit-tab.h
+/usr/local/include/gedit-49/gedit/gedit-utils.h
+/usr/local/include/gedit-49/gedit/gedit-view-activatable.h
+/usr/local/include/gedit-49/gedit/gedit-view.h
+/usr/local/include/gedit-49/gedit/gedit-window-activatable.h
+/usr/local/include/gedit-49/gedit/gedit-window.h
 /usr/local/lib64/gedit/girepository-1.0/Gedit-3.0.typelib
-/usr/local/lib64/gedit/libgedit-48.2.so
+/usr/local/lib64/gedit/libgedit-49.so
+/usr/local/lib64/gedit/plugins/codecomment.plugin
 /usr/local/lib64/gedit/plugins/docinfo.plugin
 /usr/local/lib64/gedit/plugins/filebrowser.plugin
+/usr/local/lib64/gedit/plugins/libcodecomment.so
 /usr/local/lib64/gedit/plugins/libdocinfo.so
 /usr/local/lib64/gedit/plugins/libfilebrowser.so
 /usr/local/lib64/gedit/plugins/libmodelines.so
@@ -63,6 +64,7 @@
 /usr/local/share/help/C/gedit/gedit-open-on-server.page
 /usr/local/share/help/C/gedit/gedit-open-recent.page
 /usr/local/share/help/C/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/C/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/C/gedit/gedit-plugin-guide.page
 /usr/local/share/help/C/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/C/gedit/gedit-plugins-file-browser.page
@@ -97,6 +99,7 @@
 /usr/local/share/help/ar/gedit/gedit-open-on-server.page
 /usr/local/share/help/ar/gedit/gedit-open-recent.page
 /usr/local/share/help/ar/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ar/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ar/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ar/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ar/gedit/gedit-plugins-file-browser.page
@@ -131,6 +134,7 @@
 /usr/local/share/help/bg/gedit/gedit-open-on-server.page
 /usr/local/share/help/bg/gedit/gedit-open-recent.page
 /usr/local/share/help/bg/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/bg/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/bg/gedit/gedit-plugin-guide.page
 /usr/local/share/help/bg/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/bg/gedit/gedit-plugins-file-browser.page
@@ -165,6 +169,7 @@
 /usr/local/share/help/ca/gedit/gedit-open-on-server.page
 /usr/local/share/help/ca/gedit/gedit-open-recent.page
 /usr/local/share/help/ca/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ca/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ca/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ca/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ca/gedit/gedit-plugins-file-browser.page
@@ -199,6 +204,7 @@
 /usr/local/share/help/cs/gedit/gedit-open-on-server.page
 /usr/local/share/help/cs/gedit/gedit-open-recent.page
 /usr/local/share/help/cs/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/cs/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/cs/gedit/gedit-plugin-guide.page
 /usr/local/share/help/cs/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/cs/gedit/gedit-plugins-file-browser.page
@@ -233,6 +239,7 @@
 /usr/local/share/help/da/gedit/gedit-open-on-server.page
 /usr/local/share/help/da/gedit/gedit-open-recent.page
 /usr/local/share/help/da/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/da/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/da/gedit/gedit-plugin-guide.page
 /usr/local/share/help/da/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/da/gedit/gedit-plugins-file-browser.page
@@ -267,6 +274,7 @@
 /usr/local/share/help/de/gedit/gedit-open-on-server.page
 /usr/local/share/help/de/gedit/gedit-open-recent.page
 /usr/local/share/help/de/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/de/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/de/gedit/gedit-plugin-guide.page
 /usr/local/share/help/de/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/de/gedit/gedit-plugins-file-browser.page
@@ -301,6 +309,7 @@
 /usr/local/share/help/el/gedit/gedit-open-on-server.page
 /usr/local/share/help/el/gedit/gedit-open-recent.page
 /usr/local/share/help/el/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/el/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/el/gedit/gedit-plugin-guide.page
 /usr/local/share/help/el/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/el/gedit/gedit-plugins-file-browser.page
@@ -335,6 +344,7 @@
 /usr/local/share/help/en_GB/gedit/gedit-open-on-server.page
 /usr/local/share/help/en_GB/gedit/gedit-open-recent.page
 /usr/local/share/help/en_GB/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/en_GB/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/en_GB/gedit/gedit-plugin-guide.page
 /usr/local/share/help/en_GB/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/en_GB/gedit/gedit-plugins-file-browser.page
@@ -369,6 +379,7 @@
 /usr/local/share/help/es/gedit/gedit-open-on-server.page
 /usr/local/share/help/es/gedit/gedit-open-recent.page
 /usr/local/share/help/es/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/es/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/es/gedit/gedit-plugin-guide.page
 /usr/local/share/help/es/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/es/gedit/gedit-plugins-file-browser.page
@@ -403,6 +414,7 @@
 /usr/local/share/help/eu/gedit/gedit-open-on-server.page
 /usr/local/share/help/eu/gedit/gedit-open-recent.page
 /usr/local/share/help/eu/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/eu/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/eu/gedit/gedit-plugin-guide.page
 /usr/local/share/help/eu/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/eu/gedit/gedit-plugins-file-browser.page
@@ -437,6 +449,7 @@
 /usr/local/share/help/fi/gedit/gedit-open-on-server.page
 /usr/local/share/help/fi/gedit/gedit-open-recent.page
 /usr/local/share/help/fi/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/fi/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/fi/gedit/gedit-plugin-guide.page
 /usr/local/share/help/fi/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/fi/gedit/gedit-plugins-file-browser.page
@@ -471,6 +484,7 @@
 /usr/local/share/help/fr/gedit/gedit-open-on-server.page
 /usr/local/share/help/fr/gedit/gedit-open-recent.page
 /usr/local/share/help/fr/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/fr/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/fr/gedit/gedit-plugin-guide.page
 /usr/local/share/help/fr/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/fr/gedit/gedit-plugins-file-browser.page
@@ -505,6 +519,7 @@
 /usr/local/share/help/gl/gedit/gedit-open-on-server.page
 /usr/local/share/help/gl/gedit/gedit-open-recent.page
 /usr/local/share/help/gl/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/gl/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/gl/gedit/gedit-plugin-guide.page
 /usr/local/share/help/gl/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/gl/gedit/gedit-plugins-file-browser.page
@@ -539,6 +554,7 @@
 /usr/local/share/help/hu/gedit/gedit-open-on-server.page
 /usr/local/share/help/hu/gedit/gedit-open-recent.page
 /usr/local/share/help/hu/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/hu/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/hu/gedit/gedit-plugin-guide.page
 /usr/local/share/help/hu/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/hu/gedit/gedit-plugins-file-browser.page
@@ -573,6 +589,7 @@
 /usr/local/share/help/id/gedit/gedit-open-on-server.page
 /usr/local/share/help/id/gedit/gedit-open-recent.page
 /usr/local/share/help/id/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/id/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/id/gedit/gedit-plugin-guide.page
 /usr/local/share/help/id/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/id/gedit/gedit-plugins-file-browser.page
@@ -607,6 +624,7 @@
 /usr/local/share/help/it/gedit/gedit-open-on-server.page
 /usr/local/share/help/it/gedit/gedit-open-recent.page
 /usr/local/share/help/it/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/it/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/it/gedit/gedit-plugin-guide.page
 /usr/local/share/help/it/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/it/gedit/gedit-plugins-file-browser.page
@@ -641,6 +659,7 @@
 /usr/local/share/help/ja/gedit/gedit-open-on-server.page
 /usr/local/share/help/ja/gedit/gedit-open-recent.page
 /usr/local/share/help/ja/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ja/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ja/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ja/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ja/gedit/gedit-plugins-file-browser.page
@@ -675,6 +694,7 @@
 /usr/local/share/help/ko/gedit/gedit-open-on-server.page
 /usr/local/share/help/ko/gedit/gedit-open-recent.page
 /usr/local/share/help/ko/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ko/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ko/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ko/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ko/gedit/gedit-plugins-file-browser.page
@@ -709,6 +729,7 @@
 /usr/local/share/help/lv/gedit/gedit-open-on-server.page
 /usr/local/share/help/lv/gedit/gedit-open-recent.page
 /usr/local/share/help/lv/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/lv/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/lv/gedit/gedit-plugin-guide.page
 /usr/local/share/help/lv/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/lv/gedit/gedit-plugins-file-browser.page
@@ -743,6 +764,7 @@
 /usr/local/share/help/oc/gedit/gedit-open-on-server.page
 /usr/local/share/help/oc/gedit/gedit-open-recent.page
 /usr/local/share/help/oc/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/oc/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/oc/gedit/gedit-plugin-guide.page
 /usr/local/share/help/oc/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/oc/gedit/gedit-plugins-file-browser.page
@@ -777,6 +799,7 @@
 /usr/local/share/help/pl/gedit/gedit-open-on-server.page
 /usr/local/share/help/pl/gedit/gedit-open-recent.page
 /usr/local/share/help/pl/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/pl/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/pl/gedit/gedit-plugin-guide.page
 /usr/local/share/help/pl/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/pl/gedit/gedit-plugins-file-browser.page
@@ -811,6 +834,7 @@
 /usr/local/share/help/pt_BR/gedit/gedit-open-on-server.page
 /usr/local/share/help/pt_BR/gedit/gedit-open-recent.page
 /usr/local/share/help/pt_BR/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/pt_BR/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/pt_BR/gedit/gedit-plugin-guide.page
 /usr/local/share/help/pt_BR/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/pt_BR/gedit/gedit-plugins-file-browser.page
@@ -845,6 +869,7 @@
 /usr/local/share/help/ro/gedit/gedit-open-on-server.page
 /usr/local/share/help/ro/gedit/gedit-open-recent.page
 /usr/local/share/help/ro/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ro/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ro/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ro/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ro/gedit/gedit-plugins-file-browser.page
@@ -879,6 +904,7 @@
 /usr/local/share/help/ru/gedit/gedit-open-on-server.page
 /usr/local/share/help/ru/gedit/gedit-open-recent.page
 /usr/local/share/help/ru/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/ru/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/ru/gedit/gedit-plugin-guide.page
 /usr/local/share/help/ru/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/ru/gedit/gedit-plugins-file-browser.page
@@ -913,6 +939,7 @@
 /usr/local/share/help/sl/gedit/gedit-open-on-server.page
 /usr/local/share/help/sl/gedit/gedit-open-recent.page
 /usr/local/share/help/sl/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/sl/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/sl/gedit/gedit-plugin-guide.page
 /usr/local/share/help/sl/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/sl/gedit/gedit-plugins-file-browser.page
@@ -947,6 +974,7 @@
 /usr/local/share/help/sv/gedit/gedit-open-on-server.page
 /usr/local/share/help/sv/gedit/gedit-open-recent.page
 /usr/local/share/help/sv/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/sv/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/sv/gedit/gedit-plugin-guide.page
 /usr/local/share/help/sv/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/sv/gedit/gedit-plugins-file-browser.page
@@ -981,6 +1009,7 @@
 /usr/local/share/help/te/gedit/gedit-open-on-server.page
 /usr/local/share/help/te/gedit/gedit-open-recent.page
 /usr/local/share/help/te/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/te/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/te/gedit/gedit-plugin-guide.page
 /usr/local/share/help/te/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/te/gedit/gedit-plugins-file-browser.page
@@ -1015,6 +1044,7 @@
 /usr/local/share/help/th/gedit/gedit-open-on-server.page
 /usr/local/share/help/th/gedit/gedit-open-recent.page
 /usr/local/share/help/th/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/th/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/th/gedit/gedit-plugin-guide.page
 /usr/local/share/help/th/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/th/gedit/gedit-plugins-file-browser.page
@@ -1049,6 +1079,7 @@
 /usr/local/share/help/uk/gedit/gedit-open-on-server.page
 /usr/local/share/help/uk/gedit/gedit-open-recent.page
 /usr/local/share/help/uk/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/uk/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/uk/gedit/gedit-plugin-guide.page
 /usr/local/share/help/uk/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/uk/gedit/gedit-plugins-file-browser.page
@@ -1083,6 +1114,7 @@
 /usr/local/share/help/zh_CN/gedit/gedit-open-on-server.page
 /usr/local/share/help/zh_CN/gedit/gedit-open-recent.page
 /usr/local/share/help/zh_CN/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/zh_CN/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/zh_CN/gedit/gedit-plugin-guide.page
 /usr/local/share/help/zh_CN/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/zh_CN/gedit/gedit-plugins-file-browser.page
@@ -1117,6 +1149,7 @@
 /usr/local/share/help/zh_HK/gedit/gedit-open-on-server.page
 /usr/local/share/help/zh_HK/gedit/gedit-open-recent.page
 /usr/local/share/help/zh_HK/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/zh_HK/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/zh_HK/gedit/gedit-plugin-guide.page
 /usr/local/share/help/zh_HK/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/zh_HK/gedit/gedit-plugins-file-browser.page
@@ -1151,6 +1184,7 @@
 /usr/local/share/help/zh_TW/gedit/gedit-open-on-server.page
 /usr/local/share/help/zh_TW/gedit/gedit-open-recent.page
 /usr/local/share/help/zh_TW/gedit/gedit-open-several-files-at-once.page
+/usr/local/share/help/zh_TW/gedit/gedit-plugin-code-comment.page
 /usr/local/share/help/zh_TW/gedit/gedit-plugin-guide.page
 /usr/local/share/help/zh_TW/gedit/gedit-plugins-doc-stats.page
 /usr/local/share/help/zh_TW/gedit/gedit-plugins-file-browser.page

--- a/manifest/x86_64/l/libgedit_gtksourceview.filelist
+++ b/manifest/x86_64/l/libgedit_gtksourceview.filelist
@@ -1,5 +1,7 @@
-# Total size: 3877124
+# Total size: 3889863
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/completion-providers/words/gtksourcecompletionwords.h
+/usr/local/include/libgedit-gtksourceview-300/gtksourceview/file-loading-and-saving/gtksourceiconv.h
+/usr/local/include/libgedit-gtksourceview-300/gtksourceview/file-loading-and-saving/gtksourceinputstream.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksource-enumtypes.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksource.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourceautocleanups.h
@@ -19,6 +21,7 @@
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcegutterrendererpixbuf.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcegutterrenderertext.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourceinit.h
+/usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourceiter.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcelanguage.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcelanguagemanager.h
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourcemark.h
@@ -38,7 +41,7 @@
 /usr/local/include/libgedit-gtksourceview-300/gtksourceview/gtksourceview.h
 /usr/local/lib64/girepository-1.0/GtkSource-300.typelib
 /usr/local/lib64/libgedit-gtksourceview-300.so
-/usr/local/lib64/libgedit-gtksourceview-300.so.3
+/usr/local/lib64/libgedit-gtksourceview-300.so.4
 /usr/local/lib64/pkgconfig/libgedit-gtksourceview-300.pc
 /usr/local/share/gir-1.0/GtkSource-300.gir
 /usr/local/share/libgedit-gtksourceview-300/language-specs/R.lang

--- a/manifest/x86_64/t/tepl_6.filelist
+++ b/manifest/x86_64/t/tepl_6.filelist
@@ -1,4 +1,6 @@
-# Total size: 1205825
+# Total size: 1237593
+/usr/local/include/libgedit-tepl-6/tepl/code-comment/tepl-code-comment-view.h
+/usr/local/include/libgedit-tepl-6/tepl/code-comment/tepl-code-comment.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-abstract-factory.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-application-window.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-application.h
@@ -14,7 +16,6 @@
 /usr/local/include/libgedit-tepl-6/tepl/tepl-info-bar.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-init.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-io-error-info-bars.h
-/usr/local/include/libgedit-tepl-6/tepl/tepl-iter.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-language-chooser-dialog.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-language-chooser-widget.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-language-chooser.h
@@ -41,6 +42,7 @@
 /usr/local/include/libgedit-tepl-6/tepl/tepl-signal-group.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-space-drawer-prefs.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-status-menu-button.h
+/usr/local/include/libgedit-tepl-6/tepl/tepl-statusbar.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-style-scheme-chooser-full.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-style-scheme-chooser-simple.h
 /usr/local/include/libgedit-tepl-6/tepl/tepl-tab-group.h
@@ -54,7 +56,7 @@
 /usr/local/include/libgedit-tepl-6/tepl/tepl.h
 /usr/local/lib64/girepository-1.0/Tepl-6.typelib
 /usr/local/lib64/libgedit-tepl-6.so
-/usr/local/lib64/libgedit-tepl-6.so.3
+/usr/local/lib64/libgedit-tepl-6.so.4
 /usr/local/lib64/pkgconfig/libgedit-tepl-6.pc
 /usr/local/share/gir-1.0/Tepl-6.gir
 /usr/local/share/locale/be/LC_MESSAGES/libgedit-tepl-6.mo

--- a/packages/gedit.rb
+++ b/packages/gedit.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Gedit < Meson
   description 'GNOME Text Editor'
   homepage 'https://wiki.gnome.org/Apps/Gedit'
-  version '48.2'
+  version '49.0'
   license 'GPL-2+ CC-BY-SA-3.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/gedit.git'
@@ -11,9 +11,9 @@ class Gedit < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b2f680df1b9d04e1265deb33c369dcc0ae21fb53d00b24f8b390c0c76474efb7',
-     armv7l: 'b2f680df1b9d04e1265deb33c369dcc0ae21fb53d00b24f8b390c0c76474efb7',
-     x86_64: '7dfd711561470d782f37feb7d97510d9a2db059c7cd5b1dccbc7b023097a5cca'
+    aarch64: 'ac6287afc679ad75a753df15741126b4be8fc650bfcaeea1f4cf47c77467ef5c',
+     armv7l: 'ac6287afc679ad75a753df15741126b4be8fc650bfcaeea1f4cf47c77467ef5c',
+     x86_64: 'b66022b46a4f7dee6db5d51bba361ce0ab25d25a526dbfe55b6c12b1b8c7b811'
   })
 
   depends_on 'cairo' # R
@@ -26,6 +26,7 @@ class Gedit < Meson
   depends_on 'gspell' # R
   depends_on 'gtk3' # R
   depends_on 'harfbuzz' # R
+  depends_on 'libgedit_gtksourceview' # R
   depends_on 'libpeas' # R
   depends_on 'pango' # R
   depends_on 'py3_lxml' => :build

--- a/packages/libgedit_gtksourceview.rb
+++ b/packages/libgedit_gtksourceview.rb
@@ -6,7 +6,7 @@ require 'buildsystems/meson'
 class Libgedit_gtksourceview < Meson
   description 'A library that extends GtkTextView, the standard GTK '
   homepage 'https://gedit-technology.github.io'
-  version '299.5.0'
+  version '299.6.0'
   license 'LGPL2.1'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/World/gedit/libgedit-gtksourceview.git'
@@ -14,9 +14,9 @@ class Libgedit_gtksourceview < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '4b6bbcebe2578342907bd5116110e4fccd46ff000b16d6883da636c75f7f2cc7',
-     armv7l: '4b6bbcebe2578342907bd5116110e4fccd46ff000b16d6883da636c75f7f2cc7',
-     x86_64: '1fd2f299c0a789895b5671daad278b76817a3b1672881d0bebd20fc581fa97c2'
+    aarch64: 'bf33b299ce17545a74dac05054979e2fece05c13cb9cf0a1bac83bc728ab3124',
+     armv7l: 'bf33b299ce17545a74dac05054979e2fece05c13cb9cf0a1bac83bc728ab3124',
+     x86_64: 'c61d8bb63dc8ced4d3b10b863c750bc5c1f411b36ee858d5eabfa1b1a7cfe47a'
   })
 
   depends_on 'cairo' # R

--- a/packages/tepl_6.rb
+++ b/packages/tepl_6.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Tepl_6 < Meson
   description 'Library that eases the development of GtkSourceView-based text editors and IDEs'
   homepage 'https://gitlab.gnome.org/World/gedit/libgedit-tepl'
-  version "6.13.0-#{CREW_ICU_VER}"
+  version "6.14.0-#{CREW_ICU_VER}"
   license 'LGPL-2.1+'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/World/gedit/libgedit-tepl.git'
@@ -11,9 +11,9 @@ class Tepl_6 < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '7f3bbee8e7ba59106959ee11dad127f761ac66e8ba0d926f8a82f0eb6cdfbeae',
-     armv7l: '7f3bbee8e7ba59106959ee11dad127f761ac66e8ba0d926f8a82f0eb6cdfbeae',
-     x86_64: '640e74588abc0727dd353a3b1559378b56570aa57a35ab4c590b08c95ba2800c'
+    aarch64: '36727139e79479954df6068874ce34cdfc4c1275a92ecd83967d0c46bb6e1be5',
+     armv7l: '36727139e79479954df6068874ce34cdfc4c1275a92ecd83967d0c46bb6e1be5',
+     x86_64: '00cdf9424f455b67eaea339c0f9b8f15e637ddbe4fd329e8b034371bb6a5553c'
   })
 
   depends_on 'cairo' # R

--- a/tests/package/g/gedit
+++ b/tests/package/g/gedit
@@ -1,0 +1,3 @@
+#!/bin/bash
+gedit -h | head
+gedit -V

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -93,8 +93,10 @@ freetds
 fribidi
 frp
 gambit
+gedit
 google_chrome
 libcdr
+libgedit_gtksourceview
 libvisio
 libxfce4ui
 nano
@@ -104,6 +106,7 @@ opera
 rqlite
 signal_desktop
 sphinx
+tepl_6
 usql
 vivaldi
 vscodium


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gedit crew update \
&& yes | crew upgrade

$ crew check gedit
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/gedit.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking gedit package ...
Property tests for gedit passed.
Checking gedit package ...
Buildsystem test for gedit passed.
Checking gedit package ...
Library test for gedit passed.
Checking gedit package ...
Usage:
  gedit [OPTION…] [FILE…] [+LINE[:COLUMN]]

Help Options:
  -h, --help                      Show help options
  --help-all                      Show all help options
  --help-gapplication             Show GApplication options
  --help-gtk                      Show GTK+ Options

Application Options:
gedit - Version 49.0
Package tests for gedit passed.
```