### PR TITLE
Add uasm — pkg_7_zip: 25.01 → 26.01,uasm → 2.57

### DIFF
--- a/manifest/armv7l/p/pkg_7_zip.filelist
+++ b/manifest/armv7l/p/pkg_7_zip.filelist
@@ -1,4 +1,4 @@
-# Total size: 4940716
+# Total size: 4946420
 /usr/local/bin/7z
 /usr/local/bin/7za
 /usr/local/bin/7zr

--- a/manifest/armv7l/u/uasm.filelist
+++ b/manifest/armv7l/u/uasm.filelist
@@ -1,0 +1,2 @@
+# Total size: 701572
+/usr/local/bin/uasm

--- a/manifest/i686/p/pkg_7_zip.filelist
+++ b/manifest/i686/p/pkg_7_zip.filelist
@@ -1,6 +1,0 @@
-# Total size: 6314596
-/usr/local/bin/7z
-/usr/local/bin/7za
-/usr/local/bin/7zr
-/usr/local/bin/7zz
-/usr/local/lib/7z.so

--- a/manifest/i686/u/uasm.filelist
+++ b/manifest/i686/u/uasm.filelist
@@ -1,0 +1,2 @@
+# Total size: 820904
+/usr/local/bin/uasm

--- a/manifest/x86_64/p/pkg_7_zip.filelist
+++ b/manifest/x86_64/p/pkg_7_zip.filelist
@@ -1,4 +1,4 @@
-# Total size: 5923416
+# Total size: 5930696
 /usr/local/bin/7z
 /usr/local/bin/7za
 /usr/local/bin/7zr

--- a/manifest/x86_64/u/uasm.filelist
+++ b/manifest/x86_64/u/uasm.filelist
@@ -1,0 +1,2 @@
+# Total size: 841096
+/usr/local/bin/uasm

--- a/packages/pkg_7_zip.rb
+++ b/packages/pkg_7_zip.rb
@@ -11,14 +11,15 @@ class Pkg_7_zip < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '265a5acf546bddd5562539d675bddcfddb224d268371fde4d55a012ea2ac8862',
-     armv7l: '265a5acf546bddd5562539d675bddcfddb224d268371fde4d55a012ea2ac8862',
-     x86_64: '68e0f4702cffd908bf24dcd84036e7093a2c0e882256f17992785f50178fa0cc'
+    aarch64: '146ba0924cccdbc1802b79f58328856a33ecea724ebca0effe63a68497dc1c21',
+     armv7l: '146ba0924cccdbc1802b79f58328856a33ecea724ebca0effe63a68497dc1c21',
+     x86_64: 'e5296c9c59d9b6570160c4f0c62678b87c2c63c44d7c00fa4ac5150a5ed805dc'
   })
 
   depends_on 'asmc' => :build
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'uasm' => :build
 
   no_env_options

--- a/packages/pkg_7_zip.rb
+++ b/packages/pkg_7_zip.rb
@@ -5,7 +5,7 @@ class Pkg_7_zip < Package
   homepage 'https://www.7-zip.org'
   license 'LGPL-2.1+'
   version '26.01'
-  compatibility 'all'
+  compatibility 'aarch64 armv7l x86_64'
   source_url "https://www.7-zip.org/a/7z#{version.delete('.')}-src.tar.xz"
   source_sha256 'b2389e0e930b2f9a348cf0fe7d9870a46482a8ec044ee0bdf42e2136db31c3d6'
   binary_compression 'tar.zst'
@@ -13,7 +13,6 @@ class Pkg_7_zip < Package
   binary_sha256({
     aarch64: '265a5acf546bddd5562539d675bddcfddb224d268371fde4d55a012ea2ac8862',
      armv7l: '265a5acf546bddd5562539d675bddcfddb224d268371fde4d55a012ea2ac8862',
-       i686: '84b54312cf973281258d1ba41c31d5aae6387feae429277d77b335f9e37d8575',
      x86_64: '68e0f4702cffd908bf24dcd84036e7093a2c0e882256f17992785f50178fa0cc'
   })
 

--- a/packages/pkg_7_zip.rb
+++ b/packages/pkg_7_zip.rb
@@ -20,6 +20,7 @@ class Pkg_7_zip < Package
   depends_on 'asmc' => :build
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
+  depends_on 'uasm' => :build
 
   no_env_options
 

--- a/packages/pkg_7_zip.rb
+++ b/packages/pkg_7_zip.rb
@@ -4,10 +4,10 @@ class Pkg_7_zip < Package
   description 'Official implantation of 7za.exe in Linux. File archiver with a high compression ratio.'
   homepage 'https://www.7-zip.org'
   license 'LGPL-2.1+'
-  version '25.01'
+  version '26.01'
   compatibility 'all'
   source_url "https://www.7-zip.org/a/7z#{version.delete('.')}-src.tar.xz"
-  source_sha256 'ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e'
+  source_sha256 'b2389e0e930b2f9a348cf0fe7d9870a46482a8ec044ee0bdf42e2136db31c3d6'
   binary_compression 'tar.zst'
 
   binary_sha256({

--- a/packages/uasm.rb
+++ b/packages/uasm.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Uasm < Package
+  description 'A MASM-compatible assembler'
+  homepage 'http://www.terraspace.co.uk/uasm.html'
+  version '2.57'
+  license 'JWasm'
+  compatibility 'all'
+  source_url 'https://github.com/Terraspace/UASM.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '2c49710bfd224e09b27de1b9cf6ff92fd352e96c10ff3f54ed20a9e381d51c19',
+     armv7l: '2c49710bfd224e09b27de1b9cf6ff92fd352e96c10ff3f54ed20a9e381d51c19',
+       i686: '9cf96de8d48d186d0ee76df01fa53f3d0e271e6d7edefc76dbd3e60819bd6fc2',
+     x86_64: '3e508527a193179c479fac56d964060b0b6333916cc99b88e6f5cc1fbab1f20a'
+  })
+
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+
+  ignore_updater # versioning for uasm seems to randomly add suffixes.
+
+  def self.patch
+    patches = [
+      # Build fixes
+      ['https://patch-diff.githubusercontent.com/raw/Terraspace/UASM/pull/216.diff', '679690c51900bf88dce862c93bf36db7b761afcc18d54d3f97b076fc86da3f66'],
+      # Fix for CVE-2017-16516
+      ['https://gitlab.archlinux.org/archlinux/packaging/packages/uasm/-/raw/main/add-missing-header.patch?ref_type=heads&inline=false', '4840e477c46c708b4d46c99317d5ef7985284ed5a5ff42bd014118d3dee996a1']
+    ]
+    ConvenienceFunctions.patch(patches)
+  end
+
+  def self.build
+    # See: https://stackoverflow.com/a/46223160
+    # -D_XOPEN_SOURCE=700 is needed to handle a
+    # implicit declaration of function ‘fileno’ error.
+    system "CFLAGS='-std=c17 -D_XOPEN_SOURCE=700' make -f Makefile-Linux.mak"
+  end
+
+  def self.install
+    FileUtils.install 'GccUnixR/uasm', "#{CREW_DEST_PREFIX}/bin/", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -9900,6 +9900,11 @@ url: https://github.com/microsoft/TypeScript/releases
 activity: high
 ---
 kind: url
+name: uasm
+url: https://github.com/Terraspace/UASM/releases
+activity: low
+---
+kind: url
 name: uchardet
 url: https://www.freedesktop.org/software/uchardet/releases/
 activity: none

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# version.rb version 3.35 (for Chromebrew)
+# version.rb version 3.36 (for Chromebrew)
 
 OPTIONS = %w[-a --all -h --help -j --json -u --update-package-files -v --verbose -vv]
 
@@ -111,7 +111,6 @@ CREW_ANITYA_PACKAGE_NAME_MAPPINGS = Set[
   { pkg_name: 'openssl', anitya_pkg: 'openssl-3.5-LTS', comments: 'Prefer to GitHub' },
   { pkg_name: 'owl', anitya_pkg: 'Owl Lisp', comments: '' },
   { pkg_name: 'pcre2', anitya_pkg: 'pcre2', comments: 'Prefer to GitHub' },
-  { pkg_name: 'pkg_7_zip', anitya_pkg: '7zip~stable', comments: 'Prefer to GitHub' },
   { pkg_name: 'procps', anitya_pkg: 'procps-ng', comments: '' },
   { pkg_name: 'pthread_stubs', anitya_pkg: 'libpthread-stubs', comments: '' },
   { pkg_name: 'py3_atspi', anitya_pkg: 'pyatspi', comments: '' },


### PR DESCRIPTION
## Description
#### Commits:
-  6e0bdc59c Remove i686 from pkg_7_zip.
-  cb9f10658 Add uasm build dep.
-  bc88b207e pkg_7_zip => 26.0.1
-  81b81b4d2 Add uasm
### Packages with Updated versions or Changed package files:
- `pkg_7_zip`: 25.01 &rarr; 26.01
- `uasm` &rarr; 2.57 (current version is 2.57r)
##
Builds attempted for:
### Other changed files:
- tools/packages.yaml
- tools/version.rb
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=updater-pkg_7_zip-26.0.1 crew update \
&& yes | crew upgrade
```
