### PR TITLE
Di 4.47.1 => 6.2.2.2

### DIFF
--- a/manifest/armv7l/d/di.filelist
+++ b/manifest/armv7l/d/di.filelist
@@ -1,7 +1,14 @@
-# Total size: 83976
+# Total size: 81115
 /usr/local/bin/di
-/usr/local/bin/mi
+/usr/local/include/di.h
+/usr/local/lib/libdi.so
+/usr/local/lib/libdi.so.6
+/usr/local/lib/libdi.so.6.2.2
+/usr/local/lib/pkgconfig/di.pc
+/usr/local/share/di/examples/build.sh
+/usr/local/share/di/examples/diex.c
 /usr/local/share/locale/de/LC_MESSAGES/di.mo
 /usr/local/share/locale/en/LC_MESSAGES/di.mo
 /usr/local/share/locale/es/LC_MESSAGES/di.mo
-/usr/local/share/man/man1/di.1.gz
+/usr/local/share/man/man1/di.1.zst
+/usr/local/share/man/man3/libdi.3.zst

--- a/manifest/i686/d/di.filelist
+++ b/manifest/i686/d/di.filelist
@@ -1,7 +1,14 @@
-# Total size: 92312
+# Total size: 106807
 /usr/local/bin/di
-/usr/local/bin/mi
+/usr/local/include/di.h
+/usr/local/lib/libdi.so
+/usr/local/lib/libdi.so.6
+/usr/local/lib/libdi.so.6.2.2
+/usr/local/lib/pkgconfig/di.pc
+/usr/local/share/di/examples/build.sh
+/usr/local/share/di/examples/diex.c
 /usr/local/share/locale/de/LC_MESSAGES/di.mo
 /usr/local/share/locale/en/LC_MESSAGES/di.mo
 /usr/local/share/locale/es/LC_MESSAGES/di.mo
-/usr/local/share/man/man1/di.1.gz
+/usr/local/share/man/man1/di.1.zst
+/usr/local/share/man/man3/libdi.3.zst

--- a/manifest/x86_64/d/di.filelist
+++ b/manifest/x86_64/d/di.filelist
@@ -1,7 +1,14 @@
-# Total size: 90552
+# Total size: 102545
 /usr/local/bin/di
-/usr/local/bin/mi
+/usr/local/include/di.h
+/usr/local/lib64/libdi.so
+/usr/local/lib64/libdi.so.6
+/usr/local/lib64/libdi.so.6.2.2
+/usr/local/lib64/pkgconfig/di.pc
+/usr/local/share/di/examples/build.sh
+/usr/local/share/di/examples/diex.c
 /usr/local/share/locale/de/LC_MESSAGES/di.mo
 /usr/local/share/locale/en/LC_MESSAGES/di.mo
 /usr/local/share/locale/es/LC_MESSAGES/di.mo
-/usr/local/share/man/man1/di.1.gz
+/usr/local/share/man/man1/di.1.zst
+/usr/local/share/man/man3/libdi.3.zst

--- a/packages/di.rb
+++ b/packages/di.rb
@@ -1,31 +1,24 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Di < Package
+class Di < CMake
   description 'DI is a disk information utility, displaying everything (and more) that your \'df\' command does.'
   homepage 'https://diskinfo-di.sourceforge.io/'
-  version '4.47.1'
+  version '6.2.2.2'
   license 'ZLIB'
   compatibility 'all'
-  source_url 'https://gentoo.com/di/di-4.47.1.tar.gz'
-  source_sha256 'eea8ad94197d9f11790afea0924d8bf29ec001c32eb6209e81c4e13766a2abad'
-  binary_compression 'tar.xz'
+  source_url "https://downloads.sourceforge.net/project/diskinfo-di/di-#{version}.tar.gz"
+  source_sha256 '19eeeb7ebcad3061ae7814cdae5593accfb2bb261ce24795a604a282cbfc60fe'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '7f6339ca083956c06ae62710e486cdb49a9fb9d5448ca1332fea57fe0d29a029',
-     armv7l: '7f6339ca083956c06ae62710e486cdb49a9fb9d5448ca1332fea57fe0d29a029',
-       i686: '3f3972ee14f7d38953afe50f6b5889cabad4e532264df79ab47c83ce62775874',
-     x86_64: '38e6c521776e089729a29b43dbb24e142614edb7e88e077cc69f81dbe0136ff7'
+    aarch64: '9652e3807cd9da2ec73a1c66b72f24da7b7fc8f9056d2b9c3de33b4e890ab417',
+     armv7l: '9652e3807cd9da2ec73a1c66b72f24da7b7fc8f9056d2b9c3de33b4e890ab417',
+       i686: '395ae0a7f3c58ad4a6e2520d17bfc11a6e5695ef55fca5e2ed59082387984c64',
+     x86_64: 'ca094336b13d7fb906ba9ac61a000659d680d3e97dc14506e45506ab883243d8'
   })
 
-  def self.build
-    system "sed -i 's,prefix = /usr/local,prefix = #{CREW_DEST_PREFIX},' Makefile"
-    system "sed -i 's,USER = root,USER = #{USER},' Makefile" # set correct owner
-    system "sed -i 's,GROUP = bin,GROUP = #{USER},' Makefile" # set correct group
-    system 'make -e dioptions.dat'
-    system 'make -e'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", '-e', 'install'
-  end
+  depends_on 'glibc' => :library
+  depends_on 'libtirpc' => :library
+  depends_on 'libtommath' => :library
+  depends_on 'mpdecimal' => :library
 end

--- a/tests/package/d/di
+++ b/tests/package/d/di
@@ -1,0 +1,3 @@
+#!/bin/bash
+man di | head
+di --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-di crew update \
&& yes | crew upgrade

$ crew check di
Checking di package ...
Library test for di passed.
Checking di package ...
di(1)                                                                                       General Commands Manual                                                                                       di(1)

Name
     di - disk information

Synopsis
     di [-AacghHjklLmnPqRtZ] [-B block-size] [-d display-size] [-f format] [-I include-fstyp-list] [-s sort-type] [-x exclude-fstyp-list] [-X debug‐level] [-z zone-name] [file [...]]

     If file is specified, the usage information for the partition on which file is located is printed.

di version 6.2.2.2 production
Package tests for di passed.
```