### PR TITLE
Clean up a-g packages in CREW_ANITYA_PACKAGE_NAME_MAPPINGS

### DIFF
--- a/tools/version.rb
+++ b/tools/version.rb
@@ -63,29 +63,15 @@ CREW_UPDATER_EXCLUDED_PKGS = Set[
 # Some packages have different names in anitya.
 # TODO: As per the section in CONTRIBUTING.md, most of these can be replaced with Anitya-side package mappings.
 CREW_ANITYA_PACKAGE_NAME_MAPPINGS = Set[
-  { pkg_name: 'alsa_lib', anitya_pkg: 'alsa-lib', comments: '' },
-  { pkg_name: 'asdf', anitya_pkg: 'asdf-vm', comments: '' },
-  { pkg_name: 'broadway', anitya_pkg: 'gtk+3.0~stable', comments: '' },
-  { pkg_name: 'cf', anitya_pkg: 'cf', comments: 'Prefer to GitHub' },
-  { pkg_name: 'cups', anitya_pkg: 'cups', comments: 'Prefer to GitHub' },
-  { pkg_name: 'cvs', anitya_pkg: 'cvs-stable', comments: '' },
-  { pkg_name: 'docbook_xml51', anitya_pkg: 'docbook-xml', comments: '' },
-  { pkg_name: 'doxygen', anitya_pkg: 'doxygen', comments: '' },
-  { pkg_name: 'filecmd', anitya_pkg: 'file', comments: '' },
-  { pkg_name: 'gcr_3', anitya_pkg: 'gcr~3', comments: '' },
-  { pkg_name: 'gcr_4', anitya_pkg: 'gcr', comments: '' },
-  { pkg_name: 'gemacs', anitya_pkg: 'emacs', comments: '' },
-  { pkg_name: 'gexiv2', anitya_pkg: 'gexiv2~14.x', comments: '' },
-  { pkg_name: 'gnome_docking_library', anitya_pkg: 'gdl', comments: '' },
-  { pkg_name: 'gnu_time', anitya_pkg: 'time', comments: '' },
-  { pkg_name: 'go_tools', anitya_pkg: 'golang-x-tools', comments: '' },
-  { pkg_name: 'gsfonts', anitya_pkg: 'gs-fonts', comments: '' },
-  { pkg_name: 'gtk3', anitya_pkg: 'gtk+3.0~stable', comments: '' },
-  { pkg_name: 'gtk4', anitya_pkg: 'gtk', comments: '' },
-  { pkg_name: 'gtkmm4', anitya_pkg: 'gtkmm', comments: '' },
-  { pkg_name: 'gtksharp2', anitya_pkg: 'gtk-sharp', comments: '' },
-  { pkg_name: 'gtksourceview_5', anitya_pkg: 'gtksourceview', comments: '' },
-  { pkg_name: 'gvim', anitya_pkg: 'vim', comments: '' },
+  { pkg_name: 'alsa_lib', anitya_pkg: 'alsa-lib', comments: 'PackageUtils.get_clean_name mistakenly removes the _lib from the name' },
+  { pkg_name: 'asdf', anitya_pkg: 'asdf-vm', comments: 'Anitya has a pip package named asdf' },
+  { pkg_name: 'cvs', anitya_pkg: 'cvs-stable', comments: 'Anitya has a pip package named cvs' },
+  { pkg_name: 'gexiv2', anitya_pkg: 'gexiv2~14.x', comments: 'TODO: Why are we sticking to the 0.14.x release series?' },
+  { pkg_name: 'gnome_docking_library', anitya_pkg: 'gdl', comments: 'Anitya has two gdl packages, so this mapping doesnt work' },
+  { pkg_name: 'go_tools', anitya_pkg: 'golang-tools', comments: 'Anitya has a different package named go-tools' },
+  { pkg_name: 'gtk3', anitya_pkg: 'gtk+3.0~stable', comments: 'Anitya has Hackage, Rubygems, and CPAN (Perl) packages named gtk3' },
+  { pkg_name: 'gtk4', anitya_pkg: 'gtk', comments: 'Anitya has Rubygems and crate.io packages named gtk3' },
+  { pkg_name: 'gtksharp2', anitya_pkg: 'gtk-sharp', comments: 'The upstream Anitya package is mapped to gtk-sharp3 in other distros, but it is using the outdated mono/gtk-sharp repository so it is only getting the 2.x versions. Not sure what to do here.' },
   { pkg_name: 'hunspell_en_us', anitya_pkg: 'LibreOffice', comments: '' },
   { pkg_name: 'hunspell_es_any', anitya_pkg: 'LibreOffice', comments: '' },
   { pkg_name: 'hunspell_es_us', anitya_pkg: 'LibreOffice', comments: '' },
@@ -312,6 +298,9 @@ def get_anitya_id(name, homepage, buildsystem)
       next unless json2['items'][i]['distribution'] == 'Chromebrew'
       return get_anitya_id(json2['items'][i]['project'], homepage, buildsystem) if json2['items'][i]['name'] == name
     end
+
+    # We have an explicit return here so we don't end up returning 0..0 if that is the outcome of the loop above.
+    return
   else # Anitya has more than one package with this exact name.
     candidates = json['items']
 


### PR DESCRIPTION
## Description
Remove the redundant mappings, remove the mappings for packages marked as `no_upstream_update`, and explain the remaining mappings.

The only thing different as a result of this is that `go-tools` finds the correct version now, everything else returns the same Anitya ID.

Before:
```
Package  Status           Current      Upstream     Updatable?  Compile?  Autoupdate?
-------  ------           -------      --------     ----------  --------  -----------
cf       Outdated.        8.17.0       8.18.3       Yes         Yes       No
cups     Outdated.        2.4.16       2.4.17       Yes         Yes       No
doxygen  Up to date.      1.16.1       1.16.1       Yes         Yes       No
filecmd  Up to date.      5.47         5.47         Yes         Yes       Yes
gcr_3    Up to date.      3.41.2       3.41.2       Yes         Yes       No
gcr_4    Up to date.      4.4.0.1      4.4.0.1      Yes         Yes       No
gemacs   Outdated.        29.1         30.2         No          Yes       Yes
gnu_time Outdated.        1.9          1.10         No          Yes       No
go_tools Up to date.      0.39.0       0.21.1       Yes         Yes       No
gsfonts  Not Found.       8.11                      No          Yes       No
gvim     Outdated.        9.2.0265     9.2.0360     No          Yes       No
```

After:
```
Package  Status           Current      Upstream     Updatable?  Compile?  Autoupdate?
-------  ------           -------      --------     ----------  --------  -----------
cf       Outdated.        8.17.0       8.18.3       Yes         Yes       No
cups     Outdated.        2.4.16       2.4.17       Yes         Yes       No
doxygen  Up to date.      1.16.1       1.16.1       Yes         Yes       No
filecmd  Up to date.      5.47         5.47         Yes         Yes       Yes
gcr_3    Up to date.      3.41.2       3.41.2       Yes         Yes       No
gcr_4    Up to date.      4.4.0.1      4.4.0.1      Yes         Yes       No
gemacs   Outdated.        29.1         30.2         No          Yes       Yes
gnu_time Outdated.        1.9          1.10         No          Yes       No
go_tools Outdated.        0.39.0       0.44.0       Yes         Yes       No
gsfonts  Up to date.      8.11         8.11         No          Yes       No
gvim     Outdated.        9.2.0265     9.2.0360     No          Yes       No
```

This also fixes this issue:
```
tools/version.rb:167:in 'Object#get_version': undefined method '[]' for nil (NoMethodError)

    return json['latest_version'] if json['stable_versions'][0].nil?
                                                            ^^^
	from tools/version.rb:521:in 'block in <main>'
	from tools/version.rb:462:in 'Array#each'
	from tools/version.rb:462:in '<main>'
```

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=void crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
