### PR TITLE
Dmidecode 3.5 => 3.7

### DIFF
--- a/manifest/armv7l/d/dmidecode.filelist
+++ b/manifest/armv7l/d/dmidecode.filelist
@@ -1,8 +1,12 @@
-# Total size: 102242
+# Total size: 203424
 /usr/local/sbin/biosdecode
 /usr/local/sbin/dmidecode
 /usr/local/sbin/ownership
 /usr/local/sbin/vpddecode
+/usr/local/share/bash-completion/completions/biosdecode
+/usr/local/share/bash-completion/completions/dmidecode
+/usr/local/share/bash-completion/completions/ownership
+/usr/local/share/bash-completion/completions/vpddecode
 /usr/local/share/doc/dmidecode/AUTHORS
 /usr/local/share/doc/dmidecode/NEWS
 /usr/local/share/doc/dmidecode/README

--- a/manifest/i686/d/dmidecode.filelist
+++ b/manifest/i686/d/dmidecode.filelist
@@ -1,8 +1,12 @@
-# Total size: 103250
+# Total size: 246952
 /usr/local/sbin/biosdecode
 /usr/local/sbin/dmidecode
 /usr/local/sbin/ownership
 /usr/local/sbin/vpddecode
+/usr/local/share/bash-completion/completions/biosdecode
+/usr/local/share/bash-completion/completions/dmidecode
+/usr/local/share/bash-completion/completions/ownership
+/usr/local/share/bash-completion/completions/vpddecode
 /usr/local/share/doc/dmidecode/AUTHORS
 /usr/local/share/doc/dmidecode/NEWS
 /usr/local/share/doc/dmidecode/README

--- a/manifest/x86_64/d/dmidecode.filelist
+++ b/manifest/x86_64/d/dmidecode.filelist
@@ -1,8 +1,12 @@
-# Total size: 106538
+# Total size: 252056
 /usr/local/sbin/biosdecode
 /usr/local/sbin/dmidecode
 /usr/local/sbin/ownership
 /usr/local/sbin/vpddecode
+/usr/local/share/bash-completion/completions/biosdecode
+/usr/local/share/bash-completion/completions/dmidecode
+/usr/local/share/bash-completion/completions/ownership
+/usr/local/share/bash-completion/completions/vpddecode
 /usr/local/share/doc/dmidecode/AUTHORS
 /usr/local/share/doc/dmidecode/NEWS
 /usr/local/share/doc/dmidecode/README

--- a/packages/dmidecode.rb
+++ b/packages/dmidecode.rb
@@ -3,19 +3,21 @@ require 'package'
 class Dmidecode < Package
   description "Dmidecode reports information about your system's hardware as described in your system BIOS according to the SMBIOS/DMI standard (see a sample output)."
   homepage 'http://www.nongnu.org/dmidecode/'
-  version '3.5'
+  version '3.7'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/dmidecode/dmidecode-3.5.tar.xz'
-  source_sha256 '79d76735ee8e25196e2a722964cf9683f5a09581503537884b256b01389cc073'
+  source_url "https://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{version}.tar.xz"
+  source_sha256 '2c3aed12c85a1e6a9410d406d5e417c455466dc1bc7c89278bb32cf7cad91e8a'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'cb38d8205474b2780871da16f96f109c77cde0c804f244597b4211ecb50a1c17',
-     armv7l: 'cb38d8205474b2780871da16f96f109c77cde0c804f244597b4211ecb50a1c17',
-       i686: 'be0f1f35877a1de79af3eae6604923de5bf9dbfbda28c1482bf5fae59fcfc05b',
-     x86_64: 'c8202d5a2bea79d0791074759736278a5755405ccdc7107e3bee654450ad7ddc'
+    aarch64: '1d9708685a0e268ffdb4497d60380d18d7ee8ed3b1db5cced8fa25c9a8f80f0e',
+     armv7l: '1d9708685a0e268ffdb4497d60380d18d7ee8ed3b1db5cced8fa25c9a8f80f0e',
+       i686: '92bd14db29954c7edc1c2e1d287d4f56ddf2bd587c89bbfae9d7d11e64749c0a',
+     x86_64: '4adf7327a0dae8dde677da66ee3b346eb4a9ed3e5e9f835fa41d03d8e3fe3658'
   })
+
+  depends_on 'glibc' => :executable
 
   def self.patch
     system "sed -i 's,^prefix = /usr/local,prefix = #{CREW_PREFIX},' Makefile"

--- a/tests/package/d/dmidecode
+++ b/tests/package/d/dmidecode
@@ -1,0 +1,3 @@
+#!/bin/bash
+dmidecode -h | head
+dmidecode -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-dmidecode crew update \
&& yes | crew upgrade

$ crew check dmidecode
Checking dmidecode package ...
Library test for dmidecode passed.
Checking dmidecode package ...
Usage: dmidecode [OPTIONS]
Options are:
 -d, --dev-mem FILE     Read memory from device FILE (default: /dev/mem)
 -h, --help             Display this help text and exit
 -q, --quiet            Less verbose output
     --no-quirks        Decode everything without quirks
 -s, --string KEYWORD   Only display the value of the given DMI string
     --list-strings     List available string keywords and exit
 -t, --type TYPE        Only display the entries of given type
     --list-types       List available type keywords and exit
3.7
Package tests for dmidecode passed.
```