### PR TITLE
Gnome_weather 49.0 => 50.0

### DIFF
--- a/manifest/armv7l/g/gnome_weather.filelist
+++ b/manifest/armv7l/g/gnome_weather.filelist
@@ -1,4 +1,4 @@
-# Total size: 784001
+# Total size: 808458
 /usr/local/bin/gnome-weather
 /usr/local/share/applications/org.gnome.Weather.desktop
 /usr/local/share/dbus-1/services/org.gnome.Weather.BackgroundService.service
@@ -69,6 +69,7 @@
 /usr/local/share/locale/ga/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/gd/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/gl/LC_MESSAGES/org.gnome.Weather.mo
+/usr/local/share/locale/gu/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/he/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/hi/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/hr/LC_MESSAGES/org.gnome.Weather.mo
@@ -83,6 +84,7 @@
 /usr/local/share/locale/kk/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/kn/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/ko/LC_MESSAGES/org.gnome.Weather.mo
+/usr/local/share/locale/kw/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/lo/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/lt/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/lv/LC_MESSAGES/org.gnome.Weather.mo

--- a/manifest/x86_64/g/gnome_weather.filelist
+++ b/manifest/x86_64/g/gnome_weather.filelist
@@ -1,4 +1,4 @@
-# Total size: 784005
+# Total size: 808462
 /usr/local/bin/gnome-weather
 /usr/local/share/applications/org.gnome.Weather.desktop
 /usr/local/share/dbus-1/services/org.gnome.Weather.BackgroundService.service
@@ -69,6 +69,7 @@
 /usr/local/share/locale/ga/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/gd/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/gl/LC_MESSAGES/org.gnome.Weather.mo
+/usr/local/share/locale/gu/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/he/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/hi/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/hr/LC_MESSAGES/org.gnome.Weather.mo
@@ -83,6 +84,7 @@
 /usr/local/share/locale/kk/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/kn/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/ko/LC_MESSAGES/org.gnome.Weather.mo
+/usr/local/share/locale/kw/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/lo/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/lt/LC_MESSAGES/org.gnome.Weather.mo
 /usr/local/share/locale/lv/LC_MESSAGES/org.gnome.Weather.mo

--- a/packages/gnome_weather.rb
+++ b/packages/gnome_weather.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Gnome_weather < Meson
   description 'Access current weather conditions and forecasts'
   homepage 'https://wiki.gnome.org/Apps/Weather'
-  version '49.0'
+  version '50.0'
   license 'GPL-2+, LGPL-2+, MIT, CC-BY-3.0 and CC-BY-SA-3.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-weather.git'
@@ -11,22 +11,22 @@ class Gnome_weather < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '27ef669e2907301a76381ae49b74337db9772c15a2b657b5c927bd984b38babc',
-     armv7l: '27ef669e2907301a76381ae49b74337db9772c15a2b657b5c927bd984b38babc',
-     x86_64: '53c381245c2635feb202d9aa05ddc4f9d44febe0b0006b0150d70df2ec4c2fa7'
+    aarch64: '0d35568c64296cfcd9ea1df5b2e3e07e8207371205a2ee32d8ee56e8187c8bf4',
+     armv7l: '0d35568c64296cfcd9ea1df5b2e3e07e8207371205a2ee32d8ee56e8187c8bf4',
+     x86_64: '2f233836e7205392aabff2c4d42a67727a6add480b83950995f2201637ab2e35'
   })
 
-  depends_on 'desktop_file_utilities' => :build
-  depends_on 'gtk3' => :build
-  depends_on 'gjs' => :build
-  depends_on 'libadwaita' => :build
-  depends_on 'libgweather' => :build
-  depends_on 'geoclue' => :build
-  depends_on 'gnome_desktop' => :build
-  depends_on 'gobject_introspection' => :build
-  depends_on 'appstream_glib' => :build
-  depends_on 'libhandy' => :build
-  depends_on 'typescript' => :build
+  depends_on 'desktop_file_utilities' => :executable
+  depends_on 'geoclue' => :library
+  depends_on 'gjs' => :library
+  depends_on 'gnome_desktop' => :executable
+  depends_on 'gobject_introspection' => :library
+  depends_on 'gtk3' => :executable
+  depends_on 'appstream_glib' => :library
+  depends_on 'libadwaita' => :library
+  depends_on 'libgweather' => :library
+  depends_on 'libhandy' => :library
+  depends_on 'typescript' => :library
 
   gnome
 end

--- a/tests/package/g/gnome_weather
+++ b/tests/package/g/gnome_weather
@@ -1,0 +1,2 @@
+#!/bin/bash
+gnome-weather -h


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gnome_weather crew update \
&& yes | crew upgrade

$ crew check gnome_weather
Checking gnome_weather package ...
Library test for gnome_weather passed.
Checking gnome_weather package ...
/usr/local/bin/gjs-console: error while loading shared libraries: libicui18n.so.77: cannot open shared object file: No such file or directory
/usr/local/bin/gjs-console: error while loading shared libraries: libicui18n.so.77: cannot open shared object file: No such file or directory
Package tests for gnome_weather failed.
```