### PR TITLE
Gnome_sudoku 49.2 => 49.3

### DIFF
--- a/manifest/armv7l/g/gnome_sudoku.filelist
+++ b/manifest/armv7l/g/gnome_sudoku.filelist
@@ -1,4 +1,4 @@
-# Total size: 1473743
+# Total size: 1474409
 /usr/local/bin/gnome-sudoku
 /usr/local/share/applications/org.gnome.Sudoku.desktop
 /usr/local/share/dbus-1/services/org.gnome.Sudoku.service

--- a/manifest/x86_64/g/gnome_sudoku.filelist
+++ b/manifest/x86_64/g/gnome_sudoku.filelist
@@ -1,4 +1,4 @@
-# Total size: 1534839
+# Total size: 1535617
 /usr/local/bin/gnome-sudoku
 /usr/local/share/applications/org.gnome.Sudoku.desktop
 /usr/local/share/dbus-1/services/org.gnome.Sudoku.service

--- a/packages/gnome_sudoku.rb
+++ b/packages/gnome_sudoku.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Gnome_sudoku < Meson
   description 'Sudoku puzzle game for GNOME'
   homepage 'https://wiki.gnome.org/Apps/Sudoku'
-  version '49.2'
+  version '49.3'
   license 'GPL-3+ and CC-BY-SA-3.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-sudoku.git'
@@ -11,9 +11,9 @@ class Gnome_sudoku < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f6b0745a03fbddc482287c44d620f91e4524e0c3e0b766646295796f4bb81246',
-     armv7l: 'f6b0745a03fbddc482287c44d620f91e4524e0c3e0b766646295796f4bb81246',
-     x86_64: '1b2ea31fd26f9e0d8a3281faaccacf35192681a1a9aab28b3cfa51b5aa9656ab'
+    aarch64: '7a6bd99e2ec31d276634df30bad0e999cd57dcd460968e571fe1727a614262ec',
+     armv7l: '7a6bd99e2ec31d276634df30bad0e999cd57dcd460968e571fe1727a614262ec',
+     x86_64: 'd686849dfcf126224d2dfd9d846aadc9c36f4f0f1a0d6bfbb99c5dea1483d716'
   })
 
   depends_on 'blueprint_compiler' => :build

--- a/tests/package/g/gnome_sudoku
+++ b/tests/package/g/gnome_sudoku
@@ -1,0 +1,3 @@
+#!/bin/bash
+gnome-sudoku -h
+gnome-sudoku -v 2>&1

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -102,6 +102,7 @@ glslang
 gmmlib
 gnome_console
 gnome_online_accounts
+gnome_sudoku
 gobject_introspection
 google_chrome
 libcdr


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gnome_sudoku crew update \
&& yes | crew upgrade

$ crew check gnome_sudoku
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/gnome_sudoku.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking gnome_sudoku package ...
Property tests for gnome_sudoku passed.
Checking gnome_sudoku package ...
Buildsystem test for gnome_sudoku passed.
Checking gnome_sudoku package ...
Library test for gnome_sudoku passed.
Checking gnome_sudoku package ...
Usage:
  gnome-sudoku [OPTION…]

Help Options:
  -h, --help                Show help options
  --help-all                Show all help options
  --help-gapplication       Show GApplication options

Application Options:
  -v, --version             Show release version

gnome-sudoku 49.3
Package tests for gnome_sudoku passed.
```