### PR TITLE
Add fallback for empty CREW_LOCAL_REPO_ROOT, as during installs. 

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.70.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.70.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]
@@ -97,7 +97,12 @@ CREW_KERNEL_VERSION =
 CREW_CACHE_DIR          = ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcache")
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', false)
 CREW_CACHE_BUILD        = ENV.fetch('CREW_CACHE_BUILD', false)
-CREW_LOCAL_REPO_ROOT = `git rev-parse --show-toplevel 2>/dev/null`.chomp
+crew_local_repo_root = `git rev-parse --show-toplevel 2>/dev/null`.chomp
+CREW_LOCAL_REPO_ROOT = if crew_local_repo_root.nil?
+                         File.join(CREW_PREFIX, 'lib/crew')
+                       else
+                         crew_local_repo_root
+                       end
 CREW_LOCAL_BUILD_DIR = "#{CREW_LOCAL_REPO_ROOT}/release/#{ARCH}"
 CREW_MAX_BUILD_TIME  = ENV.fetch('CREW_MAX_BUILD_TIME', '19800') # GitHub Action containers are killed after 6 hours, so set to 5.5 hours.
 CREW_GITLAB_PKG_REPO = 'https://gitlab.com/api/v4/projects/26210301/packages'


### PR DESCRIPTION
## Description
- This should hopefully fix the container images after I rebuild with this merged.

#### Commits:
-  947d7c611 Add fallback for empty CREW_LOCAL_REPO_ROOT, as during installs.
### Other changed files:
- lib/const.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=gem_redux crew update \
&& yes | crew upgrade
```
