### PR TITLE
Hello 2.12 => 2.12.3

### DIFF
--- a/manifest/armv7l/h/hello.filelist
+++ b/manifest/armv7l/h/hello.filelist
@@ -1,9 +1,10 @@
-# Total size: 111751
+# Total size: 192524
 /usr/local/bin/hello
-/usr/local/share/info/hello.info.gz
+/usr/local/share/info/hello.info.zst
 /usr/local/share/locale/ast/LC_MESSAGES/hello.mo
 /usr/local/share/locale/bg/LC_MESSAGES/hello.mo
 /usr/local/share/locale/ca/LC_MESSAGES/hello.mo
+/usr/local/share/locale/cs/LC_MESSAGES/hello.mo
 /usr/local/share/locale/da/LC_MESSAGES/hello.mo
 /usr/local/share/locale/de/LC_MESSAGES/hello.mo
 /usr/local/share/locale/el/LC_MESSAGES/hello.mo
@@ -34,6 +35,7 @@
 /usr/local/share/locale/pt_BR/LC_MESSAGES/hello.mo
 /usr/local/share/locale/ro/LC_MESSAGES/hello.mo
 /usr/local/share/locale/ru/LC_MESSAGES/hello.mo
+/usr/local/share/locale/scn/LC_MESSAGES/hello.mo
 /usr/local/share/locale/sk/LC_MESSAGES/hello.mo
 /usr/local/share/locale/sl/LC_MESSAGES/hello.mo
 /usr/local/share/locale/sr/LC_MESSAGES/hello.mo
@@ -45,4 +47,4 @@
 /usr/local/share/locale/vi/LC_MESSAGES/hello.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/hello.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/hello.mo
-/usr/local/share/man/man1/hello.1.gz
+/usr/local/share/man/man1/hello.1.zst

--- a/manifest/i686/h/hello.filelist
+++ b/manifest/i686/h/hello.filelist
@@ -1,9 +1,10 @@
-# Total size: 98007
+# Total size: 205944
 /usr/local/bin/hello
-/usr/local/share/info/hello.info.gz
+/usr/local/share/info/hello.info.zst
 /usr/local/share/locale/ast/LC_MESSAGES/hello.mo
 /usr/local/share/locale/bg/LC_MESSAGES/hello.mo
 /usr/local/share/locale/ca/LC_MESSAGES/hello.mo
+/usr/local/share/locale/cs/LC_MESSAGES/hello.mo
 /usr/local/share/locale/da/LC_MESSAGES/hello.mo
 /usr/local/share/locale/de/LC_MESSAGES/hello.mo
 /usr/local/share/locale/el/LC_MESSAGES/hello.mo
@@ -34,6 +35,7 @@
 /usr/local/share/locale/pt_BR/LC_MESSAGES/hello.mo
 /usr/local/share/locale/ro/LC_MESSAGES/hello.mo
 /usr/local/share/locale/ru/LC_MESSAGES/hello.mo
+/usr/local/share/locale/scn/LC_MESSAGES/hello.mo
 /usr/local/share/locale/sk/LC_MESSAGES/hello.mo
 /usr/local/share/locale/sl/LC_MESSAGES/hello.mo
 /usr/local/share/locale/sr/LC_MESSAGES/hello.mo
@@ -45,4 +47,4 @@
 /usr/local/share/locale/vi/LC_MESSAGES/hello.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/hello.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/hello.mo
-/usr/local/share/man/man1/hello.1.gz
+/usr/local/share/man/man1/hello.1.zst

--- a/manifest/x86_64/h/hello.filelist
+++ b/manifest/x86_64/h/hello.filelist
@@ -1,9 +1,10 @@
-# Total size: 116299
+# Total size: 204992
 /usr/local/bin/hello
-/usr/local/share/info/hello.info.gz
+/usr/local/share/info/hello.info.zst
 /usr/local/share/locale/ast/LC_MESSAGES/hello.mo
 /usr/local/share/locale/bg/LC_MESSAGES/hello.mo
 /usr/local/share/locale/ca/LC_MESSAGES/hello.mo
+/usr/local/share/locale/cs/LC_MESSAGES/hello.mo
 /usr/local/share/locale/da/LC_MESSAGES/hello.mo
 /usr/local/share/locale/de/LC_MESSAGES/hello.mo
 /usr/local/share/locale/el/LC_MESSAGES/hello.mo
@@ -34,6 +35,7 @@
 /usr/local/share/locale/pt_BR/LC_MESSAGES/hello.mo
 /usr/local/share/locale/ro/LC_MESSAGES/hello.mo
 /usr/local/share/locale/ru/LC_MESSAGES/hello.mo
+/usr/local/share/locale/scn/LC_MESSAGES/hello.mo
 /usr/local/share/locale/sk/LC_MESSAGES/hello.mo
 /usr/local/share/locale/sl/LC_MESSAGES/hello.mo
 /usr/local/share/locale/sr/LC_MESSAGES/hello.mo
@@ -45,4 +47,4 @@
 /usr/local/share/locale/vi/LC_MESSAGES/hello.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/hello.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/hello.mo
-/usr/local/share/man/man1/hello.1.gz
+/usr/local/share/man/man1/hello.1.zst

--- a/packages/hello.rb
+++ b/packages/hello.rb
@@ -1,34 +1,22 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Hello < Package
+class Hello < Autotools
   description 'GNU Hello is another implementation of the classic program that prints “Hello, world!”'
   homepage 'https://www.gnu.org/software/hello/'
-  version '2.12'
+  version '2.12.3'
   license 'FDL-1.3 GPL-3'
   compatibility 'all'
-  source_url 'https://ftp.gnu.org/gnu/hello/hello-2.12.tar.gz'
-  source_sha256 'cf04af86dc085268c5f4470fbae49b18afbc221b78096aab842d934a76bad0ab'
+  source_url "https://ftp.gnu.org/gnu/hello/hello-#{version}.tar.gz"
+  source_sha256 '0d5f60154382fee10b114a1c34e785d8b1f492073ae2d3a6f7b147687b366aa0'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1ffdc1749b56194ef9913c92d98aa29b2ed7592eb9c52828f0e458da9a84f977',
-     armv7l: '1ffdc1749b56194ef9913c92d98aa29b2ed7592eb9c52828f0e458da9a84f977',
-       i686: 'c75ebf55540a37f20fdcb80c4c0157d88ce8f269e16bf158fe35b41c37427a41',
-     x86_64: '432d72ce76e2224d5af08ddaa323b577dd625cfac7feefe18866c9afdf3b1190'
+    aarch64: 'c63124375c8ab30bbea41bee61adc596b8f48438ea3f805825e68922c61de952',
+     armv7l: 'c63124375c8ab30bbea41bee61adc596b8f48438ea3f805825e68922c61de952',
+       i686: 'fc0abcba774d6763f2dc7f0b5a459523132800e0baed90188def92968ebf2573',
+     x86_64: '6f098bd789a71eb5c5a64d6aaf735a798f421f46ee8ade36d1fa22a3ead4f58c'
   })
 
   depends_on 'glibc' => :executable
-
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.check
-    system 'make', 'check'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  depends_on 'glibc_lib' => :executable
 end

--- a/tests/package/h/hello
+++ b/tests/package/h/hello
@@ -1,0 +1,3 @@
+#!/bin/bash
+hello --help
+hello --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-hello crew update \
&& yes | crew upgrade

$ crew check hello 
Checking hello package ...
Library test for hello passed.
Checking hello package ...
Usage: hello [OPTION]...
Print a friendly, customizable greeting.

  -t, --traditional       use traditional greeting
  -g, --greeting=TEXT     use TEXT as the greeting message

      --help     display this help and exit
      --version  output version information and exit

Report bugs to: bug-hello@gnu.org
GNU Hello home page: <https://www.gnu.org/software/hello/>
General help using GNU software: <https://www.gnu.org/gethelp/>
hello (GNU Hello) 
Copyright (C) 2026 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Karl Berry, Sami Kerola, Jim Meyering,
and Reuben Thomas.
Package tests for hello passed.
```