### PR TITLE
Only set reviewers if tests have passed.

### DIFF
--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.7
+# Version 1.8
 name: Generate PR
 run-name: Generate PR for ${{ inputs.branch || github.head_ref || github.ref_name }} by @${{ github.actor }}
 on:
@@ -576,9 +576,9 @@ jobs:
             FINAL_PR_TITLE="${TITLE}"
           fi
           if [[ -z ${PR_NUMBER} ]]; then
-            PR_NUMBER=$(gh pr create -d --reviewer chromebrew/active $PR_CREATE_LABEL_FLAG --title "${FINAL_PR_TITLE}" -F /tmp/pr.txt | rev | cut -d"/" -f1  | rev)
+            PR_NUMBER=$(gh pr create -d $PR_CREATE_LABEL_FLAG --title "${FINAL_PR_TITLE}" -F /tmp/pr.txt | rev | cut -d"/" -f1  | rev)
           else
-            gh pr edit --add-reviewer chromebrew/active $PR_EDIT_LABEL_FLAG --title "${FINAL_PR_TITLE}" -F /tmp/pr.txt
+            gh pr edit $PR_EDIT_LABEL_FLAG --title "${FINAL_PR_TITLE}" -F /tmp/pr.txt
           fi
           # Try to update branch before finishing.
           gh pr update-branch --rebase || true

--- a/.github/workflows/Set-Reviewers.yml
+++ b/.github/workflows/Set-Reviewers.yml
@@ -1,0 +1,53 @@
+---
+# Version 1.0
+name: Set Reviewers
+run-name: Set Reviewers for PR for ${{ github.head_ref || github.ref_name }}
+on:
+  pull_request:
+    types: [review_requested, ready_for_review]
+  workflow_dispatch:
+permissions:
+  actions: write
+  contents: write
+  packages: write
+  pull-requests: write
+  repository-projects: read
+jobs:
+  debug:
+    if: ${{ github.repository_owner == 'chromebrew' && github.event.pull_request.draft == false }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "$STEPS_CONTEXT"
+  setup:
+    if: ${{  github.repository_owner == 'chromebrew' && github.event.pull_request.draft == false  }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get GH Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v4
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          organization: chromebrew
+          revoke_token: true
+      - name: Get Status of current ref
+        id: get-status
+        uses: danieldeichfuss/get-status@v0.10
+        with:
+          ref: ${{ github.sha }}
+      - name: Set Reviewers
+        if: ${{steps.get-status.outputs.all-checks-completed == 'true' &&  steps.get-status.outputs.all-checks-passed == 'true'}}
+        run: |
+          gh pr edit --add-reviewer chromebrew/active
+          echo "Asking Chromebrew/active for review."


### PR DESCRIPTION
## Description
#### Commits:
-  8058b7034 Only set reviewers if tests have passed.
### Updated GitHub configuration files:
- .github/workflows/Set-Reviewers.yml
- .github/workflows/Generate-PR.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=reviewers crew update \
&& yes | crew upgrade
```
