### PR TITLE
I3 4.24 => 4.25

### DIFF
--- a/manifest/armv7l/i/i3.filelist
+++ b/manifest/armv7l/i/i3.filelist
@@ -1,4 +1,4 @@
-# Total size: 1695256
+# Total size: 1680565
 /usr/local/bin/i3
 /usr/local/bin/i3-config-wizard
 /usr/local/bin/i3-dmenu-desktop

--- a/manifest/x86_64/i/i3.filelist
+++ b/manifest/x86_64/i/i3.filelist
@@ -1,4 +1,4 @@
-# Total size: 1953820
+# Total size: 1940705
 /usr/local/bin/i3
 /usr/local/bin/i3-config-wizard
 /usr/local/bin/i3-dmenu-desktop

--- a/packages/i3.rb
+++ b/packages/i3.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class I3 < Meson
   description 'Improved tiling window manager'
   homepage 'https://i3wm.org/'
-  version '4.24'
+  version '4.25'
   license 'BSD'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/i3/i3.git'
@@ -11,29 +11,29 @@ class I3 < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd0c0849c2b4b1402fe72e781c963af5aec1d84ac413f8a5616fc38becd1db3d9',
-     armv7l: 'd0c0849c2b4b1402fe72e781c963af5aec1d84ac413f8a5616fc38becd1db3d9',
-     x86_64: 'a07c0b7f085c716c60f6044a5e2904bb3d77eb392051a808348d408dcd535555'
+    aarch64: 'c80e9228de17400f0867ffdc06320a575961036da921b73c02d55792a3255a2a',
+     armv7l: 'c80e9228de17400f0867ffdc06320a575961036da921b73c02d55792a3255a2a',
+     x86_64: '1bd6abf4f8444c6be265251ca350e20fbc172300e1a36dc3f06d7c1727c8d751'
   })
 
   depends_on 'cairo' # R
   depends_on 'glib' # R
   depends_on 'glibc' # R
   depends_on 'harfbuzz' # R
-  depends_on 'libev'
+  depends_on 'libev' # R
   depends_on 'libxcb' # R
   depends_on 'libxkbcommon' # R
-  depends_on 'pango'
+  depends_on 'pango' # R
   depends_on 'pcre2' # R
-  depends_on 'sommelier'
-  depends_on 'startup_notification'
+  depends_on 'sommelier' # R
+  depends_on 'startup_notification' # R
   depends_on 'wayland' => :build
   depends_on 'xcb_util' # R
-  depends_on 'xcb_util_cursor'
-  depends_on 'xcb_util_keysyms'
-  depends_on 'xcb_util_wm'
-  depends_on 'xcb_util_xrm'
-  depends_on 'yajl'
+  depends_on 'xcb_util_cursor' # R
+  depends_on 'xcb_util_keysyms' # R
+  depends_on 'xcb_util_wm' # R
+  depends_on 'xcb_util_xrm' # R
+  depends_on 'yajl' # R
 
   meson_install_extras do
     File.write "#{CREW_DEST_PREFIX}/bin/starti3", <<~EOF, perm: 0o755

--- a/tests/package/i/i3
+++ b/tests/package/i/i3
@@ -1,0 +1,11 @@
+#!/bin/bash
+i3 --version
+i3-config-wizard --version
+i3-dmenu-desktop --version
+i3-dump-log --version
+i3-input --version
+i3-msg --version
+i3-nagbar --version
+i3-with-shmlog --version
+i3bar --version
+starti3 --version

--- a/tools/automatically_updatable_packages.txt
+++ b/tools/automatically_updatable_packages.txt
@@ -137,6 +137,7 @@ hunspell_es_us
 hunspell_fr_fr
 hurl
 hwdata
+i3
 ldc
 libcdr
 libcss


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-i3 crew update \
&& yes | crew upgrade

$ crew check i3 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/i3.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking i3 package ...
Property tests for i3 passed.
Checking i3 package ...
Buildsystem test for i3 passed.
Checking i3 package ...
Library test for i3 passed.
Checking i3 package ...
i3 version 1d8fcb8 © 2009 Michael Stapelberg and contributors
i3-config-wizard 1d8fcb8
dmenu-desktop 1.5 © 2012 Michael Stapelberg
i3-dump-log 1d8fcb8
i3-input 1d8fcb8
i3-msg 1d8fcb8
i3-nagbar 1d8fcb8
i3 version 1d8fcb8 © 2009 Michael Stapelberg and contributors
i3bar version 1d8fcb8 © 2010 Axel Wagner and contributors
i3 version 1d8fcb8 © 2009 Michael Stapelberg and contributors
Cannot run sommelier in a container.
Package tests for i3 passed.
```