### PR TITLE
Forkstat 0.03.02 => 0.04.00

### DIFF
--- a/manifest/armv7l/f/forkstat.filelist
+++ b/manifest/armv7l/f/forkstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 27982
+# Total size: 27072
 /usr/local/bin/forkstat
 /usr/local/share/bash-completion/completions/forkstat
 /usr/local/share/man/man8/forkstat.8.zst

--- a/manifest/i686/f/forkstat.filelist
+++ b/manifest/i686/f/forkstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 20190
+# Total size: 31812
 /usr/local/bin/forkstat
 /usr/local/share/bash-completion/completions/forkstat
 /usr/local/share/man/man8/forkstat.8.zst

--- a/manifest/x86_64/f/forkstat.filelist
+++ b/manifest/x86_64/f/forkstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 33174
+# Total size: 33448
 /usr/local/bin/forkstat
 /usr/local/share/bash-completion/completions/forkstat
 /usr/local/share/man/man8/forkstat.8.zst

--- a/packages/forkstat.rb
+++ b/packages/forkstat.rb
@@ -3,7 +3,7 @@ require 'package'
 class Forkstat < Package
   description 'Forkstat is a program that logs process fork(), exec() and exit() activity.'
   homepage 'https://github.com/ColinIanKing/forkstat'
-  version '0.03.02'
+  version '0.04.00'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/ColinIanKing/forkstat.git'
@@ -11,16 +11,14 @@ class Forkstat < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '89644ea699962fb37b8cc6d03a7b91edb9bce2f1bd3db7e88c721d47753b315e',
-     armv7l: '89644ea699962fb37b8cc6d03a7b91edb9bce2f1bd3db7e88c721d47753b315e',
-       i686: 'b5c0cb350fd1e77dc8eda6333fc9be26f713bfe2048410901c1c22a7a5ea2353',
-     x86_64: '35fe2345bd935fa003b2eef9689726d2b26d3884322702c1713f5988135ad183'
+    aarch64: 'cdf4cbe56b0fa65d2cf1c92dc522b61b0058e4f49d02135925629d4dd7611b6f',
+     armv7l: 'cdf4cbe56b0fa65d2cf1c92dc522b61b0058e4f49d02135925629d4dd7611b6f',
+       i686: '52df63b015a31abfa53c2d469405ce39c10c52aad3baca72e8613d70f0b71ed1',
+     x86_64: '9523f75c4619c290056ada9fc6c354fbd78c4bcb22c9d4cc1d06ca4265b25e54'
   })
 
-  def self.patch
-    downloader 'https://patch-diff.githubusercontent.com/raw/ColinIanKing/forkstat/pull/10.patch', '22d70a02a3529011c4e9fa2d11cef0037c4729ca661229254287a51c0e6ac0b6'
-    system 'git apply 10.patch'
-  end
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 
   def self.build
     system 'make'

--- a/tests/package/f/forkstat
+++ b/tests/package/f/forkstat
@@ -1,0 +1,2 @@
+#!/bin/bash
+forkstat -h


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-forkstat crew update \
&& yes | crew upgrade

$ crew check forkstat
Checking forkstat package ...
Library test for forkstat passed.
Checking forkstat package ...
forkstat, version 0.04.00

usage: forkstat [-c|-d|-D|-e|-E|-g|-h|-l|-s|-S|-q|-x|-X]
-c	use task comm field for process name.
-d	strip off directory path from process name.
-D	specify run duration in seconds.
-e	select which events to monitor.
-E	equivalent to -e all.
-g	show glyphs for event types.
-h	show this help.
-l	force stdout line buffering.
-r	run with real time FIFO scheduler.
-s	show short process name.
-S	show event statistics at end of the run.
-q	run quietly and enable -S option.
-x	show extra process information.
-X	equivalent to -EgrSx.
Package tests for forkstat passed.
```