### PR TITLE
libnfs: 4.0.0-1 → 6.0.2

### DIFF
--- a/manifest/armv7l/l/libnfs.filelist
+++ b/manifest/armv7l/l/libnfs.filelist
@@ -1,7 +1,8 @@
-# Total size: 2910636
+# Total size: 3424500
 /usr/local/bin/nfs-cat
 /usr/local/bin/nfs-cp
 /usr/local/bin/nfs-ls
+/usr/local/bin/nfs-stat
 /usr/local/include/nfsc/libnfs-raw-mount.h
 /usr/local/include/nfsc/libnfs-raw-nfs.h
 /usr/local/include/nfsc/libnfs-raw-nfs4.h
@@ -15,9 +16,9 @@
 /usr/local/lib/libnfs.a
 /usr/local/lib/libnfs.la
 /usr/local/lib/libnfs.so
-/usr/local/lib/libnfs.so.13
-/usr/local/lib/libnfs.so.13.0.0
+/usr/local/lib/libnfs.so.16
+/usr/local/lib/libnfs.so.16.0.2
 /usr/local/lib/pkgconfig/libnfs.pc
-/usr/local/share/man/man1/nfs-cat.1.gz
-/usr/local/share/man/man1/nfs-cp.1.gz
-/usr/local/share/man/man1/nfs-ls.1.gz
+/usr/local/share/man/man1/nfs-cat.1.zst
+/usr/local/share/man/man1/nfs-cp.1.zst
+/usr/local/share/man/man1/nfs-ls.1.zst

--- a/manifest/i686/l/libnfs.filelist
+++ b/manifest/i686/l/libnfs.filelist
@@ -1,7 +1,8 @@
-# Total size: 3093114
+# Total size: 3701010
 /usr/local/bin/nfs-cat
 /usr/local/bin/nfs-cp
 /usr/local/bin/nfs-ls
+/usr/local/bin/nfs-stat
 /usr/local/include/nfsc/libnfs-raw-mount.h
 /usr/local/include/nfsc/libnfs-raw-nfs.h
 /usr/local/include/nfsc/libnfs-raw-nfs4.h
@@ -15,9 +16,9 @@
 /usr/local/lib/libnfs.a
 /usr/local/lib/libnfs.la
 /usr/local/lib/libnfs.so
-/usr/local/lib/libnfs.so.13
-/usr/local/lib/libnfs.so.13.0.0
+/usr/local/lib/libnfs.so.16
+/usr/local/lib/libnfs.so.16.0.2
 /usr/local/lib/pkgconfig/libnfs.pc
-/usr/local/share/man/man1/nfs-cat.1.gz
-/usr/local/share/man/man1/nfs-cp.1.gz
-/usr/local/share/man/man1/nfs-ls.1.gz
+/usr/local/share/man/man1/nfs-cat.1.zst
+/usr/local/share/man/man1/nfs-cp.1.zst
+/usr/local/share/man/man1/nfs-ls.1.zst

--- a/manifest/x86_64/l/libnfs.filelist
+++ b/manifest/x86_64/l/libnfs.filelist
@@ -1,7 +1,8 @@
-# Total size: 3144508
+# Total size: 3913828
 /usr/local/bin/nfs-cat
 /usr/local/bin/nfs-cp
 /usr/local/bin/nfs-ls
+/usr/local/bin/nfs-stat
 /usr/local/include/nfsc/libnfs-raw-mount.h
 /usr/local/include/nfsc/libnfs-raw-nfs.h
 /usr/local/include/nfsc/libnfs-raw-nfs4.h
@@ -15,9 +16,9 @@
 /usr/local/lib64/libnfs.a
 /usr/local/lib64/libnfs.la
 /usr/local/lib64/libnfs.so
-/usr/local/lib64/libnfs.so.13
-/usr/local/lib64/libnfs.so.13.0.0
+/usr/local/lib64/libnfs.so.16
+/usr/local/lib64/libnfs.so.16.0.2
 /usr/local/lib64/pkgconfig/libnfs.pc
-/usr/local/share/man/man1/nfs-cat.1.gz
-/usr/local/share/man/man1/nfs-cp.1.gz
-/usr/local/share/man/man1/nfs-ls.1.gz
+/usr/local/share/man/man1/nfs-cat.1.zst
+/usr/local/share/man/man1/nfs-cp.1.zst
+/usr/local/share/man/man1/nfs-ls.1.zst

--- a/packages/libnfs.rb
+++ b/packages/libnfs.rb
@@ -17,8 +17,19 @@ class Libnfs < Autotools
      x86_64: '28e4008977ca30b2bc74c8cdec9ca5cdc9933aa998da8f62a2b343ab9a0517a3'
   })
 
+  depends_on 'brotli' => :executable
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'gmp' => :executable
+  depends_on 'gnutls' => :executable
   depends_on 'krb5' => :library
+  depends_on 'libidn2' => :executable
+  depends_on 'libtasn1' => :executable
+  depends_on 'libunistring' => :executable
+  depends_on 'nettle' => :executable
+  depends_on 'p11kit' => :executable
+  depends_on 'zlib' => :executable
+  depends_on 'zstd' => :executable
 
   autotools_configure_options '--enable-utils'
   autotools_pre_configure_options ('CFLAGS="$CFLAGS -Wno-cast-align"' if ARCH.include?('armv7l')).to_s

--- a/packages/libnfs.rb
+++ b/packages/libnfs.rb
@@ -11,15 +11,15 @@ class Libnfs < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '93c8332ed7a11e62196a451206a1bb01f5c8d1bba0c860fdf08a6ee52638748f',
-     armv7l: '93c8332ed7a11e62196a451206a1bb01f5c8d1bba0c860fdf08a6ee52638748f',
-       i686: 'd838e8f83938d1621884496bcc226b33c61b5d20a1c45496d98733cde4c2505c',
-     x86_64: '8ff8bdbe19ee2c2bafe7ca410729eb30fc1195de1c3cab48867375752ad59299'
+    aarch64: '6767c33c704f4240a9ad5a72c656f491696f7ff54a40ffc22adef5302ef1ddde',
+     armv7l: '6767c33c704f4240a9ad5a72c656f491696f7ff54a40ffc22adef5302ef1ddde',
+       i686: '6883e2ab1e6b20dc688eb5b4e000407d19e7f9738c9aba8d344d9af48a41a620',
+     x86_64: '28e4008977ca30b2bc74c8cdec9ca5cdc9933aa998da8f62a2b343ab9a0517a3'
   })
 
-  depends_on 'krb5' => :library
   depends_on 'glibc' => :library
+  depends_on 'krb5' => :library
 
   autotools_configure_options '--enable-utils'
-  autotools_pre_configure_options "#{'CFLAGS="$CFLAGS -Wno-cast-align"' if ARCH.include?('armv7l')}"
+  autotools_pre_configure_options ('CFLAGS="$CFLAGS -Wno-cast-align"' if ARCH.include?('armv7l')).to_s
 end

--- a/packages/libnfs.rb
+++ b/packages/libnfs.rb
@@ -1,15 +1,14 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Libnfs < Package
+class Libnfs < Autotools
   description 'client library for accessing NFS shares'
   homepage 'https://github.com/sahlberg/libnfs'
-  @_ver = '4.0.0'
-  version "#{@_ver}-1"
+  version '6.0.2'
   compatibility 'all'
   license 'GPL-3, LGPL-2.1 and BSD'
   source_url 'https://github.com/sahlberg/libnfs.git'
-  git_hashtag "libnfs-#{@_ver}"
-  binary_compression 'tpxz'
+  git_hashtag "libnfs-#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
     aarch64: '93c8332ed7a11e62196a451206a1bb01f5c8d1bba0c860fdf08a6ee52638748f',
@@ -18,18 +17,9 @@ class Libnfs < Package
      x86_64: '8ff8bdbe19ee2c2bafe7ca410729eb30fc1195de1c3cab48867375752ad59299'
   })
 
-  def self.build
-    system 'autoreconf -fiv'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
-            --enable-utils"
-    system 'make'
-  end
+  depends_on 'krb5' => :library
+  depends_on 'glibc' => :library
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.check
-    system 'make', 'check'
-  end
+  autotools_configure_options '--enable-utils'
+  autotools_pre_configure_options "#{'CFLAGS="$CFLAGS -Wno-cast-align"' if ARCH.include?('armv7l')}"
 end


### PR DESCRIPTION
## Description
#### Commits:
-  0c51cbfdc Mark packages from successful builds as automatically buildable.
-  fa889dc01 libnfs => 6.0.2
### Packages with Updated versions or Changed package files:
- `libnfs`: 4.0.0-1 &rarr; 6.0.2
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Other changed files:
- tools/automatically_updatable_packages/libnfs
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-libnfs-6.0.2 crew update \
&& yes | crew upgrade
```
