### PR TITLE
Add ldc package test

### DIFF
--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -14,6 +14,7 @@ class Ldc < Package
   depends_on 'ncurses'
   depends_on 'zlib'
 
+  conflicts_with 'dmd'
   no_compile_needed
   no_shrink
   print_source_bashrc

--- a/tests/package/l/ldc
+++ b/tests/package/l/ldc
@@ -1,0 +1,15 @@
+#!/bin/bash
+ddemangle -h 2>&1
+dub --version
+dustmite --version
+ldc-build-plugin -h | head
+ldc-build-runtime --version
+ldc-profdata --version
+ldc-profgen --version
+ldc-prune-cache -h 2>&1
+ldc2 -h | head
+ldc2 --version | head
+ldmd2 --version | head
+rdmd --version | head
+reggae --version | head
+timetrace2txt --help 2>&1

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -119,6 +119,7 @@ gnome_online_accounts
 gnome_sudoku
 gobject_introspection
 google_chrome
+ldc
 libcdr
 libgedit_gtksourceview
 libportal


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-ldc crew update \
&& yes | crew upgrade

$ crew check ldc
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/ldc.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking ldc package ...
Property tests for ldc passed.
Checking ldc package ...
Buildsystem test for ldc passed.
Checking ldc package ...
Library test for ldc passed.
Checking ldc package ...
Usage: ddemangle [options] [<inputfile>]
Demangles all occurrences of mangled D symbols in the input and writes to
standard output.
If <inputfile> is omitted, standard input is read.
Options:
    --help, -h    Show this help
DUB version 1.40.0, built on Jun  7 2025
DustMite build Jun  7 2025 (upstream), built with LDC 2111
OVERVIEW: Builds a Semantic Analysis plugin for LDC.

USAGE: ldc-build-plugin [options] sourcefiles... -of=<output file>

OPTIONS:
  Unrecognized options are passed through to LDC.
           --ldc Path to LDC executable (default: '/usr/local/bin/ldc2')
      --buildDir Path to build directory (default: './ldc-build-plugin.tmp')
     --ldcSrcDir Path to LDC source directory (if not specified: downloads & extracts source archive into '<buildDir>/ldc-src')
        --dFlags Extra LDC flags for the D module (separated by ';')
Error processing command line arguments: Unrecognized option --version
Use '--help' for help.
LLVM (http://llvm.org/):
  LLVM version 20.1.5
  Optimized build.
LLVM (http://llvm.org/):
  LLVM version 20.1.5
  Optimized build.
OVERVIEW: LDC-PRUNE-CACHE
  Prunes the LDC's object file cache to prevent the cache growing infinitely.
  When a minimum pruning interval has passed (--interval), the following
  pruning scheme is executed:
  1. remove cached files that have passed the expiry duration (--expiry);
  2. remove cached files (oldest first) until the total cache size is below a
     set limit (--max-bytes, --max-percentage-of-avail).

USAGE: ldc-prune-cache [OPTION]... PATH
  PATH should be a directory where LDC has placed its object files cache (see
  LDC's -cache option).

OPTIONS:
  --expiration=<dur>     Sets the pruning expiration time of cache files to
                         <dur> seconds (default: 1 week).
  -f, --force            Force pruning, ignoring the prune interval.
  -h, --help             Show this message.
  --interval=<dur>       Sets the cache pruning interval to <dur> seconds
                         (default: 20 min). Set to 0 to force pruning, see -f.
  --max-bytes=<size>     Sets the cache size absolute limit to <size> bytes
                         (default: no absolute limit).
  --max-percentage-of-avail=<perc>
                         Sets the cache size limit to <perc> percent of the
                         available disk space (default 75%).
OVERVIEW: LDC - the LLVM D compiler

USAGE: ldc2 [options] files --run Runs the resulting program, passing the remaining arguments to it

OPTIONS:

General options:

  -D                                           - Generate documentation
  --Dd=<directory>                             - Write documentation file to <directory>
LDC - the LLVM D compiler (1.41.0):
  based on DMD v2.111.0 and LLVM 20.1.5
  built with LDC - the LLVM D compiler (1.41.0)
  Default target: x86_64-unknown-linux-gnu
  Host CPU: znver3
  http://dlang.org - http://wiki.dlang.org/LDC


  Registered Targets:
    aarch64     - AArch64 (little endian)
LDC - the LLVM D compiler (1.41.0):
  based on DMD v2.111.0 and LLVM 20.1.5
  built with LDC - the LLVM D compiler (1.41.0)
  Default target: x86_64-unknown-linux-gnu
  Host CPU: znver3
  http://dlang.org - http://wiki.dlang.org/LDC


  Registered Targets:
    aarch64     - AArch64 (little endian)
rdmd build 20250607
Usage: rdmd [RDMD AND DMD OPTIONS...] program [PROGRAM OPTIONS...]
Builds a D program with its dependencies and runs it.
Example: rdmd -release myprog --myprogparameter 5

Any option to be passed to the compiler must occur before the program name.
In addition to compiler options, rdmd recognizes the following options:
  --build-only       just build the executable, don't run it
  --chatty           write compiler commands to stdout before executing them
  --compiler=comp    use the specified compiler (e.g. gdmd) instead of ldmd2
reggae v0.5.24+
No input file given!

Converts --ftime-trace output to text.
Usage: timetrace2txt [input file] [options]

   --indent Output items as simply indented list instead of the fancy tree. This should go well with code-folding editors.
-o          Output filename (default: 'timetrace.txt'). Specify '-' to redirect output to stdout.
      --tsv Also output to this file in duration-sorted Tab-Separated Values (TSV) format
-h   --help This help information.
Package tests for ldc passed.
```