### PR TITLE
Bazelisk 1.27.0 => 1.28.0

### DIFF
--- a/manifest/armv7l/b/bazelisk.filelist
+++ b/manifest/armv7l/b/bazelisk.filelist
@@ -1,2 +1,2 @@
-# Total size: 6555456
+# Total size: 6555344
 /usr/local/bin/bazelisk

--- a/manifest/i686/b/bazelisk.filelist
+++ b/manifest/i686/b/bazelisk.filelist
@@ -1,2 +1,2 @@
-# Total size: 6490608
+# Total size: 6498672
 /usr/local/bin/bazelisk

--- a/manifest/x86_64/b/bazelisk.filelist
+++ b/manifest/x86_64/b/bazelisk.filelist
@@ -1,2 +1,2 @@
-# Total size: 6675528
+# Total size: 6683624
 /usr/local/bin/bazelisk

--- a/packages/bazelisk.rb
+++ b/packages/bazelisk.rb
@@ -3,7 +3,7 @@ require 'package'
 class Bazelisk < Package
   description 'A user-friendly launcher for Bazel.'
   homepage 'https://github.com/bazelbuild/bazelisk'
-  version '1.27.0'
+  version '1.28.0'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/bazelbuild/bazelisk.git'
@@ -11,10 +11,10 @@ class Bazelisk < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '83d12d217865a03e4b84175a69f41a714a3c50234be2daea76757531e70bccfa',
-     armv7l: '83d12d217865a03e4b84175a69f41a714a3c50234be2daea76757531e70bccfa',
-       i686: '1ff2abd466f61d40aa8d753905189249b439043a8d51c697d63a39b8401e9714',
-     x86_64: 'aae4e2b4ac92914362d0bb989631e09f585e53e25f8cb22e1055183a8818e561'
+    aarch64: 'e604f11a477794e16d5586c96c4d20c4f1b894c3265eb56da683a236d588fbeb',
+     armv7l: 'e604f11a477794e16d5586c96c4d20c4f1b894c3265eb56da683a236d588fbeb',
+       i686: '268f9b58282c186b8a6d6a84c6d5cfcca934ebf7f57247a6ec286389bab6ae59',
+     x86_64: '248b90f3956d890e627fa3363b3ca521fe3bd801a050514ab0331359bb898162'
   })
 
   depends_on 'glibc' # R

--- a/tests/package/b/bazelisk
+++ b/tests/package/b/bazelisk
@@ -1,0 +1,3 @@
+#!/bin/bash
+bazelisk -h 2>&1 | head
+bazelisk --version

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -23,6 +23,7 @@ axel
 b2
 babl
 bazel
+bazelisk
 bc
 bdftopcf
 bind


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-bazelisk crew update \
&& yes | crew upgrade

$ crew check bazelisk
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/bazelisk.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking bazelisk package ...
Property tests for bazelisk passed.
Checking bazelisk package ...
Buildsystem test for bazelisk passed.
Checking bazelisk package ...
Library test for bazelisk passed.
Checking bazelisk package ...
WARNING: Invoking Bazel in batch mode since it is not invoked from within a workspace (below a directory having a MODULE.bazel file).
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
                                                           [bazel release 8.5.1]
Usage: bazel <command> <options> ...

Available commands:
  analyze-profile     Analyzes build profile data.
  aquery              Analyzes the given targets and queries the action graph.
  build               Builds the specified targets.
  canonicalize-flags  Canonicalizes a list of bazel options.
bazel 8.5.1
Package tests for bazelisk passed.
```