### PR TITLE
Openjdk17 17.0.17 => 17.0.18

### DIFF
--- a/manifest/armv7l/o/openjdk17.filelist
+++ b/manifest/armv7l/o/openjdk17.filelist
@@ -1,4 +1,4 @@
-# Total size: 289961624
+# Total size: 290007614
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java

--- a/manifest/i686/o/openjdk17.filelist
+++ b/manifest/i686/o/openjdk17.filelist
@@ -1,4 +1,4 @@
-# Total size: 310488192
+# Total size: 310536873
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java

--- a/manifest/x86_64/o/openjdk17.filelist
+++ b/manifest/x86_64/o/openjdk17.filelist
@@ -1,4 +1,4 @@
-# Total size: 338697763
+# Total size: 338868716
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java

--- a/packages/openjdk17.rb
+++ b/packages/openjdk17.rb
@@ -3,21 +3,21 @@ require 'package'
 class Openjdk17 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://openjdk.org/'
-  version '17.0.17'
+  version '17.0.18'
   license 'GPL-2'
   compatibility 'all'
   # Visit https://www.azul.com/downloads/?version=java-17-lts&package=jdk#zulu to download the binaries.
   source_url({
-    aarch64: 'https://cdn.azul.com/zulu-embedded/bin/zulu17.62.17-ca-jdk17.0.17-c2-linux_aarch32hf.tar.gz',
-     armv7l: 'https://cdn.azul.com/zulu-embedded/bin/zulu17.62.17-ca-jdk17.0.17-c2-linux_aarch32hf.tar.gz',
-       i686: 'https://cdn.azul.com/zulu/bin/zulu17.62.17-ca-jdk17.0.17-linux_i686.tar.gz',
-     x86_64: 'https://cdn.azul.com/zulu/bin/zulu17.62.17-ca-jdk17.0.17-linux_x64.tar.gz'
+    aarch64: 'https://cdn.azul.com/zulu/bin/zulu17.64.17-ca-jdk17.0.18-c2-linux_aarch32hf.tar.gz',
+     armv7l: 'https://cdn.azul.com/zulu/bin/zulu17.64.17-ca-jdk17.0.18-c2-linux_aarch32hf.tar.gz',
+       i686: 'https://cdn.azul.com/zulu/bin/zulu17.64.15-ca-jdk17.0.18-linux_i686.tar.gz',
+     x86_64: 'https://cdn.azul.com/zulu/bin/zulu17.64.15-ca-jdk17.0.18-linux_x64.tar.gz'
   })
   source_sha256({
-    aarch64: '0d4873a8fa56ea5427fd9b7c23838cb61266fd78b84817910bfbab7060136630',
-     armv7l: '0d4873a8fa56ea5427fd9b7c23838cb61266fd78b84817910bfbab7060136630',
-       i686: '6f1e4c9a7c9924d0322505fadcabcd750a2bfc98f3b51cf39ddad92e6e05ec2e',
-     x86_64: '1dcbbed73e95dc35f5c60402a84936f6830ff43c2a0dc0037a5657dbc25472c1'
+    aarch64: 'a8ef931ae3c5c6ee563b385b9f92a445bff382753437a4014bce3b3e311f3709',
+     armv7l: 'a8ef931ae3c5c6ee563b385b9f92a445bff382753437a4014bce3b3e311f3709',
+       i686: '473f89250a27f55d3490140565d881a1a3e5911d624bd4f791cf79e3c95d2f8c',
+     x86_64: '48dcbcb09f9802b144347b164080df762ddbd0077966e273116c973edb3020ef'
   })
 
   no_compile_needed

--- a/tests/package/o/openjdk17
+++ b/tests/package/o/openjdk17
@@ -1,0 +1,4 @@
+#!/bin/bash
+java -help 2>&1 | head
+java -version 2>&1
+javac -version 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjdk17 crew update \
&& yes | crew upgrade

$ crew check openjdk17
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/openjdk17.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking openjdk17 package ...
Property tests for openjdk17 passed.
Checking openjdk17 package ...
Buildsystem test for openjdk17 passed.
Checking openjdk17 package ...
Library test for openjdk17 passed.
Checking openjdk17 package ...
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile> [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile> [args]
           (to execute a single source-file program)

openjdk version "17.0.18" 2026-01-20 LTS
OpenJDK Runtime Environment Zulu17.64+15-CA (build 17.0.18+8-LTS)
OpenJDK Server VM Zulu17.64+15-CA (build 17.0.18+8-LTS, mixed mode, sharing)
javac 17.0.18
Package tests for openjdk17 passed.
```