### PR TITLE
Fix duplicate packages providing library in tools/getrealdeps.rb

### DIFF
--- a/packages/cmus.rb
+++ b/packages/cmus.rb
@@ -23,7 +23,6 @@ class Cmus < Package
   depends_on 'flac' # R
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
-  depends_on 'jack1' # R
   depends_on 'jack' # R
   depends_on 'libmodplug' # R
   depends_on 'libsamplerate' # R

--- a/packages/evolution_data_server.rb
+++ b/packages/evolution_data_server.rb
@@ -23,7 +23,6 @@ class Evolution_data_server < CMake
   depends_on 'gcr_3' # R
   depends_on 'gdk_pixbuf' => :library
   depends_on 'glib' => :library
-  depends_on 'glib_stub' => :library
   depends_on 'glibc' => :library
   depends_on 'gobject_introspection' => :build
   depends_on 'gperf' => :build
@@ -41,7 +40,6 @@ class Evolution_data_server < CMake
   depends_on 'libsoup' => :library
   depends_on 'libsoup2' # R
   depends_on 'libxml2' => :library
-  depends_on 'libxml2_autotools' => :library
   depends_on 'nss' => :library
   depends_on 'p11kit' # R
   depends_on 'pango' => :library

--- a/packages/gnome_online_accounts.rb
+++ b/packages/gnome_online_accounts.rb
@@ -18,7 +18,6 @@ class Gnome_online_accounts < Meson
 
   depends_on 'gcr_4' => :library
   depends_on 'glib' => :library
-  depends_on 'glib_stub' => :library
   depends_on 'glibc' => :library
   depends_on 'gobject_introspection' => :build
   depends_on 'gtk4' => :library
@@ -33,7 +32,6 @@ class Gnome_online_accounts < Meson
   depends_on 'libsecret' => :library
   depends_on 'libsoup' => :library
   depends_on 'libxml2' => :library
-  depends_on 'libxml2_autotools' => :library
   depends_on 'libxslt'
   depends_on 'rest' => :library
   depends_on 'vala' => :build

--- a/packages/gnome_sudoku.rb
+++ b/packages/gnome_sudoku.rb
@@ -22,7 +22,6 @@ class Gnome_sudoku < Meson
   depends_on 'desktop_file_utils' => :build
   depends_on 'gcc_lib' => :executable
   depends_on 'glib' => :executable
-  depends_on 'glib_stub' => :executable
   depends_on 'glibc' => :executable
   depends_on 'gsound' => :build
   depends_on 'gtk4' => :executable

--- a/packages/libgedit_gfls.rb
+++ b/packages/libgedit_gfls.rb
@@ -17,7 +17,6 @@ class Libgedit_gfls < Meson
   })
 
   depends_on 'glib' => :library
-  depends_on 'glib_stub' => :library
   depends_on 'glibc' => :library
   depends_on 'gobject_introspection'
   depends_on 'gtk3'

--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -25,13 +25,11 @@ class Pipewire < Meson
   depends_on 'eudev' => :library
   depends_on 'gcc_lib' => :library
   depends_on 'glib' => :library
-  depends_on 'glib_stub' => :library
   depends_on 'glibc' => :library
   depends_on 'gsettings_desktop_schemas' => :build
   depends_on 'gstreamer' => :library
   depends_on 'gstreamer' => :logical
   depends_on 'jack' => :library
-  depends_on 'jack1' => :library
   depends_on 'libdrm' => :library
   depends_on 'libmysofa' => :library
   depends_on 'libsndfile' => :library

--- a/packages/py3_lxml.rb
+++ b/packages/py3_lxml.rb
@@ -18,7 +18,6 @@ class Py3_lxml < Pip
 
   depends_on 'glibc' => :library
   depends_on 'libxml2' => :library
-  depends_on 'libxml2_autotools' => :library
   depends_on 'libxslt' => :library
   depends_on 'py3_cython' => :build
   depends_on 'python3' => :logical

--- a/tools/getrealdeps.rb
+++ b/tools/getrealdeps.rb
@@ -212,10 +212,16 @@ def determine_dependencies(pkg_name, pkgfiles_to_check)
   pkgdeps = pkgdeps.map { |i| i.gsub(/llvm(\d)+_lib/, 'llvm_lib') }.uniq
   pkgdeps = pkgdeps.map { |i| i.gsub(/llvm(\d)+_dev/, 'llvm_dev') }.uniq
 
+  # If two packages both provide a library, use the regular one unless this is the specific package that needs the alternative.
+  # TODO: Are there more packages like this?
+  pkgdeps = pkgdeps.map { |i| i.gsub('glib_stub', 'glib') }.uniq unless %w[gobject_introspection glib].include?(pkg_name)
+  # TODO: Since these packages aren't needed by any specific package, do we need to package them at all?
+  pkgdeps = pkgdeps.map { |i| i.gsub('jack1', 'jack') }.uniq
+  pkgdeps = pkgdeps.map { |i| i.gsub('libxml2_autotools', 'libxml2') }.uniq
+
   # Split any multi-dependency strings into individual array members.
   pkgdeps = pkgdeps.flat_map(&:split).uniq
 
-  # TODO: Handle the situation where two conflicting packages provide the same library (i.e. jack and jack1)
   if pkgdeps.blank?
     return []
   else
@@ -273,7 +279,7 @@ def main(pkg)
   # was just built.
   pkgfiles.map! { |item| item.prepend(CREW_DEST_DIR) } if @opt_use_crew_dest_dir
 
-  # TODO: Does anything create this directory? If so, that should be documented more clearly, and if not, the line can be removed.
+  # Remove the temporary directory created in determine_dependencies.
   FileUtils.rm_rf("/tmp/deps/#{pkg.name}")
   # Remove files we don't care about, such as man files and non-binaries.
   pkgfiles = pkgfiles.reject { |i| !File.file?(i.chomp) || File.read(i.chomp, 4) != "\x7FELF" || i.include?('.zst') }


### PR DESCRIPTION
## Description
When two packages provide one dependency, its usually because one package is a weird version of the other package that we only want to use in specific scenarios. 

I've added the cases I know of, but more could probably be found with a script that checks for fully identical library lines in filelists.

I've also manually removed all the existing problems.

Tested and working locally.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=sllide crew update \
&& yes | crew upgrade
```