### PR TITLE
Convert PR to draft if Unit Tests Fail.

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.6
+# Version 1.7
 name: Unit Tests
 on:
   check_run:
@@ -270,6 +270,23 @@ jobs:
       - container_tests
     if: ${{ !cancelled() }}
     steps:
-      - name: fail if container_test jobs failed
+      - name: Get GH Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v4
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          organization: chromebrew
+          revoke_token: true
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+      - name: fail and convert to draft if container_test jobs failed
         if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
+        env:
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+        run: |
+          gh pr ready --undo || true
+          exit 1


### PR DESCRIPTION
## Description
#### Commits:
-  10037aa89 Convert PR to draft if Unit Tests Fail.
### Updated GitHub configuration files:
- .github/workflows/Unit-Test.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=convert_to_draft_if_unit_tests_fail crew update \
&& yes | crew upgrade
```
