### PR TITLE
Revert crew changes in llvm22 PR.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -493,7 +493,6 @@ end
 
 def download
   test_url = PackageUtils.get_url(@pkg, build_from_source: @opt_source || @pkg.build_from_source)
-  puts "#{__LINE__}: #{@pkg.name} test_url: #{test_url} test_url.casecmp?('SKIP'): #{test_url.casecmp?('SKIP')}" if CREW_VERBOSE
   sha256sum = PackageUtils.get_sha256(@pkg, build_from_source: @opt_source || @pkg.build_from_source)
 
   # Do an early check for a missing binary package and if so rebuild.
@@ -503,15 +502,9 @@ def download
     else
       url = 'SKIP'
       @pkg.missing_binaries = true
-      puts "#{__LINE__}: Binaries are missing at #{test_url}".lightpurple
     end
-  elsif test_url.casecmp?('SKIP') || (!test_url.nil? && `curl -sI #{test_url}`.lines.first.split[1] == '200')
-    url = test_url
   else
-    @pkg.missing_binaries = true
-    puts "#{__LINE__}: Binaries are missing at #{test_url}".lightpurple
-    url = PackageUtils.get_url(@pkg, build_from_source: true)
-    sha256sum = PackageUtils.get_sha256(@pkg, build_from_source: true)
+    url = test_url
   end
 
   source = @pkg.source?(@device[:architecture])
@@ -539,8 +532,6 @@ def download
 
   git = true unless @pkg.git_hashtag.to_s.empty?
   gitlab_binary_url = "#{CREW_GITLAB_PKG_REPO}/generic/#{@pkg.name}/#{@pkg.version}_#{@device[:architecture]}/#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.#{@pkg.binary_compression}"
-  # Do a quick check to see if the binaries are available.
-  # @pkg.missing_binaries = true unless `curl -sI #{gitlab_binary_url}`.lines.first.split[1] == '200'
 
   if (@pkg.cache_build? || CREW_CACHE_BUILD) && !File.file?(build_cachefile) && !@pkg.no_source_build? && !File.file?(File.join(CREW_CACHE_DIR, "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.#{@pkg.binary_compression}")) && `curl -fsI #{gitlab_binary_url}`.lines.first.split[1] != '200'
 
@@ -615,9 +606,6 @@ def download
         else
           puts "Cannot find cached archive at #{cachefile}. 😔 Will download.".orange
           cachefile = ''
-          # If binaries are unavailable and there is no cached file,
-          # skip to next.
-          next if @pkg.missing_binaries
         end
       end
       # Download file if not cached.
@@ -1016,12 +1004,18 @@ def prepare_package(destdir)
     conflicts = ConvenienceFunctions.determine_conflicts(@pkg.name, File.join(Dir.pwd, 'filelist'), '_build', verbose: CREW_VERBOSE)
 
     if conflicts.any?
+      if CREW_CONFLICTS_ONLY_ADVISORY || @pkg.conflicts_ok?
+        puts "Warning: There is a conflict with the same file in another package:\n".orange
+      else
+        puts "Error: There is a conflict with the same file in another package:\n".lightred
+        errors = true
+      end
+
       conflicts.each_pair do |pkg_name, conflict_files|
-        if pkg_name == @pkg.conflicts_with || CREW_CONFLICTS_ONLY_ADVISORY || @pkg.conflicts_ok?
-          conflict_files.each { |file| puts "Warning: There is a conflict with the same file in another package:\n#{pkg_name}: #{file}".orange }
+        if errors
+          conflict_files.each { |file| puts "#{pkg_name}: #{file}".lightred }
         else
-          conflict_files.each { |file| puts "Error: There is a conflict with the same file in another package:\n#{pkg_name}: #{file}".lightred }
-          errors = true
+          conflict_files.each { |file| puts "#{pkg_name}: #{file}".orange }
         end
         puts
       end
@@ -1289,19 +1283,12 @@ def resolve_dependencies_and_install(no_advisory: false, ignore_dependencies: fa
       end
     end
 
+    # Only install dependencies from source if recursive.
+    @opt_source = false unless @opt_recursive
+
     to_install.each do |pkg_to_install|
       search pkg_to_install
       print_current_package
-      # Only install dependencies from source if recursive or if
-      # binaries are unavailable.
-      test_url = PackageUtils.get_url(@pkg, build_from_source: @opt_source || @pkg.build_from_source)
-      puts "#{__LINE__}: test_url: #{test_url}" if CREW_VERBOSE
-      @pkg.missing_binaries = if test_url.nil? || test_url.casecmp?('SKIP')
-                                false
-                              else
-                                `curl -sI #{test_url}`.lines.first.split[1] != '200'
-                              end
-      @opt_source = @opt_recursive || @pkg.missing_binaries
       install(skip_postinstall: true)
     end
 
@@ -1562,16 +1549,6 @@ def resolve_dependencies_and_build
     dependencies.each do |dep_to_install|
       search dep_to_install
       print_current_package
-      # Only install dependencies from source if recursive or if
-      # binaries are unavailable.
-      test_url = PackageUtils.get_url(@pkg, build_from_source: @opt_source || @pkg.build_from_source)
-      puts "#{__LINE__}: test_url: #{test_url}"
-      @pkg.missing_binaries = if test_url.nil?
-                                false
-                              else
-                                `curl -sI #{test_url}`.lines.first.split[1] != '200' || test_url.casecmp?('SKIP')
-                              end
-      @opt_source = @opt_recursive || @pkg.missing_binaries
       install(skip_postinstall: true)
     end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.74.3' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.74.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]


### PR DESCRIPTION
## Description
- Reverts `bin/crew` to the version in https://github.com/chromebrew/chromebrew/blob/2df35d8aaa5806179a88fd0716efe59090c9d7f5/bin/crew with the exception of the updated whatdepends function.
#### Commits:
-  3965c359b Revert crew changes in llvm22 PR.
### Other changed files:
- bin/crew
- lib/const.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=crew_revert crew update \
&& yes | crew upgrade
```
