### PR TITLE
Bazel 8.5.0 => 8.5.1

### DIFF
--- a/manifest/x86_64/b/bazel.filelist
+++ b/manifest/x86_64/b/bazel.filelist
@@ -1,2 +1,2 @@
-# Total size: 64080171
+# Total size: 64081725
 /usr/local/bin/bazel

--- a/packages/bazel.rb
+++ b/packages/bazel.rb
@@ -3,11 +3,11 @@ require 'package'
 class Bazel < Package
   description 'a fast, scalable, multi-language and extensible build system'
   homepage 'https://bazel.build/'
-  version '8.5.0'
+  version '8.5.1'
   license 'Apache-2.0'
   compatibility 'x86_64'
   source_url "https://github.com/bazelbuild/bazel/releases/download/#{version}/bazel-#{version}-linux-x86_64"
-  source_sha256 '18255229d933b8da10151bdef223a302744296b09af8af1988c93faa1ea3c71f'
+  source_sha256 '61d89402f0368e64b6c827be5de79d8e65382e8124c3cbb97325611a1851392e'
 
   no_compile_needed
   no_shrink

--- a/tests/package/b/bazel
+++ b/tests/package/b/bazel
@@ -1,0 +1,3 @@
+#!/bin/bash
+bazel help 2>&1 | head
+bazel version 2>&1

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -19,6 +19,7 @@ autoconf_archive
 awscli
 axel
 b2
+bazel
 bc
 bdftopcf
 bind


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-bazel crew update \
&& yes | crew upgrade

$ crew check bazel 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/bazel.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking bazel package ...
Property tests for bazel passed.
Checking bazel package ...
Buildsystem test for bazel passed.
Checking bazel package ...
Library test for bazel passed.
Checking bazel package ...
WARNING: Invoking Bazel in batch mode since it is not invoked from within a workspace (below a directory having a MODULE.bazel file).
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
                                                           [bazel release 8.5.1]
Usage: bazel <command> <options> ...

Available commands:
  analyze-profile     Analyzes build profile data.
  aquery              Analyzes the given targets and queries the action graph.
  build               Builds the specified targets.
  canonicalize-flags  Canonicalizes a list of bazel options.
WARNING: Invoking Bazel in batch mode since it is not invoked from within a workspace (below a directory having a MODULE.bazel file).
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
Build label: 8.5.1
Build target: @@//src/main/java/com/google/devtools/build/lib/bazel:BazelServer
Build time: Mon Jan 12 18:41:24 2026 (1768243284)
Build timestamp: 1768243284
Build timestamp as int: 1768243284
Package tests for bazel passed.
```