### PR TITLE
Bitcoin_core 30.0 => 30.2

### DIFF
--- a/packages/bitcoin_core.rb
+++ b/packages/bitcoin_core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Bitcoin_core < Package
   description 'Bitcoin Core is a full Bitcoin client and builds the backbone of the network.'
   homepage 'https://bitcoincore.org/'
-  version '30.0'
+  version '30.2'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.29'
@@ -13,9 +13,9 @@ class Bitcoin_core < Package
      x86_64: "https://bitcoincore.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-x86_64-linux-gnu.tar.gz"
   })
   source_sha256({
-    aarch64: '68eef66e4c18396449450f45626e023dc96023742bb760aafcf4625a59c01c56',
-     armv7l: '68eef66e4c18396449450f45626e023dc96023742bb760aafcf4625a59c01c56',
-     x86_64: '00964ae375084113b1162f2f493b9372421608af23539766e315a3cb0ee54248'
+    aarch64: 'd510542842318ea34d87cb2c93d6a7fe091dcac2e8684460be2b3c44843fb502',
+     armv7l: 'd510542842318ea34d87cb2c93d6a7fe091dcac2e8684460be2b3c44843fb502',
+     x86_64: '6aa7bb4feb699c4c6262dd23e4004191f6df7f373b5d5978b5bcdd4bb72f75d8'
   })
 
   # Dependencies needed for bitcoin-qt


### PR DESCRIPTION
## Description
Update Bitcoin Core to 30.2.

##
Builds:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##