### PR TITLE
Lha 2695022 => 86094cb

### DIFF
--- a/manifest/armv7l/l/lha.filelist
+++ b/manifest/armv7l/l/lha.filelist
@@ -1,3 +1,3 @@
-# Total size: 50396
+# Total size: 93269
 /usr/local/bin/lha
 /usr/local/share/man/man1/lha.1.zst

--- a/manifest/i686/l/lha.filelist
+++ b/manifest/i686/l/lha.filelist
@@ -1,3 +1,3 @@
-# Total size: 51368
+# Total size: 127981
 /usr/local/bin/lha
 /usr/local/share/man/man1/lha.1.zst

--- a/manifest/x86_64/l/lha.filelist
+++ b/manifest/x86_64/l/lha.filelist
@@ -1,3 +1,3 @@
-# Total size: 50444
+# Total size: 129517
 /usr/local/bin/lha
 /usr/local/share/man/man1/lha.1.zst

--- a/packages/lha.rb
+++ b/packages/lha.rb
@@ -1,29 +1,22 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Lha < Package
+class Lha < Autotools
   description 'LHa for UNIX is a console-based utility that uncompresses and compresses .lha packages.'
   homepage 'https://lha.osdn.jp/'
-  version '2695022'
+  version '86094cb'
   license 'lha'
   compatibility 'all'
   source_url 'https://github.com/jca02266/lha.git'
-  git_hashtag '26950220c9c7590fd603ecaa54a12a52371affed'
+  git_hashtag '86094cb56aba34de45668f39f74fcfb61e9d7fb6'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a9e93c81eef64714252d453f98843a2d6b00c43bbcc9b4c67c3aabeb8365db50',
-     armv7l: 'a9e93c81eef64714252d453f98843a2d6b00c43bbcc9b4c67c3aabeb8365db50',
-       i686: 'f3f0e76166650dafe0874af2b10b650f3e826503e1be6cacae4275d03fe6a918',
-     x86_64: 'b5ac02857046c1673acdb928c7a189ee350d9b0babdaaea1661c39fc81328590'
+    aarch64: '592b6de73748121453911646eb1aac2d4c021bcd6682e0fb3a3785c99686c2aa',
+     armv7l: '592b6de73748121453911646eb1aac2d4c021bcd6682e0fb3a3785c99686c2aa',
+       i686: '6cb49a5a83b052f122f776f4d0f0b592a1c429bf92b039c9e660ec63abac426b',
+     x86_64: '630894efdce3b4fa3f7e7e0072dcc975204834790c70e617d79e1e3d597978d0'
   })
 
-  def self.build
-    system 'autoreconf -sif'
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 end

--- a/tests/package/l/lha
+++ b/tests/package/l/lha
@@ -1,0 +1,3 @@
+#!/bin/bash
+lha --help | head
+lha --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-lha crew update \
&& yes | crew upgrade

$ crew check lha 
Checking lha package ...
Library test for lha passed.
Checking lha package ...
LHa for UNIX version 1.14i-ac20220213 (x86_64-pc-linux-gnu)
  configure options:  '--prefix=/usr/local' '--libdir=/usr/local/lib64' '--mandir=/usr/local/share/man' '--disable-dependency-tracking' '--program-prefix=' '--program-suffix=' 'CFLAGS=-O3 -pipe -ffat-lto-objects -fPIC -fuse-ld=mold  -flto=auto -flto=auto' 'LDFLAGS=-flto=auto'

LHarc    for UNIX  V 1.02  Copyright(C) 1989  Y.Tagawa
LHx      for MSDOS V C2.01 Copyright(C) 1990  H.Yoshizaki
LHx(arc) for OSK   V 2.01  Modified     1990  Momozou
LHa      for UNIX  V 1.00  Copyright(C) 1992  Masaru Oki
LHa      for UNIX  V 1.14  Modified     1995  Nobutaka Watazaki
LHa      for UNIX  V 1.14i Modified     2000  Tsugio Okamoto
LHA-PMA  for UNIX  V 2     PMA added    2000  Maarten ter Huurne
LHa for UNIX version 1.14i-ac20220213 (x86_64-pc-linux-gnu)
  configure options:  '--prefix=/usr/local' '--libdir=/usr/local/lib64' '--mandir=/usr/local/share/man' '--disable-dependency-tracking' '--program-prefix=' '--program-suffix=' 'CFLAGS=-O3 -pipe -ffat-lto-objects -fPIC -fuse-ld=mold  -flto=auto -flto=auto' 'LDFLAGS=-flto=auto'
Package tests for lha passed.
```