### PR TITLE
Fix upstream_name for ruby-mini-portile2

### DIFF
--- a/packages/ruby_mini_portile2.rb
+++ b/packages/ruby_mini_portile2.rb
@@ -10,4 +10,5 @@ class Ruby_mini_portile2 < RUBY
 
   conflicts_ok
   no_compile_needed
+  upstream_name 'mini_portile2'
 end


### PR DESCRIPTION
## Description
This should fix our automatic ruby package updates, which have also been broken for a while.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=season crew update \
&& yes | crew upgrade
```
