### PR TITLE
Folks 0.15.9 => 0.15.12

### DIFF
--- a/manifest/armv7l/f/folks.filelist
+++ b/manifest/armv7l/f/folks.filelist
@@ -1,4 +1,4 @@
-# Total size: 2519473
+# Total size: 2637945
 /usr/local/bin/folks-import
 /usr/local/bin/folks-inspect
 /usr/local/include/folks/folks-dummy.h
@@ -51,6 +51,7 @@
 /usr/local/share/locale/it/LC_MESSAGES/folks.mo
 /usr/local/share/locale/ja/LC_MESSAGES/folks.mo
 /usr/local/share/locale/ka/LC_MESSAGES/folks.mo
+/usr/local/share/locale/kab/LC_MESSAGES/folks.mo
 /usr/local/share/locale/kk/LC_MESSAGES/folks.mo
 /usr/local/share/locale/kn/LC_MESSAGES/folks.mo
 /usr/local/share/locale/ko/LC_MESSAGES/folks.mo
@@ -82,6 +83,7 @@
 /usr/local/share/locale/tr/LC_MESSAGES/folks.mo
 /usr/local/share/locale/ug/LC_MESSAGES/folks.mo
 /usr/local/share/locale/uk/LC_MESSAGES/folks.mo
+/usr/local/share/locale/uz/LC_MESSAGES/folks.mo
 /usr/local/share/locale/vi/LC_MESSAGES/folks.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/folks.mo
 /usr/local/share/locale/zh_HK/LC_MESSAGES/folks.mo

--- a/manifest/x86_64/f/folks.filelist
+++ b/manifest/x86_64/f/folks.filelist
@@ -1,4 +1,4 @@
-# Total size: 2795757
+# Total size: 2931397
 /usr/local/bin/folks-import
 /usr/local/bin/folks-inspect
 /usr/local/include/folks/folks-dummy.h
@@ -51,6 +51,7 @@
 /usr/local/share/locale/it/LC_MESSAGES/folks.mo
 /usr/local/share/locale/ja/LC_MESSAGES/folks.mo
 /usr/local/share/locale/ka/LC_MESSAGES/folks.mo
+/usr/local/share/locale/kab/LC_MESSAGES/folks.mo
 /usr/local/share/locale/kk/LC_MESSAGES/folks.mo
 /usr/local/share/locale/kn/LC_MESSAGES/folks.mo
 /usr/local/share/locale/ko/LC_MESSAGES/folks.mo
@@ -82,6 +83,7 @@
 /usr/local/share/locale/tr/LC_MESSAGES/folks.mo
 /usr/local/share/locale/ug/LC_MESSAGES/folks.mo
 /usr/local/share/locale/uk/LC_MESSAGES/folks.mo
+/usr/local/share/locale/uz/LC_MESSAGES/folks.mo
 /usr/local/share/locale/vi/LC_MESSAGES/folks.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/folks.mo
 /usr/local/share/locale/zh_HK/LC_MESSAGES/folks.mo

--- a/packages/folks.rb
+++ b/packages/folks.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Folks < Meson
   description 'Library to aggregates people into metacontacts'
   homepage 'https://wiki.gnome.org/Projects/Folks'
-  version '0.15.9'
+  version '0.15.12'
   license 'LGPL-2.1'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/folks.git'
@@ -11,13 +11,13 @@ class Folks < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '491428b6cb2de8c119ab455aded923b3edc697ec7f894be547eba5d9e7101384',
-     armv7l: '491428b6cb2de8c119ab455aded923b3edc697ec7f894be547eba5d9e7101384',
-     x86_64: '5acbdbbf7fe754124a526bcb1ae856af49b7ba907346e7fcc2cbec06c85e6464'
+    aarch64: 'b31d41f4b77abafa041aae54486f730c3ab25e104c5982c480bf024926d3831a',
+     armv7l: 'b31d41f4b77abafa041aae54486f730c3ab25e104c5982c480bf024926d3831a',
+     x86_64: 'f4bf40195fafb9f12bde0ace0d04f4abdda18798319872b078f1c1745777fef9'
   })
 
-  depends_on 'glibc' # R
   depends_on 'glib' # R
+  depends_on 'glibc' # R
   depends_on 'gobject_introspection' => :build
   depends_on 'gtk_doc' => :build
   depends_on 'libgee' # R

--- a/tests/package/f/folks
+++ b/tests/package/f/folks
@@ -1,0 +1,3 @@
+#!/bin/bash
+folks-import -h
+folks-inspect -h

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -77,6 +77,7 @@ firefox
 firejail
 fish
 flatseal
+folks
 flutter
 foliate
 font_adobe_100dpi


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-folks crew update \
&& yes | crew upgrade

$ crew check folks
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/folks.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking folks package ...
Property tests for folks passed.
Checking folks package ...
Buildsystem test for folks passed.
Checking folks package ...
Library test for folks passed.
Checking folks package ...
Usage:
  folks-import [OPTION…] — import meta-contact information to libfolks

Help Options:
  -h, --help            Show help options

Application Options:
  -s, --source=name     Source backend name (default: ‘pidgin’)
  --source-filename     Source filename (default: specific to source backend)

Usage:
  folks-inspect [OPTION…] [COMMAND]

Inspect meta-contact information in libfolks.

Help Options:
  -h, --help       Show help options

Package tests for folks passed.
```