### PR TITLE
Haveged 1.9.14 => 1.9.22

### DIFF
--- a/manifest/armv7l/h/haveged.filelist
+++ b/manifest/armv7l/h/haveged.filelist
@@ -1,4 +1,4 @@
-# Total size: 908315
+# Total size: 617821
 /usr/local/bin/haveged
 /usr/local/include/haveged/havege.h
 /usr/local/lib/libhavege.a
@@ -6,5 +6,5 @@
 /usr/local/lib/libhavege.so
 /usr/local/lib/libhavege.so.2
 /usr/local/lib/libhavege.so.2.0.0
-/usr/local/share/man/man3/libhavege.3.gz
-/usr/local/share/man/man8/haveged.8.gz
+/usr/local/share/man/man3/libhavege.3.zst
+/usr/local/share/man/man8/haveged.8.zst

--- a/manifest/i686/h/haveged.filelist
+++ b/manifest/i686/h/haveged.filelist
@@ -1,4 +1,4 @@
-# Total size: 700623
+# Total size: 619195
 /usr/local/bin/haveged
 /usr/local/include/haveged/havege.h
 /usr/local/lib/libhavege.a
@@ -6,5 +6,5 @@
 /usr/local/lib/libhavege.so
 /usr/local/lib/libhavege.so.2
 /usr/local/lib/libhavege.so.2.0.0
-/usr/local/share/man/man3/libhavege.3.gz
-/usr/local/share/man/man8/haveged.8.gz
+/usr/local/share/man/man3/libhavege.3.zst
+/usr/local/share/man/man8/haveged.8.zst

--- a/manifest/x86_64/h/haveged.filelist
+++ b/manifest/x86_64/h/haveged.filelist
@@ -1,4 +1,4 @@
-# Total size: 901109
+# Total size: 639175
 /usr/local/bin/haveged
 /usr/local/include/haveged/havege.h
 /usr/local/lib64/libhavege.a
@@ -6,5 +6,5 @@
 /usr/local/lib64/libhavege.so
 /usr/local/lib64/libhavege.so.2
 /usr/local/lib64/libhavege.so.2.0.0
-/usr/local/share/man/man3/libhavege.3.gz
-/usr/local/share/man/man8/haveged.8.gz
+/usr/local/share/man/man3/libhavege.3.zst
+/usr/local/share/man/man8/haveged.8.zst

--- a/packages/haveged.rb
+++ b/packages/haveged.rb
@@ -1,37 +1,35 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Haveged < Package
+class Haveged < Autotools
   description 'A simple entropy daemon based on the HAVEGE algorithm, significantly faster than /dev/urandom.'
   homepage 'https://issihosts.com/haveged/'
-  version '1.9.14'
+  version '1.9.22'
   license 'GPL-3+'
   compatibility 'all'
-  source_url 'https://github.com/jirka-h/haveged/archive/v1.9.14.tar.gz'
-  source_sha256 '938cb494bcad7e4f24e61eb50fab4aa0acbc3240c80f3ad5c6cf7e6e922618c3'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/jirka-h/haveged.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '9089376d8df95644f812c8f9226e729e12fb68c4ebe4c365a52862f0d7ba1fc9',
-     armv7l: '9089376d8df95644f812c8f9226e729e12fb68c4ebe4c365a52862f0d7ba1fc9',
-       i686: 'c3f4e3381887a68cc8a0b1194d8b16012d268dde46b32b74c1009a1b89fcd2dd',
-     x86_64: 'ed0492d5350f653b8ea93ef67ea1da5d611d3988879aa59c8c735810789da0f5'
+    aarch64: '75259359f5c0e602394376f25b06db15b2ed3c605ea7ea256522f398debdae4d',
+     armv7l: '75259359f5c0e602394376f25b06db15b2ed3c605ea7ea256522f398debdae4d',
+       i686: '9d58e2f93d8e127a05de0ce8ce423b997171095f7522a707f3aa0d704576290d',
+     x86_64: '6b6928656b656366240ab29b5a730af40f6391d48e9c5116933f3af0d9fbeb03'
   })
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS} \
-            --disable-daemon \
-            --enable-nistest \
-            --enable-enttest \
-            --enable-olt \
-            --enable-threads"
-    system 'make'
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+
+  autotools_configure_options ' \
+    --disable-daemon \
+    --enable-nistest \
+    --enable-enttest \
+    --enable-olt \
+    --enable-threads'
+
+  def self.prebuild
+    system 'autoreconf -fiv'
   end
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.check
-    system 'make', 'check'
-  end
+  run_tests
 end

--- a/tests/package/h/haveged
+++ b/tests/package/h/haveged
@@ -1,0 +1,3 @@
+#!/bin/bash
+haveged -h 2>&1 | head
+haveged -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-haveged crew update \
&& yes | crew upgrade

$ crew check haveged 
Checking haveged package ...
Library test for haveged passed.
Checking haveged package ...

Usage: haveged [options]

Collect entropy and feed into random pool or write to file.
  Options:
     --buffer       , -b [] Buffer size [KW], default: 128
     --data         , -d [] Data cache size [KB], with fallback to: 16
     --command      , -c [] Send a command mode to an already running haveged
     --inst         , -i [] Instruction cache size [KB], with fallback to: 16
     --file         , -f [] Sample output file,  default: 'sample', '-' for stdout
haveged 1.9.22

Copyright (C) 2018-2026 Jirka Hladky <hladky.jiri@gmail.com>
Copyright (C) 2009-2014 Gary Wuertz <gary@issiweb.com>
Copyright (C) 2011-2012 BenEleventh Consulting <manolson@beneleventh.com>

License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Package tests for haveged passed.
```