### PR TITLE
Conmon 2.1.13 => 2.2.0

### DIFF
--- a/manifest/armv7l/c/conmon.filelist
+++ b/manifest/armv7l/c/conmon.filelist
@@ -1,3 +1,3 @@
-# Total size: 142852
+# Total size: 158598
 /usr/local/bin/conmon
 /usr/local/share/man/man8/conmon.8.zst

--- a/manifest/x86_64/c/conmon.filelist
+++ b/manifest/x86_64/c/conmon.filelist
@@ -1,3 +1,3 @@
-# Total size: 145632
+# Total size: 161150
 /usr/local/bin/conmon
 /usr/local/share/man/man8/conmon.8.zst

--- a/packages/conmon.rb
+++ b/packages/conmon.rb
@@ -6,7 +6,7 @@ require 'package'
 class Conmon < Package
   description 'OCI container runtime monitor'
   homepage 'https://github.com/containers/conmon'
-  version '2.1.13'
+  version '2.2.0'
   license 'APACHE'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/containers/conmon.git'
@@ -14,9 +14,9 @@ class Conmon < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '44765056e635186d2346c667a628c3e6c35ab96f145c5fe732519ea334024be9',
-     armv7l: '44765056e635186d2346c667a628c3e6c35ab96f145c5fe732519ea334024be9',
-     x86_64: '282e880b018ce286885eb4be27b24634b2ae6b7f88356a81befcfb1405357200'
+    aarch64: 'ef1d4ac65976cb544587eba612821ba514316c2910307ece17f06725abe7337d',
+     armv7l: 'ef1d4ac65976cb544587eba612821ba514316c2910307ece17f06725abe7337d',
+     x86_64: '2554a5dd5092bc501e88f653ce755382b66f20b9e39036f7fa3b5664e0ed0d3f'
   })
 
   depends_on 'glib' # R

--- a/tests/package/c/conmon
+++ b/tests/package/c/conmon
@@ -1,0 +1,3 @@
+#!/bin/bash
+conmon -h | head
+conmon --version

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -36,6 +36,7 @@ caprine
 cargo_c
 codex
 composer
+conmon
 dart
 dav1d
 dbeaver


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-conmon crew update \
&& yes | crew upgrade

$ crew check conmon
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/conmon.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking conmon package ...
Property tests for conmon passed.
Checking conmon package ...
Buildsystem test for conmon passed.
Checking conmon package ...
Library test for conmon passed.
Checking conmon package ...
Usage:
  conmon [OPTION…] - conmon utility

Help Options:
  -h, --help                         Show help options

Application Options:
  --api-version                      Conmon API version to use
  -b, --bundle                       Location of the OCI Bundle path
  -c, --cid                          Identification of Container
conmon version 2.2.0
commit: ff908cce92cf89167b6b97ed240e91a6b147acc1
Package tests for conmon passed.
```