### PR TITLE
Dash 0.5.11.1 => 0.5.12-f47009f

### DIFF
--- a/manifest/armv7l/d/dash.filelist
+++ b/manifest/armv7l/d/dash.filelist
@@ -1,3 +1,3 @@
-# Total size: 532218
+# Total size: 133593
 /usr/local/bin/dash
-/usr/local/share/man/man1/dash.1.gz
+/usr/local/share/man/man1/dash.1.zst

--- a/manifest/i686/d/dash.filelist
+++ b/manifest/i686/d/dash.filelist
@@ -1,3 +1,3 @@
-# Total size: 521158
+# Total size: 175761
 /usr/local/bin/dash
-/usr/local/share/man/man1/dash.1.gz
+/usr/local/share/man/man1/dash.1.zst

--- a/manifest/x86_64/d/dash.filelist
+++ b/manifest/x86_64/d/dash.filelist
@@ -1,3 +1,3 @@
-# Total size: 628042
+# Total size: 176409
 /usr/local/bin/dash
-/usr/local/share/man/man1/dash.1.gz
+/usr/local/share/man/man1/dash.1.zst

--- a/packages/dash.rb
+++ b/packages/dash.rb
@@ -1,34 +1,26 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Dash < Package
+class Dash < Autotools
   description 'The Debian Almquist Shell (dash) is a POSIX-compliant shell derived from ash that executes scripts faster than bash and has fewer library dependencies.'
   homepage 'https://salsa.debian.org/debian/dash/'
-  version '0.5.11.1'
+  version '0.5.12-f47009f'
   license 'BSD'
   compatibility 'all'
   source_url 'https://salsa.debian.org/debian/dash.git'
-  git_hashtag 'upstream/0.5.11.2'
-  binary_compression 'tar.xz'
+  git_hashtag 'upstream/0.5.12+git20240518+f47009f9a76e'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1b44e3da6bfc8c4e10752b14da464d8a04b748025de69423f944fac8035dbb96',
-     armv7l: '1b44e3da6bfc8c4e10752b14da464d8a04b748025de69423f944fac8035dbb96',
-       i686: 'ac582d141f234881f09860bc400688b0462d92431a5ef739c59687e09cdb9299',
-     x86_64: 'fc193b1d169b2341cd99e329552740656706ae3e22867733eac7d2f7873053b8'
+    aarch64: 'c11486d7feb0581f5828bfd258433d0adfb08ee45c8dc7cbe4752586df18f4a8',
+     armv7l: 'c11486d7feb0581f5828bfd258433d0adfb08ee45c8dc7cbe4752586df18f4a8',
+       i686: 'fde5c4a4a255e7270ba026a795f93aecc4076b1327de3951598800b5a96e91d0',
+     x86_64: '57a73df2cff50a4cc86245ce85e9c2fdf5f372884af3ccda7341c0d940f3b5a8'
   })
 
-  depends_on 'libedit'
+  depends_on 'glibc' => :executable
+  depends_on 'libedit' => :executable
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS} --with-libedit"
-    system 'make'
-  end
+  autotools_configure_options '--with-libedit'
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.check
-    system 'make', 'check'
-  end
+  run_tests
 end

--- a/tests/package/d/dash
+++ b/tests/package/d/dash
@@ -1,0 +1,2 @@
+#!/bin/bash
+man dash | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-dash crew update \
&& yes | crew upgrade

$ crew check dash 
Checking dash package ...
Library test for dash passed.
Checking dash package ...
DASH(1)                                                                                      General Commands Manual                                                                                    DASH(1)

NAME
     dash —— command interpreter (shell)

SYNOPSIS
     dash [-aCefnuvxIimqVEb] [+aCefnuvxIimqVEb] [-o option_name] [+o option_name] [command_file [argument ...]]
     dash -c [-aCefnuvxIimqVEb] [+aCefnuvxIimqVEb] [-o option_name] [+o option_name] command_string [command_name [argument ...]]
     dash -s [-aCefnuvxIimqVEb] [+aCefnuvxIimqVEb] [-o option_name] [+o option_name] [argument ...]

Package tests for dash passed.
```