### PR TITLE
Fix spurious libeeudev dependency being added due to an insufficiently strict match in getrealdeps.rb. — glibc_fallthrough: 2.39 → 2.39,libinput: 1.31.2 → 1.31.2,peazip: 5.2.0 → 5.2.0,weston: 15.0.1 → 15.0.1

### DIFF
--- a/manifest/x86_64/g/glibc_fallthrough.filelist
+++ b/manifest/x86_64/g/glibc_fallthrough.filelist
@@ -1,1 +1,23 @@
-
+# Total size: 0
+/usr/local/lib64/ld-linux-x86-64.so.2
+/usr/local/lib64/libanl.so
+/usr/local/lib64/libanl.so.1
+/usr/local/lib64/libc.so.6
+/usr/local/lib64/libcrypt.so
+/usr/local/lib64/libcrypt.so.1
+/usr/local/lib64/libcrypt.so.1.1.0
+/usr/local/lib64/libcrypt.so.2
+/usr/local/lib64/libcrypt.so.2.0.0
+/usr/local/lib64/libdl.so.2
+/usr/local/lib64/libm.so.6
+/usr/local/lib64/libmvec.so
+/usr/local/lib64/libmvec.so.1
+/usr/local/lib64/libnsl.so.1
+/usr/local/lib64/libnss_dns.so.2
+/usr/local/lib64/libnss_files.so.2
+/usr/local/lib64/libresolv.so
+/usr/local/lib64/libresolv.so.2
+/usr/local/lib64/librt.so.1
+/usr/local/lib64/libthread_db.so
+/usr/local/lib64/libthread_db.so.1
+/usr/local/lib64/libutil.so.1

--- a/manifest/x86_64/p/peazip.filelist
+++ b/manifest/x86_64/p/peazip.filelist
@@ -1,7 +1,6 @@
-# Total size: 44806290
+# Total size: 44658794
 /usr/local/bin/pea
 /usr/local/bin/peazip
-/usr/local/lib64/libpthread.so.0
 /usr/local/share/application/peazip.desktop
 /usr/local/share/peazip/pea
 /usr/local/share/peazip/peazip

--- a/packages/glibc_fallthrough.rb
+++ b/packages/glibc_fallthrough.rb
@@ -20,10 +20,12 @@ class Glibc_fallthrough < Package
   depends_on 'patchelf' => :logical
 
   conflicts_ok
+  no_compile_needed
   no_env_options
   no_upstream_update
 
-  def self.postinstall
+  def self.install
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     if File.exist?("#{CREW_LIB_PREFIX}/libc.so.6")
       FileUtils.chmod 'u=wrx', "#{CREW_LIB_PREFIX}/libc.so.6"
       @crew_libcvertokens = `#{CREW_LIB_PREFIX}/libc.so.6`.lines.first.chomp.split(/\s/)
@@ -44,16 +46,16 @@ class Glibc_fallthrough < Package
       puts 'Creating symlinks to system glibc version to prevent breakage.'.lightblue
       case ARCH
       when 'aarch64', 'armv7l'
-        FileUtils.ln_sf File.realpath('/lib/ld-linux-armhf.so.3'), 'ld-linux-armhf.so.3'
+        FileUtils.ln_sf File.realpath('/lib/ld-linux-armhf.so.3'), "#{CREW_DEST_LIB_PREFIX}/ld-linux-armhf.so.3"
       when 'x86_64'
-        FileUtils.ln_sf File.realpath('/lib64/ld-linux-x86-64.so.2'), 'ld-linux-x86-64.so.2'
+        FileUtils.ln_sf File.realpath('/lib64/ld-linux-x86-64.so.2'), "#{CREW_DEST_LIB_PREFIX}/ld-linux-x86-64.so.2"
       end
       @libraries.each do |lib|
         # Reject entries which aren't libraries ending in .so, and which aren't files.
         # Reject text files such as libc.so because they points to files like
         # libc_nonshared.a, which are not provided by ChromeOS
         Dir["{,/usr}/#{ARCH_LIB}/#{lib}.so*"].compact.select { |i| ['shared object', 'symbolic link'].any? { |j| `file #{i}`.chomp.include? j } }.each do |k|
-          FileUtils.ln_sf k, File.join(CREW_LIB_PREFIX, File.basename(k))
+          FileUtils.ln_sf k, File.join(CREW_DEST_LIB_PREFIX, File.basename(k))
         end
       end
     end

--- a/packages/glibc_fallthrough.rb
+++ b/packages/glibc_fallthrough.rb
@@ -10,8 +10,6 @@ class Glibc_fallthrough < Package
   max_glibc version.split('-').first
   source_url 'SKIP'
 
-  binary_sha256({})
-
   depends_on 'gawk' => :build
   depends_on 'filecmd' => :logical # Fixes creating symlinks on a fresh install.
   depends_on 'libidn2' => :build

--- a/packages/glibc_fallthrough.rb
+++ b/packages/glibc_fallthrough.rb
@@ -9,7 +9,6 @@ class Glibc_fallthrough < Package
   min_glibc version.split('-').first
   max_glibc version.split('-').first
   source_url 'SKIP'
-  binary_compression 'tar.zst'
 
   binary_sha256({})
 

--- a/packages/peazip.rb
+++ b/packages/peazip.rb
@@ -39,14 +39,7 @@ class Peazip < Package
     FileUtils.mv 'peazip', "#{CREW_DEST_PREFIX}/share/peazip/"
     FileUtils.mv 'res/', "#{CREW_DEST_PREFIX}/share/peazip/"
     FileUtils.ln_s "#{CREW_PREFIX}/share/peazip/peazip", "#{CREW_DEST_PREFIX}/bin/peazip"
-    if File.exist?("#{CREW_PREFIX}/opt/glibc-libs/libm.so.6") && !File.exist?("#{CREW_LIB_PREFIX}/libm.so.6")
-      FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
-      FileUtils.ln_s "#{CREW_PREFIX}/opt/glibc-libs/libm.so.6", "#{CREW_DEST_LIB_PREFIX}/libm.so.6"
-    end
-    if File.exist?("#{CREW_PREFIX}/opt/glibc-libs/libpthread.so.0") && !File.exist?("#{CREW_LIB_PREFIX}/libpthread.so.0")
-      FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
-      FileUtils.ln_s "#{CREW_PREFIX}/opt/glibc-libs/libpthread.so.0", "#{CREW_DEST_LIB_PREFIX}/libpthread.so.0"
-    end
+    # Never install glibc libraries such as libm.so.6 or libpthread.so.0 from peazip.
   end
 
   def self.postinstall

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -51,7 +51,6 @@ class Weston < Meson
   depends_on 'mesa' => :library
   depends_on 'neatvnc' => :library
   depends_on 'pango' => :library
-  depends_on 'peazip' => :library
   depends_on 'pipewire' => :library
   depends_on 'pixman' => :library
   depends_on 'seatd' => :library

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -24,14 +24,14 @@ class Weston < Meson
   depends_on 'gcc_lib' => :executable
   depends_on 'glib' => :library
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'glslang' => :build
   depends_on 'graphite' => :build
   depends_on 'gstreamer' => :library
   depends_on 'harfbuzz' # R
   depends_on 'hwdata' => :build
   depends_on 'libdrm' => :library
-  depends_on 'libeeudev' => :library
-  depends_on 'libevdev' # R
+  depends_on 'libevdev' => :library
   depends_on 'libglvnd' => :library
   depends_on 'libinput' => :library
   depends_on 'libjpeg_turbo' => :library
@@ -51,6 +51,7 @@ class Weston < Meson
   depends_on 'mesa' => :library
   depends_on 'neatvnc' => :library
   depends_on 'pango' => :library
+  depends_on 'peazip' => :library
   depends_on 'pipewire' => :library
   depends_on 'pixman' => :library
   depends_on 'seatd' => :library

--- a/tools/getrealdeps.rb
+++ b/tools/getrealdeps.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby
-# getrealdeps version 2.12 (for Chromebrew)
+# getrealdeps version 2.13 (for Chromebrew)
 # Author: Satadru Pramanik (satmandu) satadru at gmail dot com
 #
 # Dependencies in Chromebrew can be:
@@ -205,6 +205,9 @@ def determine_dependencies(pkg_name, pkgfiles_to_check)
   # Figure out which Chromebrew packages provide the relevant deps.
   pkgdeps = pkgdepsfiles.map { |file| whatprovidesfxn(file, pkg_name) }
 
+  # Split any multi-dependency strings into individual array members.
+  pkgdeps = pkgdeps.flat_map(&:split).uniq
+
   # Massage the glibc entries in the dependency list.
   pkgdeps = pkgdeps.map { |i| i.gsub(/glibc_build.*/, 'glibc') }.uniq
   pkgdeps = pkgdeps.map { |i| i.gsub(/glibc_lib.*/, 'glibc_lib') }.uniq.map(&:strip).reject(&:empty?)
@@ -223,7 +226,7 @@ def determine_dependencies(pkg_name, pkgfiles_to_check)
   # TODO: Since these packages aren't needed by any specific package, do we need to package them at all?
   pkgdeps = pkgdeps.map { |i| i.gsub('jack1', 'jack') }.uniq
   pkgdeps = pkgdeps.map { |i| i.gsub('libxml2_autotools', 'libxml2') }.uniq
-  pkgdeps = pkgdeps.map { |i| i.gsub('vdev', 'eudev') }.uniq
+  pkgdeps = pkgdeps.map { |i| i.gsub(/^vdev$/, 'eudev') }.uniq
   pkgdeps = pkgdeps.map { |i| i.gsub('libudev_stub', 'eudev') }.uniq
 
   # Split any multi-dependency strings into individual array members.


### PR DESCRIPTION
## Description
#### Commits:
-  e9e4f3d7e Remove binary_compression from glibc_fallthrough.
-  bee7ed003 Adjust glibc_fallthrough and peazip packages.
-  0354f8368 Fix spurious libeeudev dependency being added due to an insufficiently strict match in getrealdeps.rb.
### Packages with Updated versions or Changed package files:
- `glibc_fallthrough`: 2.39 &rarr; 2.39
- `libinput`: 1.31.2 &rarr; 1.31.2
- `peazip`: 5.2.0 &rarr; 5.2.0 (current version is 11.1.0)
- `weston`: 15.0.1 &rarr; 15.0.1
##
Builds attempted for:
### Other changed files:
- tools/getrealdeps.rb
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=fix_libeeudev crew update \
&& yes | crew upgrade
```
