### PR TITLE
Deskreen 3.2.1 => 3.2.12

### DIFF
--- a/manifest/x86_64/d/deskreen.filelist
+++ b/manifest/x86_64/d/deskreen.filelist
@@ -1,4 +1,4 @@
-# Total size: 435716829
+# Total size: 435709031
 /usr/local/bin/deskreen
 /usr/local/share/applications/deskreen-ce.desktop
 /usr/local/share/deskreen/AppRun
@@ -157,23 +157,23 @@
 /usr/local/share/deskreen/resources/app.asar.unpacked/node_modules/jszip/tsconfig.json
 /usr/local/share/deskreen/resources/app.asar.unpacked/node_modules/jszip/vendor/FileSaver.js
 /usr/local/share/deskreen/resources/app.asar.unpacked/resources/icon.png
-/usr/local/share/deskreen/resources/client-viewer/assets/allPaths-DhINQBxu.js
-/usr/local/share/deskreen/resources/client-viewer/assets/allPaths-legacy-CLScRZ6q.js
-/usr/local/share/deskreen/resources/client-viewer/assets/allPathsLoader-BC9EcADF.js
-/usr/local/share/deskreen/resources/client-viewer/assets/allPathsLoader-legacy-JPEaoxYe.js
-/usr/local/share/deskreen/resources/client-viewer/assets/browser-ponyfill-c1FElBTD.js
-/usr/local/share/deskreen/resources/client-viewer/assets/browser-ponyfill-legacy-Bio0g65S.js
+/usr/local/share/deskreen/resources/client-viewer/assets/allPaths-DaP-Cvdz.js
+/usr/local/share/deskreen/resources/client-viewer/assets/allPaths-legacy-PUddJOlp.js
+/usr/local/share/deskreen/resources/client-viewer/assets/allPathsLoader-CEhUd1Vf.js
+/usr/local/share/deskreen/resources/client-viewer/assets/allPathsLoader-legacy-BtmPfX6N.js
+/usr/local/share/deskreen/resources/client-viewer/assets/browser-ponyfill-CeP0uL3-.js
+/usr/local/share/deskreen/resources/client-viewer/assets/browser-ponyfill-legacy-enDLEwle.js
 /usr/local/share/deskreen/resources/client-viewer/assets/deskreen_logo_128x128-ndVS49i5.png
 /usr/local/share/deskreen/resources/client-viewer/assets/index-BZITDwoa.js
 /usr/local/share/deskreen/resources/client-viewer/assets/index-C2UcLfO8.css
-/usr/local/share/deskreen/resources/client-viewer/assets/index-DqLBUiPS.js
+/usr/local/share/deskreen/resources/client-viewer/assets/index-DBBUgSH9.js
+/usr/local/share/deskreen/resources/client-viewer/assets/index-legacy-BHriLDzp.js
 /usr/local/share/deskreen/resources/client-viewer/assets/index-legacy-BMkrPMqp.js
-/usr/local/share/deskreen/resources/client-viewer/assets/index-legacy-Do81DPGL.js
 /usr/local/share/deskreen/resources/client-viewer/assets/index-legacy-VEq4rErU.js
 /usr/local/share/deskreen/resources/client-viewer/assets/index-voJy5fZe.js
 /usr/local/share/deskreen/resources/client-viewer/assets/polyfills-legacy-l6fuxk9e.js
-/usr/local/share/deskreen/resources/client-viewer/assets/splitPathsBySizeLoader-BtA_GwJW.js
-/usr/local/share/deskreen/resources/client-viewer/assets/splitPathsBySizeLoader-legacy-2ZOmNY_1.js
+/usr/local/share/deskreen/resources/client-viewer/assets/splitPathsBySizeLoader-BcDb-h7i.js
+/usr/local/share/deskreen/resources/client-viewer/assets/splitPathsBySizeLoader-legacy-D2F-S7hf.js
 /usr/local/share/deskreen/resources/client-viewer/favicon.ico
 /usr/local/share/deskreen/resources/client-viewer/img/logo512.png
 /usr/local/share/deskreen/resources/client-viewer/index.html

--- a/packages/deskreen.rb
+++ b/packages/deskreen.rb
@@ -3,11 +3,11 @@ require 'package'
 class Deskreen < Package
   description 'Turn any device into a secondary screen for your computer'
   homepage 'https://deskreen.com/lang-en'
-  version '3.2.1'
+  version '3.2.12'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   source_url "https://github.com/pavlobu/deskreen/releases/download/v#{version}/deskreen-ce-#{version}-x86_64.AppImage"
-  source_sha256 'caecfa17fb135a01fc600ef5d01c6c08d4cc6175270bef9ff0371e7e6ba092f3'
+  source_sha256 'c2ad220564000f9889ea0c49b648c27d857cd761dab8a8fce11198590808a074'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-deskreen crew update \
&& yes | crew upgrade

$ crew check deskreen
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/deskreen.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking deskreen package ...
Property tests for deskreen passed.
Checking deskreen package ...
Buildsystem test for deskreen passed.
Checking deskreen package ...
Library test for deskreen passed.
Checking deskreen package ...
[16087:0129/035814.716790:FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:169] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /usr/local/share/deskreen/chrome-sandbox is owned by root and has mode 4755.
/usr/local/bin/deskreen: line 3: 16087 Trace/breakpoint trap   GDK_BACKEND=x11 ./AppRun "$@"
[16092:0100/000000.733498:ERROR:content/zygote/zygote_linux.cc:660] write: Broken pipe (32)
Package tests for deskreen failed.
```