### PR TITLE
Lshw B.02.19.2-5840f20 => 02.20

### DIFF
--- a/manifest/armv7l/l/lshw.filelist
+++ b/manifest/armv7l/l/lshw.filelist
@@ -1,6 +1,8 @@
-# Total size: 7520139
+# Total size: 5140168
 /usr/local/bin/gtk-lshw
 /usr/local/bin/lshw
+/usr/local/share/locale/ca/LC_MESSAGES/lshw.mo
+/usr/local/share/locale/es/LC_MESSAGES/lshw.mo
 /usr/local/share/locale/fr/LC_MESSAGES/lshw.mo
 /usr/local/share/lshw/artwork/amd.svg
 /usr/local/share/lshw/artwork/audio.svg

--- a/manifest/x86_64/l/lshw.filelist
+++ b/manifest/x86_64/l/lshw.filelist
@@ -1,6 +1,8 @@
-# Total size: 6735327
+# Total size: 5225636
 /usr/local/bin/gtk-lshw
 /usr/local/bin/lshw
+/usr/local/share/locale/ca/LC_MESSAGES/lshw.mo
+/usr/local/share/locale/es/LC_MESSAGES/lshw.mo
 /usr/local/share/locale/fr/LC_MESSAGES/lshw.mo
 /usr/local/share/lshw/artwork/amd.svg
 /usr/local/share/lshw/artwork/audio.svg

--- a/packages/lshw.rb
+++ b/packages/lshw.rb
@@ -3,31 +3,30 @@ require 'package'
 class Lshw < Package
   description 'lshw (Hardware Lister) is a small tool to provide detailed information on the hardware configuration of the machine.'
   homepage 'https://ezix.org/project/wiki/HardwareLiSter'
-  version 'B.02.19.2-5840f20'
+  version '02.20'
   license 'GPL'
   compatibility 'aarch64 armv7l x86_64'
   # Use patched much more recent debian source, as primary source has
   # not been updated for years.
-  source_url 'https://salsa.debian.org/openstack-team/third-party/lshw.git'
-  git_hashtag '5840f2049cdc66115b701cd5a1e332f166cc1743'
+  source_url "https://ezix.org/software/files/lshw-B.#{version}.tar.gz"
+  source_sha256 '06d9cf122422220e5dc94e8ea5b01816a69bb6b59368f63d7f21fff31fc6922a'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '340c681ccf3ec89b89a8587b2d646454b289b7a91780c77e01dfc758668f64f5',
-     armv7l: '340c681ccf3ec89b89a8587b2d646454b289b7a91780c77e01dfc758668f64f5',
-     x86_64: 'ae50b29d704bfbffb72c166b9b30e37516e83bebe385c223252cd8f4be6c9ed8'
+    aarch64: '8750f3da6e986a8f85def4e83c70c55aec5c993250fd86f8f6e0a978df32a942',
+     armv7l: '8750f3da6e986a8f85def4e83c70c55aec5c993250fd86f8f6e0a978df32a942',
+     x86_64: '4ad53d4589c239f962e3bab6c80d580cece52b1325b512713f1594965b03362d'
   })
 
-  depends_on 'hwdata'
-  depends_on 'gcc_lib' # R
-  depends_on 'gdk_pixbuf' # R
-  depends_on 'glibc' # R
-  depends_on 'glib' # R
-  depends_on 'gtk3' # R (but not needed for the CLI app)
-  depends_on 'sqlite' # R
-  depends_on 'zlib' # R
-
-  def self.build; end
+  depends_on 'gcc_lib' => :executable
+  depends_on 'gdk_pixbuf' => :executable
+  depends_on 'glib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'gtk3' => :executable
+  depends_on 'hwdata' => :executable
+  depends_on 'sqlite' => :executable
+  depends_on 'zlib' => :executable
 
   def self.install
     system "LDFLAGS='-lz -lsqlite3' make DESTDIR=#{CREW_DEST_DIR} NO_VERSION_CHECK=1 VERSION=#{version} ZLIB=1 SQLITE=1 PREFIX=#{CREW_PREFIX} DATADIR=#{CREW_PREFIX}/share MANDIR=#{CREW_MAN_PREFIX} SBINDIR=#{CREW_PREFIX}/bin install"

--- a/tests/package/l/lshw
+++ b/tests/package/l/lshw
@@ -1,0 +1,4 @@
+#!/bin/bash
+gtk-lshw -h
+lshw -help 2>&1 | head
+lshw -version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-lshw crew update \
&& yes | crew upgrade

$ crew check lshw 
Checking lshw package ...
Library test for lshw passed.
Checking lshw package ...
Usage:
  gtk-lshw [OPTION…]

Help Options:
  -h, --help                Show help options
  --help-all                Show all help options
  --help-gapplication       Show GApplication options
  --help-gtk                Show GTK+ Options

Application Options:
  --display=DISPLAY         X display to use

Hardware Lister (lshw) - 02.20
usage: lshw [-format] [-options ...]
       lshw -version

	-version        print program version (02.20)

format can be
	-html           output hardware tree as HTML
	-xml            output hardware tree as XML
	-json           output hardware tree as a JSON object
02.20
Package tests for lshw passed.
```