### PR TITLE
Goaccess 1.2 => 1.10.2

### DIFF
--- a/manifest/armv7l/g/goaccess.filelist
+++ b/manifest/armv7l/g/goaccess.filelist
@@ -1,12 +1,18 @@
-# Total size: 959879
+# Total size: 2663918
 /usr/local/bin/goaccess
-/usr/local/etc/goaccess.conf
-/usr/local/share/doc/goaccess/app.css
-/usr/local/share/doc/goaccess/app.js
-/usr/local/share/doc/goaccess/bootstrap.min.css
-/usr/local/share/doc/goaccess/charts.js
-/usr/local/share/doc/goaccess/d3.v3.min.js
-/usr/local/share/doc/goaccess/fa.min.css
-/usr/local/share/doc/goaccess/hogan.min.js
-/usr/local/share/doc/goaccess/tpls.html
-/usr/local/share/man/man1/goaccess.1.gz
+/usr/local/etc/goaccess/browsers.list
+/usr/local/etc/goaccess/goaccess.conf
+/usr/local/etc/goaccess/podcast.list
+/usr/local/share/locale/de/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/es/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/fr/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/it/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ja/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ka/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ko/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ru/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/sv/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/uk/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/zh_CN/LC_MESSAGES/goaccess.mo
+/usr/local/share/man/man1/goaccess.1.zst

--- a/manifest/i686/g/goaccess.filelist
+++ b/manifest/i686/g/goaccess.filelist
@@ -1,12 +1,18 @@
-# Total size: 1002471
+# Total size: 2762642
 /usr/local/bin/goaccess
-/usr/local/etc/goaccess.conf
-/usr/local/share/doc/goaccess/app.css
-/usr/local/share/doc/goaccess/app.js
-/usr/local/share/doc/goaccess/bootstrap.min.css
-/usr/local/share/doc/goaccess/charts.js
-/usr/local/share/doc/goaccess/d3.v3.min.js
-/usr/local/share/doc/goaccess/fa.min.css
-/usr/local/share/doc/goaccess/hogan.min.js
-/usr/local/share/doc/goaccess/tpls.html
-/usr/local/share/man/man1/goaccess.1.gz
+/usr/local/etc/goaccess/browsers.list
+/usr/local/etc/goaccess/goaccess.conf
+/usr/local/etc/goaccess/podcast.list
+/usr/local/share/locale/de/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/es/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/fr/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/it/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ja/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ka/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ko/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ru/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/sv/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/uk/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/zh_CN/LC_MESSAGES/goaccess.mo
+/usr/local/share/man/man1/goaccess.1.zst

--- a/manifest/x86_64/g/goaccess.filelist
+++ b/manifest/x86_64/g/goaccess.filelist
@@ -1,12 +1,18 @@
-# Total size: 1000447
+# Total size: 2766378
 /usr/local/bin/goaccess
-/usr/local/etc/goaccess.conf
-/usr/local/share/doc/goaccess/app.css
-/usr/local/share/doc/goaccess/app.js
-/usr/local/share/doc/goaccess/bootstrap.min.css
-/usr/local/share/doc/goaccess/charts.js
-/usr/local/share/doc/goaccess/d3.v3.min.js
-/usr/local/share/doc/goaccess/fa.min.css
-/usr/local/share/doc/goaccess/hogan.min.js
-/usr/local/share/doc/goaccess/tpls.html
-/usr/local/share/man/man1/goaccess.1.gz
+/usr/local/etc/goaccess/browsers.list
+/usr/local/etc/goaccess/goaccess.conf
+/usr/local/etc/goaccess/podcast.list
+/usr/local/share/locale/de/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/es/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/fr/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/it/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ja/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ka/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ko/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/ru/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/sv/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/uk/LC_MESSAGES/goaccess.mo
+/usr/local/share/locale/zh_CN/LC_MESSAGES/goaccess.mo
+/usr/local/share/man/man1/goaccess.1.zst

--- a/packages/goaccess.rb
+++ b/packages/goaccess.rb
@@ -1,36 +1,35 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Goaccess < Package
+class Goaccess < Autotools
   description 'GoAccess is an open source real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems or through your browser.'
   homepage 'https://goaccess.io/'
-  version '1.2'
+  version '1.10.2'
   license 'MIT'
   compatibility 'all'
-  source_url 'http://tar.goaccess.io/goaccess-1.2.tar.gz'
-  source_sha256 '6ba9f66540ea58fc2c17f175265f9ed76d74a8432eeac1182b74ebf4f2cd3414'
-  binary_compression 'tar.xz'
+  source_url "https://tar.goaccess.io/goaccess-#{version}.tar.gz"
+  source_sha256 'b9b7484a413279863c7d92dc7dd4c19dcb55c0a2d138735efc18570bcc4eaa0e'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '0c132b27f777f1e1dc14803e511bcc39878e3d95c6505340b82a1d51574e2b7e',
-     armv7l: '0c132b27f777f1e1dc14803e511bcc39878e3d95c6505340b82a1d51574e2b7e',
-       i686: 'aac33dd81eea11108a7c54cd07abb284c54e4aa8117234409c72d775f3b6f5f8',
-     x86_64: 'df1335f8f222662081b60bae63b43549988b410f92cc3e1d4012c13ea4833769'
+    aarch64: '94d90146a9150cf8cfa0035a850745db5bf1f1f39af70dd57769206775ecb747',
+     armv7l: '94d90146a9150cf8cfa0035a850745db5bf1f1f39af70dd57769206775ecb747',
+       i686: '450e986e7e9f2550046696557488011a3e9a9a6fb6978b039e7c00a65334d355',
+     x86_64: '03aa906f945eff2bbfa8dafacd356daef109310f0ee05e2d2a7e09e9999d7cdf'
   })
 
-  depends_on 'openssl'
-  depends_on 'geoip'
-  depends_on 'ncurses'
+  depends_on 'geoip' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'ncurses' => :executable
+  depends_on 'openssl' => :executable
 
-  def self.build
-    system './configure \
-              --enable-geoip=legacy \
-              --enable-utf8 \
-              --with-getline \
-              --with-openssl'
-    system 'make'
-  end
+  autotools_pre_configure_options "CFLAGS='-I#{CREW_PREFIX}/include/ncursesw'"
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_configure_options ' \
+    --enable-geoip=legacy \
+    --enable-utf8 \
+    --with-getline \
+    --with-openssl'
+
+  run_tests
 end

--- a/tests/package/g/goaccess
+++ b/tests/package/g/goaccess
@@ -1,0 +1,3 @@
+#!/bin/bash
+goaccess -h | head
+goaccess -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-goaccess crew update \
&& yes | crew upgrade

$ crew check goaccess
Checking goaccess package ...
Library test for goaccess passed.
Checking goaccess package ...

GoAccess - 1.10.2

Usage: goaccess [filename] [ options ... ] [-c][-M][-H][-S][-q][-d][...]
The following options can also be supplied to the command:

LOG & DATE FORMAT OPTIONS

  --log-format=<logformat>        - Specify log format. Inner quotes need
                                    escaping, or use single quotes.
GoAccess - 1.10.2.
For more details visit: https://goaccess.io/
Copyright (C) 2009-2024 by Gerardo Orellana

Build configure arguments:
  --enable-utf8
  --enable-geoip=legacy
  --with-getline
  --with-openssl
Package tests for goaccess passed.
```