### PR TITLE
Gifgen 1.1.2 => 1.2.0

### DIFF
--- a/manifest/armv7l/g/gifgen.filelist
+++ b/manifest/armv7l/g/gifgen.filelist
@@ -1,3 +1,3 @@
-# Total size: 2558
+# Total size: 2863
 /usr/local/bin/gifgen
-/usr/local/man/man1/gifgen.1
+/usr/local/share/man/man1/gifgen.1.zst

--- a/manifest/x86_64/g/gifgen.filelist
+++ b/manifest/x86_64/g/gifgen.filelist
@@ -1,3 +1,3 @@
-# Total size: 2073
+# Total size: 2863
 /usr/local/bin/gifgen
-/usr/local/man/man1/gifgen.1.gz
+/usr/local/share/man/man1/gifgen.1.zst

--- a/packages/gifgen.rb
+++ b/packages/gifgen.rb
@@ -3,27 +3,25 @@ require 'package'
 class Gifgen < Package
   description 'Simple high quality GIF encoding'
   homepage 'https://github.com/lukechilds/gifgen'
-  version '1.1.2'
+  version '1.2.0'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://github.com/lukechilds/gifgen/archive/1.1.2.tar.gz'
-  source_sha256 '95f69c63158315ad869ff36611026cce1a7d03f8c84716b1c21a44e71e8d6aee'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/lukechilds/gifgen.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e1eadb94916b24ff42c9ea9dbeb3c16e2683f9dc392d39872cb355b5f54addc0',
-     armv7l: 'e1eadb94916b24ff42c9ea9dbeb3c16e2683f9dc392d39872cb355b5f54addc0',
-     x86_64: '665fff725b0e73e5f5ac373b9418f7398eb9291d0e9eda72852c58ed1b543021'
+    aarch64: 'c2dba49545770001afebe03f781972eab7ae43fcacb5d8b2cf09ec9569ce8a4d',
+     armv7l: 'c2dba49545770001afebe03f781972eab7ae43fcacb5d8b2cf09ec9569ce8a4d',
+     x86_64: '83e2435246078a0e70b0ab58a6a5d296c02809ab803c30bbd6c2aee2d294756a'
   })
 
-  depends_on 'ffmpeg'
-  depends_on 'help2man'
+  depends_on 'ffmpeg' => :executable
+  depends_on 'help2man' => :build
 
   def self.install
     system 'help2man -N ./gifgen > gifgen.1'
-    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
-    system "mkdir -p #{CREW_DEST_PREFIX}/man/man1"
-    system "cp gifgen #{CREW_DEST_PREFIX}/bin"
-    system "cp gifgen.1 #{CREW_DEST_PREFIX}/man/man1"
+    FileUtils.install 'gifgen', "#{CREW_DEST_PREFIX}/bin/gifgen", mode: 0o755
+    FileUtils.install 'gifgen.1', "#{CREW_DEST_PREFIX}/man/man1/gifgen.1", mode: 0o644
   end
 end

--- a/tests/package/g/gifgen
+++ b/tests/package/g/gifgen
@@ -1,0 +1,2 @@
+#!/bin/bash
+gifgen -h | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gifgen crew update \
&& yes | crew upgrade

$ crew check gifgen 
Checking gifgen package ...
Library test for gifgen passed.
Checking gifgen package ...
gifgen 1.2.0

Usage: gifgen [options] [input]

Options:
  -o   Output file [input.gif]
  -f   Frames per second [10]
  -s   Optimize for static background
  -v   Display verbose output from ffmpeg
  -w   Scale output with horizontal resolution
Package tests for gifgen passed.
```