### PR TITLE
Jasper 4.2.8 => 4.2.9

### DIFF
--- a/manifest/armv7l/j/jasper.filelist
+++ b/manifest/armv7l/j/jasper.filelist
@@ -1,4 +1,4 @@
-# Total size: 601637
+# Total size: 601865
 /usr/local/bin/imgcmp
 /usr/local/bin/imginfo
 /usr/local/bin/jasper

--- a/manifest/x86_64/j/jasper.filelist
+++ b/manifest/x86_64/j/jasper.filelist
@@ -1,4 +1,4 @@
-# Total size: 727759
+# Total size: 745991
 /usr/local/bin/imgcmp
 /usr/local/bin/imginfo
 /usr/local/bin/jasper

--- a/packages/jasper.rb
+++ b/packages/jasper.rb
@@ -3,7 +3,7 @@ require 'buildsystems/cmake'
 class Jasper < CMake
   description 'The JasPer Project is an open-source initiative to provide a free software-based reference implementation of the codec specified in the JPEG-2000 Part-1 standard (i.e., ISO/IEC 15444-1).'
   homepage 'https://www.ece.uvic.ca/~frodo/jasper/'
-  version '4.2.8'
+  version '4.2.9'
   license 'JasPer-2.0'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/jasper-software/jasper.git'
@@ -11,20 +11,21 @@ class Jasper < CMake
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd7cbe599c821f193b1bbae6f02dd85de4e53fafe687c592705d980a763cc0601',
-     armv7l: 'd7cbe599c821f193b1bbae6f02dd85de4e53fafe687c592705d980a763cc0601',
-     x86_64: 'f4f150c4c1cfc9b02cdb56f43ea402b1b0262b2fb71c5dce9d2eeca108371430'
+    aarch64: 'b7c062198dbb54ed7b4280dd4ba931beea277a768ee8aed97fd11514bcb007f7',
+     armv7l: 'b7c062198dbb54ed7b4280dd4ba931beea277a768ee8aed97fd11514bcb007f7',
+     x86_64: '36cacc1130e0ffc69c29ba6533c8fb07cd3d93fbd0a677d12c2e5601624affcc'
   })
 
-  depends_on 'freeglut' # R
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
-  depends_on 'libglu' # R
-  depends_on 'libglvnd' # R
-  depends_on 'libheif' # R
-  depends_on 'libjpeg_turbo' # R
-  depends_on 'libxi' # R
-  depends_on 'libxmu' # R
+  depends_on 'freeglut' => :executable
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'libglu' => :executable
+  depends_on 'libglvnd' => :executable
+  depends_on 'libheif' => :library
+  depends_on 'libjpeg_turbo' => :library
+  depends_on 'libxi' => :executable
+  depends_on 'libxmu' => :executable
   depends_on 'mesa' => :build
   depends_on 'shared_mime_info' => :build
 

--- a/tests/package/j/jasper
+++ b/tests/package/j/jasper
@@ -1,0 +1,3 @@
+#!/bin/bash
+jasper --help 2>&1 | head
+jasper --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-jasper crew update \
&& yes | crew upgrade

$ crew check jasper
Checking jasper package ...
Library test for jasper passed.
Checking jasper package ...
JasPer Transcoder (Version 4.2.9).
Copyright (c) 2001-2022 Michael David Adams.
Copyright (c) 1999-2000 Image Power, Inc. and the University of
  British Columbia.
All rights reserved.

For information about the JasPer project, see:
    https://jasper-software.github.io/jasper
    https://www.ece.uvic.ca/~mdadams/jasper
For online documentation on the JasPer software, see:
4.2.9
Package tests for jasper passed.
```