### PR TITLE
Run tools/getrealdeps.rb on all packages in core.rb

### DIFF
--- a/packages/acl.rb
+++ b/packages/acl.rb
@@ -17,6 +17,6 @@ class Acl < Autotools
      x86_64: 'e5b1beae3754bae84e18928c85a6c1c28ee196f387299b51f4cd2ea91dc09645'
   })
 
-  depends_on 'attr'
+  depends_on 'attr' # R
   depends_on 'glibc' # R
 end

--- a/packages/bash.rb
+++ b/packages/bash.rb
@@ -20,8 +20,8 @@ class Bash < Autotools
 
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
-  depends_on 'ncurses' # R
-  depends_on 'readline' # R
+  depends_on 'ncurses' => :executable_only
+  depends_on 'readline' => :executable_only
 
   autotools_configure_options '--with-curses \
     --enable-extended-glob-default \

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -17,7 +17,7 @@ class Command_not_found < Package
      x86_64: 'c231721811f8d82f61e7515dfef7ea42e3e990d7c5a31a1c85e4e53de5d12582'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable_only
 
   print_source_bashrc
 

--- a/packages/crew_mvdir.rb
+++ b/packages/crew_mvdir.rb
@@ -17,7 +17,7 @@ class Crew_mvdir < Package
      x86_64: 'd55466dacf8df9994b8ed0b33347f4cd730b4a23d34462672c00b5269e22c2e9'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable_only
 
   def self.build
     system 'make'

--- a/packages/elfutils.rb
+++ b/packages/elfutils.rb
@@ -18,9 +18,9 @@ class Elfutils < Autotools
   })
 
   depends_on 'bzip2' # R
-  depends_on 'gcc_lib' # R
+  depends_on 'gcc_lib' => :executable_only
   depends_on 'glibc' # R
-  depends_on 'libarchive' # R
+  depends_on 'libarchive' => :executable_only
   depends_on 'xzutils' # R
   depends_on 'zlib' # R
   depends_on 'zstd' # R

--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -21,7 +21,6 @@ class Filecmd < Package
   depends_on 'glibc' # R
   depends_on 'lzlib' # R Fixes checking lzlib.h usability... no
   depends_on 'xzutils' # R
-  depends_on 'zlib' # R
   depends_on 'zstd' # R
 
   def self.prebuild

--- a/packages/gawk.rb
+++ b/packages/gawk.rb
@@ -29,7 +29,7 @@ class Gawk < Autotools
   depends_on 'libsigsegv' # R
   depends_on 'mpfr' # R
   depends_on 'ncurses' => :build
-  depends_on 'readline' # R
+  depends_on 'readline' => :executable_only
 
   # Tests appear to have container issues...
   # run_tests unless ARCH == 'i686' || ARCH == 'x86_64'

--- a/packages/gdbm.rb
+++ b/packages/gdbm.rb
@@ -19,8 +19,8 @@ class Gdbm < Package
 
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
-  depends_on 'ncurses' # R
-  depends_on 'readline' # R
+  depends_on 'ncurses' => :executable_only
+  depends_on 'readline' => :executable_only
 
   def self.build
     system "./configure \

--- a/packages/grep.rb
+++ b/packages/grep.rb
@@ -20,8 +20,8 @@ class Grep < Autotools
      x86_64: '81670d54d70bebb2d2d0ae78016603838cb86d28dc844916f8b3d72d994504a0'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'pcre2' # R
+  depends_on 'glibc' => :executable_only
+  depends_on 'pcre2' => :executable_only
 
   # NOTE: built on i686 by removing the c11threads derived threads.h
   # installed by the chromebrew glibc package on this architecture.

--- a/packages/less.rb
+++ b/packages/less.rb
@@ -18,8 +18,8 @@ class Less < Autotools
   })
 
   depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
-  depends_on 'ncurses' # R
+  depends_on 'glibc' => :executable_only
+  depends_on 'ncurses' => :executable_only
   depends_on 'patch' => :build
 
   autotools_configure_options '--with-regex=posix'

--- a/packages/libcyrussasl.rb
+++ b/packages/libcyrussasl.rb
@@ -22,7 +22,8 @@ class Libcyrussasl < Autotools
   depends_on 'glibc' # R
   depends_on 'krb5' # R
   depends_on 'libdb' # R
-  depends_on 'linux_pam' # R
+  depends_on 'libxcrypt' # R
+  depends_on 'linux_pam' => :executable_only
   depends_on 'openssl' # R
 
   autotools_configure_options "--enable-shared \

--- a/packages/libpng.rb
+++ b/packages/libpng.rb
@@ -18,7 +18,7 @@ class Libpng < CMake
   })
 
   depends_on 'glibc' # R
-  depends_on 'zlib'
+  depends_on 'zlib' # R
 
   gnome
 

--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -17,13 +17,13 @@ class Libssh < CMake
      x86_64: '3a3f9eb8a3fa873d0a10a3a53fbe4fd21c21a819339eda171535e23c2833c077'
   })
 
-  depends_on 'e2fsprogs'
+  depends_on 'e2fsprogs' # R
   depends_on 'glibc' # R
-  depends_on 'krb5'
+  depends_on 'krb5' # R
   depends_on 'libgcrypt'
   depends_on 'openssl' # R
   depends_on 'py3_abimap' => :build
-  depends_on 'zlib'
+  depends_on 'zlib' # R
 
   cmake_options '-DWITH_EXAMPLES=OFF \
     -DBUILD_SHARED_LIBS=ON'

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -17,7 +17,7 @@ class Libunbound < Autotools
      x86_64: 'e6f60b3ea6334804c1ea2e1f16aa195f340aa0e4e2dd92bc46b707fec5825847'
   })
 
-  depends_on 'expat' # R
+  depends_on 'expat' => :executable_only
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'openssl' # R On i686 openssl needs to be installed before libunbound.

--- a/packages/libunistring.rb
+++ b/packages/libunistring.rb
@@ -17,7 +17,7 @@ class Libunistring < Autotools
      x86_64: '938cdcf6680fee8df992123a1fde0b3293eabf6936a09a51bd66ef46bbd7ea53'
   })
 
-  depends_on 'glibc'
+  depends_on 'glibc' # R
 
   autotools_configure_options '--enable-static \
       --enable-shared'

--- a/packages/libversion.rb
+++ b/packages/libversion.rb
@@ -17,5 +17,8 @@ class Libversion < CMake
      x86_64: '0d451b69e43e8931d79e2a097ecce63bf4d287e37ccb67c80839f06a5956c812'
   })
 
+  depends_on 'gcc_lib' => :executable_only
+  depends_on 'glibc' # R
+
   run_tests
 end

--- a/packages/lzip.rb
+++ b/packages/lzip.rb
@@ -17,6 +17,6 @@ class Lzip < Autotools
      x86_64: 'f9e9a6ea29a9bdfafb24c5eb5ca72e60ac8b6470ecec545a647667bc84630204'
   })
 
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
+  depends_on 'gcc_lib' => :executable_only
+  depends_on 'glibc' => :executable_only
 end

--- a/packages/m4.rb
+++ b/packages/m4.rb
@@ -17,6 +17,6 @@ class M4 < Autotools
      x86_64: '2ffed7ee8131ea0757f140cfb6ed1559463243d6b8049ded703c1cea28fbff39'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable_only
   depends_on 'libsigsegv' => :build
 end

--- a/packages/mawk.rb
+++ b/packages/mawk.rb
@@ -17,7 +17,7 @@ class Mawk < Autotools
      x86_64: 'f6352afff896d6dc3d964e3c5422a290b5b0cfea053e520c096765563da34c39'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable_only
 
   autotools_install_extras do
     FileUtils.ln_s "#{CREW_PREFIX}/bin/mawk", "#{CREW_DEST_PREFIX}/bin/awk"

--- a/packages/most.rb
+++ b/packages/most.rb
@@ -17,9 +17,9 @@ class Most < Package
      x86_64: 'afc592b6140eb946a257197597f624a5125ae1f694f4883d5013461be388e071'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'slang' # R
-  depends_on 'gcc_lib' # R
+  depends_on 'gcc_lib' => :executable_only
+  depends_on 'glibc' => :executable_only
+  depends_on 'slang' => :executable_only
 
   def self.build
     system "./configure #{CREW_CONFIGURE_OPTIONS}"

--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -23,7 +23,7 @@ class Openldap < Autotools
   depends_on 'krb5' => :build
   depends_on 'libcyrussasl' # R
   depends_on 'openssl' # R
-  depends_on 'util_linux' # R
+  depends_on 'util_linux' => :executable_only
 
   autotools_configure_options '--disable-slapd'
 end

--- a/packages/pcre.rb
+++ b/packages/pcre.rb
@@ -19,7 +19,7 @@ class Pcre < Autotools
 
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
-  depends_on 'readline' # R
+  depends_on 'readline' => :executable_only
 
   autotools_configure_options '--enable-shared \
       --with-pic \

--- a/packages/pcre2.rb
+++ b/packages/pcre2.rb
@@ -17,9 +17,9 @@ class Pcre2 < CMake
      x86_64: '0684ca6b8a488696d594cc0874721fae0d8314eb59b0956709ce2e9b1233cab9'
   })
 
-  depends_on 'bzip2' # R
+  depends_on 'bzip2' => :executable_only
   depends_on 'glibc' # R
-  depends_on 'zlib' # R
+  depends_on 'zlib' => :executable_only
 
   cmake_options '-DPCRE2_BUILD_TESTS=OFF \
       -DBUILD_SHARED_LIBS=ON \

--- a/packages/psmisc.rb
+++ b/packages/psmisc.rb
@@ -18,8 +18,8 @@ class Psmisc < Autotools
   })
 
   depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
-  depends_on 'ncurses' # R
+  depends_on 'glibc' => :executable_only
+  depends_on 'ncurses' => :executable_only
 
   autotools_pre_configure_options "CFLAGS+=' -I#{CREW_PREFIX}/include/ncurses'"
   autotools_configure_options '--disable-statx'

--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -17,15 +17,15 @@ class Rsync < Autotools
      x86_64: 'e1cf690b2a42be06b5d85d40cbf1fede1b1f15a70f783578742e38bd2f3b2c23'
   })
 
-  depends_on 'acl' # R
-  depends_on 'attr' # R
-  depends_on 'glibc' # R
-  depends_on 'lz4' # R
-  depends_on 'openssl' # R
-  depends_on 'popt' # R
+  depends_on 'acl' => :executable_only
+  depends_on 'attr' => :executable_only
+  depends_on 'glibc' => :executable_only
+  depends_on 'lz4' => :executable_only
+  depends_on 'openssl' => :executable_only
+  depends_on 'popt' => :executable_only
   depends_on 'py3_cmarkgfm' => :build
-  depends_on 'xxhash' # R
-  depends_on 'zstd' # R
+  depends_on 'xxhash' => :executable_only
+  depends_on 'zstd' => :executable_only
 
   no_patchelf
 

--- a/packages/sed.rb
+++ b/packages/sed.rb
@@ -19,9 +19,9 @@ class Sed < Autotools
      x86_64: '545c56168809e37a8c84381ad16905775def14949a09595453fc8ee5ffe7e0fc'
   })
 
-  depends_on 'acl' # R
-  depends_on 'attr' # R
-  depends_on 'glibc' # R
+  depends_on 'acl' => :executable_only
+  depends_on 'attr' => :executable_only
+  depends_on 'glibc' => :executable_only
   depends_on 'wget2' => :build
 
   autotools_configure_options '--without-selinux \

--- a/packages/slang.rb
+++ b/packages/slang.rb
@@ -17,11 +17,11 @@ class Slang < Package
      x86_64: '777a1a2a147ee1778a33d15fb1955aa41b1e67f3160d90bbba4c9be2f9a46206'
   })
 
+  depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'libpng' # R
   depends_on 'pcre' # R
   depends_on 'zlib' # R
-  depends_on 'gcc_lib' # R
 
   def self.build
     system "./configure #{CREW_CONFIGURE_OPTIONS} --without-x"

--- a/packages/sqlite.rb
+++ b/packages/sqlite.rb
@@ -19,8 +19,8 @@ class Sqlite < Autotools
 
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
-  depends_on 'libedit' # R
-  depends_on 'ncurses' # R
+  depends_on 'libedit' => :executable_only
+  depends_on 'ncurses' => :executable_only
   depends_on 'readline' => :build
   depends_on 'zlib' # R
 

--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -18,7 +18,7 @@ class Unzip < Package
   })
 
   depends_on 'compressdoc' => :build
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable_only
   depends_on 'patch' => :build
 
   # adapted from the homebrew recipe as seen at: https://github.com/Homebrew/homebrew-dupes/blob/master/unzip.rb

--- a/packages/upx.rb
+++ b/packages/upx.rb
@@ -20,8 +20,8 @@ class Upx < CMake
      x86_64: 'ae4289bdcc3b7c790feb54c3e316a74f47638c51ef57ffeab7f0287d75a88838'
   })
 
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
+  depends_on 'gcc_lib' => :executable_only
+  depends_on 'glibc' => :executable_only
 
   cmake_options '-DUPX_CONFIG_DISABLE_GITREV=true'
 end

--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -18,19 +18,19 @@ class Util_linux < Meson
   })
 
   depends_on 'eudev_header' => :build if ARCH == 'x86_64' # (for libudev.h)
-  depends_on 'filecmd' # R
-  depends_on 'gcc_lib' # R
+  depends_on 'filecmd' => :executable_only
+  depends_on 'gcc_lib' => :executable_only
   depends_on 'glibc' # R
-  depends_on 'libcap_ng' # R
+  depends_on 'libcap_ng' => :executable_only
   depends_on 'libeconf' # R
-  depends_on 'libxcrypt' # R
+  depends_on 'libxcrypt' => :executable_only
   depends_on 'linux_pam' # R
-  depends_on 'ncurses' # R
+  depends_on 'ncurses' => :executable_only
   depends_on 'pcre2' => :build
-  depends_on 'readline' # R
+  depends_on 'readline' => :executable_only
   depends_on 'ruby_asciidoctor' => :build
   depends_on 'sqlite' # R
-  depends_on 'zlib' # R
+  depends_on 'zlib' => :executable_only
 
   conflicts_ok
 

--- a/packages/which.rb
+++ b/packages/which.rb
@@ -17,5 +17,5 @@ class Which < Autotools
      x86_64: '97c4353ec10d5756a3ec4db272c388865b15964f32e94980560806cfc7208d1b'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable_only
 end

--- a/packages/zip.rb
+++ b/packages/zip.rb
@@ -18,7 +18,7 @@ class Zip < Package
   })
 
   depends_on 'bzip2' # R
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable_only
 
   # adapted from the homebrew recipe as seen at: https://github.com/Homebrew/homebrew-core/blob/master/Formula/zip.rb
   # Upstream is unmaintained so we use the Debian patchset:

--- a/packages/zlib_ng.rb
+++ b/packages/zlib_ng.rb
@@ -20,7 +20,7 @@ class Zlib_ng < CMake
      x86_64: 'd5c15197063e01ac52cfcc13d00c2114f6a52a21ee202072def770ff29b40d34'
   })
 
-  depends_on 'glibc'
+  depends_on 'glibc' # R
 
   cmake_options '-DWITH_GTEST=OFF \
     -DZLIB_ENABLE_TESTS=OFF \

--- a/packages/zoneinfo.rb
+++ b/packages/zoneinfo.rb
@@ -17,7 +17,7 @@ class Zoneinfo < Package
      x86_64: 'e273aef17205ded1ffdf1ba596c3856b7804231528e34fcce45ef0450df2b506'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable_only
 
   conflicts_ok # Conflicts with coreutils.
 

--- a/packages/zstd.rb
+++ b/packages/zstd.rb
@@ -17,11 +17,11 @@ class Zstd < CMake
      x86_64: '1549e818ef9ecd1cbd33aa8322aaaacaceda3c8b4a422e990b8ed8d273f4e8db'
   })
 
-  depends_on 'gcc_lib' # R
+  depends_on 'gcc_lib' => :executable_only
   depends_on 'glibc' # R
-  depends_on 'lz4' # R
-  depends_on 'xzutils' # R
-  depends_on 'zlib' # R
+  depends_on 'lz4' => :executable_only
+  depends_on 'xzutils' => :executable_only
+  depends_on 'zlib' => :executable_only
 
   conflicts_ok # Conflicts with zstd_static.
   run_tests


### PR DESCRIPTION
## Description
#### Commits:
-  036149527 Clean up core deps.
### Packages with Updated versions or Changed package files:
- `acl`: 2.3.2-1 &rarr; 2.3.2-1 (current version is 2.3.2)
- `bash`: 5.3 &rarr; 5.3
- `command_not_found`: 0.1.1 &rarr; 0.1.1
- `crew_mvdir`: 0.4 &rarr; 0.4
- `elfutils`: 0.194 &rarr; 0.194
- `filecmd`: 5.46-2 &rarr; 5.46-2 (current version is 5.46)
- `gawk`: 5.3.2-2 &rarr; 5.3.2-2 (current version is 5.3.2)
- `gdbm`: 1.26 &rarr; 1.26
- `grep`: 3.12 &rarr; 3.12
- `less`: 692 &rarr; 692
- `libcyrussasl`: 2.1.28-2 &rarr; 2.1.28-2 (current version is 2.1.28)
- `libpng`: 1.6.55 &rarr; 1.6.55
- `libssh`: 0.12.0 &rarr; 0.12.0
- `libunbound`: 1.24.2 &rarr; 1.24.2
- `libunistring`: 1.4.1 &rarr; 1.4.1
- `libversion`: 3.0.4 &rarr; 3.0.4
- `lzip`: 1.25 &rarr; 1.25
- `m4`: 1.4.21 &rarr; 1.4.21
- `mawk`: 1.3.4-20260129 &rarr; 1.3.4-20260129
- `most`: 5.2.0 &rarr; 5.2.0
- `openldap`: 2.6.12 &rarr; 2.6.12
- `pcre`: 8.45 &rarr; 8.45
- `pcre2`: 10.47-1 &rarr; 10.47-1 (current version is 10.47)
- `psmisc`: 23.7-252db9b &rarr; 23.7-252db9b (current version is 23.7)
- `rsync`: 3.4.1 &rarr; 3.4.1
- `sed`: 4.9-b4d01a9 &rarr; 4.9-b4d01a9 (current version is 4.9)
- `slang`: 2.3.3 &rarr; 2.3.3
- `sqlite`: 3.51.2 &rarr; 3.51.2
- `unzip`: 6.0-2 &rarr; 6.0-2 (current version is 6.0)
- `upx`: 5.1.0 &rarr; 5.1.0
- `util_linux`: 2.41.3-py3.14 &rarr; 2.41.3-py3.14 (current version is 2.41.3)
- `which`: 2.23 &rarr; 2.23
- `zip`: 3.0-15 &rarr; 3.0-15 (current version is 3.0)
- `zlib_ng`: 2.3.3 &rarr; 2.3.3
- `zoneinfo`: 2025c &rarr; 2025c
- `zstd`: 1.5.7-1 &rarr; 1.5.7-1 (current version is 1.5.7)
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=core_deps crew update \
&& yes | crew upgrade
```
