### PR TITLE
Add mesen package

### DIFF
--- a/manifest/x86_64/m/mesen.filelist
+++ b/manifest/x86_64/m/mesen.filelist
@@ -1,0 +1,2 @@
+# Total size: 83367840
+/usr/local/bin/mesen

--- a/packages/mesen.rb
+++ b/packages/mesen.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Mesen < Package
+  description 'Multi-system emulator (NES, SNES, GB, GBA, PCE, SMS/GG, WS) for Windows, Linux and macOS'
+  homepage 'https://www.mesen.ca/'
+  version '2.1.1'
+  license 'GPL-3.0'
+  compatibility 'x86_64'
+  min_glibc '2.29'
+  source_url "https://github.com/SourMesen/Mesen2/releases/download/#{version}/Mesen_#{version}_Linux_x64.zip"
+  source_sha256 '7a9947575cc198209f743fef83fb2b702b786ea705506bdf3f2aea01ab7c1ce9'
+
+  depends_on 'libice' => :library
+  depends_on 'libsm' => :library
+  depends_on 'sdl2' => :library
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.install 'Mesen', "#{CREW_DEST_PREFIX}/bin/mesen", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'mesen' to get started.\n"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6125,6 +6125,11 @@ url: https://gitlab.freedesktop.org/mesa/demos/-/tags
 activity: none
 ---
 kind: url
+name: mesen
+url: https://github.com/SourMesen/Mesen2/releases
+activity: low
+---
+kind: url
 name: metadata_cleaner
 url: https://gitlab.com/rmnvgr/metadata-cleaner/-/tags
 activity: low


### PR DESCRIPTION
## Description
Mesen is a multi-system emulator (NES, SNES, Game Boy, Game Boy Advance, PC Engine, SMS/Game Gear, WonderSwan) for Windows, Linux and macOS.  See https://www.mesen.ca/.
#
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-mesen-package crew update \
&& yes | crew upgrade
```