### PR TITLE
Gnome_calculator 49.1.1 => 49.2

### DIFF
--- a/manifest/armv7l/g/gnome_calculator.filelist
+++ b/manifest/armv7l/g/gnome_calculator.filelist
@@ -1,4 +1,4 @@
-# Total size: 7808736
+# Total size: 7674211
 /usr/local/bin/gcalccmd
 /usr/local/bin/gnome-calculator
 /usr/local/include/gcalc-2/gcalc/gcalc.h
@@ -13,7 +13,7 @@
 /usr/local/lib/libgci-1.so.0.0.0
 /usr/local/lib/pkgconfig/gcalc-2.pc
 /usr/local/lib/pkgconfig/gci-1.pc
-/usr/local/lib/python3.13/site-packages/blueprintcompiler/reference_docs.json
+/usr/local/lib/python3.14/site-packages/blueprintcompiler/reference_docs.json
 /usr/local/libexec/gnome-calculator-search-provider
 /usr/local/share/applications/org.gnome.Calculator.desktop
 /usr/local/share/dbus-1/services/org.gnome.Calculator.SearchProvider.service

--- a/manifest/x86_64/g/gnome_calculator.filelist
+++ b/manifest/x86_64/g/gnome_calculator.filelist
@@ -1,9 +1,9 @@
-# Total size: 8388972
+# Total size: 8029539
 /usr/local/bin/gcalccmd
 /usr/local/bin/gnome-calculator
 /usr/local/include/gcalc-2/gcalc/gcalc.h
 /usr/local/include/gci-2/gci/gci.h
-/usr/local/lib/python3.13/site-packages/blueprintcompiler/reference_docs.json
+/usr/local/lib/python3.14/site-packages/blueprintcompiler/reference_docs.json
 /usr/local/lib64/girepository-1.0/GCalc-2.typelib
 /usr/local/lib64/girepository-1.0/GCi-1.typelib
 /usr/local/lib64/libgcalc-2.so

--- a/packages/gnome_calculator.rb
+++ b/packages/gnome_calculator.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Gnome_calculator < Meson
   description 'GNOME desktop calculator'
   homepage 'https://wiki.gnome.org/Apps/Calculator'
-  version '49.1.1'
+  version '49.2'
   license 'LGPL-2.1+'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-calculator.git'
@@ -11,9 +11,9 @@ class Gnome_calculator < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'bbb2fb609c3a0d2e2ad177eb3fd231785fffe790f515345e4d39a3b85ab2efee',
-     armv7l: 'bbb2fb609c3a0d2e2ad177eb3fd231785fffe790f515345e4d39a3b85ab2efee',
-     x86_64: '236ea5bff327eeb0e879cf44d1d1c56562ff7db691a8bd830832b47f15440c0d'
+    aarch64: '54291f6315978b770b449cca3acd3525cc8da8a0526e2344ba73300f6daea131',
+     armv7l: '54291f6315978b770b449cca3acd3525cc8da8a0526e2344ba73300f6daea131',
+     x86_64: 'd6a6c62ffcff637fe5ea2e90328ba798856041a4885ec75c53db9b227308ed6d'
   })
 
   depends_on 'gcc_lib' # R

--- a/tests/package/g/gnome_calculator
+++ b/tests/package/g/gnome_calculator
@@ -1,0 +1,3 @@
+#!/bin/bash
+gnome-calculator --help | head
+gnome-calculator --version 2>&1

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -100,6 +100,7 @@ glib
 glm
 glslang
 gmmlib
+gnome_calculator
 gnome_console
 gnome_online_accounts
 gnome_sudoku


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gnome_calculator crew update \
&& yes | crew upgrade

$ crew check gnome_calculator 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/gnome_calculator.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking gnome_calculator package ...
Property tests for gnome_calculator passed.
Checking gnome_calculator package ...
Buildsystem test for gnome_calculator passed.
Checking gnome_calculator package ...
Library test for gnome_calculator passed.
Checking gnome_calculator package ...
Usage:
  gnome-calculator [OPTION…]

Help Options:
  -h, --help                  Show help options
  --help-all                  Show all help options
  --help-gapplication         Show GApplication options

Application Options:
  -m, --mode=mode             Start in given mode (basic, advanced, financial, programming, keyboard, conversion)
gnome-calculator 49.2
Package tests for gnome_calculator passed.
```