### PR TITLE
Split out determining package compatibility in CI

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -83,11 +83,6 @@ jobs:
       timestamp: ${{ steps.set-timestamp.outputs.TIMESTAMP }}  # https://stackoverflow.com/a/75142892
       current_head: ${{ steps.get-current-head.outputs.CURRENT_HEAD }}
       changed_packages: ${{ steps.changed-packages.outputs.CHANGED_PACKAGES }}
-      glibc_232_compat: ${{ steps.get-compatibility.outputs.GLIBC_232_COMPATIBLE_PACKAGES }}
-      glibc_237_compat: ${{ steps.get-compatibility.outputs.GLIBC_237_COMPATIBLE_PACKAGES }}
-      i686_packages: ${{ steps.get-compatibility.outputs.i686_PACKAGES }}
-      x86_64_packages: ${{ steps.get-compatibility.outputs.x86_64_PACKAGES }}
-      armv7l_packages: ${{ steps.get-compatibility.outputs.armv7l_PACKAGES }}
       matrix: ${{ steps.set-generate-matrix.outputs.matrix }}
     steps:
       - name: Set Timestamp
@@ -140,73 +135,41 @@ jobs:
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }} ${{ inputs.packages_to_build }}" | xargs basename -s .rb | sort -u | xargs)" >> "$GITHUB_ENV"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }} ${{ inputs.packages_to_build }}" | xargs basename -s .rb | sort -u | xargs)" >> "$GITHUB_OUTPUT"
-      - name: Determine glibc and architecture package compatibility
-        id: get-compatibility
-        run: |
-            # If a package doesnt have a min_glibc value, or if it is below 2.32, add it to GLIBC_232_COMPATIBLE_PACKAGES.
-            GLIBC_232_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.32}' || echo "${i}" ; done | xargs)"
-            export GLIBC_232_COMPATIBLE_PACKAGES
-            if [[ -n ${GLIBC_232_COMPATIBLE_PACKAGES} ]]; then
-              echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
-              echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these possibly Glibc 2.32 compatible packages: ${GLIBC_232_COMPATIBLE_PACKAGES}"
-            fi
 
-            # If a package doesnt have a min_glibc value, or if it is below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES.
-            GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo "${i}" ; done | xargs)"
-            export GLIBC_237_COMPATIBLE_PACKAGES
-            if [[ -n ${GLIBC_237_COMPATIBLE_PACKAGES} ]]; then
-              echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
-              echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
-            fi
+  get-compatibility:
+    needs: setup
+    uses: ./.github/workflows/Determine-Compatibility.yml
+    with:
+      changed_packages: ${{ needs.setup.outputs.changed_packages }}
 
-            # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
-            x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*x86_64" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            export x86_64_PACKAGES
-            if [[ -n ${x86_64_PACKAGES} ]]; then
-              echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_ENV"
-              echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
-            fi
-
-            ## If a package has a compatibility of 'all' or one that includes 'armv7l', add it to armv7l_PACKAGES.
-            armv7l_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*armv7l" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            export armv7l_PACKAGES
-            if [[ -n ${armv7l_PACKAGES} ]]; then
-              echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_ENV"
-              echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these armv7l compatible packages: ${armv7l_PACKAGES}"
-            fi
-
-            ## If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
-            i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*i686" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            export i686_PACKAGES
-            if [[ -n ${i686_PACKAGES} ]]; then
-              echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_ENV"
-              echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these i686 compatible packages: ${i686_PACKAGES}"
-            fi
+  gen-matrix:
+    needs: get-compatibility
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-generate-matrix.outputs.matrix }}
+    steps:
       - name: Generate Creation Matrix
         id: set-generate-matrix
         env:
-          i686_PACKAGES: ${{ steps.get-compatibility.outputs.i686_PACKAGES }}
-          x86_64_PACKAGES: ${{ steps.get-compatibility.outputs.x86_64_PACKAGES }}
-          armv7l_PACKAGES: ${{ steps.get-compatibility.outputs.armv7l_PACKAGES }}
+          i686_PACKAGES: ${{ needs.get-compatibility.outputs.i686_PACKAGES }}
+          x86_64_PACKAGES: ${{ needs.get-compatibility.outputs.x86_64_PACKAGES }}
+          armv7l_PACKAGES: ${{ needs.get-compatibility.outputs.armv7l_PACKAGES }}
         run: |
           function join_by { local IFS="$1"; shift; echo "$*"; }
-          [[ "${{ ( inputs.build-on) }}" =~ "i686" ]] && [[ -n "${i686_PACKAGES}" ]] && export CONTAINER_ARCH+=( "\"i686\"" )
-          [[ "${{ ( inputs.build-on) }}" =~ "x86_64" ]] && [[ -n "${x86_64_PACKAGES}" ]] && export CONTAINER_ARCH+=( "\"x86_64\"" )
-          [[ "${{ ( inputs.build-on) }}" =~ "armv7l" ]] && [[ -n "${armv7l_PACKAGES}" ]] && export CONTAINER_ARCH+=( "\"armv7l\"" )
+          [[ -n "${i686_PACKAGES}" ]] && export CONTAINER_ARCH+=( "\"i686\"" )
+          # Always run on x86_64
+          export CONTAINER_ARCH+=( "\"x86_64\"" )
+          [[ -n "${armv7l_PACKAGES}" ]] && export CONTAINER_ARCH+=( "\"armv7l\"" )
           export ARCHES="$(join_by , "${CONTAINER_ARCH[@]}")"
           echo "matrix=[${ARCHES}]" >> $GITHUB_OUTPUT
           echo "matrix=[${ARCHES}]"
+
   generate:
     needs: setup
     strategy:
       fail-fast: false
       matrix:
-        arch: ${{ fromJSON(needs.setup.outputs.matrix) }}
+        arch: ${{ fromJSON(needs.gen-matrix.outputs.matrix) }}
         runner:
           - ubuntu-24.04
           - ubuntu-24.04-arm
@@ -224,11 +187,11 @@ jobs:
       CREW_BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
       TARGET_ARCH: ${{ matrix.arch }}
       TIMESTAMP: ${{ needs.setup.outputs.timestamp }}
-      GLIBC_232_COMPATIBLE_PACKAGES: ${{ needs.setup.outputs.glibc_232_compat }}
-      GLIBC_237_COMPATIBLE_PACKAGES: ${{ needs.setup.outputs.glibc_237_compat }}
-      i686_PACKAGES: ${{ needs.setup.outputs.i686_packages }}
-      x86_64_PACKAGES: ${{ needs.setup.outputs.x86_64_packages }}
-      armv7l_PACKAGES: ${{ needs.setup.outputs.armv7l_packages }}
+      GLIBC_232_COMPATIBLE_PACKAGES: ${{ needs.get-compatibility.outputs.GLIBC_232_COMPATIBLE_PACKAGES }}
+      GLIBC_237_COMPATIBLE_PACKAGES: ${{ needs.get-compatibility.outputs.GLIBC_237_COMPATIBLE_PACKAGES }}
+      i686_PACKAGES: ${{ needs.get-compatibility.outputs.i686_PACKAGES }}
+      x86_64_PACKAGES: ${{ needs.get-compatibility.outputs.x86_64_PACKAGES }}
+      armv7l_PACKAGES: ${{ needs.get-compatibility.outputs.armv7l_PACKAGES }}
     if: ${{ !cancelled() }}
     concurrency:
       group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.head_ref || github.ref_name }}

--- a/.github/workflows/Determine-Compatibility.yml
+++ b/.github/workflows/Determine-Compatibility.yml
@@ -1,0 +1,90 @@
+---
+name: Determine glibc and architecture package compatibility
+on:
+  workflow_call:
+    inputs:
+      changed_packages:
+        required: true
+        type: string
+    outputs:
+      glibc_227_compat:
+        description: "The packages compatible with glibc 2.27"
+        value: ${{ jobs.get-compatibility.outputs.GLIBC_227_COMPATIBLE_PACKAGES }}
+      glibc_232_compat:
+        description: "The packages compatible with glibc 2.32"
+        value: ${{ jobs.get-compatibility.outputs.GLIBC_232_COMPATIBLE_PACKAGES }}
+      glibc_237_compat:
+        description: "The packages compatible with glibc 2.37"
+        value: ${{ jobs.get-compatibility.outputs.GLIBC_237_COMPATIBLE_PACKAGES }}
+      i686_packages:
+        description: "The packages compatible with i686"
+        value: ${{ jobs.get-compatibility.outputs.i686_PACKAGES }}
+      x86_64_packages:
+        description: "The packages compatible with x86_64"
+        value: ${{ jobs.get-compatibility.outputs.x86_64_PACKAGES }}
+      armv7l_packages:
+        description: "The packages compatible with armv7l"
+        value: ${{ jobs.get-compatibility.outputs.armv7l_PACKAGES }}
+jobs:
+  get-compatibility:
+    runs-on: ubuntu-latest
+    outputs:
+      GLIBC_227_COMPATIBLE_PACKAGES: ${{ steps.get-compatibility.outputs.GLIBC_227_COMPATIBLE_PACKAGES }}
+      GLIBC_232_COMPATIBLE_PACKAGES: ${{ steps.get-compatibility.outputs.GLIBC_232_COMPATIBLE_PACKAGES }}
+      GLIBC_237_COMPATIBLE_PACKAGES: ${{ steps.get-compatibility.outputs.GLIBC_237_COMPATIBLE_PACKAGES }}
+      i686_PACKAGES: ${{ steps.get-compatibility.outputs.i686_PACKAGES }}
+      x86_64_PACKAGES: ${{ steps.get-compatibility.outputs.x86_64_PACKAGES }}
+      armv7l_PACKAGES: ${{ steps.get-compatibility.outputs.armv7l_PACKAGES }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Determine glibc and architecture package compatibility
+        id: get-compatibility
+        env:
+          CHANGED_PACKAGES: ${{ inputs.changed_packages }}
+        run: |
+            # If a package doesnt have a min_glibc value, or if its below 2.27, add it to GLIBC_227_COMPATIBLE_PACKAGES.
+            GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if grep -q min_glibc packages/"${i}".rb; then grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo "${i}" ; else echo "${i}" ; fi ; done | xargs -r)"
+            if [[ -n ${GLIBC_227_COMPATIBLE_PACKAGES} ]]; then
+              echo "GLIBC_227_COMPATIBLE_PACKAGES=${GLIBC_227_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
+              echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}"
+            fi
+
+            # If a package has a min_glibc value below 2.32, add it to GLIBC_232_COMPATIBLE_PACKAGES.
+            GLIBC_232_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.32}' || echo "${i}" ; done | xargs)"
+            export GLIBC_232_COMPATIBLE_PACKAGES
+            if [[ -n ${GLIBC_232_COMPATIBLE_PACKAGES} ]]; then
+              echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
+              echo "Branch ${{ github.ref_name }} has these possibly Glibc 2.32 compatible packages: ${GLIBC_232_COMPATIBLE_PACKAGES}"
+            fi
+
+            # If a package has a min_glibc value below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES.
+            GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo "${i}" ; done | xargs)"
+            export GLIBC_237_COMPATIBLE_PACKAGES
+            if [[ -n ${GLIBC_237_COMPATIBLE_PACKAGES} ]]; then
+              echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
+              echo "Branch ${{ github.ref_name }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
+            fi
+
+            # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
+            x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*x86_64" packages/"${i}".rb && echo "${i}"; done | xargs)"
+            export x86_64_PACKAGES
+            if [[ -n ${x86_64_PACKAGES} ]]; then
+              echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_OUTPUT"
+              echo "Branch ${{ github.ref_name }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
+            fi
+
+            # If a package has a compatibility of 'all' or one that includes 'armv7l', add it to armv7l_PACKAGES.
+            armv7l_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*armv7l" packages/"${i}".rb && echo "${i}"; done | xargs)"
+            export armv7l_PACKAGES
+            if [[ -n ${armv7l_PACKAGES} ]]; then
+              echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_OUTPUT"
+              echo "Branch ${{ github.ref_name }} has these armv7l compatible packages: ${armv7l_PACKAGES}"
+            fi
+
+            # If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
+            i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*i686" packages/"${i}".rb && echo "${i}"; done | xargs)"
+            export i686_PACKAGES
+            if [[ -n ${i686_PACKAGES} ]]; then
+              echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_OUTPUT"
+              echo "Branch ${{ github.ref_name }} has these i686 compatible packages: ${i686_PACKAGES}"
+            fi

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -64,12 +64,6 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       changed_packages: ${{ steps.changed-packages.outputs.CHANGED_PACKAGES }}
-      glibc_232_compat: ${{ steps.get-compatibility.outputs.GLIBC_232_COMPATIBLE_PACKAGES }}
-      glibc_237_compat: ${{ steps.get-compatibility.outputs.GLIBC_237_COMPATIBLE_PACKAGES }}
-      i686_packages: ${{ steps.get-compatibility.outputs.i686_PACKAGES }}
-      x86_64_packages: ${{ steps.get-compatibility.outputs.x86_64_PACKAGES }}
-      armv7l_packages: ${{ steps.get-compatibility.outputs.armv7l_PACKAGES }}
-      matrix: ${{ steps.set-generate-matrix.outputs.matrix }}
     steps:
       - name: Get GH Token
         id: get_workflow_token
@@ -132,73 +126,40 @@ jobs:
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }} ${{ inputs.packages_to_check_for_build }}" | xargs basename -s .rb | sort -u | xargs)" >> "$GITHUB_ENV"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }} ${{ inputs.packages_to_check_for_build }}" | xargs basename -s .rb | sort -u | xargs)" >> "$GITHUB_OUTPUT"
-      - name: Determine glibc and architecture package compatibility
-        id: get-compatibility
-        run: |
-            # If a package doesnt have a min_glibc value, or if it is below 2.32, add it to GLIBC_232_COMPATIBLE_PACKAGES.
-            GLIBC_232_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.32}' || echo "${i}" ; done | xargs)"
-            export GLIBC_232_COMPATIBLE_PACKAGES
-            if [[ -n ${GLIBC_232_COMPATIBLE_PACKAGES} ]]; then
-              echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
-              echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these possibly Glibc 2.32 compatible packages: ${GLIBC_232_COMPATIBLE_PACKAGES}"
-            fi
 
-            # If a package doesnt have a min_glibc value, or if it is below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES.
-            GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo "${i}" ; done | xargs)"
-            export GLIBC_237_COMPATIBLE_PACKAGES
-            if [[ -n ${GLIBC_237_COMPATIBLE_PACKAGES} ]]; then
-              echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
-              echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
-            fi
+  get-compatibility:
+    needs: setup
+    uses: ./.github/workflows/Determine-Compatibility.yml
+    with:
+      changed_packages: ${{ needs.setup.outputs.changed_packages }}
 
-            # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
-            x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*x86_64" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            export x86_64_PACKAGES
-            if [[ -n ${x86_64_PACKAGES} ]]; then
-              echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_ENV"
-              echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
-            fi
-
-            ## If a package has a compatibility of 'all' or one that includes 'armv7l', add it to armv7l_PACKAGES.
-            armv7l_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*armv7l" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            export armv7l_PACKAGES
-            if [[ -n ${armv7l_PACKAGES} ]]; then
-              echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_ENV"
-              echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these armv7l compatible packages: ${armv7l_PACKAGES}"
-            fi
-
-            ## If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
-            i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*i686" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            export i686_PACKAGES
-            if [[ -n ${i686_PACKAGES} ]]; then
-              echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_ENV"
-              echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these i686 compatible packages: ${i686_PACKAGES}"
-            fi
+  gen-matrix:
+    needs: get-compatibility
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-generate-matrix.outputs.matrix }}
+    steps:
       - name: Generate Creation Matrix
         id: set-generate-matrix
         env:
-          i686_PACKAGES: ${{ steps.get-compatibility.outputs.i686_PACKAGES }}
-          x86_64_PACKAGES: ${{ steps.get-compatibility.outputs.x86_64_PACKAGES }}
-          armv7l_PACKAGES: ${{ steps.get-compatibility.outputs.armv7l_PACKAGES }}
+          i686_PACKAGES: ${{ needs.get-compatibility.outputs.i686_PACKAGES }}
+          x86_64_PACKAGES: ${{ needs.get-compatibility.outputs.x86_64_PACKAGES }}
+          armv7l_PACKAGES: ${{ needs.get-compatibility.outputs.armv7l_PACKAGES }}
         run: |
           function join_by { local IFS="$1"; shift; echo "$*"; }
           [[ -n "${i686_PACKAGES}" ]] && export CONTAINER_ARCH+=( "\"i686\"" )
-          # Always run workflow on the x86_64 container as a fallback.
+          # Always run on x86_64
           export CONTAINER_ARCH+=( "\"x86_64\"" )
           [[ -n "${armv7l_PACKAGES}" ]] && export CONTAINER_ARCH+=( "\"armv7l\"" )
           export ARCHES="$(join_by , "${CONTAINER_ARCH[@]}")"
           echo "matrix=[${ARCHES}]" >> $GITHUB_OUTPUT
           echo "matrix=[${ARCHES}]"
+
   update-package-files:
     strategy:
       max-parallel: 1
       matrix:
-        arch: ${{ fromJSON(needs.setup.outputs.matrix) }}
+        arch: ${{ fromJSON(needs.gen-matrix.outputs.matrix) }}
         runner:
           - ubuntu-24.04
           - ubuntu-24.04-arm
@@ -216,11 +177,11 @@ jobs:
       CREW_REPO: ${{ github.event.repository.clone_url }}
       CREW_BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
       TARGET_ARCH: ${{ matrix.arch }}
-      GLIBC_232_COMPATIBLE_PACKAGES: ${{ needs.setup.outputs.glibc_232_compat }}
-      GLIBC_237_COMPATIBLE_PACKAGES: ${{ needs.setup.outputs.glibc_237_compat }}
-      i686_PACKAGES: ${{ needs.setup.outputs.i686_packages }}
-      x86_64_PACKAGES: ${{ needs.setup.outputs.x86_64_packages }}
-      armv7l_PACKAGES: ${{ needs.setup.outputs.armv7l_packages }}
+      GLIBC_232_COMPATIBLE_PACKAGES: ${{ needs.get-compatibility.outputs.GLIBC_232_COMPATIBLE_PACKAGES }}
+      GLIBC_237_COMPATIBLE_PACKAGES: ${{ needs.get-compatibility.outputs.GLIBC_237_COMPATIBLE_PACKAGES }}
+      i686_PACKAGES: ${{ needs.get-compatibility.outputs.i686_PACKAGES }}
+      x86_64_PACKAGES: ${{ needs.get-compatibility.outputs.x86_64_PACKAGES }}
+      armv7l_PACKAGES: ${{ needs.get-compatibility.outputs.armv7l_PACKAGES }}
     if: ${{ !cancelled() && ( inputs.update_package_files ) && needs.setup.outputs.changed_packages }}
     concurrency:
       group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.head_ref || github.ref_name }}

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -24,19 +24,7 @@ jobs:
       timestamp: ${{ steps.set-timestamp.outputs.TIMESTAMP }}  # https://stackoverflow.com/a/75142892
       current_head: ${{ steps.get-current-head.outputs.CURRENT_HEAD }}
       changed_packages: ${{ steps.changed-packages.outputs.CHANGED_PACKAGES }}
-      glibc_232_compat: ${{ steps.get-compatibility.outputs.GLIBC_232_COMPATIBLE_PACKAGES }}
-      glibc_237_compat: ${{ steps.get-compatibility.outputs.GLIBC_237_COMPATIBLE_PACKAGES }}
-      i686_packages: ${{ steps.get-compatibility.outputs.i686_PACKAGES }}
-      x86_64_packages: ${{ steps.get-compatibility.outputs.x86_64_PACKAGES }}
-      armv7l_packages: ${{ steps.get-compatibility.outputs.armv7l_PACKAGES }}
-      matrix: ${{ steps.set-generate-matrix.outputs.matrix }}
     steps:
-      - name: Set Timestamp
-        id: set-timestamp
-        run: |
-          TIMESTAMP="$(date -u +%F-%H%Z)"
-          export TIMESTAMP
-          echo "TIMESTAMP=${TIMESTAMP}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -64,59 +52,25 @@ jobs:
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }}" | xargs basename -s .rb | xargs)" >> "$GITHUB_ENV"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }}" | xargs basename -s .rb | xargs)" >> "$GITHUB_OUTPUT"
-      - name: Determine glibc and architecture package compatibility
-        id: get-compatibility
-        run: |
-            # If a package doesnt have a min_glibc value, or if it is below 2.32, add it to GLIBC_232_COMPATIBLE_PACKAGES.
-            GLIBC_232_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.32}' || echo "${i}" ; done | xargs)"
-            export GLIBC_232_COMPATIBLE_PACKAGES
-            if [[ -n ${GLIBC_232_COMPATIBLE_PACKAGES} ]]; then
-              echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
-              echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these possibly Glibc 2.32 compatible packages: ${GLIBC_232_COMPATIBLE_PACKAGES}"
-            fi
 
-            # If a package doesnt have a min_glibc value, or if it is below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES.
-            GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo "${i}" ; done | xargs)"
-            export GLIBC_237_COMPATIBLE_PACKAGES
-            if [[ -n ${GLIBC_237_COMPATIBLE_PACKAGES} ]]; then
-              echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
-              echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
-            fi
+  get-compatibility:
+    needs: setup
+    uses: ./.github/workflows/Determine-Compatibility.yml
+    with:
+      changed_packages: ${{ needs.setup.outputs.changed_packages }}
 
-            # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
-            x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*x86_64" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            export x86_64_PACKAGES
-            if [[ -n ${x86_64_PACKAGES} ]]; then
-              echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_ENV"
-              echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
-            fi
-
-            ## If a package has a compatibility of 'all' or one that includes 'armv7l', add it to armv7l_PACKAGES.
-            armv7l_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*armv7l" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            export armv7l_PACKAGES
-            if [[ -n ${armv7l_PACKAGES} ]]; then
-              echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_ENV"
-              echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these armv7l compatible packages: ${armv7l_PACKAGES}"
-            fi
-
-            ## If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
-            i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*i686" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            export i686_PACKAGES
-            if [[ -n ${i686_PACKAGES} ]]; then
-              echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_ENV"
-              echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these i686 compatible packages: ${i686_PACKAGES}"
-            fi
+  gen-matrix:
+    needs: get-compatibility
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-generate-matrix.outputs.matrix }}
+    steps:
       - name: Generate Creation Matrix
         id: set-generate-matrix
         env:
-          i686_PACKAGES: ${{ steps.get-compatibility.outputs.i686_PACKAGES }}
-          x86_64_PACKAGES: ${{ steps.get-compatibility.outputs.x86_64_PACKAGES }}
-          armv7l_PACKAGES: ${{ steps.get-compatibility.outputs.armv7l_PACKAGES }}
+          i686_PACKAGES: ${{ needs.get-compatibility.outputs.i686_PACKAGES }}
+          x86_64_PACKAGES: ${{ needs.get-compatibility.outputs.x86_64_PACKAGES }}
+          armv7l_PACKAGES: ${{ needs.get-compatibility.outputs.armv7l_PACKAGES }}
         run: |
           function join_by { local IFS="$1"; shift; echo "$*"; }
           [[ -n "${i686_PACKAGES}" ]] && export CONTAINER_ARCH+=( "\"i686\"" )
@@ -126,13 +80,16 @@ jobs:
           export ARCHES="$(join_by , "${CONTAINER_ARCH[@]}")"
           echo "matrix=[${ARCHES}]" >> $GITHUB_OUTPUT
           echo "matrix=[${ARCHES}]"
+
   container_tests:
     if: ${{ github.repository_owner == 'chromebrew' }}
-    needs: setup
+    needs:
+      - gen-matrix
+      - get-compatibility
     strategy:
       fail-fast: false
       matrix:
-        arch: ${{ fromJSON(needs.setup.outputs.matrix) }}
+        arch: ${{ fromJSON(needs.gen-matrix.outputs.matrix) }}
         runner:
           - ubuntu-24.04
           - ubuntu-24.04-arm
@@ -175,82 +132,14 @@ jobs:
         env:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
-      - name: Get non-pkg changed files
-        id: non-pkg-changed-files
-        uses: tj-actions/changed-files@v47
-        with:
-          base_sha: ${{ github.event.pull_request.head.sha }}
-          files_ignore: |
-            .github/**
-            manifest/**
-            packages/*.rb
-            tools/packages.yaml
-            tools/repology.json
-      - name: Get all changed package files
-        id: changed-ruby-files
-        uses: tj-actions/changed-files@v47
-        with:
-          base_sha: ${{ github.event.pull_request.head.sha }}
-          files: packages/*.rb
-          since_last_remote_commit: true
-      - name: Export variables to github context
-        run: |
-            # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-ruby-files.outputs.all_changed_files) into "foo bar"
-            echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-ruby-files.outputs.all_changed_files }}" | xargs basename -s .rb | xargs)" >> "$GITHUB_ENV"
-            echo "NON_PKG_CHANGED_FILES=$(echo "${{ steps.non-pkg-changed-files.outputs.all_changed_files }}" | xargs)" >> "$GITHUB_ENV"
-      - name: Determine glibc and architecture package compatibility
-        run: |
-            # If a package doesnt have a min_glibc value, or if its below 2.27, add it to GLIBC_227_COMPATIBLE_PACKAGES.
-            GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if grep -q min_glibc packages/"${i}".rb; then grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo "${i}" ; else echo "${i}" ; fi ; done | xargs -r)"
-            if [[ -n ${GLIBC_227_COMPATIBLE_PACKAGES} ]]; then
-              echo "GLIBC_227_COMPATIBLE_PACKAGES=${GLIBC_227_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
-              echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}"
-            fi
-
-            # If a package doesnt have a min_glibc value, or if it is below 2.32, add it to GLIBC_232_COMPATIBLE_PACKAGES.
-            GLIBC_232_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.32}' || echo "${i}" ; done | xargs)"
-            if [[ -n ${GLIBC_232_COMPATIBLE_PACKAGES} ]]; then
-              echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
-              echo "Branch ${{ github.ref_name }} has these possibly Glibc 2.32 compatible packages: ${GLIBC_232_COMPATIBLE_PACKAGES}"
-            fi
-
-            # If a package doesnt have a min_glibc value, or if it is below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES.
-            GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/"${i}".rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo "${i}" ; done | xargs)"
-            if [[ -n ${GLIBC_237_COMPATIBLE_PACKAGES} ]]; then
-              echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
-              echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
-            fi
-
-            # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
-            x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*x86_64" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            if [[ -n ${x86_64_PACKAGES} ]]; then
-              echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_ENV"
-              echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
-            fi
-
-            ## If a package has a compatibility of 'all' or one that includes 'armv7l', add it to armv7l_PACKAGES.
-            armv7l_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*armv7l" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            if [[ -n ${armv7l_PACKAGES} ]]; then
-              echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_ENV"
-              echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${armv7l_PACKAGES}"
-            fi
-
-            ## If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
-            i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*i686" packages/"${i}".rb && echo "${i}"; done | xargs)"
-            if [[ -n ${i686_PACKAGES} ]]; then
-              echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_ENV"
-              echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"
-            fi
       - name: Export target docker container to github context
-        env:
-          TARGET_ARCH: ${{ matrix.arch }}
         run: |
-            case $TARGET_ARCH in
+            case ${{ matrix.arch }} in
               x86_64)
                 # Export the x86_64 container depending on whether this branch updates packages with appropriate minimum glibc.
-                if [[ $GLIBC_232_COMPATIBLE_PACKAGES ]]; then
+                if [[ -n "${{ needs.get-compatibility.outputs.glibc_232_compat }}" ]]; then
                     echo "CONTAINER=satmandu/crewbuild:nocturne-x86_64.m97" >> "$GITHUB_ENV"
-                elif [[ $GLIBC_237_COMPATIBLE_PACKAGES ]]; then
+                elif [[ -n "${{ needs.get-compatibility.outputs.glibc_237_compat }}" ]]; then
                     echo "CONTAINER=satmandu/crewbuild:hatch-x86_64.m145" >> "$GITHUB_ENV"
                 else
                     echo "CONTAINER=satmandu/crew-pre-glibc-standalone:nocturne-x86_64.m90" >> "$GITHUB_ENV"
@@ -260,9 +149,9 @@ jobs:
               ;;
               armv7l)
                 # Export the armv7l container depending on whether this branch updates packages with appropriate minimum glibc.
-                if [[ $GLIBC_232_COMPATIBLE_PACKAGES ]]; then
+                if [[ -n "${{ needs.get-compatibility.outputs.glibc_232_compat }}" ]]; then
                     echo "CONTAINER=satmandu/crewbuild:fievel-armv7l.m97" >> "$GITHUB_ENV"
-                elif [[ $GLIBC_237_COMPATIBLE_PACKAGES ]]; then
+                elif [[ -n "${{ needs.get-compatibility.outputs.glibc_237_compat }}" ]]; then
                     echo "CONTAINER=satmandu/crewbuild:strongbad-armv7l.m145" >> "$GITHUB_ENV"
                 else
                     echo "CONTAINER=satmandu/crew-pre-glibc-standalone:fievel-armv7l.m91" >> "$GITHUB_ENV"
@@ -296,15 +185,15 @@ jobs:
                 export CREW_BRANCH
                 ;;
             esac
-            if [ -z "${NON_PKG_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/arm/v7'  ] && [ -z "${armv7l_PACKAGES}" ]; }; then
+            if [ -z "${NON_PKG_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/arm/v7'  ] && [ -z "${{ needs.get-compatibility.outputs.armv7l_packages }}" ]; }; then
               # Exit the arm container if there are neither non-package changed files nor armv7l compatible packages.
               echo "Skipping armv7l container unit tests."
               exit 0
-            elif [ -z "${NON_PKG_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/amd64' ] && [ -z "${x86_64_PACKAGES}" ]; }; then
+            elif [ -z "${NON_PKG_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/amd64' ] && [ -z "${{ needs.get-compatibility.outputs.x86_64_packages }}" ]; }; then
               # Exit the x86_64 container if there are neither non-package changed files nor x86_64 compatible packages.
               echo "Skipping x86_64 container unit tests."
               exit 0
-            elif [ -z "${NON_PKG_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/386' ] && [ -z "${i686_PACKAGES}" ]; }; then
+            elif [ -z "${NON_PKG_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/386' ] && [ -z "${{ needs.get-compatibility.outputs.i686_packages }}" ]; }; then
               # Exit the i686 container if there are neither non-package changed files nor i686 compatible packages.
               echo "Skipping i686 container unit tests."
               exit 0


### PR DESCRIPTION
## Description
The less duplicated code in our CI, the easier it is for me to see where further improvements can be made.

Tested and working on unit tests, and the modifications are the exact same for the other workflows.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=triple crew update \
&& yes | crew upgrade
```