### PR TITLE
Fix prompt to copy local repo package to crew

### DIFF
--- a/commands/check.rb
+++ b/commands/check.rb
@@ -93,7 +93,7 @@ class Command
 
     return false if !force && to_copy_filelist && !Package.agree_default_yes("\nWould you like to copy #{local_filelist} to crew and start the #{operation}")
 
-    if to_copy_package && File.file?(local_package) && !FileUtils.compare_file(local_package, crew_package)
+    if to_copy_package && File.file?(local_package) && (!File.file?(crew_package) || !FileUtils.identical?(local_package, crew_package))
       FileUtils.copy_file(local_package, crew_package)
       puts "Copied #{local_package} to #{CREW_PACKAGES_PATH}".lightgreen
     end


### PR DESCRIPTION
Before:
```
$ crew install perl_javascript_beautifier -f
/usr/local/lib/ruby/4.0.0/fileutils.rb:1506:in 'File.size': No such file or directory @ rb_file_s_size - /usr/local/lib/crew/packages/perl_javascript_beautifier.rb (Errno::ENOENT)
	from /usr/local/lib/ruby/4.0.0/fileutils.rb:1506:in 'FileUtils.compare_file'
	from /usr/local/lib/crew/commands/check.rb:96:in 'Command.check'
	from /usr/local/bin/crew:2104:in 'block in Object#install_command'
	from /usr/local/bin/crew:2096:in 'Array#each'
	from /usr/local/bin/crew:2096:in 'Object#install_command'
	from /usr/local/bin/crew:2248:in '<main>'
```
After:
$ crew install perl_javascript_beautifier -f
Copied /home/chronos/user/chromebrew/packages/perl_javascript_beautifier.rb to /usr/local/lib/crew/packages
Copied /home/chronos/user/chromebrew/tests/package/p/perl_javascript_beautifier to /usr/local/lib/crew/tests/package/p
perl_javascript_beautifier: command tool to beautify your javascript files
https://metacpan.org/dist/JavaScript-Beautifier
Version: 0.25-perl5.42
License: perl_5
Performing pre-flight checks for perl_javascript_beautifier...

The following package(s) will be installed:

perl_javascript_beautifier

After installation, 0.00 B of extra disk space will be taken. (105.73 GB of free disk space available.)

Proceeding with package installation...
perl_javascript_beautifier: command tool to beautify your javascript files
Precompiled binary available, downloading...
```
