### PR TITLE
Cups 2.4.16 => 2.4.19

### DIFF
--- a/manifest/armv7l/c/cups.filelist
+++ b/manifest/armv7l/c/cups.filelist
@@ -1,4 +1,4 @@
-# Total size: 13504522
+# Total size: 13504403
 /usr/local/bin/cancel
 /usr/local/bin/cups-config
 /usr/local/bin/cupstestppd

--- a/manifest/i686/c/cups.filelist
+++ b/manifest/i686/c/cups.filelist
@@ -1,4 +1,4 @@
-# Total size: 13555090
+# Total size: 13557211
 /usr/local/bin/cancel
 /usr/local/bin/cups-config
 /usr/local/bin/cupstestppd

--- a/manifest/x86_64/c/cups.filelist
+++ b/manifest/x86_64/c/cups.filelist
@@ -1,4 +1,4 @@
-# Total size: 13722042
+# Total size: 13726067
 /usr/local/bin/cancel
 /usr/local/bin/cups-config
 /usr/local/bin/cupstestppd
@@ -47,11 +47,11 @@
 /usr/local/include/cups/sidechannel.h
 /usr/local/include/cups/transcode.h
 /usr/local/include/cups/versioning.h
-/usr/local/lib/pkgconfig/cups.pc
 /usr/local/lib64/libcups.so
 /usr/local/lib64/libcups.so.2
 /usr/local/lib64/libcupsimage.so
 /usr/local/lib64/libcupsimage.so.2
+/usr/local/lib64/pkgconfig/cups.pc
 /usr/local/libexec/cups/backend/http
 /usr/local/libexec/cups/backend/https
 /usr/local/libexec/cups/backend/ipp

--- a/packages/cups.rb
+++ b/packages/cups.rb
@@ -3,7 +3,7 @@ require 'package'
 class Cups < Package
   description 'CUPS is the standards-based, open source printing system'
   homepage 'https://openprinting.github.io/cups'
-  version '2.4.16'
+  version '2.4.19'
   compatibility 'all'
   license 'Apache-2.0'
   source_url 'https://github.com/OpenPrinting/cups.git'
@@ -11,25 +11,24 @@ class Cups < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '6bbdf0724f81cc53ac11dafd93e9868d80237068286fb9a8486bfc0b87b828e4',
-     armv7l: '6bbdf0724f81cc53ac11dafd93e9868d80237068286fb9a8486bfc0b87b828e4',
-       i686: '1c3ffa0b2ce21adb59b4a45491f3a7f8946f6ea5df60efa0733a93ae712727f5',
-     x86_64: 'd904885d6529dba0b2ce8d22191dad1e89b18e3ea077f84a6fe320e352d90bee'
+    aarch64: '317969e2827c1702e7b44dd800727bf3ac25b5b2193245c96d13ad48a6fcda7c',
+     armv7l: '317969e2827c1702e7b44dd800727bf3ac25b5b2193245c96d13ad48a6fcda7c',
+       i686: '86a86eee0cfce1a285a63dfc33ad3d0114893ff3a85989f6ae95b47a9125ba68',
+     x86_64: '057d17a9bccdd8daba89a20a4158865061180bc0b8908e77b784e8df1b6671b1'
   })
 
-  depends_on 'acl' # R
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
-  depends_on 'libusb' # R
-  depends_on 'libxcrypt' # R
-  depends_on 'linux_pam' # R
+  depends_on 'acl' => :executable
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'libusb' => :library
+  depends_on 'libxcrypt' => :library
+  depends_on 'linux_pam' => :executable
   depends_on 'llvm_dev' => :build if %w[armv7l aarch64].include?(ARCH)
-  depends_on 'openssl' # R
+  depends_on 'openssl' => :library
   depends_on 'psmisc' => :logical
-  depends_on 'zlib' # R
+  depends_on 'zlib' => :library
 
   no_env_options
-  no_fhs
 
   def self.build
     @buildoverride = %w[armv7l aarch64].include?(ARCH) ? 'CC=clang CXX=clang++ LD=mold CUPS_LINKER=mold' : ''
@@ -72,7 +71,9 @@ class Cups < Package
 
   def self.install
     system 'make',
+           "PREFIX=#{CREW_PREFIX}",
            "DESTDIR=#{CREW_DEST_DIR}",
+           "LIBDIR=#{CREW_DEST_LIB_PREFIX}",
            "DATADIR=#{CREW_DEST_PREFIX}/share/cups",
            "DOCDIR=#{CREW_DEST_PREFIX}/share/doc/cups",
            "MANDIR=#{CREW_DEST_MAN_PREFIX}",
@@ -83,8 +84,8 @@ class Cups < Package
            "SERVERBIN=#{CREW_DEST_PREFIX}/libexec/cups",
            "CACHEDIR=#{CREW_DEST_PREFIX}/var/cache/cups",
            "LOCALEDIR=#{CREW_DEST_PREFIX}/share/locale",
+           "CUPS_PKGCONFPATH=#{CREW_DEST_LIB_PREFIX}/pkgconfig",
            'install'
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.install 'startcupsd', "#{CREW_DEST_PREFIX}/bin/startcupsd", mode: 0o755
     FileUtils.install 'stopcupsd', "#{CREW_DEST_PREFIX}/bin/stopcupsd", mode: 0o755
     if File.exist?("#{CREW_DEST_DIR}/etc/dbus-1/system.d/cups.conf")
@@ -103,7 +104,6 @@ class Cups < Package
       To start the cups daemon, run 'startcupsd'
       To stop the cups daemon, run 'stopcupsd'
       For more information, see https://www.cups.org/doc/admin.html.
-
     EOM
   end
 end

--- a/tests/package/c/cups
+++ b/tests/package/c/cups
@@ -1,0 +1,8 @@
+#!/bin/bash
+cups-config -h | head
+cups-config --version
+cupstestppd -h | head
+ippeveprinter -h | head
+ippeveprinter --version
+ipptool 2>&1 | head
+ipptool --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-cups crew update \
&& yes | crew upgrade

$ crew check cups 
Checking cups package ...
Library test for cups passed.
Checking cups package ...
Usage: cups-config --api-version
       cups-config --build
       cups-config --cflags
       cups-config --datadir
       cups-config --help
       cups-config --ldflags
       cups-config [--image] [--static] --libs
       cups-config --serverbin
       cups-config --serverroot
       cups-config --version
2.4.19
Warning: This program will be removed in a future version of CUPS.
Usage: cupstestppd [options] filename1.ppd[.gz] [... filenameN.ppd[.gz]]
       program | cupstestppd [options] -
Options:
-I {filename,filters,none,profiles}
                          Ignore specific warnings
-R root-directory       Set alternate root
-W {all,none,constraints,defaults,duplex,filters,profiles,sizes,translations}
                          Issue warnings instead of errors
-q                      Run silently
Usage: ippeveprinter [options] "name"
Options:
--help                  Show program help
--no-web-forms          Disable web forms for media and supplies
--pam-service service   Use the named PAM service
--version               Show program version
-2                      Set 2-sided printing support (default=1-sided)
-A                      Enable authentication
-D device-uri           Set the device URI for the printer
-F output-type/subtype  Set the output format for the printer
CUPS v2.4.19
Usage: ipptool [options] URI filename [ ... filenameN ]
Options:
--ippserver filename    Produce ippserver attribute file
--stop-after-include-error
                        Stop tests after a failed INCLUDE
--version               Show version
-4                      Connect using IPv4
-6                      Connect using IPv6
-C                      Send requests using chunking (default)
-E                      Test with encryption using HTTP Upgrade to TLS
CUPS v2.4.19
Package tests for cups passed.
```