### PR TITLE
Asciinema 3.0.1 => 3.1.0

### DIFF
--- a/manifest/armv7l/a/asciinema.filelist
+++ b/manifest/armv7l/a/asciinema.filelist
@@ -1,2 +1,2 @@
-# Total size: 5936252
+# Total size: 6973356
 /usr/local/bin/asciinema

--- a/manifest/i686/a/asciinema.filelist
+++ b/manifest/i686/a/asciinema.filelist
@@ -1,2 +1,2 @@
-# Total size: 6863788
+# Total size: 7929132
 /usr/local/bin/asciinema

--- a/manifest/x86_64/a/asciinema.filelist
+++ b/manifest/x86_64/a/asciinema.filelist
@@ -1,2 +1,2 @@
-# Total size: 7233240
+# Total size: 8275424
 /usr/local/bin/asciinema

--- a/packages/asciinema.rb
+++ b/packages/asciinema.rb
@@ -3,7 +3,7 @@ require 'buildsystems/rust'
 class Asciinema < RUST
   description 'Terminal session recorder'
   homepage 'https://asciinema.org/'
-  version '3.0.1'
+  version '3.1.0'
   license 'GPL-3+'
   compatibility 'all'
   source_url 'https://github.com/asciinema/asciinema.git'
@@ -11,10 +11,10 @@ class Asciinema < RUST
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '99c98bb937becd11ed33a2e698825fccd57f57a7bf1eea9a4b159212537d38e6',
-     armv7l: '99c98bb937becd11ed33a2e698825fccd57f57a7bf1eea9a4b159212537d38e6',
-       i686: '0e93849e396c9686bef0a409c5f4330d2ffd4636087f3aedb84dba84b6dfa50e',
-     x86_64: '6be54897e8e98b7baa45f0d33088a72828539308d8cbf55d084e25f2cbd46554'
+    aarch64: '5904e59ee2743d01a7f9d791e68925db3bf96f23d9b018933156cfa4c0753c37',
+     armv7l: '5904e59ee2743d01a7f9d791e68925db3bf96f23d9b018933156cfa4c0753c37',
+       i686: 'b07ab36cb1b4a71a73f94694fa87bb2bd7bfc697792e9a131af19f4d73615bda',
+     x86_64: '021f9a3fda92899c292dd0fc1134ce5a5827470147895abf1edba3d942730d08'
   })
 
   depends_on 'gcc_lib' # R

--- a/tests/package/a/asciinema
+++ b/tests/package/a/asciinema
@@ -1,0 +1,3 @@
+#!/bin/bash
+asciinema -h | head
+asciinema -V

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -15,6 +15,7 @@ apr
 apr_util
 armadillo
 arp_scan
+asciinema
 asunder
 at_spi2_core
 augeas


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-asciinema crew update \
&& yes | crew upgrade

$ crew check asciinema
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/asciinema.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking asciinema package ...
Property tests for asciinema passed.
Checking asciinema package ...
Buildsystem test for asciinema passed.
Checking asciinema package ...
Library test for asciinema passed.
Checking asciinema package ...
Terminal session recorder, streamer, and player

Usage: asciinema [OPTIONS] <COMMAND>

Commands:
  record   Record a terminal session [aliases: rec]
  stream   Stream a terminal session
  session  Record and stream a terminal session
  play     Play back a terminal session
  upload   Upload a recording to an asciinema server
asciinema 3.1.0
Package tests for asciinema passed.
```