### PR TITLE
Add stub win32_registry stub package. — ruby_win32_registry → 0.1.2-ruby4.0

### DIFF
--- a/packages/ruby_win32_registry.rb
+++ b/packages/ruby_win32_registry.rb
@@ -1,0 +1,13 @@
+require 'buildsystems/ruby'
+
+class Ruby_win32_registry < RUBY
+  description 'Provides an interface to the Windows Registry in Ruby'
+  homepage 'https://github.com/ruby/win32-registry'
+  version "0.1.2-#{CREW_RUBY_VER}"
+  license 'MIT'
+  compatibility 'win32'
+  source_url 'SKIP'
+
+  conflicts_ok
+  no_compile_needed
+end


### PR DESCRIPTION
## Description
#### Commits:
-  6811f767b Add stub win32_registry stub package.
### Packages with Updated versions or Changed package files:
- `ruby_win32_registry` &rarr; 0.1.2-ruby4.0 (current version is 0.1.2)
##
Builds attempted for:
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=ruby_win32_registry crew update \
&& yes | crew upgrade
```
