### PR TITLE
Clickhouse 25.11.2.24 => 25.12.10.7-stable

### DIFF
--- a/manifest/x86_64/c/clickhouse.filelist
+++ b/manifest/x86_64/c/clickhouse.filelist
@@ -1,4 +1,4 @@
-# Total size: 704507874
+# Total size: 763558090
 /usr/local/bin/clickhouse
 /usr/local/bin/clickhouse-extract-from-config
 /usr/local/etc/env.d/10-clickhouse

--- a/packages/clickhouse.rb
+++ b/packages/clickhouse.rb
@@ -3,11 +3,11 @@ require 'package'
 class Clickhouse < Package
   description 'Real-time analytics DBMS'
   homepage 'https://clickhouse.com/'
-  version '25.11.2.24'
+  version '25.12.10.7-stable'
   license 'Apache-2.0'
   compatibility 'x86_64'
-  source_url "https://github.com/ClickHouse/ClickHouse/releases/download/v#{version}-stable/clickhouse-common-static-#{version}-amd64.tgz"
-  source_sha256 '2f2f40828c5683a6b3e3624a4e382bda79651d93eb04ce627748b29080a8abbf'
+  source_url "https://github.com/ClickHouse/ClickHouse/releases/download/v#{version}/clickhouse-common-static-#{version.split('-')[0]}-amd64.tgz"
+  source_sha256 'b6b194c5d1386cf69113fc8941bac499b2d10bd1895ec31b5b5d904eb9de5d4c'
 
   no_compile_needed
   no_shrink

--- a/tests/package/c/clickhouse
+++ b/tests/package/c/clickhouse
@@ -1,0 +1,3 @@
+#!/bin/bash
+clickhouse --help 2>&1 | head
+clickhouse -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-clickhouse crew update \
&& yes | crew upgrade

$ crew check clickhouse 
Checking clickhouse package ...
Library test for clickhouse passed.
Checking clickhouse package ...
Use one of the following commands:
clickhouse local [args] 
clickhouse client [args] 
clickhouse chdig [args] 
clickhouse dig [args] 
clickhouse benchmark [args] 
clickhouse server [args] 
clickhouse extract-from-config [args] 
clickhouse compressor [args] 
clickhouse format [args] 
ClickHouse local version 25.12.10.7 (official build).
Package tests for clickhouse passed.
```