### PR TITLE
Update ruby/setup-ruby ruby versions to 4.0.5 ; Restrict labeling event triggers for Generate PR workflow.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -390,7 +390,7 @@ jobs:
           ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.4'
+          ruby-version: '4.0.5'
       - name: Install bin/crew gem dependencies
         run: |
           # Install required gems.

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -455,7 +455,7 @@ jobs:
             fi
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.4'
+          ruby-version: '4.0.5'
       - name: Create Pull Request
         env:
           CHANGED_GITHUB_CONFIG_FILES: ${{ steps.changed-files.outputs.github_all_changed_files }}

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -1,5 +1,5 @@
 ---
-# Version 2.2
+# Version 2.3
 name: Generate PR
 run-name: Generate PR for ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} by @${{ github.actor }}
 on:
@@ -44,7 +44,7 @@ permissions:
   repository-projects: read
 jobs:
   debug:
-    if: ${{ ( github.repository_owner == 'chromebrew' ) || ( github.repository_owner == 'chromebrew' && github.event.action  == 'labeled' && github.event.label.name == 'regenerate_pr' ) || ( github.repository_owner == 'chromebrew' && github.event.action  == 'labeled' && github.event.label.name == 'update-package-files' ) }}
+    if: ${{ ( github.repository_owner == 'chromebrew' ) && ( ( github.event.action  == 'labeled' && github.event.label.name == 'regenerate_pr' ) || ( github.repository_owner == 'chromebrew' && github.event.action  == 'labeled' && github.event.label.name == 'update-package-files' ) || github.event.action  == 'workflow_dispatch') }}
     runs-on: ubuntu-24.04
     steps:
       - name: Dump GitHub context
@@ -60,7 +60,7 @@ jobs:
           STEPS_CONTEXT: ${{ toJson(steps) }}
         run: echo "$STEPS_CONTEXT"
   setup:
-    if: ${{ ( github.repository_owner == 'chromebrew' ) && ( inputs.branch != 'master' ) }}
+    if: ${{ ( github.repository_owner == 'chromebrew' ) && ( inputs.branch != 'master' ) && ( ( github.event.action  == 'labeled' && github.event.label.name == 'regenerate_pr' ) || ( github.repository_owner == 'chromebrew' && github.event.action  == 'labeled' && github.event.label.name == 'update-package-files' ) || github.event.action  == 'workflow_dispatch' ) }}
     runs-on: ubuntu-24.04
     outputs:
       changed_packages: ${{ steps.changed-packages.outputs.CHANGED_PACKAGES }}

--- a/.github/workflows/Package-Dependencies-Updater.yml
+++ b/.github/workflows/Package-Dependencies-Updater.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.4'
+          ruby-version: '4.0.5'
       - name: Install bin/crew gem dependencies
         run: |
           # Install required gems.

--- a/.github/workflows/Repology.yml
+++ b/.github/workflows/Repology.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.4'
+          ruby-version: '4.0.5'
       - name: Install highline
         run: sudo apt install -y ruby-highline
       - name: Install activesupport

--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -14,7 +14,7 @@ jobs:
        - uses: actions/checkout@v6
        - uses: ruby/setup-ruby@v1
          with:
-            ruby-version: '4.0.4'
+            ruby-version: '4.0.5'
        - name: Rubocop
          uses: reviewdog/action-rubocop@v2
          with:

--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -38,7 +38,7 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.4'
+          ruby-version: '4.0.5'
       - name: Install bin/crew gem dependencies
         run: |
           # Install required gems.


### PR DESCRIPTION
## Description
#### Commits:
-  e0ce2e0d8 Restrict labeling event triggers for Generate PR workflow.
-  1fb6b407f Update ruby/setup-ruby ruby versions to 4.0.5
### Updated GitHub configuration files:
- .github/workflows/Build.yml
- .github/workflows/Generate-PR.yml
- .github/workflows/Package-Dependencies-Updater.yml
- .github/workflows/Repology.yml
- .github/workflows/Rubocop.yml
- .github/workflows/Updater-on-Demand.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=setup_ruby crew update \
&& yes | crew upgrade
```
