### PR TITLE
Janet 1.7.0 => 1.41.2

### DIFF
--- a/manifest/armv7l/j/janet.filelist
+++ b/manifest/armv7l/j/janet.filelist
@@ -1,10 +1,12 @@
-# Total size: 2693264
+# Total size: 3815874
 /usr/local/bin/janet
-/usr/local/bin/jpm
+/usr/local/include/janet.h
 /usr/local/include/janet/janet.h
-/usr/local/include/janet/janetconf.h
+/usr/local/include/janet/janet_1.41.2.h
 /usr/local/lib/janet/.keep
 /usr/local/lib/libjanet.a
 /usr/local/lib/libjanet.so
-/usr/local/share/man/man1/janet.1.gz
-/usr/local/share/man/man1/jpm.1.gz
+/usr/local/lib/libjanet.so.1.41
+/usr/local/lib/libjanet.so.1.41.2
+/usr/local/lib/pkgconfig/janet.pc
+/usr/local/share/man/man1/janet.1.zst

--- a/manifest/i686/j/janet.filelist
+++ b/manifest/i686/j/janet.filelist
@@ -1,10 +1,12 @@
-# Total size: 2405002
+# Total size: 4391800
 /usr/local/bin/janet
-/usr/local/bin/jpm
+/usr/local/include/janet.h
 /usr/local/include/janet/janet.h
-/usr/local/include/janet/janetconf.h
+/usr/local/include/janet/janet_1.41.2.h
 /usr/local/lib/janet/.keep
 /usr/local/lib/libjanet.a
 /usr/local/lib/libjanet.so
-/usr/local/share/man/man1/janet.1.gz
-/usr/local/share/man/man1/jpm.1.gz
+/usr/local/lib/libjanet.so.1.41
+/usr/local/lib/libjanet.so.1.41.2
+/usr/local/lib/pkgconfig/janet.pc
+/usr/local/share/man/man1/janet.1.zst

--- a/manifest/x86_64/j/janet.filelist
+++ b/manifest/x86_64/j/janet.filelist
@@ -1,10 +1,12 @@
-# Total size: 2709980
+# Total size: 4505666
 /usr/local/bin/janet
-/usr/local/bin/jpm
+/usr/local/include/janet.h
 /usr/local/include/janet/janet.h
-/usr/local/include/janet/janetconf.h
+/usr/local/include/janet/janet_1.41.2.h
 /usr/local/lib64/janet/.keep
 /usr/local/lib64/libjanet.a
 /usr/local/lib64/libjanet.so
-/usr/local/share/man/man1/janet.1.gz
-/usr/local/share/man/man1/jpm.1.gz
+/usr/local/lib64/libjanet.so.1.41
+/usr/local/lib64/libjanet.so.1.41.2
+/usr/local/lib64/pkgconfig/janet.pc
+/usr/local/share/man/man1/janet.1.zst

--- a/packages/janet.rb
+++ b/packages/janet.rb
@@ -1,28 +1,24 @@
-require 'package'
+require 'buildsystems/meson'
 
-class Janet < Package
+class Janet < Meson
   description 'Janet is a functional and imperative programming language and bytecode interpreter.'
   homepage 'https://janet-lang.org'
-  version '1.7.0'
+  version '1.41.2'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/janet-lang/janet/archive/v1.7.0.tar.gz'
-  source_sha256 '2a119f3a79b209a858864e73ca3efda57ac044df3c89762a31480bbea386d2a3'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/janet-lang/janet.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '6fbc239bc6374e516ca5e63e988e50a62f5396b83cc1b5ffcc37c484f436ea07',
-     armv7l: '6fbc239bc6374e516ca5e63e988e50a62f5396b83cc1b5ffcc37c484f436ea07',
-       i686: '5037e0285af569a4a660094599bb251695387fe84936bc53315a107d2d258b61',
-     x86_64: 'db58991ce4aef8d19e17abf5e944f39bb94bbb5e7b750c217de36fae71fce1b3'
+    aarch64: '47fe7ca6d9592746455e72dda55bc38df031ac082bee998587e211c0854c82ca',
+     armv7l: '47fe7ca6d9592746455e72dda55bc38df031ac082bee998587e211c0854c82ca',
+       i686: 'e1e5e7937d97b598e9eaa26f7345196797b9e9f2991fb756681f3a3f6c3d4785',
+     x86_64: 'cc18a14abd4f1d2698d45745fefb53cb9127b130d139c01d5d7c1331626f8048'
   })
 
-  def self.build
-    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} builddir"
-    system 'ninja -C builddir'
-  end
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  meson_options '-Dos_name=ChromeOS -Dprf=true -Dreduced_os=true'
 end

--- a/tests/package/j/janet
+++ b/tests/package/j/janet
@@ -1,0 +1,3 @@
+#!/bin/bash
+janet -h | head
+janet -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-janet crew update \
&& yes | crew upgrade

$ crew check janet
Checking janet package ...
Library test for janet passed.
Checking janet package ...
usage: janet [options] script args...
Options are:
  --help (-h)             : Show this help
  --version (-v)          : Print the version string
  --stdin (-s)            : Use raw stdin instead of getline like functionality
  --eval (-e) code        : Execute a string of janet
  --expression (-E) code arguments... : Evaluate an expression as a short-fn with arguments
  --debug (-d)            : Set the debug flag in the REPL
  --repl (-r)             : Enter the REPL after running all scripts
  --noprofile (-R)        : Disables loading profile.janet when JANET_PROFILE is present
1.41.2-meson
Package tests for janet passed.
```