### PR TITLE
Dbus_glib 0.112 => 0.114

### DIFF
--- a/manifest/armv7l/d/dbus_glib.filelist
+++ b/manifest/armv7l/d/dbus_glib.filelist
@@ -1,4 +1,4 @@
-# Total size: 1677984
+# Total size: 1649346
 /usr/local/bin/dbus-binding-tool
 /usr/local/etc/bash_completion.d/dbus-bash-completion.sh
 /usr/local/include/dbus-1.0/dbus/dbus-glib-bindings.h
@@ -10,7 +10,7 @@
 /usr/local/lib/libdbus-glib-1.la
 /usr/local/lib/libdbus-glib-1.so
 /usr/local/lib/libdbus-glib-1.so.2
-/usr/local/lib/libdbus-glib-1.so.2.3.5
+/usr/local/lib/libdbus-glib-1.so.2.3.6
 /usr/local/lib/pkgconfig/dbus-glib-1.pc
 /usr/local/libexec/dbus-bash-completion-helper
 /usr/local/share/gtk-doc/html/dbus-glib/api-index-full.html
@@ -36,4 +36,4 @@
 /usr/local/share/gtk-doc/html/dbus-glib/style.css
 /usr/local/share/gtk-doc/html/dbus-glib/up-insensitive.png
 /usr/local/share/gtk-doc/html/dbus-glib/up.png
-/usr/local/share/man/man1/dbus-binding-tool.1.gz
+/usr/local/share/man/man1/dbus-binding-tool.1.zst

--- a/manifest/x86_64/d/dbus_glib.filelist
+++ b/manifest/x86_64/d/dbus_glib.filelist
@@ -1,4 +1,4 @@
-# Total size: 1821298
+# Total size: 1896262
 /usr/local/bin/dbus-binding-tool
 /usr/local/etc/bash_completion.d/dbus-bash-completion.sh
 /usr/local/include/dbus-1.0/dbus/dbus-glib-bindings.h
@@ -10,7 +10,7 @@
 /usr/local/lib64/libdbus-glib-1.la
 /usr/local/lib64/libdbus-glib-1.so
 /usr/local/lib64/libdbus-glib-1.so.2
-/usr/local/lib64/libdbus-glib-1.so.2.3.5
+/usr/local/lib64/libdbus-glib-1.so.2.3.6
 /usr/local/lib64/pkgconfig/dbus-glib-1.pc
 /usr/local/libexec/dbus-bash-completion-helper
 /usr/local/share/gtk-doc/html/dbus-glib/api-index-full.html
@@ -36,4 +36,4 @@
 /usr/local/share/gtk-doc/html/dbus-glib/style.css
 /usr/local/share/gtk-doc/html/dbus-glib/up-insensitive.png
 /usr/local/share/gtk-doc/html/dbus-glib/up.png
-/usr/local/share/man/man1/dbus-binding-tool.1.gz
+/usr/local/share/man/man1/dbus-binding-tool.1.zst

--- a/packages/dbus_glib.rb
+++ b/packages/dbus_glib.rb
@@ -1,30 +1,23 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Dbus_glib < Package
+class Dbus_glib < Autotools
   description 'An obsolete, primarily unmaintained glib binding for libdbus.'
   homepage 'https://dbus.freedesktop.org/doc/dbus-glib/index.html'
-  version '0.112'
+  version '0.114'
   license 'GPL-2 or AFL-2.1'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.112.tar.gz'
-  source_sha256 '7d550dccdfcd286e33895501829ed971eeb65c614e73aadb4a08aeef719b143a'
+  source_url "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-#{version}.tar.gz"
+  source_sha256 'c09c5c085b2a0e391b8ee7d783a1d63fe444e96717cc1814d61b5e8fc2827a7c'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'dc2cea782f496613cd24b9f27afc015f5a02ebc73f63221f581c6bb5248bf8c9',
-     armv7l: 'dc2cea782f496613cd24b9f27afc015f5a02ebc73f63221f581c6bb5248bf8c9',
-     x86_64: 'a1258d16b859c3ff11591871e97b8ad4ddb33ac45951931b196368a613451d76'
+    aarch64: '5250f9dfb4bd31afabc85a04983751fc042be77f8738f93f636a7d9fae11dfcd',
+     armv7l: '5250f9dfb4bd31afabc85a04983751fc042be77f8738f93f636a7d9fae11dfcd',
+     x86_64: 'dc681038fa4af936946d846be5da51c543a2f408e5eef29159e3b8b3bbfe4bf6'
   })
 
-  depends_on 'dbus'
-  depends_on 'glib'
-
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
-  end
+  depends_on 'dbus' => :library
+  depends_on 'expat' => :library
+  depends_on 'glib' => :library
+  depends_on 'glibc' => :library
 end

--- a/tests/package/d/dbus_glib
+++ b/tests/package/d/dbus_glib
@@ -1,0 +1,3 @@
+#!/bin/bash
+dbus-binding-tool --help 2>&1
+dbus-binding-tool --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-dbus_glib crew update \
&& yes | crew upgrade

$ crew check dbus_glib
Checking dbus_glib package ...
Library test for dbus_glib passed.
Checking dbus_glib package ...
dbus-binding-tool [--version] [--help]
dbus-binding-tool --mode=[pretty|glib-server|glib-client] [--prefix=SYMBOL_PREFIX] [--ignore-unsupported] [--force] [--output=FILE]
dbus-binding-tool --mode=glib-server --prefix=SYMBOL_PREFIX [--ignore-unsupported] [--force] [--output=FILE]
D-BUS Binding Tool 0.114
Copyright (C) 2003-2005 Red Hat, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Package tests for dbus_glib passed.
```