### PR TITLE
Fix autoupdate detection logic in version.rb

### DIFF
--- a/tools/version.rb
+++ b/tools/version.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# version.rb version 3.26 (for Chromebrew)
+# version.rb version 3.27 (for Chromebrew)
 
 OPTIONS = %w[-h --help -j --json -u --update-package-files -v --verbose -vv]
 
@@ -494,7 +494,7 @@ if filelist.length.positive?
     end
     updatable_string = (updatable_pkg[@pkg.name.to_sym] == 'Yes' ? 'Yes         '.lightgreen : 'No          '.lightred) if updatable_string.nil?
     compile_string = @pkg.no_compile_needed? || @pkg.is_fake? ? 'No        '.lightred : 'Yes       '.lightgreen
-    autoupdate_string = File.file?("#{CREW_LIB_PATH}/tools/automatically_updatable_packages/#{@pkg.name.downcase}") ? 'No'.lightred : 'Yes'.lightgreen
+    autoupdate_string = File.file?("#{CREW_LIB_PATH}/tools/automatically_updatable_packages/#{@pkg.name}") ? 'Yes'.lightgreen : 'No'.lightred
     versions.push(package: @pkg.name, update_status: versions_updated[@pkg.name.to_sym], version: cleaned_pkg_version, upstream_version: upstream_version)
 
     addendum_string = "#{@pkg.name} cannot be automatically updated: ".red + "#{updatable_pkg[@pkg.name.to_sym]}\n".purple unless updatable_pkg[@pkg.name.to_sym] == 'Yes'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-version.rb crew update \
&& yes | crew upgrade
```
Before:
```
$ crew upstream f*
Package                         Status           Current      Upstream     Updatable?  Compile?  Autoupdate?
-------                         ------           -------      --------     ----------  --------  -----------
fceux                           Outdated.        2.6.5        2.6.6        Yes         No        Yes
ffmpeg                          Outdated.        7.1.1        8.0.1        Yes         Yes       Yes
fig2dev                         Outdated.        3.2.9        3.2.9a       Yes         Yes       Yes
firefox                         Outdated.        147.0.1      147.0.2      Yes         No        No
flatpak                         Outdated.        1.16.1       1.17.2       Yes         Yes       Yes
flutter                         Outdated.        3.38.7       3.38.8       Yes         No        No
fossil                          Outdated.        2.24         2.27         Yes         Yes       No
foxit_reader                    Outdated.        2.4.5.0727   2025.3.0     Yes         No        Yes
freerdp                         Outdated.        3.21.0       3.22.0       Yes         Yes       No
fuse2                           Outdated.        2.9.9        3.18.1       Yes         Yes       Yes
```
After:
```
$ crew upstream f*
Package                         Status           Current      Upstream     Updatable?  Compile?  Autoupdate?
-------                         ------           -------      --------     ----------  --------  -----------
fceux                           Outdated.        2.6.5        2.6.6        Yes         No        No
ffmpeg                          Outdated.        7.1.1        8.0.1        Yes         Yes       No
fig2dev                         Outdated.        3.2.9        3.2.9a       Yes         Yes       No
firefox                         Outdated.        147.0.1      147.0.2      Yes         No        Yes
flatpak                         Outdated.        1.16.1       1.17.2       Yes         Yes       No
flutter                         Outdated.        3.38.7       3.38.8       Yes         No        Yes
fossil                          Outdated.        2.24         2.27         Yes         Yes       Yes
foxit_reader                    Outdated.        2.4.5.0727   2025.3.0     Yes         No        No
freerdp                         Outdated.        3.21.0       3.22.0       Yes         Yes       Yes
fuse2                           Outdated.        2.9.9        3.18.1       Yes         Yes       No
```

In color...
Before:
<img width="1890" height="448" alt="image" src="https://github.com/user-attachments/assets/ce13b660-76e5-48f1-b3b5-0b5c80d3a79c" />
After:
<img width="1890" height="448" alt="image" src="https://github.com/user-attachments/assets/f5035875-6cb3-48c8-810f-f0ca403ea4db" />
