### PR TITLE
Giflib 5.2.2 => 6.1.3

### DIFF
--- a/manifest/armv7l/g/giflib.filelist
+++ b/manifest/armv7l/g/giflib.filelist
@@ -1,4 +1,4 @@
-# Total size: 297685
+# Total size: 410974
 /usr/local/bin/gif2rgb
 /usr/local/bin/gifbg
 /usr/local/bin/gifbuild
@@ -18,17 +18,28 @@
 /usr/local/lib/libgif.so
 /usr/local/lib/libgif.so.7
 /usr/local/lib/libgif.so.7.2.0
-/usr/local/share/man/man1/gif2rgb.1.zst
-/usr/local/share/man/man1/gifbg.1.zst
+/usr/local/share/doc/giflib/html/gif2rgb.html
+/usr/local/share/doc/giflib/html/gif_lib.html
+/usr/local/share/doc/giflib/html/gifbg.html
+/usr/local/share/doc/giflib/html/gifbuild.html
+/usr/local/share/doc/giflib/html/gifclrmp.html
+/usr/local/share/doc/giflib/html/gifcolor.html
+/usr/local/share/doc/giflib/html/gifecho.html
+/usr/local/share/doc/giflib/html/giffilter.html
+/usr/local/share/doc/giflib/html/giffix.html
+/usr/local/share/doc/giflib/html/gifhisto.html
+/usr/local/share/doc/giflib/html/gifinto.html
+/usr/local/share/doc/giflib/html/giflib-logo.gif
+/usr/local/share/doc/giflib/html/giflib.html
+/usr/local/share/doc/giflib/html/gifsponge.html
+/usr/local/share/doc/giflib/html/giftext.html
+/usr/local/share/doc/giflib/html/giftool.html
+/usr/local/share/doc/giflib/html/gifwedge.html
+/usr/local/share/doc/giflib/html/index.html
+/usr/local/share/doc/giflib/html/intro.html
 /usr/local/share/man/man1/gifbuild.1.zst
 /usr/local/share/man/man1/gifclrmp.1.zst
-/usr/local/share/man/man1/gifcolor.1.zst
-/usr/local/share/man/man1/gifecho.1.zst
-/usr/local/share/man/man1/giffilter.1.zst
 /usr/local/share/man/man1/giffix.1.zst
-/usr/local/share/man/man1/gifhisto.1.zst
-/usr/local/share/man/man1/gifinto.1.zst
-/usr/local/share/man/man1/gifsponge.1.zst
 /usr/local/share/man/man1/giftext.1.zst
 /usr/local/share/man/man1/giftool.1.zst
-/usr/local/share/man/man1/gifwedge.1.zst
+/usr/local/share/man/man7/giflib.7.zst

--- a/manifest/x86_64/g/giflib.filelist
+++ b/manifest/x86_64/g/giflib.filelist
@@ -1,4 +1,4 @@
-# Total size: 327951
+# Total size: 530844
 /usr/local/bin/gif2rgb
 /usr/local/bin/gifbg
 /usr/local/bin/gifbuild
@@ -18,17 +18,28 @@
 /usr/local/lib64/libgif.so
 /usr/local/lib64/libgif.so.7
 /usr/local/lib64/libgif.so.7.2.0
-/usr/local/share/man/man1/gif2rgb.1.zst
-/usr/local/share/man/man1/gifbg.1.zst
+/usr/local/share/doc/giflib/html/gif2rgb.html
+/usr/local/share/doc/giflib/html/gif_lib.html
+/usr/local/share/doc/giflib/html/gifbg.html
+/usr/local/share/doc/giflib/html/gifbuild.html
+/usr/local/share/doc/giflib/html/gifclrmp.html
+/usr/local/share/doc/giflib/html/gifcolor.html
+/usr/local/share/doc/giflib/html/gifecho.html
+/usr/local/share/doc/giflib/html/giffilter.html
+/usr/local/share/doc/giflib/html/giffix.html
+/usr/local/share/doc/giflib/html/gifhisto.html
+/usr/local/share/doc/giflib/html/gifinto.html
+/usr/local/share/doc/giflib/html/giflib-logo.gif
+/usr/local/share/doc/giflib/html/giflib.html
+/usr/local/share/doc/giflib/html/gifsponge.html
+/usr/local/share/doc/giflib/html/giftext.html
+/usr/local/share/doc/giflib/html/giftool.html
+/usr/local/share/doc/giflib/html/gifwedge.html
+/usr/local/share/doc/giflib/html/index.html
+/usr/local/share/doc/giflib/html/intro.html
 /usr/local/share/man/man1/gifbuild.1.zst
 /usr/local/share/man/man1/gifclrmp.1.zst
-/usr/local/share/man/man1/gifcolor.1.zst
-/usr/local/share/man/man1/gifecho.1.zst
-/usr/local/share/man/man1/giffilter.1.zst
 /usr/local/share/man/man1/giffix.1.zst
-/usr/local/share/man/man1/gifhisto.1.zst
-/usr/local/share/man/man1/gifinto.1.zst
-/usr/local/share/man/man1/gifsponge.1.zst
 /usr/local/share/man/man1/giftext.1.zst
 /usr/local/share/man/man1/giftool.1.zst
-/usr/local/share/man/man1/gifwedge.1.zst
+/usr/local/share/man/man7/giflib.7.zst

--- a/packages/giflib.rb
+++ b/packages/giflib.rb
@@ -3,20 +3,21 @@ require 'package'
 class Giflib < Package
   description 'giflib is a library for reading and writing gif images.'
   homepage 'https://giflib.sourceforge.net/'
-  version '5.2.2'
+  version '6.1.3'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://downloads.sourceforge.net/project/giflib/giflib-5.2.2.tar.gz'
-  source_sha256 'be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb'
+  source_url "https://downloads.sourceforge.net/project/giflib/giflib-#{version.split('.')[0]}.x/giflib-#{version}.tar.gz"
+  source_sha256 'b65b66b99f0424b93525f987386f22fc5efb9da2bfc92ad4a532249aaffbab0e'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '73bc9172813f7d8637e5448d7c80a12270224bba12fb6f76604a9a11cc895f81',
-     armv7l: '73bc9172813f7d8637e5448d7c80a12270224bba12fb6f76604a9a11cc895f81',
-     x86_64: 'c7e4b56340c481f7007e459010ebd126b8401d8511d6e4045b4b6245c4115941'
+    aarch64: '524b6919b04736d4b72612cd27e5791dc67977f152984da2d39cc97dec9b718d',
+     armv7l: '524b6919b04736d4b72612cd27e5791dc67977f152984da2d39cc97dec9b718d',
+     x86_64: '300bdee898955cfc57d005a610f25e5b0611e941b104c04800fe2103424be8bb'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'imagemagick7' => :build
 
   no_env_options

--- a/tests/package/g/giflib
+++ b/tests/package/g/giflib
@@ -1,0 +1,12 @@
+#!/bin/bash
+gif2rgb -h 2>&1
+gifbg -h 2>&1
+gifbuild -h 2>&1
+gifclrmp -h 2>&1
+gifcolor -h 2>&1
+gifecho -h 2>&1
+giffix -h 2>&1
+gifhisto -h 2>&1
+gifinto -h 2>&1
+giftext -h 2>&1
+gifwedge -h 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-giflib crew update \
&& yes | crew upgrade

$ crew check giflib
Checking giflib package ...
Library test for giflib passed.
Checking giflib package ...
gif2rgb Version 6.1, May 30 2026, 22:05:19
Usage: gif2rgb [-v] [-c #Colors] [-s Width Height] [-1] [-o OutFileName] [-h] GifFile
gifbg Version 6.1, May 30 2026, 22:04:59
Usage: gifbg [-v] [-d Dir] [-l #Lvls] [-c R G B] [-m MinI] [-M MaxI] [-s W H] [-h]
gifbuild Version 6.1, May 30 2026, 22:04:37
Usage: gifbuild [-v] [-d] [-t Characters] [-h] GifFile(s)
gifclrmp Version 6.1, May 30 2026, 22:04:55
Usage: gifclrmp [-v] [-s] [-t TranslationFile] [-l ColorMapFile] [-g Gamma] [-i Image#] [-h] GifFile
gifcolor Version 6.1, May 30 2026, 22:05:02
Usage: gifcolor [-v] [-b Background] [-h]
gifecho Version 6.1, May 30 2026, 22:05:04
Usage: gifecho [-v] [-s ClrMapSize] [-f FGClr] [-c R G B] [-t "Text"] [-h]
giffix Version 6.1, May 30 2026, 22:04:44
Usage: giffix [-v] [-h] GifFile
gifhisto Version 6.1, May 30 2026, 22:05:09
Usage: gifhisto [-v] [-t] [-s Width Height] [-n ImageNumber] [-b] [-h] GifFile
gifinto Version 6.1, May 30 2026, 22:05:12
Usage: gifinto [-v] [-s MinFileSize] [-h] GifFile
giftext Version 6.1, May 30 2026, 22:04:48
Usage: giftext [-v] [-c] [-e] [-z] [-p] [-r] [-h] GifFile
gifwedge Version 6.1, May 30 2026, 22:05:16
Usage: gifwedge [-v] [-l #Lvls] [-s Width Height] [-h]
Package tests for giflib passed.
```