### PR TITLE
Hunspell_base 1.7.2 => 1.7.3

### DIFF
--- a/manifest/armv7l/h/hunspell_base.filelist
+++ b/manifest/armv7l/h/hunspell_base.filelist
@@ -1,4 +1,4 @@
-# Total size: 5115449
+# Total size: 5128619
 /usr/local/bin/affixcompress
 /usr/local/bin/analyze
 /usr/local/bin/chmorph
@@ -20,7 +20,7 @@
 /usr/local/lib/libhunspell-1.7.la
 /usr/local/lib/libhunspell-1.7.so
 /usr/local/lib/libhunspell-1.7.so.0
-/usr/local/lib/libhunspell-1.7.so.0.0.1
+/usr/local/lib/libhunspell-1.7.so.0.1.0
 /usr/local/lib/pkgconfig/hunspell.pc
 /usr/local/share/man/hu/man1/hunspell.1.zst
 /usr/local/share/man/man1/hunspell.1.zst

--- a/manifest/i686/h/hunspell_base.filelist
+++ b/manifest/i686/h/hunspell_base.filelist
@@ -1,4 +1,4 @@
-# Total size: 5274507
+# Total size: 5577023
 /usr/local/bin/affixcompress
 /usr/local/bin/analyze
 /usr/local/bin/chmorph
@@ -20,7 +20,7 @@
 /usr/local/lib/libhunspell-1.7.la
 /usr/local/lib/libhunspell-1.7.so
 /usr/local/lib/libhunspell-1.7.so.0
-/usr/local/lib/libhunspell-1.7.so.0.0.1
+/usr/local/lib/libhunspell-1.7.so.0.1.0
 /usr/local/lib/pkgconfig/hunspell.pc
 /usr/local/share/man/hu/man1/hunspell.1.zst
 /usr/local/share/man/man1/hunspell.1.zst

--- a/manifest/x86_64/h/hunspell_base.filelist
+++ b/manifest/x86_64/h/hunspell_base.filelist
@@ -1,4 +1,4 @@
-# Total size: 5448020
+# Total size: 5797658
 /usr/local/bin/affixcompress
 /usr/local/bin/analyze
 /usr/local/bin/chmorph
@@ -20,7 +20,7 @@
 /usr/local/lib64/libhunspell-1.7.la
 /usr/local/lib64/libhunspell-1.7.so
 /usr/local/lib64/libhunspell-1.7.so.0
-/usr/local/lib64/libhunspell-1.7.so.0.0.1
+/usr/local/lib64/libhunspell-1.7.so.0.1.0
 /usr/local/lib64/pkgconfig/hunspell.pc
 /usr/local/share/man/hu/man1/hunspell.1.zst
 /usr/local/share/man/man1/hunspell.1.zst

--- a/packages/hunspell_base.rb
+++ b/packages/hunspell_base.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Hunspell_base < Autotools
   description 'Hunspell is a spell checker and morphological analyzer library'
   homepage 'http://hunspell.github.io/'
-  version '1.7.2'
+  version '1.7.3'
   license 'MPL-1.1, GPL-2 and LGPL-2.1'
   compatibility 'all'
   source_url 'https://github.com/hunspell/hunspell.git'
@@ -11,16 +11,17 @@ class Hunspell_base < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'c8c4db6f90ce30d23c176dc7eb8453ac91253fc181d763cb0f614fbb7bf59544',
-     armv7l: 'c8c4db6f90ce30d23c176dc7eb8453ac91253fc181d763cb0f614fbb7bf59544',
-       i686: 'e18ba0d501eec99d78a57667be100f9c7406edbcff9297534769ff10dea5dda1',
-     x86_64: '58fe35f3257cfba2233b0c3259b583d81cb59a4003ab1d0b6283300f198034bf'
+    aarch64: '4c225dcf41eca361066d3db5462061493e3593b17ac9780794cffa8985709060',
+     armv7l: '4c225dcf41eca361066d3db5462061493e3593b17ac9780794cffa8985709060',
+       i686: '6556856dec7e5426f8433e92d4883360a33e62e0e49d3d784131c5e30e914e31',
+     x86_64: '5332efd061c450b1143447ac21899c878765a9da7e0a01c9f4f17d2fd15d2ce9'
   })
 
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
-  depends_on 'ncurses' # R
-  depends_on 'readline'
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'ncurses' => :library
+  depends_on 'readline' => :executable
 
   def self.patch
     system "sed -i 's,/usr/share,#{CREW_PREFIX}/share,g' man/hunspell.1"
@@ -30,4 +31,8 @@ class Hunspell_base < Autotools
 
   autotools_pre_configure_options "CPPFLAGS+=' -I#{CREW_PREFIX}/include -I#{CREW_PREFIX}/include/ncursesw -I#{CREW_PREFIX}/include/ncurses '"
   autotools_configure_options '--with-ui --with-readline'
+
+  autotools_install_extras do
+    system "sed -i 's,/usr/bin/perl,#{CREW_PREFIX}/bin/perl,' #{CREW_DEST_PREFIX}/bin/ispellaff2myspell"
+  end
 end

--- a/tests/package/h/hunspell_base
+++ b/tests/package/h/hunspell_base
@@ -1,0 +1,3 @@
+#!/bin/bash
+hunspell -h 2>&1 | head
+hunspell -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-hunspell_base crew update \
&& yes | crew upgrade

$ crew check hunspell_base
Checking hunspell_base package ...
Library test for hunspell_base passed.
Checking hunspell_base package ...
Usage: hunspell [OPTION]... [FILE]...
Check spelling of each FILE. Without FILE, check standard input.

  -1		check only first field in lines (delimiter = tabulator)
  -a		Ispell's pipe interface
  --check-url	check URLs, e-mail addresses and directory paths
  --check-apostrophe	check Unicode typographic apostrophe
  -d d[,d2,...]	use d (d2 etc.) dictionaries
  -D		show available dictionaries
  -G		print only correct words or lines
@(#) International Ispell Version 3.2.06 (but really Hunspell 1.7.3)


Copyright (C) 2002-2022 László Németh. License: MPL/GPL/LGPL.

Based on OpenOffice.org's Myspell library.
Myspell's copyright (C) Kevin Hendricks, 2001-2002, License: BSD.

This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE,
to the extent permitted by law.
Package tests for hunspell_base passed.
```