### PR TITLE
F3 7.1 => 9.0

### DIFF
--- a/manifest/armv7l/f/f3.filelist
+++ b/manifest/armv7l/f/f3.filelist
@@ -1,8 +1,8 @@
-# Total size: 345229
+# Total size: 113186
 /usr/local/bin/f3brew
 /usr/local/bin/f3fix
 /usr/local/bin/f3probe
 /usr/local/bin/f3read
 /usr/local/bin/f3write
-/usr/local/share/man/man1/f3read.1.gz
-/usr/local/share/man/man1/f3write.1.gz
+/usr/local/share/man/man1/f3read.1.zst
+/usr/local/share/man/man1/f3write.1.zst

--- a/manifest/i686/f/f3.filelist
+++ b/manifest/i686/f/f3.filelist
@@ -1,8 +1,0 @@
-# Total size: 305713
-/usr/local/bin/f3brew
-/usr/local/bin/f3fix
-/usr/local/bin/f3probe
-/usr/local/bin/f3read
-/usr/local/bin/f3write
-/usr/local/share/man/man1/f3read.1.gz
-/usr/local/share/man/man1/f3write.1.gz

--- a/manifest/x86_64/f/f3.filelist
+++ b/manifest/x86_64/f/f3.filelist
@@ -1,8 +1,8 @@
-# Total size: 307381
+# Total size: 137038
 /usr/local/bin/f3brew
 /usr/local/bin/f3fix
 /usr/local/bin/f3probe
 /usr/local/bin/f3read
 /usr/local/bin/f3write
-/usr/local/share/man/man1/f3read.1.gz
-/usr/local/share/man/man1/f3write.1.gz
+/usr/local/share/man/man1/f3read.1.zst
+/usr/local/share/man/man1/f3write.1.zst

--- a/packages/f3.rb
+++ b/packages/f3.rb
@@ -3,22 +3,22 @@ require 'package'
 class F3 < Package
   description 'F3 is a simple tool that tests flash cards\' capacity and performance to see if they live up to claimed specifications.'
   homepage 'http://oss.digirati.com.br/f3/'
-  version '7.1'
+  version '9.0'
   license 'GPL-3+'
-  compatibility 'all'
-  source_url 'https://github.com/AltraMayor/f3/archive/v7.1.tar.gz'
-  source_sha256 '1d9edf12d3f40c03a552dfc3ed36371c62933b9213483182f7a561e1a5b8e1cc'
-  binary_compression 'tar.xz'
+  compatibility 'aarch64 armv7l x86_64'
+  source_url 'https://github.com/AltraMayor/f3.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '0e024b920108a42f8c5497a045972998fd2768c3f6103c05a14785583429298f',
-     armv7l: '0e024b920108a42f8c5497a045972998fd2768c3f6103c05a14785583429298f',
-       i686: '16952ecc8722d1e56f1f0abd2f1c544b0f4c9d4abd33b3e5bb9c3d8a8da3773d',
-     x86_64: '71bd956a914f6021cedb66723f44fa145f5d3d928353fd2465316351c3b26421'
+    aarch64: 'a3f0a8080737123b8c1e85d088f5912de3cb5d287c03f813799f2259ba3adde8',
+     armv7l: 'a3f0a8080737123b8c1e85d088f5912de3cb5d287c03f813799f2259ba3adde8',
+     x86_64: 'b0aece68398809efe3c01eacef9f2ea3f7aaad29f3c7ab81d214e6301f277dcf'
   })
 
-  depends_on 'parted'
-  depends_on 'eudev'
+  depends_on 'eudev' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'parted' => :executable
 
   def self.build
     system 'make'

--- a/tests/package/f/f3
+++ b/tests/package/f/f3
@@ -1,0 +1,11 @@
+#!/bin/bash
+f3brew --help | head -5
+f3brew --version
+f3fix --help | head -5
+f3fix --version
+f3probe --help | head -5
+f3probe --version
+f3read --help | head -5
+f3read -version
+f3write --help | head -5
+f3write --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-f3 crew update \
&& yes | crew upgrade

$ crew check f3 
Checking f3 package ...
Library test for f3 passed.
Checking f3 package ...
Usage: f3brew [OPTION...] <DISK_DEV>
F3 Block REad and Write -- assess the media of a block device writing blocks,
resetting the drive, and reading the blocks back

  -e, --end-at=BLOCK         Where test ends; the default is the very last
F3 BREW 9.0
Usage: f3fix [OPTION...] <DISK_DEV>
F3 Fix -- edit the partition table of a fake flash drive to have a single
partition that fully covers the real capacity of the drive

  -a, --first-sec=SEC-NUM    Sector where the partition starts
F3 Fix 9.0
Usage: f3probe [OPTION...] <DISK_DEV>
F3 Probe -- probe a block device for counterfeit flash memory. If counterfeit,
f3probe identifies the fake type and real memory size

  -l, --min-memory           Trade speed for less use of memory
F3 Probe 9.0
Usage: f3read [OPTION...] <PATH>
F3 Read -- validate .h2w files to test the real capacity of the drive

  -e, --end-at=NUM           Last NUM.h2w file to be read
  -p, --show-progress=NUM    Show progress if NUM is not zero
Usage: f3write [OPTION...] <PATH>
F3 Write -- fill a drive out with .h2w files to test its real capacity

  -e, --end-at=NUM           Last NUM.h2w file to be written
  -p, --show-progress=NUM    Show progress if NUM is not zero
F3 Write 9.0
Package tests for f3 passed.
```