### PR TITLE
Fftw 3.3.10 => 3.3.11

### DIFF
--- a/manifest/armv7l/f/fftw.filelist
+++ b/manifest/armv7l/f/fftw.filelist
@@ -1,4 +1,4 @@
-# Total size: 8069559
+# Total size: 8208030
 /usr/local/bin/fftw-wisdom
 /usr/local/bin/fftw-wisdom-to-conf
 /usr/local/include/fftw3.f
@@ -12,7 +12,7 @@
 /usr/local/lib/libfftw3.la
 /usr/local/lib/libfftw3.so
 /usr/local/lib/libfftw3.so.3
-/usr/local/lib/libfftw3.so.3.6.10
+/usr/local/lib/libfftw3.so.3.7.11
 /usr/local/lib/pkgconfig/fftw3.pc
 /usr/local/share/info/fftw3.info-1.zst
 /usr/local/share/info/fftw3.info-2.zst

--- a/manifest/i686/f/fftw.filelist
+++ b/manifest/i686/f/fftw.filelist
@@ -1,4 +1,4 @@
-# Total size: 8480689
+# Total size: 8691642
 /usr/local/bin/fftw-wisdom
 /usr/local/bin/fftw-wisdom-to-conf
 /usr/local/include/fftw3.f
@@ -12,7 +12,7 @@
 /usr/local/lib/libfftw3.la
 /usr/local/lib/libfftw3.so
 /usr/local/lib/libfftw3.so.3
-/usr/local/lib/libfftw3.so.3.6.10
+/usr/local/lib/libfftw3.so.3.7.11
 /usr/local/lib/pkgconfig/fftw3.pc
 /usr/local/share/info/fftw3.info-1.zst
 /usr/local/share/info/fftw3.info-2.zst

--- a/manifest/x86_64/f/fftw.filelist
+++ b/manifest/x86_64/f/fftw.filelist
@@ -1,4 +1,4 @@
-# Total size: 9265479
+# Total size: 9653310
 /usr/local/bin/fftw-wisdom
 /usr/local/bin/fftw-wisdom-to-conf
 /usr/local/include/fftw3.f
@@ -12,7 +12,7 @@
 /usr/local/lib64/libfftw3.la
 /usr/local/lib64/libfftw3.so
 /usr/local/lib64/libfftw3.so.3
-/usr/local/lib64/libfftw3.so.3.6.10
+/usr/local/lib64/libfftw3.so.3.7.11
 /usr/local/lib64/pkgconfig/fftw3.pc
 /usr/local/share/info/fftw3.info-1.zst
 /usr/local/share/info/fftw3.info-2.zst

--- a/packages/fftw.rb
+++ b/packages/fftw.rb
@@ -3,19 +3,22 @@ require 'buildsystems/autotools'
 class Fftw < Autotools
   description 'FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data (as well as of even/odd data, i.e. the discrete cosine/sine transforms or DCT/DST).'
   homepage 'https://www.fftw.org/'
-  version '3.3.10'
+  version '3.3.11'
   license 'GPL-2+'
   compatibility 'all'
   source_url "https://fftw.org/fftw-#{version}.tar.gz"
-  source_sha256 '56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467'
+  source_sha256 '5630c24cdeb33b131612f7eb4b1a9934234754f9f388ff8617458d0be6f239a1'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '104ed5989de12cd2edddc03978cd1cba48e503d50eba8f4de5e63d5e44c3ec92',
-     armv7l: '104ed5989de12cd2edddc03978cd1cba48e503d50eba8f4de5e63d5e44c3ec92',
-       i686: '8bb8ff951cf62a5f339b37cdadd21836ee6499a054eceb7c7acfa19f4789896d',
-     x86_64: '3de2966c788cbd46d2c74cf010f781337651b5f7086d7b0b9c5117e131025819'
+    aarch64: '967ee876b47a3f0a8354fa5587a9cd6103cd6629a908ded148b69634cef47839',
+     armv7l: '967ee876b47a3f0a8354fa5587a9cd6103cd6629a908ded148b69634cef47839',
+       i686: '8ef033f81a7398024a7a757187bb5e259562d472752e7680746afd1cbb692ebc',
+     x86_64: '27e304bd4022d580dbc181e5f08f250179c80cd2c109639dd7e2ab619fc4e136'
   })
+
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
   # We'd need to build fftw three times with each precision option in order to support things properly.
   # https://www.linuxfromscratch.org/blfs/view/cvs/general/fftw.html

--- a/tests/package/f/fftw
+++ b/tests/package/f/fftw
@@ -1,0 +1,5 @@
+#!/bin/bash
+fftw-wisdom -h | head -5
+fftw-wisdom -V
+fftw-wisdom-to-conf -h | head -5
+fftw-wisdom-to-conf -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-fftw crew update \
&& yes | crew upgrade

$ crew check fftw 
Checking fftw package ...
Library test for fftw passed.
Checking fftw package ...
Usage: fftw-wisdom [options] [sizes]
    Create wisdom (pre-planned/optimized transforms) for specified sizes,
    writing wisdom to stdout (or to a file, using -o).

Options:
fftw-wisdom tool for FFTW version 3.3.11.

Copyright (c) 2003, 2007-14 Matteo Frigo
Copyright (c) 2003, 2007-14 Massachusetts Institute of Technology

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

You should have received a copy of the GNU General Public License
along with this program; if not, write to the Free Software
Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
Usage: fftw-wisdom-to-conf [OPTIONS] [< INPUT] [> OUTPUT]
Convert wisdom (stdin) to C configuration routine (stdout).

Options:
        -h, --help: print this help
fftw-wisdom-to-conf from FFTW version 3.3.11

Copyright (c) 2003, 2007-14 Matteo Frigo
Copyright (c) 2003, 2007-14 Massachusetts Institute of Technology

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

You should have received a copy of the GNU General Public License
along with this program; if not, write to the Free Software
Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA    
Package tests for fftw passed.
```