### PR TITLE
Add static_get package

### DIFF
--- a/manifest/armv7l/s/static_get.filelist
+++ b/manifest/armv7l/s/static_get.filelist
@@ -1,0 +1,2 @@
+# Total size: 26373
+/usr/local/bin/static-get

--- a/manifest/i686/s/static_get.filelist
+++ b/manifest/i686/s/static_get.filelist
@@ -1,0 +1,2 @@
+# Total size: 26373
+/usr/local/bin/static-get

--- a/manifest/x86_64/s/static_get.filelist
+++ b/manifest/x86_64/s/static_get.filelist
@@ -1,0 +1,2 @@
+# Total size: 26373
+/usr/local/bin/static-get

--- a/packages/static_get.rb
+++ b/packages/static_get.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Static_get < Package
+  description 'Portable binaries for Linux'
+  homepage 'http://s.minos.io/'
+  version '61cdcec'
+  license 'Unknown'
+  compatibility 'all'
+  source_url 'https://raw.githubusercontent.com/minos-org/minos-static/61cdcec177d400182b7f36062e808cee21999777/static-get'
+  source_sha256 '135194e727f8b73cf460714a893bee8651a1e8d7a1d6142450c7b5168bc03549'
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.install 'static-get', "#{CREW_DEST_PREFIX}/bin/static-get", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'static-get -h' to get started.\n"
+  end
+end

--- a/tests/package/s/static_get
+++ b/tests/package/s/static_get
@@ -1,0 +1,3 @@
+#!/bin/bash
+static-get -h | head
+static-get -V

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -9260,6 +9260,11 @@ url: https://freedesktop.org/software/startup-notification/releases
 activity: none
 ---
 kind: url
+name: static_get
+url: https://github.com/minos-org/minos-static
+activity: none
+---
+kind: url
 name: stellarium
 url: https://github.com/Stellarium/stellarium/releases
 activity: medium


### PR DESCRIPTION
## Description
Static linking is a technique where all the dependencies of a program are copied into the executable image, this requires extra disk space and memory (multiple copies of the same dependency could be located in several programs) but helps with portability and ease of usage, just download the binary and run it. Dynamic linking on the other hand is accomplished by placing only a reference of a sharable library in the executable. Actual linking with the library routines does not occur until the image is run, when both the executable and the library are placed in memory. An advantage of dynamic linking is that multiple programs can share a single copy of the library which saves space and allows to provide security updates efficiently.  See https://github.com/minos-org/minos-static.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-static_get-package crew update \
&& yes | crew upgrade

$ crew check static_get 
Using rubocop to sanitize /home/chronos/user/chromebrew/packages/static_get.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
Checking static_get package ...
Property tests for static_get passed.
Checking static_get package ...
Buildsystem test for static_get passed.
Checking static_get package ...
Library test for static_get passed.
Checking static_get package ...
Usage: static-get [OPTION]... PACKAGE ...
Retrieve static linux binaries from s.minos.io and mirrors.

  -d, --download [dir]        write in the specified directory
  -o, --output [file]         write to file
  -s, --search [pattern]      search packages by pattern
  -x, --extract               extract after download
  -i, --install               install after download
  -p, --prefix [dir]          specifies an install location for the package
  -n, --dry-run               perform a trial run with no changes made
static-get 2020.02.11-00:21
Package tests for static_get passed.
```