### PR TITLE
Keep version.rb from updating package if there is a bad source.

### DIFF
--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.3
+# Version 1.4
 name: Generate Updates PRs on Demand
 run-name: Generating Updates PRs on Demand using ${{ inputs.version_cmd_input }}
 on:
@@ -82,7 +82,7 @@ jobs:
           # for i in $(git status --porcelain | awk '{print $2}' | grep ^packages/)
           # do
           #  git stash pop || true
-            ruby tools/version.rb -v -u $i
+            ruby tools/version.rb -v -u $i || continue
             pkg=${i%.rb}
             pkg=${pkg#packages/}
             # The updated package version will be the one in the package file.

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# version.rb version 3.31 (for Chromebrew)
+# version.rb version 3.32 (for Chromebrew)
 
 OPTIONS = %w[-h --help -j --json -u --update-package-files -v --verbose -vv]
 
@@ -410,6 +410,7 @@ if filelist.length.positive?
                     FileUtils.cp "#{filename}.bak", filename
                     FileUtils.rm "#{filename}.bak"
                   end
+                  exit! if !CREW_OUTPUT_JSON && (filelist.length == 1)
                   next filename
                 end
                 new_hash[arch] = `curl -Ls #{@pkg.source_url[arch.to_sym]} | sha256sum - | awk '{print $1}'`.chomp
@@ -434,6 +435,7 @@ if filelist.length.positive?
                   FileUtils.cp "#{filename}.bak", filename
                   FileUtils.rm "#{filename}.bak"
                 end
+                exit! if !CREW_OUTPUT_JSON && (filelist.length == 1)
                 next filename
               end
               new_hash[arch] = `curl -Ls #{@pkg.source_url} | sha256sum - | awk '{print $1}'`.chomp
@@ -501,7 +503,7 @@ if filelist.length.positive?
     print version_line_string[@pkg.name.to_sym] if !CREW_OUTPUT_JSON && ((versions_updated[@pkg.name.to_sym] == 'Outdated.' && updatable_pkg[@pkg.name.to_sym] == 'Yes') || OUTPUT_ALL)
     print addendum_string unless addendum_string.blank? || CREW_OUTPUT_JSON || !CREW_VERBOSE
 
-    print "Failed to update version in #{@pkg.name} to #{upstream_version}".yellow if !CREW_OUTPUT_JSON && (versions_updated[@pkg.name.to_sym].to_s == 'false')
+    print "Failed to update version in #{@pkg.name} to #{upstream_version}".yellow if !CREW_OUTPUT_JSON && ['false', 'Bad Source'].include?(versions_updated[@pkg.name.to_sym].to_s)
     print "Failed to update binary_compression in #{@pkg.name}".yellow if !CREW_OUTPUT_JSON && (bc_updated[@pkg.name.to_sym].to_s == 'false')
   end
   puts versions.to_json if CREW_OUTPUT_JSON


### PR DESCRIPTION
## Description
Fixes https://github.com/chromebrew/chromebrew/issues/14615
#### Commits:
-  45f952a6c Keep version.rb from updating package if there is a bad source.
### Updated GitHub configuration files:
- .github/workflows/Updater-on-Demand.yml
### Other changed files:
- tools/version.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=updater_workflow_broken_source crew update \
&& yes | crew upgrade
```
