### PR TITLE
jemalloc: 5.3.0 → 5.3.1

### DIFF
--- a/manifest/armv7l/j/jemalloc.filelist
+++ b/manifest/armv7l/j/jemalloc.filelist
@@ -1,4 +1,4 @@
-# Total size: 62333820
+# Total size: 69930913
 /usr/local/bin/jemalloc-config
 /usr/local/bin/jemalloc.sh
 /usr/local/bin/jeprof

--- a/manifest/i686/j/jemalloc.filelist
+++ b/manifest/i686/j/jemalloc.filelist
@@ -1,4 +1,4 @@
-# Total size: 37288402
+# Total size: 42203387
 /usr/local/bin/jemalloc-config
 /usr/local/bin/jemalloc.sh
 /usr/local/bin/jeprof

--- a/manifest/x86_64/j/jemalloc.filelist
+++ b/manifest/x86_64/j/jemalloc.filelist
@@ -1,4 +1,4 @@
-# Total size: 52540792
+# Total size: 59283923
 /usr/local/bin/jemalloc-config
 /usr/local/bin/jemalloc.sh
 /usr/local/bin/jeprof

--- a/packages/jemalloc.rb
+++ b/packages/jemalloc.rb
@@ -11,13 +11,13 @@ class Jemalloc < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '9484d742bccf179955042cf64e600264da004e3dca493ea3c62138398a0923c5',
-     armv7l: '9484d742bccf179955042cf64e600264da004e3dca493ea3c62138398a0923c5',
-       i686: 'c024f394bc1964745453c0f4cfbd845567c26e8bb3b1d373d3ffe02cca6c5b42',
-     x86_64: '18fcc5b3f4412293a0f72723bbebcba5571750691a6e5ca6f5db8a7a146d5b4c'
+    aarch64: '92dbc8c2871919aa16f7baba2c39417e9424e7ec4e83487e80ead28626feda5d',
+     armv7l: '92dbc8c2871919aa16f7baba2c39417e9424e7ec4e83487e80ead28626feda5d',
+       i686: '2b9c95d8873fe5e1861af5da1ac12f34a669b4ae298021fc429cfd42a13c6908',
+     x86_64: '04071152be5af61c3688f0df4f5662b4c3f37a2d02ca18ef0142a2579296f05f'
   })
 
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
   depends_on 'libxslt' => :build
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
 end

--- a/packages/jemalloc.rb
+++ b/packages/jemalloc.rb
@@ -3,11 +3,11 @@ require 'buildsystems/autotools'
 class Jemalloc < Autotools
   description 'jemalloc is a general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support.'
   homepage 'http://jemalloc.net/'
-  version '5.3.0'
+  version '5.3.1'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2'
-  source_sha256 '2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa'
+  source_url "https://github.com/jemalloc/jemalloc/releases/download/#{version}/jemalloc-#{version}.tar.bz2"
+  source_sha256 '3826bc80232f22ed5c4662f3034f799ca316e819103bdc7bb99018a421706f92'
   binary_compression 'tar.zst'
 
   binary_sha256({


### PR DESCRIPTION
## Description
#### Commits:
-  ac4fe509f Mark packages from successful builds as automatically buildable.
-  dd685233a jemalloc => 5.3.1
### Packages with Updated versions or Changed package files:
- `jemalloc`: 5.3.0 &rarr; 5.3.1
##
Builds attempted for:
### Other changed files:
- tools/automatically_updatable_packages/jemalloc
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=jemalloc_531 crew update \
&& yes | crew upgrade
```
