### PR TITLE
Libsndfile 1.2.2 => 1.2.2-68f6c16f

### DIFF
--- a/manifest/armv7l/l/libsndfile.filelist
+++ b/manifest/armv7l/l/libsndfile.filelist
@@ -1,4 +1,4 @@
-# Total size: 748783
+# Total size: 814831
 /usr/local/bin/sndfile-cmp
 /usr/local/bin/sndfile-concat
 /usr/local/bin/sndfile-convert
@@ -11,7 +11,10 @@
 /usr/local/bin/sndfile-salvage
 /usr/local/include/sndfile.h
 /usr/local/include/sndfile.hh
-/usr/local/lib/libsndfile.la
+/usr/local/lib/cmake/SndFile/SndFileConfig.cmake
+/usr/local/lib/cmake/SndFile/SndFileConfigVersion.cmake
+/usr/local/lib/cmake/SndFile/SndFileTargets-release.cmake
+/usr/local/lib/cmake/SndFile/SndFileTargets.cmake
 /usr/local/lib/libsndfile.so
 /usr/local/lib/libsndfile.so.1
 /usr/local/lib/libsndfile.so.1.0.37

--- a/manifest/i686/l/libsndfile.filelist
+++ b/manifest/i686/l/libsndfile.filelist
@@ -1,4 +1,4 @@
-# Total size: 921739
+# Total size: 1149131
 /usr/local/bin/sndfile-cmp
 /usr/local/bin/sndfile-concat
 /usr/local/bin/sndfile-convert
@@ -11,7 +11,10 @@
 /usr/local/bin/sndfile-salvage
 /usr/local/include/sndfile.h
 /usr/local/include/sndfile.hh
-/usr/local/lib/libsndfile.la
+/usr/local/lib/cmake/SndFile/SndFileConfig.cmake
+/usr/local/lib/cmake/SndFile/SndFileConfigVersion.cmake
+/usr/local/lib/cmake/SndFile/SndFileTargets-release.cmake
+/usr/local/lib/cmake/SndFile/SndFileTargets.cmake
 /usr/local/lib/libsndfile.so
 /usr/local/lib/libsndfile.so.1
 /usr/local/lib/libsndfile.so.1.0.37

--- a/manifest/x86_64/l/libsndfile.filelist
+++ b/manifest/x86_64/l/libsndfile.filelist
@@ -1,4 +1,4 @@
-# Total size: 850039
+# Total size: 1076513
 /usr/local/bin/sndfile-cmp
 /usr/local/bin/sndfile-concat
 /usr/local/bin/sndfile-convert
@@ -11,7 +11,10 @@
 /usr/local/bin/sndfile-salvage
 /usr/local/include/sndfile.h
 /usr/local/include/sndfile.hh
-/usr/local/lib64/libsndfile.la
+/usr/local/lib64/cmake/SndFile/SndFileConfig.cmake
+/usr/local/lib64/cmake/SndFile/SndFileConfigVersion.cmake
+/usr/local/lib64/cmake/SndFile/SndFileTargets-release.cmake
+/usr/local/lib64/cmake/SndFile/SndFileTargets.cmake
 /usr/local/lib64/libsndfile.so
 /usr/local/lib64/libsndfile.so.1
 /usr/local/lib64/libsndfile.so.1.0.37

--- a/packages/libsndfile.rb
+++ b/packages/libsndfile.rb
@@ -1,29 +1,35 @@
-require 'buildsystems/autotools'
+require 'buildsystems/cmake'
 
-class Libsndfile < Autotools
+class Libsndfile < CMake
   description 'Libsndfile is a C library for reading and writing files containing sampled sound (such as MS Windows WAV and the Apple/SGI AIFF format) through one standard library interface.'
   homepage 'https://github.com/libsndfile/libsndfile'
-  version '1.2.2'
+  version '1.2.2-68f6c16f'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url 'https://github.com/libsndfile/libsndfile/releases/download/1.2.2/libsndfile-1.2.2.tar.xz'
-  source_sha256 '3799ca9924d3125038880367bf1468e53a1b7e3686a934f098b7e1d286cdb80e'
+  source_url 'https://github.com/libsndfile/libsndfile.git'
+  git_hashtag '68f6c16fe1407eff4cdde158566694c3ed666c2f'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e64d75555b4ff9383478bbe2588693ba41a024b281a64a8de47ee0cf03e0f2f6',
-     armv7l: 'e64d75555b4ff9383478bbe2588693ba41a024b281a64a8de47ee0cf03e0f2f6',
-       i686: '6d28a661b4ec8e0c85db4b57902aef01b253edfc633b3f9d791d53ffbbe31278',
-     x86_64: 'be7071f6c235ed413cda0f328506a3661e513c7053882c8ef7fbe8426a9047e8'
+    aarch64: '2d0471943a1768ec65ce97a472a0abe9fc1c45167bebadf36702068b759716a5',
+     armv7l: '2d0471943a1768ec65ce97a472a0abe9fc1c45167bebadf36702068b759716a5',
+       i686: '3222e03b9e2be06aa7e9434675bb227b09581552b78698be1654a11b846e285c',
+     x86_64: 'fd1387be738c0d74d05633da1c0449d08dcead3170cd7b38b3572ebbaea6b352'
   })
 
-  depends_on 'alsa_lib' # R
-  depends_on 'flac' # R
-  depends_on 'glibc' # R
-  depends_on 'libogg' # R
-  depends_on 'libvorbis' # R
+  depends_on 'alsa_lib' => :executable
+  depends_on 'flac' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'libmp3lame' => :library
+  depends_on 'libogg' => :library
+  depends_on 'libvorbis' => :library
+  depends_on 'mpg123' => :library
   depends_on 'nasm' => :build
-  depends_on 'opus' # R
+  depends_on 'opus' => :library
+  depends_on 'sane_backends' => :library
   depends_on 'speex' => :build
   depends_on 'sqlite' => :build
+
+  cmake_options '-DBUILD_SHARED_LIBS=ON'
 end

--- a/tests/package/l/libsndfile
+++ b/tests/package/l/libsndfile
@@ -1,0 +1,11 @@
+#!/bin/bash
+sndfile-cmp | head -5
+sndfile-concat | head -5
+sndfile-convert | head -5
+sndfile-deinterleave | head -5
+sndfile-info | head -5
+sndfile-interleave | head -5
+sndfile-metadata-get | head -5
+sndfile-metadata-set | head -5
+sndfile-play | head -5
+sndfile-salvage | head -5


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-libsndfile crew update \
&& yes | crew upgrade

$ crew check libsndfile 
Checking libsndfile package ...
Library test for libsndfile passed.
Checking libsndfile package ...
Usage : sndfile-cmp <filename> <filename>
	Compare the PCM data of two sound files.

Using libsndfile-1.2.2.


Usage : sndfile-concat <infile1> <infile2>  ... <outfile>

    Create a new output file <outfile> containing the concatenated
    audio data from <infile1> <infile2> ....

Usage : sndfile-convert [options] [encoding] <input file> <output file>

    where [option] may be:


Usage : sndfile-deinterleave <filename>

Split a mutli-channel file into a set of mono files.

Usage :
  sndfile-info <file> ...
    Prints out information about one or more sound files.

  sndfile-info --instrument <file>

Usage : sndfile-interleave <input 1> <input 2> ... -o <output file>

Merge two or more mono files into a single multi-channel file.


Usage :
  sndfile-metadata-get [options] <file>

Options:

Usage :

  sndfile-metadata-set [options] <file>
  sndfile-metadata-set [options] <input file> <output file>

Usage : sndfile-play <input sound file>

Using libsndfile-1.2.2.

Usage :

  sndfile-salvage <broken wav file> <fixed w64 file>

Salvages the audio data from WAV files which are more than 4G in length.
Package tests for libsndfile passed.
```