### PR TITLE
Use github.event.workflow_run.head_branch in workflow branch determination.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,7 +1,7 @@
 ---
-# Version 1.4
+# Version 1.5
 name: Build
-run-name: Build ${{ inputs.packages_to_build }} for ${{ inputs.build-on }} on branch ${{ inputs.branch || github.head_ref || github.ref_name }} requested by @${{ github.actor }}
+run-name: Build ${{ inputs.packages_to_build }} for ${{ inputs.build-on }} on branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} requested by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:
@@ -52,7 +52,7 @@ on:
         type: string
         required: false
 env:
-  BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
+  BRANCH: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
 permissions:
   actions: write
   contents: write
@@ -95,13 +95,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - name: Set PR to Draft
         id: set-to-draft
         env:
           GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}
         run: |
-          PR_NUMBER=$(gh pr list -L 1 -s open -H ${{ inputs.branch || github.head_ref || github.ref_name }} | cut -f1)
+          PR_NUMBER=$(gh pr list -L 1 -s open -H ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} | cut -f1)
           if [[ -n ${PR_NUMBER} ]]; then
             echo "Setting ${PR_NUMBER} to Draft while workflow runs."
             gh pr ready --undo || true
@@ -129,7 +129,7 @@ jobs:
             # Add inputs.packages_to_build to the packages we will
             # check for architecture and glibc compatibility.
             if [[ -z "${{ steps.changed-files.outputs.packages_all_changed_files }} ${{ inputs.packages_to_build }}" ]]; then
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has no changed package files."
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has no changed package files."
               exit 1
             fi
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
@@ -141,7 +141,7 @@ jobs:
     uses: ./.github/workflows/Determine-Compatibility.yml
     with:
       changed_packages: ${{ needs.setup.outputs.changed_packages }}
-      branch: ${{ inputs.branch || github.head_ref || github.ref_name }}
+      branch: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
 
   gen-matrix:
     needs: get-compatibility
@@ -188,7 +188,7 @@ jobs:
     env:
       CREW_BUILD_NO_PACKAGE_FILE_HASH_UPDATES: 1
       CREW_REPO: ${{ github.event.repository.clone_url }}
-      CREW_BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
+      CREW_BRANCH: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       TARGET_ARCH: ${{ matrix.arch }}
       TIMESTAMP: ${{ needs.setup.outputs.timestamp }}
       GLIBC_232_COMPATIBLE_PACKAGES: ${{ needs.get-compatibility.outputs.GLIBC_232_COMPATIBLE_PACKAGES }}
@@ -198,7 +198,7 @@ jobs:
       armv7l_PACKAGES: ${{ needs.get-compatibility.outputs.armv7l_PACKAGES }}
     if: ${{ !cancelled() }}
     concurrency:
-      group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.head_ref || github.ref_name }}
+      group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
     steps:
       - name: Dump GitHub context
         env:
@@ -303,8 +303,8 @@ jobs:
             sudo apt-get autoremove -qq -o=Dpkg::Use-Pty=0 -y &>/dev/null) &
 
             git fetch origin
-            git checkout "${{ inputs.branch || github.head_ref || github.ref_name }}"
-            git reset --hard "origin/${{ inputs.branch || github.head_ref || github.ref_name }}"
+            git checkout "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
+            git reset --hard "origin/${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
             git log --oneline -10
             docker pull --platform "${PLATFORM}" "${CONTAINER}"
             # Detection of /output/pkg_cache dir triggers setting
@@ -345,7 +345,7 @@ jobs:
               -e GCONV_PATH="/usr/local/lib${LIB_SUFFIX}/gconv" \
               -e CREW_BUILD_NO_PACKAGE_FILE_HASH_UPDATES="${CREW_BUILD_NO_PACKAGE_FILE_HASH_UPDATES}" \
               -e CREW_REPO="${CREW_REPO}" \
-              -e CREW_BRANCH="${{ inputs.branch || github.head_ref || github.ref_name }}" \
+              -e CREW_BRANCH="${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}" \
               -e GITLAB_TOKEN="${{ secrets.GITLAB_TOKEN }}" \
               -e GITLAB_TOKEN_USERNAME="${{ secrets.GITLAB_TOKEN_USERNAME }}" \
               ${CI_PASSTHROUGH} \
@@ -387,7 +387,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '4.0.1'
@@ -438,7 +438,7 @@ jobs:
         id: trigger-pr-workflow
         env:
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
-          PR_TITLE: ${{ inputs.pr_title || inputs.branch || github.ref_name }}
+          PR_TITLE: ${{ inputs.pr_title || inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
         run: |
-            echo "PR title being passed to the Generate PR workflow is: ${{ inputs.pr_title || inputs.branch || github.ref_name }}"
-            gh workflow run Generate-PR.yml -R ${{ github.repository }} -r ${{ inputs.branch || github.head_ref || github.ref_name }} -f branch="${{ inputs.branch || github.head_ref || github.ref_name }}" -f packages_to_check_for_build="${{ inputs.packages_to_build }}" -f pr_label="${{ inputs.pr_label }}" -f draft_pr="${{ github.event.inputs.with_pr == 'Draft Pull Request' }}" -f pr_title="$(echo "${{ inputs.pr_title || inputs.branch || github.ref_name }}" | ( read -rsd '' x; echo ${x@Q} ))"
+            echo "PR title being passed to the Generate PR workflow is: ${{ inputs.pr_title || inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
+            gh workflow run Generate-PR.yml -R ${{ github.repository }} -r ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} -f branch="${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}" -f packages_to_check_for_build="${{ inputs.packages_to_build }}" -f pr_label="${{ inputs.pr_label }}" -f draft_pr="${{ github.event.inputs.with_pr == 'Draft Pull Request' }}" -f pr_title="$(echo "${{ inputs.pr_title || inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}" | ( read -rsd '' x; echo ${x@Q} ))"

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -1,7 +1,7 @@
 ---
-# Version 1.8
+# Version 1.9
 name: Generate PR
-run-name: Generate PR for ${{ inputs.branch || github.head_ref || github.ref_name }} by @${{ github.actor }}
+run-name: Generate PR for ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} by @${{ github.actor }}
 on:
   pull_request:
     types: [labeled]
@@ -35,7 +35,7 @@ on:
         type: number
         default: 5.5
 env:
-  BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
+  BRANCH: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
 permissions:
   actions: write
   contents: write
@@ -77,13 +77,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - name: Set PR to Draft
         id: set-to-draft
         env:
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         run: |
-          PR_NUMBER=$(gh pr list -L 1 -s open -H ${{ inputs.branch || github.head_ref || github.ref_name }} | cut -f1)
+          PR_NUMBER=$(gh pr list -L 1 -s open -H ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} | cut -f1)
           if [[ -n ${PR_NUMBER} ]]; then
             echo "Setting ${PR_NUMBER} to Draft while workflow runs."
             gh pr ready --undo || true
@@ -93,9 +93,9 @@ jobs:
             gh pr update-branch || true
           else
             echo -e "##\n### Run the following to get this pull request's changes locally for testing.\n\`\`\`bash" >> /tmp/wip_pr.txt
-            echo -e "CREW_REPO=https://github.com/${{ github.repository }}.git CREW_BRANCH=${{ inputs.branch || github.head_ref || github.ref_name }} crew update \\" >> /tmp/wip_pr.txt
+            echo -e "CREW_REPO=https://github.com/${{ github.repository }}.git CREW_BRANCH=${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} crew update \\" >> /tmp/wip_pr.txt
             echo -e "&& yes | crew upgrade\n\`\`\`" >> /tmp/wip_pr.txt
-            gh pr create -d -b WIP -t "WIP ${{ inputs.branch || github.head_ref || github.ref_name }}" -F /tmp/wip_pr.txt
+            gh pr create -d -b WIP -t "WIP ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}" -F /tmp/wip_pr.txt
             # Create a draft PR and immediately try to update the branch
             # before continuing.
             gh pr update-branch || true
@@ -120,7 +120,7 @@ jobs:
             # Add inputs.packages_to_check_for_build to the packages we
             # will check for architecture and glibc compatibility.
             if [[ -z "${{ steps.changed-files.outputs.packages_all_changed_files }} ${{ inputs.packages_to_check_for_build }}" ]]; then
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has no changed package files."
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has no changed package files."
               exit 1
             fi
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
@@ -132,7 +132,7 @@ jobs:
     uses: ./.github/workflows/Determine-Compatibility.yml
     with:
       changed_packages: ${{ needs.setup.outputs.changed_packages }}
-      branch: ${{ inputs.branch || github.head_ref || github.ref_name }}
+      branch: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
 
   gen-matrix:
     needs: get-compatibility
@@ -178,7 +178,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       CREW_REPO: ${{ github.event.repository.clone_url }}
-      CREW_BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
+      CREW_BRANCH: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       TARGET_ARCH: ${{ matrix.arch }}
       GLIBC_232_COMPATIBLE_PACKAGES: ${{ needs.get-compatibility.outputs.GLIBC_232_COMPATIBLE_PACKAGES }}
       GLIBC_237_COMPATIBLE_PACKAGES: ${{ needs.get-compatibility.outputs.GLIBC_237_COMPATIBLE_PACKAGES }}
@@ -187,7 +187,7 @@ jobs:
       armv7l_PACKAGES: ${{ needs.get-compatibility.outputs.armv7l_PACKAGES }}
     if: ${{ !cancelled() && ( inputs.update_package_files ) && needs.setup.outputs.changed_packages }}
     concurrency:
-      group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.head_ref || github.ref_name }}
+      group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       cancel-in-progress: true
     steps:
       - name: Fail if build jobs failed
@@ -295,8 +295,8 @@ jobs:
             sudo apt-get autoremove -qq -o=Dpkg::Use-Pty=0 -y &>/dev/null) &
 
             git fetch origin
-            git checkout "${{ inputs.branch || github.head_ref || github.ref_name }}"
-            git reset --hard "origin/${{ inputs.branch || github.head_ref || github.ref_name }}"
+            git checkout "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
+            git reset --hard "origin/${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
             git log --oneline -10
             docker pull --platform "${PLATFORM}" "${CONTAINER}"
             # Detection of /output/pkg_cache dir triggers setting
@@ -337,7 +337,7 @@ jobs:
               -e GCONV_PATH="/usr/local/lib${LIB_SUFFIX}/gconv" \
               -e CREW_BUILD_NO_PACKAGE_FILE_HASH_UPDATES="${CREW_BUILD_NO_PACKAGE_FILE_HASH_UPDATES}" \
               -e CREW_REPO="${CREW_REPO}" \
-              -e CREW_BRANCH="${{ inputs.branch || github.head_ref || github.ref_name }}" \
+              -e CREW_BRANCH="${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}" \
               -e GITLAB_TOKEN="${{ secrets.GITLAB_TOKEN }}" \
               -e GITLAB_TOKEN_USERNAME="${{ secrets.GITLAB_TOKEN_USERNAME }}" \
               ${CI_PASSTHROUGH} \
@@ -360,9 +360,9 @@ jobs:
             git config user.email "${{ github.actor }}@users.noreply.github.com"
             git add .
             git stash || true
-            git fetch origin ${{ inputs.branch || github.head_ref || github.ref_name }}
+            git fetch origin${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
             git stash pop || true
-            git commit -am "${{ inputs.branch || github.head_ref || github.ref_name }}: Package File Update Run on ${PLATFORM} container." && git push origin ${{ inputs.branch || github.head_ref || github.ref_name }}
+            git commit -am "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}: Package File Update Run on ${PLATFORM} container." && git push origin ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
             git log --oneline -10
           fi
   build-check:
@@ -383,7 +383,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - name: Get GH Token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v4
@@ -397,12 +397,12 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         run: |
-          PR_NUMBER=$(gh pr list -L 1 -s open -H ${{ inputs.branch || github.head_ref || github.ref_name }} | cut -f1)
+          PR_NUMBER=$(gh pr list -L 1 -s open -H ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} | cut -f1)
           if [[ -n ${PR_NUMBER} ]]; then
             # Try to update branch immediately.
             gh pr update-branch --rebase || true
           else
-            gh pr create -d -b WIP -t "WIP ${{ inputs.branch || github.head_ref || github.ref_name }}"
+            gh pr create -d -b WIP -t "WIP ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
             # Create a draft PR and immediately try to update the branch
             # before continuing.
             gh pr update-branch --rebase || true
@@ -410,10 +410,10 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git checkout master && git fetch origin master
-          git checkout "${{ inputs.branch || github.head_ref || github.ref_name }}"
-          git fetch origin "${{ inputs.branch || github.head_ref || github.ref_name }}"
+          git checkout "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
+          git fetch origin "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
           git log --no-merges --oneline -10
-          git log --no-merges --oneline master..${{ inputs.branch || github.head_ref || github.ref_name }} | grep -v "Merge branch 'master'\|Build Run on\|Package File Update Run on\|lint$" | tr '\n' '\0' | xargs -0 -n1 echo "- $*" >> /tmp/commits.txt
+          git log --no-merges --oneline master..${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} | grep -v "Merge branch 'master'\|Build Run on\|Package File Update Run on\|lint$" | tr '\n' '\0' | xargs -0 -n1 echo "- $*" >> /tmp/commits.txt
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v47
@@ -440,10 +440,10 @@ jobs:
             git config user.name "${{ github.actor }}"
             git config user.email "${{ github.actor }}@users.noreply.github.com"
             git checkout master && git fetch origin master
-            git checkout "${{ inputs.branch || github.head_ref || github.ref_name }}"
-            git fetch origin "${{ inputs.branch || github.head_ref || github.ref_name }}"
+            git checkout "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
+            git fetch origin "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
             set +e
-            CHANGED_PACKAGE_FILES=$(git diff --name-only master..${{ inputs.branch || github.head_ref || github.ref_name }} | grep '^packages/')
+            CHANGED_PACKAGE_FILES=$(git diff --name-only master..${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} | grep '^packages/')
             set -e
             if [[ -n "${CHANGED_PACKAGE_FILES}" ]]; then
               # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
@@ -461,7 +461,7 @@ jobs:
           CHANGED_MANIFEST_FILES: ${{ steps.changed-files.outputs.manifest_all_changed_files }}
           CHANGED_OTHER_FILES: ${{ steps.changed-files.outputs.other_all_changed_files }}
           CHANGED_PACKAGES: ${{ steps.changed-packages.outputs.CHANGED_PACKAGES }}
-          CREW_BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          CREW_BRANCH: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
           DRAFT_PR: ${{ inputs.draft_pr }}
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
           PR_LABEL: ${{ inputs.pr_label }}
@@ -537,22 +537,22 @@ jobs:
             echo -e "##\n- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_" >> /tmp/pr.txt
           fi
           echo -e "##\n### Run the following to get this pull request's changes locally for testing.\n\`\`\`bash" >> /tmp/pr.txt
-          echo -e "CREW_REPO=https://github.com/${{ github.repository }}.git CREW_BRANCH=${{ inputs.branch || github.head_ref || github.ref_name }} crew update \\" >> /tmp/pr.txt
+          echo -e "CREW_REPO=https://github.com/${{ github.repository }}.git CREW_BRANCH=${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} crew update \\" >> /tmp/pr.txt
           echo -e "&& yes | crew upgrade\n\`\`\`" >> /tmp/pr.txt
           [[ -n "${PKG_DELTA[*]}" ]] && PKG_DELTAS="$(join_by , "${PKG_DELTA[@]}")"
           echo "PKG_DELTAS: $PKG_DELTAS"
           cat /tmp/pr.txt
-          PR_NUMBER=$(gh pr list -L 1 -s open -H ${{ inputs.branch || github.head_ref || github.ref_name }} | cut -f1)
+          PR_NUMBER=$(gh pr list -L 1 -s open -H ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} | cut -f1)
           PR_TITLE_INPUT="${{ inputs.pr_title }}"
           if [[ -z ${PR_TITLE_INPUT} ]]; then
-            PR_TITLE="$(git log --oneline master..${{ inputs.branch || github.head_ref || github.ref_name }} | grep -v "Merge branch 'master'\|Build Run on\|Package File Update Run on" | tail -n 1 | cut -c 11-)"
+            PR_TITLE="$(git log --oneline master..${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} | grep -v "Merge branch 'master'\|Build Run on\|Package File Update Run on" | tail -n 1 | cut -c 11-)"
             if [[ -z ${PKG_DELTAS} ]]; then
               TITLE="$(echo "${PR_TITLE}" | sed -e "s/^'//" -e "s/'$//")"
             else
               TITLE="$(echo "${PR_TITLE}" | sed -e "s/^'//" -e "s/'$//") — ${PKG_DELTAS}"
             fi
           else
-            if [[ "${PR_TITLE_INPUT}" == *"${{ inputs.branch || github.head_ref || github.ref_name }}"* ]]; then
+            if [[ "${PR_TITLE_INPUT}" == *"${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"* ]]; then
               PR_TITLE="${PKG_DELTAS}"
               TITLE="${PR_TITLE}"
             else
@@ -599,5 +599,5 @@ jobs:
           # Remove the regenerate_pr label if set.
           gh pr edit --remove-label regenerate_pr || true
           # Trigger workflow runs:
-          # gh workflow run Unit-Test.yml -R ${{ github.repository }} -r ${{ inputs.branch || github.head_ref || github.ref_name }}
-          # gh workflow run Linter-Handoff.yml -R ${{ github.repository }} -r ${{ inputs.branch || github.head_ref || github.ref_name }}
+          # gh workflow run Unit-Test.yml -R ${{ github.repository }} -r ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+          # gh workflow run Linter-Handoff.yml -R ${{ github.repository }} -r ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}

--- a/.github/workflows/No-Compile-Needed.yml
+++ b/.github/workflows/No-Compile-Needed.yml
@@ -1,7 +1,7 @@
 ---
-# Version 1.0
+# Version 1.1
 name: No-Compile-Needed
-run-name: Generate No-Compile-Needed PR for ${{ inputs.branch || github.head_ref || github.ref_name }} by @${{ github.actor }}
+run-name: Generate No-Compile-Needed PR for ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:
@@ -15,7 +15,7 @@ on:
         required: false
 env:
   GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}  # setting GH_TOKEN for the entire workflow
-  BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
+  BRANCH: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
 permissions:
   actions: write
   contents: write
@@ -56,7 +56,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - name: Rebase to master
         run: |
             git config user.name "${{ github.actor }}"
@@ -66,7 +66,7 @@ jobs:
       - name: Push rebase changes
         uses: ad-m/github-push-action@master
         with:
-          branch: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          branch: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
           force: true
       - name: Set Timestamp
         id: set-timestamp
@@ -87,7 +87,7 @@ jobs:
         id: changed-packages
         run: |
             if [[ -z "${{ steps.changed-files.outputs.packages_all_changed_files }}" ]]; then
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has no changed package files."
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has no changed package files."
               exit 1
             fi
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
@@ -102,9 +102,9 @@ jobs:
             if [[ -n ${NO_COMPILE_PACKAGES} ]]; then
               echo "NO_COMPILE_PACKAGES=${NO_COMPILE_PACKAGES}" >> "$GITHUB_ENV"
               echo "NO_COMPILE_PACKAGES=${NO_COMPILE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these no_compile_needed packages: ${NO_COMPILE_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has these no_compile_needed packages: ${NO_COMPILE_PACKAGES}"
             else
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} is missing no_compile_needed packages that require updates."
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} is missing no_compile_needed packages that require updates."
               exit 1
             fi
 
@@ -114,7 +114,7 @@ jobs:
             if [[ -n ${GLIBC_232_COMPATIBLE_PACKAGES} ]]; then
               echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
               echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these possibly Glibc 2.32 compatible packages: ${GLIBC_232_COMPATIBLE_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has these possibly Glibc 2.32 compatible packages: ${GLIBC_232_COMPATIBLE_PACKAGES}"
             fi
 
             # If a package doesnt have a min_glibc value, or if it is below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES.
@@ -123,7 +123,7 @@ jobs:
             if [[ -n ${GLIBC_237_COMPATIBLE_PACKAGES} ]]; then
               echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_ENV"
               echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
             fi
 
             # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
@@ -132,7 +132,7 @@ jobs:
             if [[ -n ${x86_64_PACKAGES} ]]; then
               echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_ENV"
               echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
             fi
 
             ## If a package has a compatibility of 'all' or one that includes 'armv7l', add it to armv7l_PACKAGES.
@@ -141,7 +141,7 @@ jobs:
             if [[ -n ${armv7l_PACKAGES} ]]; then
               echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_ENV"
               echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these armv7l compatible packages: ${armv7l_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has these armv7l compatible packages: ${armv7l_PACKAGES}"
             fi
 
             ## If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
@@ -150,7 +150,7 @@ jobs:
             if [[ -n ${i686_PACKAGES} ]]; then
               echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_ENV"
               echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ inputs.branch || github.head_ref || github.ref_name }} has these i686 compatible packages: ${i686_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has these i686 compatible packages: ${i686_PACKAGES}"
             fi
   generate:
     strategy:
@@ -171,7 +171,7 @@ jobs:
     needs: setup
     env:
       CREW_REPO: ${{ github.event.repository.clone_url }}
-      CREW_BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
+      CREW_BRANCH: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       TARGET_ARCH: ${{ matrix.arch }}
       TIMESTAMP: ${{ needs.setup.outputs.timestamp }}
       NO_COMPILE_PACKAGES: ${{ needs.setup.outputs.no_compile_packages }}
@@ -182,7 +182,7 @@ jobs:
       armv7l_PACKAGES: ${{ needs.setup.outputs.armv7l_packages }}
     if: ${{ !cancelled() }}
     concurrency:
-      group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.head_ref || github.ref_name }}
+      group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       cancel-in-progress: true
     steps:
       - name: Container cleanup
@@ -269,8 +269,8 @@ jobs:
             fi
 
             git fetch origin
-            git checkout "${{ inputs.branch || github.head_ref || github.ref_name }}"
-            git reset --hard "origin/${{ inputs.branch || github.head_ref || github.ref_name }}"
+            git checkout "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
+            git reset --hard "origin/${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
             git log --oneline -10
             docker pull --platform "${PLATFORM}" "${CONTAINER}"
             sudo setfacl -R -m u:1000:rwx .
@@ -289,7 +289,7 @@ jobs:
               -e LD_LIBRARY_PATH="/usr/local/lib${LIB_SUFFIX}" \
               -e GCONV_PATH="/usr/local/lib${LIB_SUFFIX}/gconv" \
               -e CREW_REPO="${CREW_REPO}" \
-              -e CREW_BRANCH="${{ inputs.branch || github.head_ref || github.ref_name }}" \
+              -e CREW_BRANCH="${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}" \
               -e GITLAB_TOKEN="${{ secrets.GITLAB_TOKEN }}" \
               -e GITLAB_TOKEN_USERNAME="${{ secrets.GITLAB_TOKEN_USERNAME }}" \
               -v "$(pwd)":/output \
@@ -309,7 +309,7 @@ jobs:
             git pull
             git stash pop || true
             git add -A
-            git commit -m "${{ inputs.branch || github.head_ref || github.ref_name }}: Package File Update Run on ${PLATFORM} container." && git push
+            git commit -m "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}: Package File Update Run on ${PLATFORM} container." && git push
             git log --oneline -10
           fi
   update-check:
@@ -328,20 +328,20 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - name: Rebase to master and save git log
         id: rebase-and-git-log
         run: |
             git config user.name "${{ github.actor }}"
             git config user.email "${{ github.actor }}@users.noreply.github.com"
             git fetch origin
-            git checkout "${{ inputs.branch || github.head_ref || github.ref_name }}"
-            git reset --hard "origin/${{ inputs.branch || github.head_ref || github.ref_name }}"
+            git checkout "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
+            git reset --hard "origin/${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
             git pull --rebase origin master && git push -f
             git log --oneline -10
             git checkout master && git pull
-            git log --oneline master..${{ inputs.branch || github.head_ref || github.ref_name }} | tr '\n' '\0' | xargs -0 -n1 echo "- $*" >> /tmp/commits.txt
-            git checkout "${{ inputs.branch || github.head_ref || github.ref_name }}"
+            git log --oneline master..${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} | tr '\n' '\0' | xargs -0 -n1 echo "- $*" >> /tmp/commits.txt
+            git checkout "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v47
@@ -383,7 +383,7 @@ jobs:
         run: |
           rm -rf /tmp/pr.txt
           echo -e "## Description" >> /tmp/pr.txt
-          echo -e "- This PR was built using the No-Compile-Needed.yml workflow, which was pointed to the ${{ inputs.branch || github.head_ref || github.ref_name }} branch.\n" >> /tmp/pr.txt
+          echo -e "- This PR was built using the No-Compile-Needed.yml workflow, which was pointed to the ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} branch.\n" >> /tmp/pr.txt
           echo -e "#### Commits:" >> /tmp/pr.txt
           # Get git log from rebase-and-git-log step.
           cat /tmp/commits.txt >> /tmp/pr.txt
@@ -416,14 +416,14 @@ jobs:
             echo -e "##\n- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_" >> /tmp/pr.txt
           fi
           echo -e "##\n### Run the following to get this pull request's changes locally for testing.\n\`\`\`bash" >> /tmp/pr.txt
-          echo -e "CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=${{ inputs.branch || github.head_ref || github.ref_name }} crew update \\" >> /tmp/pr.txt
+          echo -e "CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} crew update \\" >> /tmp/pr.txt
           echo -e "&& yes | crew upgrade\n\`\`\`" >> /tmp/pr.txt
           cat /tmp/pr.txt
           [[ $DRAFT_PR == 'true' ]] && export PR_DRAFT_FLAG='-d'
           if [[ -z ${PR_NUMBER} ]]; then
-            PR_NUMBER=$(gh pr create ${PR_DRAFT_FLAG} --reviewer chromebrew/active --title "${{ inputs.branch || github.head_ref || github.ref_name }}: Build for ${CHANGED_PACKAGES}" -F /tmp/pr.txt | rev | cut -d"/" -f1  | rev)
+            PR_NUMBER=$(gh pr create ${PR_DRAFT_FLAG} --reviewer chromebrew/active --title "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}: Build for ${CHANGED_PACKAGES}" -F /tmp/pr.txt | rev | cut -d"/" -f1  | rev)
           else
-            gh pr edit --title "${{ inputs.branch || github.head_ref || github.ref_name }}: Build for ${CHANGED_PACKAGES}" -F /tmp/pr.txt
+            gh pr edit --title "${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}: Build for ${CHANGED_PACKAGES}" -F /tmp/pr.txt
           fi
           # Draft PRs can not be set to automerge.
           if [[ $DRAFT_PR == 'true' ]]; then

--- a/.github/workflows/Set-Reviewers.yml
+++ b/.github/workflows/Set-Reviewers.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.4
+# Version 1.5
 name: Set Reviewers
 run-name: Set Reviewers for PR for ${{ github.head_ref || github.ref_name }}
 on:
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - name: Get Status of current ref
         id: get-status
         uses: danieldeichfuss/get-status@v0.0.10

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.3
+# Version 1.4
 name: Unit Tests
 on:
   check_run:
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - name: Get Current HEAD hash
         id: get-current-head
         run: |
@@ -68,7 +68,7 @@ jobs:
         id: changed-packages
         run: |
             if [[ -z "${{ steps.changed-files.outputs.packages_all_changed_files }}" ]]; then
-              echo "Branch ${{ github.ref_name }} has no changed package files."
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has no changed package files."
             fi
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }}" | xargs basename -s .rb | xargs)" >> "$GITHUB_ENV"
@@ -123,7 +123,7 @@ jobs:
             runner: ubuntu-24.04
     runs-on: ${{ matrix.runner }}
     concurrency:
-      group: ${{ matrix.arch }}-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+      group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}-${{ github.sha }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6
@@ -199,13 +199,13 @@ jobs:
       - name: Run unit tests
         env:
           GITHUB_EVENT: ${{ github.event_name }}
-          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REF: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
         run: |
             case $GITHUB_EVENT in
               check_run | merge_group | push | workflow_run | workflow_dispatch)
                 CREW_REPO="${{ github.event.repository.clone_url }}"
                 export CREW_REPO
-                CREW_BRANCH="${{ github.ref_name }}"
+                CREW_BRANCH="${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}"
                 export CREW_BRANCH
                 ;;
               pull_request)
@@ -262,7 +262,7 @@ jobs:
           revoke_token: true
       - name: trigger_set_reviewers
         env:
-          BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          BRANCH: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         run: |
           echo "Container test jobs succeeded. Triggering Set Reviewers workflow for ${BRANCH}."


### PR DESCRIPTION
## Description
- As per https://stackoverflow.com/questions/63343937/how-to-use-the-github-actions-workflow-run-event#65081720
#### Commits:
-  8298097 Use github.event.workflow_run.head_branch in workflow branch determination.
### Updated GitHub configuration files:
- .github/workflows/Build.yml
- .github/workflows/Generate-PR.yml
- .github/workflows/No-Compile-Needed.yml
- .github/workflows/Set-Reviewers.yml
- .github/workflows/Unit-Test.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=unit_test_branch crew update \
&& yes | crew upgrade
```
