### PR TITLE
Bubblewrap 0.11.0 => 0.11.1

### DIFF
--- a/manifest/armv7l/b/bubblewrap.filelist
+++ b/manifest/armv7l/b/bubblewrap.filelist
@@ -1,6 +1,7 @@
-# Total size: 47384
+# Total size: 74060
 /usr/local/bin/bwrap
 /usr/local/bin/bwrap.elf
+/usr/local/etc/env.d/10-bwrap
 /usr/local/share/bash-completion/completions/bwrap
 /usr/local/share/man/man1/bwrap.1.zst
 /usr/local/share/zsh/site-functions/_bwrap

--- a/manifest/i686/b/bubblewrap.filelist
+++ b/manifest/i686/b/bubblewrap.filelist
@@ -1,6 +1,7 @@
-# Total size: 47708
+# Total size: 92152
 /usr/local/bin/bwrap
 /usr/local/bin/bwrap.elf
+/usr/local/etc/env.d/10-bwrap
 /usr/local/share/bash-completion/completions/bwrap
 /usr/local/share/man/man1/bwrap.1.zst
 /usr/local/share/zsh/site-functions/_bwrap

--- a/manifest/x86_64/b/bubblewrap.filelist
+++ b/manifest/x86_64/b/bubblewrap.filelist
@@ -1,6 +1,7 @@
-# Total size: 47224
+# Total size: 88704
 /usr/local/bin/bwrap
 /usr/local/bin/bwrap.elf
+/usr/local/etc/env.d/10-bwrap
 /usr/local/share/bash-completion/completions/bwrap
 /usr/local/share/man/man1/bwrap.1.zst
 /usr/local/share/zsh/site-functions/_bwrap

--- a/packages/bubblewrap.rb
+++ b/packages/bubblewrap.rb
@@ -3,29 +3,35 @@ require 'buildsystems/meson'
 class Bubblewrap < Meson
   description 'bubblewrap works by creating a new, completely empty, mount namespace'
   homepage 'https://github.com/containers/bubblewrap'
-  version '0.11.0'
+  version '0.11.1'
   license 'LGPL-2+'
   compatibility 'all'
   source_url "https://github.com/containers/bubblewrap/releases/download/v#{version}/bubblewrap-#{version}.tar.xz"
-  source_sha256 '988fd6b232dafa04b8b8198723efeaccdb3c6aa9c1c7936219d5791a8b7a8646'
+  source_sha256 'c1b7455a1283b1295879a46d5f001dfd088c0bb0f238abb5e128b3583a246f71'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b0febfc984247217480a4268557c31250726ff2df9b267608c2c91eecdee1d32',
-     armv7l: 'b0febfc984247217480a4268557c31250726ff2df9b267608c2c91eecdee1d32',
-       i686: '191f69c05e2d9196d37c6b25013f98f89a52f3841bf2ce29271eff662c408629',
-     x86_64: 'd59f8e762e6596b9245437d465445aadb876352b11e4f450d34f28da02c095ac'
+    aarch64: '0c0086c78e562a6fe025ecc5a1907a86c65be1897fe40c654456a02c687fe6ca',
+     armv7l: '0c0086c78e562a6fe025ecc5a1907a86c65be1897fe40c654456a02c687fe6ca',
+       i686: '03101523d589234d8698f67fc9c16bc9960fbaa62ac67288981f03610b9931fe',
+     x86_64: '913623af164bf957debeaa12feb862ffb74183e76ae043422820814a7105d7a1'
   })
 
   depends_on 'dconf' => :build
   depends_on 'docbook_xml' => :build
-  depends_on 'glibc' # R
-  depends_on 'libcap' # R
+  depends_on 'glibc' => :executable
+  depends_on 'libcap' => :executable
   depends_on 'libxslt' => :build
+
+  print_source_bashrc
 
   meson_options '-Dman=enabled'
 
   meson_build_extras do
+    File.write '10-bwrap', <<~BWRAP_COMPLETION
+      #!/bin/bash
+      source #{CREW_PREFIX}/share/bash-completion/completions/bwrap
+    BWRAP_COMPLETION
     File.write 'bwrap.sh', <<~BWRAP_HEREDOC
       #!/bin/bash
       sudo chown root "#{CREW_PREFIX}/bin/bwrap.elf"
@@ -36,6 +42,7 @@ class Bubblewrap < Meson
   end
 
   meson_install_extras do
+    FileUtils.install '10-bwrap', "#{CREW_DEST_PREFIX}/etc/env.d/10-bwrap", mode: 0o644
     FileUtils.install "#{CREW_DEST_PREFIX}/bin/bwrap", "#{CREW_DEST_PREFIX}/bin/bwrap.elf", mode: 0o755
     FileUtils.install 'bwrap.sh', "#{CREW_DEST_PREFIX}/bin/bwrap", mode: 0o755
   end

--- a/tests/package/b/bubblewrap
+++ b/tests/package/b/bubblewrap
@@ -1,0 +1,2 @@
+#!/bin/bash
+bwrap --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-bubblewrap crew update \
&& yes | crew upgrade

$ crew check bubblewrap 
Checking bubblewrap package ...
Library test for bubblewrap passed.
Checking bubblewrap package ...
bubblewrap 0.11.1
Package tests for bubblewrap passed.
```