### PR TITLE
Yarn 1.22.21 => 1.22.22

### DIFF
--- a/manifest/armv7l/y/yarn.filelist
+++ b/manifest/armv7l/y/yarn.filelist
@@ -1,0 +1,6 @@
+# Total size: 5317887
+/usr/local/bin/yarn
+/usr/local/bin/yarn.js
+/usr/local/bin/yarnpkg
+/usr/local/lib/cli.js
+/usr/local/lib/v8-compile-cache.js

--- a/manifest/i686/y/yarn.filelist
+++ b/manifest/i686/y/yarn.filelist
@@ -1,0 +1,6 @@
+# Total size: 5332739
+/usr/local/bin/yarn
+/usr/local/bin/yarn.js
+/usr/local/bin/yarnpkg
+/usr/local/lib/cli.js
+/usr/local/lib/v8-compile-cache.js

--- a/manifest/x86_64/y/yarn.filelist
+++ b/manifest/x86_64/y/yarn.filelist
@@ -1,5 +1,6 @@
+# Total size: 5332743
 /usr/local/bin/yarn
 /usr/local/bin/yarn.js
 /usr/local/bin/yarnpkg
-/usr/local/lib/cli.js
-/usr/local/lib/v8-compile-cache.js
+/usr/local/lib64/cli.js
+/usr/local/lib64/v8-compile-cache.js

--- a/packages/yarn.rb
+++ b/packages/yarn.rb
@@ -3,18 +3,26 @@ require 'package'
 class Yarn < Package
   description 'Yarn is a new package manager for JavaScript and an alternative to npm.'
   homepage 'https://yarnpkg.com/en/'
-  version '1.22.21'
+  version '1.22.22'
   license 'BSD-2'
   compatibility 'all'
-  source_url 'https://github.com/yarnpkg/yarn/releases/download/v1.22.21/yarn-v1.22.21.tar.gz'
-  source_sha256 'a55bb4e85405f5dfd6e7154a444e7e33ad305d7ca858bad8546e932a6688df08'
+  source_url "https://github.com/yarnpkg/yarn/releases/download/v#{version}/yarn-v#{version}.tar.gz"
+  source_sha256 '88268464199d1611fcf73ce9c0a6c4d44c7d5363682720d8506f6508addf36a0'
 
   node_version = `node -v 2> /dev/null`.chomp
   depends_on 'nodebrew' unless node_version.to_s != ''
 
+  no_compile_needed
+
+  def self.patch
+    # Fix for fhs compliance.
+    system "sed -i 's,/lib/,/lib#{CREW_LIB_SUFFIX}/,' bin/yarn.js" if ARCH.eql?('x86_64')
+  end
+
   def self.install
-    FileUtils.mkdir_p CREW_DEST_PREFIX
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.rm_f ['bin/yarn.cmd', 'bin/yarnpkg.cmd']
-    FileUtils.cp_r ['bin/', 'lib/'], CREW_DEST_PREFIX
+    FileUtils.mv 'bin/', CREW_DEST_PREFIX
+    FileUtils.mv Dir['lib/*'], CREW_DEST_LIB_PREFIX
   end
 end

--- a/tests/package/y/yarn
+++ b/tests/package/y/yarn
@@ -1,0 +1,3 @@
+#!/bin/bash
+yarn -h | head
+yarn -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-yarn crew update \
&& yes | crew upgrade

$ crew check yarn 
Checking yarn package ...
Library test for yarn passed.
Checking yarn package ...

  Usage: yarn [command] [flags]

  Displays help information.

  Options:

    --cache-folder <path>               specify a custom folder that must be used to store the yarn cache
    --check-files                       install will verify file tree of packages for consistency
    --cwd <cwd>                         working directory to use (default: /home/chronos/user/chromebrew/packages)
1.22.22
Package tests for yarn passed.
```