### PR TITLE
Do not run Set Reviewer workflow on master branch.

### DIFF
--- a/.github/workflows/Set-Reviewers.yml
+++ b/.github/workflows/Set-Reviewers.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.2
+# Version 1.3
 name: Set Reviewers
 run-name: Set Reviewers for PR for ${{ github.head_ref || github.ref_name }}
 on:
@@ -22,7 +22,7 @@ permissions:
   repository-projects: read
 jobs:
   debug:
-    if: ${{ github.repository_owner == 'chromebrew' && github.event.pull_request.draft == false }}
+    if: ${{ github.repository_owner == 'chromebrew' && inputs.branch != 'master' && github.ref_name != 'master' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     steps:
       - name: Dump GitHub context
@@ -38,7 +38,8 @@ jobs:
           STEPS_CONTEXT: ${{ toJson(steps) }}
         run: echo "$STEPS_CONTEXT"
   setup:
-    if: ${{  github.repository_owner == 'chromebrew' && github.event.pull_request.draft == false && github.event.workflow_run.conclusion == 'success' }}
+    needs: debug
+    if: ${{  github.repository_owner == 'chromebrew' && inputs.branch != 'master' && github.ref_name != 'master' && github.event.pull_request.draft == false && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Get GH Token


### PR DESCRIPTION
## Description
#### Commits:
-  f2920e83d Do not run Set Reviewer workflow on master branch.
### Updated GitHub configuration files:
- .github/workflows/Set-Reviewers.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=no_reviewer_on_master crew update \
&& yes | crew upgrade
```
