### PR TITLE
Adjust Generate Updates PR on Demand to use continue instead of exit 1.

### DIFF
--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -1,5 +1,5 @@
 ---
-# Version 1.5
+# Version 1.6
 name: Generate Updates PRs on Demand
 run-name: Generating Updates PRs on Demand using ${{ inputs.version_cmd_input }}
 on:
@@ -103,7 +103,7 @@ jobs:
               if gh pr list -l "block-updater-workflow" --json number | jq --arg PR_NUMBER "$PR_NUMBER"  -e -r '.[]|select(.number=='$PR_NUMBER')' &>/dev/null; then
                 # Abort if we don't want the updater workflow to run on this branch with a PR already.
                 echo "PR #${PR_NUMBER} for branch ${updater_branch} has the block-updater-workflow label set."
-                exit 1
+                continue
               fi
             fi
             if [[ "$(git branch -a --list ${updater_branch} | wc -l)" != '0' ]]; then


### PR DESCRIPTION
## Description
#### Commits:
-  9c48eee41 Adjust Generate Updates PR on Demand to use continue instead of exit 1.
### Updated GitHub configuration files:
- .github/workflows/Updater-on-Demand.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=fix_generate_updates_workflow crew update \
&& yes | crew upgrade
```
