### PR TITLE
Add mpreal package

### DIFF
--- a/manifest/armv7l/m/mpreal.filelist
+++ b/manifest/armv7l/m/mpreal.filelist
@@ -1,0 +1,2 @@
+# Total size: 133033
+/usr/local/include/mpreal.h

--- a/manifest/i686/m/mpreal.filelist
+++ b/manifest/i686/m/mpreal.filelist
@@ -1,0 +1,2 @@
+# Total size: 133033
+/usr/local/include/mpreal.h

--- a/manifest/x86_64/m/mpreal.filelist
+++ b/manifest/x86_64/m/mpreal.filelist
@@ -1,0 +1,2 @@
+# Total size: 133033
+/usr/local/include/mpreal.h

--- a/packages/mpreal.rb
+++ b/packages/mpreal.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Mpreal < Package
+  description 'Thin wrapper for MPFR'
+  homepage 'https://github.com/advanpix/mpreal'
+  version '3.7.2'
+  license 'GPL-3'
+  compatibility 'all'
+  source_url 'https://github.com/advanpix/mpreal.git'
+  git_hashtag "mpfrc++-#{version}"
+
+  depends_on 'mpfr' => :library
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.install 'mpreal.h', "#{CREW_DEST_PREFIX}/include/mpreal.h", mode: 0o644
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6295,6 +6295,11 @@ url: https://sourceforge.net/projects/mpg123/files/mpg123/
 activity: none
 ---
 kind: url
+name: mpreal
+url: https://github.com/advanpix/mpreal/tags
+activity: low
+---
+kind: url
 name: mpv
 url: https://github.com/mpv-player/mpv/releases
 activity: high


### PR DESCRIPTION
## Description
MPFR C++ (MPREAL):     Multiple precision floating point arithmetic library for C++.
                       Thread-safe, cross-platform (MSVC, GCC, ICC), one-header C++ library.
                       Supports C++11 features if available, C++03 compatible otherwise.

See https://github.com/advanpix/mpreal.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-mpreal-package crew update \
&& yes | crew upgrade
```
