### PR TITLE
Iputils 20221126 => 20250605

### DIFF
--- a/manifest/armv7l/i/iputils.filelist
+++ b/manifest/armv7l/i/iputils.filelist
@@ -1,20 +1,24 @@
-# Total size: 364051
+# Total size: 639986
 /usr/local/bin/arping
 /usr/local/bin/clockdiff
 /usr/local/bin/ping
 /usr/local/bin/tracepath
 /usr/local/share/locale/cs/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/de/LC_MESSAGES/iputils.mo
+/usr/local/share/locale/es/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/fi/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/fr/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/id/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/ja/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/ka/LC_MESSAGES/iputils.mo
+/usr/local/share/locale/kab/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/ko/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/pt_BR/LC_MESSAGES/iputils.mo
+/usr/local/share/locale/ro/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/tr/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/uk/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/iputils.mo
+/usr/local/share/locale/zh_Hant/LC_MESSAGES/iputils.mo
 /usr/local/share/man/man8/arping.8.zst
 /usr/local/share/man/man8/clockdiff.8.zst
 /usr/local/share/man/man8/ping.8.zst

--- a/manifest/x86_64/i/iputils.filelist
+++ b/manifest/x86_64/i/iputils.filelist
@@ -1,20 +1,24 @@
-# Total size: 358795
+# Total size: 671778
 /usr/local/bin/arping
 /usr/local/bin/clockdiff
 /usr/local/bin/ping
 /usr/local/bin/tracepath
 /usr/local/share/locale/cs/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/de/LC_MESSAGES/iputils.mo
+/usr/local/share/locale/es/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/fi/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/fr/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/id/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/ja/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/ka/LC_MESSAGES/iputils.mo
+/usr/local/share/locale/kab/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/ko/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/pt_BR/LC_MESSAGES/iputils.mo
+/usr/local/share/locale/ro/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/tr/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/uk/LC_MESSAGES/iputils.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/iputils.mo
+/usr/local/share/locale/zh_Hant/LC_MESSAGES/iputils.mo
 /usr/local/share/man/man8/arping.8.zst
 /usr/local/share/man/man8/clockdiff.8.zst
 /usr/local/share/man/man8/ping.8.zst

--- a/packages/iputils.rb
+++ b/packages/iputils.rb
@@ -3,23 +3,25 @@ require 'buildsystems/meson'
 class Iputils < Meson
   description 'A set of small useful utilities for Linux networking.'
   homepage 'https://github.com/iputils/iputils'
-  version '20221126'
+  version '20250605'
   license 'GPL-2, BSD-3'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://github.com/iputils/iputils/archive/refs/tags/20221126.tar.gz'
-  source_sha256 '745ea711fe06d5c57d470d21acce3c3ab866eb6afb69379a16c6d60b89bd4311'
+  source_url 'https://github.com/iputils/iputils.git'
+  git_hashtag version
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd93ed9cbd3a46ecb6c11cd00f57d7fa752b1b795834ff6a1c661a3378f3e2319',
-     armv7l: 'd93ed9cbd3a46ecb6c11cd00f57d7fa752b1b795834ff6a1c661a3378f3e2319',
-     x86_64: 'd1121876b22ad730e6bad1d4caca60b14da247990f27202d5a7120eba38d5efc'
+    aarch64: 'c2449c8e3dc9b8214f057df980ae203538bef3aa4943971fdc9ab085e6e5b0b3',
+     armv7l: 'c2449c8e3dc9b8214f057df980ae203538bef3aa4943971fdc9ab085e6e5b0b3',
+     x86_64: '8af2447b0919cc0f6dac4d599cafc6511233b17c824a7586b0d9d39ce8dcf5c0'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'libcap' # R
-  depends_on 'libidn2' # R
-  depends_on 'gcc_lib' # R
+  depends_on 'gcc_lib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libcap' => :executable
+  depends_on 'libidn2' => :executable
+  depends_on 'libxslt' => :build
 
   meson_options '-DSKIP_TESTS=true'
 end

--- a/tests/package/i/iputils
+++ b/tests/package/i/iputils
@@ -1,0 +1,9 @@
+#!/bin/bash
+arping -h 2>&1 | head -5
+arping -V
+clockdiff -h 2>&1 | head -5
+clockdiff -V
+ping -h 2>&1 | head -5
+ping -V
+tracepath -h 2>&1 | head -5
+tracepath -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-iputils crew update \
&& yes | crew upgrade

$ crew check iputils 
Checking iputils package ...
Library test for iputils passed.
Checking iputils package ...

Usage:
  arping [options] <destination>

Options:
arping from iputils 6e1cb14
libcap: yes, IDN: yes, NLS: yes, error.h: yes, getrandom(): yes, __fpending(): yes

Usage:
  clockdiff [options] <destination>

Options:
clockdiff from iputils 6e1cb14
libcap: yes, IDN: yes, NLS: yes, error.h: yes, getrandom(): yes, __fpending(): yes

Usage
  ping [options] <destination>

Options:
ping from iputils 6e1cb14
libcap: yes, IDN: yes, NLS: yes, error.h: yes, getrandom(): yes, __fpending(): yes

Usage
  tracepath [options] <destination>

Options:
tracepath from iputils 6e1cb14
libcap: yes, IDN: yes, NLS: yes, error.h: yes, getrandom(): yes, __fpending(): yes
Package tests for iputils passed.
```