### PR TITLE
Dosfstools 4.1 => 4.2

### DIFF
--- a/manifest/armv7l/d/dosfstools.filelist
+++ b/manifest/armv7l/d/dosfstools.filelist
@@ -1,4 +1,4 @@
-# Total size: 527621
+# Total size: 380402
 /usr/local/sbin/dosfsck
 /usr/local/sbin/dosfslabel
 /usr/local/sbin/fatlabel
@@ -10,20 +10,24 @@
 /usr/local/sbin/mkfs.msdos
 /usr/local/sbin/mkfs.vfat
 /usr/local/share/doc/dosfstools/ANNOUNCE.mkdosfs
+/usr/local/share/doc/dosfstools/COPYING
+/usr/local/share/doc/dosfstools/ChangeLog
 /usr/local/share/doc/dosfstools/ChangeLog.dosfsck
 /usr/local/share/doc/dosfstools/ChangeLog.dosfstools-2.x
 /usr/local/share/doc/dosfstools/ChangeLog.mkdosfs
+/usr/local/share/doc/dosfstools/NEWS
+/usr/local/share/doc/dosfstools/README
 /usr/local/share/doc/dosfstools/README.dosfsck
 /usr/local/share/doc/dosfstools/README.dosfstools-2.x
 /usr/local/share/doc/dosfstools/README.mkdosfs
 /usr/local/share/doc/dosfstools/TODO.dosfstools-2.x
-/usr/local/share/man/man8/dosfsck.8.gz
-/usr/local/share/man/man8/dosfslabel.8.gz
-/usr/local/share/man/man8/fatlabel.8.gz
-/usr/local/share/man/man8/fsck.fat.8.gz
-/usr/local/share/man/man8/fsck.msdos.8.gz
-/usr/local/share/man/man8/fsck.vfat.8.gz
-/usr/local/share/man/man8/mkdosfs.8.gz
-/usr/local/share/man/man8/mkfs.fat.8.gz
-/usr/local/share/man/man8/mkfs.msdos.8.gz
-/usr/local/share/man/man8/mkfs.vfat.8.gz
+/usr/local/share/man/man8/dosfsck.8.zst
+/usr/local/share/man/man8/dosfslabel.8.zst
+/usr/local/share/man/man8/fatlabel.8.zst
+/usr/local/share/man/man8/fsck.fat.8.zst
+/usr/local/share/man/man8/fsck.msdos.8.zst
+/usr/local/share/man/man8/fsck.vfat.8.zst
+/usr/local/share/man/man8/mkdosfs.8.zst
+/usr/local/share/man/man8/mkfs.fat.8.zst
+/usr/local/share/man/man8/mkfs.msdos.8.zst
+/usr/local/share/man/man8/mkfs.vfat.8.zst

--- a/manifest/i686/d/dosfstools.filelist
+++ b/manifest/i686/d/dosfstools.filelist
@@ -1,4 +1,4 @@
-# Total size: 487605
+# Total size: 420846
 /usr/local/sbin/dosfsck
 /usr/local/sbin/dosfslabel
 /usr/local/sbin/fatlabel
@@ -10,20 +10,24 @@
 /usr/local/sbin/mkfs.msdos
 /usr/local/sbin/mkfs.vfat
 /usr/local/share/doc/dosfstools/ANNOUNCE.mkdosfs
+/usr/local/share/doc/dosfstools/COPYING
+/usr/local/share/doc/dosfstools/ChangeLog
 /usr/local/share/doc/dosfstools/ChangeLog.dosfsck
 /usr/local/share/doc/dosfstools/ChangeLog.dosfstools-2.x
 /usr/local/share/doc/dosfstools/ChangeLog.mkdosfs
+/usr/local/share/doc/dosfstools/NEWS
+/usr/local/share/doc/dosfstools/README
 /usr/local/share/doc/dosfstools/README.dosfsck
 /usr/local/share/doc/dosfstools/README.dosfstools-2.x
 /usr/local/share/doc/dosfstools/README.mkdosfs
 /usr/local/share/doc/dosfstools/TODO.dosfstools-2.x
-/usr/local/share/man/man8/dosfsck.8.gz
-/usr/local/share/man/man8/dosfslabel.8.gz
-/usr/local/share/man/man8/fatlabel.8.gz
-/usr/local/share/man/man8/fsck.fat.8.gz
-/usr/local/share/man/man8/fsck.msdos.8.gz
-/usr/local/share/man/man8/fsck.vfat.8.gz
-/usr/local/share/man/man8/mkdosfs.8.gz
-/usr/local/share/man/man8/mkfs.fat.8.gz
-/usr/local/share/man/man8/mkfs.msdos.8.gz
-/usr/local/share/man/man8/mkfs.vfat.8.gz
+/usr/local/share/man/man8/dosfsck.8.zst
+/usr/local/share/man/man8/dosfslabel.8.zst
+/usr/local/share/man/man8/fatlabel.8.zst
+/usr/local/share/man/man8/fsck.fat.8.zst
+/usr/local/share/man/man8/fsck.msdos.8.zst
+/usr/local/share/man/man8/fsck.vfat.8.zst
+/usr/local/share/man/man8/mkdosfs.8.zst
+/usr/local/share/man/man8/mkfs.fat.8.zst
+/usr/local/share/man/man8/mkfs.msdos.8.zst
+/usr/local/share/man/man8/mkfs.vfat.8.zst

--- a/manifest/x86_64/d/dosfstools.filelist
+++ b/manifest/x86_64/d/dosfstools.filelist
@@ -1,4 +1,4 @@
-# Total size: 596397
+# Total size: 412586
 /usr/local/sbin/dosfsck
 /usr/local/sbin/dosfslabel
 /usr/local/sbin/fatlabel
@@ -10,20 +10,24 @@
 /usr/local/sbin/mkfs.msdos
 /usr/local/sbin/mkfs.vfat
 /usr/local/share/doc/dosfstools/ANNOUNCE.mkdosfs
+/usr/local/share/doc/dosfstools/COPYING
+/usr/local/share/doc/dosfstools/ChangeLog
 /usr/local/share/doc/dosfstools/ChangeLog.dosfsck
 /usr/local/share/doc/dosfstools/ChangeLog.dosfstools-2.x
 /usr/local/share/doc/dosfstools/ChangeLog.mkdosfs
+/usr/local/share/doc/dosfstools/NEWS
+/usr/local/share/doc/dosfstools/README
 /usr/local/share/doc/dosfstools/README.dosfsck
 /usr/local/share/doc/dosfstools/README.dosfstools-2.x
 /usr/local/share/doc/dosfstools/README.mkdosfs
 /usr/local/share/doc/dosfstools/TODO.dosfstools-2.x
-/usr/local/share/man/man8/dosfsck.8.gz
-/usr/local/share/man/man8/dosfslabel.8.gz
-/usr/local/share/man/man8/fatlabel.8.gz
-/usr/local/share/man/man8/fsck.fat.8.gz
-/usr/local/share/man/man8/fsck.msdos.8.gz
-/usr/local/share/man/man8/fsck.vfat.8.gz
-/usr/local/share/man/man8/mkdosfs.8.gz
-/usr/local/share/man/man8/mkfs.fat.8.gz
-/usr/local/share/man/man8/mkfs.msdos.8.gz
-/usr/local/share/man/man8/mkfs.vfat.8.gz
+/usr/local/share/man/man8/dosfsck.8.zst
+/usr/local/share/man/man8/dosfslabel.8.zst
+/usr/local/share/man/man8/fatlabel.8.zst
+/usr/local/share/man/man8/fsck.fat.8.zst
+/usr/local/share/man/man8/fsck.msdos.8.zst
+/usr/local/share/man/man8/fsck.vfat.8.zst
+/usr/local/share/man/man8/mkdosfs.8.zst
+/usr/local/share/man/man8/mkfs.fat.8.zst
+/usr/local/share/man/man8/mkfs.msdos.8.zst
+/usr/local/share/man/man8/mkfs.vfat.8.zst

--- a/packages/dosfstools.rb
+++ b/packages/dosfstools.rb
@@ -1,28 +1,23 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Dosfstools < Package
+class Dosfstools < Autotools
   description 'dosfstools consists of the programs mkfs.fat, fsck.fat and fatlabel to create, check and label file systems of the FAT family.'
   homepage 'https://github.com/dosfstools/dosfstools'
-  version '4.1'
+  version '4.2'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://github.com/dosfstools/dosfstools/releases/download/v4.1/dosfstools-4.1.tar.xz'
-  source_sha256 'e6b2aca70ccc3fe3687365009dd94a2e18e82b688ed4e260e04b7412471cc173'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/dosfstools/dosfstools.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a2fa41c25a7aee9ae85cd1b7759d3de0f89c6e3863ab26b7959d0b7f7c4acae6',
-     armv7l: 'a2fa41c25a7aee9ae85cd1b7759d3de0f89c6e3863ab26b7959d0b7f7c4acae6',
-       i686: '5e71d1e528360ce349a3a609ffad1d5723a91fc2687a76b8fe5f2a8c8437665c',
-     x86_64: '430a5579234dd68276ecb94cd24c0e5b894b26f04e76b09d2268aeaef7467046'
+    aarch64: 'bccc3d266c65d5fda76a4694a49afe9a580633ae911d1af23c52f1d6ef69220b',
+     armv7l: 'bccc3d266c65d5fda76a4694a49afe9a580633ae911d1af23c52f1d6ef69220b',
+       i686: '72d1784288c75e9cdafa4b56e31bd9c02b33fc4a17ea922200a5fa676979e1cb',
+     x86_64: 'f63c26700393920c65db0cd4dc9d5d071c444472fb99ae84b16759714db40e53'
   })
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS} --enable-compat-symlinks"
-    system 'make'
-  end
+  depends_on 'glibc' => :executable
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_configure_options '--enable-compat-symlinks'
 end

--- a/tests/package/d/dosfstools
+++ b/tests/package/d/dosfstools
@@ -1,0 +1,7 @@
+#!/bin/bash
+dosfsck --help 2>&1 | head -5
+dosfslabel -h
+dosfslabel -V
+fatlabel -h
+fatlabel -V
+mkdosfs --help 2>&1 | head -5


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-dosfstools crew update \
&& yes | crew upgrade

$ crew check dosfstools
Checking dosfstools package ...
Library test for dosfstools passed.
Checking dosfstools package ...
Usage: dosfsck [OPTIONS] DEVICE
Check FAT filesystem on DEVICE for errors.

Options:
  -a              automatically repair the filesystem
Usage: fatlabel [OPTIONS] DEVICE [NEW]
Change the FAT filesystem label or serial on DEVICE to NEW or display the
existing label or serial if NEW is not given.

Options:
  -i, --volume-id     Work on serial number instead of label
  -r, --reset         Remove label or generate new serial number
  -c N, --codepage=N  use DOS codepage N to encode/decode label (default: 850)
  -V, --version       Show version number and terminate
  -h, --help          Print this message and terminate
fatlabel 4.2 (2021-01-31)
Usage: fatlabel [OPTIONS] DEVICE [NEW]
Change the FAT filesystem label or serial on DEVICE to NEW or display the
existing label or serial if NEW is not given.

Options:
  -i, --volume-id     Work on serial number instead of label
  -r, --reset         Remove label or generate new serial number
  -c N, --codepage=N  use DOS codepage N to encode/decode label (default: 850)
  -V, --version       Show version number and terminate
  -h, --help          Print this message and terminate
fatlabel 4.2 (2021-01-31)
Usage: mkdosfs [OPTIONS] TARGET [BLOCKS]
Create FAT filesystem in TARGET, which can be a block device or file. Use only
up to BLOCKS 1024 byte blocks if specified. With the -C option, file TARGET will be
created with a size of 1024 bytes times BLOCKS, which must be specified.

Package tests for dosfstools passed.
```