### PR TITLE
Fix downloader filename default parameter

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -25,7 +25,7 @@ rescue RuntimeError => e
   end
 end
 
-def downloader(url, sha256sum, filename = File.basename(url).gsub(/[^\w\s]/, ''), no_update_hash: false, verbose: false)
+def downloader(url, sha256sum, filename = File.basename(url).gsub(/\s+/, ''), no_update_hash: false, verbose: false)
   # downloader: wrapper for all Chromebrew downloaders (`net/http`,`curl`...)
   # Usage: downloader <url>, <sha256sum>, <filename::optional>, <verbose::optional>
   #


### PR DESCRIPTION
Fixes previous issue where the `.` was removed in the filename.

##
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebew/chromebrew.git CREW_BRANCH=fix-downloader crew update \
&& yes | crew upgrade
```