### PR TITLE
Fix eudev dependencies causing vdev and libudev_stub dependencies

### DIFF
--- a/packages/btrfs_progs.rb
+++ b/packages/btrfs_progs.rb
@@ -22,11 +22,9 @@ class Btrfs_progs < Autotools
   depends_on 'glibc' => :library
   depends_on 'libgcrypt' => :library
   depends_on 'libsodium' => :library
-  depends_on 'libudev_stub' => :library
   depends_on 'libuuid' => :library
   depends_on 'lzo' => :executable
   depends_on 'util_linux' => :library
-  depends_on 'vdev' => :library
   depends_on 'zlib' => :executable
   depends_on 'zstd' => :executable
 

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -27,7 +27,6 @@ class Mesa < Meson
   depends_on 'libdrm' => :library
   depends_on 'libminigbm' => :library
   depends_on 'libomxil_bellagio' => :build
-  depends_on 'libudev_stub' => :library
   depends_on 'libunwind' => :library
   depends_on 'libva' => :build
   depends_on 'libvdpau' => :build
@@ -49,7 +48,6 @@ class Mesa < Meson
   depends_on 'spirv_llvm_translator' => :build
   depends_on 'spirv_tools' => :library
   depends_on 'valgrind' => :build
-  depends_on 'vdev' => :library
   depends_on 'vulkan_headers' => :build
   depends_on 'wayland' => :library
   depends_on 'wayland_protocols' => :build

--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -33,7 +33,6 @@ class Pipewire < Meson
   depends_on 'libdrm' => :library
   depends_on 'libmysofa' => :library
   depends_on 'libsndfile' => :library
-  depends_on 'libudev_stub' => :library
   depends_on 'lilv' => :library
   depends_on 'ncurses' => :executable
   depends_on 'openssl' => :library
@@ -41,7 +40,6 @@ class Pipewire < Meson
   depends_on 'pulseaudio' => :library
   depends_on 'py3_lxml' => :build
   depends_on 'readline' => :executable
-  depends_on 'vdev' => :library
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader' => :library
   depends_on 'webrtc_audio_processing' => :library

--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -32,7 +32,6 @@ class Xorg_server < Meson
   depends_on 'libminigbm' => :library
   depends_on 'libpciaccess' => :executable
   depends_on 'libtirpc' => :executable
-  depends_on 'libudev_stub' => :library
   depends_on 'libunwind' => :build
   depends_on 'libx11' => :executable
   depends_on 'libxau' => :executable
@@ -48,7 +47,6 @@ class Xorg_server < Meson
   depends_on 'lzma' => :build
   depends_on 'mesa' => :library
   depends_on 'pixman' => :library
-  depends_on 'vdev' => :library
   depends_on 'xcb_util' => :executable
   depends_on 'xcb_util_cursor' => :build
   depends_on 'xcb_util_image' => :executable

--- a/tools/getrealdeps.rb
+++ b/tools/getrealdeps.rb
@@ -218,6 +218,8 @@ def determine_dependencies(pkg_name, pkgfiles_to_check)
   # TODO: Since these packages aren't needed by any specific package, do we need to package them at all?
   pkgdeps = pkgdeps.map { |i| i.gsub('jack1', 'jack') }.uniq
   pkgdeps = pkgdeps.map { |i| i.gsub('libxml2_autotools', 'libxml2') }.uniq
+  pkgdeps = pkgdeps.map { |i| i.gsub('vdev', 'eudev') }.uniq
+  pkgdeps = pkgdeps.map { |i| i.gsub('libudev_stub', 'eudev') }.uniq
 
   # Split any multi-dependency strings into individual array members.
   pkgdeps = pkgdeps.flat_map(&:split).uniq


### PR DESCRIPTION
## Description
This is probably a sign that I should automate detection of these packages like I was talking about in the last PR. Anyway:

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=flux crew update \
&& yes | crew upgrade
```

