### PR TITLE
Do not use rdfind unless it works.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1117,7 +1117,7 @@ end
 def shrink_dir(dir)
   unless CREW_NOT_SHRINK_ARCHIVE || @pkg.no_shrink?
     Dir.chdir dir do
-      if File.file?("#{CREW_PREFIX}/bin/rdfind")
+      if File.executable?("#{CREW_PREFIX}/bin/rdfind") && system('rdfind --help', %i[out err] => File::NULL)
         puts 'Using rdfind to convert duplicate files to hard links.'
         system "#{CREW_PREFIX}/bin/rdfind -removeidentinode true -makesymlinks false -makehardlinks true -makeresultsfile false ."
       end
@@ -1214,7 +1214,7 @@ def install_package(pkgdir)
           end
         end
       end
-      if File.executable?("#{CREW_PREFIX}/bin/rdfind")
+      if File.executable?("#{CREW_PREFIX}/bin/rdfind") && system('rdfind --help', %i[out err] => File::NULL)
         puts 'Using rdfind to convert duplicate files to hard links.'
         system 'rdfind -removeidentinode true -makesymlinks false -makehardlinks true -makeresultsfile false .'
       end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.71.9' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.72.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]


### PR DESCRIPTION
## Description
- Due to breakage: https://github.com/chromebrew/chromebrew/issues/14590
#### Commits:
-  51b933cbf Do not use rdfind unless it works.
### Other changed files:
- bin/crew
- lib/const.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=no_rdfind crew update \
&& yes | crew upgrade
```
