### PR TITLE
Libraw 0.20.2 => 0.22.1

### DIFF
--- a/manifest/armv7l/l/libraw.filelist
+++ b/manifest/armv7l/l/libraw.filelist
@@ -1,4 +1,4 @@
-# Total size: 16130980
+# Total size: 17265070
 /usr/local/bin/4channels
 /usr/local/bin/dcraw_emu
 /usr/local/bin/dcraw_half
@@ -20,13 +20,13 @@
 /usr/local/lib/libraw.a
 /usr/local/lib/libraw.la
 /usr/local/lib/libraw.so
-/usr/local/lib/libraw.so.20
-/usr/local/lib/libraw.so.20.0.0
+/usr/local/lib/libraw.so.25
+/usr/local/lib/libraw.so.25.0.0
 /usr/local/lib/libraw_r.a
 /usr/local/lib/libraw_r.la
 /usr/local/lib/libraw_r.so
-/usr/local/lib/libraw_r.so.20
-/usr/local/lib/libraw_r.so.20.0.0
+/usr/local/lib/libraw_r.so.25
+/usr/local/lib/libraw_r.so.25.0.0
 /usr/local/lib/pkgconfig/libraw.pc
 /usr/local/lib/pkgconfig/libraw_r.pc
 /usr/local/share/doc/libraw/COPYRIGHT

--- a/packages/libraw.rb
+++ b/packages/libraw.rb
@@ -1,37 +1,27 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Libraw < Package
+class Libraw < Autotools
   description 'Raw image decoder library'
   homepage 'https://www.libraw.org'
-  version '0.20.2'
+  version '0.22.1'
   license 'LGPL-2.1 and CDDL'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://www.libraw.org/data/LibRaw-0.20.2.tar.gz'
-  source_sha256 'dc1b486c2003435733043e4e05273477326e51c3ea554c6864a4eafaff1004a6'
+  source_url "https://www.libraw.org/data/LibRaw-#{version}.tar.gz"
+  source_sha256 'a789dc4e2409e2901d93793a4e0b80c7b49d0d97cf6ad71c850eb7616acfd786'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '8c49ae291667a77b2656a9530f7aa3afcc5ba60849b421c122384c9be24fb80b',
-     armv7l: '8c49ae291667a77b2656a9530f7aa3afcc5ba60849b421c122384c9be24fb80b',
-     x86_64: 'e73d06cfb8317be20e801930eba8b4f96c9e0d1a021594f66164972441e600d1'
+    aarch64: 'e76ea68b2b0411fa84e81dcdbd6d5a9c5a6d0d05379c6e5b212924fbfa5b0067',
+     armv7l: 'e76ea68b2b0411fa84e81dcdbd6d5a9c5a6d0d05379c6e5b212924fbfa5b0067',
+     x86_64: '848f56c2d17585c7d9fdc2408e9e6753535a0efd9ceb513e685a2ce0a3f1d438'
   })
 
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'jasper'
-  depends_on 'lcms'
+  depends_on 'lcms' => :library
+  depends_on 'libjpeg_turbo' => :library
   depends_on 'openmp'
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
-  depends_on 'libjpeg_turbo' # R
-  depends_on 'zlib' # R
-
-  def self.build
-    system 'autoreconf -fiv'
-    system 'filefix'
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system "make install DESTDIR=#{CREW_DEST_DIR}"
-  end
+  depends_on 'zlib' => :library
 end

--- a/tests/package/l/libraw
+++ b/tests/package/l/libraw
@@ -1,0 +1,12 @@
+#!/bin/bash
+4channels | head -5
+dcraw_emu | head -5
+dcraw_half | head -5
+half_mt | head -5
+mem_image | head -5
+multirender_test | head -5
+postprocessing_benchmark | head -5
+raw-identify | head -5
+rawtextdump | head -5
+simple_dcraw | head -5
+unprocessed_raw | head -5


### PR DESCRIPTION
Fixes GEGL-Message: 00:07:33.623: Module '/usr/local/lib64/gegl-0.4/raw-load.so' load error: libraw.so.20: cannot open shared object file: No such file or directory

Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-libraw crew update \
&& yes | crew upgrade

$ crew check libraw 
Checking libraw package ...
Library test for libraw passed.
Checking libraw package ...
4channels - LibRaw 0.22.1-Release sample. 1258 cameras supported
Usage: 4channels [-s N] [-g] [-A] [-B] raw-files....
	-s N - select Nth image in file (default=0)
	-g - use gamma correction with gamma 2.2 (not precise,use for visual inspection only)
	-A - autoscaling (by integer factor)
dcraw_emu: almost complete dcraw emulator
Usage:  dcraw_emu [OPTION]... [FILE]...
-c float-num       Set adjust maximum threshold (default 0.75)
-v        Verbose: print progress messages (repeated -v will add verbosity)
-w        Use camera white balance, if possible
half_mt: Multi-threaded LibRaw sample app. Emulates dcraw -h [-w] [-a]
Options:
-J n  - set parallel job count (default 2)
-v    - verbose
-w    - use camera white balance
mem_image - LibRaw sample, to illustrate work for memory buffers.
Emulates dcraw [-4] [-1] [-e] [-h]
Usage: mem_image [-D] [-j[nn]] [-T] [-v] [-e] raw-files....
	-6 - output 16-bit PPM
	-4 - linear 16-bit data
multirender_test - LibRaw 0.22.1-Release sample. Performs 4 different renderings of one file
 1258 cameras supported
Usage: multirender_test raw-files....
postprocessing benchmark: LibRaw 0.22.1-Release sample, 1258 cameras supported
Measures postprocessing speed with different options
Usage: postprocessing_benchmark [-a] [-H N] [-q N] [-h] [-m N] [-n N] [-s N] [-B x y w h] [-R N]
-a             average image for white balance
-H <num>       Highlight mode (0=clip, 1=unclip, 2=blend, 3+=rebuild)
Usage: raw-identify [options] inputfiles
Options:
	-v	verbose output
	-w	print white balance
	-u	print unpack function
Dump (small) selection of RAW file as tab-separated text file
Usage: rawtextdump inputfile COL ROW [CHANNEL] [width] [height]
  COL - start column
  ROW - start row
  CHANNEL - raw channel to dump, default is 0 (red for rggb)
simple_dcraw - LibRaw 0.22.1-Release sample. Emulates dcraw [-D] [-T] [-v] [-e] [-E]
 1258 cameras supported
Usage: simple_dcraw [-D] [-T] [-v] [-e] raw-files....
	-4 - 16-bit mode
	-L - list supported cameras and exit
unprocessed_raw - LibRaw 0.22.1-Release sample. 1258 cameras supported
Usage: unprocessed_raw [-q] [-A] [-g] [-s N] raw-files....
	-q - be quiet
	-s N - select Nth image in file (default=0)
	-g - use gamma correction with gamma 2.2 (not precise,use for visual inspection only)
Package tests for libraw passed.
```