### PR TITLE
Fix so rerunning crew upgrade preserves the force option

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -478,7 +478,12 @@ def upgrade(*pkgs, build_from_source: false)
   if rerun_upgrade
     at_exit do
       puts "Rerunning 'crew upgrade' to make sure upgrades are complete.".lightblue
-      exec 'crew upgrade'
+      # Rerunning does not preserve the force option.
+      if @opt_force
+        exec 'crew upgrade -f'
+      else
+        exec 'crew upgrade'
+      end
     end
   else
     puts 'Packages have been updated.'.lightgreen

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.72.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.72.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-crew crew update \
&& yes | crew upgrade
```