### PR TITLE
Add OpenSSL cert dir workaround and add --ignore-dependencies to gem installs.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1247,7 +1247,8 @@ def resolve_dependencies_and_install(no_advisory: false, ignore_dependencies: fa
                  else
                    resolve_dependencies + [@pkg.name]
                  end
-    free_space   = `df --output=avail #{CREW_PREFIX}`.lines(chomp: true).last.to_i * 1024
+    df_free_space, = Open3.capture3("df --output=avail #{CREW_PREFIX}")
+    free_space = df_free_space.empty? ? nil : df_free_space.lines(chomp: true).last.to_i * 1024
     install_size = to_install.sum do |pkg|
       filelist = "#{CREW_LIB_PATH}/manifest/#{ARCH}/#{pkg[0]}/#{pkg}.filelist"
       if File.exist?(filelist)
@@ -1257,7 +1258,7 @@ def resolve_dependencies_and_install(no_advisory: false, ignore_dependencies: fa
       end
     end
 
-    if free_space < install_size
+    if !free_space.nil? && free_space < install_size
       abort <<~EOT.chomp.lightred
         #{@pkg.name.capitalize} needs #{MiscFunctions.human_size(install_size)} of disk space to install.
 
@@ -1272,7 +1273,7 @@ def resolve_dependencies_and_install(no_advisory: false, ignore_dependencies: fa
 
         #{to_install.join(' ')}
 
-        After installation, #{MiscFunctions.human_size(install_size)} of extra disk space will be taken. (#{MiscFunctions.human_size(free_space)} of free disk space available)
+        After installation, #{MiscFunctions.human_size(install_size)} of extra disk space will be taken. (#{MiscFunctions.human_size(free_space)} of free disk space available.)
 
       EOT
 

--- a/commands/check.rb
+++ b/commands/check.rb
@@ -93,7 +93,7 @@ class Command
 
     return false if !force && to_copy_filelist && !Package.agree_default_yes("\nWould you like to copy #{local_filelist} to crew and start the #{operation}")
 
-    if to_copy_package && File.file?(local_package)
+    if to_copy_package && File.file?(local_package) && !FileUtils.compare_file(local_package, crew_package)
       FileUtils.copy_file(local_package, crew_package)
       puts "Copied #{local_package} to #{CREW_PACKAGES_PATH}".lightgreen
     end

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -128,7 +128,7 @@ def install_gem_deps(gem_name = nil, gem_version = nil, gem_deps = nil)
       else
         install_pkg = Package.load_package("packages/#{gem_dep}.rb")
         crewlog "#{install_pkg.name} installed".orange if PackageUtils.installed?(install_pkg.name)
-        system("yes | crew install #{gem_dep}")
+        system("crew install -f #{gem_dep}")
       end
     else
       puts "Will not install #{gem_dep} from a Chromebrew package, as one does not exist.".orange
@@ -187,7 +187,7 @@ class RUBY < Package
 
     Kernel.system "gem fetch #{@ruby_gem_name} --platform=ruby --version=#{@ruby_gem_version}"
     Kernel.system "gem unpack #{@ruby_gem_name}-#{@ruby_gem_version}.gem"
-    system 'gem install --no-update-sources -N gem-compiler --conservative' unless Kernel.system('gem compile --help 2>/dev/null', %i[out err] => File::NULL)
+    system 'gem install --ignore-dependencies --no-update-sources -N gem-compiler --conservative' unless Kernel.system('gem compile --help 2>/dev/null', %i[out err] => File::NULL)
     system "gem compile --strip --prune #{@ruby_gem_name}-#{@ruby_gem_version}.gem -O #{CREW_DEST_DIR}/ -- --build-flags --with-cflags='#{CREW_LINKER_FLAGS}' --with-ldflags='#{CREW_LINKER_FLAGS}'"
     @just_built_gem = true
   end
@@ -219,7 +219,7 @@ class RUBY < Package
       end
       if File.file?("#{CREW_DEST_DIR}/#{@ruby_gem_name}-#{@ruby_gem_version}-#{GEM_ARCH}.gem") && (gem_sha256 == gem_pkg_sha256sum || @just_built_gem)
         puts "Installing #{@ruby_gem_name} gem #{@ruby_gem_version}...".orange
-        Kernel.system "gem install --no-update-sources -N --local #{CREW_DEST_DIR}/#{@ruby_gem_name}-#{@ruby_gem_version}-#{GEM_ARCH}.gem --conservative"
+        Kernel.system "gem install --ignore-dependencies --no-update-sources -N --local #{CREW_DEST_DIR}/#{@ruby_gem_name}-#{@ruby_gem_version}-#{GEM_ARCH}.gem --conservative"
       end
     elsif !@gem_latest_version_installed || Gem::Version.new(@ruby_gem_version) <= Gem::Version.new(@json_gem_pkg_version)
       puts "Updating #{@ruby_gem_name} gem: #{@gem_installed_version} 🔜 #{@ruby_gem_version} ...".orange

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.74.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.74.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/misc_functions.rb
+++ b/lib/misc_functions.rb
@@ -5,6 +5,9 @@ require_relative 'color'
 
 class MiscFunctions
   def self.human_size(bytes)
+    # Handle if function is passed nil because disk space can not be
+    # determined.
+    return 'Unknown YB' if bytes.nil?
     kilobyte = 1024.0
     megabyte = kilobyte * kilobyte
     gigabyte = megabyte * kilobyte

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -148,7 +148,7 @@ class PackageUtils
       # See https://github.com/ruby/openssl/issues/949 for some
       # discussion of this error.
       # http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      puts "SSL error for https://rubygems.org with SSL_CERT_DIR #{SSL_CERT_DIR}:\n#{e}\n Using /et/ssl/certs SSL_CERT_DIR fallback.".lightred if CREW_VERBOSE
+      puts "SSL error for https://rubygems.org with SSL_CERT_DIR #{SSL_CERT_DIR}:\n#{e}\n Using /etc/ssl/certs SSL_CERT_DIR fallback.".lightred if CREW_VERBOSE
       http.ca_path = '/etc/ssl/certs'
       response = http.request(request)
     end

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -144,9 +144,12 @@ class PackageUtils
     request = Net::HTTP::Get.new(url.path)
     begin
       response = http.request(request)
-    rescue OpenSSL::SSL::SSLError
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      puts "SSL error for https://rubygems.org with SSL_CERT_DIR #{SSL_CERT_DIR}.".lightred
+    rescue OpenSSL::SSL::SSLError => e
+      # See https://github.com/ruby/openssl/issues/949 for some
+      # discussion of this error.
+      # http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      puts "SSL error for https://rubygems.org with SSL_CERT_DIR #{SSL_CERT_DIR}:\n#{e}\n Using /et/ssl/certs SSL_CERT_DIR fallback.".lightred if CREW_VERBOSE
+      http.ca_path = '/etc/ssl/certs'
       response = http.request(request)
     end
     ruby_gem_json = JSON.parse(response.body)


### PR DESCRIPTION
## Description
- I will add a caveat here that with this change to add `--ignore-dependencies` to the gem installs that we will have to be vigilant if the dependencies on gems change, otherwise we might get breakage. `tools/create_gem_packages.rb` can create a package and add required gems, so we might want to modify that at some point to recursively check gem packages to see if we are missing dependencies. @Zopolis4 if you want to take a look at that?

#### Commits:
-  bd5373ef5 Add OpenSSL cert dir workaround and add --ignore-dependencies to gem installs.
### Other changed files:
- bin/crew
- commands/check.rb
- lib/buildsystems/ruby.rb
- lib/misc_functions.rb
- lib/package_utils.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=gem_install crew update \
&& yes | crew upgrade
```
