### PR TITLE
Update libgsf binaries

### DIFF
--- a/manifest/armv7l/l/libgsf.filelist
+++ b/manifest/armv7l/l/libgsf.filelist
@@ -1,3 +1,4 @@
+# Total size: 3572404
 /usr/local/bin/gsf
 /usr/local/bin/gsf-office-thumbnailer
 /usr/local/bin/gsf-vba-dump

--- a/manifest/x86_64/l/libgsf.filelist
+++ b/manifest/x86_64/l/libgsf.filelist
@@ -1,3 +1,4 @@
+# Total size: 3922624
 /usr/local/bin/gsf
 /usr/local/bin/gsf-office-thumbnailer
 /usr/local/bin/gsf-vba-dump

--- a/packages/libgsf.rb
+++ b/packages/libgsf.rb
@@ -12,16 +12,16 @@ class Libgsf < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'bf5545a06b87dcfe050261ec24f2d4bde2e171fc9738888d37da71010bbcc618',
-     armv7l: 'bf5545a06b87dcfe050261ec24f2d4bde2e171fc9738888d37da71010bbcc618',
-     x86_64: '55290360c18f65034004fb5e4f747e034fbbcb04ce7705134bc654820bd0b9fc'
+    aarch64: '1b1733aadf3d130e5838417b8ed0c1be4612292c6e3cd091d95779a0b3cbf3de',
+     armv7l: '1b1733aadf3d130e5838417b8ed0c1be4612292c6e3cd091d95779a0b3cbf3de',
+     x86_64: '39d75477e83bbfe3b0c595eb98acb2059212dd1bbafd340462f8d783f7e33304'
   })
 
   depends_on 'bzip2' # R
   depends_on 'gcc_lib' # R
-  depends_on 'gdk_pixbuf' # R
-  depends_on 'glibc' # R
+  depends_on 'gdk_pixbuf' => :executable_only
   depends_on 'glib' # R
+  depends_on 'glibc' # R
   depends_on 'gtk_doc' => :build
   depends_on 'icu4c' # R
   depends_on 'libxml2' # R


### PR DESCRIPTION
Fixes the following:
```
libgsf: The G Structured File Library
Precompiled binary available, downloading...
Download of https://gitlab.com/api/v4/projects/26210301/packages/generic/libgsf/1.14.52-634340d-icu77.1_armv7l/libgsf-1.14.52-634340d-icu77.1-chromeos-armv7l.tar.zst failed with error 404: Not Found
```
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-libgsf crew update \
&& yes | crew upgrade
```