### PR TITLE
Add ssl cert validation fallback to downloaders. Fix more workflow branch detection logic. Fix non-package-file detection in workflows.

### DIFF
--- a/.github/workflows/Determine-Compatibility.yml
+++ b/.github/workflows/Determine-Compatibility.yml
@@ -1,4 +1,5 @@
 ---
+# Version 1.1
 name: Determine glibc and architecture package compatibility
 on:
   workflow_call:
@@ -41,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - name: Determine glibc and architecture package compatibility
         id: get-compatibility
         env:
@@ -59,7 +60,7 @@ jobs:
             export GLIBC_232_COMPATIBLE_PACKAGES
             if [[ -n ${GLIBC_232_COMPATIBLE_PACKAGES} ]]; then
               echo "GLIBC_232_COMPATIBLE_PACKAGES=${GLIBC_232_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these possibly Glibc 2.32 compatible packages: ${GLIBC_232_COMPATIBLE_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}has these possibly Glibc 2.32 compatible packages: ${GLIBC_232_COMPATIBLE_PACKAGES}"
             fi
 
             # If a package has a min_glibc value below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES.
@@ -67,7 +68,7 @@ jobs:
             export GLIBC_237_COMPATIBLE_PACKAGES
             if [[ -n ${GLIBC_237_COMPATIBLE_PACKAGES} ]]; then
               echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
             fi
 
             # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
@@ -75,7 +76,7 @@ jobs:
             export x86_64_PACKAGES
             if [[ -n ${x86_64_PACKAGES} ]]; then
               echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}has these x86_64 compatible packages: ${x86_64_PACKAGES}"
             fi
 
             # If a package has a compatibility of 'all' or one that includes 'armv7l', add it to armv7l_PACKAGES.
@@ -83,7 +84,7 @@ jobs:
             export armv7l_PACKAGES
             if [[ -n ${armv7l_PACKAGES} ]]; then
               echo "armv7l_PACKAGES=${armv7l_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these armv7l compatible packages: ${armv7l_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}has these armv7l compatible packages: ${armv7l_PACKAGES}"
             fi
 
             # If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
@@ -91,5 +92,5 @@ jobs:
             export i686_PACKAGES
             if [[ -n ${i686_PACKAGES} ]]; then
               echo "i686_PACKAGES=${i686_PACKAGES}" >> "$GITHUB_OUTPUT"
-              echo "Branch ${{ github.ref_name }} has these i686 compatible packages: ${i686_PACKAGES}"
+              echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}has these i686 compatible packages: ${i686_PACKAGES}"
             fi

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -44,6 +44,7 @@ jobs:
     outputs:
       current_head: ${{ steps.get-current-head.outputs.CURRENT_HEAD }}
       changed_packages: ${{ steps.changed-packages.outputs.CHANGED_PACKAGES }}
+      non_changed_packages: ${{ steps.changed-files.outputs.non-package_all_changed_files }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -60,20 +61,22 @@ jobs:
         uses: tj-actions/changed-files@v47
         with:
           base_sha: ${{ steps.get-current-head.outputs.CURRENT_HEAD }}
-          files_yaml: |
-            packages:
-              - packages/*.rb
           since_last_remote_commit: true
-      - name: Export variables to github context
+          files_yaml: |
+            non-package:
+              - '**'
+              - '!packages/**.rb'
+            packages:
+              - packages/**.rb
+      - name: Sanitize and export changed packages to github context.
         id: changed-packages
         run: |
             if [[ -z "${{ steps.changed-files.outputs.packages_all_changed_files }}" ]]; then
               echo "Branch ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} has no changed package files."
             fi
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
-            echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }}" | xargs basename -s .rb | xargs)" >> "$GITHUB_ENV"
-            echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }}" | xargs basename -s .rb | xargs)" >> "$GITHUB_OUTPUT"
-
+            echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }}" | xargs --no-run-if-empty basename -s .rb | xargs --no-run-if-empty)" >> "$GITHUB_ENV"
+            echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }}" | xargs --no-run-if-empty basename -s .rb | xargs --no-run-if-empty)" >> "$GITHUB_OUTPUT"
   get-compatibility:
     needs: setup
     uses: ./.github/workflows/Determine-Compatibility.yml
@@ -105,6 +108,7 @@ jobs:
   container_tests:
     if: ${{ github.repository_owner == 'chromebrew' }}
     needs:
+      - setup
       - gen-matrix
       - get-compatibility
     strategy:
@@ -201,6 +205,7 @@ jobs:
         env:
           GITHUB_EVENT: ${{ github.event_name }}
           HEAD_REF: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+          NON_PKG_CHANGED_FILES: ${{ needs.setup.outputs.non_changed_packages }}
         run: |
             case $GITHUB_EVENT in
               check_run | merge_group | push | workflow_run | workflow_dispatch)

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.4
+# Version 1.5
 name: Unit Tests
 on:
   check_run:
@@ -129,6 +129,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: true
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.73.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.73.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -102,6 +102,7 @@ end
 def get_http_response(uri)
   uri             = URI(uri) if uri.is_a?(String)
   ssl_error_retry = 0
+  ssl_cert_verification_bypass_threshold = 3
 
   # open http connection
   Net::HTTP.start(uri.host, uri.port, {
@@ -109,14 +110,17 @@ def get_http_response(uri)
     use_ssl:     uri.scheme.eql?('https'),
     min_version: :TLS1_2,
     ca_file:     SSL_CERT_FILE,
-    ca_path:     SSL_CERT_DIR
+    ca_path:     SSL_CERT_DIR,
+    verify_depth: 5,
+    verify_mode: ssl_error_retry <= ssl_cert_verification_bypass_threshold ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
   }) do |http|
     return http.get(uri)
   end
 rescue OpenSSL::SSL::SSLError
   # handle SSL errors
   ssl_error_retry += 1
-  ssl_error_retry <= 3 ? retry : raise
+  puts 'Attempting https without ssl cert verification as a fallback.'.lightred if ssl_error_retry > ssl_cert_verification_bypass_threshold
+  ssl_error_retry <= 8 ? retry : raise
 end
 
 def http_downloader(uri, filename = File.basename(url), verbose: false)

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -1,6 +1,7 @@
 # lib/package_utils.rb
 # Utility functions that take either a package object or a component of a package object as primary input.
 require 'json'
+require_relative 'color'
 require_relative 'const'
 require_relative 'downloader'
 
@@ -127,7 +128,28 @@ class PackageUtils
     # The package name probably just used dashes as separators, but if it didn't then the correct name is in the upstream_name argument.
     ruby_gem_name = upstream_name.nil? ? passed_name.delete_prefix('ruby_').delete_prefix('Ruby_').gsub('_', '-') : upstream_name
 
-    ruby_gem_json = JSON.parse(Net::HTTP.get(URI("https://rubygems.org/api/v1/gems/#{ruby_gem_name}.json")))
+    # As per https://stackoverflow.com/a/2627836
+    # try to handle breakage with OpenSSL.
+
+    url = URI("https://rubygems.org/api/v1/gems/#{ruby_gem_name}.json")
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = true
+    if File.directory?(SSL_CERT_DIR) && http.use_ssl?
+      http.ca_path = SSL_CERT_DIR
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      http.verify_depth = 5
+    else
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+    request = Net::HTTP::Get.new(url.path)
+    begin
+      response = http.request(request)
+    rescue OpenSSL::SSL::SSLError
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      puts "SSL error for https://rubygems.org with SSL_CERT_DIR #{SSL_CERT_DIR}.".lightred
+      response = http.request(request)
+    end
+    ruby_gem_json = JSON.parse(response.body)
 
     # Use the latest gem version.
     remote_ruby_gem_version = ruby_gem_json['version']


### PR DESCRIPTION
## Description
#### Commits:
-  9bf1328bc Restore NON_PKG_CHANGED_FILES logic.
-  0e371b027 Fix checkout ref for unit test and get compatibility workflows.
-  4312bd8ed Add ssl cert validation fallback to downloaders.
### Updated GitHub configuration files:
- .github/workflows/Determine-Compatibility.yml
- .github/workflows/Unit-Test.yml
### Other changed files:
- lib/const.rb
- lib/downloader.rb
- lib/package_utils.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=ssl_debug crew update \
&& yes | crew upgrade
```
