### PR TITLE
Font_util 1.4.1 => 1.4.2

### DIFF
--- a/manifest/armv7l/f/font_util.filelist
+++ b/manifest/armv7l/f/font_util.filelist
@@ -1,4 +1,4 @@
-# Total size: 202964
+# Total size: 203683
 /usr/local/bin/bdftruncate
 /usr/local/bin/ucs2any
 /usr/local/lib/pkgconfig/fontutil.pc

--- a/manifest/i686/f/font_util.filelist
+++ b/manifest/i686/f/font_util.filelist
@@ -1,4 +1,4 @@
-# Total size: 205360
+# Total size: 207567
 /usr/local/bin/bdftruncate
 /usr/local/bin/ucs2any
 /usr/local/lib/pkgconfig/fontutil.pc

--- a/manifest/x86_64/f/font_util.filelist
+++ b/manifest/x86_64/f/font_util.filelist
@@ -1,4 +1,4 @@
-# Total size: 209358
+# Total size: 210649
 /usr/local/bin/bdftruncate
 /usr/local/bin/ucs2any
 /usr/local/lib64/pkgconfig/fontutil.pc

--- a/packages/font_util.rb
+++ b/packages/font_util.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Font_util < Autotools
   description 'Tools for truncating and subseting of ISO10646-1 BDF fonts'
   homepage 'https://gitlab.freedesktop.org/xorg/font/util'
-  version '1.4.1'
+  version '1.4.2'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/xorg/font/util.git'
@@ -11,12 +11,14 @@ class Font_util < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1ef384a719dd423ee9529ad503f52ffa13af4afc4802a20e9e5cccac455e90c3',
-     armv7l: '1ef384a719dd423ee9529ad503f52ffa13af4afc4802a20e9e5cccac455e90c3',
-       i686: '50f78fd1b51145eced75ea02b93955be8c11e6fa100d47686a87481010229b4f',
-     x86_64: '9e65f04191f8f2d120bff3e71368fc09b2ba41063de84eea202041a3785d72d8'
+    aarch64: '3b83ecd6672fb870c4cad80b6492b5536fec3df82960e5ed66635c3061151600',
+     armv7l: '3b83ecd6672fb870c4cad80b6492b5536fec3df82960e5ed66635c3061151600',
+       i686: '75eae3617d4add8b1a060ecbd3d1a1da5e9c5154df45fdfd0fe14e25482b0f07',
+     x86_64: '63d511ff979e9e8af5dba620d259780e04e4003f988cffaf4f9f5c14f049048d'
   })
 
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'xorg_macros' => :build
 
   autotools_configure_options "--with-fontrootdir=#{CREW_PREFIX}/share/fonts"

--- a/tests/package/f/font_util
+++ b/tests/package/f/font_util
@@ -1,0 +1,5 @@
+#!/bin/bash
+bdftruncate --help 2>&1 | head -5
+bdftruncate --version
+ucs2any --help | head -5
+ucs2any --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-font_util crew update \
&& yes | crew upgrade

$ crew check font_util 
Checking font_util package ...
Library test for font_util passed.
Checking font_util package ...
Usage: bdftruncate [+w|-w] threshold <source.bdf >destination.bdf
   or: bdftruncate [--help|--version]

Example:

font-util 1.4.2

Usage: ucs2any [+d|-d] <source-name> { <mapping-file> <registry-encoding> }
   or: ucs2any [--help|--version]

where
font-util 1.4.2
Package tests for font_util passed.
```