### PR TITLE
Acquia_cli 2.54.0 => 2.55.0

### DIFF
--- a/manifest/armv7l/a/acquia_cli.filelist
+++ b/manifest/armv7l/a/acquia_cli.filelist
@@ -1,2 +1,2 @@
-# Total size: 17122454
+# Total size: 17163194
 /usr/local/bin/acli

--- a/manifest/x86_64/a/acquia_cli.filelist
+++ b/manifest/x86_64/a/acquia_cli.filelist
@@ -1,2 +1,2 @@
-# Total size: 17122454
+# Total size: 17163194
 /usr/local/bin/acli

--- a/packages/acquia_cli.rb
+++ b/packages/acquia_cli.rb
@@ -3,11 +3,11 @@ require 'package'
 class Acquia_cli < Package
   description 'Acquia CLI - The official command-line tool for interacting with the Drupal Cloud Platform and services.'
   homepage 'https://github.com/acquia/cli'
-  version '2.54.0'
+  version '2.55.0'
   license 'GPL-2.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://github.com/acquia/cli/releases/download/#{version}/acli.phar"
-  source_sha256 'ed007de717dda1001d949f22f4724df29ac9e2bf627cff298c777b818d5c6d32'
+  source_sha256 '5350c973a9e5b5d2ee611d556fe1e3d1013c0387a4bf23821b7465be5b9f1de1'
 
   depends_on 'php83' unless File.exist? "#{CREW_PREFIX}/bin/php"
 

--- a/tests/package/a/acquia_cli
+++ b/tests/package/a/acquia_cli
@@ -1,0 +1,3 @@
+#!/bin/bash
+acli -h | head
+acli -V

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -1,6 +1,7 @@
 acl
 acpi
 acpica
+acquia_cli
 act
 aliyun_cli
 alsa_lib


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-acquia_cli crew update \
&& yes | crew upgrade

$ crew check acquia_cli 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/acquia_cli.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking acquia_cli package ...
Property tests for acquia_cli passed.
Checking acquia_cli package ...
Buildsystem test for acquia_cli passed.
Checking acquia_cli package ...
Library test for acquia_cli passed.
Checking acquia_cli package ...
Description:
  List commands

Usage:
  list [options] [--] [<namespace>]
  self:list

Arguments:
  namespace             The namespace name

Acquia CLI 2.55.0
Package tests for acquia_cli passed.
```