### PR TITLE
Colordiff 1.0.18 => 1.0.22

### DIFF
--- a/manifest/armv7l/c/colordiff.filelist
+++ b/manifest/armv7l/c/colordiff.filelist
@@ -1,7 +1,7 @@
-# Total size: 24273
+# Total size: 28504
 /home/chronos/user/.colordiffrc
 /usr/local/bin/cdiff
 /usr/local/bin/colordiff
 /usr/local/etc/colordiffrc
-/usr/local/man/man1/cdiff.1.gz
-/usr/local/man/man1/colordiff.1.gz
+/usr/local/share/man/man1/cdiff.1.zst
+/usr/local/share/man/man1/colordiff.1.zst

--- a/manifest/i686/c/colordiff.filelist
+++ b/manifest/i686/c/colordiff.filelist
@@ -1,7 +1,7 @@
-# Total size: 24273
+# Total size: 28504
 /home/chronos/user/.colordiffrc
 /usr/local/bin/cdiff
 /usr/local/bin/colordiff
 /usr/local/etc/colordiffrc
-/usr/local/man/man1/cdiff.1.gz
-/usr/local/man/man1/colordiff.1.gz
+/usr/local/share/man/man1/cdiff.1.zst
+/usr/local/share/man/man1/colordiff.1.zst

--- a/manifest/x86_64/c/colordiff.filelist
+++ b/manifest/x86_64/c/colordiff.filelist
@@ -1,7 +1,7 @@
-# Total size: 24273
+# Total size: 28504
 /home/chronos/user/.colordiffrc
 /usr/local/bin/cdiff
 /usr/local/bin/colordiff
 /usr/local/etc/colordiffrc
-/usr/local/man/man1/cdiff.1.gz
-/usr/local/man/man1/colordiff.1.gz
+/usr/local/share/man/man1/cdiff.1.zst
+/usr/local/share/man/man1/colordiff.1.zst

--- a/packages/colordiff.rb
+++ b/packages/colordiff.rb
@@ -3,33 +3,28 @@ require 'package'
 class Colordiff < Package
   description "The Perl script colordiff is a wrapper for 'diff' and produces the same output but with pretty 'syntax' highlighting."
   homepage 'https://www.colordiff.org/'
-  version '1.0.18'
+  version '1.0.22'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://www.colordiff.org/colordiff-1.0.18.tar.gz'
-  source_sha256 '29cfecd8854d6e19c96182ee13706b84622d7b256077df19fbd6a5452c30d6e0'
-  binary_compression 'tar.xz'
+  source_url "https://www.colordiff.org/colordiff-#{version}.tar.gz"
+  source_sha256 'f96f73c54521c53f14dc164d5a3920c9ca21a0e5f8e9613f43812a98af3e22af'
 
-  binary_sha256({
-    aarch64: 'f8e3848078a822375729d5243697ed856e45db41badef0db95052dac3beac452',
-     armv7l: 'f8e3848078a822375729d5243697ed856e45db41badef0db95052dac3beac452',
-       i686: 'f47a74e3d39e7b72989925434897313ca1a98c11e6895c30c1db7f23049ac166',
-     x86_64: 'd0cafc057a6967a0232ec57769a9b013e1e4cc8412b3b0ece257cc622f2a3234'
-  })
+  depends_on 'perl' => :executable
 
-  depends_on 'perl'
+  no_compile_needed
 
-  def self.install
+  def self.patch
     system "sed -i 's,/etc,#{CREW_PREFIX}/etc,g' colordiff.pl"
     system "sed -i 's,/usr/bin/perl,#{CREW_PREFIX}/bin/perl,' colordiff.pl"
-    system "install -Dm755 colordiff.pl #{CREW_DEST_PREFIX}/bin/colordiff"
-    system "install -Dm755 cdiff.sh #{CREW_DEST_PREFIX}/bin/cdiff"
-    system 'gzip -9 cdiff.1 colordiff.1'
-    system "install -Dm644 cdiff.1.gz #{CREW_DEST_PREFIX}/man/man1/cdiff.1.gz"
-    system "install -Dm644 colordiff.1.gz #{CREW_DEST_PREFIX}/man/man1/colordiff.1.gz"
-    system "install -Dm644 colordiffrc #{CREW_DEST_PREFIX}/etc/colordiffrc"
-    system "mkdir -p #{CREW_DEST_DIR}/$HOME"
-    system "ln -s #{CREW_PREFIX}/etc/colordiffrc #{CREW_DEST_DIR}/$HOME/.colordiffrc"
-    system "ln -sf #{CREW_PREFIX}/etc/colordiffrc $HOME/.colordiffrc"
+  end
+
+  def self.install
+    FileUtils.install 'cdiff.sh', "#{CREW_DEST_PREFIX}/bin/cdiff", mode: 0o755
+    FileUtils.install 'colordiff.pl', "#{CREW_DEST_PREFIX}/bin/colordiff", mode: 0o755
+    FileUtils.install 'colordiffrc', "#{CREW_DEST_PREFIX}/etc/colordiffrc", mode: 0o644
+    FileUtils.install 'cdiff.1', "#{CREW_DEST_PREFIX}/man/man1/cdiff.1", mode: 0o644
+    FileUtils.install 'colordiff.1', "#{CREW_DEST_PREFIX}/man/man1/colordiff.1", mode: 0o644
+    FileUtils.mkdir_p CREW_DEST_HOME
+    FileUtils.ln_s "#{CREW_PREFIX}/etc/colordiffrc", "#{CREW_DEST_HOME}/.colordiffrc"
   end
 end

--- a/tests/package/c/colordiff
+++ b/tests/package/c/colordiff
@@ -1,0 +1,5 @@
+#!/bin/bash
+cdiff --help | head
+cdiff --version
+colordiff --help
+colordiff --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-colordiff crew update \
&& yes | crew upgrade

$ crew check colordiff 
Checking colordiff package ...
Library test for colordiff passed.
Checking colordiff package ...
Usage: gzip [OPTION]... [FILE]...
Compress or uncompress FILEs (by default, compress FILES in-place).

Mandatory arguments to long options are mandatory for short options too.

  -c, --stdout      write on standard output, keep original files unchanged
  -d, --decompress  decompress
  -f, --force       force overwrite of output file and compress links
  -h, --help        give this help
  -k, --keep        keep (don't delete) input files
gzip 1.9
Copyright (C) 2017 Free Software Foundation, Inc.
Copyright (C) 1993 Jean-loup Gailly.
This is free software.  You may redistribute copies of it under the terms of
the GNU General Public License <https://www.gnu.org/licenses/gpl.html>.
There is NO WARRANTY, to the extent permitted by law.

Written by Jean-loup Gailly.
colordiff:
    --help                   : Displays this help
    --color=(yes|no)         : Force (or suppress) display of colours in output
    --color=patches=(yes|no) : Force (or suppress) inclusion of colour codes in patch output
    --color-term-output-only : Force (or suppress) colour to only appear in terminal output
    --difftype=DIFFTYPE      : Force difftype detection to specified format
    --(no)banner             : Show (or suppress) the colordiff banner

    DIFFTYPE is usually auto-detected, but can be set to:
          diff, diffc, diffu, diffy, debdiff or wdiff
diff (GNU diffutils) UNKNOWN
Copyright (C) 2025 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Paul Eggert, Mike Haertel, David Hayes,
Richard Stallman, and Len Tower.
Package tests for colordiff passed.
```