### PR TITLE
Add py3_charset_normalizer to buildessential. — buildessential: 1.50 → 1.51

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.50'
+  version '1.51'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -148,6 +148,7 @@ class Buildessential < Package
   depends_on 'py3_wheel'
   depends_on 'py3_pyproject_hooks'
   depends_on 'py3_libxml2'
+  depends_on 'py3_charset_normalizer'
   # Pax_utils needs this.
   depends_on 'py3_pyelftools'
   # Needed for pypi uploads to gitlab


### PR DESCRIPTION
## Description
#### Commits:
-  f83f3cb6b Add py3_charset_normalizer to buildessential.
### Packages with Updated versions or Changed package files:
- `buildessential`: 1.50 &rarr; 1.51
##
Builds attempted for:
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add_py3_charset_normalizer_to_buildessential crew update \
&& yes | crew upgrade
```
