### PR TITLE
Edit 1.2.1 => 2.0.0

### DIFF
--- a/manifest/armv7l/e/edit.filelist
+++ b/manifest/armv7l/e/edit.filelist
@@ -1,2 +1,6 @@
-# Total size: 551880
+# Total size: 637501
 /usr/local/bin/edit
+/usr/local/bin/msedit
+/usr/local/share/applications/com.microsoft.edit.desktop
+/usr/local/share/icons/edit.ico
+/usr/local/share/man/man1/edit.1.zst

--- a/manifest/i686/e/edit.filelist
+++ b/manifest/i686/e/edit.filelist
@@ -1,2 +1,6 @@
-# Total size: 618920
+# Total size: 721889
 /usr/local/bin/edit
+/usr/local/bin/msedit
+/usr/local/share/applications/com.microsoft.edit.desktop
+/usr/local/share/icons/edit.ico
+/usr/local/share/man/man1/edit.1.zst

--- a/manifest/x86_64/e/edit.filelist
+++ b/manifest/x86_64/e/edit.filelist
@@ -1,2 +1,6 @@
-# Total size: 639688
+# Total size: 746493
 /usr/local/bin/edit
+/usr/local/bin/msedit
+/usr/local/share/applications/com.microsoft.edit.desktop
+/usr/local/share/icons/edit.ico
+/usr/local/share/man/man1/edit.1.zst

--- a/packages/edit.rb
+++ b/packages/edit.rb
@@ -1,9 +1,9 @@
-require 'buildsystems/rust'
+require 'package'
 
-class Edit < RUST
+class Edit < Package
   description 'A simple editor for simple needs.'
   homepage 'https://github.com/microsoft/edit'
-  version '1.2.1'
+  version '2.0.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/microsoft/edit.git'
@@ -11,14 +11,31 @@ class Edit < RUST
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '31ce1e9925dded90169f46ba07b7cb324c77981ebe44910ce44556361dcf8ce1',
-     armv7l: '31ce1e9925dded90169f46ba07b7cb324c77981ebe44910ce44556361dcf8ce1',
-       i686: '1e5c2bf3970c1e8df1b7ea724707a404f448042f5935d20adb11318021d9aaa9',
-     x86_64: '1bee42d4b0f48e0b8ce76cdeeb50fde5514798f3e6d4b3441f28978e8c232c15'
+    aarch64: '33192a2763cd52dce9d73a9bdb1a611e9666e12aec855aebf70b22e97710548a',
+     armv7l: '33192a2763cd52dce9d73a9bdb1a611e9666e12aec855aebf70b22e97710548a',
+       i686: 'bff933e27ffda8a7536984d96c38d4a53de1f00a651350f4e9d538f371de1e71',
+     x86_64: '4aa60ab9ea1e29a9b06023d3a91aaa588fadefba0e25e3d9b6375ed5b0af6794'
   })
 
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
+  depends_on 'gcc_lib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'rust' => :build
 
-  rust_channel 'nightly'
+  def self.build
+    system "curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/microsoft/edit/main/assets/install.sh -o install.sh"
+    system "sed -i 's,\$tmpdir/edit-src,.,' install.sh"
+    system "sed -i '165,203d' install.sh"
+    system "sed -i '141d' install.sh"
+    system "sed -i '71,72d' install.sh"
+    system "sed -i '34,37d' install.sh"
+  end
+
+  def self.install
+    system 'sh ./install.sh'
+    FileUtils.install 'target/release/edit', "#{CREW_DEST_PREFIX}/bin/edit", mode: 0o755
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/edit", "#{CREW_DEST_PREFIX}/bin/msedit"
+    FileUtils.install 'assets/manpage/edit.1', "#{CREW_DEST_MAN_PREFIX}/man1/edit.1", mode: 0o644
+    FileUtils.install 'assets/edit.ico', "#{CREW_DEST_PREFIX}/share/icons/edit.ico", mode: 0o644
+    FileUtils.install 'assets/com.microsoft.edit.desktop', "#{CREW_DEST_PREFIX}/share/applications/com.microsoft.edit.desktop", mode: 0o644
+  end
 end

--- a/tests/package/e/edit
+++ b/tests/package/e/edit
@@ -1,0 +1,3 @@
+#!/bin/bash
+edit -h
+edit -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-edit crew update \
&& yes | crew upgrade

$ crew check edit 
Checking edit package ...
Library test for edit passed.
Checking edit package ...
Usage: edit [OPTIONS] [FILE[:LINE[:COLUMN]]]
Options:
    -h, --help       Print this help message
    -v, --version    Print the version number

Arguments:
    FILE[:LINE[:COLUMN]]    The file to open, optionally with line and column (e.g., foo.txt:123:45)
edit version 2.0.0
Package tests for edit passed.
```