### PR TITLE
Make sure ruby_ prefix is removed in gem name

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.72.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.72.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -125,7 +125,7 @@ class PackageUtils
     # For example, name 'Ruby_awesome' and version '1.0.0-ruby-3.3'.
 
     # The package name probably just used dashes as separators, but if it didn't then the correct name is in the upstream_name argument.
-    ruby_gem_name = upstream_name.nil? ? passed_name.delete_prefix('Ruby_').gsub('_', '-') : upstream_name
+    ruby_gem_name = upstream_name.nil? ? passed_name.delete_prefix('ruby_').delete_prefix('Ruby_').gsub('_', '-') : upstream_name
 
     ruby_gem_json = JSON.parse(Net::HTTP.get(URI("https://rubygems.org/api/v1/gems/#{ruby_gem_name}.json")))
 


### PR DESCRIPTION
Fixes #14760.

Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=fix-ruby-gem-error crew update \
&& yes | crew upgrade
```