### PR TITLE
Antigravity 1.13.3 => 1.14.2

### DIFF
--- a/manifest/x86_64/a/antigravity.filelist
+++ b/manifest/x86_64/a/antigravity.filelist
@@ -1,4 +1,4 @@
-# Total size: 733706599
+# Total size: 736416838
 /usr/local/bin/antigravity
 /usr/local/share/antigravity/LICENSES.chromium.html
 /usr/local/share/antigravity/antigravity
@@ -13021,6 +13021,20 @@
 /usr/local/share/antigravity/resources/app/node_modules/rc/node_modules/strip-json-comments/license
 /usr/local/share/antigravity/resources/app/node_modules/rc/node_modules/strip-json-comments/package.json
 /usr/local/share/antigravity/resources/app/node_modules/rc/package.json
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/LICENSE
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/client.js
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/client.mjs
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/index.js
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/index.mjs
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/jsx-dev-runtime.js
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/jsx-dev-runtime.mjs
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/jsx-runtime.js
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/jsx-runtime.mjs
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/lib/ReactCSSTransitionGroup.js
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/lib/ReactComponentWithPureRenderMixin.js
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/package.json
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/server.js
+/usr/local/share/antigravity/resources/app/node_modules/react-dom/server.mjs
 /usr/local/share/antigravity/resources/app/node_modules/react-error-boundary/LICENSE
 /usr/local/share/antigravity/resources/app/node_modules/react-error-boundary/dist/react-error-boundary.cjs.js
 /usr/local/share/antigravity/resources/app/node_modules/react-error-boundary/dist/react-error-boundary.esm.js
@@ -13066,6 +13080,20 @@
 /usr/local/share/antigravity/resources/app/node_modules/react-tooltip/dist/react-tooltip.umd.js
 /usr/local/share/antigravity/resources/app/node_modules/react-tooltip/dist/react-tooltip.umd.min.js
 /usr/local/share/antigravity/resources/app/node_modules/react-tooltip/package.json
+/usr/local/share/antigravity/resources/app/node_modules/react/LICENSE
+/usr/local/share/antigravity/resources/app/node_modules/react/client.js
+/usr/local/share/antigravity/resources/app/node_modules/react/client.mjs
+/usr/local/share/antigravity/resources/app/node_modules/react/index.js
+/usr/local/share/antigravity/resources/app/node_modules/react/index.mjs
+/usr/local/share/antigravity/resources/app/node_modules/react/jsx-dev-runtime.js
+/usr/local/share/antigravity/resources/app/node_modules/react/jsx-dev-runtime.mjs
+/usr/local/share/antigravity/resources/app/node_modules/react/jsx-runtime.js
+/usr/local/share/antigravity/resources/app/node_modules/react/jsx-runtime.mjs
+/usr/local/share/antigravity/resources/app/node_modules/react/lib/ReactCSSTransitionGroup.js
+/usr/local/share/antigravity/resources/app/node_modules/react/lib/ReactComponentWithPureRenderMixin.js
+/usr/local/share/antigravity/resources/app/node_modules/react/package.json
+/usr/local/share/antigravity/resources/app/node_modules/react/server.js
+/usr/local/share/antigravity/resources/app/node_modules/react/server.mjs
 /usr/local/share/antigravity/resources/app/node_modules/reactivity-store/LICENSE
 /usr/local/share/antigravity/resources/app/node_modules/reactivity-store/dist/cjs/index.development.js
 /usr/local/share/antigravity/resources/app/node_modules/reactivity-store/dist/cjs/index.production.js

--- a/packages/antigravity.rb
+++ b/packages/antigravity.rb
@@ -3,13 +3,13 @@ require 'package'
 class Antigravity < Package
   description 'Next-generation IDE from Google'
   homepage 'https://antigravity.google/'
-  version '1.13.3'
+  version '1.14.2'
   license 'Google Terms of Service'
   compatibility 'x86_64'
   min_glibc '2.28'
   # To display this url, the latest Debian package must be installed and then run 'apt download --print-uris antigravity'
-  source_url 'https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_1.13.3-1766182170_amd64_365061c50063f9bd47a9ff88432261b8.deb'
-  source_sha256 'd9920f9e0788245b1dab0f73a607b4eea00605bfb70e16795da1c1ac89eabd4b'
+  source_url 'https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_1.14.2-1768287740_amd64_5527204873323b09e7e6bc003cf22f91.deb'
+  source_sha256 '770f440b025afba6d140a0791e91f16e957456f501c766948710c939eff09206'
 
   no_compile_needed
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-antigravity crew update \
&& yes | crew upgrade

$ crew check antigravity 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/antigravity.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking antigravity package ...
Property tests for antigravity passed.
Checking antigravity package ...
Buildsystem test for antigravity passed.
Checking antigravity package ...
Library test for antigravity passed.
Checking antigravity package ...
1.104.0
450b6b28083d737992adc5d19637f22c95ffba7b
x64
Package tests for antigravity passed.
```