### PR TITLE
Fakeroot 1.37.1.2 => 1.37.2

### DIFF
--- a/manifest/armv7l/f/fakeroot.filelist
+++ b/manifest/armv7l/f/fakeroot.filelist
@@ -1,4 +1,4 @@
-# Total size: 231710
+# Total size: 231724
 /usr/local/bin/faked
 /usr/local/bin/fakeroot
 /usr/local/lib/libfakeroot-0.so

--- a/manifest/i686/f/fakeroot.filelist
+++ b/manifest/i686/f/fakeroot.filelist
@@ -1,4 +1,4 @@
-# Total size: 202406
+# Total size: 202404
 /usr/local/bin/faked
 /usr/local/bin/fakeroot
 /usr/local/lib/libfakeroot-0.so

--- a/manifest/x86_64/f/fakeroot.filelist
+++ b/manifest/x86_64/f/fakeroot.filelist
@@ -1,4 +1,4 @@
-# Total size: 233694
+# Total size: 233692
 /usr/local/bin/faked
 /usr/local/bin/fakeroot
 /usr/local/lib64/libfakeroot-0.so

--- a/packages/fakeroot.rb
+++ b/packages/fakeroot.rb
@@ -3,18 +3,18 @@ require 'buildsystems/autotools'
 class Fakeroot < Autotools
   description 'Run a command in an environment faking root privileges for file manipulation.'
   homepage 'https://wiki.debian.org/FakeRoot'
-  version '1.37.1.2'
+  version '1.37.2'
   license 'GPL-3'
   compatibility 'all'
   source_url "https://deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_#{version}.orig.tar.gz"
-  source_sha256 '959496928c8a676ec8377f665ff6a19a707bfad693325f9cc4a4126642f53224'
+  source_sha256 '0eea60fbe89771b88fcf415c8f2f0a6ccfe9edebbcf3ba5dc0212718d98884db'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '51a0e401806e8102e06eef577a7edf927c13df93f0823f45c2c15fa28610d7e2',
-     armv7l: '51a0e401806e8102e06eef577a7edf927c13df93f0823f45c2c15fa28610d7e2',
-       i686: '37cd31b4ddebe9bf6a4928e9d1dd60fef33a6f29407d331d9257b265b31d7f14',
-     x86_64: 'bf8e53c22d7df9c5c08b971220b6d627b3255b69b73226e88363edca8041581a'
+    aarch64: '29312d3f89552a9876c215b7c0dfb2d9b4e34639c5ce3a0d0bd6c687bf0f9868',
+     armv7l: '29312d3f89552a9876c215b7c0dfb2d9b4e34639c5ce3a0d0bd6c687bf0f9868',
+       i686: '5f31abf62547f183d5db5f5c138cf24ba8ab907dcf6145b2e0a6fd406d288e80',
+     x86_64: 'fa89066a514460c8bf00e77b02f7bf1a07e7152be920ede97fce767916c86c65'
   })
 
   depends_on 'glibc' # R

--- a/tests/package/f/fakeroot
+++ b/tests/package/f/fakeroot
@@ -1,0 +1,3 @@
+#!/bin/bash
+fakeroot -h 2>&1
+fakeroot -v

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -66,6 +66,7 @@ exo
 extra_cmake_modules
 f2fs_tools
 faad2
+fakeroot
 fastfetch
 fcft
 fdupes


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-fakeroot crew update \
&& yes | crew upgrade

$ crew check fakeroot 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/fakeroot.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking fakeroot package ...
Property tests for fakeroot passed.
Checking fakeroot package ...
Buildsystem test for fakeroot passed.
Checking fakeroot package ...
Library test for fakeroot passed.
Checking fakeroot package ...
fakeroot, create a fake root environment.
   usage: fakeroot [-l|--lib fakerootlib] [-f|--faked fakedbin]
                   [-i file] [-s file] [-u|--unknown-is-real]
		   [-b|--fd-base fd] [-h|--help] [-v|--version]
                   [--] [command]
fakeroot version 1.37.2
Package tests for fakeroot passed.
```