### PR TITLE
Cf 8.17.0 => 8.18.3

### DIFF
--- a/manifest/i686/c/cf.filelist
+++ b/manifest/i686/c/cf.filelist
@@ -1,4 +1,4 @@
-# Total size: 25657402
+# Total size: 25473688
 /usr/local/bin/cf
-/usr/local/etc/bash.d/cf
+/usr/local/etc/bash.d/10-cf
 /usr/local/share/cf/bash-completion/cf.bash

--- a/manifest/x86_64/c/cf.filelist
+++ b/manifest/x86_64/c/cf.filelist
@@ -1,4 +1,4 @@
-# Total size: 27168446
+# Total size: 27320984
 /usr/local/bin/cf
-/usr/local/etc/bash.d/cf
+/usr/local/etc/bash.d/10-cf
 /usr/local/share/cf/bash-completion/cf.bash

--- a/packages/cf.rb
+++ b/packages/cf.rb
@@ -3,39 +3,38 @@ require 'package'
 class Cf < Package
   description 'The official command line client for Cloud Foundry'
   homepage 'https://docs.cloudfoundry.org/cf-cli/'
-  version '8.17.0'
+  version '8.18.3'
   license 'Apache-2.0'
   compatibility 'i686 x86_64'
-  case ARCH
-  when 'i686'
-    source_url "https://github.com/cloudfoundry/cli/releases/download/v#{version}/cf8-cli_#{version}_linux_i686.tgz"
-    source_sha256 '92d2960b950d16387c8fa9c8d5e279708930734daa5cf2ba905e0b640ed4799d'
-  when 'x86_64'
-    source_url "https://github.com/cloudfoundry/cli/releases/download/v#{version}/cf8-cli_#{version}_linux_x86-64.tgz"
-    source_sha256 '922b91e5651d141ff8756e631adc613c820610c84dcae6cb59f57e22ae073112'
-  end
-  binary_compression 'tar.zst'
-
-  binary_sha256({
-       i686: '29ceffd87acb1dd0f9a315e3ccd595e8a95fd74ef1c74f28eb23aa3d9b43388f',
-     x86_64: 'b4c73807c554f1d2c88fe6c57490d81e177beb538e0c37a9d7d252265fa71b38'
+  source_url({
+      i686: "https://github.com/cloudfoundry/cli/releases/download/v#{version}/cf8-cli_#{version}_linux_i686.tgz",
+    x86_64: "https://github.com/cloudfoundry/cli/releases/download/v#{version}/cf8-cli_#{version}_linux_x86-64.tgz"
+  })
+  source_sha256({
+      i686: '911a9206d288ae31b0c51d80d8430d98c326cf5cf938d326a34563f6554c5251',
+    x86_64: '8942e2c3c98e83c7e14edbce939876bba7ff12a26f0f722c5aa5b079d357d50b'
   })
 
-  def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin/"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d/"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/cf/bash-completion/"
-    FileUtils.install 'cf', "#{CREW_DEST_PREFIX}/bin/cf", mode: 0o755
+  no_compile_needed
+  print_source_bashrc
+
+  def self.build
     # There isn't a version for cf8...
-    downloader 'https://raw.githubusercontent.com/cloudfoundry/cli-ci/main/ci/installers/completion/cf7', '7ee78e471d6924b81e9062083e1ad13be2b18e70135a7cc9da9b75f5984c0fee', 'cf.bash'
+    downloader 'https://raw.githubusercontent.com/cloudfoundry/cli-ci/main/ci/installers/completion/cf7',
+               '7ee78e471d6924b81e9062083e1ad13be2b18e70135a7cc9da9b75f5984c0fee', 'cf.bash'
     cf_major_version = version.split('.').first
     file = File.read('cf.bash')
     file.sub!('cf7', "cf#{cf_major_version}")
     File.write('cf.bash', file)
-    FileUtils.install 'cf.bash', "#{CREW_DEST_PREFIX}/share/cf/bash-completion/cf.bash", mode: 0o644
-    File.write "#{CREW_DEST_PREFIX}/etc/bash.d/cf", <<~EOF
+    File.write '10-cf', <<~EOF
       # Cloud Foundry CLI configuration
       source #{CREW_PREFIX}/share/cf/bash-completion/cf.bash
     EOF
+  end
+
+  def self.install
+    FileUtils.install 'cf', "#{CREW_DEST_PREFIX}/bin/cf", mode: 0o755
+    FileUtils.install '10-cf', "#{CREW_DEST_PREFIX}/etc/bash.d/10-cf", mode: 0o644
+    FileUtils.install 'cf.bash', "#{CREW_DEST_PREFIX}/share/cf/bash-completion/cf.bash", mode: 0o644
   end
 end

--- a/tests/package/c/cf
+++ b/tests/package/c/cf
@@ -1,0 +1,3 @@
+#!/bin/bash
+cf -h | head
+cf -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-cf crew update \
&& yes | crew upgrade

$ crew check cf
Checking cf package ...
Library test for cf passed.
Checking cf package ...
cf version 8.18.3+83ce51d.2026-04-16, Cloud Foundry command line tool
Usage: cf [global options] command [arguments...] [command options]

Before getting started:
  config    login,l      target,t
  help,h    logout,lo    

Application lifecycle:
  apps,a        run-task,rt    events
  push,p        logs           set-env,se
cf version 8.18.3+83ce51d.2026-04-16
Package tests for cf passed.
```