### PR TITLE
Daq 3.0.15 => 3.0.27

### DIFF
--- a/manifest/armv7l/d/daq.filelist
+++ b/manifest/armv7l/d/daq.filelist
@@ -1,4 +1,4 @@
-# Total size: 1382861
+# Total size: 1381657
 /usr/local/bin/daqtest
 /usr/local/bin/daqtest-static
 /usr/local/include/daq.h

--- a/manifest/i686/d/daq.filelist
+++ b/manifest/i686/d/daq.filelist
@@ -1,4 +1,4 @@
-# Total size: 1111209
+# Total size: 1326771
 /usr/local/bin/daqtest
 /usr/local/bin/daqtest-static
 /usr/local/include/daq.h

--- a/manifest/x86_64/d/daq.filelist
+++ b/manifest/x86_64/d/daq.filelist
@@ -1,4 +1,4 @@
-# Total size: 1559211
+# Total size: 1597599
 /usr/local/bin/daqtest
 /usr/local/bin/daqtest-static
 /usr/local/include/daq.h

--- a/packages/daq.rb
+++ b/packages/daq.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Daq < Autotools
   description 'Data Acquisition library, for packet I/O.'
   homepage 'https://www.snort.org'
-  version '3.0.15'
+  version '3.0.27'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/snort3/libdaq.git'
@@ -11,14 +11,16 @@ class Daq < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '3c809aeb3c5663f7a3b84e573679dd5c68acb6b4f188ad7961721bf45470019f',
-     armv7l: '3c809aeb3c5663f7a3b84e573679dd5c68acb6b4f188ad7961721bf45470019f',
-       i686: 'cdf573c9b712ea6e17b6ac49bdd8553343aecedeb44987439f2e2428be5d4aec',
-     x86_64: '1f5b8b93b32144d8c603ef13752a7ddbee93c16b5df5a0bcbacd03d5463b91fd'
+    aarch64: '665a396c382f92e9f4f72c404dd02cc572cc555d19940f74870f89d219365e51',
+     armv7l: '665a396c382f92e9f4f72c404dd02cc572cc555d19940f74870f89d219365e51',
+       i686: 'd1899623019f3b89ea36662ce91e2247670d29ab93da80c1f63a3e03f0482a70',
+     x86_64: 'f71eb7d7e0c8ed0db4004cb64473e7a7b2ed0a9f3de60ea898cffef66364ab60'
   })
 
   # depends_on 'cmocka' => :build
-  depends_on 'libpcap'
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'libpcap' => :library
 
   # https://github.com/snort3/libdaq/issues/30
   # run_tests

--- a/tests/package/d/daq
+++ b/tests/package/d/daq
@@ -1,0 +1,3 @@
+#!/bin/bash
+daqtest -h | head
+daqtest-static -h | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-daq crew update \
&& yes | crew upgrade

$ crew check daq
Checking daq package ...
Library test for daq passed.
Checking daq package ...
Usage: daqtest -d <daq_module> -i <input> [OPTION]...
  -A <ip>           Specify an IP to respond to ARPs on (may be specified multiple times)
  -b <num>          Specify the number of messages to request per receive call (default = 16)
  -c <num>          Maximum number of packets to acquire (default = 0, <= 0 is unlimited)
  -C <key[=value]>  Set a DAQ configuration variable key/value pair
  -D <delay>        Specify a millisecond delay to be added to each packet processed
  -f <bpf>          Specify the Berkley Packet Filter string to use for filtering
  -g <groupname>    Run as the specified group after initialization (accepts GID)
  -h                Display this usage text and exit
  -k                Ignore checksum errors during protocol decoding
Usage: daqtest -d <daq_module> -i <input> [OPTION]...
  -A <ip>           Specify an IP to respond to ARPs on (may be specified multiple times)
  -b <num>          Specify the number of messages to request per receive call (default = 16)
  -c <num>          Maximum number of packets to acquire (default = 0, <= 0 is unlimited)
  -C <key[=value]>  Set a DAQ configuration variable key/value pair
  -D <delay>        Specify a millisecond delay to be added to each packet processed
  -f <bpf>          Specify the Berkley Packet Filter string to use for filtering
  -g <groupname>    Run as the specified group after initialization (accepts GID)
  -h                Display this usage text and exit
  -k                Ignore checksum errors during protocol decoding
Package tests for daq passed.
```