### PR TITLE
Disable Style/OneClassPerFile rubocop cop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,7 +89,7 @@ Style/NumericLiterals:
 
 # TODO
 Style/OneClassPerFile:
-  Enabled: false
+ Enabled: false
 
 # TODO
 Style/RedundantStringEscape:


### PR DESCRIPTION
## Description
#### Commits:
-  ff0264502 Disable Style/OneClassPerFile rubocop cop.
### Other changed files:
- .rubocop.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=disable_StyleOneClassPerFile_cop crew update \
&& yes | crew upgrade
```
