### PR TITLE
Gphoto 2.5.23 => 2.5.32

### DIFF
--- a/manifest/armv7l/g/gphoto.filelist
+++ b/manifest/armv7l/g/gphoto.filelist
@@ -1,4 +1,5 @@
-# Total size: 1094042
+# Total size: 864592
+/usr/local/bin/gphoto
 /usr/local/bin/gphoto2
 /usr/local/share/doc/gphoto2/test-hook.sh
 /usr/local/share/locale/az/LC_MESSAGES/gphoto2.mo
@@ -29,4 +30,4 @@
 /usr/local/share/locale/vi/LC_MESSAGES/gphoto2.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/gphoto2.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/gphoto2.mo
-/usr/local/share/man/man1/gphoto2.1.gz
+/usr/local/share/man/man1/gphoto2.1.zst

--- a/manifest/i686/g/gphoto.filelist
+++ b/manifest/i686/g/gphoto.filelist
@@ -1,4 +1,5 @@
-# Total size: 1078638
+# Total size: 915940
+/usr/local/bin/gphoto
 /usr/local/bin/gphoto2
 /usr/local/share/doc/gphoto2/test-hook.sh
 /usr/local/share/locale/az/LC_MESSAGES/gphoto2.mo
@@ -29,4 +30,4 @@
 /usr/local/share/locale/vi/LC_MESSAGES/gphoto2.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/gphoto2.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/gphoto2.mo
-/usr/local/share/man/man1/gphoto2.1.gz
+/usr/local/share/man/man1/gphoto2.1.zst

--- a/manifest/x86_64/g/gphoto.filelist
+++ b/manifest/x86_64/g/gphoto.filelist
@@ -1,4 +1,5 @@
-# Total size: 1163778
+# Total size: 906432
+/usr/local/bin/gphoto
 /usr/local/bin/gphoto2
 /usr/local/share/doc/gphoto2/test-hook.sh
 /usr/local/share/locale/az/LC_MESSAGES/gphoto2.mo
@@ -29,4 +30,4 @@
 /usr/local/share/locale/vi/LC_MESSAGES/gphoto2.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/gphoto2.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/gphoto2.mo
-/usr/local/share/man/man1/gphoto2.1.gz
+/usr/local/share/man/man1/gphoto2.1.zst

--- a/packages/gphoto.rb
+++ b/packages/gphoto.rb
@@ -1,38 +1,35 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Gphoto < Package
+class Gphoto < Autotools
   description 'The gphoto2 commandline tool for accessing and controlling digital cameras.'
   homepage 'http://www.gphoto.org/'
-  version '2.5.23'
+  version '2.5.32'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://github.com/gphoto/gphoto2/archive/gphoto2-2_5_23-release.tar.gz'
-  source_sha256 'dc78b7f8a88803937301d157b5b32cd45f6defcc771564438a477a7fb05f4489'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/gphoto/gphoto2.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '055e881c56a7e40a0208176d08555a8992f15844aedc204f53d99db8e86e1f31',
-     armv7l: '055e881c56a7e40a0208176d08555a8992f15844aedc204f53d99db8e86e1f31',
-       i686: '72969ad37c17319ce08ca6a80d26d8cfd1bbeac71cbfbcf4ae89f582d6db0f52',
-     x86_64: '92fcfd96e8a3a8d40d5a2661d5a9b37dad019ef086b925c97a738c9879c82663'
+    aarch64: '05e47afcfc1416eaae1f94cabe5f34ef95321a3f559ab09162798376ed397f11',
+     armv7l: '05e47afcfc1416eaae1f94cabe5f34ef95321a3f559ab09162798376ed397f11',
+       i686: '4b2e14c9fc24acc7963ef86f1ac71d1a5fe84837589e800f1630ea5014be8ba7',
+     x86_64: '15c44dd84d053db86ba8198727afc9f34f902a5fee5d00967144aaa57c69a5ff'
   })
 
-  depends_on 'libgphoto'
-  depends_on 'popt'
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libexif' => :executable
+  depends_on 'libgphoto' => :executable
+  depends_on 'libjpeg_turbo' => :executable
+  depends_on 'libtool' => :executable
+  depends_on 'popt' => :executable
+  depends_on 'readline' => :executable
 
-  def self.build
-    system 'autoreconf -is'
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
-    system 'make'
+  autotools_install_extras do
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/gphoto2", "#{CREW_DEST_PREFIX}/bin/gphoto"
   end
 
-  def self.check
-    system 'make', 'check'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  run_tests
 end

--- a/tests/package/g/gphoto
+++ b/tests/package/g/gphoto
@@ -1,0 +1,3 @@
+#!/bin/bash
+gphoto2 -h
+gphoto2 -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gphoto crew update \
&& yes | crew upgrade

$ crew check gphoto 
Checking gphoto package ...
Library test for gphoto passed.
Checking gphoto package ...
gphoto2 2.5.32

Copyright (c) 2000-2025 Marcus Meissner and others

gphoto2 comes with NO WARRANTY, to the extent permitted by law. You may
redistribute copies of gphoto2 under the terms of the GNU General Public
License. For more information about these matters, see the files named COPYING.

This version of gphoto2 is using the following software versions and options:
gphoto2         2.5.32         gcc, popt(m), exif, no cdk, no aa, jpeg, readline
libgphoto2      2.5.33         NON-STANDARD CAMLIB SET (adc65 agfa_cl20 aox ax203 barbie canon casio_qv clicksmart310 digigr8 digita dimagev dimera3500 directory enigma13 fuji gsmart300 hp215 iclick jamcam jd11 jl2005a jl2005c kodak_dc120 kodak_dc210 kodak_dc240 kodak_dc3200 kodak_ez200 konica konica_qm150 largan lg_gsm lumix mars mustek panasonic_coolshot panasonic_dc1000 panasonic_dc1580 panasonic_l859 pccam300 pccam600 pentax polaroid_pdc320 polaroid_pdc640 polaroid_pdc700 ptp2 quicktake1x0 ricoh ricoh_g3 samsung sierra sipix_blink2 sipix_web2 smal sonix sony_dscf1 sony_dscf55 soundvision spca50x sq905 st2205 stv0674 stv0680 sx330z topfield toshiba_pdrm11 tp6801 SKIPPING docupen), gcc, no ltdl, EXIF
libgphoto2_port 0.12.2         iolibs: disk ptpip serial usb1 usbdiskdirect usbscsi, gcc, no ltdl, EXIF, USB, serial without locking
Package tests for gphoto passed.
```