### PR TITLE
Fswatch 1.17.1 => 1.21.0

### DIFF
--- a/manifest/armv7l/f/fswatch.filelist
+++ b/manifest/armv7l/f/fswatch.filelist
@@ -1,11 +1,10 @@
-# Total size: 4993996
+# Total size: 531880
 /usr/local/bin/fswatch
 /usr/local/include/libfswatch/c++/event.hpp
+/usr/local/include/libfswatch/c++/fanotify_monitor.hpp
 /usr/local/include/libfswatch/c++/filter.hpp
 /usr/local/include/libfswatch/c++/inotify_monitor.hpp
 /usr/local/include/libfswatch/c++/libfswatch_exception.hpp
-/usr/local/include/libfswatch/c++/libfswatch_map.hpp
-/usr/local/include/libfswatch/c++/libfswatch_set.hpp
 /usr/local/include/libfswatch/c++/monitor.hpp
 /usr/local/include/libfswatch/c++/monitor_factory.hpp
 /usr/local/include/libfswatch/c++/path_utils.hpp
@@ -18,11 +17,10 @@
 /usr/local/include/libfswatch/c/libfswatch.h
 /usr/local/include/libfswatch/c/libfswatch_log.h
 /usr/local/include/libfswatch/c/libfswatch_types.h
-/usr/local/lib/libfswatch.a
 /usr/local/lib/libfswatch.la
 /usr/local/lib/libfswatch.so
-/usr/local/lib/libfswatch.so.13
-/usr/local/lib/libfswatch.so.13.0.0
+/usr/local/lib/libfswatch.so.15
+/usr/local/lib/libfswatch.so.15.0.0
 /usr/local/lib/pkgconfig/libfswatch.pc
 /usr/local/share/doc/fswatch/ABOUT-NLS
 /usr/local/share/doc/fswatch/AUTHORS

--- a/manifest/x86_64/f/fswatch.filelist
+++ b/manifest/x86_64/f/fswatch.filelist
@@ -1,11 +1,10 @@
-# Total size: 5214424
+# Total size: 675043
 /usr/local/bin/fswatch
 /usr/local/include/libfswatch/c++/event.hpp
+/usr/local/include/libfswatch/c++/fanotify_monitor.hpp
 /usr/local/include/libfswatch/c++/filter.hpp
 /usr/local/include/libfswatch/c++/inotify_monitor.hpp
 /usr/local/include/libfswatch/c++/libfswatch_exception.hpp
-/usr/local/include/libfswatch/c++/libfswatch_map.hpp
-/usr/local/include/libfswatch/c++/libfswatch_set.hpp
 /usr/local/include/libfswatch/c++/monitor.hpp
 /usr/local/include/libfswatch/c++/monitor_factory.hpp
 /usr/local/include/libfswatch/c++/path_utils.hpp
@@ -18,11 +17,10 @@
 /usr/local/include/libfswatch/c/libfswatch.h
 /usr/local/include/libfswatch/c/libfswatch_log.h
 /usr/local/include/libfswatch/c/libfswatch_types.h
-/usr/local/lib64/libfswatch.a
 /usr/local/lib64/libfswatch.la
 /usr/local/lib64/libfswatch.so
-/usr/local/lib64/libfswatch.so.13
-/usr/local/lib64/libfswatch.so.13.0.0
+/usr/local/lib64/libfswatch.so.15
+/usr/local/lib64/libfswatch.so.15.0.0
 /usr/local/lib64/pkgconfig/libfswatch.pc
 /usr/local/share/doc/fswatch/ABOUT-NLS
 /usr/local/share/doc/fswatch/AUTHORS

--- a/packages/fswatch.rb
+++ b/packages/fswatch.rb
@@ -1,27 +1,27 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Fswatch < Package
+class Fswatch < Autotools
   description 'fswatch is a file change monitor that receives notifications when the contents of the specified files or directories are modified.'
   homepage 'https://github.com/emcrisostomo/fswatch'
-  version '1.17.1'
+  version '1.21.0'
   license 'GPL-3+'
-  compatibility 'all'
-  source_url 'https://github.com/emcrisostomo/fswatch/releases/download/1.17.1/fswatch-1.17.1.tar.gz'
-  source_sha256 'c38e341c567f5f16bfa64b72fc48bba5e93873d8572522e670e6f320bbc2122f'
+  compatibility 'aarch64 armv7l x86_64'
+  min_glibc '2.41'
+  source_url 'https://github.com/emcrisostomo/fswatch.git'
+  git_hashtag version
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'c7aa03d97680a5eb2b74a62a6f4de45ee1f901625ce133f4226e89e3ca3875f8',
-     armv7l: 'c7aa03d97680a5eb2b74a62a6f4de45ee1f901625ce133f4226e89e3ca3875f8',
-     x86_64: '3067616e2a4e9d0e6286398392e6f6d97b1b30b355a9f9279bdb96b08a227da9'
+    aarch64: 'f389a976f06ca857551fc2cd587f1cbec578a8f63d82f0231e3c576283c6ef5c',
+     armv7l: 'f389a976f06ca857551fc2cd587f1cbec578a8f63d82f0231e3c576283c6ef5c',
+     x86_64: '9446f340de6c2319824b27357c3b2216b88af76662a182bdd512eaf3d742c7be'
   })
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_configure_options '--disable-static'
+
+  run_tests
 end

--- a/tests/package/f/fswatch
+++ b/tests/package/f/fswatch
@@ -1,0 +1,3 @@
+#!/bin/bash
+fswatch -h | head
+fswatch --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-fswatch crew update \
&& yes | crew upgrade

$ crew check fswatch
Checking fswatch package ...
Library test for fswatch passed.
Checking fswatch package ...
fswatch 1.21.0

Usage:
fswatch [OPTION] ... path ...

Options:
 -0, --print0          Use the ASCII NUL character (0) as line separator.
 -1, --one-event       Exit fswatch after the first set of events is received.
     --allow-overflow  Allow a monitor to overflow and report it as a change event.
     --batch-marker    Print a marker at the end of every batch.
fswatch 1.21.0
Copyright (C) 2013-2025 Enrico M. Crisostomo <enrico.m.crisostomo@gmail.com>.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Enrico M. Crisostomo.
Package tests for fswatch passed.
```