### PR TITLE
Add whatdepends command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Where available commands are:
 | upload              | upload binaries for all or specific package(s) |
 | upstream            | check if an upstream version is available for package(s) |
 | version             | check for the Chromebrew version, or if a package is specified, the package version |
+| whatdepends         | search for package(s) that depend on the provided package |
 | whatprovides        | regex search for package(s) that contains file(s) |
 
 Available packages are listed in the [packages directory](https://github.com/chromebrew/chromebrew/tree/master/packages).

--- a/bin/crew
+++ b/bin/crew
@@ -2201,6 +2201,12 @@ def version_command(args)
   end
 end
 
+def whatdepends_command(args)
+  args['<name>'].each do |pkg|
+    Command.whatdepends(pkg)
+  end
+end
+
 def whatprovides_command(args)
   args['<pattern>'].each do |regex|
     Command.whatprovides(regex)

--- a/commands/help.rb
+++ b/commands/help.rb
@@ -172,6 +172,11 @@ class Command
         Display the crew version.
         Usage: crew version
       EOT
+    when 'whatdepends'
+      puts <<~EOT
+        Determine which package(s) depend on the provided package.
+        Usage: crew whatdepends <package> ...
+      EOT
     when 'whatprovides'
       puts <<~EOT
         Determine which package(s) contains file(s).

--- a/commands/whatdepends.rb
+++ b/commands/whatdepends.rb
@@ -1,0 +1,29 @@
+require_relative '../lib/const'
+require_relative '../lib/package'
+require_relative '../lib/package_utils'
+
+class Command
+  def self.whatdepends(pkg)
+    pkg_count = 0
+    puts "#{pkg.lightgreen} is a dependency of:"
+    `grep -lER "depends_on '#{pkg}'" #{CREW_PACKAGES_PATH}/*.rb`.lines(chomp: true).flat_map do |result|
+      pkg_name = File.basename(result, '.rb')
+      if PackageUtils.compatible?(Package.load_package(File.join(CREW_PACKAGES_PATH, "#{pkg_name}.rb")))
+        if PackageUtils.installed?(pkg_name)
+          puts pkg_name.lightgreen
+        else
+          puts pkg_name.lightblue
+        end
+      else
+        puts pkg_name.lightred
+      end
+      pkg_count += 1
+    end
+
+    if pkg_count.zero?
+      puts "Total found: #{pkg_count}\n".lightred
+    else
+      puts "Total found: #{pkg_count}\n".lightgreen
+    end
+  end
+end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.72.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.72.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]
@@ -525,6 +525,7 @@ CREW_DOCOPT = <<~DOCOPT
     crew upload [options] [-f|--force] [-v|--verbose] [<name> ...]
     crew upstream [options] [-j|--json|-u|--update-package-files|-v|--verbose|-vv] <name> ...
     crew version [options] [<name>]
+    crew whatdepends <name> ...
     crew whatprovides [options] <pattern> ...
 
     -b --include-build-deps    Include build dependencies in output.


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-whatdepends-command crew update \
&& yes | crew upgrade

$ crew whatdepends libffcall libiconv
libffcall is a dependency of:
clisp
Total found: 1

libiconv is a dependency of:
clamav
php72
vice
Total found: 3

$ crew help whatdepends
Determine which package(s) depend on the provided package.
Usage: crew whatdepends <package> ...
```