### PR TITLE
Chromaprint 1.5.1-aa67c95-1 => 1.6.0

### DIFF
--- a/manifest/armv7l/c/chromaprint.filelist
+++ b/manifest/armv7l/c/chromaprint.filelist
@@ -1,7 +1,11 @@
-# Total size: 66100
+# Total size: 84819
 /usr/local/bin/fpcalc
 /usr/local/include/chromaprint.h
+/usr/local/lib/cmake/Chromaprint/ChromaprintConfig.cmake
+/usr/local/lib/cmake/Chromaprint/ChromaprintConfigVersion.cmake
+/usr/local/lib/cmake/Chromaprint/ChromaprintTargets-release.cmake
+/usr/local/lib/cmake/Chromaprint/ChromaprintTargets.cmake
 /usr/local/lib/libchromaprint.so
 /usr/local/lib/libchromaprint.so.1
-/usr/local/lib/libchromaprint.so.1.5.1
+/usr/local/lib/libchromaprint.so.1.6.0
 /usr/local/lib/pkgconfig/libchromaprint.pc

--- a/manifest/x86_64/c/chromaprint.filelist
+++ b/manifest/x86_64/c/chromaprint.filelist
@@ -1,7 +1,11 @@
-# Total size: 83104
+# Total size: 111939
 /usr/local/bin/fpcalc
 /usr/local/include/chromaprint.h
+/usr/local/lib64/cmake/Chromaprint/ChromaprintConfig.cmake
+/usr/local/lib64/cmake/Chromaprint/ChromaprintConfigVersion.cmake
+/usr/local/lib64/cmake/Chromaprint/ChromaprintTargets-release.cmake
+/usr/local/lib64/cmake/Chromaprint/ChromaprintTargets.cmake
 /usr/local/lib64/libchromaprint.so
 /usr/local/lib64/libchromaprint.so.1
-/usr/local/lib64/libchromaprint.so.1.5.1
+/usr/local/lib64/libchromaprint.so.1.6.0
 /usr/local/lib64/pkgconfig/libchromaprint.pc

--- a/packages/chromaprint.rb
+++ b/packages/chromaprint.rb
@@ -1,37 +1,26 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Chromaprint < Package
+class Chromaprint < CMake
   description 'Chromaprint is a client-side library that implements a custom algorithm for extracting fingerprints from any audio source.'
   homepage 'https://acoustid.org/chromaprint'
-  version '1.5.1-aa67c95-1'
+  version '1.6.0'
   license 'LGPL-2.1'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/acoustid/chromaprint.git'
-  git_hashtag 'aa67c95b9e486884a6d3ee8b0c91207d8c2b0551'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '50ac01fa69b92c8a140a3ab02c26cfcb9974a2e4917d626ca523a2b22edb775f',
-     armv7l: '50ac01fa69b92c8a140a3ab02c26cfcb9974a2e4917d626ca523a2b22edb775f',
-     x86_64: '05f5a2e30fcbd6ccc344388701b9b2e27a867d2d7e0fe39f71a9a989cee7aa23'
+    aarch64: '0ec5001fb45e2c2c422c1237459649c4ba030af3391927d20f9bb92f115f555e',
+     armv7l: '0ec5001fb45e2c2c422c1237459649c4ba030af3391927d20f9bb92f115f555e',
+     x86_64: '8dd5d84eecb9076122aa19f63e324c5fbc97e9bd97809f1f849e93f3637ed802'
   })
 
-  depends_on 'ffmpeg' => :build
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
+  depends_on 'ffmpeg' => :library
+  depends_on 'fftw' => :library
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'libvpx' => :library
 
-  def self.build
-    system "cmake -B builddir -G Ninja #{CREW_CMAKE_LIBSUFFIX_OPTIONS} \
-      -DBUILD_TOOLS=ON \
-      -DBUILD_TESTS=ON"
-    system "#{CREW_NINJA} -C builddir"
-  end
-
-  def self.check
-    system "#{CREW_NINJA} -C builddir check"
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-  end
+  cmake_options '-DBUILD_TOOLS=ON -DBUILD_TESTS=ON'
 end

--- a/tests/package/c/chromaprint
+++ b/tests/package/c/chromaprint
@@ -1,0 +1,3 @@
+#!/bin/bash
+fpcalc -h | head
+fpcalc -version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-chromaprint crew update \
&& yes | crew upgrade

$ crew check chromaprint 
Checking chromaprint package ...
Library test for chromaprint passed.
Checking chromaprint package ...
Usage: fpcalc [OPTIONS] FILE [FILE...]

Generate fingerprints from audio files/streams.

Options:
  -format NAME   Set the input format name
  -rate NUM      Set the sample rate of the input audio
  -channels NUM  Set the number of channels in the input audio
  -length SECS   Restrict the duration of the processed input audio (default 120)
  -chunk SECS    Split the input audio into chunks of this duration
fpcalc version 1.6.0 (FFmpeg Lavc62.11.100 Lavf62.3.100 SwR6.1.100)
Package tests for chromaprint passed.
```