### PR TITLE
Hdparm 9.32 => 9.65

### DIFF
--- a/manifest/armv7l/h/hdparm.filelist
+++ b/manifest/armv7l/h/hdparm.filelist
@@ -1,3 +1,3 @@
-# Total size: 102639
+# Total size: 128661
 /usr/local/sbin/hdparm
-/usr/local/share/man/man8/hdparm.8.gz
+/usr/local/share/man/man8/hdparm.8.zst

--- a/manifest/i686/h/hdparm.filelist
+++ b/manifest/i686/h/hdparm.filelist
@@ -1,3 +1,3 @@
-# Total size: 126547
+# Total size: 170365
 /usr/local/sbin/hdparm
-/usr/local/share/man/man8/hdparm.8.gz
+/usr/local/share/man/man8/hdparm.8.zst

--- a/manifest/x86_64/h/hdparm.filelist
+++ b/manifest/x86_64/h/hdparm.filelist
@@ -1,3 +1,3 @@
-# Total size: 114075
+# Total size: 162033
 /usr/local/sbin/hdparm
-/usr/local/share/man/man8/hdparm.8.gz
+/usr/local/share/man/man8/hdparm.8.zst

--- a/packages/hdparm.rb
+++ b/packages/hdparm.rb
@@ -3,23 +3,29 @@ require 'package'
 class Hdparm < Package
   description 'hdparm is a GNU/Linux shell utility for viewing and manipulating various IDE drive and driver parameters.'
   homepage 'https://directory.fsf.org/wiki/Hdparm'
-  version '9.32'
+  version '9.65'
   license 'BSD and GPL-2'
   compatibility 'all'
-  source_url 'http://www.ibiblio.org/pub/Linux/system/hardware/hdparm-9.32.tar.gz'
-  source_sha256 '90d80632695759ec12c8a9da94471f04bc88d5b73d34fc6a370775b534d09319'
-  binary_compression 'tar.xz'
+  source_url "https://downloads.sourceforge.net/project/hdparm/hdparm/hdparm-#{version}.tar.gz"
+  source_sha256 'd14929f910d060932e717e9382425d47c2e7144235a53713d55a94f7de535a4b'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f796fcce23fca3c9a2830533b5cb63da0fc2be44c12e8e102db3f06ecf3d3a4e',
-     armv7l: 'f796fcce23fca3c9a2830533b5cb63da0fc2be44c12e8e102db3f06ecf3d3a4e',
-       i686: '7d0b697a2a64ec02a2b9938f0942b30922afc167daae5a05fea06dc4b480c1b3',
-     x86_64: '2c8d90661eaee768b43a87ac0c659fa2f9d24a3b83ef904f0cee61669e867724'
+    aarch64: '23f018926ee1d887b6aab0b2c4d90dcc8df16a081daeebc49e41d0a279bad46d',
+     armv7l: '23f018926ee1d887b6aab0b2c4d90dcc8df16a081daeebc49e41d0a279bad46d',
+       i686: '725a35873d65a5c43bff13bffd7216488b64cf835b82669187f62a37fa658f3d',
+     x86_64: 'eff15bef5a29e1fde9fcdd4154f970c475d850b326b41be6d105517fb9264faa'
   })
 
-  def self.build
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+
+  def self.patch
     system "sed -i 's,binprefix = ,binprefix = #{CREW_PREFIX},' Makefile"
     system "sed -i 's,manprefix = /usr,manprefix = #{CREW_PREFIX},' Makefile"
+  end
+
+  def self.build
     system 'make'
   end
 

--- a/tests/package/h/hdparm
+++ b/tests/package/h/hdparm
@@ -1,0 +1,3 @@
+#!/bin/bash
+hdparm -h | head
+hdparm -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-hdparm crew update \
&& yes | crew upgrade

$ crew check hdparm 
Checking hdparm package ...
Library test for hdparm passed.
Checking hdparm package ...

hdparm - get/set hard disk parameters - version v9.65, by Mark Lord.

Usage:  hdparm  [options] [device ...]

Options:
 -a   Get/set fs readahead
 -A   Get/set the drive look-ahead flag (0/1)
 -b   Get/set bus state (0 == off, 1 == on, 2 == tristate)
 -B   Set Advanced Power Management setting (1-255)
hdparm v9.65
Package tests for hdparm passed.
```