### PR TITLE
Run tests only if the local repo and crew repo packages are different

### DIFF
--- a/commands/check.rb
+++ b/commands/check.rb
@@ -28,20 +28,23 @@ class Command
       return true
     end
 
-    # Use rubocop to sanitize package file, and let errors get flagged.
-    if Kernel.system('rubocop --version', %i[out err] => File::NULL)
-      puts "Using rubocop to sanitize #{local_package}".yellow
-      # The .rubocop.yml file is found in the rubocop-chromebrew gem
-      require_gem('rubocop-chromebrew')
-      if File.file?(File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml'))
-        system "rubocop -c #{File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml')} -A #{local_package}", exception: true
+    # Compare local repo package to the crew repo package and only run tests if the local package is different unless forced.
+    if !force && File.file?(local_package) && File.file?(crew_package) && !FileUtils.identical?(local_package, crew_package)
+      # Use rubocop to sanitize package file, and let errors get flagged.
+      if Kernel.system('rubocop --version', %i[out err] => File::NULL)
+        puts "Using rubocop to sanitize #{local_package}".yellow
+        # The .rubocop.yml file is found in the rubocop-chromebrew gem
+        require_gem('rubocop-chromebrew')
+        if File.file?(File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml'))
+          system "rubocop -c #{File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml')} -A #{local_package}", exception: true
+        else
+          puts 'The configuration file for rubocop in .rubocop.yml, from the rubocop-chromebrew gem, was not found.'.lightred
+          puts 'To install rubocop-chromebrew, run the following command: '.lightred + "crew #{'re' if PackageUtils.installed?('ruby_rubocop_chromebrew')}install ruby_rubocop_chromebrew".lightblue
+        end
       else
-        puts 'The configuration file for rubocop in .rubocop.yml, from the rubocop-chromebrew gem, was not found.'.lightred
-        puts 'To install rubocop-chromebrew, run the following command: '.lightred + "crew #{'re' if PackageUtils.installed?('ruby_rubocop_chromebrew')}install ruby_rubocop_chromebrew".lightblue
+        puts "Rubocop is not installed, and thus will not be used to sanitize #{local_package}".lightred
+        puts 'To install Rubocop, run the following command: '.lightred + "crew #{'re' if PackageUtils.installed?('ruby_rubocop')}install ruby_rubocop".lightblue
       end
-    else
-      puts "Rubocop is not installed, and thus will not be used to sanitize #{local_package}".lightred
-      puts 'To install Rubocop, run the following command: '.lightred + "crew #{'re' if PackageUtils.installed?('ruby_rubocop')}install ruby_rubocop".lightblue
     end
 
     to_copy_package = force
@@ -107,12 +110,16 @@ class Command
       puts "Copied #{local_filelist} to #{crew_filelist_path}".lightgreen
     end
 
-    # Run property and buildsystem tests on the package, and fail if they fail.
-    return false unless system "#{CREW_LIB_PATH}/tests/prop_test.rb #{name}"
-    return false unless system "#{CREW_LIB_PATH}/tests/buildsystem_test.rb #{name}"
-    if ARGV[0] == 'check'
-      return false unless system("#{CREW_LIB_PATH}/tests/library_test.rb #{name}")
-      return false unless system("#{CREW_LIB_PATH}/tests/package_test.rb #{name}")
+    # Compare local repo package to the crew repo package and only run tests if the local package is different unless forced.
+    if !force && File.file?(local_package) && File.file?(crew_package) && !FileUtils.identical?(local_package, crew_package)
+      # Run property and buildsystem tests on the package, and fail if they fail.
+      return false unless system "#{CREW_LIB_PATH}/tests/prop_test.rb #{name}"
+      return false unless system "#{CREW_LIB_PATH}/tests/buildsystem_test.rb #{name}"
+      # Only run library and package tests with crew check.
+      if ARGV[0] == 'check'
+        return false unless system("#{CREW_LIB_PATH}/tests/library_test.rb #{name}")
+        return false unless system("#{CREW_LIB_PATH}/tests/package_test.rb #{name}")
+      end
     end
 
     # If we're still here every test has passed, so return true.


### PR DESCRIPTION
This avoids unnecessary redundant testing

Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-crew-check crew update \
&& yes | crew upgrade
```