### PR TITLE
Revert "Refactor and speed up PackageUtils.get_gem_vars (#14198)" — ruby_connection_pool: 3.0.2-ruby4.0 → 3.0.2-ruby4.0,ruby_error_highlight: 0.7.1-ruby4.0 → 0.7.1-ruby4.0,ruby_jaro_winkler: 1.7.0-ruby4.0 → 1.7.0-ruby4.0,ruby_language_server_protocol: 3.17.0.5-ruby4.0 → 3.17.0.5-ruby4.0,ruby_lint_roller: 1.1.0-ruby4.0 → 1.1.0-ruby4.0,ruby_method_source: 1.1.0-ruby4.0 → 1.1.0-ruby4.0,ruby_mini_mime: 1.1.5-ruby4.0 → 1.1.5-ruby4.0,ruby_multi_xml: 0.8.1-ruby4.0 → 0.8.1-ruby4.0,ruby_mutex_m: 0.3.0-ruby4.0 → 0.3.0-ruby4.0,ruby_power_assert: 3.0.1-ruby4.0 → 3.0.1-ruby4.0,ruby_regexp_parser: 2.11.3-ruby4.0 → 2.11.3-ruby4.0,ruby_repl_type_completor: 0.1.13-ruby4.0 → 0.1.13-ruby4.0,ruby_ruby2_keywords: 0.0.5-ruby4.0 → 0.0.5-ruby4.0,ruby_syntax_suggest: 2.0.3-ruby4.0 → 2.0.3-ruby4.0,ruby_unicode_display_width: 3.2.0-ruby4.0 → 3.2.0-ruby4.0

### DIFF
--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -119,32 +119,75 @@ class PackageUtils
     return new_version
   end
 
-  def self.get_gem_vars(passed_name = nil, passed_version = '0', upstream_name = nil)
+  def self.get_gem_vars(passed_name = nil, passed_version = nil, upstream_name = nil)
+    require_relative 'gem_compact_index_client'
+    # crewlog "Setting gem variables... name: #{passed_name}, version: #{passed_version}"
     # This assumes the package class name starts with 'Ruby_' and
     # version is in the form '(gem version)-ruby-(ruby version)'.
     # For example, name 'Ruby_awesome' and version '1.0.0-ruby-3.3'.
-
-    # The package name probably just used dashes as separators, but if it didn't then the correct name is in the upstream_name argument.
-    ruby_gem_name = upstream_name.nil? ? passed_name.delete_prefix('Ruby_').gsub('_', '-') : upstream_name
-
-    ruby_gem_json = JSON.parse(Net::HTTP.get(URI("https://rubygems.org/api/v1/gems/#{ruby_gem_name}.json")))
-
-    # Use the latest gem version.
-    remote_ruby_gem_version = ruby_gem_json['version']
+    # Just use the fetcher.suggest_gems_from_name function to figure out
+    # proper gem name with the appropriate dashes and underscores.
+    if CREW_VERY_VERBOSE
+      # Voluminous info about the gem fetcher network connection...
+      require 'rubygems/request'
+      Gem::Request.prepend(Module.new do
+        def perform_request(req)
+          super.tap { |rsp| p [self, req, rsp] }
+        end
+      end)
+    end
+    if $gems.blank?
+      puts 'Populating gem information using compact index client...'.lightgreen unless CREW_OUTPUT_JSON
+      $gems ||= BasicCompactIndexClient.new.gems
+      puts 'Done populating gem information.'.lightgreen unless CREW_OUTPUT_JSON
+    end
+    # Parse gem information from compact index, the format for which is
+    # here: https://guides.rubygems.org/rubygems-org-compact-index-api/
+    # Figure out gem name, noting that there may be dashes and underscores
+    # in the name.
+    if upstream_name.nil?
+      gem_test = $gems.grep(/#{"^#{passed_name.gsub(/^ruby_/, '')}\\s.*$"}/).last.blank? ? $gems.grep(/#{"^\(#{passed_name.gsub(/^ruby_/, '').gsub('_', ')+.(')}\\s\).*$"}/).last : $gems.grep(/#{"^#{passed_name.gsub(/^ruby_/, '')}\\s.*$"}/).last
+      abort "Cannot find #{passed_name} gem to install.".lightred if gem_test.blank?
+      gem_test_name = gem_test.split.first
+      ruby_gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(passed_name.gsub(/^ruby_/, '')).first : gem_test_name
+    else
+      ruby_gem_name = upstream_name
+      gem_test = $gems.grep(/#{"^#{ruby_gem_name}\\s.*$"}/).last
+    end
+    gem_test_versions = gem_test.split[1].split(',')
+    # Remove minus prefixed versions, as those have been yanked as per
+    # https://guides.rubygems.org/rubygems-org-compact-index-api/
+    gem_test_versions.delete_if { |i| i.start_with?('-') }
     # Any version with a letter is considered a prerelease as per
-    # https://docs.ruby-lang.org/en/master/Gem/Version.html#method-i-prerelease-3F
-    remote_ruby_gem_version = -1 if remote_ruby_gem_version.match?(/[a-zA-Z]/)
-    ruby_gem_version = get_clean_version(passed_version)
-    ruby_gem_version = remote_ruby_gem_version if Gem::Version.new(remote_ruby_gem_version) > Gem::Version.new(ruby_gem_version)
+    # https://github.com/rubygems/rubygems/blob/b5798efd348935634d4e0e2b846d4f455582db48/lib/rubygems/version.rb#L305
+    gem_test_versions.delete_if { |i| i.match?(/[a-zA-Z]/) }
+    gem_test_version = gem_test_versions.map { |v| Gem::Version.new(v) }.max.to_s
+    remote_gem_version_test = Gem.latest_version_for(ruby_gem_name).to_s
+    remote_ruby_gem_version = remote_gem_version_test.blank? ? gem_test_version : Gem.latest_version_for(ruby_gem_name).to_s
+    ruby_gem_version = passed_version.split('-').first.to_s
+    # Use latest gem version.
+    ruby_gem_version = remote_ruby_gem_version.to_s if Gem::Version.new(remote_ruby_gem_version.to_s) > Gem::Version.new(ruby_gem_version)
+    require_relative 'gem_compact_index_client_deps'
 
-    # Get the installed version of the gem.
-    gem_installed_version = `gem list --no-update-sources -l -e #{ruby_gem_name}`.gsub(/[^[:digit:]. ]/, '').split.last
-
-    # TODO: These are just the inverse of each other, so there's probably not a lot of reason to return them both.
-    gem_outdated = Gem::Version.new(ruby_gem_version) > Gem::Version.new(gem_installed_version)
-    gem_latest_version_installed = Gem::Version.new(ruby_gem_version) <= Gem::Version.new(gem_installed_version)
-
-    gem_deps = ruby_gem_json['dependencies']['runtime'].map { it['name'] }
+    deps = BasicCompactIndexClientDeps.new.deps(ruby_gem_name)
+    gem_deps = deps.grep(/#{"^#{ruby_gem_version}\\s.*$"}/).last.gsub(/^#{ruby_gem_version} /, '').gsub(/\|.*$/, '').split(',').map { |dep| dep.gsub(/:.*$/, '') }
+    gem_installed_version = nil
+    gem_outdated = nil
+    gem_latest_version_installed = false
+    installed_gem_search = [`gem list --no-update-sources -l -e #{ruby_gem_name}`.chomp.to_s].grep(/#{ruby_gem_name}/)[0]
+    if installed_gem_search
+      installed_gem_info = installed_gem_search.delete('()').gsub('default:', '').gsub(',', '').split
+      gem_installed_version = installed_gem_info[1]
+      gem_outdated = (Gem::Version.new(ruby_gem_version) > Gem::Version.new(gem_installed_version))
+      gem_latest_version_installed = Gem::Version.new(ruby_gem_version) <= Gem::Version.new(gem_installed_version)
+    else
+      # If the current gem being installed is not installed this should
+      # be false. This will also handle cases of the current installed
+      # gem as per 'gem list' being the same version as the version
+      # being upgraded to.
+      gem_latest_version_installed = false
+    end
+    crewlog "ruby_gem_name: #{ruby_gem_name} ruby_gem_version: #{ruby_gem_version} gem_installed_version: #{gem_installed_version} gem_outdated: #{gem_outdated} gem_latest_version_installed: #{gem_latest_version_installed}" if CREW_VERY_VERBOSE
 
     return ruby_gem_name, ruby_gem_version, remote_ruby_gem_version, gem_installed_version, gem_latest_version_installed, gem_outdated, gem_deps
   end

--- a/packages/ruby_connection_pool.rb
+++ b/packages/ruby_connection_pool.rb
@@ -10,5 +10,4 @@ class Ruby_connection_pool < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'connection_pool'
 end

--- a/packages/ruby_error_highlight.rb
+++ b/packages/ruby_error_highlight.rb
@@ -10,5 +10,4 @@ class Ruby_error_highlight < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'error_highlight'
 end

--- a/packages/ruby_jaro_winkler.rb
+++ b/packages/ruby_jaro_winkler.rb
@@ -21,5 +21,4 @@ class Ruby_jaro_winkler < RUBY
 
   conflicts_ok
   gem_compile_needed
-  upstream_name 'jaro_winkler'
 end

--- a/packages/ruby_language_server_protocol.rb
+++ b/packages/ruby_language_server_protocol.rb
@@ -10,5 +10,4 @@ class Ruby_language_server_protocol < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'language_server-protocol'
 end

--- a/packages/ruby_lint_roller.rb
+++ b/packages/ruby_lint_roller.rb
@@ -10,5 +10,4 @@ class Ruby_lint_roller < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'lint_roller'
 end

--- a/packages/ruby_method_source.rb
+++ b/packages/ruby_method_source.rb
@@ -10,5 +10,4 @@ class Ruby_method_source < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'method_source'
 end

--- a/packages/ruby_mini_mime.rb
+++ b/packages/ruby_mini_mime.rb
@@ -10,5 +10,4 @@ class Ruby_mini_mime < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'mini_mime'
 end

--- a/packages/ruby_multi_xml.rb
+++ b/packages/ruby_multi_xml.rb
@@ -12,5 +12,4 @@ class Ruby_multi_xml < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'multi_xml'
 end

--- a/packages/ruby_mutex_m.rb
+++ b/packages/ruby_mutex_m.rb
@@ -10,5 +10,4 @@ class Ruby_mutex_m < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'mutex_m'
 end

--- a/packages/ruby_power_assert.rb
+++ b/packages/ruby_power_assert.rb
@@ -10,5 +10,4 @@ class Ruby_power_assert < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'power_assert'
 end

--- a/packages/ruby_regexp_parser.rb
+++ b/packages/ruby_regexp_parser.rb
@@ -10,5 +10,4 @@ class Ruby_regexp_parser < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'regexp_parser'
 end

--- a/packages/ruby_repl_type_completor.rb
+++ b/packages/ruby_repl_type_completor.rb
@@ -13,5 +13,4 @@ class Ruby_repl_type_completor < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'repl_type_completor'
 end

--- a/packages/ruby_ruby2_keywords.rb
+++ b/packages/ruby_ruby2_keywords.rb
@@ -10,5 +10,4 @@ class Ruby_ruby2_keywords < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'ruby2_keywords'
 end

--- a/packages/ruby_syntax_suggest.rb
+++ b/packages/ruby_syntax_suggest.rb
@@ -10,5 +10,4 @@ class Ruby_syntax_suggest < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'syntax_suggest'
 end

--- a/packages/ruby_unicode_display_width.rb
+++ b/packages/ruby_unicode_display_width.rb
@@ -12,5 +12,4 @@ class Ruby_unicode_display_width < RUBY
 
   conflicts_ok
   no_compile_needed
-  upstream_name 'unicode-display_width'
 end


### PR DESCRIPTION
## Description
- Appears to fix the error in https://github.com/chromebrew/chromebrew/issues/14760#issuecomment-3939661036
Fixes #14760
#### Commits:
-  df9650289 Revert "Refactor and speed up PackageUtils.get_gem_vars (#14198)"
### Packages with Updated versions or Changed package files:
- `ruby_connection_pool`: 3.0.2-ruby4.0 &rarr; 3.0.2-ruby4.0 (current version is 3.0.2)
- `ruby_error_highlight`: 0.7.1-ruby4.0 &rarr; 0.7.1-ruby4.0 (current version is 0.7.1)
- `ruby_jaro_winkler`: 1.7.0-ruby4.0 &rarr; 1.7.0-ruby4.0 (current version is 1.7.0)
- `ruby_language_server_protocol`: 3.17.0.5-ruby4.0 &rarr; 3.17.0.5-ruby4.0 (current version is 3.17.0.5)
- `ruby_lint_roller`: 1.1.0-ruby4.0 &rarr; 1.1.0-ruby4.0 (current version is 1.1.0)
- `ruby_method_source`: 1.1.0-ruby4.0 &rarr; 1.1.0-ruby4.0 (current version is 1.1.0)
- `ruby_mini_mime`: 1.1.5-ruby4.0 &rarr; 1.1.5-ruby4.0 (current version is 1.1.5)
- `ruby_multi_xml`: 0.8.1-ruby4.0 &rarr; 0.8.1-ruby4.0 (current version is 0.8.1)
- `ruby_mutex_m`: 0.3.0-ruby4.0 &rarr; 0.3.0-ruby4.0 (current version is 0.3.0)
- `ruby_power_assert`: 3.0.1-ruby4.0 &rarr; 3.0.1-ruby4.0 (current version is 3.0.1)
- `ruby_regexp_parser`: 2.11.3-ruby4.0 &rarr; 2.11.3-ruby4.0 (current version is 2.11.3)
- `ruby_repl_type_completor`: 0.1.13-ruby4.0 &rarr; 0.1.13-ruby4.0 (current version is 0.1.13)
- `ruby_ruby2_keywords`: 0.0.5-ruby4.0 &rarr; 0.0.5-ruby4.0 (current version is 0.0.5)
- `ruby_syntax_suggest`: 2.0.3-ruby4.0 &rarr; 2.0.3-ruby4.0 (current version is 2.0.3)
- `ruby_unicode_display_width`: 3.2.0-ruby4.0 &rarr; 3.2.0-ruby4.0 (current version is 3.2.0)
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Other changed files:
- lib/package_utils.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=revert-14198-vestige crew update \
&& yes | crew upgrade
```
