### PR TITLE
Collectl 4.3.1 => 4.3.20.2

### DIFF
--- a/manifest/armv7l/c/collectl.filelist
+++ b/manifest/armv7l/c/collectl.filelist
@@ -1,4 +1,4 @@
-# Total size: 1637530
+# Total size: 1642088
 /usr/local/bin/collectl
 /usr/local/bin/colmux
 /usr/local/etc/collectl.conf
@@ -77,5 +77,5 @@
 /usr/local/share/doc/collectl/colmux.html
 /usr/local/share/doc/collectl/slub.jpg
 /usr/local/share/doc/collectl/style.css
-/usr/local/share/man/man1/collectl.1.gz
-/usr/local/share/man/man1/colmux.1.gz
+/usr/local/share/man/man1/collectl.1.zst
+/usr/local/share/man/man1/colmux.1.zst

--- a/manifest/i686/c/collectl.filelist
+++ b/manifest/i686/c/collectl.filelist
@@ -1,4 +1,4 @@
-# Total size: 1637530
+# Total size: 1642088
 /usr/local/bin/collectl
 /usr/local/bin/colmux
 /usr/local/etc/collectl.conf
@@ -77,5 +77,5 @@
 /usr/local/share/doc/collectl/colmux.html
 /usr/local/share/doc/collectl/slub.jpg
 /usr/local/share/doc/collectl/style.css
-/usr/local/share/man/man1/collectl.1.gz
-/usr/local/share/man/man1/colmux.1.gz
+/usr/local/share/man/man1/collectl.1.zst
+/usr/local/share/man/man1/colmux.1.zst

--- a/manifest/x86_64/c/collectl.filelist
+++ b/manifest/x86_64/c/collectl.filelist
@@ -1,4 +1,4 @@
-# Total size: 1637530
+# Total size: 1642088
 /usr/local/bin/collectl
 /usr/local/bin/colmux
 /usr/local/etc/collectl.conf
@@ -77,5 +77,5 @@
 /usr/local/share/doc/collectl/colmux.html
 /usr/local/share/doc/collectl/slub.jpg
 /usr/local/share/doc/collectl/style.css
-/usr/local/share/man/man1/collectl.1.gz
-/usr/local/share/man/man1/colmux.1.gz
+/usr/local/share/man/man1/collectl.1.zst
+/usr/local/share/man/man1/colmux.1.zst

--- a/packages/collectl.rb
+++ b/packages/collectl.rb
@@ -3,21 +3,16 @@ require 'package'
 class Collectl < Package
   description 'Collectl is a light-weight performance monitoring tool capable of reporting interactively as well as logging to disk.'
   homepage 'https://collectl.sourceforge.net/'
-  version '4.3.1'
+  version '4.3.20.2'
   license 'GPL-2 and Artistic'
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/project/collectl/collectl/collectl-4.3.1/collectl-4.3.1.src.tar.gz'
-  source_sha256 '2187264d974b36a653c8a4b028ac6eeab23e1885f8b2563a33f06358f39889f1'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/sharkcz/collectl.git'
+  git_hashtag version
 
-  binary_sha256({
-    aarch64: 'c7dfcb941c97ae272b888d9c6257f931285ce51d453c08bc53cfcfb419b02486',
-     armv7l: 'c7dfcb941c97ae272b888d9c6257f931285ce51d453c08bc53cfcfb419b02486',
-       i686: '9df81b18774e4f086d53b646da72a3fb3c2dd0abc574b2d71728d77857dc80b2',
-     x86_64: '3726cff22c73deab81018a66b27e75696db94ab3de9a40239407077f07a885b3'
-  })
+  no_compile_needed
+  no_fhs
 
-  def self.build
+  def self.patch
     system "sed -i 's,/usr/bin/perl,#{CREW_PREFIX}/bin/perl,' colmux"
     system "sed -i 's,/usr/bin/perl,#{CREW_PREFIX}/bin/perl,' collectl"
     system "sed -i 's,/etc/\$ConfigFile,#{CREW_PREFIX}/etc/\$ConfigFile,' collectl"

--- a/tests/package/c/collectl
+++ b/tests/package/c/collectl
@@ -1,0 +1,5 @@
+#!/bin/bash
+collectl -h | head
+collectl -v
+colmux -help | head
+colmux -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-collectl crew update \
&& yes | crew upgrade

$ crew check collectl 
Checking collectl package ...
Library test for collectl passed.
Checking collectl package ...
This is a subset of the most common switches and even the descriptions are
abbreviated.  To see all type 'collectl -x', to get started just type 'collectl'

usage: collectl [switches]
  -c, --count      count      collect this number of samples and exit
  -f, --filename   file       name of directory/file to write to
  -i, --interval   int        collection interval in seconds [default=1]
  -o, --options    options    misc formatting options, --showoptions for all
                                d|D - include date in output
                                  T - include time in output
collectl V4.3.20.1 (zlib:2.213,HiRes:1.9778)

Copyright 2003-2018 Hewlett-Packard Development Company, L.P.
collectl may be copied only under the terms of either the Artistic License
or the GNU General Public License, which may be found in the source kit
usage: colmux -address -command [-switches]

Common Switches
  -address    addr[,addr]  comma separated list of address to connect or filename
  -command    string       collectl command string
  -help                    print this message
  -hostwidth  number       minimum width to use for printing hostname [def=8]
  -lines      number       limit displays to this number of lines
  -noescape                disable printing ALL escape sequences
  -port       port         port remote collectl should use for communications
colmux: 5.0.0 (Term::ReadKey: not installed Threads: 2.43)

Copyright 2005-2018 Hewlett-Packard Development Company, L.P.
colmux may be copied only under the terms of either the Artistic License
or the GNU General Public License, which may be found in the source kit
Package tests for collectl passed.
```