### PR TITLE
Gsm 1.0.23 => 1.0.24

### DIFF
--- a/manifest/armv7l/g/gsm.filelist
+++ b/manifest/armv7l/g/gsm.filelist
@@ -1,4 +1,4 @@
-# Total size: 497205
+# Total size: 497189
 /usr/local/bin/tcat
 /usr/local/bin/toast
 /usr/local/bin/untoast

--- a/manifest/i686/g/gsm.filelist
+++ b/manifest/i686/g/gsm.filelist
@@ -1,4 +1,4 @@
-# Total size: 442797
+# Total size: 441765
 /usr/local/bin/tcat
 /usr/local/bin/toast
 /usr/local/bin/untoast

--- a/manifest/x86_64/g/gsm.filelist
+++ b/manifest/x86_64/g/gsm.filelist
@@ -1,4 +1,4 @@
-# Total size: 480081
+# Total size: 479617
 /usr/local/bin/tcat
 /usr/local/bin/toast
 /usr/local/bin/untoast

--- a/packages/gsm.rb
+++ b/packages/gsm.rb
@@ -3,21 +3,22 @@ require 'package'
 class Gsm < Package
   description 'Shared libraries for GSM 06.10 lossy speech compression'
   homepage 'https://www.quut.com/gsm/'
-  version '1.0.23'
+  version '1.0.24'
   license 'gsm'
   compatibility 'all'
   source_url "https://www.quut.com/gsm/gsm-#{version}.tar.gz"
-  source_sha256 '8b7591a85ac9adce858f2053005e6b2eb20c23b8b8a868dffb2969645fa323c0'
+  source_sha256 'a3c40c6471928383f4abfcb2e8f24012a1f562be2f17b8d672145d5986681a92'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '659c0eb1a7140734d4c6cfbfedae38fd616956901f2d69530a01ff7169adb279',
-     armv7l: '659c0eb1a7140734d4c6cfbfedae38fd616956901f2d69530a01ff7169adb279',
-       i686: 'e48c6609c640a88d5eccc20dc9c44ebdeba8ff835d1b5bf94739bd5547db0547',
-     x86_64: 'bb114f37bbd159fbd29c473891b4f8ac3f8665dc0697a158f1508c02021e96e3'
+    aarch64: 'a692a3c60d8d84d3b7057180a826335df9e1a7e35662361e69954e50ecde2866',
+     armv7l: 'a692a3c60d8d84d3b7057180a826335df9e1a7e35662361e69954e50ecde2866',
+       i686: '518f2c55d8c5f7a2485cbff3c4929f28ce390cdbbc1d964b2f4fc69b4f6f6f55',
+     x86_64: '8031da6c2168e2d3f54b43b413c700d82f7d03158a4d6cc5cc3af4505dd829c0'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 
   def self.build
     system "env CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \

--- a/tests/package/g/gsm
+++ b/tests/package/g/gsm
@@ -1,0 +1,7 @@
+#!/bin/bash
+tcat -h | head -5
+tcat -v
+toast -h | head -5
+toast -v
+untoast -h | head -5
+untoast -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-gsm crew update \
&& yes | crew upgrade

$ crew check gsm 
Checking gsm package ...
Library test for gsm passed.
Checking gsm package ...
Usage: tcat [-fcpdhvaulsFC] [files...]

 -f  force     Replace existing files without asking
 -c  cat       Write to stdout, do not remove source files
 -d  decode    Decode data (default is encode)
tcat 1.0, version $Id: toast.c,v 1.8 1996/07/02 10:41:04 jutta Exp $
Usage: toast [-fcpdhvaulsFC] [files...]

 -f  force     Replace existing files without asking
 -c  cat       Write to stdout, do not remove source files
 -d  decode    Decode data (default is encode)
toast 1.0, version $Id: toast.c,v 1.8 1996/07/02 10:41:04 jutta Exp $
Usage: untoast [-fcpdhvaulsFC] [files...]

 -f  force     Replace existing files without asking
 -c  cat       Write to stdout, do not remove source files
 -d  decode    Decode data (default is encode)
untoast 1.0, version $Id: toast.c,v 1.8 1996/07/02 10:41:04 jutta Exp $
Package tests for gsm passed.
```