### PR TITLE
Firefox 146.0.1 => 147.0

### DIFF
--- a/manifest/x86_64/f/firefox.filelist
+++ b/manifest/x86_64/f/firefox.filelist
@@ -1,4 +1,4 @@
-# Total size: 300736776
+# Total size: 302698779
 /usr/local/bin/firefox
 /usr/local/share/applications/firefox.desktop
 /usr/local/share/firefox/application.ini

--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -3,12 +3,12 @@ require 'package'
 class Firefox < Package
   description 'Mozilla Firefox (or simply Firefox) is a free and open-source web browser'
   homepage 'https://www.mozilla.org/en-US/firefox/'
-  version '146.0.1'
+  version '147.0'
   license 'MPL-2.0, GPL-2 and LGPL-2.1'
   compatibility 'x86_64'
   min_glibc '2.35'
   source_url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-x86_64/en-US/firefox-#{version}.tar.xz"
-  source_sha256 '36a4dc0e3be8af2d49d8388021abf790976d2398162b9d13a6d758cc8c37f8dd'
+  source_sha256 'f055b9c0d7346a10d22edc7f10e08679af2ea495367381ab2be9cab3ec6add97'
 
   depends_on 'at_spi2_core'
   depends_on 'cairo'

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -57,6 +57,7 @@ fdupes
 feh
 finch
 findutils
+firefox
 firejail
 fish
 flatseal


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-firefox crew update \
&& yes | crew upgrade

$ crew check firefox 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/firefox.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking firefox package ...
Property tests for firefox passed.
Checking firefox package ...
Buildsystem test for firefox passed.
Checking firefox package ...
Library test for firefox passed.
Checking firefox package ...
Mozilla Firefox 147.0
Package tests for firefox passed.
```