### PR TITLE
Ethtool 6.15 => 7.0

### DIFF
--- a/manifest/armv7l/e/ethtool.filelist
+++ b/manifest/armv7l/e/ethtool.filelist
@@ -1,4 +1,4 @@
-# Total size: 989555
+# Total size: 880498
 /usr/local/bin/ethtool
 /usr/local/share/bash-completion/completions/ethtool
 /usr/local/share/man/man8/ethtool.8.zst

--- a/manifest/i686/e/ethtool.filelist
+++ b/manifest/i686/e/ethtool.filelist
@@ -1,4 +1,4 @@
-# Total size: 1130563
+# Total size: 1155282
 /usr/local/bin/ethtool
 /usr/local/share/bash-completion/completions/ethtool
 /usr/local/share/man/man8/ethtool.8.zst

--- a/manifest/x86_64/e/ethtool.filelist
+++ b/manifest/x86_64/e/ethtool.filelist
@@ -1,4 +1,4 @@
-# Total size: 1098887
+# Total size: 1122614
 /usr/local/bin/ethtool
 /usr/local/share/bash-completion/completions/ethtool
 /usr/local/share/man/man8/ethtool.8.zst

--- a/packages/ethtool.rb
+++ b/packages/ethtool.rb
@@ -6,23 +6,24 @@ require 'buildsystems/autotools'
 class Ethtool < Autotools
   description 'Utility for controlling network drivers and hardware'
   homepage 'https://www.kernel.org/pub/software/network/ethtool/'
-  version '6.15'
+  version '7.0'
   license 'LGPL2.1'
   compatibility 'all'
   source_url "https://www.kernel.org/pub/software/network/ethtool/ethtool-#{version}.tar.xz"
-  source_sha256 '9477c365114d910120aaec5336a1d16196c833d8486f7c6da67bedef57880ade'
+  source_sha256 '660bf9725a7871343a0d232068a7634fbcfb69b6c2f8eff455827faefb0cd162'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1af70078a68fc26cb6f95d8405e59a74c8986a1287205d01ff985d76a5835870',
-     armv7l: '1af70078a68fc26cb6f95d8405e59a74c8986a1287205d01ff985d76a5835870',
-       i686: 'dfd309329efc727a024894d5aaf89a37c891bd0713bfa1448eb3dcf2064b3185',
-     x86_64: '851d246301bdbde1d68a33e1cddc6c09a69d4eef077f708947faf7e10d052136'
+    aarch64: '9bd4247a1327f5bff2086059b05dc651ef57e7e9ebb68320d53afa4c42b5d643',
+     armv7l: '9bd4247a1327f5bff2086059b05dc651ef57e7e9ebb68320d53afa4c42b5d643',
+       i686: 'e837069d04e0451e35fac0822f95e7ab5edaf25b03581b5142ac26afe5f1847c',
+     x86_64: '975f5bb6cb23a229f71bd5b1dd50af40e5cfbe506466dfabe716e29390493d5b'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'libmnl' # R
+  depends_on 'glibc' => :executable
+  depends_on 'libmnl' => :executable
 
+  # Tests fail for arm builds.
   run_tests
 
   autotools_configure_options "--sbindir=#{CREW_PREFIX}/bin"

--- a/tests/package/e/ethtool
+++ b/tests/package/e/ethtool
@@ -1,0 +1,3 @@
+#!/bin/bash
+ethtool -h | head
+ethtool --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-ethtool crew update \
&& yes | crew upgrade

$ crew check ethtool 
Checking ethtool package ...
Library test for ethtool passed.
dChecking ethtool package ...
ethtool version 7.0
Usage:
        ethtool [ FLAGS ]  DEVNAME	Display standard information about device
        ethtool [ FLAGS ] -s|--change DEVNAME	Change generic options
		[ speed %d ]
		[ lanes %d ]
		[ duplex half|full ]
		[ port tp|aui|bnc|mii|fibre|da ]
		[ mdix auto|on|off ]
		[ autoneg on|off ]
ethtool version 7.0
Package tests for ethtool passed.

Arm build test errors:
make  check-TESTS
make[1]: Entering directory '/usr/local/tmp/crew/ethtool.20260512235137.dir/ethtool-7.0'
make[2]: Entering directory '/usr/local/tmp/crew/ethtool.20260512235137.dir/ethtool-7.0'
FAIL: test-cmdline
============================================================================
Testsuite summary for ethtool 7.0
============================================================================
# TOTAL: 1
# PASS:  0
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
============================================================================
See ./test-suite.log for debugging.
Some test(s) failed.  Please report this to netdev@vger.kernel.org,
together with the test-suite.log file (gzipped) and your system
information.  Thanks.
============================================================================
make[2]: *** [Makefile:4229: test-suite.log] Error 1
make[2]: Leaving directory '/usr/local/tmp/crew/ethtool.20260512235137.dir/ethtool-7.0'
make[1]: *** [Makefile:4364: check-TESTS] Error 2
make[1]: Leaving directory '/usr/local/tmp/crew/ethtool.20260512235137.dir/ethtool-7.0'
make: *** [Makefile:4592: check-am] Error 2
/usr/local/lib/crew/lib/package.rb:423:in 'Package.system': Command failed with exit 2: make
ethtool failed to build: `CFLAGS="-O3 -pipe -ffat-lto-objects -fPIC -fuse-ld=mold -mfloat-abi=hard -mthumb -mfpu=vfpv3-d16 -march=armv7-a+fp -flto=auto -flto=auto" CXXFLAGS="-O3 -pipe -ffat-lto-objects -fPIC -fuse-ld=mold -mfloat-abi=hard -mthumb -mfpu=vfpv3-d16 -march=armv7-a+fp -flto=auto -flto=auto" FCFLAGS="-O3 -pipe -ffat-lto-objects -fPIC -fuse-ld=mold -mfloat-abi=hard -mthumb -mfpu=vfpv3-d16 -march=armv7-a+fp -flto=auto -flto=auto" FFLAGS="-O3 -pipe -ffat-lto-objects -fPIC -fuse-ld=mold -mfloat-abi=hard -mthumb -mfpu=vfpv3-d16 -march=armv7-a+fp -flto=auto -flto=auto" LDFLAGS="-flto=auto" CREW_PRELOAD_ENABLE_COMPILE_HACKS="1" CC_LD="mold" CXX_LD="mold" CREW_PRELOAD_NO_MOLD="0" make DESTDIR=/usr/local/tmp/crew/dest check` exited with 2
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
