### PR TITLE
Cfitsio 4.3.0 => 4.6.3

### DIFF
--- a/manifest/armv7l/c/cfitsio.filelist
+++ b/manifest/armv7l/c/cfitsio.filelist
@@ -1,18 +1,21 @@
-# Total size: 7474766
+# Total size: 1709850
 /usr/local/bin/cookbook
 /usr/local/bin/fitscopy
+/usr/local/bin/fitsverify
 /usr/local/bin/fpack
 /usr/local/bin/funpack
 /usr/local/bin/imcopy
 /usr/local/bin/smem
 /usr/local/bin/speed
-/usr/local/bin/testprog
-/usr/local/include/drvrsmem.h
+/usr/local/include/cfitsio_export.h
 /usr/local/include/fitsio.h
 /usr/local/include/fitsio2.h
 /usr/local/include/longnam.h
-/usr/local/lib/libcfitsio.a
+/usr/local/lib/cmake/cfitsio/cfitsioConfig.cmake
+/usr/local/lib/cmake/cfitsio/cfitsioConfigVersion.cmake
+/usr/local/lib/cmake/cfitsio/cfitsioTargets-release.cmake
+/usr/local/lib/cmake/cfitsio/cfitsioTargets.cmake
 /usr/local/lib/libcfitsio.so
 /usr/local/lib/libcfitsio.so.10
-/usr/local/lib/libcfitsio.so.10.4.3.0
+/usr/local/lib/libcfitsio.so.4.6.3
 /usr/local/lib/pkgconfig/cfitsio.pc

--- a/manifest/i686/c/cfitsio.filelist
+++ b/manifest/i686/c/cfitsio.filelist
@@ -1,18 +1,21 @@
-# Total size: 7029386
+# Total size: 2700982
 /usr/local/bin/cookbook
 /usr/local/bin/fitscopy
+/usr/local/bin/fitsverify
 /usr/local/bin/fpack
 /usr/local/bin/funpack
 /usr/local/bin/imcopy
 /usr/local/bin/smem
 /usr/local/bin/speed
-/usr/local/bin/testprog
-/usr/local/include/drvrsmem.h
+/usr/local/include/cfitsio_export.h
 /usr/local/include/fitsio.h
 /usr/local/include/fitsio2.h
 /usr/local/include/longnam.h
-/usr/local/lib/libcfitsio.a
+/usr/local/lib/cmake/cfitsio/cfitsioConfig.cmake
+/usr/local/lib/cmake/cfitsio/cfitsioConfigVersion.cmake
+/usr/local/lib/cmake/cfitsio/cfitsioTargets-release.cmake
+/usr/local/lib/cmake/cfitsio/cfitsioTargets.cmake
 /usr/local/lib/libcfitsio.so
 /usr/local/lib/libcfitsio.so.10
-/usr/local/lib/libcfitsio.so.10.4.3.0
+/usr/local/lib/libcfitsio.so.4.6.3
 /usr/local/lib/pkgconfig/cfitsio.pc

--- a/manifest/x86_64/c/cfitsio.filelist
+++ b/manifest/x86_64/c/cfitsio.filelist
@@ -1,18 +1,21 @@
-# Total size: 7376190
+# Total size: 2495078
 /usr/local/bin/cookbook
 /usr/local/bin/fitscopy
+/usr/local/bin/fitsverify
 /usr/local/bin/fpack
 /usr/local/bin/funpack
 /usr/local/bin/imcopy
 /usr/local/bin/smem
 /usr/local/bin/speed
-/usr/local/bin/testprog
-/usr/local/include/drvrsmem.h
+/usr/local/include/cfitsio_export.h
 /usr/local/include/fitsio.h
 /usr/local/include/fitsio2.h
 /usr/local/include/longnam.h
-/usr/local/lib64/libcfitsio.a
+/usr/local/lib64/cmake/cfitsio/cfitsioConfig.cmake
+/usr/local/lib64/cmake/cfitsio/cfitsioConfigVersion.cmake
+/usr/local/lib64/cmake/cfitsio/cfitsioTargets-release.cmake
+/usr/local/lib64/cmake/cfitsio/cfitsioTargets.cmake
 /usr/local/lib64/libcfitsio.so
 /usr/local/lib64/libcfitsio.so.10
-/usr/local/lib64/libcfitsio.so.10.4.3.0
+/usr/local/lib64/libcfitsio.so.4.6.3
 /usr/local/lib64/pkgconfig/cfitsio.pc

--- a/packages/cfitsio.rb
+++ b/packages/cfitsio.rb
@@ -1,33 +1,23 @@
-require 'buildsystems/autotools'
+require 'buildsystems/cmake'
 
-class Cfitsio < Autotools
+class Cfitsio < CMake
   description 'A library of C and Fortran subroutines for reading and writing data files in FITS Flexible Image Transport System data format'
   homepage 'https://heasarc.gsfc.nasa.gov/fitsio/'
-  version '4.3.0'
+  version '4.6.3'
   license 'ISC'
   compatibility 'all'
-  source_url 'https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.3.0.tar.gz'
-  source_sha256 '734ab0198714fe43eab94a67d6987085bde5573e6babde4d05799a8d04ebb04c'
+  source_url "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-#{version}.tar.gz"
+  source_sha256 'fad44fff274fdda5ffcc0c0fff3bc3c596362722b9292fc8944db91187813600'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e20497a3684e21bf81000fc303fb0ade188df0f2068cc7918e0a534732d37a40',
-     armv7l: 'e20497a3684e21bf81000fc303fb0ade188df0f2068cc7918e0a534732d37a40',
-       i686: '8dadcdebac97e67bfe8f6f5fa8cfbc2cdf5a90e76015b69b0c47bd649f1d53bb',
-     x86_64: 'ff5400768a004da517c07aa25334aec8e4caf4b7cc761202dba3b068913baf2b'
+    aarch64: '893c4305e83b2257ccae7a7695a7816a4b6b66960eb6f43136e230002d3713cf',
+     armv7l: '893c4305e83b2257ccae7a7695a7816a4b6b66960eb6f43136e230002d3713cf',
+       i686: '60c458e9588a54b77128f2021d246415bfe6c72484bd45733f01bb492f9ca29f',
+     x86_64: '2bf2f306ed51f38e1a544da2dc6bdae4b79538bec181bdc13e70e0cca8619bbe'
   })
 
-  def self.patch
-    system "sed -e 's|LDFLAGS=.*|LDFLAGS=$LDFLAGS|g' -i configure.in" # Fix LDFLAGS
-  end
-
-  def self.build
-    system 'autoreconf -vi'
-    system "CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_CONFIGURE_OPTIONS} --enable-reentrant"
-    system 'make shared'
-    system 'make utils'
-  end
+  depends_on 'curl' => :library
+  depends_on 'glibc' => :library
+  depends_on 'zlib' => :library
 end

--- a/tests/package/c/cfitsio
+++ b/tests/package/c/cfitsio
@@ -1,0 +1,6 @@
+#!/bin/bash
+fitsverify -h | head
+fpack -H | head
+fpack -V
+funpack -H | head
+funpack -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-cfitsio crew update \
&& yes | crew upgrade

$ crew check cfitsio 
Checking cfitsio package ...
Library test for cfitsio passed.
Checking cfitsio package ...
fitsverify -- Verify that the input files conform to the FITS Standard.

USAGE:   fitsverify filename ...  - verify one or more FITS files
                                    (may use wildcard characters)
   or    fitsverify @filelist.txt - verify a list of FITS files
      
   Optional flags:
          -H  test ESO HIERARCH keywords
          -l  list all header keywords
          -q  quiet; print one-line pass/fail summary per file
fpack, a FITS image compression program.  Version 1.7.0 (Dec 2013) CFITSIO version 4.060
usage: fpack [-r|-h|-g|-p] [-w|-t <axes>] [-q <level>] [-s <scale>] [-n <noise>] -v <FITS>
more:   [-T] [-R] [-F] [-D] [-Y] [-O <file>] [-S] [-L] [-C] [-H] [-V] [-i2f]

NOTE: the compression parameters specified on the fpack command line may
be over-ridden by compression directive keywords in the header of each HDU
of the input file(s). See the fpack User's Guide for more details

Flags must be separate and appear before filenames:
 -r          Rice compression [default], or
1.7.0 (Dec 2013) CFITSIO version 4.060
funpack, decompress fpacked files.  Version 1.7.0 (Dec 2013) CFITSIO version 4.060
usage: funpack [-E <HDUlist>] [-P <pre>] [-O <name>] [-Z] -v <FITS>
more:   [-F] [-D] [-S] [-L] [-C] [-H] [-V] 

Flags must be separate and appear before filenames:
 -E <HDUlist> Unpack only the list of HDU names or numbers in the file.
 -P <pre>    Prepend <pre> to create new output filenames.
 -O <name>   Specify full output file name.
 -Z          Recompress the output file with host GZIP program.
 -F          Overwrite input file by output file with same name.
1.7.0 (Dec 2013) CFITSIO version 4.060
Package tests for cfitsio passed.
```