### PR TITLE
Cheat 4.4.2 => 5.1.0

### DIFF
--- a/manifest/armv7l/c/cheat.filelist
+++ b/manifest/armv7l/c/cheat.filelist
@@ -1,1 +1,2 @@
+# Total size: 12714164
 /usr/local/bin/cheat

--- a/manifest/i686/c/cheat.filelist
+++ b/manifest/i686/c/cheat.filelist
@@ -1,1 +1,2 @@
+# Total size: 12736484
 /usr/local/bin/cheat

--- a/manifest/x86_64/c/cheat.filelist
+++ b/manifest/x86_64/c/cheat.filelist
@@ -1,1 +1,2 @@
+# Total size: 13369608
 /usr/local/bin/cheat

--- a/packages/cheat.rb
+++ b/packages/cheat.rb
@@ -3,7 +3,7 @@ require 'package'
 class Cheat < Package
   description 'Create and view interactive cheatsheets on the command-line.'
   homepage 'https://github.com/cheat/cheat'
-  version '4.4.2'
+  version '5.1.0'
   license 'MIT'
   compatibility 'all'
   min_glibc '2.32' if ARCH.eql?('x86_64')
@@ -14,10 +14,10 @@ class Cheat < Package
      x86_64: "https://github.com/cheat/cheat/releases/download/#{version}/cheat-linux-amd64.gz"
   })
   source_sha256({
-    aarch64: '52ca1e355f46ae36b04717e431ef03b6158e41d1df0c3cf381abe36a147dfe43',
-     armv7l: '52ca1e355f46ae36b04717e431ef03b6158e41d1df0c3cf381abe36a147dfe43',
-       i686: '1ee7f6b4b40447684c80f3920b1841cb54d9f3f8cd543671c2453c34769cdde1',
-     x86_64: 'b81f5ba21f134087c0294d809f89e5442d641d7be297bb128807cbce00849e9b'
+    aarch64: '1b01797e1ccb482562eaa1b704379373f1fec12657c142443467fefcda09826d',
+     armv7l: '1b01797e1ccb482562eaa1b704379373f1fec12657c142443467fefcda09826d',
+       i686: '586794f83d13fbb08c47bce47ecdba2e6934becd6bbcfe34e10b584ef5a0c758',
+     x86_64: '8c8405574d51d63ee89594bfed241f478d507d96af78e5c370dcbe65633d7b34'
   })
 
   depends_on 'xdg_base'

--- a/tests/package/c/cheat
+++ b/tests/package/c/cheat
@@ -1,0 +1,3 @@
+#!/bin/bash
+cheat -h | head
+cheat -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-cheat crew update \
&& yes | crew upgrade

$ crew check cheat 
Checking cheat package ...
Library test for cheat passed.
Checking cheat package ...
cheat allows you to create and view interactive cheatsheets on the
command-line. It was designed to help remind *nix system administrators of
options for commands that they use frequently, but not frequently enough to
remember.

Usage:
  cheat [cheatsheet] [flags]

Examples:
  To initialize a config file:
5.1.0
Package tests for cheat passed.
```