### PR TITLE
Crystal 1.18.2 => 1.19.0

### DIFF
--- a/manifest/x86_64/c/crystal.filelist
+++ b/manifest/x86_64/c/crystal.filelist
@@ -1,11 +1,9 @@
-# Total size: 147551631
+# Total size: 160581714
 /usr/local/bin/crystal
 /usr/local/bin/shards
 /usr/local/etc/bash.d/10-crystal
-/usr/local/lib/crystal/libevent.a
-/usr/local/lib/crystal/libevent_pthreads.a
-/usr/local/lib/crystal/libgc.a
-/usr/local/lib/crystal/libpcre2-8.a
+/usr/local/lib64/crystal/libgc.a
+/usr/local/lib64/crystal/libpcre2-8.a
 /usr/local/share/bash-completion/completions/crystal
 /usr/local/share/crystal/src/SOURCE_DATE_EPOCH
 /usr/local/share/crystal/src/VERSION
@@ -332,6 +330,7 @@
 /usr/local/share/crystal/src/crystal/event_loop/libevent.cr
 /usr/local/share/crystal/src/crystal/event_loop/libevent/event.cr
 /usr/local/share/crystal/src/crystal/event_loop/libevent/lib_event2.cr
+/usr/local/share/crystal/src/crystal/event_loop/lock.cr
 /usr/local/share/crystal/src/crystal/event_loop/polling.cr
 /usr/local/share/crystal/src/crystal/event_loop/polling/arena.cr
 /usr/local/share/crystal/src/crystal/event_loop/polling/event.cr
@@ -341,6 +340,7 @@
 /usr/local/share/crystal/src/crystal/event_loop/socket.cr
 /usr/local/share/crystal/src/crystal/event_loop/timers.cr
 /usr/local/share/crystal/src/crystal/event_loop/wasi.cr
+/usr/local/share/crystal/src/crystal/fd_lock.cr
 /usr/local/share/crystal/src/crystal/hasher.cr
 /usr/local/share/crystal/src/crystal/iconv.cr
 /usr/local/share/crystal/src/crystal/interpreter.cr
@@ -407,6 +407,7 @@
 /usr/local/share/crystal/src/crystal/system/unix/pthread_mutex.cr
 /usr/local/share/crystal/src/crystal/system/unix/signal.cr
 /usr/local/share/crystal/src/crystal/system/unix/socket.cr
+/usr/local/share/crystal/src/crystal/system/unix/spawn.cr
 /usr/local/share/crystal/src/crystal/system/unix/syscall.cr
 /usr/local/share/crystal/src/crystal/system/unix/sysconf_cpucount.cr
 /usr/local/share/crystal/src/crystal/system/unix/sysctl_cpucount.cr
@@ -469,6 +470,7 @@
 /usr/local/share/crystal/src/crystal/system/windows.cr
 /usr/local/share/crystal/src/crystal/thread_local_value.cr
 /usr/local/share/crystal/src/crystal/tracing.cr
+/usr/local/share/crystal/src/crystal/value_with_finalizer.cr
 /usr/local/share/crystal/src/csv.cr
 /usr/local/share/crystal/src/csv/builder.cr
 /usr/local/share/crystal/src/csv/error.cr
@@ -636,6 +638,7 @@
 /usr/local/share/crystal/src/kernel.cr
 /usr/local/share/crystal/src/levenshtein.cr
 /usr/local/share/crystal/src/lib_c.cr
+/usr/local/share/crystal/src/lib_c/aarch64-android
 /usr/local/share/crystal/src/lib_c/aarch64-android/c/arpa/inet.cr
 /usr/local/share/crystal/src/lib_c/aarch64-android/c/dirent.cr
 /usr/local/share/crystal/src/lib_c/aarch64-android/c/dlfcn.cr
@@ -644,6 +647,7 @@
 /usr/local/share/crystal/src/lib_c/aarch64-android/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/aarch64-android/c/grp.cr
 /usr/local/share/crystal/src/lib_c/aarch64-android/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/aarch64-android/c/limits.cr
 /usr/local/share/crystal/src/lib_c/aarch64-android/c/link.cr
 /usr/local/share/crystal/src/lib_c/aarch64-android/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/aarch64-android/c/netdb.cr
@@ -686,7 +690,7 @@
 /usr/local/share/crystal/src/lib_c/aarch64-darwin/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/aarch64-darwin/c/grp.cr
 /usr/local/share/crystal/src/lib_c/aarch64-darwin/c/iconv.cr
-/usr/local/share/crystal/src/lib_c/aarch64-darwin/c/mach/mach_time.cr
+/usr/local/share/crystal/src/lib_c/aarch64-darwin/c/limits.cr
 /usr/local/share/crystal/src/lib_c/aarch64-darwin/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/aarch64-darwin/c/netdb.cr
 /usr/local/share/crystal/src/lib_c/aarch64-darwin/c/netinet/in.cr
@@ -715,6 +719,50 @@
 /usr/local/share/crystal/src/lib_c/aarch64-darwin/c/termios.cr
 /usr/local/share/crystal/src/lib_c/aarch64-darwin/c/time.cr
 /usr/local/share/crystal/src/lib_c/aarch64-darwin/c/unistd.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/arpa/inet.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/dirent.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/dlfcn.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/elf.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/errno.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/fcntl.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/grp.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/limits.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/link.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/net/if.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/netdb.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/netinet/in.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/netinet/tcp.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/pthread.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/pwd.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sched.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/signal.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/stdarg.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/stddef.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/stdint.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/stdio.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/stdlib.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/string.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/epoll.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/eventfd.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/file.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/ioctl.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/mman.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/random.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/resource.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/select.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/socket.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/stat.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/syscall.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/system_properties.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/time.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/timerfd.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/types.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/un.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/sys/wait.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/termios.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/time.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-android/c/unistd.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/arpa/inet.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/dirent.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/dlfcn.cr
@@ -723,6 +771,7 @@
 /usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/grp.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/limits.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/link.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-gnu/c/netdb.cr
@@ -763,6 +812,7 @@
 /usr/local/share/crystal/src/lib_c/aarch64-linux-musl/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-musl/c/grp.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-musl/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/aarch64-linux-musl/c/limits.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-musl/c/link.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-musl/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/aarch64-linux-musl/c/netdb.cr
@@ -803,6 +853,7 @@
 /usr/local/share/crystal/src/lib_c/aarch64-windows-gnu/c/consoleapi2.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-gnu/c/corecrt.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-gnu/c/dbghelp.cr
+/usr/local/share/crystal/src/lib_c/aarch64-windows-gnu/c/debugapi.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-gnu/c/delayimp.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-gnu/c/direct.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-gnu/c/errhandlingapi.cr
@@ -879,6 +930,7 @@
 /usr/local/share/crystal/src/lib_c/aarch64-windows-msvc/c/consoleapi2.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-msvc/c/corecrt.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-msvc/c/dbghelp.cr
+/usr/local/share/crystal/src/lib_c/aarch64-windows-msvc/c/debugapi.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-msvc/c/delayimp.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-msvc/c/direct.cr
 /usr/local/share/crystal/src/lib_c/aarch64-windows-msvc/c/errhandlingapi.cr
@@ -956,6 +1008,7 @@
 /usr/local/share/crystal/src/lib_c/amd64-unknown-openbsd/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/amd64-unknown-openbsd/c/grp.cr
 /usr/local/share/crystal/src/lib_c/amd64-unknown-openbsd/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/amd64-unknown-openbsd/c/limits.cr
 /usr/local/share/crystal/src/lib_c/amd64-unknown-openbsd/c/link.cr
 /usr/local/share/crystal/src/lib_c/amd64-unknown-openbsd/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/amd64-unknown-openbsd/c/netdb.cr
@@ -994,6 +1047,7 @@
 /usr/local/share/crystal/src/lib_c/arm-linux-gnueabihf/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/arm-linux-gnueabihf/c/grp.cr
 /usr/local/share/crystal/src/lib_c/arm-linux-gnueabihf/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/arm-linux-gnueabihf/c/limits.cr
 /usr/local/share/crystal/src/lib_c/arm-linux-gnueabihf/c/link.cr
 /usr/local/share/crystal/src/lib_c/arm-linux-gnueabihf/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/arm-linux-gnueabihf/c/netdb.cr
@@ -1034,6 +1088,7 @@
 /usr/local/share/crystal/src/lib_c/i386-linux-gnu/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-gnu/c/grp.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-gnu/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/i386-linux-gnu/c/limits.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-gnu/c/link.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-gnu/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-gnu/c/netdb.cr
@@ -1074,6 +1129,7 @@
 /usr/local/share/crystal/src/lib_c/i386-linux-musl/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-musl/c/grp.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-musl/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/i386-linux-musl/c/limits.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-musl/c/link.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-musl/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/i386-linux-musl/c/netdb.cr
@@ -1115,6 +1171,7 @@
 /usr/local/share/crystal/src/lib_c/i686-linux-gnu/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-gnu/c/grp.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-gnu/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/i686-linux-gnu/c/limits.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-gnu/c/link.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-gnu/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-gnu/c/netdb.cr
@@ -1156,6 +1213,7 @@
 /usr/local/share/crystal/src/lib_c/i686-linux-musl/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-musl/c/grp.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-musl/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/i686-linux-musl/c/limits.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-musl/c/link.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-musl/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/i686-linux-musl/c/netdb.cr
@@ -1220,7 +1278,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-darwin/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-darwin/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-darwin/c/iconv.cr
-/usr/local/share/crystal/src/lib_c/x86_64-darwin/c/mach/mach_time.cr
+/usr/local/share/crystal/src/lib_c/x86_64-darwin/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-darwin/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-darwin/c/netdb.cr
 /usr/local/share/crystal/src/lib_c/x86_64-darwin/c/netinet/in.cr
@@ -1257,6 +1315,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-dragonfly/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-dragonfly/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-dragonfly/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/x86_64-dragonfly/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-dragonfly/c/link.cr
 /usr/local/share/crystal/src/lib_c/x86_64-dragonfly/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-dragonfly/c/netdb.cr
@@ -1295,6 +1354,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-freebsd/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-freebsd/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-freebsd/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/x86_64-freebsd/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-freebsd/c/link.cr
 /usr/local/share/crystal/src/lib_c/x86_64-freebsd/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-freebsd/c/netdb.cr
@@ -1334,6 +1394,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-linux-gnu/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-gnu/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-gnu/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/x86_64-linux-gnu/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-gnu/c/link.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-gnu/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-gnu/c/netdb.cr
@@ -1374,6 +1435,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-linux-musl/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-musl/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-musl/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/x86_64-linux-musl/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-musl/c/link.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-musl/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-linux-musl/c/netdb.cr
@@ -1414,7 +1476,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-macosx-darwin/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-macosx-darwin/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-macosx-darwin/c/iconv.cr
-/usr/local/share/crystal/src/lib_c/x86_64-macosx-darwin/c/mach/mach_time.cr
+/usr/local/share/crystal/src/lib_c/x86_64-macosx-darwin/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-macosx-darwin/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-macosx-darwin/c/netdb.cr
 /usr/local/share/crystal/src/lib_c/x86_64-macosx-darwin/c/netinet/in.cr
@@ -1451,6 +1513,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-netbsd/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-netbsd/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-netbsd/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/x86_64-netbsd/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-netbsd/c/link.cr
 /usr/local/share/crystal/src/lib_c/x86_64-netbsd/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-netbsd/c/netdb.cr
@@ -1489,6 +1552,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-openbsd/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-openbsd/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-openbsd/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/x86_64-openbsd/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-openbsd/c/link.cr
 /usr/local/share/crystal/src/lib_c/x86_64-openbsd/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-openbsd/c/netdb.cr
@@ -1528,6 +1592,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-portbld-freebsd/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-portbld-freebsd/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-portbld-freebsd/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/x86_64-portbld-freebsd/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-portbld-freebsd/c/link.cr
 /usr/local/share/crystal/src/lib_c/x86_64-portbld-freebsd/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-portbld-freebsd/c/netdb.cr
@@ -1567,6 +1632,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-solaris/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-solaris/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-solaris/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/x86_64-solaris/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-solaris/c/link.cr
 /usr/local/share/crystal/src/lib_c/x86_64-solaris/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-solaris/c/netdb.cr
@@ -1607,6 +1673,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-unknown-freebsd/c/fcntl.cr
 /usr/local/share/crystal/src/lib_c/x86_64-unknown-freebsd/c/grp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-unknown-freebsd/c/iconv.cr
+/usr/local/share/crystal/src/lib_c/x86_64-unknown-freebsd/c/limits.cr
 /usr/local/share/crystal/src/lib_c/x86_64-unknown-freebsd/c/link.cr
 /usr/local/share/crystal/src/lib_c/x86_64-unknown-freebsd/c/net/if.cr
 /usr/local/share/crystal/src/lib_c/x86_64-unknown-freebsd/c/netdb.cr
@@ -1646,6 +1713,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-windows-gnu/c/consoleapi2.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-gnu/c/corecrt.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-gnu/c/dbghelp.cr
+/usr/local/share/crystal/src/lib_c/x86_64-windows-gnu/c/debugapi.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-gnu/c/delayimp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-gnu/c/direct.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-gnu/c/errhandlingapi.cr
@@ -1721,6 +1789,7 @@
 /usr/local/share/crystal/src/lib_c/x86_64-windows-msvc/c/consoleapi2.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-msvc/c/corecrt.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-msvc/c/dbghelp.cr
+/usr/local/share/crystal/src/lib_c/x86_64-windows-msvc/c/debugapi.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-msvc/c/delayimp.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-msvc/c/direct.cr
 /usr/local/share/crystal/src/lib_c/x86_64-windows-msvc/c/errhandlingapi.cr
@@ -1820,6 +1889,7 @@
 /usr/local/share/crystal/src/llvm/lib_llvm/analysis.cr
 /usr/local/share/crystal/src/llvm/lib_llvm/bit_reader.cr
 /usr/local/share/crystal/src/llvm/lib_llvm/bit_writer.cr
+/usr/local/share/crystal/src/llvm/lib_llvm/config.cr
 /usr/local/share/crystal/src/llvm/lib_llvm/core.cr
 /usr/local/share/crystal/src/llvm/lib_llvm/debug_info.cr
 /usr/local/share/crystal/src/llvm/lib_llvm/error.cr
@@ -1889,7 +1959,6 @@
 /usr/local/share/crystal/src/oauth/consumer.cr
 /usr/local/share/crystal/src/oauth/error.cr
 /usr/local/share/crystal/src/oauth/oauth.cr
-/usr/local/share/crystal/src/oauth/params.cr
 /usr/local/share/crystal/src/oauth/request_token.cr
 /usr/local/share/crystal/src/oauth/signature.cr
 /usr/local/share/crystal/src/oauth2.cr
@@ -1997,6 +2066,18 @@
 /usr/local/share/crystal/src/string_scanner.cr
 /usr/local/share/crystal/src/struct.cr
 /usr/local/share/crystal/src/symbol.cr
+/usr/local/share/crystal/src/sync/condition_variable.cr
+/usr/local/share/crystal/src/sync/cv.cr
+/usr/local/share/crystal/src/sync/errors.cr
+/usr/local/share/crystal/src/sync/exclusive.cr
+/usr/local/share/crystal/src/sync/lockable.cr
+/usr/local/share/crystal/src/sync/mu.cr
+/usr/local/share/crystal/src/sync/mutex.cr
+/usr/local/share/crystal/src/sync/rw_lock.cr
+/usr/local/share/crystal/src/sync/shared.cr
+/usr/local/share/crystal/src/sync/sync.cr
+/usr/local/share/crystal/src/sync/type.cr
+/usr/local/share/crystal/src/sync/waiter.cr
 /usr/local/share/crystal/src/syscall.cr
 /usr/local/share/crystal/src/syscall/aarch64-linux.cr
 /usr/local/share/crystal/src/syscall/arm-linux.cr
@@ -2017,6 +2098,7 @@
 /usr/local/share/crystal/src/time/format/formatter.cr
 /usr/local/share/crystal/src/time/format/parser.cr
 /usr/local/share/crystal/src/time/format/pattern.cr
+/usr/local/share/crystal/src/time/instant.cr
 /usr/local/share/crystal/src/time/location.cr
 /usr/local/share/crystal/src/time/location/loader.cr
 /usr/local/share/crystal/src/time/span.cr

--- a/packages/crystal.rb
+++ b/packages/crystal.rb
@@ -3,18 +3,19 @@ require 'package'
 class Crystal < Package
   description 'A language for humans and computers'
   homepage 'https://crystal-lang.org/'
-  version '1.18.2'
+  version '1.19.0'
   license 'Apache-2.0'
   compatibility 'x86_64'
   source_url "https://github.com/crystal-lang/crystal/releases/download/#{version}/crystal-#{version}-1-linux-x86_64-bundled.tar.gz"
-  source_sha256 '179c48162365e1f84426a3d352fe7a97e7fc798fd73b4232d1f491b11a0ef2dc'
+  source_sha256 'ad56c419748b9b289aff61e17c44ff56aebebb14c4798ea0592ebe0ae30a4845'
 
   no_compile_needed
   print_source_bashrc
 
   def self.install
-    FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX} #{CREW_DEST_PREFIX}/etc/bash.d]
-    FileUtils.mv %w[bin lib share], CREW_DEST_PREFIX
+    FileUtils.mkdir_p %W[#{CREW_DEST_LIB_PREFIX} #{CREW_DEST_PREFIX}/etc/bash.d]
+    FileUtils.mv %w[bin share], CREW_DEST_PREFIX
+    FileUtils.mv Dir['lib/*'], CREW_DEST_LIB_PREFIX
     FileUtils.ln_s "#{CREW_PREFIX}/share/bash-completion/completions/crystal", "#{CREW_DEST_PREFIX}/etc/bash.d/10-crystal"
   end
 end

--- a/tests/package/c/crystal
+++ b/tests/package/c/crystal
@@ -1,0 +1,3 @@
+#!/bin/bash
+crystal -h | head
+crystal -v

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -41,6 +41,7 @@ cargo_c
 codex
 composer
 conmon
+crystal
 dart
 dav1d
 dbeaver


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-crystal crew update \
&& yes | crew upgrade

$ crew check crystal 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/crystal.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking crystal package ...
Property tests for crystal passed.
Checking crystal package ...
Buildsystem test for crystal passed.
Checking crystal package ...
Library test for crystal passed.
Checking crystal package ...
Usage: crystal [command] [switches] [program file] [--] [arguments]

Command:
    init                     generate a new project
    build                    build an executable
    clear_cache              clear the compiler cache
    docs                     generate documentation
    env                      print Crystal environment information
    eval                     eval code from args or standard input
    i/interactive            starts interactive Crystal
Crystal 1.19.0 [5a4407796] (2026-01-14)

LLVM: 20.1.8
Default target: x86_64-unknown-linux-gnu
Package tests for crystal passed.
```