### PR TITLE
Lazygit 0.57.0 => 0.58.1

### DIFF
--- a/manifest/armv7l/l/lazygit.filelist
+++ b/manifest/armv7l/l/lazygit.filelist
@@ -1,2 +1,2 @@
-# Total size: 20512952
+# Total size: 20381880
 /usr/local/bin/lazygit

--- a/manifest/i686/l/lazygit.filelist
+++ b/manifest/i686/l/lazygit.filelist
@@ -1,2 +1,2 @@
-# Total size: 20361400
+# Total size: 20287672
 /usr/local/bin/lazygit

--- a/manifest/x86_64/l/lazygit.filelist
+++ b/manifest/x86_64/l/lazygit.filelist
@@ -1,2 +1,2 @@
-# Total size: 21762232
+# Total size: 21754040
 /usr/local/bin/lazygit

--- a/packages/lazygit.rb
+++ b/packages/lazygit.rb
@@ -3,7 +3,7 @@ require 'package'
 class Lazygit < Package
   description 'A simple terminal UI for git commands'
   homepage 'https://github.com/jesseduffield/lazygit'
-  version '0.57.0'
+  version '0.58.1'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Lazygit < Package
      x86_64: "https://github.com/jesseduffield/lazygit/releases/download/v#{version}/lazygit_#{version}_linux_x86_64.tar.gz"
   })
   source_sha256({
-    aarch64: '2984e480923f8685b5184f497c14e5fe9d4b7890e70ef50fdead3d5846212ae6',
-     armv7l: '2984e480923f8685b5184f497c14e5fe9d4b7890e70ef50fdead3d5846212ae6',
-       i686: 'cd5c17dab07b0db999ab4691f5e6bcdd700b3402d30d3f447ba1e88f84f2de49',
-     x86_64: 'ced011ecd1459d069c66128fbf172b7248c8b99d8983fa17d84a247a98146d5e'
+    aarch64: 'ca30bfdff93856095690623f5c45995a3369e197e139f65e6f55c9c2791fcb2a',
+     armv7l: 'ca30bfdff93856095690623f5c45995a3369e197e139f65e6f55c9c2791fcb2a',
+       i686: 'ea5e6ca5ef78d174db9c3d3b70f80022019093802563736c5ecb0963b797fe34',
+     x86_64: '61b6b839390c193466fb692f75df4e75ef5e9ced2bf5e0ca8b3848902f0adea9'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-lazygit crew update \
&& yes | crew upgrade

$ crew check lazygit
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/lazygit.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking lazygit package ...
Property tests for lazygit passed.
Checking lazygit package ...
Buildsystem test for lazygit passed.
Checking lazygit package ...
Library test for lazygit passed.
Checking lazygit package ...
lazygit

  Usage:
    lazygit [git-arg]

  Positional Variables: 
    git-arg   Panel to focus upon opening lazygit. Accepted values (based on git terminology): status, branch, log, stash. Ignored if --filter arg is passed.
  Flags: 
    -h --help               Displays help with available flag, subcommand, and positional value parameters.
    -p --path               Path of git repo. (equivalent to --work-tree=<path> --git-dir=<path>/.git/)
    -f --filter             Path to filter on in `git log -- <path>`. When in filter mode, the commits, reflog, and stash are filtered based on the given path, and some operations are restricted
    -v --version            Print the current version
    -d --debug              Run in debug mode with logging (see --logs flag below). Use the LOG_LEVEL env var to set the log level (debug/info/warn/error)
    -l --logs               Tail lazygit logs (intended to be used when `lazygit --debug` is called in a separate terminal tab)
       --profile            Start the profiler and serve it on http port 6060. See CONTRIBUTING.md for more info.
    -c --config             Print the default config
    -cd --print-config-dir   Print the config directory
    -ucd --use-config-dir     override default config directory with provided directory
    -w --work-tree          equivalent of the --work-tree git argument
    -g --git-dir            equivalent of the --git-dir git argument
    -ucf --use-config-file    Comma separated list to custom config file(s)
    -sm --screen-mode        The initial screen-mode, which determines the size of the focused panel. Valid options: 'normal' (default), 'half', 'full'

commit=4486c86271fc83e9ace700b1a472016d692513a5, build date=2026-01-12T19:47:02Z, build source=binaryRelease, version=0.58.1, os=linux, arch=amd64, git version=2.52.0
Package tests for lazygit passed.
```