### PR TITLE
Split out and add tests for update_package_file in tools/version.rb

### DIFF
--- a/tests/tools/version.rb
+++ b/tests/tools/version.rb
@@ -1,6 +1,21 @@
 require 'minitest/autorun'
 require_relative '../../tools/version'
 
+def update_package_test_wrapper(input_file, version, expected_pkg_file, version_updated: true, bc_updated: nil)
+  # Create a temporary file in the packages directory with the filename of the class name of the input package.
+  package_file_path = "#{CREW_LOCAL_REPO_ROOT}/packages/#{input_file.match('class ([A-z][a-z]*) < Package')[1]}.rb"
+  File.write(package_file_path, input_file)
+
+  # Update the temporary package file, checking that we get the right return values
+  assert_equal [version_updated, bc_updated], update_package_file(package_file_path, version)
+
+  # Check that the updated temporary package file matches our expectations.
+  assert_equal File.read(package_file_path), expected_pkg_file
+
+  # Delete the temporary package file.
+  FileUtils.rm(package_file_path)
+end
+
 class VersionMonitorTest < Minitest::Test
   def test_github_fallback
     assert_equal('2025-11-03', github_fallback(URI.parse('https://github.com/artichoke/nightly.git')))
@@ -99,5 +114,94 @@ class VersionMonitorTest < Minitest::Test
   def test_get_multi_homepage_ecosystem_anitya_id
     # There should be multiple candidates that survive the ecosystem check, but only one will pass the homepage check.
     assert_equal(247, get_anitya_id('cairo', 'https://www.cairographics.org', 'Meson'))
+  end
+
+  def test_update_package_file_version
+    input_file = <<~EOF
+      class Foo < Package
+        version '1.16.1'
+        binary_compression 'tar.zst'
+      end
+    EOF
+
+    update_package_test_wrapper(input_file, '1.0', input_file.sub('1.16.1', '1.0'))
+  end
+
+  def test_update_package_file_binary_compression
+    input_file = <<~EOF
+      class Bar < Package
+        version '3.65.0'
+        binary_compression 'tar.xz'
+      end
+    EOF
+
+    update_package_test_wrapper(input_file, '3.65.0', input_file.sub("binary_compression 'tar.xz'", "binary_compression 'tar.zst'"), bc_updated: true)
+  end
+
+  def test_update_package_file_version_source_sha256
+    input_file = <<~'EOF'
+      class Qux < Package
+        version '1.0.0'
+        binary_compression 'tar.zst'
+        source_url "https://www.samba.org/ftp/ldb/ldb-#{version}.tar.gz"
+        source_sha256 'c63eaca1f84d5149c38ff747f9ac83d05edcd0b5b5d7c0b836100685f968795d'
+      end
+    EOF
+
+    update_package_test_wrapper(input_file, '1.0.2', input_file.sub('1.0.0', '1.0.2').sub('c63eaca1f84d5149c38ff747f9ac83d05edcd0b5b5d7c0b836100685f968795d', '275a8c2ce111558d7ae573ee6922c86eda6d0df2280721e18b3aa8166e5ab3fb'))
+  end
+
+  def test_update_package_file_version_multi_source_sha256
+    input_file = <<~'EOF'
+      class Quux < Package
+        version '0.5.0'
+        binary_compression 'tar.zst'
+        source_url({
+          armv7l: "https://github.com/koalaman/shellcheck/releases/download/v#{version}/shellcheck-v#{version}.linux.armv6hf.tar.xz",
+          x86_64: "https://github.com/koalaman/shellcheck/releases/download/v#{version}/shellcheck-v#{version}.linux.x86_64.tar.xz"
+        })
+        source_sha256({
+          armv7l: '49a0a2c75a464f35b17c2254f979e48b460350ad3eccffdec53f9ee746950950',
+          x86_64: '7d4c073a0342cf39bdb99c32b4749f1c022cf2cffdfb080c12c106aa9d341708'
+        })
+
+      end
+    EOF
+
+    update_package_test_wrapper(input_file, '0.7.2', input_file.sub('0.5.0', '0.7.2').sub('49a0a2c75a464f35b17c2254f979e48b460350ad3eccffdec53f9ee746950950', '29c7291985ad391fc8af930ba89c7441d5764aa3415ef1d77171aea0b34d35b9').sub('7d4c073a0342cf39bdb99c32b4749f1c022cf2cffdfb080c12c106aa9d341708', '70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188'))
+  end
+
+  # TODO: Why is this the only one that returns a false bc_updated value?
+  def test_update_package_file_version_bad_source_sha256
+    input_file = <<~'EOF'
+      class Quuux < Package
+        version '3.56.0'
+        binary_compression 'tar.zst'
+        source_url "https://example.com/#{version}.tar.gz"
+        source_sha256 'iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii'
+      end
+    EOF
+
+    update_package_test_wrapper(input_file, '9.1.8', input_file, version_updated: 'Bad Source', bc_updated: false)
+  end
+
+  # TODO: Why doesn't this have the same behavior as the single source_url case?
+  def test_update_package_file_version_bad_multi_source_sha256
+    input_file = <<~'EOF'
+      class Quuuux < Package
+        version '1.4.0'
+        binary_compression 'tar.zst'
+        source_url({
+          armv7l: "ftp://example.hats/ia32-#{version}.tar.bz3",
+            i686: "ftp://example.hats/strongarmv7-#{version}.tar.bz3"
+        })
+        source_sha256({
+          armv7l: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            i686: 'iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii'
+        })
+      end
+    EOF
+
+    update_package_test_wrapper(input_file, '2.7.0', input_file.sub('1.4.0', '2.7.0'))
   end
 end

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -256,6 +256,98 @@ def get_anitya_id(name, homepage, buildsystem)
   end
 end
 
+def update_package_file(filename, upstream_version)
+  @pkg = Package.load_package(filename, true)
+
+  versions_updated = {}
+  bc_updated = {}
+
+  file = File.read(filename)
+  FileUtils.cp filename, "#{filename}.bak"
+  if file.sub!(PackageUtils.get_clean_version(@pkg.version), upstream_version).nil?
+    versions_updated[@pkg.name.to_sym] = false
+  else
+    # Version update succeeded. Now check for a sha256 update.
+    old_hash = {}
+    new_hash = {}
+    # Handle source_url whether hash or not.
+    if !@pkg.source_sha256.nil? && @pkg.source_sha256.is_a?(Hash) && @pkg.source_sha256&.key?(ARCH.to_sym)
+      # Get old hashes
+      (@pkg.source_url.keys.map &:to_s).each do |arch|
+        puts "old source_url: #{@pkg.source_url[arch.to_sym]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
+        old_hash[arch] = @pkg.source_sha256[arch.to_sym]
+        puts "old hash: #{old_hash[arch]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
+      end
+      File.write(filename, file)
+      @pkg = Package.load_package(filename, true)
+      (@pkg.source_url.keys.map &:to_s).each do |arch|
+        puts "new source_url: #{@pkg.source_url[arch.to_sym]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
+        status = `curl -fsI #{@pkg.source_url[arch.to_sym]}`.lines.first.split[1]
+        puts "new source_url response status: #{status}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
+        unless %w[200 302].include?(status)
+          versions_updated[@pkg.name.to_sym] = 'Bad Source'
+          puts "#{@pkg.source_url[arch.to_sym]} is a bad source".lightred if CREW_VERBOSE && !CREW_OUTPUT_JSON
+          if File.file?("#{filename}.bak")
+            FileUtils.cp "#{filename}.bak", filename
+            FileUtils.rm "#{filename}.bak"
+          end
+          return versions_updated[@pkg.name.to_sym], false
+        end
+        new_hash[arch] = `curl -Ls #{@pkg.source_url[arch.to_sym]} | sha256sum - | awk '{print $1}'`.chomp
+        puts "new hash: #{new_hash[arch]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
+        file.sub!(old_hash[arch], new_hash[arch])
+      end
+    elsif !@pkg.source_sha256.nil? && !@pkg.source_sha256.is_a?(Hash)
+      arch = :all
+      # Get old hashes
+      old_hash[arch] = @pkg.source_sha256
+      puts "old source_url: #{@pkg.source_url}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
+      puts "old hash: #{old_hash[arch]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
+      File.write(filename, file)
+      # Now get new hashes
+      @pkg = Package.load_package(filename, true)
+      puts "new source_url: #{@pkg.source_url}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
+      status = `curl -fsI #{@pkg.source_url}`.lines.first.split[1]
+      unless %w[200 302].include?(status)
+        versions_updated[@pkg.name.to_sym] = 'Bad Source'
+        puts "#{@pkg.source_url} is a bad source.".lightred if CREW_VERBOSE && !CREW_OUTPUT_JSON
+        if File.file?("#{filename}.bak")
+          FileUtils.cp "#{filename}.bak", filename
+          FileUtils.rm "#{filename}.bak"
+        end
+        return versions_updated[@pkg.name.to_sym], false
+      end
+      new_hash[arch] = `curl -Ls #{@pkg.source_url} | sha256sum - | awk '{print $1}'`.chomp
+      puts "new hash: #{new_hash[arch]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
+      file.sub!(old_hash[arch], new_hash[arch])
+    end
+    File.write(filename, file)
+    puts "Successfully updated #{filename} to version #{upstream_version}.".lightgreen
+    local_repo_root = ''
+    Dir.chdir(ENV.fetch('PWD', nil)) do
+      local_repo_root = `git rev-parse --show-toplevel 2> /dev/null`.chomp
+    end
+    if local_repo_root && File.file?("#{local_repo_root}/packages/#{@pkg.name}.rb") && (Pathname.new(filename).realpath.to_s != "#{local_repo_root}/packages/#{@pkg.name}.rb")
+      FileUtils.cp filename, "#{local_repo_root}/packages/#{@pkg.name}.rb"
+      puts "Successfully updated #{local_repo_root}/packages/#{@pkg.name}.rb to version #{upstream_version}.".lightgreen
+    end
+    versions_updated[@pkg.name.to_sym] = true
+    FileUtils.rm "#{filename}.bak" if File.file?("#{filename}.bak")
+  end
+
+  if @pkg.binary_compression == 'tar.xz' && !@pkg.no_zstd?
+    file = File.read(filename)
+    if file.sub!("binary_compression 'tar.xz'", "binary_compression 'tar.zst'").nil?
+      bc_updated[@pkg.name.to_sym] = false
+    else
+      File.write(filename, file)
+      bc_updated[@pkg.name.to_sym] = true
+    end
+  end
+
+  return versions_updated[@pkg.name.to_sym], bc_updated[@pkg.name.to_sym]
+end
+
 # If we have been required from another file (i.e. for testing) don't run any of this, as we're only interested in the functions up above.
 return if __FILE__ != $PROGRAM_NAME
 
@@ -375,94 +467,9 @@ if filelist.length.positive?
         crewlog "Libversion.version_compare2(PackageUtils.get_clean_version(@pkg.version), upstream_version) >= 0: #{Libversion.version_compare2(PackageUtils.get_clean_version(@pkg.version), upstream_version) >= 0}"
       end
       versions_updated[@pkg.name.to_sym] = 'Up to date.' if Libversion.version_compare2(PackageUtils.get_clean_version(@pkg.version), upstream_version) >= 0
-      if Libversion.version_compare2(PackageUtils.get_clean_version(@pkg.version), upstream_version) == -1
-        if UPDATE_PACKAGE_FILES && !CREW_UPDATER_EXCLUDED_PKGS.key?(@pkg.name) && updatable_pkg[@pkg.name.to_sym] == 'Yes'
-          file = File.read(filename)
-          FileUtils.cp filename, "#{filename}.bak"
-          if file.sub!(PackageUtils.get_clean_version(@pkg.version), upstream_version).nil?
-            versions_updated[@pkg.name.to_sym] = false
-          else
-            # Version update succeeded. Now check for a sha256 update.
-            old_hash = {}
-            new_hash = {}
-            # Handle source_url whether hash or not.
-            if !@pkg.source_sha256.nil? && @pkg.source_sha256.is_a?(Hash) && @pkg.source_sha256&.key?(ARCH.to_sym)
-              # Get old hashes
-              (@pkg.source_url.keys.map &:to_s).each do |arch|
-                puts "old source_url: #{@pkg.source_url[arch.to_sym]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
-                old_hash[arch] = @pkg.source_sha256[arch.to_sym]
-                puts "old hash: #{old_hash[arch]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
-              end
-              File.write(filename, file)
-              # Now get new hashes
-              @pkg = Package.load_package(filename, true)
-              (@pkg.source_url.keys.map &:to_s).each do |arch|
-                puts "new source_url: #{@pkg.source_url[arch.to_sym]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
-                status = `curl -fsI #{@pkg.source_url[arch.to_sym]}`.lines.first.split[1]
-                puts "new source_url response status: #{status}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
-                unless %w[200 302].include?(status)
-                  versions_updated[@pkg.name.to_sym] = 'Bad Source'
-                  puts "#{@pkg.source_url[arch.to_sym]} is a bad source".lightred if CREW_VERBOSE && !CREW_OUTPUT_JSON
-                  if File.file?("#{filename}.bak")
-                    FileUtils.cp "#{filename}.bak", filename
-                    FileUtils.rm "#{filename}.bak"
-                  end
-                  exit! if !CREW_OUTPUT_JSON && (filelist.length == 1)
-                  next filename
-                end
-                new_hash[arch] = `curl -Ls #{@pkg.source_url[arch.to_sym]} | sha256sum - | awk '{print $1}'`.chomp
-                puts "new hash: #{new_hash[arch]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
-                file.sub!(old_hash[arch], new_hash[arch])
-              end
-            elsif !@pkg.source_sha256.nil? && !@pkg.source_sha256.is_a?(Hash)
-              arch = :all
-              # Get old hashes
-              old_hash[arch] = @pkg.source_sha256
-              puts "old source_url: #{@pkg.source_url}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
-              puts "old hash: #{old_hash[arch]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
-              File.write(filename, file)
-              # Now get new hashes
-              @pkg = Package.load_package(filename, true)
-              puts "new source_url: #{@pkg.source_url}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
-              status = `curl -fsI #{@pkg.source_url}`.lines.first.split[1]
-              unless %w[200 302].include?(status)
-                versions_updated[@pkg.name.to_sym] = 'Bad Source'
-                puts "#{@pkg.source_url} is a bad source.".lightred if CREW_VERBOSE && !CREW_OUTPUT_JSON
-                if File.file?("#{filename}.bak")
-                  FileUtils.cp "#{filename}.bak", filename
-                  FileUtils.rm "#{filename}.bak"
-                end
-                exit! if !CREW_OUTPUT_JSON && (filelist.length == 1)
-                next filename
-              end
-              new_hash[arch] = `curl -Ls #{@pkg.source_url} | sha256sum - | awk '{print $1}'`.chomp
-              puts "new hash: #{new_hash[arch]}" if CREW_VERBOSE && !CREW_OUTPUT_JSON
-              file.sub!(old_hash[arch], new_hash[arch])
-            end
-            File.write(filename, file)
-            puts "Successfully updated #{filename} to version #{upstream_version}.".lightgreen
-            local_repo_root = ''
-            Dir.chdir(ENV.fetch('PWD', nil)) do
-              local_repo_root = `git rev-parse --show-toplevel 2> /dev/null`.chomp
-            end
-            if local_repo_root && File.file?("#{local_repo_root}/packages/#{@pkg.name}.rb") && (filename != "#{local_repo_root}/packages/#{@pkg.name}.rb")
-              FileUtils.cp filename, "#{local_repo_root}/packages/#{@pkg.name}.rb"
-              puts "Successfully updated #{local_repo_root}/packages/#{@pkg.name}.rb to version #{upstream_version}.".lightgreen
-            end
-            versions_updated[@pkg.name.to_sym] = true
-            FileUtils.rm "#{filename}.bak" if File.file?("#{filename}.bak")
-          end
+      if (Libversion.version_compare2(PackageUtils.get_clean_version(@pkg.version), upstream_version) == -1) && UPDATE_PACKAGE_FILES && !CREW_UPDATER_EXCLUDED_PKGS.key?(@pkg.name) && updatable_pkg[@pkg.name.to_sym] == 'Yes'
+        versions_updated[@pkg.name.to_sym], bc_updated[@pkg.name.to_sym] = update_package_file(filename, upstream_version)
 
-          if @pkg.binary_compression == 'tar.xz' && !@pkg.no_zstd?
-            file = File.read(filename)
-            if file.sub!("binary_compression 'tar.xz'", "binary_compression 'tar.zst'").nil?
-              bc_updated[@pkg.name.to_sym] = false
-            else
-              File.write(filename, file)
-              bc_updated[@pkg.name.to_sym] = true
-            end
-          end
-        end
         versions_updated[@pkg.name.to_sym] = if UPDATE_PACKAGE_FILES && !CREW_UPDATER_EXCLUDED_PKGS.key?(@pkg.name) && versions_updated[@pkg.name.to_sym]
                                                'Updated.'
                                              else


### PR DESCRIPTION
## Description
The classic "split a large chunk of code out into a method and add tests for it to enable a regression-free refactor in a separate PR" method strikes again.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=lavender crew update \
&& yes | crew upgrade
```
