### PR TITLE
asmc: 2.37.92-c3789a9 → 2.38

### DIFF
--- a/manifest/armv7l/a/asmc.filelist
+++ b/manifest/armv7l/a/asmc.filelist
@@ -1,2 +1,2 @@
-# Total size: 385134
+# Total size: 389884
 /usr/local/bin/asmc

--- a/manifest/i686/a/asmc.filelist
+++ b/manifest/i686/a/asmc.filelist
@@ -1,2 +1,2 @@
-# Total size: 385134
+# Total size: 389884
 /usr/local/bin/asmc

--- a/manifest/x86_64/a/asmc.filelist
+++ b/manifest/x86_64/a/asmc.filelist
@@ -1,2 +1,2 @@
-# Total size: 385134
+# Total size: 393784
 /usr/local/bin/asmc

--- a/packages/asmc.rb
+++ b/packages/asmc.rb
@@ -4,15 +4,24 @@ class Asmc < Package
   description 'Asmc Macro Assembler'
   homepage 'https://github.com/nidud/asmc'
   license 'GPL-2.0'
-  @_commit = 'c3789a9cafd0548fa1777b1c61ce3bd2edaeb253'
-  version "2.37.92-#{@_commit[0..6]}"
+  version '2.38'
   compatibility 'all'
-  source_url "https://github.com/nidud/asmc/raw/#{@_commit}/bin/asmc"
-  source_sha256 'fb654cb5d3538267c8b46774126b2a32044008e1b6eff1d824667f7893c72bf2'
+  source_url 'https://github.com/nidud/asmc.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
-  no_compile_needed
+  binary_sha256({
+    aarch64: 'a2916448cb69f6e19dccd24e50b4418db76aab39f657b0b3d62be042a6371476',
+     armv7l: 'a2916448cb69f6e19dccd24e50b4418db76aab39f657b0b3d62be042a6371476',
+       i686: 'b9ed1b02d45dad14a9e013a0177f436ffce15844a2d8588afd895bb002126cbd',
+     x86_64: '54473d9215b5e13215f7221e2692dd8d071b51d40926e301cc3cb2effb81c505'
+  })
+
+  def self.build
+    system 'make', chdir: 'source/asmc'
+  end
 
   def self.install
-    FileUtils.install 'asmc', "#{CREW_DEST_PREFIX}/bin/asmc", mode: 0o755
+    FileUtils.install "bin/asmc#{CREW_LIB_SUFFIX}", "#{CREW_DEST_PREFIX}/bin/asmc", mode: 0o755
   end
 end


### PR DESCRIPTION
## Description
#### Commits:
-  e2f827f98 asmc => 2.38
### Packages with Updated versions or Changed package files:
- `asmc`: 2.37.92-c3789a9 &rarr; 2.38
##
Builds attempted for:
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=updater-asmc_2.38 crew update \
&& yes | crew upgrade
```
