### PR TITLE
Add make_cli package

### DIFF
--- a/manifest/x86_64/m/make_cli.filelist
+++ b/manifest/x86_64/m/make_cli.filelist
@@ -1,0 +1,2 @@
+# Total size: 102164800
+/usr/local/bin/make-cli

--- a/packages/make_cli.rb
+++ b/packages/make_cli.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Make_cli < Package
+  description 'A command-line tool for Make automation platform'
+  homepage 'https://developers.make.com/make-cli'
+  version '1.4.0'
+  license 'MIT'
+  compatibility 'x86_64'
+  source_url "https://github.com/integromat/make-cli/releases/download/v#{version}/make-cli-linux-amd64.tar.gz"
+  source_sha256 'ca0ef36dffdb3afd94bbdd85b6a24ab70d9a5d8705a1955b1b1603e4cca9a9bd'
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.install 'make-cli-linux-amd64', "#{CREW_DEST_PREFIX}/bin/make-cli", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'make-cli -h' to get started.\n"
+  end
+end

--- a/tests/package/m/make_cli
+++ b/tests/package/m/make_cli
@@ -1,0 +1,3 @@
+#!/bin/bash
+make-cli -h | head
+make-cli -V

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6010,6 +6010,11 @@ url: https://ftp.gnu.org/gnu/make
 activity: none
 ---
 kind: url
+name: make_cli
+url: https://github.com/integromat/make-cli/releases
+activity: high
+---
+kind: url
 name: makedepend
 url: https://www.x.org/releases/individual/util/
 activity: none


### PR DESCRIPTION
## Description
A command-line tool for Make automation platform.  See https://developers.make.com/make-cli.
#
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-make_cli-package crew update \
&& yes | crew upgrade

$ crew check make_cli 
Checking make_cli package ...
Library test for make_cli passed.
Checking make_cli package ...
Usage: make-cli [options] [command]

A command-line tool for Make automation platform

Options:
  -V, --version          output the version number
  --api-key <key>        Make API key (or set MAKE_API_KEY)
  --zone <zone>          Make zone, e.g. eu1.make.com (or set MAKE_ZONE)
  --output <format>      Output format (choices: "json", "compact", "table",
                         default: "json")
1.4.0
Package tests for make_cli passed.
```