### PR TITLE
Gnome_maps 49.2 => 49.3, Libportal 0.8.1 => 0.9.1

### DIFF
--- a/manifest/armv7l/g/gnome_maps.filelist
+++ b/manifest/armv7l/g/gnome_maps.filelist
@@ -1,4 +1,4 @@
-# Total size: 5800096
+# Total size: 5805748
 /usr/local/bin/gnome-maps
 /usr/local/lib/gnome-maps/girepository-1.0/GnomeMaps-1.0.typelib
 /usr/local/lib/gnome-maps/libgnome-maps.so

--- a/manifest/armv7l/l/libportal.filelist
+++ b/manifest/armv7l/l/libportal.filelist
@@ -1,4 +1,4 @@
-# Total size: 237833
+# Total size: 587589
 /usr/local/include/libportal-gtk3/portal-gtk3.h
 /usr/local/include/libportal-gtk4/portal-gtk4.h
 /usr/local/include/libportal/account.h
@@ -7,6 +7,7 @@
 /usr/local/include/libportal/dynamic-launcher.h
 /usr/local/include/libportal/email.h
 /usr/local/include/libportal/filechooser.h
+/usr/local/include/libportal/glib-backports.h
 /usr/local/include/libportal/inhibit.h
 /usr/local/include/libportal/inputcapture-pointerbarrier.h
 /usr/local/include/libportal/inputcapture-zone.h
@@ -28,6 +29,9 @@
 /usr/local/include/libportal/types.h
 /usr/local/include/libportal/updates.h
 /usr/local/include/libportal/wallpaper.h
+/usr/local/lib/girepository-1.0/Xdp-1.0.typelib
+/usr/local/lib/girepository-1.0/XdpGtk3-1.0.typelib
+/usr/local/lib/girepository-1.0/XdpGtk4-1.0.typelib
 /usr/local/lib/libportal-gtk3.so
 /usr/local/lib/libportal-gtk3.so.1
 /usr/local/lib/libportal-gtk3.so.1.0.0
@@ -40,3 +44,12 @@
 /usr/local/lib/pkgconfig/libportal-gtk3.pc
 /usr/local/lib/pkgconfig/libportal-gtk4.pc
 /usr/local/lib/pkgconfig/libportal.pc
+/usr/local/share/gir-1.0/Xdp-1.0.gir
+/usr/local/share/gir-1.0/XdpGtk3-1.0.gir
+/usr/local/share/gir-1.0/XdpGtk4-1.0.gir
+/usr/local/share/vala/vapi/libportal-gtk3.deps
+/usr/local/share/vala/vapi/libportal-gtk3.vapi
+/usr/local/share/vala/vapi/libportal-gtk4.deps
+/usr/local/share/vala/vapi/libportal-gtk4.vapi
+/usr/local/share/vala/vapi/libportal.deps
+/usr/local/share/vala/vapi/libportal.vapi

--- a/manifest/x86_64/g/gnome_maps.filelist
+++ b/manifest/x86_64/g/gnome_maps.filelist
@@ -1,4 +1,4 @@
-# Total size: 5824434
+# Total size: 5830086
 /usr/local/bin/gnome-maps
 /usr/local/lib64/gnome-maps/girepository-1.0/GnomeMaps-1.0.typelib
 /usr/local/lib64/gnome-maps/libgnome-maps.so

--- a/manifest/x86_64/l/libportal.filelist
+++ b/manifest/x86_64/l/libportal.filelist
@@ -1,4 +1,4 @@
-# Total size: 326323
+# Total size: 657471
 /usr/local/include/libportal-gtk3/portal-gtk3.h
 /usr/local/include/libportal-gtk4/portal-gtk4.h
 /usr/local/include/libportal/account.h
@@ -7,6 +7,7 @@
 /usr/local/include/libportal/dynamic-launcher.h
 /usr/local/include/libportal/email.h
 /usr/local/include/libportal/filechooser.h
+/usr/local/include/libportal/glib-backports.h
 /usr/local/include/libportal/inhibit.h
 /usr/local/include/libportal/inputcapture-pointerbarrier.h
 /usr/local/include/libportal/inputcapture-zone.h
@@ -28,6 +29,9 @@
 /usr/local/include/libportal/types.h
 /usr/local/include/libportal/updates.h
 /usr/local/include/libportal/wallpaper.h
+/usr/local/lib64/girepository-1.0/Xdp-1.0.typelib
+/usr/local/lib64/girepository-1.0/XdpGtk3-1.0.typelib
+/usr/local/lib64/girepository-1.0/XdpGtk4-1.0.typelib
 /usr/local/lib64/libportal-gtk3.so
 /usr/local/lib64/libportal-gtk3.so.1
 /usr/local/lib64/libportal-gtk3.so.1.0.0
@@ -40,3 +44,12 @@
 /usr/local/lib64/pkgconfig/libportal-gtk3.pc
 /usr/local/lib64/pkgconfig/libportal-gtk4.pc
 /usr/local/lib64/pkgconfig/libportal.pc
+/usr/local/share/gir-1.0/Xdp-1.0.gir
+/usr/local/share/gir-1.0/XdpGtk3-1.0.gir
+/usr/local/share/gir-1.0/XdpGtk4-1.0.gir
+/usr/local/share/vala/vapi/libportal-gtk3.deps
+/usr/local/share/vala/vapi/libportal-gtk3.vapi
+/usr/local/share/vala/vapi/libportal-gtk4.deps
+/usr/local/share/vala/vapi/libportal-gtk4.vapi
+/usr/local/share/vala/vapi/libportal.deps
+/usr/local/share/vala/vapi/libportal.vapi

--- a/packages/gnome_maps.rb
+++ b/packages/gnome_maps.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Gnome_maps < Meson
   description 'A simple GNOME maps application'
   homepage 'https://wiki.gnome.org/Apps/Maps'
-  version '49.2'
+  version '49.3'
   license 'GPL-2+, LGPL-2+, MIT, CC-BY-3.0 and CC-BY-SA-3.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-maps.git'
@@ -11,17 +11,17 @@ class Gnome_maps < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'aa8e60521f23ca1a3263114605fcf6dcc381caf6eaf086a223a03781cef64251',
-     armv7l: 'aa8e60521f23ca1a3263114605fcf6dcc381caf6eaf086a223a03781cef64251',
-     x86_64: 'c05459c1373316f079482fbb475ee9a1587dca8456ff897805aedd5ea0dc443c'
+    aarch64: '757812f0671443c6fb4eba9aa727d5db6c8a54d5614771f644c82582877c1c04',
+     armv7l: '757812f0671443c6fb4eba9aa727d5db6c8a54d5614771f644c82582877c1c04',
+     x86_64: '5aca499e006b3831ec8acf82ed669de79f65f982ffd7fbff9ddc2c35370dbd9f'
   })
 
   depends_on 'cairo' # R
   depends_on 'desktop_file_utils' => :build
   depends_on 'folks' => :build
-  depends_on 'geoclue' => :build
-  depends_on 'geocode_glib2' => :build
-  depends_on 'gjs' => :build
+  depends_on 'geoclue' # R
+  depends_on 'geocode_glib2' # R
+  depends_on 'gjs' # R
   depends_on 'glib' # R
   depends_on 'glibc' # R
   depends_on 'gnome_weather' => :build
@@ -29,16 +29,18 @@ class Gnome_maps < Meson
   depends_on 'gtk4' # R
   depends_on 'harfbuzz' # R
   depends_on 'json_glib' # R
-  depends_on 'libadwaita' => :build
+  depends_on 'libadwaita' # R
   depends_on 'libchamplain' => :build
   depends_on 'libgee' => :build
-  depends_on 'libgweather' => :build
+  depends_on 'libgweather' # R
   depends_on 'libhandy' => :build
-  depends_on 'libportal' => :build
+  depends_on 'libportal' # R
   depends_on 'librsvg' # R
+  depends_on 'libsecret' # R
   depends_on 'libshumate' # R
   depends_on 'libxml2' # R
   depends_on 'pango' # R
+  depends_on 'rest' # R
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader'
   depends_on 'yelp_tools' => :build

--- a/packages/libportal.rb
+++ b/packages/libportal.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Libportal < Meson
   description 'libportal provides GIO-style async APIs for most Flatpak portals.'
   homepage 'https://github.com/flatpak/libportal'
-  version '0.8.1'
+  version '0.9.1'
   license 'GPL-2+'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/flatpak/libportal.git'
@@ -12,20 +12,20 @@ class Libportal < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '99a2d190d5b99e391625ad833188f8cf59c745b42e09475cebdddb8d1af640d6',
-     armv7l: '99a2d190d5b99e391625ad833188f8cf59c745b42e09475cebdddb8d1af640d6',
-     x86_64: '74764a5ced5cfd38b12c8415a656115a2eb037967b071c9a85d50fa5e6506fd8'
+    aarch64: '703ee0582fdf3999400ec69eb24208ca09e646e5519623d9c2eb681a9f9bd611',
+     armv7l: '703ee0582fdf3999400ec69eb24208ca09e646e5519623d9c2eb681a9f9bd611',
+     x86_64: 'd0ed166b4c9437e9660fb1de34de0ba7d84ba38a6120fe35aa288862e79db532'
   })
 
-  depends_on 'glibc' # R
   depends_on 'glib' # R
+  depends_on 'glibc' # R
   depends_on 'gtk3' # R
   depends_on 'gtk4' # R
+  depends_on 'vala' # R
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader' => :build
 
   meson_options '-Ddocs=false \
-    -Dintrospection=false \
     -Dportal-tests=false \
     -Dtests=false'
 end

--- a/tests/package/g/gnome_maps
+++ b/tests/package/g/gnome_maps
@@ -1,0 +1,3 @@
+#!/bin/bash
+gnome-maps -h 2>&1
+gnome-maps -v 2>&1

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -106,12 +106,14 @@ glslang
 gmmlib
 gnome_calculator
 gnome_console
+gnome_maps
 gnome_online_accounts
 gnome_sudoku
 gobject_introspection
 google_chrome
 libcdr
 libgedit_gtksourceview
+libportal
 libvisio
 libxfce4ui
 nano


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gnome_maps crew update \
&& yes | crew upgrade

$ crew check gnome_maps
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/gnome_maps.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking gnome_maps package ...
Property tests for gnome_maps passed.
Checking gnome_maps package ...
Buildsystem test for gnome_maps passed.
Checking gnome_maps package ...
Library test for gnome_maps passed.
Checking gnome_maps package ...
Usage:
  org.gnome.Maps [OPTION…] [FILE…|URI]

Help Options:
  -h, --help                Show help options
  --help-all                Show all help options
  --help-gapplication       Show GApplication options

Application Options:
  --local                   A path to a local tiles directory structure
  --local-tile-size         Tile size for local tiles directory
  -v, --version             Show the version of the program
  -S, --search              Search for places

_amdgpu_device_initialize: amdgpu_get_auth (1) failed (-1)
amdgpu: amdgpu_device_initialize failed.
libEGL warning: egl: failed to create dri2 screen

(org.gnome.Maps:9975): Gtk-WARNING **: 09:32:26.922: Unknown key monospace-font-name in /usr/local/.config/gtk-4.0/settings.ini
49.3
Package tests for gnome_maps passed.
```