### PR TITLE
Libavc1394 0.5.4-1 => 0.5.4

### DIFF
--- a/manifest/armv7l/l/libavc1394.filelist
+++ b/manifest/armv7l/l/libavc1394.filelist
@@ -1,4 +1,4 @@
-# Total size: 257477
+# Total size: 243525
 /usr/local/bin/dvcont
 /usr/local/bin/mkrfc2734
 /usr/local/bin/panelctl
@@ -16,6 +16,6 @@
 /usr/local/lib/librom1394.so.0
 /usr/local/lib/librom1394.so.0.3.0
 /usr/local/lib/pkgconfig/libavc1394.pc
-/usr/local/share/man/man1/dvcont.1.gz
-/usr/local/share/man/man1/mkrfc2734.1.gz
-/usr/local/share/man/man1/panelctl.1.gz
+/usr/local/share/man/man1/dvcont.1.zst
+/usr/local/share/man/man1/mkrfc2734.1.zst
+/usr/local/share/man/man1/panelctl.1.zst

--- a/manifest/i686/l/libavc1394.filelist
+++ b/manifest/i686/l/libavc1394.filelist
@@ -1,4 +1,4 @@
-# Total size: 271569
+# Total size: 256857
 /usr/local/bin/dvcont
 /usr/local/bin/mkrfc2734
 /usr/local/bin/panelctl
@@ -16,6 +16,6 @@
 /usr/local/lib/librom1394.so.0
 /usr/local/lib/librom1394.so.0.3.0
 /usr/local/lib/pkgconfig/libavc1394.pc
-/usr/local/share/man/man1/dvcont.1.gz
-/usr/local/share/man/man1/mkrfc2734.1.gz
-/usr/local/share/man/man1/panelctl.1.gz
+/usr/local/share/man/man1/dvcont.1.zst
+/usr/local/share/man/man1/mkrfc2734.1.zst
+/usr/local/share/man/man1/panelctl.1.zst

--- a/manifest/x86_64/l/libavc1394.filelist
+++ b/manifest/x86_64/l/libavc1394.filelist
@@ -1,4 +1,4 @@
-# Total size: 273223
+# Total size: 274215
 /usr/local/bin/dvcont
 /usr/local/bin/mkrfc2734
 /usr/local/bin/panelctl
@@ -16,6 +16,6 @@
 /usr/local/lib64/librom1394.so.0
 /usr/local/lib64/librom1394.so.0.3.0
 /usr/local/lib64/pkgconfig/libavc1394.pc
-/usr/local/share/man/man1/dvcont.1.gz
-/usr/local/share/man/man1/mkrfc2734.1.gz
-/usr/local/share/man/man1/panelctl.1.gz
+/usr/local/share/man/man1/dvcont.1.zst
+/usr/local/share/man/man1/mkrfc2734.1.zst
+/usr/local/share/man/man1/panelctl.1.zst

--- a/packages/libavc1394.rb
+++ b/packages/libavc1394.rb
@@ -1,34 +1,24 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Libavc1394 < Package
+class Libavc1394 < Autotools
   description 'libavc1394 is a programming interface for the 1394 Trade Association AV/C (Audio/Video Control) Digital Interface Command Set.'
   homepage 'https://sourceforge.net/projects/libavc1394/'
-  version '0.5.4-1'
+  version '0.5.4'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/project/libavc1394/libavc1394/libavc1394-0.5.4.tar.gz'
+  source_url "https://downloads.sourceforge.net/project/libavc1394/libavc1394/libavc1394-#{version}.tar.gz"
   source_sha256 '7cb1ff09506ae911ca9860bef4af08c2403f3e131f6c913a2cbd6ddca4215b53'
-  binary_compression 'tpxz'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '23401f9493493c0368a6fcc3039df80bfb840661b3f6846a45acc991856b149a',
-     armv7l: '23401f9493493c0368a6fcc3039df80bfb840661b3f6846a45acc991856b149a',
-       i686: '0097f563822dfbeb71df4d74d06a53df9a68e15bea70bfd677a22c3a71e0fb82',
-     x86_64: '844ced6d6835b915bc7882ce5503e893c52426c9a789bc2aeb274bbf82dbc219'
+    aarch64: '395fb3d835b1a0a284b052fe2b73517c50ca30e1287a8bd12d316ad250c1c121',
+     armv7l: '395fb3d835b1a0a284b052fe2b73517c50ca30e1287a8bd12d316ad250c1c121',
+       i686: '580942148f6366e81a7a910811a49b5dd8b8ea1acc2a61d833691df1f1a06605',
+     x86_64: '06cb06e5364a113ddfb582e58fac8137a944f80d530d376af7248bb1f6f70582'
   })
 
-  depends_on 'libraw1394'
+  depends_on 'glibc' => :library
+  depends_on 'libraw1394' => :library
 
-  def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.check
-    system 'make', 'check'
-  end
+  run_tests
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-libavc1394 crew update \
&& yes | crew upgrade
```