### PR TITLE
Btm 0.11.1 => 0.12.3

### DIFF
--- a/manifest/armv7l/b/btm.filelist
+++ b/manifest/armv7l/b/btm.filelist
@@ -1,3 +1,3 @@
-# Total size: 4313846
+# Total size: 4072791
 /usr/local/bin/btm
 /usr/local/etc/bash.d/btm.bash

--- a/manifest/i686/b/btm.filelist
+++ b/manifest/i686/b/btm.filelist
@@ -1,3 +1,3 @@
-# Total size: 5034478
+# Total size: 4719759
 /usr/local/bin/btm
 /usr/local/etc/bash.d/btm.bash

--- a/manifest/x86_64/b/btm.filelist
+++ b/manifest/x86_64/b/btm.filelist
@@ -1,3 +1,3 @@
-# Total size: 5266886
+# Total size: 4990427
 /usr/local/bin/btm
 /usr/local/etc/bash.d/btm.bash

--- a/packages/btm.rb
+++ b/packages/btm.rb
@@ -3,7 +3,7 @@ require 'package'
 class Btm < Package
   description 'Yet another cross-platform graphical process/system monitor.'
   homepage 'https://clementtsang.github.io/bottom'
-  version '0.11.1'
+  version '0.12.3'
   license 'MIT'
   compatibility 'all'
   min_glibc '2.28' if ARCH.eql?('x86_64')
@@ -14,10 +14,10 @@ class Btm < Package
      x86_64: "https://github.com/ClementTsang/bottom/releases/download/#{version}/bottom_x86_64-unknown-linux-gnu.tar.gz"
   })
   source_sha256({
-    aarch64: '7746990396832690e97d465fd040dd4ed7a6ccf0d3db1bfe383a84feac982f4a',
-     armv7l: '7746990396832690e97d465fd040dd4ed7a6ccf0d3db1bfe383a84feac982f4a',
-       i686: 'b6fe94e41bde3f8b03cf06733a2005e38424ddfef934e6286369b97fe20f7537',
-     x86_64: 'b173d13b0206e941b1b646ac18756c63a18fbe8b07744ab8ee992807aa2bad8a'
+    aarch64: '42554905f61056d760206a466e3732b348f9fa78221f2dfdb0700d6707661938',
+     armv7l: '42554905f61056d760206a466e3732b348f9fa78221f2dfdb0700d6707661938',
+       i686: 'e479e7f6e4cfeb96bc6c9045e266e6f5fa1bcdf937fd53d9561171221fc95e24',
+     x86_64: '468131d586dee6f4cce23fae597646cfd032103ecf749a478acb9d236adab6d6'
   })
 
   no_compile_needed
@@ -30,6 +30,6 @@ class Btm < Package
   end
 
   def self.postinstall
-    ExitMessage.add "\nType 'btm' to get started.\n".lightblue
+    ExitMessage.add "\nType 'btm' to get started.\n"
   end
 end

--- a/tests/package/b/btm
+++ b/tests/package/b/btm
@@ -1,0 +1,3 @@
+#!/bin/bash
+btm -h | head
+btm -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-btm crew update \
&& yes | crew upgrade

$ crew check btm
Checking btm package ...
Library test for btm passed.
Checking btm package ...
bottom 0.12.3
Clement Tsang <cjhtsang@uwaterloo.ca>

A customizable cross-platform graphical process/system monitor for the terminal. Supports Linux,
macOS, and Windows.

Usage: btm [OPTIONS]

General Options:
      --autohide_time                 Temporarily shows the time scale in graphs.
bottom 0.12.3
Package tests for btm passed.
```