### PR TITLE
Workflow Updates

### DIFF
--- a/.github/workflows/Actions-Updater.yml
+++ b/.github/workflows/Actions-Updater.yml
@@ -1,0 +1,29 @@
+---
+# Version 1.0
+name: Actions Updater
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+env:
+  GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}
+permissions:
+  actions: write
+  contents: write
+  packages: write
+  pull-requests: write
+  repository-projects: read
+jobs:
+  autocheck:
+    if: ${{ github.repository_owner == 'chromebrew' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.9.0
+        with:
+          token: ${{ secrets.CREW_PR_TOKEN}}
+          pull_request_team_reviewers: chromebrew/active
+          pull_request_labels: updater

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -390,7 +390,7 @@ jobs:
           ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.1'
+          ruby-version: '4.0.4'
       - name: Install bin/crew gem dependencies
         run: |
           # Install required gems.

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -454,7 +454,7 @@ jobs:
             fi
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.1'
+          ruby-version: '4.0.4'
       - name: Create Pull Request
         env:
           CHANGED_GITHUB_CONFIG_FILES: ${{ steps.changed-files.outputs.github_all_changed_files }}

--- a/.github/workflows/Package-Dependencies-Updater.yml
+++ b/.github/workflows/Package-Dependencies-Updater.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.1'
+          ruby-version: '4.0.4'
       - name: Install bin/crew gem dependencies
         run: |
           # Install required gems.

--- a/.github/workflows/Repology.yml
+++ b/.github/workflows/Repology.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.1'
+          ruby-version: '4.0.4'
       - name: Install highline
         run: sudo apt install -y ruby-highline
       - name: Install activesupport

--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -14,7 +14,7 @@ jobs:
        - uses: actions/checkout@v6
        - uses: ruby/setup-ruby@v1
          with:
-            ruby-version: '4.0.1'
+            ruby-version: '4.0.4'
        - name: Rubocop
          uses: reviewdog/action-rubocop@v2
          with:

--- a/.github/workflows/Set-Reviewers.yml
+++ b/.github/workflows/Set-Reviewers.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.9
+# Version 2.0
 name: Set Reviewers
 run-name: Set Reviewers for PR from ${{ github.event.workflow_run.display_title }} ${{ inputs.branch || github.event.workflow_run.head_commit.message || github.head_ref || github.ref_name }}
 on:
@@ -37,6 +37,19 @@ jobs:
         env:
           STEPS_CONTEXT: ${{ toJson(steps) }}
         run: echo "$STEPS_CONTEXT"
+      - name: Dump setup job go/no-go variables
+        env:
+          REPO_OWNER: ${{ github.repository_owner == 'chromebrew' }}
+          INPUTS_BRANCH_NOT_MASTER: ${{ inputs.branch != 'master' }}
+          EVENT_WORKFLOW_RUN_HEAD_BRANCH_NOT_MASTER: ${{ github.event.workflow_run.head_branch != 'master' }}
+          EVENT_PULL_REQUEST_DRAFT_FALSE: ${{ github.event.pull_request.draft == false }}
+          EVENT_WORKFLOW_RUN_CONCLUSION_SUCCESS: ${{ github.event.workflow_run.conclusion == 'success' }}
+        run: |
+          echo "github.repository_owner == 'chromebrew' : ${OWNER}"
+          echo "inputs.branch != 'master' : ${INPUTS_BRANCH_NOT_MASTER}"
+          echo "github.event.workflow_run.head_branch != 'master' : ${EVENT_WORKFLOW_RUN_HEAD_BRANCH_NOT_MASTER}"
+          echo "github.event.pull_request.draft == false : ${EVENT_PULL_REQUEST_DRAFT_FALSE}"
+          echo "github.event.workflow_run.conclusion == 'success' : ${EVENT_WORKFLOW_RUN_CONCLUSION_SUCCESS}"
   setup:
     if: ${{ github.repository_owner == 'chromebrew' && inputs.branch != 'master' && github.event.workflow_run.head_branch != 'master' && github.event.pull_request.draft == false && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.7
+# Version 1.8
 name: Unit Tests
 on:
   check_run:
@@ -43,11 +43,19 @@ jobs:
   setup:
     if: ${{ github.repository_owner == 'chromebrew' }}
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}-${{ github.sha }}
+      cancel-in-progress: true
     outputs:
       current_head: ${{ steps.get-current-head.outputs.CURRENT_HEAD }}
       changed_packages: ${{ steps.changed-packages.outputs.CHANGED_PACKAGES }}
       non_changed_packages: ${{ steps.changed-files.outputs.non-package_all_changed_files }}
     steps:
+      - name: Dump Concurrency Group
+        env:
+          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}-${{ github.sha }}
+        run: |
+          echo "Concurrency Group: ${CONCURRENCY_GROUP}"
       - name: Get GH Token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v4
@@ -146,6 +154,11 @@ jobs:
       group: ${{ matrix.arch }}-${{ github.workflow }}-${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}-${{ github.sha }}
       cancel-in-progress: true
     steps:
+      - name: Dump Concurrency Group
+        env:
+          CONCURRENCY_GROUP: $${{ matrix.arch }}-{{ github.workflow }}-${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}-${{ github.sha }}
+        run: |
+          echo "Concurrency Group: ${CONCURRENCY_GROUP}"
       - uses: actions/checkout@v6
         with:
           persist-credentials: true

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -49,7 +49,8 @@ jobs:
     outputs:
       current_head: ${{ steps.get-current-head.outputs.CURRENT_HEAD }}
       changed_packages: ${{ steps.changed-packages.outputs.CHANGED_PACKAGES }}
-      non_changed_packages: ${{ steps.changed-files.outputs.non-package_all_changed_files }}
+      non_package_non_workflow_files: ${{ steps.changed-files.outputs.non-package-non-workflow_all_changed_files }}
+      changed_workflow_files: ${{ steps.changed-files.outputs.workflows_all_changed_files }}
     steps:
       - name: Dump Concurrency Group
         env:
@@ -87,11 +88,14 @@ jobs:
           base_sha: ${{ steps.get-current-head.outputs.CURRENT_HEAD }}
           since_last_remote_commit: true
           files_yaml: |
-            non-package:
+            non-package-non-workflow:
               - '**'
+              - '!.github/workflows/*.yml'
               - '!packages/**.rb'
             packages:
               - packages/**.rb
+            workflows:
+              - '.github/workflows/*.yml'
       - name: Sanitize and export changed packages to github context.
         id: changed-packages
         run: |
@@ -101,8 +105,18 @@ jobs:
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }}" | xargs --no-run-if-empty basename -s .rb | xargs --no-run-if-empty)" >> "$GITHUB_ENV"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-files.outputs.packages_all_changed_files }}" | xargs --no-run-if-empty basename -s .rb | xargs --no-run-if-empty)" >> "$GITHUB_OUTPUT"
+      - name: Check Setup Outputs
+        env:
+          STEPS_CHANGED_PACKAGES_EMPTY: ${{ steps.changed-packages.outputs.CHANGED_PACKAGES != '' }}
+          STEPS_NON_PKG_NON_WORKFLOW_CHANGED_FILES_EMPTY: ${{ steps.changed-files.outputs.non-package-non-workflow_all_changed_files != '' }}
+          NON_PKG_NON_WORKFLOW_CHANGED_FILES: ${{ steps.changed-files.outputs.non-package-non-workflow_all_changed_files }}
+        run: |
+          echo "steps.changed-packages.outputs.CHANGED_PACKAGES != '' : ${STEPS_CHANGED_PACKAGES_EMPTY}"
+          echo "steps.changed-files.outputs.non-package-non-workflow_all_changed_files != '' : ${STEPS_NON_PKG_NON_WORKFLOW_CHANGED_FILES_EMPTY}"
+          [[ -n ${NON_PKG_NON_WORKFLOW_CHANGED_FILES} ]] && echo "NON_PKG_NON_WORKFLOW_CHANGED_FILES: ${NON_PKG_NON_WORKFLOW_CHANGED_FILES}"
   get-compatibility:
     needs: setup
+    if: ${{ ( needs.setup.outputs.changed_packages != '' ) || ( needs.setup.outputs.non_package_non_workflow_files != '' ) }}
     uses: ./.github/workflows/Determine-Compatibility.yml
     with:
       changed_packages: ${{ needs.setup.outputs.changed_packages }}
@@ -233,7 +247,7 @@ jobs:
       - name: Run unit tests
         env:
           GITHUB_EVENT: ${{ github.event_name }}
-          NON_PKG_CHANGED_FILES: ${{ needs.setup.outputs.non_changed_packages }}
+          NON_PKG_NON_WORKFLOW_CHANGED_FILES: ${{ needs.setup.outputs.non_package_non_workflow_files }}
         run: |
             case $GITHUB_EVENT in
               check_run | merge_group | push | workflow_run | workflow_dispatch)
@@ -249,15 +263,15 @@ jobs:
                 export CREW_BRANCH
                 ;;
             esac
-            if [ -z "${NON_PKG_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/arm/v7'  ] && [ -z "${{ needs.get-compatibility.outputs.armv7l_packages }}" ]; }; then
+            if [ -z "${NON_PKG_NON_WORKFLOW_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/arm/v7'  ] && [ -z "${{ needs.get-compatibility.outputs.armv7l_packages }}" ]; }; then
               # Exit the arm container if there are neither non-package changed files nor armv7l compatible packages.
               echo "Skipping armv7l container unit tests."
               exit 0
-            elif [ -z "${NON_PKG_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/amd64' ] && [ -z "${{ needs.get-compatibility.outputs.x86_64_packages }}" ]; }; then
+            elif [ -z "${NON_PKG_NON_WORKFLOW_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/amd64' ] && [ -z "${{ needs.get-compatibility.outputs.x86_64_packages }}" ]; }; then
               # Exit the x86_64 container if there are neither non-package changed files nor x86_64 compatible packages.
               echo "Skipping x86_64 container unit tests."
               exit 0
-            elif [ -z "${NON_PKG_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/386' ] && [ -z "${{ needs.get-compatibility.outputs.i686_packages }}" ]; }; then
+            elif [ -z "${NON_PKG_NON_WORKFLOW_CHANGED_FILES}" ] && { [ "$PLATFORM" == 'linux/386' ] && [ -z "${{ needs.get-compatibility.outputs.i686_packages }}" ]; }; then
               # Exit the i686 container if there are neither non-package changed files nor i686 compatible packages.
               echo "Skipping i686 container unit tests."
               exit 0
@@ -268,7 +282,7 @@ jobs:
                 --rm \
                 --platform "${PLATFORM}" \
                 -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
-                -e NON_PKG_CHANGED_FILES="${NON_PKG_CHANGED_FILES}" \
+                -e NON_PKG_NON_WORKFLOW_CHANGED_FILES="${NON_PKG_NON_WORKFLOW_CHANGED_FILES}" \
                 -e GCONV_PATH="/usr/local/lib${LIB_SUFFIX}/gconv" \
                 -e CREW_REPO="${CREW_REPO}" \
                 -e CREW_BRANCH="${CREW_BRANCH}" \

--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -38,7 +38,7 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.1'
+          ruby-version: '4.0.4'
       - name: Install bin/crew gem dependencies
         run: |
           # Install required gems.

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # This is for use as a Github CI Unit Test.
-# Version 1.8
+# Version 1.9
 set -e
 cd /usr/local/lib/crew/packages/
 
 # We have some tests for specific files that aren't run as part of our general testsuite, but we should run those tests if those files are changed.
-for file in ${NON_PKG_CHANGED_FILES}; do
+for file in ${NON_PKG_NON_WORKFLOW_CHANGED_FILES}; do
   # The only files with direct corresponding tests are located in the root of the commands, lib, and tools directories.
   echo "commands lib tools" | grep -q "$(dirname "${file}")" || continue
   # If we have modified a file that has a direct corresponding test, run that test.
@@ -47,7 +47,7 @@ yes | crew remove vim
 # This fails due to glibc changes since the older git tag we are testing
 # against.
 ## Only test the core functionality of crew if non-package files were modified.
-#if [[ -n ${NON_PKG_CHANGED_FILES-} ]]; then
+#if [[ -n ${NON_PKG_NON_WORKFLOW_CHANGED_FILES-} ]]; then
   ## Check if rake is installed and working, and if not install it.
   #rake --help &>/dev/null || gem install rake
   ## This runs the default rake action, which in our case runs the tests for commands and libraries.

--- a/tests/unit_test_stub.sh
+++ b/tests/unit_test_stub.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # This is for use in Chromebrew Github CI Unit Tests.
-# Version 1.4
+# Version 1.5
 set -e
 echo "Chromebrew GitHub Action Unit Test Stub"
 last_update=$(stat -c %y /usr/local/lib/crew/tests/unit_test_stub.sh)
 echo "Last Updated: ${last_update}"
 stub_mtime=$(stat -c %Y /usr/local/lib/crew/tests/unit_test_stub.sh)
 echo "CHANGED_PACKAGES: ${CHANGED_PACKAGES}"
-echo "NON_PKG_CHANGED_FILES: ${NON_PKG_CHANGED_FILES}"
+echo "NON_PKG_NON_WORKFLOW_CHANGED_FILES: ${NON_PKG_NON_WORKFLOW_CHANGED_FILES}"
 cd /usr/local/lib/crew/packages/
 yes | crew update
 yes | crew upgrade


### PR DESCRIPTION
## Description
#### Commits:
-  870572c48 Do not run Unit Test container checks if only workflows have changed. (Workflows are still linted.)
-  f72b2e8b1 Use concurrency in Unit Test invocation.
-  b4107c82a Add more debug output for Set Reviewers workflow.
-  def9ad9f6 Update ruby version for workflows to 4.0.4. (4.0.5 is not available yet.)
-  f612133e7 Add GitHub Actions Updater workflow.
### Updated GitHub configuration files:
- .github/workflows/Actions-Updater.yml
- .github/workflows/Build.yml
- .github/workflows/Generate-PR.yml
- .github/workflows/Package-Dependencies-Updater.yml
- .github/workflows/Repology.yml
- .github/workflows/Rubocop.yml
- .github/workflows/Set-Reviewers.yml
- .github/workflows/Unit-Test.yml
- .github/workflows/Updater-on-Demand.yml
### Other changed files:
- tests/unit_test.sh
- tests/unit_test_stub.sh
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=actions_updater crew update \
&& yes | crew upgrade
```
