### PR TITLE
Go_tools 0.39.0 => 0.45.0

### DIFF
--- a/manifest/armv7l/g/go_tools.filelist
+++ b/manifest/armv7l/g/go_tools.filelist
@@ -1,4 +1,4 @@
-# Total size: 110646844
+# Total size: 112959764
 /usr/local/bin/benchcmp
 /usr/local/bin/bisect
 /usr/local/bin/callgraph

--- a/manifest/i686/g/go_tools.filelist
+++ b/manifest/i686/g/go_tools.filelist
@@ -1,4 +1,4 @@
-# Total size: 107440100
+# Total size: 110125764
 /usr/local/bin/benchcmp
 /usr/local/bin/bisect
 /usr/local/bin/callgraph

--- a/manifest/x86_64/g/go_tools.filelist
+++ b/manifest/x86_64/g/go_tools.filelist
@@ -1,4 +1,4 @@
-# Total size: 114455160
+# Total size: 118044552
 /usr/local/bin/benchcmp
 /usr/local/bin/bisect
 /usr/local/bin/callgraph

--- a/packages/go_tools.rb
+++ b/packages/go_tools.rb
@@ -3,7 +3,7 @@ require 'package'
 class Go_tools < Package
   description 'Developer tools for the Go programming language'
   homepage 'https://github.com/golang/tools'
-  version '0.39.0'
+  version '0.45.0'
   license 'BSD'
   compatibility 'all'
   source_url 'https://github.com/golang/tools.git'
@@ -11,13 +11,14 @@ class Go_tools < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '8b16a0ea24997fbb30685c98ed7dda96a6038508a11015880be5f7df2a04011d',
-     armv7l: '8b16a0ea24997fbb30685c98ed7dda96a6038508a11015880be5f7df2a04011d',
-       i686: '8578feede07c22d87fcfbd644070de078ceec9e47449f774c13339b2f26645c4',
-     x86_64: 'cb272fa3956a58cdca188a676e6ebd8956c969764d0bc6652bedf5c8c8a980d2'
+    aarch64: '5792d13307485a68048df47a93ef23b6ce0aa2bdc9c61202906f3b3aebf0cfc5',
+     armv7l: '5792d13307485a68048df47a93ef23b6ce0aa2bdc9c61202906f3b3aebf0cfc5',
+       i686: '5acdf01f3d1e6bd6014f8ecd2e8a3ccdb4389f684e94d8906cf9e62c2d73b616',
+     x86_64: 'd9939997f73171866d6df18d8c3edc7ae120e8a35bb5d30e6b8ec2b8cadf27b3'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'go' => :build
 
   def self.install

--- a/tests/package/g/go_tools
+++ b/tests/package/g/go_tools
@@ -1,0 +1,2 @@
+#!/bin/bash
+for b in $(crew files go_tools | grep /usr/local/bin); do $b -h 2>&1 | head -5; done


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-go_tools crew update \
&& yes | crew upgrade

$ crew check go_tools 
Checking go_tools package ...
Library test for go_tools passed.
Checking go_tools package ...
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
usage: /usr/local/bin/benchcmp old.txt new.txt

  -best
    	compare best times from old and new
usage: bisect [flags] [var=value...] command [arguments...]
  -compile rewrite
    	bisect source locations affected by Go compiler rewrite (fma, loopvar, ...)
  -count n
    	run target n times for each trial (default 2)
Usage of /usr/local/bin/callgraph:
  -algo string
    	Call graph construction algorithm (static, cha, rta, vta) (default "rta")
  -format string
    	A template expression specifying how to format an edge (default "{{.Caller}}\t--{{.Dynamic}}-{{.Line}}:{{.Column}}-->\t{{.Callee}}")
usage: compilebench [options]
options:
  -alloc
    	report allocations
  -asm exe
The deadcode command reports unreachable functions in Go programs.

	Usage: deadcode [flags] package...

The deadcode command loads a Go program from source then uses Rapid

The digraph command performs queries over unlabelled directed graphs
represented in text form.  It is intended to integrate nicely with
typical UNIX command pipelines.

Usage of /usr/local/bin/eg:
  -beforeedit string
    	A command to exec before each file is edited (e.g. chmod, checkout).  Whitespace delimits argument words.  The string '{}' is replaced by the file name.
  -help
    	show detailed help message
usage: file2fuzz [-o output] [input...]
converts files to Go fuzzer corpus format
	input: files to convert
	-o: where to write converted file(s)
Usage of /usr/local/bin/fiximports:
  -baddomains string
    	a comma-separated list of domains from which packages should not be imported (default "code.google.com")
  -n	dry run: show changes, but don't apply them
  -replace string
Usage of /usr/local/bin/fuzz-driver:
  -badfcnidx int
    	[Testing only] select index of bad function (used with -emitbad)
  -badpkgidx int
    	[Testing only] select index of bad package (used with -emitbad)
Usage of /usr/local/bin/fuzz-runner:
  -badfcnidx int
    	[Testing only] select index of bad function (used with -emitbad)
  -badpkgidx int
    	[Testing only] select index of bad package (used with -emitbad)
Usage of /usr/local/bin/go-contrib-init:
  -dry-run
    	Fail with problems instead of trying to fix things.
  -repo string
    	Which go repo you want to contribute to. Use "go" for the core, or e.g. "net" for golang.org/x/net/* (default "go")
Usage: bundle [options] <src>
  -dst path
    	set destination import path (default ".")
  -import map
    	rewrite import using map, of form old=new (can be repeated)
usage: godex [flags] {path|qualifiedIdent}
  -s string
    	only consider packages from src, where src is one of the supported compilers
  -v	verbose mode
usage: goimports [flags] [path ...]
  -cpuprofile string
    	CPU profile output
  -d	display diffs instead of rewriting files
  -e	report all errors (not just the first 10 on different lines)
Usage of /usr/local/bin/gomvpkg:
  -from string
    	Import path of package to be moved
  -help
    	show usage message
usage: gonew srcmod[@version] [dstmod [dir]]
See https://pkg.go.dev/golang.org/x/tools/cmd/gonew.
usage: gotype [flags] [path ...]

The gotype command, like the front-end of a Go compiler, parses and
type-checks a single Go package. Errors are reported if the analysis
fails; otherwise gotype is quiet (unless -v is set).
Usage of /usr/local/bin/goyacc:
  -l	disable line directives
  -o string
    	parser output (default "y.go")
  -p string
Usage of /usr/local/bin/html2article:
Usage of /usr/local/bin/present:
  -base string
    	base path for slide template and static resources
  -content string
    	base path for presentation content (default ".")
usage: present2md [-w] [file ...]
open -h: no such file or directory
Usage of /usr/local/bin/ssadump:
  -arg value
    	add argument to interpreted program
  -build value
    	Options controlling the SSA builder.
The stress utility is intended for catching sporadic failures.
It runs a given process in parallel in a loop and collects any failures.
Usage:

	$ stress ./fmt.test -test.run=TestSometing -test.cpu=10
Usage of stringer:
	stringer [flags] -type T [directory]
	stringer [flags] -type T files... # Must be a single package
For more information, see:
	https://pkg.go.dev/golang.org/x/tools/cmd/stringer
usage: toolstash [-n] [-v] [-cmp] command line

Examples:
	toolstash save
	toolstash restore
Package tests for go_tools passed.
```