### PR TITLE
Fuse3 3.16.2 => 3.18.1

### DIFF
--- a/manifest/armv7l/f/fuse3.filelist
+++ b/manifest/armv7l/f/fuse3.filelist
@@ -1,4 +1,4 @@
-# Total size: 359268
+# Total size: 412793
 /usr/local/bin/fusermount3
 /usr/local/etc/fuse.conf
 /usr/local/etc/init.d/fuse3
@@ -11,8 +11,8 @@
 /usr/local/include/fuse3/fuse_opt.h
 /usr/local/include/fuse3/libfuse_config.h
 /usr/local/lib/libfuse3.so
-/usr/local/lib/libfuse3.so.3
-/usr/local/lib/libfuse3.so.3.16.2
+/usr/local/lib/libfuse3.so.3.18.1
+/usr/local/lib/libfuse3.so.4
 /usr/local/lib/pkgconfig/fuse3.pc
 /usr/local/sbin/fusermount3
 /usr/local/sbin/mount.fuse3

--- a/manifest/i686/f/fuse3.filelist
+++ b/manifest/i686/f/fuse3.filelist
@@ -1,4 +1,4 @@
-# Total size: 448520
+# Total size: 535861
 /usr/local/bin/fusermount3
 /usr/local/etc/fuse.conf
 /usr/local/etc/init.d/fuse3
@@ -11,8 +11,8 @@
 /usr/local/include/fuse3/fuse_opt.h
 /usr/local/include/fuse3/libfuse_config.h
 /usr/local/lib/libfuse3.so
-/usr/local/lib/libfuse3.so.3
-/usr/local/lib/libfuse3.so.3.16.2
+/usr/local/lib/libfuse3.so.3.18.1
+/usr/local/lib/libfuse3.so.4
 /usr/local/lib/pkgconfig/fuse3.pc
 /usr/local/sbin/fusermount3
 /usr/local/sbin/mount.fuse3

--- a/manifest/x86_64/f/fuse3.filelist
+++ b/manifest/x86_64/f/fuse3.filelist
@@ -1,4 +1,4 @@
-# Total size: 459822
+# Total size: 524599
 /usr/local/bin/fusermount3
 /usr/local/etc/fuse.conf
 /usr/local/etc/init.d/fuse3
@@ -11,8 +11,8 @@
 /usr/local/include/fuse3/fuse_opt.h
 /usr/local/include/fuse3/libfuse_config.h
 /usr/local/lib64/libfuse3.so
-/usr/local/lib64/libfuse3.so.3
-/usr/local/lib64/libfuse3.so.3.16.2
+/usr/local/lib64/libfuse3.so.3.18.1
+/usr/local/lib64/libfuse3.so.4
 /usr/local/lib64/pkgconfig/fuse3.pc
 /usr/local/sbin/fusermount3
 /usr/local/sbin/mount.fuse3

--- a/packages/fuse3.rb
+++ b/packages/fuse3.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Fuse3 < Meson
   description 'The reference implementation of the Linux FUSE (Filesystem in Userspace) interface.'
   homepage 'https://github.com/libfuse/libfuse/'
-  version '3.16.2'
+  version '3.18.1'
   license 'GPL-2+'
   compatibility 'all'
   source_url 'https://github.com/libfuse/libfuse.git'
@@ -11,10 +11,10 @@ class Fuse3 < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '7596282fa27cbe6683c81cb3158159421b3a21834db71f4130fbea2d7d8ca59a',
-     armv7l: '7596282fa27cbe6683c81cb3158159421b3a21834db71f4130fbea2d7d8ca59a',
-       i686: 'b6197530830442cb1225334e9fa29d00a113ded9a4ff7e072c335e91e468244e',
-     x86_64: '14b191a1e6b19c58f9e45861fae0be8b50a10803dab46b98ac82a3c6f906c60b'
+    aarch64: 'a07a40a56054303557bac6c18a4d500eb2779900bdb34183fd9fa122f644a675',
+     armv7l: 'a07a40a56054303557bac6c18a4d500eb2779900bdb34183fd9fa122f644a675',
+       i686: '27ee11c7cca4f8e7336d8d88bffe6066472b9de3223ecc0c600a854f0a821d35',
+     x86_64: 'f2215c568cf0b7f378ee63d7b558ee409abfe974a54aa271f270cf2542d5119b'
   })
 
   depends_on 'gcc_lib' # R

--- a/tests/package/f/fuse3
+++ b/tests/package/f/fuse3
@@ -1,0 +1,3 @@
+#!/bin/bash
+fusermount3 -h
+fusermount3 -V

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -110,6 +110,7 @@ freerdp
 freetds
 fribidi
 frp
+fuse3
 gambit
 gedit
 git_lfs


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-fuse3 crew update \
&& yes | crew upgrade

$ crew check fuse3 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/fuse3.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking fuse3 package ...
Property tests for fuse3 passed.
Checking fuse3 package ...
Buildsystem test for fuse3 passed.
Checking fuse3 package ...
Library test for fuse3 passed.
Checking fuse3 package ...
fusermount3: [options] mountpoint
Options:
 -h		    print help
 -V		    print version
 -o opt[,opt...]    mount options
 -u		    unmount
 -q		    quiet
 -z		    lazy unmount
fusermount3 version: 3.18.1
Package tests for fuse3 passed.
```