### PR TITLE
Protobuf_c 1.4.1 => 1.5.2

### DIFF
--- a/manifest/armv7l/p/protobuf_c.filelist
+++ b/manifest/armv7l/p/protobuf_c.filelist
@@ -1,4 +1,4 @@
-# Total size: 567306
+# Total size: 381816
 /usr/local/bin/protoc-c
 /usr/local/bin/protoc-gen-c
 /usr/local/include/google/protobuf-c/protobuf-c.h

--- a/manifest/i686/p/protobuf_c.filelist
+++ b/manifest/i686/p/protobuf_c.filelist
@@ -1,4 +1,4 @@
-# Total size: 634290
+# Total size: 478564
 /usr/local/bin/protoc-c
 /usr/local/bin/protoc-gen-c
 /usr/local/include/google/protobuf-c/protobuf-c.h

--- a/manifest/x86_64/p/protobuf_c.filelist
+++ b/manifest/x86_64/p/protobuf_c.filelist
@@ -1,4 +1,4 @@
-# Total size: 341590
+# Total size: 484492
 /usr/local/bin/protoc-c
 /usr/local/bin/protoc-gen-c
 /usr/local/include/google/protobuf-c/protobuf-c.h

--- a/packages/protobuf_c.rb
+++ b/packages/protobuf_c.rb
@@ -1,35 +1,39 @@
 # Adapted from Arch Linux protobuf-c PKGBUILD at:
 # https://github.com/archlinux/svntogit-packages/raw/packages/protobuf-c/trunk/PKGBUILD
+# Before upgrading protobuf_c, make sure to upgrade protobuf first.
 
-require 'package'
+require 'buildsystems/autotools'
 
-class Protobuf_c < Package
+class Protobuf_c < Autotools
   description 'Protocol Buffers implementation in C'
   homepage 'https://github.com/protobuf-c/protobuf-c'
-  version '1.4.1'
+  version '1.5.2'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://github.com/protobuf-c/protobuf-c/releases/download/v1.4.1/protobuf-c-1.4.1.tar.gz'
-  source_sha256 '4cc4facd508172f3e0a4d3a8736225d472418aee35b4ad053384b137b220339f'
+  source_url 'https://github.com/protobuf-c/protobuf-c.git'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f7b0d4df39c76edd82f3b150edf5d660a9613440755bcb35a0c267d97c34d650',
-     armv7l: 'f7b0d4df39c76edd82f3b150edf5d660a9613440755bcb35a0c267d97c34d650',
-       i686: 'c2b26a13859ebbfcfff7436e40ca45b9cd051255e090ae04852b91db190cbbb4',
-     x86_64: '1aaf27b5d3f5bc90042f1beeb3f5b08240695bcf7fae46b80f5a72b81f4aeb86'
+    aarch64: 'd769f5261492bde10ed8cda59432ebebf9d06b17ea25d78c986402e633e22300',
+     armv7l: 'd769f5261492bde10ed8cda59432ebebf9d06b17ea25d78c986402e633e22300',
+       i686: '7fb8eac7dd6a5af65b3ea10d061d8404d9baedcc829994e396a3d71dbd504535',
+     x86_64: '2b605a6ad5f1bc6ab6988b04621078d2357edc0febf0474d6c6b4a101202a6de'
   })
 
-  depends_on 'protobuf'
-  depends_on 'glibc' # R
-  depends_on 'gcc_lib' # R
+  depends_on 'abseil_cpp' => :executable
+  depends_on 'gcc_lib' => :executable
+  depends_on 'glibc' => :library
+  depends_on 'protobuf' => :executable
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  def self.patch
+    patch = [
+      [
+        # Fix error: ‘const class google::protobuf::FieldDescriptor’ has no member named ‘label’; did you mean ‘Label’?
+        'https://patch-diff.githubusercontent.com/raw/protobuf-c/protobuf-c/pull/797.diff',
+        'bbb5543aafba2611c5b450f2403804a0e8fad0e082e22c1f838b5190ce298089'
+      ]
+    ]
+    ConvenienceFunctions.patch(patch)
   end
 end

--- a/tests/package/p/protobuf_c
+++ b/tests/package/p/protobuf_c
@@ -1,0 +1,3 @@
+#!/bin/bash
+protoc-c --help | head
+protoc-c --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-protobuf_c crew update \
&& yes | crew upgrade

$ crew check protobuf_c 
Checking protobuf_c package ...
Library test for protobuf_c passed.
Checking protobuf_c package ...
Usage: protoc-c [OPTION] PROTO_FILES
Parse PROTO_FILES and generate output based on the options given:
  -IPATH, --proto_path=PATH   Specify the directory in which to search for
                              imports.  May be specified multiple times;
                              directories will be searched in order.  If not
                              given, the current working directory is used.
                              If not found in any of the these directories,
                              the --descriptor_set_in descriptors will be
                              checked for required proto file.
  --version                   Show version info and exit.
protobuf-c 1.5.2
libprotoc 34.1
Package tests for protobuf_c passed.
```