### PR TITLE
Gnome_console 49.1 => 49.2

### DIFF
--- a/manifest/armv7l/g/gnome_console.filelist
+++ b/manifest/armv7l/g/gnome_console.filelist
@@ -1,4 +1,4 @@
-# Total size: 902728
+# Total size: 919058
 /usr/local/bin/kgx
 /usr/local/share/applications/org.gnome.Console.desktop
 /usr/local/share/dbus-1/services/org.gnome.Console.service

--- a/manifest/x86_64/g/gnome_console.filelist
+++ b/manifest/x86_64/g/gnome_console.filelist
@@ -1,4 +1,4 @@
-# Total size: 949528
+# Total size: 965874
 /usr/local/bin/kgx
 /usr/local/share/applications/org.gnome.Console.desktop
 /usr/local/share/dbus-1/services/org.gnome.Console.service

--- a/packages/gnome_console.rb
+++ b/packages/gnome_console.rb
@@ -6,7 +6,7 @@ require 'buildsystems/meson'
 class Gnome_console < Meson
   description 'A simple user-friendly terminal emulator for the GNOME desktop'
   homepage 'https://gitlab.gnome.org/GNOME/console'
-  version '49.1'
+  version '49.2'
   license 'GPL3'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/console.git'
@@ -14,9 +14,9 @@ class Gnome_console < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f56540d1fbbefd9f235ca86078d0240d9a5a831ec3ec438f57e44b55e90e3b52',
-     armv7l: 'f56540d1fbbefd9f235ca86078d0240d9a5a831ec3ec438f57e44b55e90e3b52',
-     x86_64: '4a981963bac36a6b21d989c2097228e5cb9ff4cb0281b53e4dadef937a2466fb'
+    aarch64: '36bea987e21d954b5dddaae7a1a84cba56fd082e1058d3fdc7ab5fe69a14df94',
+     armv7l: '36bea987e21d954b5dddaae7a1a84cba56fd082e1058d3fdc7ab5fe69a14df94',
+     x86_64: '35746d34093f1d5b2e109fdee4ba49f6dbec112c8716e6929f4e390add0170af'
   })
 
   depends_on 'desktop_file_utils' => :build

--- a/tests/package/g/gnome_console
+++ b/tests/package/g/gnome_console
@@ -1,0 +1,3 @@
+#!/bin/bash
+kgx --help
+kgx --version

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -100,6 +100,7 @@ glib
 glm
 glslang
 gmmlib
+gnome_console
 gobject_introspection
 google_chrome
 libcdr


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gnome_console crew update \
&& yes | crew upgrade

$ crew check gnome_console 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/gnome_console.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking gnome_console package ...
Property tests for gnome_console passed.
Checking gnome_console package ...
Buildsystem test for gnome_console passed.
Checking gnome_console package ...
Library test for gnome_console passed.
Checking gnome_console package ...
Usage:
  kgx [OPTION…] [-e|-- COMMAND [ARGUMENT...]]

KGX 49.2 — Terminal Emulator

Help Options:
  -h, --help                      Show help options
  --help-all                      Show all help options
  --help-gapplication             Show GApplication options

Application Options:
  --version                       
  --about                         
  --tab                           
  -e, --command=COMMAND           Execute the argument to this option inside the terminal
  --working-directory=DIRNAME     Set the working directory
  --wait                          Wait until the child exits (TODO)
  -T, --title=TITLE               Set the initial window title
  --set-shell=SHELL               ADVANCED: Set the shell to launch
  --set-scrollback=LINES          ADVANCED: Set the scrollback length

https://apps.gnome.org/Console/
# KGX 49.2 using VTE 0.82.0 +BIDI +GNUTLS +ICU -SYSTEMD
Package tests for gnome_console passed.
```