### PR TITLE
Clib 1.8.1 => 2.8.7

### DIFF
--- a/manifest/armv7l/c/clib.filelist
+++ b/manifest/armv7l/c/clib.filelist
@@ -1,5 +1,11 @@
-# Total size: 865324
+# Total size: 468380
 /usr/local/bin/clib
+/usr/local/bin/clib-build
+/usr/local/bin/clib-configure
+/usr/local/bin/clib-init
 /usr/local/bin/clib-install
 /usr/local/bin/clib-search
+/usr/local/bin/clib-uninstall
+/usr/local/bin/clib-update
+/usr/local/bin/clib-upgrade
 /usr/local/bin/cpm

--- a/manifest/i686/c/clib.filelist
+++ b/manifest/i686/c/clib.filelist
@@ -1,5 +1,11 @@
-# Total size: 798636
+# Total size: 646648
 /usr/local/bin/clib
+/usr/local/bin/clib-build
+/usr/local/bin/clib-configure
+/usr/local/bin/clib-init
 /usr/local/bin/clib-install
 /usr/local/bin/clib-search
+/usr/local/bin/clib-uninstall
+/usr/local/bin/clib-update
+/usr/local/bin/clib-upgrade
 /usr/local/bin/cpm

--- a/manifest/x86_64/c/clib.filelist
+++ b/manifest/x86_64/c/clib.filelist
@@ -1,5 +1,11 @@
-# Total size: 977488
+# Total size: 694720
 /usr/local/bin/clib
+/usr/local/bin/clib-build
+/usr/local/bin/clib-configure
+/usr/local/bin/clib-init
 /usr/local/bin/clib-install
 /usr/local/bin/clib-search
+/usr/local/bin/clib-uninstall
+/usr/local/bin/clib-update
+/usr/local/bin/clib-upgrade
 /usr/local/bin/cpm

--- a/packages/clib.rb
+++ b/packages/clib.rb
@@ -1,31 +1,32 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Clib < Package
+class Clib < Autotools
   description 'C package manager-ish'
   homepage 'https://github.com/clibs/clib'
-  version '1.8.1'
+  version '2.8.7'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/clibs/clib/archive/1.8.1.tar.gz'
-  source_sha256 'f5718e316771571971cb4e5a0142f91b47c6bfe32997fd869fc5a90ec091a066'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/clibs/clib.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2e9535f72f2b36bef76aa7cbd17b4264652d94f9c46408c81a6d1400df379851',
-     armv7l: '2e9535f72f2b36bef76aa7cbd17b4264652d94f9c46408c81a6d1400df379851',
-       i686: '5923d5873728497d41d187697bc6ad1daeef621a6c1deecae728083a65ac2388',
-     x86_64: '06c1bac595387b7eeb3e2fddd64c94d3ef6394492e4315f4604e4c4f719efeb9'
+    aarch64: 'e012bd99c11f7c1d8bbfca3143dbe8431cde6dec12772fb05691bfca1d3d5f72',
+     armv7l: 'e012bd99c11f7c1d8bbfca3143dbe8431cde6dec12772fb05691bfca1d3d5f72',
+       i686: '3b97511ce7043ead923a635b150b596dc5582e4e4cc37c27a3bf64734b661bcd',
+     x86_64: 'fee509e32859c3be85c6ee2fe8315351c76033a4c8ab8326aa68f0c879c687f1'
   })
 
-  depends_on 'curl'
+  depends_on 'curl' => :executable
+  depends_on 'glibc' => :executable
 
-  def self.build
+  def self.patch
     system "sed -i 's,PREFIX ?= /usr/local,PREFIX ?= #{CREW_DEST_PREFIX},' Makefile"
-    system 'make'
   end
 
-  def self.install
-    system 'make install'
-    system "ln -s #{CREW_PREFIX}/bin/clib #{CREW_DEST_PREFIX}/bin/cpm"
+  autotools_skip_configure
+
+  autotools_install_extras do
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/clib", "#{CREW_DEST_PREFIX}/bin/cpm"
   end
 end

--- a/tests/package/c/clib
+++ b/tests/package/c/clib
@@ -1,0 +1,2 @@
+#!/bin/bash
+for b in $(crew files clib | grep /usr/local/bin); do $b -V; done


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-clib crew update \
&& yes | crew upgrade

$ crew check clib
Checking clib package ...
Library test for clib passed.
Checking clib package ...
2.8.7
2.8.7
2.8.7
2.8.7
2.8.7
2.8.7
2.8.7
2.8.7
2.8.7
2.8.7
Package tests for clib passed.
```