### PR TITLE
Jp2a 1.3.2 => 1.3.3

### DIFF
--- a/manifest/armv7l/j/jp2a.filelist
+++ b/manifest/armv7l/j/jp2a.filelist
@@ -1,4 +1,5 @@
-# Total size: 42728
+# Total size: 55329
 /usr/local/bin/jp2a
 /usr/local/share/bash-completion/completions/jp2a
 /usr/local/share/man/man1/jp2a.1.zst
+/usr/local/share/zsh/site-functions/_jp2a

--- a/manifest/i686/j/jp2a.filelist
+++ b/manifest/i686/j/jp2a.filelist
@@ -1,4 +1,0 @@
-# Total size: 53092
-/usr/local/bin/jp2a
-/usr/local/share/bash-completion/completions/jp2a
-/usr/local/share/man/man1/jp2a.1.zst

--- a/manifest/x86_64/j/jp2a.filelist
+++ b/manifest/x86_64/j/jp2a.filelist
@@ -1,4 +1,5 @@
-# Total size: 52320
+# Total size: 76709
 /usr/local/bin/jp2a
 /usr/local/share/bash-completion/completions/jp2a
 /usr/local/share/man/man1/jp2a.1.zst
+/usr/local/share/zsh/site-functions/_jp2a

--- a/packages/jp2a.rb
+++ b/packages/jp2a.rb
@@ -3,25 +3,27 @@ require 'buildsystems/autotools'
 class Jp2a < Autotools
   description 'jp2a is a simple JPEG/PNG to ASCII converter.'
   homepage 'https://github.com/Talinx/jp2a'
-  version '1.3.2'
+  version '1.3.3'
   license 'GPL-2'
-  compatibility 'all'
-  source_url 'https://github.com/Talinx/jp2a/releases/download/v1.1.1/jp2a-1.1.1.tar.bz2'
-  source_sha256 '3b91f26f79eca4e963b1b1ae2473722a706bf642218f20bfe4ade5333aebb106'
+  compatibility 'aarch64 armv7l x86_64'
+  source_url 'https://github.com/Talinx/jp2a.git'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '6f27bfadc6dd38133c88500d05b3f5cedb26c79a5bf632e65d0bdf1045c96407',
-     armv7l: '6f27bfadc6dd38133c88500d05b3f5cedb26c79a5bf632e65d0bdf1045c96407',
-       i686: '1ff7e8633fb8b8d9a58beed5b2bfd2ddc844a51991f456cbf634eea213ffe6ef',
-     x86_64: 'a557c2f043bc5694010481cad6e41db5daf6487a78d761d935633cc1f1eed391'
+    aarch64: '9ee3d3bd47e418ec3631fd92f3b350b26704b10fe8853a3ff29f1e019932b0c1',
+     armv7l: '9ee3d3bd47e418ec3631fd92f3b350b26704b10fe8853a3ff29f1e019932b0c1',
+     x86_64: 'b7e1e269dbfd6a9c25e29790981f61c67f07ac7fd451275882f703b4e58b8a1c'
   })
 
-  depends_on 'curl' # R
-  depends_on 'glibc' # R
-  depends_on 'libjpeg_turbo' # R
-  depends_on 'libpng' # R
-  depends_on 'ncurses' # R
+  depends_on 'curl' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libexif' => :executable
+  depends_on 'libjpeg_turbo' => :executable
+  depends_on 'libpng' => :executable
+  depends_on 'libwebp' => :executable
+  depends_on 'ncurses' => :executable
 
   autotools_pre_configure_options "CFLAGS='-lncurses -ltinfo -I#{CREW_PREFIX}/include/ncurses #{CREW_ENV_OPTIONS_HASH['CFLAGS']}' LDFLAGS='-L#{CREW_LIB_PREFIX} -lncurses -ltinfo #{CREW_ENV_OPTIONS_HASH['LDFLAGS']}'"
   autotools_configure_options '--enable-curl'

--- a/tests/package/j/jp2a
+++ b/tests/package/j/jp2a
@@ -1,0 +1,3 @@
+#!/bin/bash
+jp2a -h 2>&1 | head
+jp2a -V 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-jp2a crew update \
&& yes | crew upgrade

$ crew check jp2a 
Checking jp2a package ...
Library test for jp2a passed.
Checking jp2a package ...
jp2a 1.3.3
Copyright 2006-2016 Christian Stigen Larsen
and 2020-2024 Christoph Raitzig
Distributed under the GNU General Public License (GPL) v2.

Usage: jp2a [ options ] [ file(s) | URL(s) ]

Convert files or URLs from JPEG/PNG/WebP format to ASCII.

OPTIONS
jp2a 1.3.3
Copyright 2006-2016 Christian Stigen Larsen
and 2020-2024 Christoph Raitzig
Distributed under the GNU General Public License (GPL) v2.
Package tests for jp2a passed.
```