### PR TITLE
Add json2csv package

### DIFF
--- a/manifest/armv7l/j/json2csv.filelist
+++ b/manifest/armv7l/j/json2csv.filelist
@@ -1,0 +1,2 @@
+# Total size: 2078076
+/usr/local/bin/json2csv

--- a/manifest/i686/j/json2csv.filelist
+++ b/manifest/i686/j/json2csv.filelist
@@ -1,0 +1,2 @@
+# Total size: 1968484
+/usr/local/bin/json2csv

--- a/manifest/x86_64/j/json2csv.filelist
+++ b/manifest/x86_64/j/json2csv.filelist
@@ -1,0 +1,2 @@
+# Total size: 2112648
+/usr/local/bin/json2csv

--- a/packages/json2csv.rb
+++ b/packages/json2csv.rb
@@ -1,0 +1,31 @@
+require 'package'
+
+class Json2csv < Package
+  description 'command line tool to convert json to csv'
+  homepage 'https://github.com/jehiah/json2csv'
+  version '1.2.1'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'SKIP'
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: 'e67418f6e6ea2ed05d6fbb5e74cf4db372ea27d6ab81dd61a4a9226d9bb53577',
+     armv7l: 'e67418f6e6ea2ed05d6fbb5e74cf4db372ea27d6ab81dd61a4a9226d9bb53577',
+       i686: '363a35b5d36b38900f9fbc09aaa1e36c7efcbdf62a0054fc560d4556a64e6a69',
+     x86_64: 'b10d4622d48afd8f9efc9081ff786cb911995dd9d80893c51198979fa31eceaa'
+  })
+
+  depends_on 'glibc' # R
+  depends_on 'go' => :build
+
+  no_source_build
+
+  def self.install
+    system "GOBIN=#{CREW_DEST_PREFIX}/bin go install github.com/jehiah/json2csv@v#{version}"
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'json2csv -h' to get started.\n"
+  end
+end

--- a/tests/package/j/json2csv
+++ b/tests/package/j/json2csv
@@ -1,0 +1,3 @@
+#!/bin/bash
+json2csv -h 2>&1
+json2csv -version

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -3765,6 +3765,11 @@ url: https://download.gnome.org/sources/json-glib/
 activity: low
 ---
 kind: url
+name: json2csv
+url: https://github.com/jehiah/json2csv/releases
+activity: none
+---
+kind: url
 name: jsonc
 url: https://github.com/json-c/json-c/releases
 activity: low


### PR DESCRIPTION
## Description
Command line tool to convert json to csv.  See https://github.com/jehiah/json2csv.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-json2csv-package crew update \
&& yes | crew upgrade

$ crew check json2csv 
Checking json2csv package ...
Library test for json2csv passed.
Checking json2csv package ...
Usage of json2csv:
  -d string
    	delimiter used for output values (default ",")
  -i string
    	/path/to/input.json (optional; default is stdin)
  -k value
    	fields to output
  -o string
    	/path/to/output.csv (optional; default is stdout)
  -p	prints header to output
  -version
    	print version string
json2csv v1.2.1 (built w/go1.26.3)
Package tests for json2csv passed.
```