### PR TITLE
Cryptsetup 2.7.3 => 2.8.6

### DIFF
--- a/manifest/armv7l/c/cryptsetup.filelist
+++ b/manifest/armv7l/c/cryptsetup.filelist
@@ -1,11 +1,11 @@
-# Total size: 2622350
+# Total size: 3185257
 /usr/local/include/libcryptsetup.h
 /usr/local/lib/cryptsetup/libcryptsetup-token-ssh.la
 /usr/local/lib/cryptsetup/libcryptsetup-token-ssh.so
 /usr/local/lib/libcryptsetup.la
 /usr/local/lib/libcryptsetup.so
 /usr/local/lib/libcryptsetup.so.12
-/usr/local/lib/libcryptsetup.so.12.10.0
+/usr/local/lib/libcryptsetup.so.12.11.0
 /usr/local/lib/pkgconfig/libcryptsetup.pc
 /usr/local/sbin/cryptsetup
 /usr/local/sbin/cryptsetup-ssh
@@ -26,6 +26,7 @@
 /usr/local/share/locale/pt_BR/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/ro/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/ru/LC_MESSAGES/cryptsetup.mo
+/usr/local/share/locale/sk/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/sr/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/sv/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/uk/LC_MESSAGES/cryptsetup.mo

--- a/manifest/i686/c/cryptsetup.filelist
+++ b/manifest/i686/c/cryptsetup.filelist
@@ -1,11 +1,11 @@
-# Total size: 2734846
+# Total size: 3609117
 /usr/local/include/libcryptsetup.h
 /usr/local/lib/cryptsetup/libcryptsetup-token-ssh.la
 /usr/local/lib/cryptsetup/libcryptsetup-token-ssh.so
 /usr/local/lib/libcryptsetup.la
 /usr/local/lib/libcryptsetup.so
 /usr/local/lib/libcryptsetup.so.12
-/usr/local/lib/libcryptsetup.so.12.10.0
+/usr/local/lib/libcryptsetup.so.12.11.0
 /usr/local/lib/pkgconfig/libcryptsetup.pc
 /usr/local/sbin/cryptsetup
 /usr/local/sbin/cryptsetup-ssh
@@ -26,6 +26,7 @@
 /usr/local/share/locale/pt_BR/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/ro/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/ru/LC_MESSAGES/cryptsetup.mo
+/usr/local/share/locale/sk/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/sr/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/sv/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/uk/LC_MESSAGES/cryptsetup.mo

--- a/manifest/x86_64/c/cryptsetup.filelist
+++ b/manifest/x86_64/c/cryptsetup.filelist
@@ -1,11 +1,11 @@
-# Total size: 2790290
+# Total size: 3473153
 /usr/local/include/libcryptsetup.h
 /usr/local/lib64/cryptsetup/libcryptsetup-token-ssh.la
 /usr/local/lib64/cryptsetup/libcryptsetup-token-ssh.so
 /usr/local/lib64/libcryptsetup.la
 /usr/local/lib64/libcryptsetup.so
 /usr/local/lib64/libcryptsetup.so.12
-/usr/local/lib64/libcryptsetup.so.12.10.0
+/usr/local/lib64/libcryptsetup.so.12.11.0
 /usr/local/lib64/pkgconfig/libcryptsetup.pc
 /usr/local/sbin/cryptsetup
 /usr/local/sbin/cryptsetup-ssh
@@ -26,6 +26,7 @@
 /usr/local/share/locale/pt_BR/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/ro/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/ru/LC_MESSAGES/cryptsetup.mo
+/usr/local/share/locale/sk/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/sr/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/sv/LC_MESSAGES/cryptsetup.mo
 /usr/local/share/locale/uk/LC_MESSAGES/cryptsetup.mo

--- a/packages/cryptsetup.rb
+++ b/packages/cryptsetup.rb
@@ -3,24 +3,28 @@ require 'buildsystems/autotools'
 class Cryptsetup < Autotools
   description 'The cryptsetup utility is used to conveniently setup disk en-/decryption based on DMCrypt kernel module.'
   homepage 'https://gitlab.com/cryptsetup/cryptsetup'
-  version '2.7.3'
+  version '2.8.6'
   license 'GPL-2+'
   compatibility 'all'
-  source_url 'https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v2.7/cryptsetup-2.7.3.tar.xz'
-  source_sha256 'b772ae4f6df0cee7200b28cea960e4daaff2a203d2fd502beab3c1317b07a456'
+  source_url "https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v#{version.sub(/\.\d+$/, '')}/cryptsetup-#{version}.tar.xz"
+  source_sha256 '8004265fd993885d08f7b633dbe056851de1a210307613a4ebddc743fccefe5a'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '0a48fd6d1484d347870e919a53a0de9700ccb8f01994acca02bc8b00448e585e',
-     armv7l: '0a48fd6d1484d347870e919a53a0de9700ccb8f01994acca02bc8b00448e585e',
-       i686: '8b14383a9cadf16697e12eafea51ef990e8a7e03018becb2ee814cb79d626ab5',
-     x86_64: '47cd09d893cfd85342ecac90a564396743e209f53ebed70aee9fd94d6bdb19ed'
+    aarch64: 'f41f0851a056c8ec2e48a15da9d388163e41f40326934a32a3597fdb5bbc946a',
+     armv7l: 'f41f0851a056c8ec2e48a15da9d388163e41f40326934a32a3597fdb5bbc946a',
+       i686: '7ed753be31eedd86c2527136305dbc0e651010573d37cb64f3789c9d602c2355',
+     x86_64: 'c54367b164056afc9cc065d4a0affeb62c7774cb68058a86309ce6f0176e690f'
   })
 
-  depends_on 'lvm2'
-  depends_on 'json_c'
-  depends_on 'libgcrypt'
-  depends_on 'popt'
+  depends_on 'glibc' => :library
+  depends_on 'json_c' => :library
+  depends_on 'libgcrypt' => :library
+  depends_on 'libssh' => :library
+  depends_on 'lvm2' => :library
+  depends_on 'openssl' => :library
+  depends_on 'popt' => :executable
+  depends_on 'util_linux' => :library
 
   autotools_configure_options '--disable-asciidoc'
 end

--- a/tests/package/c/cryptsetup
+++ b/tests/package/c/cryptsetup
@@ -1,0 +1,9 @@
+#!/bin/bash
+/usr/local/sbin/cryptsetup --help | head
+/usr/local/sbin/cryptsetup -V
+/usr/local/sbin/cryptsetup-ssh --help | head
+/usr/local/sbin/cryptsetup-ssh -V
+/usr/local/sbin/integritysetup --help | head
+/usr/local/sbin/integritysetup -V
+/usr/local/sbin/veritysetup --help | head
+/usr/local/sbin/veritysetup -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-cryptsetup crew update \
&& yes | crew upgrade

$ crew check cryptsetup
Checking cryptsetup package ...
Library test for cryptsetup passed.
Checking cryptsetup package ...
cryptsetup 2.8.6 flags: UDEV BLKID KEYRING KERNEL_CAPI HW_OPAL 
Usage: cryptsetup [OPTION...] <action> <action-specific>

Help options:
  -?, --help                              Show this help message
      --usage                             Display brief usage
  -V, --version                           Print package version
      --active-name=STRING                Override device autodetection of dm
                                          device to be reencrypted
      --align-payload=SECTORS             Align payload at <n> sector
cryptsetup 2.8.6 flags: UDEV BLKID KEYRING KERNEL_CAPI HW_OPAL 
Usage: cryptsetup-ssh [OPTION...] <action> <device>
Experimental cryptsetup plugin for unlocking LUKS2 devices with token connected
to an SSH server

 Options for the 'add' action:
      --external-tokens-path=STRING
                             Path to directory containinig libcryptsetup
                             external tokens
      --key-slot=NUM         Keyslot to assign the token to. If not specified,
                             token will be assigned to the first keyslot
cryptsetup-ssh 2.8.6
integritysetup 2.8.6 flags: UDEV BLKID KEYRING KERNEL_CAPI HW_OPAL 
Usage: integritysetup [OPTION...] <action> <action-specific>

Help options:
  -?, --help                                  Show this help message
      --usage                                 Display brief usage
  -V, --version                               Print package version
      --allow-discards                        Allow discards (aka TRIM)
                                              requests for device
  -q, --batch-mode                            Do not ask for confirmation
integritysetup 2.8.6 flags: UDEV BLKID KEYRING KERNEL_CAPI HW_OPAL 
veritysetup 2.8.6 flags: UDEV BLKID KEYRING KERNEL_CAPI HW_OPAL 
Usage: veritysetup [OPTION...] <action> <action-specific>

Help options:
  -?, --help                           Show this help message
      --usage                          Display brief usage
  -V, --version                        Print package version
      --cancel-deferred                Cancel a previously set deferred device
                                       removal
      --check-at-most-once             Verify data block only the first time
veritysetup 2.8.6 flags: UDEV BLKID KEYRING KERNEL_CAPI HW_OPAL 
Package tests for cryptsetup passed.
```