### PR TITLE
Halibut 1.2 => 1.3

### DIFF
--- a/manifest/armv7l/h/halibut.filelist
+++ b/manifest/armv7l/h/halibut.filelist
@@ -1,3 +1,16 @@
-# Total size: 1490190
+# Total size: 1371762
 /usr/local/bin/halibut
-/usr/local/man/man1/halibut.1
+/usr/local/share/doc/halibut/IndexPage.html
+/usr/local/share/doc/halibut/index.html
+/usr/local/share/doc/halibut/input.html
+/usr/local/share/doc/halibut/intro.html
+/usr/local/share/doc/halibut/licence.html
+/usr/local/share/doc/halibut/manpage.html
+/usr/local/share/doc/halibut/output.html
+/usr/local/share/doc/halibut/running.html
+/usr/local/share/info/halibut.info-1.zst
+/usr/local/share/info/halibut.info-2.zst
+/usr/local/share/info/halibut.info-3.zst
+/usr/local/share/info/halibut.info-4.zst
+/usr/local/share/info/halibut.info.zst
+/usr/local/share/man/man1/halibut.1.zst

--- a/manifest/i686/h/halibut.filelist
+++ b/manifest/i686/h/halibut.filelist
@@ -1,3 +1,16 @@
-# Total size: 1407040
+# Total size: 1543487
 /usr/local/bin/halibut
-/usr/local/man/man1/halibut.1.gz
+/usr/local/share/doc/halibut/IndexPage.html
+/usr/local/share/doc/halibut/index.html
+/usr/local/share/doc/halibut/input.html
+/usr/local/share/doc/halibut/intro.html
+/usr/local/share/doc/halibut/licence.html
+/usr/local/share/doc/halibut/manpage.html
+/usr/local/share/doc/halibut/output.html
+/usr/local/share/doc/halibut/running.html
+/usr/local/share/info/halibut.info-1.zst
+/usr/local/share/info/halibut.info-2.zst
+/usr/local/share/info/halibut.info-3.zst
+/usr/local/share/info/halibut.info-4.zst
+/usr/local/share/info/halibut.info.zst
+/usr/local/share/man/man1/halibut.1.zst

--- a/manifest/x86_64/h/halibut.filelist
+++ b/manifest/x86_64/h/halibut.filelist
@@ -1,3 +1,16 @@
-# Total size: 1563916
+# Total size: 1710639
 /usr/local/bin/halibut
-/usr/local/man/man1/halibut.1.gz
+/usr/local/share/doc/halibut/IndexPage.html
+/usr/local/share/doc/halibut/index.html
+/usr/local/share/doc/halibut/input.html
+/usr/local/share/doc/halibut/intro.html
+/usr/local/share/doc/halibut/licence.html
+/usr/local/share/doc/halibut/manpage.html
+/usr/local/share/doc/halibut/output.html
+/usr/local/share/doc/halibut/running.html
+/usr/local/share/info/halibut.info-1.zst
+/usr/local/share/info/halibut.info-2.zst
+/usr/local/share/info/halibut.info-3.zst
+/usr/local/share/info/halibut.info-4.zst
+/usr/local/share/info/halibut.info.zst
+/usr/local/share/man/man1/halibut.1.zst

--- a/packages/halibut.rb
+++ b/packages/halibut.rb
@@ -1,33 +1,24 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Halibut < Package
+class Halibut < CMake
   description 'Halibut is a documentation production system, with elements similar to TeX, debiandoc-sgml, TeXinfo, and others.'
   homepage 'https://www.chiark.greenend.org.uk/~sgtatham/halibut/'
-  version '1.2'
+  version '1.3'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.chiark.greenend.org.uk/~sgtatham/halibut/halibut-1.2/halibut-1.2.tar.gz'
-  source_sha256 '1aedfb6240f27190c36a390fcac9ce732edbdbaa31c85ee675b994e2b083163f'
-  binary_compression 'tar.xz'
+  source_url "https://www.chiark.greenend.org.uk/~sgtatham/halibut/halibut-#{version}/halibut-#{version}.tar.gz"
+  source_sha256 'aaa0f7696f17f74f42d97d0880aa088f5d68ed3079f3ed15d13b6e74909d3132'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '04f12bb5ff68ea5c4c279f98591f8b98e07ec60286dff0bcadf5c20a5a42e257',
-     armv7l: '04f12bb5ff68ea5c4c279f98591f8b98e07ec60286dff0bcadf5c20a5a42e257',
-       i686: '8281a31fe9ebfe71053d6a219064714470fe1e8261ab6483a85e731604e64d1b',
-     x86_64: '93bd79b97de9b7be01ccbe82ab3272ad9be6ead4e26376ac2ce4529e5b50a9dc'
+    aarch64: '6fca8d925335afcce21b9d8259602c8fafdc10549b6501fcb2b35f2dace995e2',
+     armv7l: '6fca8d925335afcce21b9d8259602c8fafdc10549b6501fcb2b35f2dace995e2',
+       i686: 'c2d2b3455e26ec0272d473d868f5d49dcc4ae37ce10bc7dd7aefcbfb2059cf67',
+     x86_64: 'b39d24f538cb1ed90c436b0d5479e7d6fed08266378f218773c977fc5290dc40'
   })
 
-  def self.build
-    system 'make'
-    FileUtils.cd('doc') do
-      system 'make'
-    end
-  end
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 
-  def self.install
-    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
-    system "mkdir -p #{CREW_DEST_PREFIX}/man/man1"
-    system "cp build/halibut #{CREW_DEST_PREFIX}/bin"
-    system "cp doc/halibut.1 #{CREW_DEST_PREFIX}/man/man1"
-  end
+  cmake_options '-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
 end

--- a/tests/package/h/halibut
+++ b/tests/package/h/halibut
@@ -1,0 +1,3 @@
+#!/bin/bash
+halibut --help | head
+halibut --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-halibut crew update \
&& yes | crew upgrade

$ crew check halibut 
Checking halibut package ...
Library test for halibut passed.
Checking halibut package ...
usage:   halibut [options] files
options: --text[=filename]     generate plain text output
         --html[=filename]     generate HTML or XHTML output
         --chm[=filename]      generate Windows HTML Help output
         --winhelp[=filename]  generate legacy Windows Help output
         --man[=filename]      generate man page output
         --info[=filename]     generate GNU info output
         --ps[=filename]       generate PostScript output
         --pdf[=filename]      generate PDF output
         -Cfoo:bar:baz         append \cfg{foo}{bar}{baz} to input
Halibut, version 1.3
Package tests for halibut passed.
```