### PR TITLE
Krb5 1.22.1 => 1.22.2

### DIFF
--- a/manifest/armv7l/k/krb5.filelist
+++ b/manifest/armv7l/k/krb5.filelist
@@ -1,4 +1,4 @@
-# Total size: 4226179
+# Total size: 4226200
 /usr/local/bin/gss-client
 /usr/local/bin/k5srvutil
 /usr/local/bin/kadmin

--- a/manifest/i686/k/krb5.filelist
+++ b/manifest/i686/k/krb5.filelist
@@ -1,4 +1,4 @@
-# Total size: 4765579
+# Total size: 4765664
 /usr/local/bin/gss-client
 /usr/local/bin/k5srvutil
 /usr/local/bin/kadmin

--- a/manifest/x86_64/k/krb5.filelist
+++ b/manifest/x86_64/k/krb5.filelist
@@ -1,4 +1,4 @@
-# Total size: 4706685
+# Total size: 4706770
 /usr/local/bin/gss-client
 /usr/local/bin/k5srvutil
 /usr/local/bin/kadmin

--- a/packages/krb5.rb
+++ b/packages/krb5.rb
@@ -3,18 +3,18 @@ require 'buildsystems/autotools'
 class Krb5 < Autotools
   description 'Kerberos is a network authentication protocol.'
   homepage 'https://web.mit.edu/kerberos/'
-  version '1.22.1'
+  version '1.22.2'
   license 'openafs-krb5-a, BSD, MIT, OPENLDAP, BSD-2, HPND, BSD-4, ISC, RSA, CC-BY-SA-3.0 and BSD-2 or GPL-2+ )'
   compatibility 'all'
-  source_url "https://web.mit.edu/kerberos/dist/krb5/#{version.split('.')[0..1].join('.')}/krb5-#{version}.tar.gz"
-  source_sha256 '9560941a9d843c0243a71b17a7ac6fe31c7cebb5bce3983db79e52ae7e850491'
+  source_url "https://web.mit.edu/kerberos/dist/krb5/#{version.sub(/\.\d+$/, '')}/krb5-#{version}.tar.gz"
+  source_sha256 '074de0ecf72199f091c88812d46090c27724fd36a1284b5f44bc35b8dd31a59e'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '62318d53977497f7bf6c6038f5d17603685af369b8ba35ae1fa705e9f084bc59',
-     armv7l: '62318d53977497f7bf6c6038f5d17603685af369b8ba35ae1fa705e9f084bc59',
-       i686: 'd08304b052307c1ad9d484f405ab7452e8bf9250fd9a62473e6e4fec1fe4db05',
-     x86_64: '6f0019b8f7c1d58dcdd4ddaf6dc74f3d59c52f43fa7ffabe0da05dccfdb36afd'
+    aarch64: 'd07b691662223916e3c030af5db17e7931e15a06ed5c6275bf0ccfafb9865261',
+     armv7l: 'd07b691662223916e3c030af5db17e7931e15a06ed5c6275bf0ccfafb9865261',
+       i686: '9ebda0a19b9270d9faedea58287c69c83e720b1ab28f25659259bf12cdf9c770',
+     x86_64: '2e15c20afb9dbe75a27ac94a4c8a3b01ec093ae22145a8a5b9604e535b4737be'
   })
 
   depends_on 'ccache' => :build

--- a/tests/package/k/krb5
+++ b/tests/package/k/krb5
@@ -1,0 +1,3 @@
+#!/bin/bash
+klist -V
+krb5-config --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-krb5 crew update \
&& yes | crew upgrade

$ crew check krb5 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/krb5.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking krb5 package ...
Property tests for krb5 passed.
Checking krb5 package ...
Buildsystem test for krb5 passed.
Checking krb5 package ...
Library test for krb5 passed.
Checking krb5 package ...
Kerberos 5 version 1.22.2
Kerberos 5 release 1.22.2
Package tests for krb5 passed.
```