### PR TITLE
Add gitlab_runner package

### DIFF
--- a/manifest/armv7l/g/gitlab_runner.filelist
+++ b/manifest/armv7l/g/gitlab_runner.filelist
@@ -1,0 +1,2 @@
+# Total size: 112932064
+/usr/local/bin/gitlab-runner

--- a/manifest/i686/g/gitlab_runner.filelist
+++ b/manifest/i686/g/gitlab_runner.filelist
@@ -1,0 +1,2 @@
+# Total size: 114307206
+/usr/local/bin/gitlab-runner

--- a/manifest/x86_64/g/gitlab_runner.filelist
+++ b/manifest/x86_64/g/gitlab_runner.filelist
@@ -1,0 +1,2 @@
+# Total size: 121943755
+/usr/local/bin/gitlab-runner

--- a/packages/gitlab_runner.rb
+++ b/packages/gitlab_runner.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Gitlab_runner < Package
+  description 'Run your CI/CD jobs and send the results back to GitLab'
+  homepage 'https://gitlab.com/gitlab-org/gitlab-runner'
+  version '19.1.0'
+  license 'MIT'
+  compatibility 'all'
+  source_url({
+    aarch64: "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/v#{version}/binaries/gitlab-runner-linux-arm",
+     armv7l: "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/v#{version}/binaries/gitlab-runner-linux-arm",
+       i686: "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/v#{version}/binaries/gitlab-runner-linux-386",
+     x86_64: "https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/v#{version}/binaries/gitlab-runner-linux-amd64"
+  })
+  source_sha256({
+    aarch64: 'b1cff0e2c47ffd3c7f1e64e9a86561769ba201f75dcadf3e9da248d38c762d06',
+     armv7l: 'b1cff0e2c47ffd3c7f1e64e9a86561769ba201f75dcadf3e9da248d38c762d06',
+       i686: '23360335711960146ac683bef6e8989dcb421da04667ec1e8dd0f14cf85bde84',
+     x86_64: '895e4dfb4bae77b6c0f0611cf9af75b95312ab40c5d8d2c607b5be1c1fae9511'
+  })
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    case ARCH
+    when 'aarch64', 'armv7l'
+      arch = 'arm'
+    when 'i686'
+      arch = '386'
+    when 'x86_64'
+      arch = 'amd64'
+    end
+    FileUtils.install "gitlab-runner-linux-#{arch}", "#{CREW_DEST_PREFIX}/bin/gitlab-runner", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'gitlab-runner -h' to get started.\n"
+  end
+end

--- a/tests/package/g/gitlab_runner
+++ b/tests/package/g/gitlab_runner
@@ -1,0 +1,3 @@
+#!/bin/bash
+gitlab-runner -h | head
+gitlab-runner -v

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -2640,6 +2640,11 @@ url: https://www.gitkraken.com/download
 activity: high
 ---
 kind: url
+name: gitlab_runner
+url: https://gitlab.com/gitlab-org/gitlab-runner/-/tags
+activity: high
+---
+kind: url
 name: gittools
 url: https://github.com/internetwache/GitTools/
 activity: none


### PR DESCRIPTION
## Description
Run your CI/CD jobs and send the results back to GitLab.  See https://gitlab.com/gitlab-org/gitlab-runner.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-gitlab_runner-package crew update \
&& yes | crew upgrade

$ crew check gitlab_runner
Checking gitlab_runner package ...
Library test for gitlab_runner passed.
Checking gitlab_runner package ...
NAME:
   gitlab-runner - a GitLab Runner

USAGE:
   gitlab-runner [global options] command [command options] [arguments...]

VERSION:
   19.1.0 (5eb085ab)

AUTHOR:
Version:      19.1.0
Git revision: 5eb085ab
Git branch:   19-1-stable
GO version:   go1.26.3
Built:        2026-06-16T21:55:37Z
OS/Arch:      linux/amd64
Package tests for gitlab_runner passed.
```