### PR TITLE
Enable rtree support in sqlite package

### DIFF
--- a/manifest/armv7l/s/sqlite.filelist
+++ b/manifest/armv7l/s/sqlite.filelist
@@ -1,4 +1,4 @@
-# Total size: 12285662
+# Total size: 12609244
 /usr/local/bin/sqlite3
 /usr/local/include/sqlite3.h
 /usr/local/include/sqlite3ext.h

--- a/manifest/i686/s/sqlite.filelist
+++ b/manifest/i686/s/sqlite.filelist
@@ -1,4 +1,4 @@
-# Total size: 14922772
+# Total size: 15398422
 /usr/local/bin/sqlite3
 /usr/local/include/sqlite3.h
 /usr/local/include/sqlite3ext.h

--- a/manifest/x86_64/s/sqlite.filelist
+++ b/manifest/x86_64/s/sqlite.filelist
@@ -1,4 +1,4 @@
-# Total size: 14876596
+# Total size: 15482578
 /usr/local/bin/sqlite3
 /usr/local/include/sqlite3.h
 /usr/local/include/sqlite3ext.h

--- a/packages/sqlite.rb
+++ b/packages/sqlite.rb
@@ -11,20 +11,22 @@ class Sqlite < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a5dfbcca60f0b38ef01e7df644d36384f109ed9ca7cb09c94f71bdc93f7a9f9f',
-     armv7l: 'a5dfbcca60f0b38ef01e7df644d36384f109ed9ca7cb09c94f71bdc93f7a9f9f',
-       i686: '6d1208e0a0c1eea69e9357652acd1052eb76b5d9bc948df10cc46717438a61d3',
-     x86_64: 'f649cdc852be03ed6891a66d20274fc8bc31349caad0caa23173346912551ad7'
+    aarch64: 'a04f32e410a978fe63d56adb467675ff712253bec97b276fb0adee659ebf0705',
+     armv7l: 'a04f32e410a978fe63d56adb467675ff712253bec97b276fb0adee659ebf0705',
+       i686: 'c7597a3a9b32af7366ac17d3d4d5031ed11edfdb1f6e297cf1fb5fa51a75129a',
+     x86_64: 'f2376b78b38299979fa68112ab8ca04071a41db101b04b7d2a47ef36e8539a49'
   })
 
-  depends_on 'gcc_lib' # R
+  depends_on 'gcc_lib' => :library
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'libedit' => :executable
   depends_on 'ncurses' => :executable
   depends_on 'readline' => :build
   depends_on 'zlib' => :library
 
-  autotools_configure_options '--enable-shared \
+  autotools_configure_options '--enable-rtree \
+    --enable-shared \
     --enable-editline \
     --enable-readline \
     --enable-fts3 \

--- a/tests/package/s/sqlite
+++ b/tests/package/s/sqlite
@@ -1,0 +1,3 @@
+#!/bin/bash
+sqlite3 -help 2>&1 | head -5
+sqlite3 -version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-sqlite crew update \
&& yes | crew upgrade

$ crew check sqlite
Checking sqlite package ...
Library test for sqlite passed.
Checking sqlite package ...
Usage: sqlite3 [OPTIONS] [FILENAME [SQL...]]
FILENAME is the name of an SQLite database. A new database is created
if the file does not previously exist. Defaults to :memory:.
OPTIONS include:
   --                   treat no subsequent arguments as options
3.53.1 2026-05-05 10:34:17 c88b22011a54b4f6fbd149e9f8e4de77658ce58143a1af0e3785e4e64751alt1 (64-bit)
Package tests for sqlite passed.
```
