### PR TITLE
Openjdk21 21.0.9 => 21.0.10

### DIFF
--- a/manifest/x86_64/o/openjdk21.filelist
+++ b/manifest/x86_64/o/openjdk21.filelist
@@ -1,4 +1,4 @@
-# Total size: 367970122
+# Total size: 368161150
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java

--- a/packages/openjdk21.rb
+++ b/packages/openjdk21.rb
@@ -3,12 +3,12 @@ require 'package'
 class Openjdk21 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://openjdk.org/'
-  version '21.0.9'
+  version '21.0.10'
   license 'GPL-2'
   compatibility 'x86_64'
   # Visit https://www.azul.com/downloads/?version=java-21-lts&package=jdk#zulu to download the binary.
-  source_url 'https://cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-linux_x64.tar.gz'
-  source_sha256 '67e810b31427ac0ff1c249473595066a00bdf0f9265df186c32905d5f75c93b8'
+  source_url 'https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz'
+  source_sha256 '7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670'
 
   no_compile_needed
   no_shrink

--- a/tests/package/o/openjdk21
+++ b/tests/package/o/openjdk21
@@ -1,0 +1,4 @@
+#!/bin/bash
+java -help 2>&1 | head
+java -version 2>&1
+javac -version 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjdk21 crew update \
&& yes | crew upgrade

$ crew check openjdk21 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/openjdk21.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking openjdk21 package ...
Property tests for openjdk21 passed.
Checking openjdk21 package ...
Buildsystem test for openjdk21 passed.
Checking openjdk21 package ...
Library test for openjdk21 passed.
Checking openjdk21 package ...
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile> [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile> [args]
           (to execute a single source-file program)

openjdk version "21.0.10" 2026-01-20 LTS
OpenJDK Runtime Environment Zulu21.48+15-CA (build 21.0.10+7-LTS)
OpenJDK 64-Bit Server VM Zulu21.48+15-CA (build 21.0.10+7-LTS, mixed mode, sharing)
javac 21.0.10
Package tests for openjdk21 passed.
```