### PR TITLE
Civetweb 1.13 => 1.16

### DIFF
--- a/manifest/armv7l/c/civetweb.filelist
+++ b/manifest/armv7l/c/civetweb.filelist
@@ -1,12 +1,17 @@
-# Total size: 331936
+# Total size: 280637
 /usr/local/bin/civetweb
 /usr/local/include/CivetServer.h
 /usr/local/include/civetweb.h
+/usr/local/lib/cmake/civetweb/FindLibDl.cmake
+/usr/local/lib/cmake/civetweb/FindLibRt.cmake
+/usr/local/lib/cmake/civetweb/FindWinSock.cmake
 /usr/local/lib/cmake/civetweb/civetweb-config-version.cmake
 /usr/local/lib/cmake/civetweb/civetweb-config.cmake
 /usr/local/lib/cmake/civetweb/civetweb-targets-release.cmake
 /usr/local/lib/cmake/civetweb/civetweb-targets.cmake
 /usr/local/lib/libcivetweb-cpp.so
-/usr/local/lib/libcivetweb-cpp.so.1.13.0
+/usr/local/lib/libcivetweb-cpp.so.1.15.0
 /usr/local/lib/libcivetweb.so
-/usr/local/lib/libcivetweb.so.1.13.0
+/usr/local/lib/libcivetweb.so.1.15.0
+/usr/local/share/pkgconfig/civetweb-cpp.pc
+/usr/local/share/pkgconfig/civetweb.pc

--- a/manifest/i686/c/civetweb.filelist
+++ b/manifest/i686/c/civetweb.filelist
@@ -1,12 +1,17 @@
-# Total size: 362520
+# Total size: 361681
 /usr/local/bin/civetweb
 /usr/local/include/CivetServer.h
 /usr/local/include/civetweb.h
+/usr/local/lib/cmake/civetweb/FindLibDl.cmake
+/usr/local/lib/cmake/civetweb/FindLibRt.cmake
+/usr/local/lib/cmake/civetweb/FindWinSock.cmake
 /usr/local/lib/cmake/civetweb/civetweb-config-version.cmake
 /usr/local/lib/cmake/civetweb/civetweb-config.cmake
 /usr/local/lib/cmake/civetweb/civetweb-targets-release.cmake
 /usr/local/lib/cmake/civetweb/civetweb-targets.cmake
 /usr/local/lib/libcivetweb-cpp.so
-/usr/local/lib/libcivetweb-cpp.so.1.13.0
+/usr/local/lib/libcivetweb-cpp.so.1.15.0
 /usr/local/lib/libcivetweb.so
-/usr/local/lib/libcivetweb.so.1.13.0
+/usr/local/lib/libcivetweb.so.1.15.0
+/usr/local/share/pkgconfig/civetweb-cpp.pc
+/usr/local/share/pkgconfig/civetweb.pc

--- a/manifest/x86_64/c/civetweb.filelist
+++ b/manifest/x86_64/c/civetweb.filelist
@@ -1,12 +1,17 @@
-# Total size: 366592
+# Total size: 349059
 /usr/local/bin/civetweb
 /usr/local/include/CivetServer.h
 /usr/local/include/civetweb.h
+/usr/local/lib64/cmake/civetweb/FindLibDl.cmake
+/usr/local/lib64/cmake/civetweb/FindLibRt.cmake
+/usr/local/lib64/cmake/civetweb/FindWinSock.cmake
 /usr/local/lib64/cmake/civetweb/civetweb-config-version.cmake
 /usr/local/lib64/cmake/civetweb/civetweb-config.cmake
 /usr/local/lib64/cmake/civetweb/civetweb-targets-release.cmake
 /usr/local/lib64/cmake/civetweb/civetweb-targets.cmake
 /usr/local/lib64/libcivetweb-cpp.so
-/usr/local/lib64/libcivetweb-cpp.so.1.13.0
+/usr/local/lib64/libcivetweb-cpp.so.1.15.0
 /usr/local/lib64/libcivetweb.so
-/usr/local/lib64/libcivetweb.so.1.13.0
+/usr/local/lib64/libcivetweb.so.1.15.0
+/usr/local/share/pkgconfig/civetweb-cpp.pc
+/usr/local/share/pkgconfig/civetweb.pc

--- a/packages/civetweb.rb
+++ b/packages/civetweb.rb
@@ -1,43 +1,32 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Civetweb < Package
+class Civetweb < CMake
   description 'Embedded C/C++ web server'
   homepage 'https://github.com/civetweb/civetweb/'
-  version '1.13'
+  version '1.16'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/civetweb/civetweb/archive/v1.13.tar.gz'
-  source_sha256 'a7ccc76c2f1b5f4e8d855eb328ed542f8fe3b882a6da868781799a98f4acdedc'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/civetweb/civetweb.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a9c69122c495afd89473928171d8b6528d8d1980d136cc16160733a317e21704',
-     armv7l: 'a9c69122c495afd89473928171d8b6528d8d1980d136cc16160733a317e21704',
-       i686: '856eeb6d5543fe03baec996f21324ad0bb14bc0a2e9c080d61cf33614697a36d',
-     x86_64: 'a314284c9ea9b1f3190174645c5c13872387520dc1877a3fb7eb5397916b8bed'
+    aarch64: '5fb14b489952ec14441dfb8d46963c7a649212e771f38348d4c543ea0a884914',
+     armv7l: '5fb14b489952ec14441dfb8d46963c7a649212e771f38348d4c543ea0a884914',
+       i686: '7510b42696d93f2e6758a108d468de165e87d786da4e4593e648f374175bfc44',
+     x86_64: '0882f5f23adf43bb16669240e5996cbe97ffe737e711838c57109d0a69803403'
   })
 
-  def self.build
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "cmake -G 'Ninja' #{CREW_CMAKE_OPTIONS} \
-		          -DBUILD_TESTING=OFF \
-		          -DBUILD_SHARED_LIBS=ON \
-		          -DCIVETWEB_BUILD_TESTING=OFF \
-		          -DCIVETWEB_ENABLE_LUA=OFF \
-		          -DCIVETWEB_ENABLE_DUKTAPE=OFF \
-		          -DCIVETWEB_ENABLE_CXX=ON \
-		          -DCIVETWEB_ENABLE_SERVER_EXECUTABLE=ON \
-		          -DCIVETWEB_ENABLE_SSL=ON .."
-      system 'ninja'
-    end
-  end
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
 
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
-
-  def self.check
-    system 'ninja -C builddir test'
-  end
+  cmake_options '-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCIVETWEB_BUILD_TESTING=OFF \
+    -DCIVETWEB_ENABLE_LUA=OFF \
+    -DCIVETWEB_ENABLE_DUKTAPE=OFF \
+    -DCIVETWEB_ENABLE_CXX=ON \
+    -DCIVETWEB_ENABLE_SERVER_EXECUTABLE=ON \
+    -DCIVETWEB_ENABLE_SSL=ON'
 end

--- a/tests/package/c/civetweb
+++ b/tests/package/c/civetweb
@@ -1,0 +1,2 @@
+#!/bin/bash
+civetweb -h 2>&1 | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-civetweb crew update \
&& yes | crew upgrade

$ crew check civetweb
Checking civetweb package ...
Library test for civetweb passed.
Checking civetweb package ...
CivetWeb v1.16, built on Apr 24 2026

Usage:
  Start server with a set of options:
    civetweb [config_file]
    civetweb [-option value ...]
  Run as client:
    civetweb -C url
  Show system information:
    civetweb -I
Package tests for civetweb passed.
```