### PR TITLE
Fuse_overlayfs 1.10 => 1.16

### DIFF
--- a/manifest/armv7l/f/fuse_overlayfs.filelist
+++ b/manifest/armv7l/f/fuse_overlayfs.filelist
@@ -1,3 +1,3 @@
-# Total size: 80799
+# Total size: 106452
 /usr/local/bin/fuse-overlayfs
 /usr/local/share/man/man1/fuse-overlayfs.1.zst

--- a/manifest/i686/f/fuse_overlayfs.filelist
+++ b/manifest/i686/f/fuse_overlayfs.filelist
@@ -1,3 +1,3 @@
-# Total size: 45807
+# Total size: 126328
 /usr/local/bin/fuse-overlayfs
 /usr/local/share/man/man1/fuse-overlayfs.1.zst

--- a/manifest/x86_64/f/fuse_overlayfs.filelist
+++ b/manifest/x86_64/f/fuse_overlayfs.filelist
@@ -1,3 +1,3 @@
-# Total size: 103631
+# Total size: 118576
 /usr/local/bin/fuse-overlayfs
 /usr/local/share/man/man1/fuse-overlayfs.1.zst

--- a/packages/fuse_overlayfs.rb
+++ b/packages/fuse_overlayfs.rb
@@ -6,7 +6,7 @@ require 'package'
 class Fuse_overlayfs < Package
   description 'FUSE implementation of overlayfs'
   homepage 'https://github.com/containers/fuse-overlayfs'
-  version '1.10'
+  version '1.16'
   license 'GPL3'
   compatibility 'all'
   source_url 'https://github.com/containers/fuse-overlayfs.git'
@@ -14,15 +14,15 @@ class Fuse_overlayfs < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '676a073380c10bd30130c76d61a58edace6477bc0762e156645cf0e4749582cd',
-     armv7l: '676a073380c10bd30130c76d61a58edace6477bc0762e156645cf0e4749582cd',
-       i686: 'fce98a2f2b1bacaaba55baf06f5299c8dfba0d0101126e31f9508ba1a6c2d73b',
-     x86_64: 'b87612894c390f30a49be7edc6fd51279acf74bae16535b7d0808435a0252a9c'
+    aarch64: 'f5f34e8005324799c5dd3e6e9287c92f549c6751bc956f1c226a41b98ff3c717',
+     armv7l: 'f5f34e8005324799c5dd3e6e9287c92f549c6751bc956f1c226a41b98ff3c717',
+       i686: '47c5e67a8066685d834b918c64d62f84cfec1a5519ca355ea397e623f9982dfe',
+     x86_64: '7d6f6ff5fdcd81f2cf3b2ca91811a23baa4c4aaab25de136bc51fe80d961f6fa'
   })
 
   depends_on 'fuse3' # R
-  depends_on 'go_md2man' => :build
   depends_on 'glibc' # R
+  depends_on 'go_md2man' => :build
 
   def self.build
     system 'autoreconf -fiv'

--- a/tests/package/f/fuse_overlayfs
+++ b/tests/package/f/fuse_overlayfs
@@ -1,0 +1,3 @@
+#!/bin/bash
+fuse-overlayfs -h | head
+fuse-overlayfs -V

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -110,6 +110,7 @@ freerdp
 freetds
 fribidi
 frp
+fuse_overlayfs
 fuse3
 gambit
 gedit


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-fuse_overlayfs crew update \
&& yes | crew upgrade

$ crew check fuse_overlayfs 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/fuse_overlayfs.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking fuse_overlayfs package ...
Property tests for fuse_overlayfs passed.
Checking fuse_overlayfs package ...
Buildsystem test for fuse_overlayfs passed.
Checking fuse_overlayfs package ...
Library test for fuse_overlayfs passed.
Checking fuse_overlayfs package ...
usage: fuse-overlayfs [options] <mountpoint>

    -h   --help            print help
    -V   --version         print version
    -d   -o debug          enable debug output (implies -f)
    -f                     foreground operation
    -s                     disable multi-threaded operation
    -o clone_fd            use separate fuse device fd for each thread
                           (may improve performance)
    -o max_idle_threads    the maximum number of idle worker threads
fusermount3 version: 3.18.1
fuse-overlayfs: version 1.16
FUSE library version 3.18.1
using FUSE kernel interface version 7.45
Package tests for fuse_overlayfs passed.
```