### PR TITLE
Dnsmasq 2.89 => 2.92

### DIFF
--- a/manifest/armv7l/d/dnsmasq.filelist
+++ b/manifest/armv7l/d/dnsmasq.filelist
@@ -1,3 +1,3 @@
-# Total size: 191601
+# Total size: 433760
 /usr/local/sbin/dnsmasq
 /usr/local/share/man/man8/dnsmasq.8.zst

--- a/manifest/i686/d/dnsmasq.filelist
+++ b/manifest/i686/d/dnsmasq.filelist
@@ -1,3 +1,3 @@
-# Total size: 224397
+# Total size: 517484
 /usr/local/sbin/dnsmasq
 /usr/local/share/man/man8/dnsmasq.8.zst

--- a/manifest/x86_64/d/dnsmasq.filelist
+++ b/manifest/x86_64/d/dnsmasq.filelist
@@ -1,3 +1,3 @@
-# Total size: 218341
+# Total size: 481500
 /usr/local/sbin/dnsmasq
 /usr/local/share/man/man8/dnsmasq.8.zst

--- a/packages/dnsmasq.rb
+++ b/packages/dnsmasq.rb
@@ -3,19 +3,21 @@ require 'package'
 class Dnsmasq < Package
   description 'Lightweight, easy to configure DNS forward ,TFTP server and DHCP server'
   homepage 'https://thekelleys.org.uk/dnsmasq/doc.html'
-  version '2.89'
+  version '2.92'
   license 'GPL-2 or GPL-3'
   compatibility 'all'
-  source_url 'http://thekelleys.org.uk/dnsmasq/dnsmasq-2.89.tar.xz'
-  source_sha256 '02bd230346cf0b9d5909f5e151df168b2707103785eb616b56685855adebb609'
+  source_url "https://thekelleys.org.uk/dnsmasq/dnsmasq-#{version}.tar.xz"
+  source_sha256 '4bf50c2c1018f9fbc26037df51b90ecea0cb73d46162846763b92df0d6c3a458'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e798ec6969f5ec63d9975efbeef5f82d537fc8349f95b4151d07dd19de9792e2',
-     armv7l: 'e798ec6969f5ec63d9975efbeef5f82d537fc8349f95b4151d07dd19de9792e2',
-       i686: 'a73b32027305d5d9d28331624f95272c47675b25fe0be8b65ff51a3e59b0a442',
-     x86_64: 'aa5c65411792ffc97c989e8b3f5e7447e12a68f7c6c992e4e4e747236e626845'
+    aarch64: '909462504985225785fe23c88806120a7f1a544b2ce47ff221e4d2cd3fc28f57',
+     armv7l: '909462504985225785fe23c88806120a7f1a544b2ce47ff221e4d2cd3fc28f57',
+       i686: 'c76c7b8bad418e3f64b8fca2eab47d64a1ac5b21cf06b948f0ea19a8c0985607',
+     x86_64: '9670b1ee33df42da9078e77b568f3edacaf994c9d326b48bea53114a708bb758'
   })
+
+  depends_on 'glibc' => :executable
 
   def self.build
     system 'make'

--- a/tests/package/d/dnsmasq
+++ b/tests/package/d/dnsmasq
@@ -1,0 +1,4 @@
+#!/bin/bash
+man dnsmasq | head
+dnsmasq --help | head
+dnsmasq --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-dnsmasq crew update \
&& yes | crew upgrade

$ crew check dnsmasq 
Checking dnsmasq package ...
Library test for dnsmasq passed.
Checking dnsmasq package ...
DNSMASQ(8)                                                                                  System Manager’s Manual                                                                                  DNSMASQ(8)

NAME
     dnsmasq - A lightweight DHCP and caching DNS server.

SYNOPSIS
     dnsmasq [OPTION]...

DESCRIPTION
     dnsmasq is a lightweight DNS, TFTP, PXE, router advertisement and DHCP server. It is intended to provide coupled DNS and DHCP service to a LAN.
Usage: dnsmasq [options]

Valid options are:
-a, --listen-address=<ipaddr>                          Specify local address(es) to listen on.
-A, --address=/<domain>/<ipaddr>                       Return ipaddr for all hosts in specified domains.
-b, --bogus-priv                                       Fake reverse lookups for RFC1918 private address ranges.
-B, --bogus-nxdomain=<ipaddr>                          Treat ipaddr as NXDOMAIN (defeats Verisign wildcard).
-c, --cache-size=<integer>                             Specify the size of the cache in entries (defaults to 150).
-C, --conf-file=<path>                                 Specify configuration file (defaults to /etc/dnsmasq.conf).
-d, --no-daemon                                        Do NOT fork into the background: run in debug mode.
Dnsmasq version 2.92  Copyright (c) 2000-2025 Simon Kelley
Compile time options: IPv6 GNU-getopt no-DBus no-UBus no-i18n no-IDN DHCP DHCPv6 no-Lua TFTP no-conntrack ipset no-nftset auth no-DNSSEC loop-detect inotify dumpfile

This software comes with ABSOLUTELY NO WARRANTY.
Dnsmasq is free software, and you are welcome to redistribute it
under the terms of the GNU General Public License, version 2 or 3.
Package tests for dnsmasq passed.
```