### PR TITLE
Add qrupdate package

### DIFF
--- a/manifest/armv7l/q/qrupdate.filelist
+++ b/manifest/armv7l/q/qrupdate.filelist
@@ -1,0 +1,5 @@
+# Total size: 386080
+/usr/local/lib/libqrupdate.a
+/usr/local/lib/libqrupdate.so
+/usr/local/lib/libqrupdate.so.1
+/usr/local/lib/libqrupdate.so.1.1

--- a/manifest/i686/q/qrupdate.filelist
+++ b/manifest/i686/q/qrupdate.filelist
@@ -1,0 +1,5 @@
+# Total size: 421376
+/usr/local/lib/libqrupdate.a
+/usr/local/lib/libqrupdate.so
+/usr/local/lib/libqrupdate.so.1
+/usr/local/lib/libqrupdate.so.1.1

--- a/manifest/x86_64/q/qrupdate.filelist
+++ b/manifest/x86_64/q/qrupdate.filelist
@@ -1,0 +1,5 @@
+# Total size: 492320
+/usr/local/lib64/libqrupdate.a
+/usr/local/lib64/libqrupdate.so
+/usr/local/lib64/libqrupdate.so.1
+/usr/local/lib64/libqrupdate.so.1.1

--- a/packages/qrupdate.rb
+++ b/packages/qrupdate.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Qrupdate < Package
+  description 'Fortran library for fast updates of QR and Cholesky decompositions.'
+  homepage 'https://sourceforge.net/projects/qrupdate/'
+  version '1.1.2'
+  license 'GPL-2'
+  compatibility 'all'
+  source_url 'https://downloads.sourceforge.net/project/qrupdate/qrupdate/1.2/qrupdate-1.1.2.tar.gz'
+  source_sha256 'e2a1c711dc8ebc418e21195833814cb2f84b878b90a2774365f0166402308e08'
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: 'befef8bdb1b37619e8164e57a951864fbe702ab45c8f95f69ba915fd23d370b9',
+     armv7l: 'befef8bdb1b37619e8164e57a951864fbe702ab45c8f95f69ba915fd23d370b9',
+       i686: 'bc827d61f4a8ed932eeba1596efe4b4f8439e2e33fabd389ccff3d88c8c113e4',
+     x86_64: '41c1bcf2c8128eb44ef19338cac33e0a5f10356f4517c6e858b0cfc4dced3e39'
+  })
+
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc' # R
+  depends_on 'lapack' # R
+
+  def self.build
+    system 'make', 'lib'
+    system 'make', 'solib'
+  end
+
+  def self.install
+    system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=lib#{CREW_LIB_SUFFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -8130,6 +8130,11 @@ url: https://github.com/fukuchi/libqrencode/releases
 activity: none
 ---
 kind: url
+name: qrupdate
+url: https://sourceforge.net/projects/qrupdate/files/qrupdate/
+activity: none
+---
+kind: url
 name: qt5_base
 url: https://invent.kde.org/qt/qt/qtbase/-/tags
 activity: medium


### PR DESCRIPTION
## Description
qrupdate is a Fortran library for fast updates of QR and Cholesky decompositions.  See https://sourceforge.net/projects/qrupdate/.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-qrupdate-package crew update \
&& yes | crew upgrade
```