### PR TITLE
Adjust Updater workflow to do more gem installs, adjust lib/require_gem algorithm to install gems w/o documentation.

### DIFF
--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.0
+# Version 1.1
 name: Generate Updates PRs on Demand
 run-name: Generating Updates PRs on Demand using ${{ inputs.version_cmd_input }}
 on:
@@ -48,7 +48,7 @@ jobs:
           git stash drop || true
           echo "pwd is $(pwd)"
           # Install required gems.
-          ruby -e "require_relative 'lib/require_gem' ; require_gem 'regexp_parser' ; require_gem 'dagwood' ; require_gem 'rubocop' ; require_gem 'rubocop-chromebrew' ; puts 'Required gems installed.'.orange"
+          ruby -e "require_relative 'lib/require_gem' ; require_gem 'regexp_parser' ; require_gem 'dagwood' ; require_gem 'ruby-libversion', 'ruby_libversion' ; require_gem 'highline' ; require_gem 'ptools'; require_gem 'cgi' ;  require_gem 'rubocop' ; require_gem 'rubocop-chromebrew' ; puts 'Required gems installed.'.orange"
           # Force creation of temporary device.json.
           LD_LIBRARY_PATH=/usr/local/lib ruby bin/crew version
           # Force creation of temporary device.json.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.71.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.71.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/require_gem.rb
+++ b/lib/require_gem.rb
@@ -14,12 +14,12 @@ def require_gem(ruby_gem_name_and_require = nil, require_override = nil)
     require 'rubygems/gem_runner'
     Gem::GemRunner.new.run %w[check doctor #{ruby_gem_name}]
     Gem::GemRunner.new.run ['sources', '-u']
-    puts " -> install #{ruby_gem_name} gem".orange
-    Gem.install(ruby_gem_name)
+    puts " -> install #{ruby_gem_name} gem".orange CREW_OUTPUT_JSON if CREW_VERBOSE && !CREW_OUTPUT_JSON
+    system "gem install #{ruby_gem_name} -N #{'--silent -q' unless CREW_VERBOSE && !CREW_OUTPUT_JSON}"
     gem ruby_gem_name
   rescue LoadError
-    puts " -> install #{ruby_gem_name} gem".orange
-    Gem.install(ruby_gem_name)
+    puts " -> install #{ruby_gem_name} gem".orange if CREW_VERBOSE && !CREW_OUTPUT_JSON
+    system "gem install #{ruby_gem_name} -N #{'--silent -q' unless CREW_VERBOSE && !CREW_OUTPUT_JSON}"
     gem ruby_gem_name
   end
   requires = if require_override.nil?


### PR DESCRIPTION
## Description
#### Commits:
-  811a9da88 Adjust require_gem to use gem install options without doc installation.
-  b1375e9f5 Add no document option to runner gemrc.
### Updated GitHub configuration files:
- .github/workflows/Updater-on-Demand.yml
### Other changed files:
- lib/const.rb
- lib/require_gem.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=updater_workflow crew update \
&& yes | crew upgrade
```
