### PR TITLE
Get_iplayer 3.31-perl5.34 => 3.36-perl5.42

### DIFF
--- a/manifest/armv7l/g/get_iplayer.filelist
+++ b/manifest/armv7l/g/get_iplayer.filelist
@@ -1,2 +1,2 @@
-# Total size: 355274
+# Total size: 361234
 /usr/local/bin/get_iplayer

--- a/manifest/armv7l/p/perl_io_socket_ssl.filelist
+++ b/manifest/armv7l/p/perl_io_socket_ssl.filelist
@@ -1,3 +1,4 @@
+# Total size: 596889
 /usr/local/share/man/man3/IO::Socket::SSL.3.zst
 /usr/local/share/man/man3/IO::Socket::SSL::Intercept.3.zst
 /usr/local/share/man/man3/IO::Socket::SSL::PublicSuffix.3.zst

--- a/manifest/i686/p/perl_io_socket_ssl.filelist
+++ b/manifest/i686/p/perl_io_socket_ssl.filelist
@@ -1,3 +1,4 @@
+# Total size: 596889
 /usr/local/share/man/man3/IO::Socket::SSL.3.zst
 /usr/local/share/man/man3/IO::Socket::SSL::Intercept.3.zst
 /usr/local/share/man/man3/IO::Socket::SSL::PublicSuffix.3.zst

--- a/manifest/x86_64/g/get_iplayer.filelist
+++ b/manifest/x86_64/g/get_iplayer.filelist
@@ -1,2 +1,2 @@
-# Total size: 355274
+# Total size: 361234
 /usr/local/bin/get_iplayer

--- a/manifest/x86_64/p/perl_io_socket_ssl.filelist
+++ b/manifest/x86_64/p/perl_io_socket_ssl.filelist
@@ -1,3 +1,4 @@
+# Total size: 596889
 /usr/local/share/man/man3/IO::Socket::SSL.3.zst
 /usr/local/share/man/man3/IO::Socket::SSL::Intercept.3.zst
 /usr/local/share/man/man3/IO::Socket::SSL::PublicSuffix.3.zst

--- a/packages/get_iplayer.rb
+++ b/packages/get_iplayer.rb
@@ -3,28 +3,27 @@ require 'package'
 class Get_iplayer < Package
   description 'A utility for downloading TV and radio programmes from BBC iPlayer'
   homepage 'https://github.com/get-iplayer/get_iplayer'
-  version '3.31-perl5.34'
+  version "3.36-#{CREW_PERL_VER}"
   license 'GPL-3'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://github.com/get-iplayer/get_iplayer/archive/v3.31.tar.gz'
-  source_sha256 '21bc00887365034f76e56b829eeba8b6d510f83424ebf1840ff9ca76713f58d5'
+  source_url 'https://github.com/get-iplayer/get_iplayer.git'
+  git_hashtag "v#{version.split('-')[0]}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '0fc9ba7a18b419cba3f94655b4004a9526f56907e486e7201e259230a1acca63',
-     armv7l: '0fc9ba7a18b419cba3f94655b4004a9526f56907e486e7201e259230a1acca63',
-     x86_64: 'fcafafde21e3763f926e2b2babe13fdea1465d422660fa992258b23c61b1c48c'
+    aarch64: '85141bd76ec610d7924f6dbf4bf784a3ccf8bf2bf338771f5c3e8e11c0b97b01',
+     armv7l: '85141bd76ec610d7924f6dbf4bf784a3ccf8bf2bf338771f5c3e8e11c0b97b01',
+     x86_64: 'e1ffcf0476747896dda2b7bbe8f33be0fb3fffeee2062e16fe7b61ac41e83122'
   })
 
-  depends_on 'perl'
+  depends_on 'perl' => :logical
   depends_on 'perl_app_cpanminus' => :build
-  depends_on 'perl_lwp_protocol_https' # R
-  depends_on 'ffmpeg'
-  depends_on 'atomicparsley'
-  depends_on 'libxml2'
-  depends_on 'zlib'
-
-  def self.build; end
+  depends_on 'perl_io_socket_ssl' => :executable
+  depends_on 'perl_lwp_protocol_https' => :executable
+  depends_on 'ffmpeg' => :executable
+  depends_on 'atomicparsley' => :library
+  depends_on 'libxml2' => :library
+  depends_on 'zlib' => :library
 
   def self.install
     FileUtils.install 'get_iplayer', "#{CREW_DEST_PREFIX}/bin/", mode: 0o755

--- a/packages/perl_io_socket_ssl.rb
+++ b/packages/perl_io_socket_ssl.rb
@@ -1,35 +1,16 @@
-require 'package'
+require 'buildsystems/perl'
 
-class Perl_io_socket_ssl < Package
+class Perl_io_socket_ssl < PERL
   description 'IO::Socket::SSL - SSL sockets with IO::Socket interface'
   homepage 'https://metacpan.org/pod/IO::Socket::SSL'
   version "2.085-#{CREW_PERL_VER}"
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url 'https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.085.tar.gz'
+  source_url "https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-#{version.split('-')[0]}.tar.gz"
   source_sha256 '95b2f7c0628a7e246a159665fbf0620d0d7835e3a940f22d3fdd47c3aa799c2e'
-  binary_compression 'tar.zst'
-
-  binary_sha256({
-    aarch64: '4a4e91e12ea60ad3735550e33a8b3d02fc0e70681e1e131f1571d3069b6b16c2',
-     armv7l: '4a4e91e12ea60ad3735550e33a8b3d02fc0e70681e1e131f1571d3069b6b16c2',
-       i686: '9f7e88cb139c43bf7e0a2e0c262dde0cdd49a60048db12ab614803baee6d1708',
-     x86_64: 'e72ee9f49b9f3d7a6b7ae26ac629d5571ad9458eac3bbeaf932f0bc775c32b18'
-  })
 
   depends_on 'perl_net_ssleay' => :build
   depends_on 'perl_mozilla_ca' => :build
 
-  def self.prebuild
-    system 'perl', 'Makefile.PL'
-    system "sed -i 's,/usr/local,#{CREW_PREFIX},g' Makefile"
-  end
-
-  def self.build
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  no_compile_needed
 end

--- a/tests/package/g/get_iplayer
+++ b/tests/package/g/get_iplayer
@@ -1,0 +1,3 @@
+#!/bin/bash
+get_iplayer -h | head
+get_iplayer -V


### PR DESCRIPTION
Convert perl_io_socket_ssl to PERL buildsystem

Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-get_iplayer crew update \
&& yes | crew upgrade

$ crew check get_iplayer 
Checking get_iplayer package ...
Library test for get_iplayer passed.
Checking get_iplayer package ...
get_iplayer v3.36
  Copyright (C) 2008-2010 Phil Lewis, 2010- get_iplayer contributors
  This program comes with ABSOLUTELY NO WARRANTY; for details use --warranty.
  This is free software, and you are welcome to redistribute it under certain
  conditions; use --conditions for details.

Usage ( Also see https://github.com/get-iplayer/get_iplayer/wiki/documentation ):
 List All Programmes:            get_iplayer [--type=<TYPE>] ".*"
 Search Programmes:              get_iplayer [--type=<TYPE>] <REGEX>
 Record Programmes by Search:    get_iplayer [--type=<TYPE>] <REGEX> --get
Package tests for get_iplayer passed.
```