### PR TITLE
Gnome_mines 49.0.1 => 50.0

### DIFF
--- a/manifest/armv7l/g/gnome_mines.filelist
+++ b/manifest/armv7l/g/gnome_mines.filelist
@@ -1,4 +1,4 @@
-# Total size: 1317169
+# Total size: 1320861
 /usr/local/bin/gnome-mines
 /usr/local/share/applications/org.gnome.Mines.desktop
 /usr/local/share/dbus-1/services/org.gnome.Mines.service

--- a/manifest/x86_64/g/gnome_mines.filelist
+++ b/manifest/x86_64/g/gnome_mines.filelist
@@ -1,4 +1,4 @@
-# Total size: 1366513
+# Total size: 1375529
 /usr/local/bin/gnome-mines
 /usr/local/share/applications/org.gnome.Mines.desktop
 /usr/local/share/dbus-1/services/org.gnome.Mines.service

--- a/packages/gnome_mines.rb
+++ b/packages/gnome_mines.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Gnome_mines < Meson
   description 'GNOME Mines (formerly known as Gnomine) is minesweeper clone for GNOME'
   homepage 'https://wiki.gnome.org/Apps/Mines'
-  version '49.0.1'
+  version '50.0'
   license 'GPL-3+ and CC-BY-SA-3.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-mines.git'
@@ -11,19 +11,20 @@ class Gnome_mines < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd73ee740fc15ad7336544d9ec41255f7838377a28927de5bd06cb3c7eb5610f5',
-     armv7l: 'd73ee740fc15ad7336544d9ec41255f7838377a28927de5bd06cb3c7eb5610f5',
-     x86_64: 'b350dd6d4692bf330f78806c7b00210e15d45430994322bf3bc83717366f2699'
+    aarch64: '8e9b521a87af43f0c2cf5f5ad5df9767dfb724c46d53d71af531d862cad50466',
+     armv7l: '8e9b521a87af43f0c2cf5f5ad5df9767dfb724c46d53d71af531d862cad50466',
+     x86_64: 'e566702d5da2c0aa2336cbeafd4d1044fbd9a9fb2cb41e4a1e69c04d1e0a5e9e'
   })
 
   depends_on 'clutter_gtk' => :build
   depends_on 'desktop_file_utils' => :build
-  depends_on 'glib' # R
-  depends_on 'glibc' # R
+  depends_on 'glib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'gsound' => :build
-  depends_on 'gtk4' # R
-  depends_on 'libadwaita' # R
-  depends_on 'libgee' # R
+  depends_on 'gtk4' => :executable
+  depends_on 'libadwaita' => :executable
+  depends_on 'libgee' => :executable
   depends_on 'librsvg' => :build
   depends_on 'py3_itstool' => :build
   depends_on 'vala' => :build

--- a/tests/package/g/gnome_mines
+++ b/tests/package/g/gnome_mines
@@ -1,0 +1,3 @@
+#!/bin/bash
+gnome-mines -h | head
+gnome-mines -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gnome_mines crew update \
&& yes | crew upgrade

$ crew check gnome_mines
Checking gnome_mines package ...
Library test for gnome_mines passed.
Checking gnome_mines package ...
Usage:
  gnome-mines [OPTION…]

Help Options:
  -h, --help                Show help options
  --help-all                Show all help options
  --help-gapplication       Show GApplication options

Application Options:
  -v, --version             Print release version and exit
Package tests for gnome_mines passed.
```