### PR TITLE
Add py3cairo binaries. — py3cairo: 1.29.0-py3.14 → 1.29.0-py3.14

### DIFF
--- a/packages/py3cairo.rb
+++ b/packages/py3cairo.rb
@@ -10,6 +10,12 @@ class Py3cairo < Meson
   git_hashtag "v#{version.gsub("-#{CREW_PY_VER}", '')}"
   binary_compression 'tar.zst'
 
+  binary_sha256({
+    aarch64: '0c4dabe05355a5753cdb449584f81093aad714aae34e5e507759b616bd24ad59',
+     armv7l: '0c4dabe05355a5753cdb449584f81093aad714aae34e5e507759b616bd24ad59',
+     x86_64: '57ab0997fcf80d0855dba1483cc17a89f33bdc2bab7a02b302caab9a8bc96faf'
+  })
+
   depends_on 'cairo' => :library
   depends_on 'glibc' => :library
   depends_on 'glibc_lib' => :library


### PR DESCRIPTION
## Description
#### Commits:
-  53b5c3b9c Add py3cairo binaries.
### Packages with Updated versions or Changed package files:
- `py3cairo`: 1.29.0-py3.14 &rarr; 1.29.0-py3.14 (current version is 1.29.0)
##
Builds attempted for:
- [x] `x86_64`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=py3cairo_binaries crew update \
&& yes | crew upgrade
```
