### PR TITLE
Glog 0.3.5 => 0.7.1

### DIFF
--- a/manifest/armv7l/g/gflags.filelist
+++ b/manifest/armv7l/g/gflags.filelist
@@ -1,0 +1,19 @@
+# Total size: 222064
+/usr/local/bin/gflags_completions.sh
+/usr/local/include/gflags/gflags.h
+/usr/local/include/gflags/gflags_completions.h
+/usr/local/include/gflags/gflags_declare.h
+/usr/local/include/gflags/gflags_gflags.h
+/usr/local/lib/cmake/gflags/gflags-config-version.cmake
+/usr/local/lib/cmake/gflags/gflags-config.cmake
+/usr/local/lib/cmake/gflags/gflags-nonamespace-targets-release.cmake
+/usr/local/lib/cmake/gflags/gflags-nonamespace-targets.cmake
+/usr/local/lib/cmake/gflags/gflags-targets-release.cmake
+/usr/local/lib/cmake/gflags/gflags-targets.cmake
+/usr/local/lib/libgflags.so
+/usr/local/lib/libgflags.so.2.3
+/usr/local/lib/libgflags.so.2.3.0
+/usr/local/lib/libgflags_nothreads.so
+/usr/local/lib/libgflags_nothreads.so.2.3
+/usr/local/lib/libgflags_nothreads.so.2.3.0
+/usr/local/lib/pkgconfig/gflags.pc

--- a/manifest/armv7l/g/glog.filelist
+++ b/manifest/armv7l/g/glog.filelist
@@ -1,21 +1,19 @@
-# Total size: 2087679
+# Total size: 302885
+/usr/local/include/glog/export.h
+/usr/local/include/glog/flags.h
 /usr/local/include/glog/log_severity.h
 /usr/local/include/glog/logging.h
+/usr/local/include/glog/platform.h
 /usr/local/include/glog/raw_logging.h
 /usr/local/include/glog/stl_logging.h
+/usr/local/include/glog/types.h
 /usr/local/include/glog/vlog_is_on.h
-/usr/local/lib/libglog.a
-/usr/local/lib/libglog.la
+/usr/local/lib/cmake/glog/glog-config-version.cmake
+/usr/local/lib/cmake/glog/glog-config.cmake
+/usr/local/lib/cmake/glog/glog-modules.cmake
+/usr/local/lib/cmake/glog/glog-targets-release.cmake
+/usr/local/lib/cmake/glog/glog-targets.cmake
 /usr/local/lib/libglog.so
-/usr/local/lib/libglog.so.0
-/usr/local/lib/libglog.so.0.0.0
-/usr/local/lib/pkgconfig/libglog.pc
-/usr/local/share/doc/glog-0.3.5/AUTHORS
-/usr/local/share/doc/glog-0.3.5/COPYING
-/usr/local/share/doc/glog-0.3.5/ChangeLog
-/usr/local/share/doc/glog-0.3.5/INSTALL
-/usr/local/share/doc/glog-0.3.5/NEWS
-/usr/local/share/doc/glog-0.3.5/README
-/usr/local/share/doc/glog-0.3.5/README.windows
-/usr/local/share/doc/glog-0.3.5/designstyle.css
-/usr/local/share/doc/glog-0.3.5/glog.html
+/usr/local/lib/libglog.so.0.7.1
+/usr/local/lib/libglog.so.2
+/usr/local/share/glog/cmake/FindUnwind.cmake

--- a/manifest/i686/g/gflags.filelist
+++ b/manifest/i686/g/gflags.filelist
@@ -1,0 +1,19 @@
+# Total size: 335268
+/usr/local/bin/gflags_completions.sh
+/usr/local/include/gflags/gflags.h
+/usr/local/include/gflags/gflags_completions.h
+/usr/local/include/gflags/gflags_declare.h
+/usr/local/include/gflags/gflags_gflags.h
+/usr/local/lib/cmake/gflags/gflags-config-version.cmake
+/usr/local/lib/cmake/gflags/gflags-config.cmake
+/usr/local/lib/cmake/gflags/gflags-nonamespace-targets-release.cmake
+/usr/local/lib/cmake/gflags/gflags-nonamespace-targets.cmake
+/usr/local/lib/cmake/gflags/gflags-targets-release.cmake
+/usr/local/lib/cmake/gflags/gflags-targets.cmake
+/usr/local/lib/libgflags.so
+/usr/local/lib/libgflags.so.2.3
+/usr/local/lib/libgflags.so.2.3.0
+/usr/local/lib/libgflags_nothreads.so
+/usr/local/lib/libgflags_nothreads.so.2.3
+/usr/local/lib/libgflags_nothreads.so.2.3.0
+/usr/local/lib/pkgconfig/gflags.pc

--- a/manifest/i686/g/glog.filelist
+++ b/manifest/i686/g/glog.filelist
@@ -1,21 +1,19 @@
-# Total size: 1605515
+# Total size: 390265
+/usr/local/include/glog/export.h
+/usr/local/include/glog/flags.h
 /usr/local/include/glog/log_severity.h
 /usr/local/include/glog/logging.h
+/usr/local/include/glog/platform.h
 /usr/local/include/glog/raw_logging.h
 /usr/local/include/glog/stl_logging.h
+/usr/local/include/glog/types.h
 /usr/local/include/glog/vlog_is_on.h
-/usr/local/lib/libglog.a
-/usr/local/lib/libglog.la
+/usr/local/lib/cmake/glog/glog-config-version.cmake
+/usr/local/lib/cmake/glog/glog-config.cmake
+/usr/local/lib/cmake/glog/glog-modules.cmake
+/usr/local/lib/cmake/glog/glog-targets-release.cmake
+/usr/local/lib/cmake/glog/glog-targets.cmake
 /usr/local/lib/libglog.so
-/usr/local/lib/libglog.so.0
-/usr/local/lib/libglog.so.0.0.0
-/usr/local/lib/pkgconfig/libglog.pc
-/usr/local/share/doc/glog-0.3.5/AUTHORS
-/usr/local/share/doc/glog-0.3.5/COPYING
-/usr/local/share/doc/glog-0.3.5/ChangeLog
-/usr/local/share/doc/glog-0.3.5/INSTALL
-/usr/local/share/doc/glog-0.3.5/NEWS
-/usr/local/share/doc/glog-0.3.5/README
-/usr/local/share/doc/glog-0.3.5/README.windows
-/usr/local/share/doc/glog-0.3.5/designstyle.css
-/usr/local/share/doc/glog-0.3.5/glog.html
+/usr/local/lib/libglog.so.0.7.1
+/usr/local/lib/libglog.so.2
+/usr/local/share/glog/cmake/FindUnwind.cmake

--- a/manifest/x86_64/g/gflags.filelist
+++ b/manifest/x86_64/g/gflags.filelist
@@ -1,0 +1,19 @@
+# Total size: 343599
+/usr/local/bin/gflags_completions.sh
+/usr/local/include/gflags/gflags.h
+/usr/local/include/gflags/gflags_completions.h
+/usr/local/include/gflags/gflags_declare.h
+/usr/local/include/gflags/gflags_gflags.h
+/usr/local/lib64/cmake/gflags/gflags-config-version.cmake
+/usr/local/lib64/cmake/gflags/gflags-config.cmake
+/usr/local/lib64/cmake/gflags/gflags-nonamespace-targets-release.cmake
+/usr/local/lib64/cmake/gflags/gflags-nonamespace-targets.cmake
+/usr/local/lib64/cmake/gflags/gflags-targets-release.cmake
+/usr/local/lib64/cmake/gflags/gflags-targets.cmake
+/usr/local/lib64/libgflags.so
+/usr/local/lib64/libgflags.so.2.3
+/usr/local/lib64/libgflags.so.2.3.0
+/usr/local/lib64/libgflags_nothreads.so
+/usr/local/lib64/libgflags_nothreads.so.2.3
+/usr/local/lib64/libgflags_nothreads.so.2.3.0
+/usr/local/lib64/pkgconfig/gflags.pc

--- a/manifest/x86_64/g/glog.filelist
+++ b/manifest/x86_64/g/glog.filelist
@@ -1,21 +1,19 @@
-# Total size: 2510351
+# Total size: 399597
+/usr/local/include/glog/export.h
+/usr/local/include/glog/flags.h
 /usr/local/include/glog/log_severity.h
 /usr/local/include/glog/logging.h
+/usr/local/include/glog/platform.h
 /usr/local/include/glog/raw_logging.h
 /usr/local/include/glog/stl_logging.h
+/usr/local/include/glog/types.h
 /usr/local/include/glog/vlog_is_on.h
-/usr/local/lib64/libglog.a
-/usr/local/lib64/libglog.la
+/usr/local/lib64/cmake/glog/glog-config-version.cmake
+/usr/local/lib64/cmake/glog/glog-config.cmake
+/usr/local/lib64/cmake/glog/glog-modules.cmake
+/usr/local/lib64/cmake/glog/glog-targets-release.cmake
+/usr/local/lib64/cmake/glog/glog-targets.cmake
 /usr/local/lib64/libglog.so
-/usr/local/lib64/libglog.so.0
-/usr/local/lib64/libglog.so.0.0.0
-/usr/local/lib64/pkgconfig/libglog.pc
-/usr/local/share/doc/glog-0.3.5/AUTHORS
-/usr/local/share/doc/glog-0.3.5/COPYING
-/usr/local/share/doc/glog-0.3.5/ChangeLog
-/usr/local/share/doc/glog-0.3.5/INSTALL
-/usr/local/share/doc/glog-0.3.5/NEWS
-/usr/local/share/doc/glog-0.3.5/README
-/usr/local/share/doc/glog-0.3.5/README.windows
-/usr/local/share/doc/glog-0.3.5/designstyle.css
-/usr/local/share/doc/glog-0.3.5/glog.html
+/usr/local/lib64/libglog.so.0.7.1
+/usr/local/lib64/libglog.so.2
+/usr/local/share/glog/cmake/FindUnwind.cmake

--- a/packages/gflags.rb
+++ b/packages/gflags.rb
@@ -1,0 +1,25 @@
+require 'buildsystems/cmake'
+
+class Gflags < CMake
+  description 'C++ library that implements commandline flags processing'
+  homepage 'https://gflags.github.io/gflags/'
+  version '2.3.0'
+  license 'BSD-3 Clause'
+  compatibility 'all'
+  source_url 'https://github.com/gflags/gflags.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '3b9ae630e0eda5c6a270644f860cc6218ca6a21cb62f5795b51b5ddd745317a2',
+     armv7l: '3b9ae630e0eda5c6a270644f860cc6218ca6a21cb62f5795b51b5ddd745317a2',
+       i686: '32d97b57e7a03528de9e58208f3f4b58a0b33888f35689394893452c9cdf8f84',
+     x86_64: '0802944972dfddee0cce69d5c6e011f946c4d2df73be827481dc3ec60f1d1ea5'
+  })
+
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+
+  cmake_options "-DBUILD_SHARED_LIBS=ON -DLIBRARY_INSTALL_DIR=#{CREW_LIB_PREFIX}"
+end

--- a/packages/glog.rb
+++ b/packages/glog.rb
@@ -1,34 +1,28 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Glog < Package
+class Glog < CMake
   description 'A C++ implementation of the Google logging module.'
   homepage 'https://github.com/google/glog'
-  version '0.3.5'
+  version '0.7.1'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://github.com/google/glog/archive/v0.3.5.zip'
-  source_sha256 '267103f8a1e9578978aa1dc256001e6529ef593e5aea38193d31c2872ee025e8'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/google/glog.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'bd0c7e649bb6e1128e44c8989ab4182f60665e50e5d992341d8bf19235a6dd2e',
-     armv7l: 'bd0c7e649bb6e1128e44c8989ab4182f60665e50e5d992341d8bf19235a6dd2e',
-       i686: '0ae1c98ddcbf078e0a7c63e38d8f1c993f2b1d80956b1e208490ad62f687a917',
-     x86_64: '978c0906643f11a9c53c1a523a5d6824e948edb9ebb89cbfa24395486f435f87'
+    aarch64: 'c07ece254b3993f76859a9dd526fc27a74e6f93fa15703afdb7923ce51ec994f',
+     armv7l: 'c07ece254b3993f76859a9dd526fc27a74e6f93fa15703afdb7923ce51ec994f',
+       i686: '74b692b165ed385418b6a5e426404f3e0b7ae95dc3615358c5db6cc49aea8a07',
+     x86_64: 'ada23d70ad1f16e1aeb701cf76ea0c12bcbe932f7cc92bd66f8d3e99a16a01db'
   })
 
-  depends_on 'unzip' => :build
+  depends_on 'gcc_lib' => :library
+  depends_on 'gflags' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'libunwind' => :library
 
-  def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make',
-           "DESTDIR=#{CREW_DEST_DIR}",
-           'install'
-  end
+  cmake_options '-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF'
 end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -2535,6 +2535,11 @@ url: https://gitlab.gnome.org/GNOME/libgfbgraph/-/tags
 activity: low
 ---
 kind: url
+name: gflags
+url: https://github.com/gflags/gflags/releases
+activity: low
+---
+kind: url
 name: ghc
 url: https://www.haskell.org/ghc/
 activity: medium


### PR DESCRIPTION
Add gflags package dependency

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-glog crew update \
&& yes | crew upgrade
```