### PR TITLE
Gsettings_desktop_schemas 49.1 => 50.1

### DIFF
--- a/manifest/armv7l/g/gsettings_desktop_schemas.filelist
+++ b/manifest/armv7l/g/gsettings_desktop_schemas.filelist
@@ -1,4 +1,4 @@
-# Total size: 5986054
+# Total size: 6395231
 /usr/local/include/gsettings-desktop-schemas/gdesktop-enums.h
 /usr/local/lib/girepository-1.0/GDesktopEnums-3.0.typelib
 /usr/local/share/GConf/gsettings/gsettings-desktop-schemas.convert

--- a/manifest/x86_64/g/gsettings_desktop_schemas.filelist
+++ b/manifest/x86_64/g/gsettings_desktop_schemas.filelist
@@ -1,4 +1,4 @@
-# Total size: 5986054
+# Total size: 6395231
 /usr/local/include/gsettings-desktop-schemas/gdesktop-enums.h
 /usr/local/lib64/girepository-1.0/GDesktopEnums-3.0.typelib
 /usr/local/share/GConf/gsettings/gsettings-desktop-schemas.convert

--- a/packages/gsettings_desktop_schemas.rb
+++ b/packages/gsettings_desktop_schemas.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Gsettings_desktop_schemas < Meson
   description 'Collection of GSettings schemas for GNOME desktop.'
   homepage 'https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas'
-  version '49.1'
+  version '50.1'
   license 'LGPL-2.1+'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas.git'
@@ -11,9 +11,9 @@ class Gsettings_desktop_schemas < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2bd792a903c09a81c5eba9507767d3c2084ab0b89fd98d9b015b5c401285e88d',
-     armv7l: '2bd792a903c09a81c5eba9507767d3c2084ab0b89fd98d9b015b5c401285e88d',
-     x86_64: 'fe86343441cbca7b82c36f07623a3ebf77a4b8dbb967dba310244715c7d6a2a6'
+    aarch64: 'e8e83600b2ffd1d4a126e9160b1dc916c263ddbe13c88566a5aa304da185d932',
+     armv7l: 'e8e83600b2ffd1d4a126e9160b1dc916c263ddbe13c88566a5aa304da185d932',
+     x86_64: '9919ac7be6fb7a8ed8b5bf34f90aaba7699fef21e9dad77586a7d209b0f9689f'
   })
 
   depends_on 'glib' => :build


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gsettings_desktop_schemas crew update \
&& yes | crew upgrade
```
