### PR TITLE
Openjdk8 1.8.0_472 => 1.8.0_482

### DIFF
--- a/manifest/armv7l/o/openjdk8.filelist
+++ b/manifest/armv7l/o/openjdk8.filelist
@@ -1,4 +1,4 @@
-# Total size: 79284537
+# Total size: 79046849
 /usr/local/bin/appletviewer
 /usr/local/bin/extcheck
 /usr/local/bin/idlj
@@ -106,7 +106,7 @@
 /usr/local/jre/lib/aarch32/libawt_xawt.so
 /usr/local/jre/lib/aarch32/libdt_socket.so
 /usr/local/jre/lib/aarch32/libfontmanager.so
-/usr/local/jre/lib/aarch32/libfreetype.so.6
+/usr/local/jre/lib/aarch32/libfreetype.so
 /usr/local/jre/lib/aarch32/libhprof.so
 /usr/local/jre/lib/aarch32/libinstrument.so
 /usr/local/jre/lib/aarch32/libj2gss.so

--- a/manifest/i686/o/openjdk8.filelist
+++ b/manifest/i686/o/openjdk8.filelist
@@ -1,4 +1,4 @@
-# Total size: 158302867
+# Total size: 158521856
 /usr/local/bin/appletviewer
 /usr/local/bin/clhsdb
 /usr/local/bin/extcheck
@@ -141,7 +141,6 @@
 /usr/local/jre/lib/i386/libdt_socket.so
 /usr/local/jre/lib/i386/libfontmanager.so
 /usr/local/jre/lib/i386/libfreetype.so
-/usr/local/jre/lib/i386/libfreetype.so.6
 /usr/local/jre/lib/i386/libhprof.so
 /usr/local/jre/lib/i386/libinstrument.so
 /usr/local/jre/lib/i386/libj2gss.so

--- a/manifest/x86_64/o/openjdk8.filelist
+++ b/manifest/x86_64/o/openjdk8.filelist
@@ -1,4 +1,4 @@
-# Total size: 151414986
+# Total size: 151666152
 /usr/local/bin/appletviewer
 /usr/local/bin/clhsdb
 /usr/local/bin/extcheck
@@ -108,7 +108,6 @@
 /usr/local/jre/lib/amd64/libdt_socket.so
 /usr/local/jre/lib/amd64/libfontmanager.so
 /usr/local/jre/lib/amd64/libfreetype.so
-/usr/local/jre/lib/amd64/libfreetype.so.6
 /usr/local/jre/lib/amd64/libhprof.so
 /usr/local/jre/lib/amd64/libinstrument.so
 /usr/local/jre/lib/amd64/libj2gss.so

--- a/packages/openjdk8.rb
+++ b/packages/openjdk8.rb
@@ -3,21 +3,21 @@ require 'package'
 class Openjdk8 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://openjdk.org/'
-  version '1.8.0_472'
+  version '1.8.0_482'
   license 'GPL-2'
   compatibility 'all'
   # Visit https://www.azul.com/downloads/?version=java-8-lts&package=jdk#zulu to download the binaries.
   source_url({
-    aarch64: 'https://cdn.azul.com/zulu-embedded/bin/zulu8.90.0.19-ca-jdk8.0.472-linux_aarch32hf.tar.gz',
-     armv7l: 'https://cdn.azul.com/zulu-embedded/bin/zulu8.90.0.19-ca-jdk8.0.472-linux_aarch32hf.tar.gz',
-       i686: 'https://cdn.azul.com/zulu/bin/zulu8.90.0.19-ca-jdk8.0.472-linux_i686.tar.gz',
-     x86_64: 'https://cdn.azul.com/zulu/bin/zulu8.90.0.19-ca-jdk8.0.472-linux_x64.tar.gz'
+    aarch64: 'https://cdn.azul.com/zulu/bin/zulu8.92.0.21-ca-jdk8.0.482-linux_aarch32hf.tar.gz',
+     armv7l: 'https://cdn.azul.com/zulu/bin/zulu8.92.0.21-ca-jdk8.0.482-linux_aarch32hf.tar.gz',
+       i686: 'https://cdn.azul.com/zulu/bin/zulu8.92.0.19-ca-jdk8.0.482-linux_i686.tar.gz',
+     x86_64: 'https://cdn.azul.com/zulu/bin/zulu8.92.0.19-ca-jdk8.0.482-linux_x64.tar.gz'
   })
   source_sha256({
-    aarch64: 'e4bd2a5550280d4b0dcf12c9d33345a3d843cc04e6f7e03e5e34d86691a2ea57',
-     armv7l: 'e4bd2a5550280d4b0dcf12c9d33345a3d843cc04e6f7e03e5e34d86691a2ea57',
-       i686: '396ae342a40766657585c09cef68f4baa2427029d17ea70644788a3b1d3de5c7',
-     x86_64: '6f9e3fa773829ac2553411fb0cdeb394980627c47c9ab8f8892d4b917b70e2dd'
+    aarch64: 'a24d7b7ae8a2a306d06fa64019ac7d7abc2c2b265d9d313b14d44b1833daf194',
+     armv7l: 'a24d7b7ae8a2a306d06fa64019ac7d7abc2c2b265d9d313b14d44b1833daf194',
+       i686: 'a1ff064b7d8c79b2f2f1448f1e7c5f93909bd76d2495dffad579e8e662ca461d',
+     x86_64: '47d09e2fd824bb34c7e46fa086ca4ab9ddbf7fbae34ffe9bb4baedf4659631e1'
   })
 
   no_compile_needed

--- a/tests/package/o/openjdk8
+++ b/tests/package/o/openjdk8
@@ -1,0 +1,4 @@
+#!/bin/bash
+java -help 2>&1 | head
+java -version 2>&1
+javac -version 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjdk8 crew update \
&& yes | crew upgrade

$ crew check openjdk8 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/openjdk8.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking openjdk8 package ...
Property tests for openjdk8 passed.
Checking openjdk8 package ...
Buildsystem test for openjdk8 passed.
Checking openjdk8 package ...
Library test for openjdk8 passed.
Checking openjdk8 package ...
Usage: java [-options] class [args...]
           (to execute a class)
   or  java [-options] -jar jarfile [args...]
           (to execute a jar file)
where options include:
    -d32	  use a 32-bit data model if available
    -d64	  use a 64-bit data model if available
    -client	  to select the "client" VM
    -server	  to select the "server" VM
    -minimal	  to select the "minimal" VM
openjdk version "1.8.0_482"
OpenJDK Runtime Environment (Zulu 8.92.0.19-CA-linux32) (build 1.8.0_482-b08)
OpenJDK Server VM (Zulu 8.92.0.19-CA-linux32) (build 25.482-b08, mixed mode)
javac 1.8.0_482
Package tests for openjdk8 passed.
```