### PR TITLE
Log4cplus 2.0.5 => 2.1.2

### DIFF
--- a/manifest/armv7l/l/log4cplus.filelist
+++ b/manifest/armv7l/l/log4cplus.filelist
@@ -1,4 +1,4 @@
-# Total size: 18225726
+# Total size: 1224766
 /usr/local/include/log4cplus/appender.h
 /usr/local/include/log4cplus/asyncappender.h
 /usr/local/include/log4cplus/boost/deviceappender.hxx
@@ -13,10 +13,12 @@
 /usr/local/include/log4cplus/config/windowsh-inc.h
 /usr/local/include/log4cplus/configurator.h
 /usr/local/include/log4cplus/consoleappender.h
+/usr/local/include/log4cplus/exception.h
 /usr/local/include/log4cplus/fileappender.h
 /usr/local/include/log4cplus/fstreams.h
 /usr/local/include/log4cplus/helpers/appenderattachableimpl.h
 /usr/local/include/log4cplus/helpers/connectorthread.h
+/usr/local/include/log4cplus/helpers/eventcounter.h
 /usr/local/include/log4cplus/helpers/fileinfo.h
 /usr/local/include/log4cplus/helpers/lockfile.h
 /usr/local/include/log4cplus/helpers/loglog.h
@@ -75,12 +77,12 @@
 /usr/local/include/log4cplus/version.h
 /usr/local/include/log4cplus/win32consoleappender.h
 /usr/local/include/log4cplus/win32debugappender.h
-/usr/local/lib/liblog4cplus-2.0.so.3
-/usr/local/lib/liblog4cplus-2.0.so.3.4.5
+/usr/local/lib/liblog4cplus-2.1.so.9
+/usr/local/lib/liblog4cplus-2.1.so.9.1.1
 /usr/local/lib/liblog4cplus.la
 /usr/local/lib/liblog4cplus.so
-/usr/local/lib/liblog4cplusU-2.0.so.3
-/usr/local/lib/liblog4cplusU-2.0.so.3.4.5
+/usr/local/lib/liblog4cplusU-2.1.so.9
+/usr/local/lib/liblog4cplusU-2.1.so.9.1.1
 /usr/local/lib/liblog4cplusU.la
 /usr/local/lib/liblog4cplusU.so
 /usr/local/lib/pkgconfig/log4cplus.pc

--- a/manifest/i686/l/log4cplus.filelist
+++ b/manifest/i686/l/log4cplus.filelist
@@ -1,4 +1,4 @@
-# Total size: 17873450
+# Total size: 1617398
 /usr/local/include/log4cplus/appender.h
 /usr/local/include/log4cplus/asyncappender.h
 /usr/local/include/log4cplus/boost/deviceappender.hxx
@@ -13,10 +13,12 @@
 /usr/local/include/log4cplus/config/windowsh-inc.h
 /usr/local/include/log4cplus/configurator.h
 /usr/local/include/log4cplus/consoleappender.h
+/usr/local/include/log4cplus/exception.h
 /usr/local/include/log4cplus/fileappender.h
 /usr/local/include/log4cplus/fstreams.h
 /usr/local/include/log4cplus/helpers/appenderattachableimpl.h
 /usr/local/include/log4cplus/helpers/connectorthread.h
+/usr/local/include/log4cplus/helpers/eventcounter.h
 /usr/local/include/log4cplus/helpers/fileinfo.h
 /usr/local/include/log4cplus/helpers/lockfile.h
 /usr/local/include/log4cplus/helpers/loglog.h
@@ -75,12 +77,12 @@
 /usr/local/include/log4cplus/version.h
 /usr/local/include/log4cplus/win32consoleappender.h
 /usr/local/include/log4cplus/win32debugappender.h
-/usr/local/lib/liblog4cplus-2.0.so.3
-/usr/local/lib/liblog4cplus-2.0.so.3.4.5
+/usr/local/lib/liblog4cplus-2.1.so.9
+/usr/local/lib/liblog4cplus-2.1.so.9.1.1
 /usr/local/lib/liblog4cplus.la
 /usr/local/lib/liblog4cplus.so
-/usr/local/lib/liblog4cplusU-2.0.so.3
-/usr/local/lib/liblog4cplusU-2.0.so.3.4.5
+/usr/local/lib/liblog4cplusU-2.1.so.9
+/usr/local/lib/liblog4cplusU-2.1.so.9.1.1
 /usr/local/lib/liblog4cplusU.la
 /usr/local/lib/liblog4cplusU.so
 /usr/local/lib/pkgconfig/log4cplus.pc

--- a/manifest/x86_64/l/log4cplus.filelist
+++ b/manifest/x86_64/l/log4cplus.filelist
@@ -1,4 +1,4 @@
-# Total size: 21451120
+# Total size: 1649378
 /usr/local/include/log4cplus/appender.h
 /usr/local/include/log4cplus/asyncappender.h
 /usr/local/include/log4cplus/boost/deviceappender.hxx
@@ -13,10 +13,12 @@
 /usr/local/include/log4cplus/config/windowsh-inc.h
 /usr/local/include/log4cplus/configurator.h
 /usr/local/include/log4cplus/consoleappender.h
+/usr/local/include/log4cplus/exception.h
 /usr/local/include/log4cplus/fileappender.h
 /usr/local/include/log4cplus/fstreams.h
 /usr/local/include/log4cplus/helpers/appenderattachableimpl.h
 /usr/local/include/log4cplus/helpers/connectorthread.h
+/usr/local/include/log4cplus/helpers/eventcounter.h
 /usr/local/include/log4cplus/helpers/fileinfo.h
 /usr/local/include/log4cplus/helpers/lockfile.h
 /usr/local/include/log4cplus/helpers/loglog.h
@@ -75,12 +77,12 @@
 /usr/local/include/log4cplus/version.h
 /usr/local/include/log4cplus/win32consoleappender.h
 /usr/local/include/log4cplus/win32debugappender.h
-/usr/local/lib64/liblog4cplus-2.0.so.3
-/usr/local/lib64/liblog4cplus-2.0.so.3.4.5
+/usr/local/lib64/liblog4cplus-2.1.so.9
+/usr/local/lib64/liblog4cplus-2.1.so.9.1.1
 /usr/local/lib64/liblog4cplus.la
 /usr/local/lib64/liblog4cplus.so
-/usr/local/lib64/liblog4cplusU-2.0.so.3
-/usr/local/lib64/liblog4cplusU-2.0.so.3.4.5
+/usr/local/lib64/liblog4cplusU-2.1.so.9
+/usr/local/lib64/liblog4cplusU-2.1.so.9.1.1
 /usr/local/lib64/liblog4cplusU.la
 /usr/local/lib64/liblog4cplusU.so
 /usr/local/lib64/pkgconfig/log4cplus.pc

--- a/packages/log4cplus.rb
+++ b/packages/log4cplus.rb
@@ -1,28 +1,25 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Log4cplus < Package
+class Log4cplus < Autotools
   description 'log4cplus is a simple to use C++ logging API providing thread-safe, flexible, and arbitrarily granular control over log management and configuration.'
   homepage 'https://sourceforge.net/projects/log4cplus/'
-  version '2.0.5'
+  version '2.1.2'
   license 'Apache-2.0 or BSD-2'
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/project/log4cplus/log4cplus-stable/2.0.5/log4cplus-2.0.5.tar.xz'
-  source_sha256 '6046f0867ce4734f298418c7b7db0d35c27403090bb751d98e6e76aa4935f1af'
-  binary_compression 'tar.xz'
+  source_url "https://downloads.sourceforge.net/project/log4cplus/log4cplus-stable/#{version}/log4cplus-#{version}.tar.xz"
+  source_sha256 'fbdabb4ef734fe1cc62169b23f0b480cc39127ac7b09b810a9c1229490d67e9e'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '4bab42054f71f29b8c3f6711ed6ca465de3a4a82b796f598f1a39d3af5187dd6',
-     armv7l: '4bab42054f71f29b8c3f6711ed6ca465de3a4a82b796f598f1a39d3af5187dd6',
-       i686: 'b4ccfd3eb86de7a875e4168b39221c338321262054a16d01eda42a3dec5a484a',
-     x86_64: '543f5fd76ecaeeb6dcad62035fd8bb32f3f95a2afef36bca971da22e208557d0'
+    aarch64: 'ab2406e8e579c35201e60ab7ac8b46eb7bb0612def03d8f4d6bf65213a77d5da',
+     armv7l: 'ab2406e8e579c35201e60ab7ac8b46eb7bb0612def03d8f4d6bf65213a77d5da',
+       i686: '4feed5b0f4c270770c9b7280da681a8acbaeb0e07e0b2f5f14500207611004df',
+     x86_64: 'd0926fbe1829e193f7b0d79929037fcf6eda7f1edbb5a194e84895bbf6a99034'
   })
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_configure_options '--disable-year2038' unless ARCH.eql?('x86_64')
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-log4cplus crew update \
&& yes | crew upgrade
```
