### PR TITLE
Gccmakedep 1.0.3 => 1.0.4

### DIFF
--- a/manifest/armv7l/g/gccmakedep.filelist
+++ b/manifest/armv7l/g/gccmakedep.filelist
@@ -1,3 +1,3 @@
-# Total size: 3669
+# Total size: 3682
 /usr/local/bin/gccmakedep
-/usr/local/share/man/man1/gccmakedep.1.gz
+/usr/local/share/man/man1/gccmakedep.1.zst

--- a/manifest/i686/g/gccmakedep.filelist
+++ b/manifest/i686/g/gccmakedep.filelist
@@ -1,3 +1,3 @@
-# Total size: 3661
+# Total size: 3682
 /usr/local/bin/gccmakedep
-/usr/local/share/man/man1/gccmakedep.1.gz
+/usr/local/share/man/man1/gccmakedep.1.zst

--- a/manifest/x86_64/g/gccmakedep.filelist
+++ b/manifest/x86_64/g/gccmakedep.filelist
@@ -1,3 +1,3 @@
-# Total size: 3663
+# Total size: 3682
 /usr/local/bin/gccmakedep
-/usr/local/share/man/man1/gccmakedep.1.gz
+/usr/local/share/man/man1/gccmakedep.1.zst

--- a/packages/gccmakedep.rb
+++ b/packages/gccmakedep.rb
@@ -1,29 +1,21 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Gccmakedep < Package
+class Gccmakedep < Autotools
   description 'A utility to list the resource database of an X application.'
   homepage 'https://xorg.freedesktop.org/wiki/'
-  version '1.0.3'
+  version '1.0.4'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.x.org/releases/individual/util/gccmakedep-1.0.3.tar.gz'
-  source_sha256 'f9e2e7a590e27f84b6708ab7a81e546399b949bf652fb9b95193e0e543e6a548'
-  binary_compression 'tar.xz'
+  source_url "https://www.x.org/releases/individual/util/gccmakedep-#{version}.tar.gz"
+  source_sha256 '5f36cde3f7cce8150a6eeb8026759977be523068a64fad899776122c3f03311f'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '768024cf21b9a07a48bf15edd114b1c6e0f3a741c72e2a71cb262c1115d2e43e',
-     armv7l: '768024cf21b9a07a48bf15edd114b1c6e0f3a741c72e2a71cb262c1115d2e43e',
-       i686: '70429af7d9233dc37fadfde9eae739dd55fb497f6315c54ec3430c3b1060ed87',
-     x86_64: 'c90cb0f4a6dc67e2f2da5d39a3038e8db28ed1f0949373b56aac6c2f5b302b96'
+    aarch64: 'e090d5a887b8414dca5ae2f83d5322f534970484f81e01c805fb359fac8d581e',
+     armv7l: 'e090d5a887b8414dca5ae2f83d5322f534970484f81e01c805fb359fac8d581e',
+       i686: '30f7429353e187f9fb945e65e42f4320103cfc864d7f63c70c43d0e5b3b6961e',
+     x86_64: 'e9caaaf4e8e527008b80d19882cfbc788e53298c17a2e4b933f0fb267a999bad'
   })
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS} \
-            --sysconfdir=#{CREW_PREFIX}/etc"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  run_tests
 end

--- a/tests/package/g/gccmakedep
+++ b/tests/package/g/gccmakedep
@@ -1,0 +1,2 @@
+#!/bin/bash
+man gccmakedep | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gccmakedep crew update \
&& yes | crew upgrade

$ crew check gccmakedep
Checking gccmakedep package ...
Library test for gccmakedep passed.
Checking gccmakedep package ...
gccmakedep(1)                                                                               General Commands Manual                                                                               gccmakedep(1)

NAME
     gccmakedep - create dependencies in makefiles using ’gcc ‐M’

SYNOPSIS
     gccmakedep [ -sseparator ] [ -fmakefile ] [ -a ] [ -- options -- ] sourcefile ...

DESCRIPTION
     The gccmakedep program calls ’gcc ‐M’ to output makefile rules describing the dependencies of each sourcefile, so that make(1) knows which object files must be recompiled when a dependency has changed.
Package tests for gccmakedep passed.
```