### PR TITLE
Imlib2 1.12.5 => 1.12.6

### DIFF
--- a/manifest/armv7l/i/imlib2.filelist
+++ b/manifest/armv7l/i/imlib2.filelist
@@ -1,4 +1,4 @@
-# Total size: 3139597
+# Total size: 3140243
 /usr/local/bin/imlib2_bumpmap
 /usr/local/bin/imlib2_colorspace
 /usr/local/bin/imlib2_conv
@@ -66,7 +66,7 @@
 /usr/local/lib/libImlib2.la
 /usr/local/lib/libImlib2.so
 /usr/local/lib/libImlib2.so.1
-/usr/local/lib/libImlib2.so.1.12.5
+/usr/local/lib/libImlib2.so.1.12.6
 /usr/local/lib/pkgconfig/imlib2.pc
 /usr/local/share/imlib2/data/fonts/cinema.ttf
 /usr/local/share/imlib2/data/fonts/grunge.ttf

--- a/manifest/x86_64/i/imlib2.filelist
+++ b/manifest/x86_64/i/imlib2.filelist
@@ -1,4 +1,4 @@
-# Total size: 3700142
+# Total size: 3698524
 /usr/local/bin/imlib2_bumpmap
 /usr/local/bin/imlib2_colorspace
 /usr/local/bin/imlib2_conv
@@ -66,7 +66,7 @@
 /usr/local/lib64/libImlib2.la
 /usr/local/lib64/libImlib2.so
 /usr/local/lib64/libImlib2.so.1
-/usr/local/lib64/libImlib2.so.1.12.5
+/usr/local/lib64/libImlib2.so.1.12.6
 /usr/local/lib64/pkgconfig/imlib2.pc
 /usr/local/share/imlib2/data/fonts/cinema.ttf
 /usr/local/share/imlib2/data/fonts/grunge.ttf

--- a/packages/imlib2.rb
+++ b/packages/imlib2.rb
@@ -3,17 +3,17 @@ require 'buildsystems/autotools'
 class Imlib2 < Autotools
   description 'library that does image file loading and saving as well as rendering, manipulation, arbitrary polygon support, etc.'
   homepage 'https://sourceforge.net/projects/enlightenment/'
-  version '1.12.5'
+  version '1.12.6'
   license 'BSD'
   compatibility 'aarch64 armv7l x86_64'
-  source_url "https://sourceforge.net/projects/enlightenment/files/imlib2-src/#{version.split('-').first}/imlib2-#{version.split('-').first}.tar.xz"
-  source_sha256 'fa2315f28379b430a6e6605b4284b07be06a3ef422d4f5e1c9bb24714c4cf6dd'
+  source_url "https://downloads.sourceforge.net/project/enlightenment/imlib2-src/#{version}/imlib2-#{version}.tar.xz"
+  source_sha256 '250f9752f69dc522e529a81aaa9395705f7fc312ff2453e5de59ac2ba1f2858f'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '7a0d4d31970a5f4cf2d0c9ba47b66f176cffbe801fa01220fe600d58c3048fc0',
-     armv7l: '7a0d4d31970a5f4cf2d0c9ba47b66f176cffbe801fa01220fe600d58c3048fc0',
-     x86_64: '7dacae0624fcec95d158c4abd8ed10c8cc5eaecc999685c139900b10c74dc2fb'
+    aarch64: '5012edbb6108b16c76c11cec5236daf3a520d414d7bd1c4ee9463082e0e8f440',
+     armv7l: '5012edbb6108b16c76c11cec5236daf3a520d414d7bd1c4ee9463082e0e8f440',
+     x86_64: '32d0498a80b9123c59259ac059adebefb36a47908e8b98ee7e1d7f76a10ca1d0'
   })
 
   depends_on 'bzip2' # R

--- a/tests/package/i/imlib2
+++ b/tests/package/i/imlib2
@@ -1,0 +1,5 @@
+#!/bin/bash
+imlib2_conv
+imlib2_grab
+imlib2_load
+imlib2_view


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-imlib2 crew update \
&& yes | crew upgrade

$ crew check imlib2
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/imlib2.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking imlib2 package ...
Property tests for imlib2 passed.
Checking imlib2 package ...
Buildsystem test for imlib2 passed.
Checking imlib2 package ...
Library test for imlib2 passed.
Checking imlib2 package ...
Usage:
  imlib2_conv [OPTIONS] [ input-file output-file[.fmt] ]
    <fmt> defaults to jpg if not provided.

OPTIONS:
  -h            : Show this help
  -b 0xRRGGBB   : Render on solid background before saving
  -i key=value  : Attach tag with integer value for saver
  -j key=string : Attach tag with string value for saver
  -g WxH        : Specify output image size
Usage: imlib2_grab [-v] [-id <drawable id>] [-width <width>] [-height <height>] [-noshape] <output file>
Usage:
  imlib2_load [OPTIONS] FILE...
OPTIONS:
  -C  : Print CRC32 of image data
  -c  : Enable image caching
  -e  : Break on error
  -f  : Load with imlib_load_image_fd()
  -h  : Show help
  -i  : Load image immediately (don't defer data loading)
  -j  : Load image header only
  -m  : Load with imlib_load_image_mem()
  -n N: Repeat load N times
  -p  : Check that progress is called
  -v  : Increase verbosity
  -x  : Print to stderr
Usage:
  imlib2_view [OPTIONS] {FILE | XID}...
OPTIONS:
  -C         : Print CRC32 of image data
  -a         : Disable final anti-aliased rendering
  -b L,R,T,B : Set border
  -c         : Enable image caching (implies -e)
  -d         : Enable debug
  -e         : Do rendering explicitly (not via progress callback)
  -h         : Show help
  -g N       : Set progress granularity to N% (default 10(%))
  -l N       : Introduce N ms delay in progress callback (default 0)
  -p         : Print info in progress callback (default no)
  -s Sx[,Sy] : Set output x/y scaling factors to Sx,Sy (default 1.0)
  -S Sx[,Sy] : Set input x/y scaling factors to Sx,Sy (default 1.0)
  -t N       : Set background checkerboard field size (default 8)
  -T CA,CB   : Set background checkerboard colors (0xRRGGBB,0xRRGGBB)
  -v         : Increase verbosity
Package tests for imlib2 passed.
```