### PR TITLE
Darkhttpd 1.12 => 1.17

### DIFF
--- a/manifest/armv7l/d/darkhttpd.filelist
+++ b/manifest/armv7l/d/darkhttpd.filelist
@@ -1,2 +1,2 @@
-# Total size: 41936
+# Total size: 38288
 /usr/local/bin/darkhttpd

--- a/manifest/i686/d/darkhttpd.filelist
+++ b/manifest/i686/d/darkhttpd.filelist
@@ -1,2 +1,2 @@
-# Total size: 42300
+# Total size: 50052
 /usr/local/bin/darkhttpd

--- a/manifest/x86_64/d/darkhttpd.filelist
+++ b/manifest/x86_64/d/darkhttpd.filelist
@@ -1,2 +1,2 @@
-# Total size: 47048
+# Total size: 50344
 /usr/local/bin/darkhttpd

--- a/packages/darkhttpd.rb
+++ b/packages/darkhttpd.rb
@@ -3,26 +3,27 @@ require 'package'
 class Darkhttpd < Package
   description 'Minimal webserver written by Emil Mikulic'
   homepage 'https://unix4lyfe.org/darkhttpd/'
-  version '1.12'
+  version '1.17'
   license 'ISC'
   compatibility 'all'
-  source_url 'https://unix4lyfe.org/darkhttpd/darkhttpd-1.12.tar.bz2'
-  source_sha256 'a50417b622b32b5f421b3132cb94ebeff04f02c5fb87fba2e31147d23de50505'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/emikulic/darkhttpd.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2e0d63b59129bae92d3d957b655a9d4bf07a66586d5427f8fbe1b0d181541b0f',
-     armv7l: '2e0d63b59129bae92d3d957b655a9d4bf07a66586d5427f8fbe1b0d181541b0f',
-       i686: '56f4e98ccfe4f04ca4fd7bf3c1268de0dc44600da4b4257d32cc0cfe634485c9',
-     x86_64: 'c60d1cb89689bd4ecbe0503b37cfeefa7b64a0db310644fbe4e987bfd3f6699e'
+    aarch64: '59fd02af9dd5e20d656d3b8e0bef55eeea072c1b9d20aaf42517842a6c78cd38',
+     armv7l: '59fd02af9dd5e20d656d3b8e0bef55eeea072c1b9d20aaf42517842a6c78cd38',
+       i686: '1a66fb3d85ea1771b77b3fe58421b194a5ede18b151dead9105da58cbce0bf04',
+     x86_64: '1a100d14938b55db98f78001b07cc555019cb7582a77dff0106ab505a573b99b'
   })
+
+  depends_on 'glibc' => :executable
 
   def self.build
     system 'make'
   end
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.cp 'darkhttpd', "#{CREW_DEST_PREFIX}/bin/"
+    FileUtils.install 'darkhttpd', "#{CREW_DEST_PREFIX}/bin/darkhttpd", mode: 0o755
   end
 end

--- a/tests/package/d/darkhttpd
+++ b/tests/package/d/darkhttpd
@@ -1,0 +1,2 @@
+#!/bin/bash
+darkhttpd --help | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-darkhttpd crew update \
&& yes | crew upgrade

$ crew check darkhttpd 
Checking darkhttpd package ...
Library test for darkhttpd passed.
Checking darkhttpd package ...
darkhttpd/1.17, copyright (c) 2003-2025 Emil Mikulic.
usage:	darkhttpd /path/to/wwwroot [flags]

flags:	--port number (default: 8080, or 80 if running as root)
		Specifies which port to listen on for connections.
		Pass 0 to let the system choose any free port for you.

	--addr ip (default: all)
		If multiple interfaces are present, specifies
		which one to bind the listening port to.
Package tests for darkhttpd passed.
```