### PR TITLE
Restrict merge conflict label workflow to only target pull requests

### DIFF
--- a/.github/workflows/repo-merge-conflict.yaml
+++ b/.github/workflows/repo-merge-conflict.yaml
@@ -1,10 +1,9 @@
 ---
 name: Repo / Label merge conflict
 on:
-  push:
   pull_request_target:
-    types:
-      - synchronize
+    types: [opened, synchronize]
+
 jobs:
   triage:
     name: Triage


### PR DESCRIPTION
## Description
This is being run on every commit to main for some reason, where it will never find any merge conflicts nor any pull requests to label.

Also, its kinda flaky, so whenever it fails on a push to main it leaves a misleading CI failure mark that makes it look like something important failed.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=barely crew update \
&& yes | crew upgrade
```