### PR TITLE
Entr 5.7 => 5.8

### DIFF
--- a/manifest/armv7l/e/entr.filelist
+++ b/manifest/armv7l/e/entr.filelist
@@ -1,3 +1,3 @@
-# Total size: 22807
+# Total size: 20541
 /usr/local/bin/entr
 /usr/local/share/man/man1/entr.1.zst

--- a/manifest/i686/e/entr.filelist
+++ b/manifest/i686/e/entr.filelist
@@ -1,3 +1,3 @@
-# Total size: 24651
+# Total size: 24697
 /usr/local/bin/entr
 /usr/local/share/man/man1/entr.1.zst

--- a/manifest/x86_64/e/entr.filelist
+++ b/manifest/x86_64/e/entr.filelist
@@ -1,3 +1,3 @@
-# Total size: 25647
+# Total size: 26545
 /usr/local/bin/entr
 /usr/local/share/man/man1/entr.1.zst

--- a/packages/entr.rb
+++ b/packages/entr.rb
@@ -3,7 +3,7 @@ require 'package'
 class Entr < Package
   description 'Run arbitrary commands when files change'
   homepage 'https://eradman.com/entrproject/'
-  version '5.7'
+  version '5.8'
   license 'ISC'
   compatibility 'all'
   source_url 'https://github.com/eradman/entr.git'
@@ -11,13 +11,13 @@ class Entr < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'fc219af7c71433e90fbd4d94386205188fff62731e7ad3e4ef13195533aa5da7',
-     armv7l: 'fc219af7c71433e90fbd4d94386205188fff62731e7ad3e4ef13195533aa5da7',
-       i686: '1bcccb6bb885cfef5742ef86e7899fb45e01aadab843295fa0df65f352499359',
-     x86_64: '687b29d4ac0f1975eb0fc0401e6732d8007f6f81794eb90e515da13cd68a7af7'
+    aarch64: '53ae3ab1123a429789ab0bad3eb397805fb389a912f95d0fece345e39024046f',
+     armv7l: '53ae3ab1123a429789ab0bad3eb397805fb389a912f95d0fece345e39024046f',
+       i686: 'bebd1e8e021e67aa6744f86f2014aeb0cf4f9d2e8f68271590c92322c2599b61',
+     x86_64: '9f341edb971b00389b2acdb0a1d21ccd2a523f0f1a78a9a0481e96244ff35133'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable
 
   def self.build
     system './configure' # Not an autotools script, despite appearances.

--- a/tests/package/e/entr
+++ b/tests/package/e/entr
@@ -1,0 +1,2 @@
+#!/bin/bash
+entr -h 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-entr crew update \
&& yes | crew upgrade

$ crew check entr 
Checking entr package ...
Library test for entr passed.
Checking entr package ...
release: 5.7
usage: entr [-acdnprsxz] utility [argument [/_] ...] < filenames
summary:
    -a  Do not consolidate events
    -c  Clear screen before execution
    -d  Track files added or removed from directories
    -n  Non-interactive mode
    -p  Wait for first event
    -r  Run as a background process, use signal to restart
    -s  Evaluate using a shell
    -x  Format exit status
    -z  Exit after the utility completes
docs:
    man entr
Package tests for entr passed.
```