### PR TITLE
Gox 0.4.0 => 1.0.1

### DIFF
--- a/manifest/armv7l/g/gox.filelist
+++ b/manifest/armv7l/g/gox.filelist
@@ -1,2 +1,2 @@
-# Total size: 3017249
+# Total size: 3443204
 /usr/local/bin/gox

--- a/manifest/i686/g/gox.filelist
+++ b/manifest/i686/g/gox.filelist
@@ -1,2 +1,2 @@
-# Total size: 2878312
+# Total size: 3331652
 /usr/local/bin/gox

--- a/manifest/x86_64/g/gox.filelist
+++ b/manifest/x86_64/g/gox.filelist
@@ -1,2 +1,2 @@
-# Total size: 3379125
+# Total size: 3551240
 /usr/local/bin/gox

--- a/packages/gox.rb
+++ b/packages/gox.rb
@@ -3,25 +3,23 @@ require 'package'
 class Gox < Package
   description 'A dead simple, no frills Go cross compile tool.'
   homepage 'https://github.com/mitchellh/gox'
-  version '0.4.0'
+  version '1.0.1'
   license 'MPL-2.0'
   compatibility 'all'
-  source_url 'https://github.com/mitchellh/gox/archive/v0.4.0.tar.gz'
-  source_sha256 '2df7439e9901877685ff4e6377de863c3c2ec4cde43d0ca631ff65d1b64774ad'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/mitchellh/gox.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'bd18d1ee7da98692c0aaa53e9016d16a7a2cb5ecf07236c340a2613b6837f087',
-     armv7l: 'bd18d1ee7da98692c0aaa53e9016d16a7a2cb5ecf07236c340a2613b6837f087',
-       i686: '70e31b0602ad26369b711a0f740391d43cd297b4a5d16c4d1a04bdb843f99fb0',
-     x86_64: 'd6d6c6c6d5aa168bea5c25a202c902d8b965040218a52291701c3e172d29c991'
+    aarch64: '686fb964bbcc9e4ecd9e54c7e2e0697f8b956ff0a72da51770d798888b7e153e',
+     armv7l: '686fb964bbcc9e4ecd9e54c7e2e0697f8b956ff0a72da51770d798888b7e153e',
+       i686: 'abf7a1af826d58ac36858b3d672c277674fbd98fdbb11562a91e8ce461fa8f94',
+     x86_64: '3e5a08aaecf58d05a8140689ca095f7812fe992317902bd7d293aef625079afe'
   })
 
   depends_on 'go'
 
   def self.install
-    system 'go get github.com/mitchellh/iochan'
-    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
     system "go build -o #{CREW_DEST_PREFIX}/bin/gox"
   end
 end

--- a/tests/package/g/gox
+++ b/tests/package/g/gox
@@ -1,0 +1,2 @@
+#!/bin/bash
+gox -h 2>&1 | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gox crew update \
&& yes | crew upgrade

$ crew check gox 
Checking gox package ...
Library test for gox passed.
Checking gox package ...
flag provided but not defined: -version
Usage: gox [options] [packages]

  Gox cross-compiles Go applications in parallel.

  If no specific operating systems or architectures are specified, Gox
  will build for all pairs supported by your version of Go.

Options:

Package tests for gox passed.
```