### PR TITLE
Add static curl build. — curl_static → 20260301.1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CREW_INSTALLER_VERSION=2026021201
+CREW_INSTALLER_VERSION=2026050901
 export CREW_INSTALLER_RUNNING=1
 # Exit on fail.
 set -eE
@@ -601,7 +601,7 @@ export CREW_LOCAL_REPO_ROOT="${CREW_PREFIX}/lib/crew"
 # This is needed for SSL env variables to be populated so ruby doesn't
 # complain about missing certs, resulting in failed https connections.
 echo_info "Installing crew_profile_base...\n"
-yes | ${PREFIX_CMD} crew install crew_profile_base
+yes | ${PREFIX_CMD} crew install crew_profile_base curl_static
 
 # shellcheck disable=SC1090
 trap - ERR && source ~/.bashrc && set_trap

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.73.3' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.73.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -204,9 +204,11 @@ def external_downloader(uri, filename = File.basename(url), verbose: false)
   #       %<url>s: Will be substitute to #{url}
   #    %<output>s: Will be substitute to #{filename}
   # i686 curl throws a "SSL certificate problem: self signed certificate in certificate chain" error.
+  # The static curl build may be incompatible with the system glibc, so test it before using it.
   # Only bypass this when we are using the system curl early in install.
-  @default_curl = File.which('curl')
-  curl_cmdline = ARCH == 'i686' && @default_curl == '/usr/bin/curl' ? 'curl %<verbose>s -kL -# --retry %<retry>s %<url>s -o %<output>s' : 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
+  @curl_binary = File.which('curl_static') && `curl_static --version` ? File.which('curl_static') : File.which('curl')
+
+  curl_cmdline = ARCH == 'i686' && @curl_binary == '/usr/bin/curl' ? "#{@curl_binary} %<verbose>s -kL -# --retry %<retry>s %<url>s -o %<output>s" : "#{@curl_binary} %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s"
 
   # use CREW_DOWNLOADER if specified, use curl by default
   downloader_cmdline = CREW_DOWNLOADER || curl_cmdline

--- a/manifest/armv7l/c/curl_static.filelist
+++ b/manifest/armv7l/c/curl_static.filelist
@@ -1,0 +1,2 @@
+# Total size: 4471536
+/usr/local/bin/curl_static

--- a/manifest/i686/c/curl_static.filelist
+++ b/manifest/i686/c/curl_static.filelist
@@ -1,0 +1,2 @@
+# Total size: 6286872
+/usr/local/bin/curl_static

--- a/manifest/x86_64/c/curl_static.filelist
+++ b/manifest/x86_64/c/curl_static.filelist
@@ -1,0 +1,2 @@
+# Total size: 7870880
+/usr/local/bin/curl_static

--- a/packages/curl_static.rb
+++ b/packages/curl_static.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Curl_static < Package
+  description 'Static curl 8.x via alpine build'
+  homepage 'https://github.com/chromebrew/static-binaries/'
+  version '20260301.1'
+  license 'GPL-3'
+  compatibility 'all'
+  source_url({
+      aarch64: "https://github.com/chromebrew/static-binaries/releases/download/v#{version}/curl_v#{version}_linux_arm64",
+       armv7l: "https://github.com/chromebrew/static-binaries/releases/download/v#{version}/curl_v#{version}_linux_arm32v7",
+         i686: "https://github.com/chromebrew/static-binaries/releases/download/v#{version}/curl_v#{version}_linux_i386",
+       x86_64: "https://github.com/chromebrew/static-binaries/releases/download/v#{version}/curl_v#{version}_linux_amd64"
+    })
+  source_sha256({
+      aarch64: '2f8b71fcc54be75eb12fafaa7275c3407a0bbe454747c550bd70a39e132a703c',
+       armv7l: '95ebdc40fc11261e0675575973705c097f42bd8a7ab09c22f18b01cd7bbf49dc',
+         i686: '1299836a610ad2ea8f51670e20d43e1c0a8ebc00d1f757deeb7c195fb37d4964',
+       x86_64: '7cdd59b027cd1f01cd23a20dcadbbdead992a78ef035accebd999ccb7f84080c'
+    })
+
+  ignore_updater
+  no_compile_needed
+
+  def self.install
+    case ARCH
+    when 'aarch64'
+      FileUtils.install "curl_v#{version}_linux_arm64", "#{CREW_DEST_PREFIX}/bin/curl_static", mode: 0o755
+    when 'armv7l'
+      FileUtils.install "curl_v#{version}_linux_arm32v7", "#{CREW_DEST_PREFIX}/bin/curl_static", mode: 0o755
+    when 'i686'
+      FileUtils.install "curl_v#{version}_linux_i386", "#{CREW_DEST_PREFIX}/bin/curl_static", mode: 0o755
+    when 'x86_64'
+      FileUtils.install "curl_v#{version}_linux_amd64", "#{CREW_DEST_PREFIX}/bin/curl_static", mode: 0o755
+    end
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1345,6 +1345,11 @@ url: https://github.com/curl/curl/releases
 activity: high
 ---
 kind: url
+name: curl_static
+url: https://curl.se/
+activity: none
+---
+kind: url
 name: cursor
 url: https://www.cursor.com/downloads
 activity: medium


### PR DESCRIPTION
## Description
#### Commits:
-  df794154d Add static curl build.
### Packages with Updated versions or Changed package files:
- `curl_static` &rarr; 20260301.1
##
Builds attempted for:
### Other changed files:
- install.sh
- lib/const.rb
- lib/downloader.rb
- tools/packages.yaml
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=static_curl crew update \
&& yes | crew upgrade
```
