### PR TITLE
Fix py3_itstool

### DIFF
--- a/manifest/armv7l/p/py3_itstool.filelist
+++ b/manifest/armv7l/p/py3_itstool.filelist
@@ -1,4 +1,4 @@
-# Total size: 134460
+# Total size: 134468
 /usr/local/bin/itstool
 /usr/local/lib/python3.14/site-packages/itstool-2.0.7.dist-info/AUTHORS
 /usr/local/lib/python3.14/site-packages/itstool-2.0.7.dist-info/COPYING

--- a/manifest/i686/p/py3_itstool.filelist
+++ b/manifest/i686/p/py3_itstool.filelist
@@ -1,4 +1,4 @@
-# Total size: 134460
+# Total size: 134468
 /usr/local/bin/itstool
 /usr/local/lib/python3.14/site-packages/itstool-2.0.7.dist-info/AUTHORS
 /usr/local/lib/python3.14/site-packages/itstool-2.0.7.dist-info/COPYING

--- a/manifest/x86_64/p/py3_itstool.filelist
+++ b/manifest/x86_64/p/py3_itstool.filelist
@@ -1,4 +1,4 @@
-# Total size: 134460
+# Total size: 134468
 /usr/local/bin/itstool
 /usr/local/lib/python3.14/site-packages/itstool-2.0.7.dist-info/AUTHORS
 /usr/local/lib/python3.14/site-packages/itstool-2.0.7.dist-info/COPYING

--- a/packages/py3_itstool.rb
+++ b/packages/py3_itstool.rb
@@ -10,10 +10,10 @@ class Py3_itstool < Pip
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd009a0414b16e306bd53e12edd4924c9a07200e4136b5209ce23c4558f8aa7a5',
-     armv7l: 'd009a0414b16e306bd53e12edd4924c9a07200e4136b5209ce23c4558f8aa7a5',
-       i686: '9730d43c2aeaa6c103e3bc8e43fc2943edee9b92f04f9a7a63d7def1a2838787',
-     x86_64: '000d264ed866829beb57e73b2f46af87b75e8927ed95df99793cc755025d5243'
+    aarch64: '3ea9de66bc8638d7fdd0d4c86cdad42b8784c59bd58345906b669a85be9d3289',
+     armv7l: '3ea9de66bc8638d7fdd0d4c86cdad42b8784c59bd58345906b669a85be9d3289',
+       i686: '3db62eac24c81f82d19c0f7770b9977f009e2fc6f9e50729a31667ad9c62b276',
+     x86_64: '9b1028b33eaef6fbc5a14c8f51652eb323100a95ebc3e6aad1a813537188bbb2'
   })
 
   depends_on 'coreutils' if ARCH == 'i686'
@@ -22,4 +22,11 @@ class Py3_itstool < Pip
   depends_on 'python3' => :build
 
   no_source_build
+
+  pip_install_extras do
+    system "sed -i 's,\\\\s,\\\\\\\\s,g' #{CREW_DEST_PREFIX}/bin/itstool"
+    system "sed -i 's,\\\\<,\\\\\\\\<,g' #{CREW_DEST_PREFIX}/bin/itstool"
+    system "sed -i 's,\\\\>,\\\\\\\\>,g' #{CREW_DEST_PREFIX}/bin/itstool"
+    system "sed -i 's,\\\\\.\\[,\\\\\\\\\\.\\[,g' #{CREW_DEST_PREFIX}/bin/itstool"
+  end
 end


### PR DESCRIPTION
Fixes #14729.  Nothing like double escaping. :)

Fixes the following:
```
/usr/local/bin/itstool:223: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
  if re.sub('\s+', ' ', text).strip() != '':
/usr/local/bin/itstool:321: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
  message = re.sub('\s+', ' ', message).strip()
/usr/local/bin/itstool:459: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
  return re.sub('\s+', ' ', self.locnote).strip()
/usr/local/bin/itstool:461: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
  return '(itstool) link: ' + re.sub('\s+', ' ', self.locnoteref).strip()
/usr/local/bin/itstool:892: SyntaxWarning: "\<" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\<"? A raw string is also an option.
  regex = re.compile('(.*) \<(.*)\>, (.*)')
/usr/local/bin/itstool:927: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
  if re.sub('\s+', '', prevtext) == '':
/usr/local/bin/itstool:1471: SyntaxWarning: "\." is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\."? A raw string is also an option.
  _locale_pattern = re.compile('([a-zA-Z0-9-]+)(_[A-Za-z0-9]+)?(@[A-Za-z0-9]+)?(\.[A-Za-z0-9]+)?')
```

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-py3_itstool crew update \
&& yes | crew upgrade
```