### PR TITLE
Openjdk25 25.0.1 => 25.0.2

### DIFF
--- a/manifest/x86_64/o/openjdk25.filelist
+++ b/manifest/x86_64/o/openjdk25.filelist
@@ -1,4 +1,4 @@
-# Total size: 413846219
+# Total size: 414007268
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java

--- a/packages/openjdk25.rb
+++ b/packages/openjdk25.rb
@@ -3,12 +3,12 @@ require 'package'
 class Openjdk25 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://openjdk.org/'
-  version '25.0.1'
+  version '25.0.2'
   license 'GPL-2'
   compatibility 'x86_64'
   # Visit https://www.azul.com/downloads/?version=java-25-lts&package=jdk#zulu to download the binary.
-  source_url 'https://cdn.azul.com/zulu/bin/zulu25.30.17-ca-jdk25.0.1-linux_x64.tar.gz'
-  source_sha256 '471b3e62bdffaed27e37005d842d8639f10d244ccce1c7cdebf7abce06c8313e'
+  source_url 'https://cdn.azul.com/zulu/bin/zulu25.32.17-ca-jdk25.0.2-linux_x64.tar.gz'
+  source_sha256 'f1752d0051b6ca233625ddb2c18c9170edbe55c5ee6515bfefd8ea0197ee1c20'
 
   no_compile_needed
   no_shrink

--- a/tests/package/o/openjdk25
+++ b/tests/package/o/openjdk25
@@ -1,0 +1,4 @@
+#!/bin/bash
+java -help 2>&1 | head
+java -version 2>&1
+javac -version 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjdk25 crew update \
&& yes | crew upgrade

$ crew check openjdk25 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/openjdk25.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking openjdk25 package ...
Property tests for openjdk25 passed.
Checking openjdk25 package ...
Buildsystem test for openjdk25 passed.
Checking openjdk25 package ...
Library test for openjdk25 passed.
Checking openjdk25 package ...
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile>.jar [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile>.java [args]
           (to execute a source-file program)

openjdk version "25.0.2" 2026-01-20 LTS
OpenJDK Runtime Environment Zulu25.32+17-CA (build 25.0.2+10-LTS)
OpenJDK 64-Bit Server VM Zulu25.32+17-CA (build 25.0.2+10-LTS, mixed mode, sharing)
javac 25.0.2
Package tests for openjdk25 passed.
```