### PR TITLE
mesa -> 26.1.1-llvm21 in updater-mesa-26.1.1-llvm21 — gstreamer: 1.28.3 → 1.28.3,mesa: 26.0.5-llvm21 → 26.1.1-llvm21,qt5_base: kde-5.15.16-2529f7f-icu78.3 → kde-5.15.16-2529f7f-icu78.3,weston: 15.0.1 → 15.0.1,wlroots: 0.20.1 → 0.20.1,xorg...

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1004,18 +1004,12 @@ def prepare_package(destdir)
     conflicts = ConvenienceFunctions.determine_conflicts(@pkg.name, File.join(Dir.pwd, 'filelist'), '_build', verbose: CREW_VERBOSE)
 
     if conflicts.any?
-      if CREW_CONFLICTS_ONLY_ADVISORY || @pkg.conflicts_ok?
-        puts "Warning: There is a conflict with the same file in another package:\n".orange
-      else
-        puts "Error: There is a conflict with the same file in another package:\n".lightred
-        errors = true
-      end
-
       conflicts.each_pair do |pkg_name, conflict_files|
-        if errors
-          conflict_files.each { |file| puts "#{pkg_name}: #{file}".lightred }
+        if pkg_name == @pkg.conflicts_with || CREW_CONFLICTS_ONLY_ADVISORY || @pkg.conflicts_ok?
+          conflict_files.each { |file| puts "Warning: There is a conflict with the same file in another package:\n#{pkg_name}: #{file}".orange }
         else
-          conflict_files.each { |file| puts "#{pkg_name}: #{file}".orange }
+          conflict_files.each { |file| puts "Error: There is a conflict with the same file in another package:\n#{pkg_name}: #{file}".lightred }
+          errors = true
         end
         puts
       end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.74.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.74.1' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/manifest/armv7l/m/mesa.filelist
+++ b/manifest/armv7l/m/mesa.filelist
@@ -1,4 +1,4 @@
-# Total size: 98582333
+# Total size: 99803933
 /usr/local/include/EGL/eglext_angle.h
 /usr/local/include/EGL/eglmesaext.h
 /usr/local/include/GL/internal/dri_interface.h
@@ -124,7 +124,7 @@
 /usr/local/lib/libGLX_mesa.so
 /usr/local/lib/libGLX_mesa.so.0
 /usr/local/lib/libGLX_mesa.so.0.0.0
-/usr/local/lib/libgallium-26.0.5.so
+/usr/local/lib/libgallium-26.1.1.so
 /usr/local/lib/libgbm.so
 /usr/local/lib/libgbm.so.1
 /usr/local/lib/libgbm.so.1.0.0

--- a/manifest/x86_64/m/mesa.filelist
+++ b/manifest/x86_64/m/mesa.filelist
@@ -1,4 +1,4 @@
-# Total size: 133552202
+# Total size: 137383701
 /usr/local/include/EGL/eglext_angle.h
 /usr/local/include/EGL/eglmesaext.h
 /usr/local/include/GL/internal/dri_interface.h
@@ -123,7 +123,7 @@
 /usr/local/lib64/libGLX_mesa.so
 /usr/local/lib64/libGLX_mesa.so.0
 /usr/local/lib64/libGLX_mesa.so.0.0.0
-/usr/local/lib64/libgallium-26.0.5.so
+/usr/local/lib64/libgallium-26.1.1.so
 /usr/local/lib64/libgbm.so
 /usr/local/lib64/libgbm.so.1
 /usr/local/lib64/libgbm.so.1.0.0

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -31,6 +31,7 @@ class Gstreamer < Meson
   depends_on 'gdk_pixbuf' => :library
   depends_on 'glib' => :library
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'gnutls' => :library
   depends_on 'graphene' => :library
   depends_on 'gtk3' => :library

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -50,7 +50,6 @@ class Gstreamer < Meson
   depends_on 'libgudev' => :library
   depends_on 'libiec61883' => :library
   depends_on 'libjpeg_turbo' => :library
-  depends_on 'libminigbm' => :library
   depends_on 'libmodplug' => :library
   depends_on 'libmp3lame' => :library
   depends_on 'libogg' => :library

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -11,9 +11,9 @@ class Mesa < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '670f02ee5a14601099deb2f0e5f577651ab7102f0f0bebda1b90ba098ed0dab3',
-     armv7l: '670f02ee5a14601099deb2f0e5f577651ab7102f0f0bebda1b90ba098ed0dab3',
-     x86_64: '6362ab7d19c7653d9fc074f2e14f6e7ec25df16586ab823a9d6c57f973ab3f9b'
+    aarch64: '16327e1161cc0a14883905be60788b3550497423c8786bbe316d0aa574e7dd9a',
+     armv7l: '16327e1161cc0a14883905be60788b3550497423c8786bbe316d0aa574e7dd9a',
+     x86_64: '5e049f471424d254da3720c59a1e9eb39d4c2b80b5ee50a85f81599986bb8c45'
   })
 
   depends_on 'elfutils' => :library
@@ -22,6 +22,7 @@ class Mesa < Meson
   depends_on 'gcc_dev' => :build
   depends_on 'gcc_lib' => :library
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'glslang' => :build
   depends_on 'libclc' => :build
   depends_on 'libdrm' => :library

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -25,7 +25,6 @@ class Mesa < Meson
   depends_on 'glslang' => :build
   depends_on 'libclc' => :build
   depends_on 'libdrm' => :library
-  depends_on 'libminigbm' => :library
   depends_on 'libomxil_bellagio' => :build
   depends_on 'libunwind' => :library
   depends_on 'libva' => :build

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -55,6 +55,7 @@ class Mesa < Meson
   depends_on 'zlib' => :library
   depends_on 'zstd' => :library
 
+  conflicts_with 'libminigbm'
   no_lto # As per https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/39671
 
   meson_options "-Db_asneeded=false \

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -57,8 +57,7 @@ class Mesa < Meson
 
   no_lto # As per https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/39671
 
-  meson_options "#{CREW_MESON_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} \
-    -Db_asneeded=false \
+  meson_options "-Db_asneeded=false \
     -Degl=enabled \
     -Dgbm=enabled \
     -Dgles1=disabled \

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Mesa < Meson
   description 'Open-source implementation of the OpenGL specification'
   homepage 'https://www.mesa3d.org'
-  version "26.0.5-#{CREW_LLVM_VER}"
+  version "26.1.1-#{CREW_LLVM_VER}"
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.freedesktop.org/mesa/mesa.git'

--- a/packages/qt5_base.rb
+++ b/packages/qt5_base.rb
@@ -17,6 +17,7 @@ class Qt5_base < Package
      x86_64: '4d3f4459f9ca3f5c76932da91a2992037e03c138185fc91f0cef7cb96529ceb3'
   })
 
+  depends_on 'mysql' => :library
   depends_on 'alsa_plugins' => :build
   depends_on 'at_spi2_core' => :library
   depends_on 'cairo' => :library
@@ -31,6 +32,7 @@ class Qt5_base < Package
   depends_on 'gdk_pixbuf' => :library
   depends_on 'glib' => :library
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'gstreamer' => :build
   depends_on 'gtk3' => :library
   depends_on 'harfbuzz' => :library
@@ -70,7 +72,6 @@ class Qt5_base < Package
   if ARCH.eql?('x86_64')
     # Note that mysql can't be built for 32-bit arm, so we do
     # not want that dependency from preventing arm builds here.
-    depends_on 'mysql' => :library
   end
 
   def self.build

--- a/packages/qt5_base.rb
+++ b/packages/qt5_base.rb
@@ -44,7 +44,6 @@ class Qt5_base < Package
   depends_on 'libice' => :library
   depends_on 'libinput' => :library
   depends_on 'libjpeg_turbo' => :library
-  depends_on 'libminigbm' => :library
   depends_on 'libpng' => :library
   depends_on 'libsm' => :library
   depends_on 'libvpx' => :build

--- a/packages/qt5_base.rb
+++ b/packages/qt5_base.rb
@@ -54,7 +54,6 @@ class Qt5_base < Package
   depends_on 'libxkbcommon' => :library
   depends_on 'mesa' => :library
   depends_on 'mtdev' => :library
-  depends_on 'mysql' => :library
   depends_on 'pango' => :library
   depends_on 'pcre2' => :library
   depends_on 'protobuf' => :build
@@ -72,6 +71,7 @@ class Qt5_base < Package
   if ARCH.eql?('x86_64')
     # Note that mysql can't be built for 32-bit arm, so we do
     # not want that dependency from preventing arm builds here.
+    depends_on 'mysql' => :library
   end
 
   def self.build

--- a/packages/qt5_base.rb
+++ b/packages/qt5_base.rb
@@ -17,7 +17,6 @@ class Qt5_base < Package
      x86_64: '4d3f4459f9ca3f5c76932da91a2992037e03c138185fc91f0cef7cb96529ceb3'
   })
 
-  depends_on 'mysql' => :library
   depends_on 'alsa_plugins' => :build
   depends_on 'at_spi2_core' => :library
   depends_on 'cairo' => :library
@@ -55,6 +54,7 @@ class Qt5_base < Package
   depends_on 'libxkbcommon' => :library
   depends_on 'mesa' => :library
   depends_on 'mtdev' => :library
+  depends_on 'mysql' => :library
   depends_on 'pango' => :library
   depends_on 'pcre2' => :library
   depends_on 'protobuf' => :build

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -35,7 +35,6 @@ class Weston < Meson
   depends_on 'libglvnd' => :library
   depends_on 'libinput' => :library
   depends_on 'libjpeg_turbo' => :library
-  depends_on 'libminigbm' => :library
   depends_on 'libpng' => :library
   depends_on 'libunwind'
   depends_on 'libva' # R

--- a/packages/wlroots.rb
+++ b/packages/wlroots.rb
@@ -27,7 +27,6 @@ class Wlroots < Meson
   depends_on 'libglvnd' => :library
   depends_on 'libinput' => :library
   depends_on 'libliftoff' => :library
-  depends_on 'libminigbm' => :library
   depends_on 'libxcb' => :library
   depends_on 'libxkbcommon' => :library
   depends_on 'mesa' => :library

--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -21,6 +21,7 @@ class Xorg_server < Meson
   depends_on 'font_util' => :build
   depends_on 'gcc_lib' => :build
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'graphite' => :build
   depends_on 'libbsd' => :library
   depends_on 'libdrm' => :library

--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -29,7 +29,6 @@ class Xorg_server < Meson
   depends_on 'libglvnd' => :library
   depends_on 'libinput' => :build
   depends_on 'libmd' => :executable
-  depends_on 'libminigbm' => :library
   depends_on 'libpciaccess' => :executable
   depends_on 'libtirpc' => :executable
   depends_on 'libunwind' => :build

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -24,6 +24,7 @@ class Xwayland < Meson
   depends_on 'font_util' => :build
   depends_on 'gcc_lib' => :build
   depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'graphite' => :build
   depends_on 'libbsd' => :executable
   depends_on 'libdecor' => :executable

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -32,7 +32,6 @@ class Xwayland < Meson
   depends_on 'libfontenc' => :build
   depends_on 'libglvnd' => :executable
   depends_on 'libmd' => :executable
-  depends_on 'libminigbm' => :executable
   depends_on 'libtirpc' => :executable
   depends_on 'libunwind' => :logical # Runtime dependency for sommelier
   depends_on 'libxau' => :executable

--- a/tools/getrealdeps.rb
+++ b/tools/getrealdeps.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby
-# getrealdeps version 2.14 (for Chromebrew)
+# getrealdeps version 2.15 (for Chromebrew)
 # Author: Satadru Pramanik (satmandu) satadru at gmail dot com
 #
 # Dependencies in Chromebrew can be:
@@ -67,6 +67,7 @@ def write_deps(pkg_file, pkgdeps, pkg, label)
     { name_regex: 'gcc_build', exclusion_regex: 'gcc.*_*', comments: 'created from the gcc_build package.' },
     { name_regex: '(gcc_dev|gcc_lib|libssp)', exclusion_regex: 'gcc_build', comments: 'should only be a build dep.' },
     { name_regex: 'gcc_lib', exclusion_regex: 'gcc_lib', comments: 'should only be a build dep.' },
+    { name_regex: 'mesa', exclusion_regex: 'libminigbm', comments: 'Conflicts with mesa' },
     { name_regex: 'python3', exclusion_regex: '(tcl|tk)', comments: 'optional for i686, which does not have gui libraries.' },
     { name_regex: 'qt5_base', exclusion_regex: 'mysql', comments: 'Do not want dep for armv7l, since mysql us 64 bit only.' },
     { name_regex: 'smbclient', exclusion_regex: 'nethack4', comments: 'We want libjansson.so.4 to be pulled from the jansson package.' },
@@ -213,6 +214,8 @@ def determine_dependencies(pkg_name, pkgfiles_to_check)
   pkgdeps = pkgdeps.map { |i| i.gsub('glibc_fallthrough', 'glibc') }.uniq
   pkgdeps = pkgdeps.map { |i| i.gsub(/glibc_lib.*/, 'glibc_lib') }.uniq.map(&:strip).reject(&:empty?)
 
+  # Prefer mesa to libminigbm
+  pkgdeps = pkgdeps.map { it.gsub('libminigbm', 'mesa') }.uniq
   # Massage the gcc entries in the dependency list.
   pkgdeps = pkgdeps.map { |i| i.gsub('gcc_build', 'gcc_lib') }.uniq
 


### PR DESCRIPTION
## Description
#### Commits:
-  8c2adbf84 Fix mysql dep in qt5_base.
-  1c683abff Handle libminigbm conflict.
-  2d140163c Let conflicts_with act like conflicts_ok.
-  8489089fb Add libminigbm conflict.
-  63f4c09e1 Fix mesa package.
-  bed89c554 mesa -> 26.1.1-llvm21 in updater-mesa-26.1.1-llvm21
### Packages with Updated versions or Changed package files:
- `gstreamer`: 1.28.3 &rarr; 1.28.3
- `mesa`: 26.0.5-llvm21 &rarr; 26.1.1-llvm21 (current version is 26.1.1)
- `qt5_base`: kde-5.15.16-2529f7f-icu78.3 &rarr; kde-5.15.16-2529f7f-icu78.3
- `weston`: 15.0.1 &rarr; 15.0.1
- `wlroots`: 0.20.1 &rarr; 0.20.1
- `xorg_server`: 21.1.22 &rarr; 21.1.22
- `xwayland`: 24.1.11 &rarr; 24.1.11
##
Builds attempted for:
### Other changed files:
- bin/crew
- lib/const.rb
- tools/getrealdeps.rb
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=updater-mesa-26.1.1-llvm21 crew update \
&& yes | crew upgrade
```
