### PR TITLE
Jpegoptim 1.5.0 => 1.5.6

### DIFF
--- a/manifest/armv7l/j/jpegoptim.filelist
+++ b/manifest/armv7l/j/jpegoptim.filelist
@@ -1,3 +1,3 @@
-# Total size: 22248
+# Total size: 37049
 /usr/local/bin/jpegoptim
-/usr/local/share/man/man1/jpegoptim.1.gz
+/usr/local/share/man/man1/jpegoptim.1.zst

--- a/manifest/i686/j/jpegoptim.filelist
+++ b/manifest/i686/j/jpegoptim.filelist
@@ -1,3 +1,3 @@
-# Total size: 24244
+# Total size: 45697
 /usr/local/bin/jpegoptim
-/usr/local/share/man/man1/jpegoptim.1.gz
+/usr/local/share/man/man1/jpegoptim.1.zst

--- a/manifest/x86_64/j/jpegoptim.filelist
+++ b/manifest/x86_64/j/jpegoptim.filelist
@@ -1,3 +1,3 @@
-# Total size: 23208
+# Total size: 49537
 /usr/local/bin/jpegoptim
-/usr/local/share/man/man1/jpegoptim.1.gz
+/usr/local/share/man/man1/jpegoptim.1.zst

--- a/packages/jpegoptim.rb
+++ b/packages/jpegoptim.rb
@@ -1,31 +1,23 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Jpegoptim < Package
+class Jpegoptim < Autotools
   description 'Utility to optimize/compress JPEG files'
   homepage 'https://github.com/tjko/jpegoptim'
-  version '1.5.0'
+  version '1.5.6'
   license 'GPL-3.0'
   compatibility 'all'
-  source_url 'https://github.com/tjko/jpegoptim/archive/v1.5.0.tar.gz'
-  source_sha256 '67b0feba73fd72f0bd383f25bf84149a73378d34c0c25bc0b9b25b0264d85824'
+  source_url 'https://github.com/tjko/jpegoptim.git'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd4decc886ec846db2b6c730ddac7593c806fdad9f271dfdd91f164a3f167f751',
-     armv7l: 'd4decc886ec846db2b6c730ddac7593c806fdad9f271dfdd91f164a3f167f751',
-       i686: '8c944bed8ae566930095f00fcf73e9c6dd26e49f00162a46e5574050227df70b',
-     x86_64: '0954751ef6aada53613c24fba136c5a2257c64338ad972e6bc07597041d0bddc'
+    aarch64: '3c6e44e4ced81e9c727cec6e4e67388193baf9d0080c61b52b939f433b8eb26b',
+     armv7l: '3c6e44e4ced81e9c727cec6e4e67388193baf9d0080c61b52b939f433b8eb26b',
+       i686: 'db69dbb9747a28806678d54618de75c236b1d7c4c8f0c6031f78657ff449477e',
+     x86_64: '809fcd8a7778d7bc519e09a2188785280717708ca12dd96b4cca1acdb2676df3'
   })
 
-  depends_on 'libjpeg_turbo'
-
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-    system 'make', 'strip'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libjpeg_turbo' => :executable
 end

--- a/tests/package/j/jpegoptim
+++ b/tests/package/j/jpegoptim
@@ -1,0 +1,3 @@
+#!/bin/bash
+jpegoptim -h 2>&1 | head
+jpegoptim -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-jpegoptim crew update \
&& yes | crew upgrade

$ crew check jpegoptim 
Checking jpegoptim package ...
Library test for jpegoptim passed.
Checking jpegoptim package ...
jpegoptim v1.5.6  Copyright (C) 1996-2025, Timo Kokkonen
Usage: jpegoptim [options] <filenames> 

  -d<path>, --dest=<path>
                    specify alternative destination directory for 
                    optimized files (default is to overwrite originals)
  -f, --force       force optimization
  -h, --help        display this help and exit
  -m<quality>, --max=<quality>
                    set maximum image quality factor (disables lossless
jpegoptim v1.5.6  x86_64-pc-linux-gnu (Jun 15 2026)
Copyright (C) 1996-2025, Timo Kokkonen

This program comes with ABSOLUTELY NO WARRANTY. This is free software,
and you are welcome to redistribute it under certain conditions.
See the GNU General Public License for more details.


libjpeg version: 6b  27-Mar-1998
Copyright (C) 1991-2025 The libjpeg-turbo Project and many others
Package tests for jpegoptim passed.
```