### PR TITLE
Add nanosvg package

### DIFF
--- a/manifest/armv7l/n/nanosvg.filelist
+++ b/manifest/armv7l/n/nanosvg.filelist
@@ -1,0 +1,9 @@
+# Total size: 368549
+/usr/local/include/nanosvg/nanosvg.h
+/usr/local/include/nanosvg/nanosvgrast.h
+/usr/local/lib/cmake/NanoSVG/NanoSVGConfig.cmake
+/usr/local/lib/cmake/NanoSVG/NanoSVGConfigVersion.cmake
+/usr/local/lib/cmake/NanoSVG/NanoSVGTargets-release.cmake
+/usr/local/lib/cmake/NanoSVG/NanoSVGTargets.cmake
+/usr/local/lib/libnanosvg.a
+/usr/local/lib/libnanosvgrast.a

--- a/manifest/i686/n/nanosvg.filelist
+++ b/manifest/i686/n/nanosvg.filelist
@@ -1,0 +1,9 @@
+# Total size: 372201
+/usr/local/include/nanosvg/nanosvg.h
+/usr/local/include/nanosvg/nanosvgrast.h
+/usr/local/lib/cmake/NanoSVG/NanoSVGConfig.cmake
+/usr/local/lib/cmake/NanoSVG/NanoSVGConfigVersion.cmake
+/usr/local/lib/cmake/NanoSVG/NanoSVGTargets-release.cmake
+/usr/local/lib/cmake/NanoSVG/NanoSVGTargets.cmake
+/usr/local/lib/libnanosvg.a
+/usr/local/lib/libnanosvgrast.a

--- a/manifest/x86_64/n/nanosvg.filelist
+++ b/manifest/x86_64/n/nanosvg.filelist
@@ -1,0 +1,9 @@
+# Total size: 372439
+/usr/local/include/nanosvg/nanosvg.h
+/usr/local/include/nanosvg/nanosvgrast.h
+/usr/local/lib64/cmake/NanoSVG/NanoSVGConfig.cmake
+/usr/local/lib64/cmake/NanoSVG/NanoSVGConfigVersion.cmake
+/usr/local/lib64/cmake/NanoSVG/NanoSVGTargets-release.cmake
+/usr/local/lib64/cmake/NanoSVG/NanoSVGTargets.cmake
+/usr/local/lib64/libnanosvg.a
+/usr/local/lib64/libnanosvgrast.a

--- a/packages/nanosvg.rb
+++ b/packages/nanosvg.rb
@@ -1,0 +1,35 @@
+require 'buildsystems/cmake'
+
+class Nanosvg < CMake
+  description 'Simple stupid SVG parser'
+  homepage 'https://github.com/memononen/nanosvg'
+  version '5cefd98'
+  license 'Zlib'
+  compatibility 'all'
+  source_url 'https://github.com/memononen/nanosvg.git'
+  git_hashtag '5cefd9847949af6df13f65027fd43af5a7513633'
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '966062905fe09ac6386b2d9a0864f2fb288dddd139072ad659ea69e61dc7ef74',
+     armv7l: '966062905fe09ac6386b2d9a0864f2fb288dddd139072ad659ea69e61dc7ef74',
+       i686: 'fab71dc07e59e19c655aa2e9083f92cd7e70847b9b956342f0a8834827e65a74',
+     x86_64: '0c5f572e5563a433f35a608eecff82a02bb6f08eb983e21852174dcd5d1d6a0e'
+  })
+
+  def self.patch
+    patches = [
+      [
+        # Fix cmake library installation.
+        'https://patch-diff.githubusercontent.com/raw/memononen/nanosvg/pull/245.diff',
+        '97efc38f2f655a1056da15c57587e2efc1226913a59e4730452dccf3d1a204f2'
+      ],
+      [
+        # Add soversion number 0.
+        'https://patch-diff.githubusercontent.com/raw/memononen/nanosvg/pull/246.diff',
+        '22b237158e0ff0976aaf946cc66656d4c2e15a7fd8c01d4f97ef7b2c593ba5d7'
+      ]
+    ]
+    ConvenienceFunctions.patch(patches)
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6415,6 +6415,11 @@ url: https://www.nano-editor.org/dist
 activity: high
 ---
 kind: url
+name: nanosvg
+url: https://github.com/memononen/nanosvg/releases
+activity: none
+---
+kind: url
 name: nanomsg
 url: https://github.com/nanomsg/nanomsg/releases
 activity: medium


### PR DESCRIPTION
## Description
NanoSVG is a simple stupid single-header-file SVG parse. The output of the parser is a list of cubic bezier shapes.

The library suits well for anything from rendering scalable icons in your editor application to prototyping a game.

See https://github.com/memononen/nanosvg.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-nanosvg-package crew update \
&& yes | crew upgrade
```
