### PR TITLE
Openjdk11 11.0.29 => 11.0.30

### DIFF
--- a/manifest/i686/o/openjdk11.filelist
+++ b/manifest/i686/o/openjdk11.filelist
@@ -1,4 +1,4 @@
-# Total size: 293576667
+# Total size: 293765928
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java

--- a/manifest/x86_64/o/openjdk11.filelist
+++ b/manifest/x86_64/o/openjdk11.filelist
@@ -1,4 +1,4 @@
-# Total size: 329972912
+# Total size: 330183049
 /usr/local/bin/jaotc
 /usr/local/bin/jar
 /usr/local/bin/jarsigner

--- a/packages/openjdk11.rb
+++ b/packages/openjdk11.rb
@@ -3,21 +3,21 @@ require 'package'
 class Openjdk11 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://openjdk.org/'
-  version '11.0.29'
+  version %w[i686 x86_64].include?(ARCH) ? '11.0.30' : '11.0.29'
   license 'GPL-2'
   compatibility 'all'
   # Visit https://www.azul.com/downloads/?version=java-11-lts&package=jdk#zulu to download the binaries.
   source_url({
     aarch64: 'https://cdn.azul.com/zulu-embedded/bin/zulu11.84.17-ca-jdk11.0.29-linux_aarch32hf.tar.gz',
      armv7l: 'https://cdn.azul.com/zulu-embedded/bin/zulu11.84.17-ca-jdk11.0.29-linux_aarch32hf.tar.gz',
-       i686: 'https://cdn.azul.com/zulu/bin/zulu11.84.17-ca-jdk11.0.29-linux_i686.tar.gz',
-     x86_64: 'https://cdn.azul.com/zulu/bin/zulu11.84.17-ca-jdk11.0.29-linux_x64.tar.gz'
+       i686: 'https://cdn.azul.com/zulu/bin/zulu11.86.19-ca-jdk11.0.30-linux_i686.tar.gz',
+     x86_64: 'https://cdn.azul.com/zulu/bin/zulu11.86.19-ca-jdk11.0.30-linux_x64.tar.gz'
   })
   source_sha256({
     aarch64: '2b1e9764868f2f20678390b86a2c7527afc008bf53f3440788b9c1dc9b0f729e',
      armv7l: '2b1e9764868f2f20678390b86a2c7527afc008bf53f3440788b9c1dc9b0f729e',
-       i686: '91f8c36c1967dec2fb8f0893a22c4c20d54a271f738f64a2bf5a9294e1b3d603',
-     x86_64: '681b2e4bf7fedf4d20666fc2a954b83ff5675ccfb916c867267d29c85c2ee310'
+       i686: '4a87875925a64b640f18ca9cc70baf7054d8c2642e3f749102b1ba139cb1c25c',
+     x86_64: 'ac3ae99b3bedd81b672467279656a91bf34d1887ebd244e1cedcf2498a78d1c8'
   })
 
   no_compile_needed

--- a/tests/package/o/openjdk11
+++ b/tests/package/o/openjdk11
@@ -1,0 +1,4 @@
+#!/bin/bash
+java -help 2>&1 | head
+java -version 2>&1
+javac -version 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjdk11 crew update \
&& yes | crew upgrade

$ crew check openjdk11 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/openjdk11.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking openjdk11 package ...
Property tests for openjdk11 passed.
Checking openjdk11 package ...
Buildsystem test for openjdk11 passed.
Checking openjdk11 package ...
Library test for openjdk11 passed.
Checking openjdk11 package ...
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile> [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile> [args]
           (to execute a single source-file program)

openjdk version "11.0.30" 2026-01-20 LTS
OpenJDK Runtime Environment Zulu11.86+19-CA (build 11.0.30+7-LTS)
OpenJDK 64-Bit Server VM Zulu11.86+19-CA (build 11.0.30+7-LTS, mixed mode)
javac 11.0.30
Package tests for openjdk11 passed.
```