### PR TITLE
Iw 6.9 => 6.17

### DIFF
--- a/manifest/armv7l/i/iw.filelist
+++ b/manifest/armv7l/i/iw.filelist
@@ -1,3 +1,3 @@
-# Total size: 282459
+# Total size: 288299
 /usr/local/sbin/iw
 /usr/local/share/man/man8/iw.8.zst

--- a/manifest/i686/i/iw.filelist
+++ b/manifest/i686/i/iw.filelist
@@ -1,3 +1,3 @@
-# Total size: 346727
+# Total size: 354823
 /usr/local/sbin/iw
 /usr/local/share/man/man8/iw.8.zst

--- a/manifest/x86_64/i/iw.filelist
+++ b/manifest/x86_64/i/iw.filelist
@@ -1,3 +1,3 @@
-# Total size: 314475
+# Total size: 322795
 /usr/local/sbin/iw
 /usr/local/share/man/man8/iw.8.zst

--- a/packages/iw.rb
+++ b/packages/iw.rb
@@ -3,7 +3,7 @@ require 'package'
 class Iw < Package
   description 'iw is a new nl80211 based CLI configuration utility for wireless devices.'
   homepage 'https://wireless.wiki.kernel.org/en/users/documentation/iw'
-  version '6.9'
+  version '6.17'
   license 'ISC'
   compatibility 'all'
   source_url 'https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git'
@@ -11,10 +11,10 @@ class Iw < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '036fd416b734ff209e72e69f9ae47a51956e3a2f1ddff7ba1b7e53eaa824ed2f',
-     armv7l: '036fd416b734ff209e72e69f9ae47a51956e3a2f1ddff7ba1b7e53eaa824ed2f',
-       i686: 'af8ad685b5578cc5a960ccebffeccf7c720fb8cb880161224fbb3ff439249c47',
-     x86_64: 'e5009956bb7fb6f74075f22e87057cfeca8adc2e2549fafdc37fac2bd7251854'
+    aarch64: 'f65cd3f859b5745625cb8998b22e2899d1b708a7948fcbb26d61fa8fd833a0e2',
+     armv7l: 'f65cd3f859b5745625cb8998b22e2899d1b708a7948fcbb26d61fa8fd833a0e2',
+       i686: '74020b7325f7ca7f32a764f5e4438e9923f6edb38e20ae1b036f61415aaa8843',
+     x86_64: 'f8d182e34944226a9e52b525054b4ce70c603b06bd17acfa7d735f01658b570c'
   })
 
   depends_on 'gcc_lib' # R
@@ -29,11 +29,11 @@ class Iw < Package
     system 'make'
   end
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
   def self.check
     system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/tests/package/i/iw
+++ b/tests/package/i/iw
@@ -1,0 +1,3 @@
+#!/bin/bash
+iw --help | head
+iw --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-iw crew update \
&& yes | crew upgrade

$ crew check iw
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/iw.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking iw package ...
Property tests for iw passed.
Checking iw package ...
Buildsystem test for iw passed.
Checking iw package ...
Library test for iw passed.
Checking iw package ...
Usage:	iw [options] command
Options:
	--debug		enable netlink debugging
	--version	show version (6.17)
Commands:
	dev <devname> ap start <SSID> <SSID> <freq> [NOHT|HT20|HT40+|HT40-|5MHz|10MHz|80MHz|160MHz|320MHz] [punct <bitmap>] <beacon interval in TU> <DTIM period> [hidden-ssid|zeroed-ssid] head <beacon head in hexadecimal> [tail <beacon tail in hexadecimal>] [inactivity-time <inactivity time in seconds>] [key0:abcde d:1:6162636465]
	dev <devname> ap start <SSID> <control freq> [5|10|20|40|80|80+80|160|320] [<center1_freq> [<center2_freq>]] [punct <bitmap>] <beacon interval in TU> <DTIM period> [hidden-ssid|zeroed-ssid] head <beacon head in hexadecimal> [tail <beacon tail in hexadecimal>] [inactivity-time <inactivity time in seconds>] [key0:abcde d:1:6162636465]
		Start an AP. Note that this usually requires hostapd or similar.
		

iw version 6.17
Package tests for iw passed.
```