### PR TITLE
Hugo 0.153.1 => 0.154.5

### DIFF
--- a/manifest/armv7l/h/hugo.filelist
+++ b/manifest/armv7l/h/hugo.filelist
@@ -1,2 +1,2 @@
-# Total size: 50023508
+# Total size: 50069688
 /usr/local/bin/hugo

--- a/manifest/i686/h/hugo.filelist
+++ b/manifest/i686/h/hugo.filelist
@@ -1,2 +1,2 @@
-# Total size: 47227696
+# Total size: 47230976
 /usr/local/bin/hugo

--- a/manifest/x86_64/h/hugo.filelist
+++ b/manifest/x86_64/h/hugo.filelist
@@ -1,2 +1,2 @@
-# Total size: 56703208
+# Total size: 56748696
 /usr/local/bin/hugo

--- a/packages/hugo.rb
+++ b/packages/hugo.rb
@@ -3,7 +3,7 @@ require 'package'
 class Hugo < Package
   description 'Hugo is one of the most popular open-source static site generators.'
   homepage 'https://gohugo.io'
-  version ARCH.eql?('i686') ? '0.101.0' : '0.153.1'
+  version %w[aarch64 armv7l x86_64].include?(ARCH) ? '0.154.5' : '0.101.0'
   license 'Apache-2.0, Unlicense, BSD, BSD-2 and MPL-2.0'
   compatibility 'all'
   min_glibc '2.29' if ARCH.eql?('x86_64')
@@ -14,10 +14,10 @@ class Hugo < Package
      x86_64: "https://github.com/gohugoio/hugo/releases/download/v#{version}/hugo_extended_#{version}_linux-amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'a26f56c368dd7077560d7e9ba57e6d95e5f143e1d0347a3a346c2715920fb658',
-     armv7l: 'a26f56c368dd7077560d7e9ba57e6d95e5f143e1d0347a3a346c2715920fb658',
+    aarch64: '9ef096e3ae139421b9d9f4ebec4b6023d796f35bf5360770fa88822933a7fc5d',
+     armv7l: '9ef096e3ae139421b9d9f4ebec4b6023d796f35bf5360770fa88822933a7fc5d',
        i686: '9ae794edd86415a611cae15fc72382ee6f2b729754e15319c144057a5457eaed',
-     x86_64: 'e5806957b8696d10a713199503b21b577abf92e1bcb85730124269479e7f5fc6'
+     x86_64: '372d2f0538b24d2bb9285f0583c1e3b02d023ec2c2b8eb90e5c3bbfb3139fb13'
   })
 
   no_compile_needed

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -131,6 +131,7 @@ go
 gobject_introspection
 google_chrome
 gradle
+hugo
 ldc
 libcdr
 libcss


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-hugo crew update \
&& yes | crew upgrade

$ crew check hugo
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/hugo.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking hugo package ...
Property tests for hugo passed.
Checking hugo package ...
Buildsystem test for hugo passed.
Checking hugo package ...
Library test for hugo passed.
Checking hugo package ...
hugo is the main command, used to build your Hugo site.

Hugo is a Fast and Flexible Static Site Generator
built with love by spf13 and friends in Go.

Complete documentation is available at https://gohugo.io/.

Usage:
  hugo [flags]
  hugo [command]
hugo v0.154.5-a6f99cca223a29cad1d4cdaa6a1a90508ac1da71+extended linux/amd64 BuildDate=2026-01-11T20:53:23Z VendorInfo=gohugoio
Package tests for hugo passed.
```
