### PR TITLE
Glab 1.100.0 => 1.101.0

### DIFF
--- a/manifest/armv7l/g/glab.filelist
+++ b/manifest/armv7l/g/glab.filelist
@@ -1,2 +1,2 @@
-# Total size: 48169122
+# Total size: 48234658
 /usr/local/bin/glab

--- a/manifest/i686/g/glab.filelist
+++ b/manifest/i686/g/glab.filelist
@@ -1,2 +1,2 @@
-# Total size: 48115874
+# Total size: 48181410
 /usr/local/bin/glab

--- a/manifest/x86_64/g/glab.filelist
+++ b/manifest/x86_64/g/glab.filelist
@@ -1,2 +1,2 @@
-# Total size: 50913442
+# Total size: 50974882
 /usr/local/bin/glab

--- a/packages/glab.rb
+++ b/packages/glab.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glab < Package
   description 'A GitLab CLI tool bringing GitLab to your command line'
   homepage 'https://gitlab.com/gitlab-org/cli'
-  version '1.100.0'
+  version '1.101.0'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Glab < Package
      x86_64: "https://gitlab.com/gitlab-org/cli/-/releases/v#{version}/downloads/glab_#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'e3719a7ff6dee1525b2ac3fbddb1e1cf2ac8573eb5b54fa7f639602e97bc5942',
-     armv7l: 'e3719a7ff6dee1525b2ac3fbddb1e1cf2ac8573eb5b54fa7f639602e97bc5942',
-       i686: '1fcf4a4f4d3d1b313c2d62e608d669b22ee2bbb1fa2c482cd3b201a8727b4c24',
-     x86_64: 'd2a8ccffe924d3ad22feb2d1338840e9a610041c6ea6fd76e9aeda3744f210c2'
+    aarch64: '9069dce60325efd08adcb1b43f15af9e15a2d05211d1b9918eacb5854d0387d4',
+     armv7l: '9069dce60325efd08adcb1b43f15af9e15a2d05211d1b9918eacb5854d0387d4',
+       i686: '296db69b8edcc176633f73e7f8479d3050a8ec7aa122518f3be6ae024ee37efe',
+     x86_64: 'f8f40309a622416b769a455a85509bae7800070cd023466f2d33d8ee82f3fc61'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-glab crew update \
&& yes | crew upgrade

$ crew check glab 
Checking glab package ...
Library test for glab passed.
Checking glab package ...

  GLab is an open source GitLab CLI tool that brings GitLab to your command line.                                       
         
  USAGE  
         
    glab <command> <subcommand> [command] [--flags]  
            
  COMMANDS  
            
    alias [command] [--flags]                        Create, list, and delete aliases.
glab 1.101.0 (b3786045)
Package tests for glab passed.
```