### PR TITLE
Gjs 1.86.0 => 1.88.0-icu78.3

### DIFF
--- a/manifest/armv7l/g/gjs.filelist
+++ b/manifest/armv7l/g/gjs.filelist
@@ -1,4 +1,4 @@
-# Total size: 1633892
+# Total size: 1662007
 /usr/local/bin/gjs
 /usr/local/bin/gjs-console
 /usr/local/include/gjs-1.0/gjs/context.h

--- a/manifest/x86_64/g/gjs.filelist
+++ b/manifest/x86_64/g/gjs.filelist
@@ -1,4 +1,4 @@
-# Total size: 2216658
+# Total size: 2288301
 /usr/local/bin/gjs
 /usr/local/bin/gjs-console
 /usr/local/include/gjs-1.0/gjs/context.h

--- a/packages/gjs.rb
+++ b/packages/gjs.rb
@@ -3,31 +3,32 @@ require 'buildsystems/meson'
 class Gjs < Meson
   description 'Javascript Bindings for GNOME'
   homepage 'https://gitlab.gnome.org/GNOME/gjs/'
-  version '1.86.0'
+  version "1.88.0-#{CREW_ICU_VER}"
   license 'MIT and MPL-1.1, LGPL-2+ or GPL-2+'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/gjs.git'
-  git_hashtag version
+  git_hashtag version.split('-')[0]
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'eb53897926520377b10ef2d3483c4ca2c103f780a54fb514a8cbd87017747341',
-     armv7l: 'eb53897926520377b10ef2d3483c4ca2c103f780a54fb514a8cbd87017747341',
-     x86_64: 'e6311b3433b322b9b616b5f58224d9f6c9d0ff95e254574d1c69d357cb285c4f'
+    aarch64: '07a5458ca2d001efcf5d44bb811c50640930316353166b0f99208c82534a7cda',
+     armv7l: '07a5458ca2d001efcf5d44bb811c50640930316353166b0f99208c82534a7cda',
+     x86_64: '9a55b764efaf9bfbf2dbd0a2b21834c3f9fc7e9b5f37f8b0fbb44a32a3d36f67'
   })
 
-  depends_on 'cairo' # R
+  depends_on 'cairo' => :library
   depends_on 'dbus' => :build
   depends_on 'dconf' => :build
-  depends_on 'gcc_lib' # R
-  depends_on 'glib' # R
-  depends_on 'glibc' # R
+  depends_on 'gcc_lib' => :library
+  depends_on 'glib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'gobject_introspection' => :build
   depends_on 'gtk4' => :build
   depends_on 'harfbuzz' # R
-  depends_on 'js140' # R
-  depends_on 'libffi' # R
-  depends_on 'libx11' # R
+  depends_on 'js140' => :library
+  depends_on 'libffi' => :library
+  depends_on 'libx11' => :library
 
   gnome
 
@@ -36,4 +37,9 @@ class Gjs < Meson
     -Dskip_gtk_tests=true \
     -Dprofiler=disabled \
     -Dreadline=disabled'
+
+  def self.patch
+    # Remove SpiderMonkey sanity check.
+    system "sed -i '299,315d' meson.build"
+  end
 end

--- a/tests/package/g/gjs
+++ b/tests/package/g/gjs
@@ -1,0 +1,5 @@
+#!/bin/bash
+gjs --help | head
+gjs --version
+gjs-console --help | head
+gjs-console --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gjs crew update \
&& yes | crew upgrade

$ crew check gjs 
Checking gjs package ...
Library test for gjs passed.
Checking gjs package ...
Usage:
  gjs [OPTION…]

Help Options:
  -h, --help                       Show help options

Application Options:
  --version                        Print GJS version and exit
  --jsversion                      Print version of the JS engine and exit
  -c, --command=COMMAND            Program passed in as a string
gjs 1.88.0
Usage:
  gjs-console [OPTION…]

Help Options:
  -h, --help                       Show help options

Application Options:
  --version                        Print GJS version and exit
  --jsversion                      Print version of the JS engine and exit
  -c, --command=COMMAND            Program passed in as a string
gjs 1.88.0
Package tests for gjs passed.
```