### PR TITLE
Add uasm — uasm → 2.57

### DIFF
--- a/manifest/armv7l/u/uasm.filelist
+++ b/manifest/armv7l/u/uasm.filelist
@@ -1,0 +1,2 @@
+# Total size: 701572
+/usr/local/bin/uasm

--- a/manifest/i686/u/uasm.filelist
+++ b/manifest/i686/u/uasm.filelist
@@ -1,0 +1,2 @@
+# Total size: 820904
+/usr/local/bin/uasm

--- a/manifest/x86_64/u/uasm.filelist
+++ b/manifest/x86_64/u/uasm.filelist
@@ -1,0 +1,2 @@
+# Total size: 841096
+/usr/local/bin/uasm

--- a/packages/uasm.rb
+++ b/packages/uasm.rb
@@ -1,0 +1,45 @@
+require 'package'
+
+class Uasm < Package
+  description 'A MASM-compatible assembler'
+  homepage 'http://www.terraspace.co.uk/uasm.html'
+  version '2.57'
+  license 'JWasm'
+  compatibility 'all'
+  source_url 'https://github.com/Terraspace/UASM.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '2c49710bfd224e09b27de1b9cf6ff92fd352e96c10ff3f54ed20a9e381d51c19',
+     armv7l: '2c49710bfd224e09b27de1b9cf6ff92fd352e96c10ff3f54ed20a9e381d51c19',
+       i686: '9cf96de8d48d186d0ee76df01fa53f3d0e271e6d7edefc76dbd3e60819bd6fc2',
+     x86_64: '3e508527a193179c479fac56d964060b0b6333916cc99b88e6f5cc1fbab1f20a'
+  })
+
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+
+  ignore_updater # versioning for uasm seems to randomly add suffixes.
+
+  def self.patch
+    patches = [
+      # Build fixes
+      ['https://patch-diff.githubusercontent.com/raw/Terraspace/UASM/pull/216.diff', '679690c51900bf88dce862c93bf36db7b761afcc18d54d3f97b076fc86da3f66'],
+      # Fix for CVE-2017-16516
+      ['https://gitlab.archlinux.org/archlinux/packaging/packages/uasm/-/raw/main/add-missing-header.patch?ref_type=heads&inline=false', '4840e477c46c708b4d46c99317d5ef7985284ed5a5ff42bd014118d3dee996a1']
+    ]
+    ConvenienceFunctions.patch(patches)
+  end
+
+  def self.build
+    # See: https://stackoverflow.com/a/46223160
+    # -D_XOPEN_SOURCE=700 is needed to handle a
+    # implicit declaration of function ‘fileno’ error.
+    system "CFLAGS='-std=c17 -D_XOPEN_SOURCE=700' make -f Makefile-Linux.mak"
+  end
+
+  def self.install
+    FileUtils.install 'GccUnixR/uasm', "#{CREW_DEST_PREFIX}/bin/", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -9900,6 +9900,11 @@ url: https://github.com/microsoft/TypeScript/releases
 activity: high
 ---
 kind: url
+name: uasm
+url: https://github.com/Terraspace/UASM/releases
+activity: low
+---
+kind: url
 name: uchardet
 url: https://www.freedesktop.org/software/uchardet/releases/
 activity: none


### PR DESCRIPTION
## Description
#### Commits:
-  702cfcc62 Add uasm
### Packages with Updated versions or Changed package files:
- `uasm` &rarr; 2.57 (current version is 2.57r)
##
Builds attempted for:
### Other changed files:
- tools/packages.yaml
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add_uasm crew update \
&& yes | crew upgrade
```
