### PR TITLE
Mullvad 15.0.3 => 15.0.4

### DIFF
--- a/manifest/x86_64/m/mullvad.filelist
+++ b/manifest/x86_64/m/mullvad.filelist
@@ -1,4 +1,4 @@
-# Total size: 276742611
+# Total size: 276950207
 /usr/local/bin/mullvad
 /usr/local/share/applications/start-mullvad-browser.desktop
 /usr/local/share/icons/default/64x64/apps/web-browser.png

--- a/packages/mullvad.rb
+++ b/packages/mullvad.rb
@@ -4,11 +4,11 @@ require 'convenience_functions'
 class Mullvad < Package
   description 'Privacy-focused browser'
   homepage 'https://mullvad.net/browser'
-  version '15.0.3'
+  version '15.0.4'
   license 'Mozilla Public License V2'
   compatibility 'x86_64'
   source_url "https://github.com/mullvad/mullvad-browser/releases/download/#{version}/mullvad-browser-linux-x86_64-#{version}.tar.xz"
-  source_sha256 'aab8ca19a4b8198a7c0b82f31256cdf7ffafe4c60ab154476990ec0597b605cb'
+  source_sha256 '978d529faf61bd05f06f5dd3d68eae90858ec695ee01103e27cf908cd87e6dda'
 
   depends_on 'gtk3'
   depends_on 'gdk_base'

--- a/tests/package/m/mullvad
+++ b/tests/package/m/mullvad
@@ -1,0 +1,2 @@
+#!/bin/bash
+mullvad -h | head

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -132,6 +132,7 @@ libparserutils
 libportal
 libvisio
 libxfce4ui
+mullvad
 nano
 ocaml
 opencode


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-mullvad crew update \
&& yes | crew upgrade

$ crew check mullvad
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/mullvad.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking mullvad package ...
Property tests for mullvad passed.
Checking mullvad package ...
Buildsystem test for mullvad passed.
Checking mullvad package ...
Library test for mullvad passed.
Checking mullvad package ...
Usage: ./mullvadbrowser.real [ options ... ] [URL]
       where options include:

X11 options
  --display=DISPLAY  X display to use
  --sync             Make X calls synchronous
  --g-fatal-warnings Make all warnings fatal

MullvadBrowser options
  -h or --help       Print this message.
Package tests for mullvad passed.
```