### PR TITLE
Partially move away from instance variables in `tools/build_updated_packages.rb` 

### DIFF
--- a/tests/tools/build_updated_packages.rb
+++ b/tests/tools/build_updated_packages.rb
@@ -1,0 +1,37 @@
+require 'minitest/autorun'
+require_relative '../../lib/color'
+# We have to set these environment variables before requiring tools/build_updated_packages.rb, as otherwise it will abort because they are missing.
+ENV['GITLAB_TOKEN'] = ''
+ENV['GITLAB_TOKEN_USERNAME'] = ''
+require_relative '../../tools/build_updated_packages'
+
+# This is needed to force --no-color mode.
+String.use_color = false
+
+class BuildUpdatedPackagesTest < Minitest::Test
+  # To avoid having to update these tests frequently, the only packages currently tested are those tagged with no_upstream_update.
+  def test_multiple_dependencies
+    determine_recursive_deps 'js78'
+
+    expected_output = '{:js78=>[:nss], :nss=>[:gcc_lib, :glibc, :sqlite, :zlib], :gcc_lib=>[:glibc], :glibc=>[:crew_preload], :crew_preload=>[], :sqlite=>[:gcc_lib], :zlib=>[:glibc]}
+crew_preload
+glibc
+gcc_lib
+sqlite
+zlib
+nss
+js78
+'
+    assert_output(expected_output, nil) do
+      print_recursive_deps 'js78'
+    end
+  end
+
+  def test_no_dependencies
+    determine_recursive_deps 'clear_cache'
+
+    assert_output("{:clear_cache=>[]}\nclear_cache\n", nil) do
+      print_recursive_deps 'clear_cache'
+    end
+  end
+end

--- a/tools/build_updated_packages.rb
+++ b/tools/build_updated_packages.rb
@@ -50,6 +50,7 @@ if ARGV.include?('-h') || ARGV.include?('--help')
   EOM
 end
 
+# We don't directly use the GITLAB_TOKEN* environment variables, but crew upload does, so we check for them here so that we don't build a package and then fail to upload it.
 abort "\nGITLAB_TOKEN environment variable not set.\n".lightred if ENV['GITLAB_TOKEN'].nil?
 abort "\nGITLAB_TOKEN_USERNAME environment variable not set.\n".lightred if ENV['GITLAB_TOKEN_USERNAME'].nil?
 puts "Setting the CREW_AGREE_TIMEOUT_SECONDS environment variable to less than the default of #{CREW_AGREE_TIMEOUT_SECONDS} may speed this up...".orange if ENV['CREW_AGREE_TIMEOUT_SECONDS'].nil?


### PR DESCRIPTION
## Description
Some minor refactoring here and there, mostly just laying the groundwork for a simplification of the recursive dependency code as well as the PR generation workflow.

Basic functionality tested and working in an `x86_64` container.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=battle crew update \
&& yes | crew upgrade
```