### PR TITLE
Add uv package

### DIFF
--- a/manifest/armv7l/u/uv.filelist
+++ b/manifest/armv7l/u/uv.filelist
@@ -1,0 +1,3 @@
+# Total size: 49674628
+/usr/local/bin/uv
+/usr/local/bin/uvx

--- a/manifest/i686/u/uv.filelist
+++ b/manifest/i686/u/uv.filelist
@@ -1,0 +1,3 @@
+# Total size: 57645976
+/usr/local/bin/uv
+/usr/local/bin/uvx

--- a/manifest/x86_64/u/uv.filelist
+++ b/manifest/x86_64/u/uv.filelist
@@ -1,0 +1,3 @@
+# Total size: 60334264
+/usr/local/bin/uv
+/usr/local/bin/uvx

--- a/packages/uv.rb
+++ b/packages/uv.rb
@@ -1,0 +1,32 @@
+require 'package'
+
+class Uv < Package
+  description 'An extremely fast Python package and project manager, written in Rust.'
+  homepage 'https://docs.astral.sh/uv/'
+  version '0.11.7'
+  license 'Apache-2.0, MIT'
+  compatibility 'all'
+  source_url({
+    aarch64: "https://releases.astral.sh/github/uv/releases/download/#{version}/uv-armv7-unknown-linux-gnueabihf.tar.gz",
+     armv7l: "https://releases.astral.sh/github/uv/releases/download/#{version}/uv-armv7-unknown-linux-gnueabihf.tar.gz",
+       i686: "https://releases.astral.sh/github/uv/releases/download/#{version}/uv-i686-unknown-linux-gnu.tar.gz",
+     x86_64: "https://releases.astral.sh/github/uv/releases/download/#{version}/uv-x86_64-unknown-linux-gnu.tar.gz"
+  })
+  source_sha256({
+    aarch64: '7aa9ddc128f58c0e667227feb84e0aac3bb65301604c5f6f2ab0f442aaaafd99',
+     armv7l: '7aa9ddc128f58c0e667227feb84e0aac3bb65301604c5f6f2ab0f442aaaafd99',
+       i686: '9c77e5b5f2ad4151c6dc29db5511af549e205dbd6e836e544c80ebfadd7a07ec',
+     x86_64: '6681d691eb7f9c00ac6a3af54252f7ab29ae72f0c8f95bdc7f9d1401c23ea868'
+  })
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.install %w[uv uvx], "#{CREW_DEST_PREFIX}/bin", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'uv -h' to get started.\n"
+  end
+end

--- a/tests/package/u/uv
+++ b/tests/package/u/uv
@@ -1,0 +1,5 @@
+#!/bin/bash
+uv -h | head
+uv -V
+uvx -h | head
+uvx -V

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -9985,6 +9985,11 @@ url: https://github.com/uutils/coreutils/releases
 activity: medium
 ---
 kind: url
+name: uv
+url: https://github.com/astral-sh/uv/releases
+activity: high
+---
+kind: url
 name: uwsgi
 url: https://github.com/unbit/uwsgi/releases
 activity: medium


### PR DESCRIPTION
## Description
An extremely fast Python package and project manager, written in Rust.

Highlights
- A single tool to replace pip, pip-tools, pipx, poetry, pyenv, twine, virtualenv, and more.
- [10-100x faster](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md) than pip.
- Provides [comprehensive project management](https://github.com/astral-sh/uv#projects), with a [universal lockfile](https://docs.astral.sh/uv/concepts/projects/layout#the-lockfile).
- [Runs scripts](https://github.com/astral-sh/uv#scripts), with support for [inline dependency metadata](https://docs.astral.sh/uv/guides/scripts#declaring-script-dependencies).
- [Installs and manages](https://github.com/astral-sh/uv#python-versions) Python versions.
- [Runs and installs](https://github.com/astral-sh/uv#tools) tools published as Python packages.
- Includes a [pip-compatible interface](https://github.com/astral-sh/uv#the-pip-interface) for a performance boost with a familiar CLI.
- Supports Cargo-style [workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces) for scalable projects.
- Disk-space efficient, with a [global cache](https://docs.astral.sh/uv/concepts/cache) for dependency deduplication.
- Installable without Rust or Python via curl or pip.
- Supports macOS, Linux, and Windows.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-uv-package crew update \
&& yes | crew upgrade

$ crew check uv
Checking uv package ...
Library test for uv passed.
Checking uv package ...
An extremely fast Python package manager.

Usage: uv [OPTIONS] <COMMAND>

Commands:
  auth     Manage authentication
  run      Run a command or script
  init     Create a new project
  add      Add dependencies to the project
  remove   Remove dependencies from the project
uv 0.11.7 (x86_64-unknown-linux-gnu)
Run a command provided by a Python package.

Usage: uvx [OPTIONS] [COMMAND]

Options:
      --from <FROM>                            Use the given package to provide the command
  -w, --with <WITH>                            Run with the given packages installed
      --with-editable <WITH_EDITABLE>          Run with the given packages installed in editable mode
      --with-requirements <WITH_REQUIREMENTS>  Run with the packages listed in the given files
  -c, --constraints <CONSTRAINTS>              Constrain versions using the given requirements files [env: UV_CONSTRAINT=]
uvx 0.11.7 (x86_64-unknown-linux-gnu)
Package tests for uv passed.
```