### PR TITLE
Exif 0.6.21 => 0.6.22

### DIFF
--- a/manifest/armv7l/e/exif.filelist
+++ b/manifest/armv7l/e/exif.filelist
@@ -1,3 +1,34 @@
-# Total size: 111761
+# Total size: 215198
 /usr/local/bin/exif
-/usr/local/share/man/man1/exif.1.gz
+/usr/local/share/locale/ast/LC_MESSAGES/exif.mo
+/usr/local/share/locale/cs/LC_MESSAGES/exif.mo
+/usr/local/share/locale/da/LC_MESSAGES/exif.mo
+/usr/local/share/locale/de/LC_MESSAGES/exif.mo
+/usr/local/share/locale/eo/LC_MESSAGES/exif.mo
+/usr/local/share/locale/es/LC_MESSAGES/exif.mo
+/usr/local/share/locale/fi/LC_MESSAGES/exif.mo
+/usr/local/share/locale/fr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/fur/LC_MESSAGES/exif.mo
+/usr/local/share/locale/gl/LC_MESSAGES/exif.mo
+/usr/local/share/locale/hr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/id/LC_MESSAGES/exif.mo
+/usr/local/share/locale/is/LC_MESSAGES/exif.mo
+/usr/local/share/locale/it/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ja/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ko/LC_MESSAGES/exif.mo
+/usr/local/share/locale/lv/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ms/LC_MESSAGES/exif.mo
+/usr/local/share/locale/nl/LC_MESSAGES/exif.mo
+/usr/local/share/locale/pl/LC_MESSAGES/exif.mo
+/usr/local/share/locale/pt/LC_MESSAGES/exif.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ro/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ru/LC_MESSAGES/exif.mo
+/usr/local/share/locale/sk/LC_MESSAGES/exif.mo
+/usr/local/share/locale/sr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/sv/LC_MESSAGES/exif.mo
+/usr/local/share/locale/tr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/uk/LC_MESSAGES/exif.mo
+/usr/local/share/locale/vi/LC_MESSAGES/exif.mo
+/usr/local/share/locale/zh_CN/LC_MESSAGES/exif.mo
+/usr/local/share/man/man1/exif.1.zst

--- a/manifest/i686/e/exif.filelist
+++ b/manifest/i686/e/exif.filelist
@@ -1,3 +1,34 @@
-# Total size: 102769
+# Total size: 221978
 /usr/local/bin/exif
-/usr/local/share/man/man1/exif.1.gz
+/usr/local/share/locale/ast/LC_MESSAGES/exif.mo
+/usr/local/share/locale/cs/LC_MESSAGES/exif.mo
+/usr/local/share/locale/da/LC_MESSAGES/exif.mo
+/usr/local/share/locale/de/LC_MESSAGES/exif.mo
+/usr/local/share/locale/eo/LC_MESSAGES/exif.mo
+/usr/local/share/locale/es/LC_MESSAGES/exif.mo
+/usr/local/share/locale/fi/LC_MESSAGES/exif.mo
+/usr/local/share/locale/fr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/fur/LC_MESSAGES/exif.mo
+/usr/local/share/locale/gl/LC_MESSAGES/exif.mo
+/usr/local/share/locale/hr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/id/LC_MESSAGES/exif.mo
+/usr/local/share/locale/is/LC_MESSAGES/exif.mo
+/usr/local/share/locale/it/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ja/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ko/LC_MESSAGES/exif.mo
+/usr/local/share/locale/lv/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ms/LC_MESSAGES/exif.mo
+/usr/local/share/locale/nl/LC_MESSAGES/exif.mo
+/usr/local/share/locale/pl/LC_MESSAGES/exif.mo
+/usr/local/share/locale/pt/LC_MESSAGES/exif.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ro/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ru/LC_MESSAGES/exif.mo
+/usr/local/share/locale/sk/LC_MESSAGES/exif.mo
+/usr/local/share/locale/sr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/sv/LC_MESSAGES/exif.mo
+/usr/local/share/locale/tr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/uk/LC_MESSAGES/exif.mo
+/usr/local/share/locale/vi/LC_MESSAGES/exif.mo
+/usr/local/share/locale/zh_CN/LC_MESSAGES/exif.mo
+/usr/local/share/man/man1/exif.1.zst

--- a/manifest/x86_64/e/exif.filelist
+++ b/manifest/x86_64/e/exif.filelist
@@ -1,3 +1,34 @@
-# Total size: 128193
+# Total size: 224418
 /usr/local/bin/exif
-/usr/local/share/man/man1/exif.1.gz
+/usr/local/share/locale/ast/LC_MESSAGES/exif.mo
+/usr/local/share/locale/cs/LC_MESSAGES/exif.mo
+/usr/local/share/locale/da/LC_MESSAGES/exif.mo
+/usr/local/share/locale/de/LC_MESSAGES/exif.mo
+/usr/local/share/locale/eo/LC_MESSAGES/exif.mo
+/usr/local/share/locale/es/LC_MESSAGES/exif.mo
+/usr/local/share/locale/fi/LC_MESSAGES/exif.mo
+/usr/local/share/locale/fr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/fur/LC_MESSAGES/exif.mo
+/usr/local/share/locale/gl/LC_MESSAGES/exif.mo
+/usr/local/share/locale/hr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/id/LC_MESSAGES/exif.mo
+/usr/local/share/locale/is/LC_MESSAGES/exif.mo
+/usr/local/share/locale/it/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ja/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ko/LC_MESSAGES/exif.mo
+/usr/local/share/locale/lv/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ms/LC_MESSAGES/exif.mo
+/usr/local/share/locale/nl/LC_MESSAGES/exif.mo
+/usr/local/share/locale/pl/LC_MESSAGES/exif.mo
+/usr/local/share/locale/pt/LC_MESSAGES/exif.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ro/LC_MESSAGES/exif.mo
+/usr/local/share/locale/ru/LC_MESSAGES/exif.mo
+/usr/local/share/locale/sk/LC_MESSAGES/exif.mo
+/usr/local/share/locale/sr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/sv/LC_MESSAGES/exif.mo
+/usr/local/share/locale/tr/LC_MESSAGES/exif.mo
+/usr/local/share/locale/uk/LC_MESSAGES/exif.mo
+/usr/local/share/locale/vi/LC_MESSAGES/exif.mo
+/usr/local/share/locale/zh_CN/LC_MESSAGES/exif.mo
+/usr/local/share/man/man1/exif.1.zst

--- a/packages/exif.rb
+++ b/packages/exif.rb
@@ -1,36 +1,25 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Exif < Package
+class Exif < Autotools
   description 'A small command-line utility to show EXIF information hidden in JPEG files'
   homepage 'https://libexif.github.io/'
-  version '0.6.21'
+  version '0.6.22'
   license 'LGPL-2+'
   compatibility 'all'
-  source_url 'https://github.com/libexif/exif/archive/exif-0_6_21-release.tar.gz'
-  source_sha256 'f55e125eee6c2a75d367d3b388bcd7bea75dc944fabe8671bb32e889192f4b77'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/libexif/exif.git'
+  git_hashtag "exif-#{version.gsub('.', '_')}-release"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '8f8de193c0571c268e8004876a0365178237107d2e21d44766ef128f204adcb3',
-     armv7l: '8f8de193c0571c268e8004876a0365178237107d2e21d44766ef128f204adcb3',
-       i686: '66264ec4145cb0ea008eeb7a584dbda2339e1b3f2209e712e5bb8b6e794f3db8',
-     x86_64: '5d99ef721aafe110f565698a8ee42d258d89748cbb37073175781af7ec7cc617'
+    aarch64: '160f7c51344f87189820a99ef8da0db87a5fce3bc33c796e51d435adce7eeb57',
+     armv7l: '160f7c51344f87189820a99ef8da0db87a5fce3bc33c796e51d435adce7eeb57',
+       i686: 'd4cf687aa7365857f08c914bab891223366cb2b321876e2fe0665ec9cbeef12e',
+     x86_64: '90e05f7b4a54269966f7fd3f954082f10005fa49169c55e2a35de79e61dca650'
   })
 
-  depends_on 'libexif'
-  depends_on 'popt'
+  depends_on 'glibc' => :executable
+  depends_on 'libexif' => :executable
+  depends_on 'popt' => :executable
 
-  def self.build
-    system 'autoreconf -i -f'
-    system "sed -i '69,70d' po/Makefile.in.in"
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-maintainer-mode'
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  run_tests
 end

--- a/tests/package/e/exif
+++ b/tests/package/e/exif
@@ -1,0 +1,3 @@
+#!/bin/bash
+exif | head
+exif -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-exif crew update \
&& yes | crew upgrade

$ crew check exif 
Checking exif package ...
Library test for exif passed.
Checking exif package ...
Usage: exif [OPTION...] file
  -v, --version                   Display software version
  -i, --ids                       Show IDs instead of tag names
  -t, --tag=tag                   Select tag
      --ifd=IFD                   Select IFD
  -l, --list-tags                 List all EXIF tags
  -|, --show-mnote                Show contents of tag MakerNote
      --remove                    Remove tag or ifd
  -s, --show-description          Show description of tag
  -e, --extract-thumbnail         Extract thumbnail
0.6.22
Package tests for exif passed.
```