### PR TITLE
Run file-specific tests when those files are modified

### DIFF
--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 # This is for use as a Github CI Unit Test.
-# Version 1.7
+# Version 1.8
 set -e
 cd /usr/local/lib/crew/packages/
+
+# We have some tests for specific files that aren't run as part of our general testsuite, but we should run those tests if those files are changed.
+for file in ${NON_PKG_CHANGED_FILES}; do
+  # The only files with direct corresponding tests are located in the root of the commands, lib, and tools directories.
+  echo "commands lib tools" | grep -q "$(dirname "${file}")" || continue
+  # If we have modified a file that has a direct corresponding test, run that test.
+  [[ -f "../tests/${file}" ]] && ruby "../tests/${file}"
+done
+
 echo "CREW_BRANCH: $CREW_BRANCH"
 git clone --depth=1 --branch="$CREW_BRANCH" "$CREW_REPO" ~/build_test
 require_gem () {


### PR DESCRIPTION
We have file-specific tests that aren't run as part of our general testsuite, but we should still run them when we modify those files, otherwise they are liable to get neglected. This happened in https://github.com/chromebrew/chromebrew/pull/14604, where the test for `tools/getrealdeps.rb` was broken, and I only noticed just now.

Tested and working:
<img width="1458" height="505" alt="image" src="https://github.com/user-attachments/assets/b4f4e93d-a0f8-4f05-942c-03100f6abc27" />

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=wow crew update \
&& yes | crew upgrade
```
