### PR TITLE
Etcd 3.6.7 => 3.6.11

### DIFF
--- a/manifest/x86_64/e/etcd.filelist
+++ b/manifest/x86_64/e/etcd.filelist
@@ -1,4 +1,4 @@
-# Total size: 60539432
+# Total size: 61706792
 /usr/local/bin/etcd
 /usr/local/bin/etcdctl
 /usr/local/bin/etcdutl

--- a/packages/etcd.rb
+++ b/packages/etcd.rb
@@ -3,17 +3,16 @@ require 'package'
 class Etcd < Package
   description 'Distributed reliable key-value store for the most critical data of a distributed system'
   homepage 'https://etcd.io/'
-  version '3.6.7'
+  version '3.6.11'
   license 'Apache-2.0'
   compatibility 'x86_64'
   source_url "https://github.com/etcd-io/etcd/releases/download/v#{version}/etcd-v#{version}-linux-amd64.tar.gz"
-  source_sha256 'cf8af880c5a01ee5363cefa14a3e0cb7e5308dcf4ed17a6973099c9a7aee5a9a'
+  source_sha256 '8756f7a4eaf921668a83de0bf13c0f65cae9186a165696e3ae8396afe6f557ed'
 
   no_compile_needed
   no_shrink
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.install %w[etcd etcdctl etcdutl], "#{CREW_DEST_PREFIX}/bin", mode: 0o755
   end
 

--- a/tests/package/e/etcd
+++ b/tests/package/e/etcd
@@ -1,2 +1,7 @@
 #!/bin/bash
+etcd -h 2>&1 | head
 etcd --version
+etcdctl -h 2>&1 | head
+etcdctl version
+etcdutl -h 2>&1 | head
+etcdutl version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-etcd crew update \
&& yes | crew upgrade

$ crew check etcd 
Checking etcd package ...
Library test for etcd passed.
Checking etcd package ...
Usage:

  etcd [flags]
    Start an etcd server.

  etcd --version
    Show the version of etcd.

  etcd -h | --help
    Show the help information about etcd.
etcd Version: 3.6.11
Git SHA: ec166e2
Go Version: go1.25.9
Go OS/Arch: linux/amd64
NAME:
  etcdctl - A simple command line client for etcd3.

USAGE:
  etcdctl [flags]

VERSION:
  3.6.11

API VERSION:
etcdctl version: 3.6.11
API version: 3.6
Usage:
  etcdutl [command]

Available Commands:
  completion  Generate completion script
  defrag      Defragments the storage of the etcd
  hashkv      Prints the KV history hash of a given file
  help        Help about any command
  migrate     Migrates schema of etcd data dir files to make them compatible with different etcd version
  snapshot    Manages etcd node snapshots
etcdutl version: 3.6.11
API version: 3.6
Package tests for etcd passed.
```