### PR TITLE
Termius 9.34.6 => 9.35.4

### DIFF
--- a/manifest/x86_64/t/termius.filelist
+++ b/manifest/x86_64/t/termius.filelist
@@ -1,4 +1,4 @@
-# Total size: 408527020
+# Total size: 409071806
 /usr/local/bin/termius
 /usr/local/share/Termius/LICENSE.electron.txt
 /usr/local/share/Termius/LICENSES.chromium.html

--- a/packages/termius.rb
+++ b/packages/termius.rb
@@ -3,12 +3,12 @@ require 'package'
 class Termius < Package
   description 'Modern SSH Client'
   homepage 'https://termius.com/'
-  version '9.34.8'
+  version '9.35.4'
   license 'Apache-2.0, LGPL-2.1, MIT'
   compatibility 'x86_64'
   min_glibc '2.33'
   source_url 'https://www.termius.com/download/linux/Termius.deb'
-  source_sha256 '5f383906fd20a910e73148a98f6c71e12fe58f921994c8ddda5842d182c01f24'
+  source_sha256 '5fe9eb848254a9189da9d4e4e4e5234e79c92bb49b50155980fd181fcc3139a3'
 
   depends_on 'sommelier'
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-termius crew update \
&& yes | crew upgrade

$ crew check termius
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/termius.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking termius package ...
Property tests for termius passed.
Checking termius package ...
Buildsystem test for termius passed.
Checking termius package ...
Library test for termius passed.
Checking termius package ...
[16461:0115/000603.496234:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /usr/local/share/Termius/chrome-sandbox is owned by root and has mode 4755.
/usr/local/lib/crew/tests/package/t/termius: line 2: 16461 Trace/breakpoint trap   termius --version
[16463:0100/000000.515671:ERROR:zygote_linux.cc(649)] write: Broken pipe (32)
Package tests for termius failed.
```