### PR TITLE
Refactor dependency labeling to use '=> :executable_only

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.72.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.72.1' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/manifest/x86_64/p/py3_smartypants.filelist
+++ b/manifest/x86_64/p/py3_smartypants.filelist
@@ -1,11 +1,11 @@
-# Total size: 45918
+# Total size: 46202
 /usr/local/bin/smartypants
-/usr/local/lib/python3.13/site-packages/__pycache__/smartypants.cpython-313.pyc
-/usr/local/lib/python3.13/site-packages/smartypants-2.0.2.dist-info/INSTALLER
-/usr/local/lib/python3.13/site-packages/smartypants-2.0.2.dist-info/METADATA
-/usr/local/lib/python3.13/site-packages/smartypants-2.0.2.dist-info/RECORD
-/usr/local/lib/python3.13/site-packages/smartypants-2.0.2.dist-info/REQUESTED
-/usr/local/lib/python3.13/site-packages/smartypants-2.0.2.dist-info/WHEEL
-/usr/local/lib/python3.13/site-packages/smartypants-2.0.2.dist-info/licenses/COPYING
-/usr/local/lib/python3.13/site-packages/smartypants-2.0.2.dist-info/top_level.txt
-/usr/local/lib/python3.13/site-packages/smartypants.py
+/usr/local/lib/python3.14/site-packages/__pycache__/smartypants.cpython-314.pyc
+/usr/local/lib/python3.14/site-packages/smartypants-2.0.2.dist-info/INSTALLER
+/usr/local/lib/python3.14/site-packages/smartypants-2.0.2.dist-info/METADATA
+/usr/local/lib/python3.14/site-packages/smartypants-2.0.2.dist-info/RECORD
+/usr/local/lib/python3.14/site-packages/smartypants-2.0.2.dist-info/REQUESTED
+/usr/local/lib/python3.14/site-packages/smartypants-2.0.2.dist-info/WHEEL
+/usr/local/lib/python3.14/site-packages/smartypants-2.0.2.dist-info/licenses/COPYING
+/usr/local/lib/python3.14/site-packages/smartypants-2.0.2.dist-info/top_level.txt
+/usr/local/lib/python3.14/site-packages/smartypants.py

--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -20,13 +20,13 @@ class Cairo < Meson
   depends_on 'fontconfig' # R
   depends_on 'freetype' # R
   depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
   depends_on 'glib' # R
+  depends_on 'glibc' # R
   depends_on 'harfbuzz' # R
   depends_on 'libpng' # R
   depends_on 'libx11' # R
   depends_on 'libxcb' # R
-  depends_on 'libxrender' # R
+  depends_on 'libxrender' => :build
   depends_on 'lzo' # R
   depends_on 'mesa' => :build
   depends_on 'pixman' # R

--- a/packages/chafa.rb
+++ b/packages/chafa.rb
@@ -16,16 +16,16 @@ class Chafa < Autotools
      x86_64: 'bb460334e3a93e55c323b9d3269558b1c62071291950b2a924e4ef6d5764ec3c'
   })
 
-  depends_on 'cairo' # R
-  depends_on 'freetype' # R
-  depends_on 'gdk_pixbuf' # R
+  depends_on 'cairo' => :executable_only
+  depends_on 'freetype' => :executable_only
+  depends_on 'gdk_pixbuf' => :executable_only
   depends_on 'glib' # R
   depends_on 'glibc' # R
-  depends_on 'harfbuzz' # R
-  depends_on 'libjpeg_turbo' # R
-  depends_on 'librsvg' # R
-  depends_on 'libtiff' # R
-  depends_on 'libxslt' # R
+  depends_on 'harfbuzz' => :executable_only
+  depends_on 'libjpeg_turbo' => :executable_only
+  depends_on 'librsvg' => :executable_only
+  depends_on 'libtiff' => :executable_only
+  depends_on 'libxslt' => :build
 
   autotools_configure_options '--enable-gtk-doc'
 end

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -23,7 +23,7 @@ class Fontconfig < Meson
   depends_on 'glibc' # R
   depends_on 'gperf' => :build
   depends_on 'graphite' => :build
-  depends_on 'harfbuzz' # R
+  depends_on 'harfbuzz' => :executable_only
   depends_on 'json_c' => :build
   depends_on 'libpng' => :build
   depends_on 'util_linux' => :build

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -22,7 +22,8 @@ class Harfbuzz < Meson
 
   depends_on 'brotli' # R
   depends_on 'bzip2' # R
-  depends_on 'chafa' # R
+  depends_on 'cairo' => :executable_only
+  depends_on 'chafa' => :executable_only
   depends_on 'expat' # R
   # depends_on 'fontconfig' # This pulls in freetype.
   # depends_on 'freetype' # R harfbuzz provides this.

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -19,7 +19,7 @@ class Librsvg < Meson
   depends_on 'cairo' # R
   depends_on 'cargo_c' => :build
   depends_on 'dav1d' # R
-  depends_on 'fontconfig' # R
+  depends_on 'fontconfig' => :executable_only
   depends_on 'fribidi' => :build
   depends_on 'gcc_lib' # R
   depends_on 'gdk_pixbuf' # R

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -22,8 +22,8 @@ class Pango < Meson
   depends_on 'freetype' # R
   depends_on 'fribidi' # R
   depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
   depends_on 'glib' # R
+  depends_on 'glibc' # R
   depends_on 'gobject_introspection' => :build # add this package to build gtk+, avoid compilation error
   depends_on 'harfbuzz' # R
   depends_on 'libx11' # R


### PR DESCRIPTION
## Description
#### Commits:
-  ccaf706 Refactor dependency labeling to use '=> :executable_only'.
### Packages with Updated versions or Changed package files:
- `cairo`: 1.18.4-1 &rarr; 1.18.4-1 (current version is 1.18.4)
- `chafa`: 1.18.1 &rarr; 1.18.1
- `fontconfig`: 2.17.1-1 &rarr; 2.17.1-1 (current version is 2.17.1)
- `harfbuzz`: 12.2.0-icu77.1 &rarr; 12.2.0-icu77.1 (current version is 12.3.2)
- `librsvg`: 2.61.3-1-icu77.1 &rarr; 2.61.3-1-icu77.1 (current version is 2.61.91)
- `pango`: 1.56.4-1 &rarr; 1.56.4-1 (current version is 1.56.4)
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Other changed files:
- lib/const.rb
- tools/getrealdeps.rb
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=dep_versioning crew update \
&& yes | crew upgrade
```
