### PR TITLE
Btrfs_progs 6.17.1 => 6.19.1

### DIFF
--- a/manifest/armv7l/b/btrfs_progs.filelist
+++ b/manifest/armv7l/b/btrfs_progs.filelist
@@ -1,4 +1,4 @@
-# Total size: 6838172
+# Total size: 5522032
 /usr/local/bin/btrfs
 /usr/local/bin/btrfs-find-root
 /usr/local/bin/btrfs-image
@@ -21,12 +21,12 @@
 /usr/local/lib/libbtrfs.so
 /usr/local/lib/libbtrfs.so.0
 /usr/local/lib/libbtrfs.so.0.1
-/usr/local/lib/libbtrfs.so.0.1.4
+/usr/local/lib/libbtrfs.so.0.1.5
 /usr/local/lib/libbtrfsutil.a
 /usr/local/lib/libbtrfsutil.so
 /usr/local/lib/libbtrfsutil.so.1
-/usr/local/lib/libbtrfsutil.so.1.3
-/usr/local/lib/libbtrfsutil.so.1.3.2
+/usr/local/lib/libbtrfsutil.so.1.4
+/usr/local/lib/libbtrfsutil.so.1.4.0
 /usr/local/lib/pkgconfig/libbtrfsutil.pc
 /usr/local/lib/udev/rules.d/64-btrfs-dm.rules
 /usr/local/lib/udev/rules.d/64-btrfs-zoned.rules

--- a/manifest/x86_64/b/btrfs_progs.filelist
+++ b/manifest/x86_64/b/btrfs_progs.filelist
@@ -1,4 +1,4 @@
-# Total size: 6927354
+# Total size: 6970850
 /usr/local/bin/btrfs
 /usr/local/bin/btrfs-find-root
 /usr/local/bin/btrfs-image
@@ -21,12 +21,12 @@
 /usr/local/lib64/libbtrfs.so
 /usr/local/lib64/libbtrfs.so.0
 /usr/local/lib64/libbtrfs.so.0.1
-/usr/local/lib64/libbtrfs.so.0.1.4
+/usr/local/lib64/libbtrfs.so.0.1.5
 /usr/local/lib64/libbtrfsutil.a
 /usr/local/lib64/libbtrfsutil.so
 /usr/local/lib64/libbtrfsutil.so.1
-/usr/local/lib64/libbtrfsutil.so.1.3
-/usr/local/lib64/libbtrfsutil.so.1.3.2
+/usr/local/lib64/libbtrfsutil.so.1.4
+/usr/local/lib64/libbtrfsutil.so.1.4.0
 /usr/local/lib64/pkgconfig/libbtrfsutil.pc
 /usr/local/lib64/udev/rules.d/64-btrfs-dm.rules
 /usr/local/lib64/udev/rules.d/64-btrfs-zoned.rules

--- a/packages/btrfs_progs.rb
+++ b/packages/btrfs_progs.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Btrfs_progs < Autotools
   description 'BTRFS is a modern copy on write filesystem for Linux aimed at implementing advanced features while also focusing on fault tolerance, repair and easy administration.'
   homepage 'https://btrfs.readthedocs.io/en/latest/'
-  version '6.17.1'
+  version '6.19.1'
   license 'GPL-2'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/kdave/btrfs-progs.git'
@@ -11,22 +11,24 @@ class Btrfs_progs < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '093314c5f1cf6c974bfea1c9980d7fb644850a53d14d2df05d41e499ede93b7a',
-     armv7l: '093314c5f1cf6c974bfea1c9980d7fb644850a53d14d2df05d41e499ede93b7a',
-     x86_64: 'caa3bfd5d60bae8f3fab608b5bcd5e1ee649eb4c4e5a7152599efcb0c33f2c3d'
+    aarch64: '110813d0c17f56cb6e0d58b404d756bcce56cb8b5c986abfc29c1028069cb30f',
+     armv7l: '110813d0c17f56cb6e0d58b404d756bcce56cb8b5c986abfc29c1028069cb30f',
+     x86_64: '4bd86d3a76d2c747dc22d0466cc6fd5b011738ff06253b186a1157ce298004a7'
   })
 
   depends_on 'e2fsprogs'
-  depends_on 'eudev' # R
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
-  depends_on 'libgcrypt' # R
-  depends_on 'libsodium' # R
-  depends_on 'libuuid' # R
-  depends_on 'lzo' # R
-  depends_on 'util_linux' # R
-  depends_on 'zlib' # R
-  depends_on 'zstd' # R
+  depends_on 'eudev' => :library
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'libgcrypt' => :library
+  depends_on 'libsodium' => :library
+  depends_on 'libudev_stub' => :library
+  depends_on 'libuuid' => :library
+  depends_on 'lzo' => :executable
+  depends_on 'util_linux' => :library
+  depends_on 'vdev' => :library
+  depends_on 'zlib' => :executable
+  depends_on 'zstd' => :executable
 
   autotools_configure_options '--disable-documentation \
     --disable-convert \


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-btrfs_progs crew update \
&& yes | crew upgrade

$ crew check btrfs_progs 
Checking btrfs_progs package ...
Library test for btrfs_progs passed.
Checking btrfs_progs package ...
btrfs-progs v6.19.1
-EXPERIMENTAL -INJECT -STATIC +LZO +ZSTD +UDEV +FSVERITY +ZONED CRYPTO=libgcrypt
btrfs-image, part of btrfs-progs v6.19.1
-EXPERIMENTAL -INJECT -STATIC +LZO +ZSTD +UDEV +FSVERITY +ZONED CRYPTO=libgcrypt
btrfstune, part of btrfs-progs v6.19.1
-EXPERIMENTAL -INJECT -STATIC +LZO +ZSTD +UDEV +FSVERITY +ZONED CRYPTO=libgcrypt
mkfs.btrfs, part of btrfs-progs v6.19.1
-EXPERIMENTAL -INJECT -STATIC +LZO +ZSTD +UDEV +FSVERITY +ZONED CRYPTO=libgcrypt
Package tests for btrfs_progs passed.
```