### PR TITLE
Imgur v9 => v10.1

### DIFF
--- a/manifest/armv7l/i/imgur.filelist
+++ b/manifest/armv7l/i/imgur.filelist
@@ -1,2 +1,2 @@
-# Total size: 3161
+# Total size: 3440
 /usr/local/bin/imgur

--- a/manifest/i686/i/imgur.filelist
+++ b/manifest/i686/i/imgur.filelist
@@ -1,2 +1,2 @@
-# Total size: 3161
+# Total size: 3440
 /usr/local/bin/imgur

--- a/manifest/x86_64/i/imgur.filelist
+++ b/manifest/x86_64/i/imgur.filelist
@@ -1,2 +1,2 @@
-# Total size: 3161
+# Total size: 3440
 /usr/local/bin/imgur

--- a/packages/imgur.rb
+++ b/packages/imgur.rb
@@ -3,22 +3,15 @@ require 'package'
 class Imgur < Package
   description 'Upload images to Imgur via a small bash script.'
   homepage 'https://github.com/tremby/imgur.sh'
-  version 'v9'
+  version '10.1'
   license 'unlicense'
   compatibility 'all'
-  source_url 'https://github.com/tremby/imgur.sh/archive/v9.tar.gz'
-  source_sha256 '27283385658ea5223e6cb42de6a2486591c98d8adaeacf581b7f0a541d467645'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/tremby/imgur.sh.git'
+  git_hashtag "v#{version}"
 
-  binary_sha256({
-    aarch64: '5052a66866c1b32f38124232b3472e545d6e180a4edce44bb9ec0c2dd396b1bf',
-     armv7l: '5052a66866c1b32f38124232b3472e545d6e180a4edce44bb9ec0c2dd396b1bf',
-       i686: '72d9323a5899f239a66045e472df1b404842381a34d38fe5391c39d6dc7d43ee',
-     x86_64: 'eeebdb18fc194abe25f3c5c6e3782560be1771291f15316b047c1b357d60e10d'
-  })
+  no_compile_needed
 
   def self.install
-    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
-    system "cp imgur.sh #{CREW_DEST_PREFIX}/bin/imgur"
+    FileUtils.install 'imgur.sh', "#{CREW_DEST_PREFIX}/bin/imgur", mode: 0o755
   end
 end

--- a/tests/package/i/imgur
+++ b/tests/package/i/imgur
@@ -1,0 +1,2 @@
+#!/bin/bash
+imgur -h 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-imgur crew update \
&& yes | crew upgrade

$ crew check imgur
Checking imgur package ...
Library test for imgur passed.
Checking imgur package ...
Usage: imgur [<filename|URL> [...]]

Upload images to imgur and output their new URLs to stdout. Each one's
delete page is output to stderr between the view URLs.

A filename can be - to read from stdin. If no filename is given, stdin is read.

If xsel, xclip, pbcopy, or clip is available,
the URLs are put on the X selection or clipboard for easy pasting.
Use environment variables to set special options for your clipboard program (see code).
Package tests for imgur passed.
```