### PR TITLE
Lttng_ust 2.13.7 => 2.15.1

### DIFF
--- a/manifest/armv7l/l/liburcu.filelist
+++ b/manifest/armv7l/l/liburcu.filelist
@@ -1,4 +1,4 @@
-# Total size: 770297
+# Total size: 693741
 /usr/local/include/urcu-bp.h
 /usr/local/include/urcu-call-rcu.h
 /usr/local/include/urcu-defer.h
@@ -6,6 +6,7 @@
 /usr/local/include/urcu-pointer.h
 /usr/local/include/urcu-qsbr.h
 /usr/local/include/urcu.h
+/usr/local/include/urcu/annotate.h
 /usr/local/include/urcu/arch.h
 /usr/local/include/urcu/arch/aarch64.h
 /usr/local/include/urcu/arch/alpha.h
@@ -14,6 +15,7 @@
 /usr/local/include/urcu/arch/generic.h
 /usr/local/include/urcu/arch/hppa.h
 /usr/local/include/urcu/arch/ia64.h
+/usr/local/include/urcu/arch/loongarch.h
 /usr/local/include/urcu/arch/m68k.h
 /usr/local/include/urcu/arch/mips.h
 /usr/local/include/urcu/arch/nios2.h
@@ -40,7 +42,6 @@
 /usr/local/include/urcu/map/urcu-mb.h
 /usr/local/include/urcu/map/urcu-memb.h
 /usr/local/include/urcu/map/urcu-qsbr.h
-/usr/local/include/urcu/map/urcu-signal.h
 /usr/local/include/urcu/map/urcu.h
 /usr/local/include/urcu/pointer.h
 /usr/local/include/urcu/rcuhlist.h
@@ -58,8 +59,6 @@
 /usr/local/include/urcu/static/urcu-mb.h
 /usr/local/include/urcu/static/urcu-memb.h
 /usr/local/include/urcu/static/urcu-qsbr.h
-/usr/local/include/urcu/static/urcu-signal-nr.h
-/usr/local/include/urcu/static/urcu-signal.h
 /usr/local/include/urcu/static/urcu.h
 /usr/local/include/urcu/static/wfcqueue.h
 /usr/local/include/urcu/static/wfqueue.h
@@ -70,11 +69,16 @@
 /usr/local/include/urcu/uatomic.h
 /usr/local/include/urcu/uatomic/aarch64.h
 /usr/local/include/urcu/uatomic/alpha.h
+/usr/local/include/urcu/uatomic/api.h
 /usr/local/include/urcu/uatomic/arm.h
+/usr/local/include/urcu/uatomic/builtins-generic.h
+/usr/local/include/urcu/uatomic/builtins-x86.h
+/usr/local/include/urcu/uatomic/builtins.h
 /usr/local/include/urcu/uatomic/gcc.h
 /usr/local/include/urcu/uatomic/generic.h
 /usr/local/include/urcu/uatomic/hppa.h
 /usr/local/include/urcu/uatomic/ia64.h
+/usr/local/include/urcu/uatomic/loongarch.h
 /usr/local/include/urcu/uatomic/m68k.h
 /usr/local/include/urcu/uatomic/mips.h
 /usr/local/include/urcu/uatomic/nios2.h
@@ -83,6 +87,7 @@
 /usr/local/include/urcu/uatomic/s390.h
 /usr/local/include/urcu/uatomic/sparc64.h
 /usr/local/include/urcu/uatomic/tile.h
+/usr/local/include/urcu/uatomic/uassert.h
 /usr/local/include/urcu/uatomic/x86.h
 /usr/local/include/urcu/uatomic_arch.h
 /usr/local/include/urcu/urcu-bp.h
@@ -91,7 +96,6 @@
 /usr/local/include/urcu/urcu-memb.h
 /usr/local/include/urcu/urcu-poll.h
 /usr/local/include/urcu/urcu-qsbr.h
-/usr/local/include/urcu/urcu-signal.h
 /usr/local/include/urcu/urcu.h
 /usr/local/include/urcu/urcu_ref.h
 /usr/local/include/urcu/wfcqueue.h
@@ -121,10 +125,6 @@
 /usr/local/lib/liburcu-qsbr.so
 /usr/local/lib/liburcu-qsbr.so.8
 /usr/local/lib/liburcu-qsbr.so.8.1.0
-/usr/local/lib/liburcu-signal.la
-/usr/local/lib/liburcu-signal.so
-/usr/local/lib/liburcu-signal.so.8
-/usr/local/lib/liburcu-signal.so.8.1.0
 /usr/local/lib/liburcu.la
 /usr/local/lib/liburcu.so
 /usr/local/lib/liburcu.so.8
@@ -134,9 +134,8 @@
 /usr/local/lib/pkgconfig/liburcu-mb.pc
 /usr/local/lib/pkgconfig/liburcu-memb.pc
 /usr/local/lib/pkgconfig/liburcu-qsbr.pc
-/usr/local/lib/pkgconfig/liburcu-signal.pc
 /usr/local/lib/pkgconfig/liburcu.pc
-/usr/local/share/doc/userspace-rcu/LICENSE
+/usr/local/share/doc/userspace-rcu/LICENSE.md
 /usr/local/share/doc/userspace-rcu/README.md
 /usr/local/share/doc/userspace-rcu/cds-api.md
 /usr/local/share/doc/userspace-rcu/examples/Makefile
@@ -196,12 +195,10 @@
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.mb
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.membarrier
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.qsbr
-/usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.signal
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/bp.c
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/mb.c
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/membarrier.c
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/qsbr.c
-/usr/local/share/doc/userspace-rcu/examples/urcu-flavors/signal.c
 /usr/local/share/doc/userspace-rcu/examples/wfcqueue/Makefile
 /usr/local/share/doc/userspace-rcu/examples/wfcqueue/Makefile.cds_wfcq_dequeue
 /usr/local/share/doc/userspace-rcu/examples/wfcqueue/Makefile.cds_wfcq_enqueue

--- a/manifest/armv7l/l/lttng_ust.filelist
+++ b/manifest/armv7l/l/lttng_ust.filelist
@@ -1,4 +1,4 @@
-# Total size: 1102067
+# Total size: 1460516
 /usr/local/bin/lttng-gen-tp
 /usr/local/include/lttng/tp/lttng-ust-tracef.h
 /usr/local/include/lttng/tp/lttng-ust-tracelog.h
@@ -24,6 +24,7 @@
 /usr/local/include/lttng/ust-endian.h
 /usr/local/include/lttng/ust-error.h
 /usr/local/include/lttng/ust-events.h
+/usr/local/include/lttng/ust-fd.h
 /usr/local/include/lttng/ust-fork.h
 /usr/local/include/lttng/ust-getcpu.h
 /usr/local/include/lttng/ust-libc-wrapper.h
@@ -43,8 +44,8 @@
 /usr/local/lib/liblttng-ust-common.so.1.0.0
 /usr/local/lib/liblttng-ust-ctl.la
 /usr/local/lib/liblttng-ust-ctl.so
-/usr/local/lib/liblttng-ust-ctl.so.5
-/usr/local/lib/liblttng-ust-ctl.so.5.0.0
+/usr/local/lib/liblttng-ust-ctl.so.6
+/usr/local/lib/liblttng-ust-ctl.so.6.0.0
 /usr/local/lib/liblttng-ust-cyg-profile-fast.la
 /usr/local/lib/liblttng-ust-cyg-profile-fast.so
 /usr/local/lib/liblttng-ust-cyg-profile-fast.so.1
@@ -86,9 +87,9 @@
 /usr/local/share/doc/lttng-ust/ChangeLog
 /usr/local/share/doc/lttng-ust/LICENSE
 /usr/local/share/doc/lttng-ust/README.md
-/usr/local/share/doc/lttng-ust/examples/README
+/usr/local/share/doc/lttng-ust/examples/README.md
 /usr/local/share/doc/lttng-ust/examples/clock-override/Makefile
-/usr/local/share/doc/lttng-ust/examples/clock-override/README
+/usr/local/share/doc/lttng-ust/examples/clock-override/README.md
 /usr/local/share/doc/lttng-ust/examples/clock-override/lttng-ust-clock-override-example.c
 /usr/local/share/doc/lttng-ust/examples/clock-override/run-clock-override
 /usr/local/share/doc/lttng-ust/examples/cmake-multiple-shared-libraries/CMakeLists.txt
@@ -104,15 +105,15 @@
 /usr/local/share/doc/lttng-ust/examples/cmake-multiple-shared-libraries/tracepoint-provider.cpp
 /usr/local/share/doc/lttng-ust/examples/cmake-multiple-shared-libraries/tracepoint-provider.h
 /usr/local/share/doc/lttng-ust/examples/demo-tracef/Makefile
-/usr/local/share/doc/lttng-ust/examples/demo-tracef/README
+/usr/local/share/doc/lttng-ust/examples/demo-tracef/README.md
 /usr/local/share/doc/lttng-ust/examples/demo-tracef/demo-tracef.c
 /usr/local/share/doc/lttng-ust/examples/demo-tracef/demo-vtracef.c
 /usr/local/share/doc/lttng-ust/examples/demo-tracelog/Makefile
-/usr/local/share/doc/lttng-ust/examples/demo-tracelog/README
+/usr/local/share/doc/lttng-ust/examples/demo-tracelog/README.md
 /usr/local/share/doc/lttng-ust/examples/demo-tracelog/demo-tracelog.c
 /usr/local/share/doc/lttng-ust/examples/demo-tracelog/demo-vtracelog.c
 /usr/local/share/doc/lttng-ust/examples/demo/Makefile
-/usr/local/share/doc/lttng-ust/examples/demo/README
+/usr/local/share/doc/lttng-ust/examples/demo/README.md
 /usr/local/share/doc/lttng-ust/examples/demo/demo-trace
 /usr/local/share/doc/lttng-ust/examples/demo/demo.c
 /usr/local/share/doc/lttng-ust/examples/demo/tp.c
@@ -129,15 +130,16 @@
 /usr/local/share/doc/lttng-ust/examples/gen-tp/sample.c
 /usr/local/share/doc/lttng-ust/examples/gen-tp/sample_tracepoint.tp
 /usr/local/share/doc/lttng-ust/examples/getcpu-override/Makefile
-/usr/local/share/doc/lttng-ust/examples/getcpu-override/README
+/usr/local/share/doc/lttng-ust/examples/getcpu-override/README.md
 /usr/local/share/doc/lttng-ust/examples/getcpu-override/lttng-ust-getcpu-override-example.c
 /usr/local/share/doc/lttng-ust/examples/getcpu-override/run-getcpu-override
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/Makefile
-/usr/local/share/doc/lttng-ust/examples/hello-static-lib/README
+/usr/local/share/doc/lttng-ust/examples/hello-static-lib/README.md
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/hello.c
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/tp.c
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/ust_tests_hello.h
-/usr/local/share/doc/lttng-ust/java-agent.txt
+/usr/local/share/doc/lttng-ust/java-agent.md
+/usr/local/share/doc/lttng-ust/python-agent.md
 /usr/local/share/man/man1/lttng-gen-tp.1.zst
 /usr/local/share/man/man3/do_tracepoint.3.zst
 /usr/local/share/man/man3/lttng-ust-cyg-profile.3.zst

--- a/manifest/i686/l/liburcu.filelist
+++ b/manifest/i686/l/liburcu.filelist
@@ -1,4 +1,4 @@
-# Total size: 842789
+# Total size: 757833
 /usr/local/include/urcu-bp.h
 /usr/local/include/urcu-call-rcu.h
 /usr/local/include/urcu-defer.h
@@ -6,6 +6,7 @@
 /usr/local/include/urcu-pointer.h
 /usr/local/include/urcu-qsbr.h
 /usr/local/include/urcu.h
+/usr/local/include/urcu/annotate.h
 /usr/local/include/urcu/arch.h
 /usr/local/include/urcu/arch/aarch64.h
 /usr/local/include/urcu/arch/alpha.h
@@ -14,6 +15,7 @@
 /usr/local/include/urcu/arch/generic.h
 /usr/local/include/urcu/arch/hppa.h
 /usr/local/include/urcu/arch/ia64.h
+/usr/local/include/urcu/arch/loongarch.h
 /usr/local/include/urcu/arch/m68k.h
 /usr/local/include/urcu/arch/mips.h
 /usr/local/include/urcu/arch/nios2.h
@@ -40,7 +42,6 @@
 /usr/local/include/urcu/map/urcu-mb.h
 /usr/local/include/urcu/map/urcu-memb.h
 /usr/local/include/urcu/map/urcu-qsbr.h
-/usr/local/include/urcu/map/urcu-signal.h
 /usr/local/include/urcu/map/urcu.h
 /usr/local/include/urcu/pointer.h
 /usr/local/include/urcu/rcuhlist.h
@@ -58,8 +59,6 @@
 /usr/local/include/urcu/static/urcu-mb.h
 /usr/local/include/urcu/static/urcu-memb.h
 /usr/local/include/urcu/static/urcu-qsbr.h
-/usr/local/include/urcu/static/urcu-signal-nr.h
-/usr/local/include/urcu/static/urcu-signal.h
 /usr/local/include/urcu/static/urcu.h
 /usr/local/include/urcu/static/wfcqueue.h
 /usr/local/include/urcu/static/wfqueue.h
@@ -70,11 +69,16 @@
 /usr/local/include/urcu/uatomic.h
 /usr/local/include/urcu/uatomic/aarch64.h
 /usr/local/include/urcu/uatomic/alpha.h
+/usr/local/include/urcu/uatomic/api.h
 /usr/local/include/urcu/uatomic/arm.h
+/usr/local/include/urcu/uatomic/builtins-generic.h
+/usr/local/include/urcu/uatomic/builtins-x86.h
+/usr/local/include/urcu/uatomic/builtins.h
 /usr/local/include/urcu/uatomic/gcc.h
 /usr/local/include/urcu/uatomic/generic.h
 /usr/local/include/urcu/uatomic/hppa.h
 /usr/local/include/urcu/uatomic/ia64.h
+/usr/local/include/urcu/uatomic/loongarch.h
 /usr/local/include/urcu/uatomic/m68k.h
 /usr/local/include/urcu/uatomic/mips.h
 /usr/local/include/urcu/uatomic/nios2.h
@@ -83,6 +87,7 @@
 /usr/local/include/urcu/uatomic/s390.h
 /usr/local/include/urcu/uatomic/sparc64.h
 /usr/local/include/urcu/uatomic/tile.h
+/usr/local/include/urcu/uatomic/uassert.h
 /usr/local/include/urcu/uatomic/x86.h
 /usr/local/include/urcu/uatomic_arch.h
 /usr/local/include/urcu/urcu-bp.h
@@ -91,7 +96,6 @@
 /usr/local/include/urcu/urcu-memb.h
 /usr/local/include/urcu/urcu-poll.h
 /usr/local/include/urcu/urcu-qsbr.h
-/usr/local/include/urcu/urcu-signal.h
 /usr/local/include/urcu/urcu.h
 /usr/local/include/urcu/urcu_ref.h
 /usr/local/include/urcu/wfcqueue.h
@@ -121,10 +125,6 @@
 /usr/local/lib/liburcu-qsbr.so
 /usr/local/lib/liburcu-qsbr.so.8
 /usr/local/lib/liburcu-qsbr.so.8.1.0
-/usr/local/lib/liburcu-signal.la
-/usr/local/lib/liburcu-signal.so
-/usr/local/lib/liburcu-signal.so.8
-/usr/local/lib/liburcu-signal.so.8.1.0
 /usr/local/lib/liburcu.la
 /usr/local/lib/liburcu.so
 /usr/local/lib/liburcu.so.8
@@ -134,9 +134,8 @@
 /usr/local/lib/pkgconfig/liburcu-mb.pc
 /usr/local/lib/pkgconfig/liburcu-memb.pc
 /usr/local/lib/pkgconfig/liburcu-qsbr.pc
-/usr/local/lib/pkgconfig/liburcu-signal.pc
 /usr/local/lib/pkgconfig/liburcu.pc
-/usr/local/share/doc/userspace-rcu/LICENSE
+/usr/local/share/doc/userspace-rcu/LICENSE.md
 /usr/local/share/doc/userspace-rcu/README.md
 /usr/local/share/doc/userspace-rcu/cds-api.md
 /usr/local/share/doc/userspace-rcu/examples/Makefile
@@ -196,12 +195,10 @@
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.mb
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.membarrier
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.qsbr
-/usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.signal
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/bp.c
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/mb.c
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/membarrier.c
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/qsbr.c
-/usr/local/share/doc/userspace-rcu/examples/urcu-flavors/signal.c
 /usr/local/share/doc/userspace-rcu/examples/wfcqueue/Makefile
 /usr/local/share/doc/userspace-rcu/examples/wfcqueue/Makefile.cds_wfcq_dequeue
 /usr/local/share/doc/userspace-rcu/examples/wfcqueue/Makefile.cds_wfcq_enqueue

--- a/manifest/i686/l/lttng_ust.filelist
+++ b/manifest/i686/l/lttng_ust.filelist
@@ -1,4 +1,4 @@
-# Total size: 1340217
+# Total size: 1901575
 /usr/local/bin/lttng-gen-tp
 /usr/local/include/lttng/tp/lttng-ust-tracef.h
 /usr/local/include/lttng/tp/lttng-ust-tracelog.h
@@ -24,6 +24,7 @@
 /usr/local/include/lttng/ust-endian.h
 /usr/local/include/lttng/ust-error.h
 /usr/local/include/lttng/ust-events.h
+/usr/local/include/lttng/ust-fd.h
 /usr/local/include/lttng/ust-fork.h
 /usr/local/include/lttng/ust-getcpu.h
 /usr/local/include/lttng/ust-libc-wrapper.h
@@ -43,8 +44,8 @@
 /usr/local/lib/liblttng-ust-common.so.1.0.0
 /usr/local/lib/liblttng-ust-ctl.la
 /usr/local/lib/liblttng-ust-ctl.so
-/usr/local/lib/liblttng-ust-ctl.so.5
-/usr/local/lib/liblttng-ust-ctl.so.5.0.0
+/usr/local/lib/liblttng-ust-ctl.so.6
+/usr/local/lib/liblttng-ust-ctl.so.6.0.0
 /usr/local/lib/liblttng-ust-cyg-profile-fast.la
 /usr/local/lib/liblttng-ust-cyg-profile-fast.so
 /usr/local/lib/liblttng-ust-cyg-profile-fast.so.1
@@ -86,9 +87,9 @@
 /usr/local/share/doc/lttng-ust/ChangeLog
 /usr/local/share/doc/lttng-ust/LICENSE
 /usr/local/share/doc/lttng-ust/README.md
-/usr/local/share/doc/lttng-ust/examples/README
+/usr/local/share/doc/lttng-ust/examples/README.md
 /usr/local/share/doc/lttng-ust/examples/clock-override/Makefile
-/usr/local/share/doc/lttng-ust/examples/clock-override/README
+/usr/local/share/doc/lttng-ust/examples/clock-override/README.md
 /usr/local/share/doc/lttng-ust/examples/clock-override/lttng-ust-clock-override-example.c
 /usr/local/share/doc/lttng-ust/examples/clock-override/run-clock-override
 /usr/local/share/doc/lttng-ust/examples/cmake-multiple-shared-libraries/CMakeLists.txt
@@ -104,15 +105,15 @@
 /usr/local/share/doc/lttng-ust/examples/cmake-multiple-shared-libraries/tracepoint-provider.cpp
 /usr/local/share/doc/lttng-ust/examples/cmake-multiple-shared-libraries/tracepoint-provider.h
 /usr/local/share/doc/lttng-ust/examples/demo-tracef/Makefile
-/usr/local/share/doc/lttng-ust/examples/demo-tracef/README
+/usr/local/share/doc/lttng-ust/examples/demo-tracef/README.md
 /usr/local/share/doc/lttng-ust/examples/demo-tracef/demo-tracef.c
 /usr/local/share/doc/lttng-ust/examples/demo-tracef/demo-vtracef.c
 /usr/local/share/doc/lttng-ust/examples/demo-tracelog/Makefile
-/usr/local/share/doc/lttng-ust/examples/demo-tracelog/README
+/usr/local/share/doc/lttng-ust/examples/demo-tracelog/README.md
 /usr/local/share/doc/lttng-ust/examples/demo-tracelog/demo-tracelog.c
 /usr/local/share/doc/lttng-ust/examples/demo-tracelog/demo-vtracelog.c
 /usr/local/share/doc/lttng-ust/examples/demo/Makefile
-/usr/local/share/doc/lttng-ust/examples/demo/README
+/usr/local/share/doc/lttng-ust/examples/demo/README.md
 /usr/local/share/doc/lttng-ust/examples/demo/demo-trace
 /usr/local/share/doc/lttng-ust/examples/demo/demo.c
 /usr/local/share/doc/lttng-ust/examples/demo/tp.c
@@ -129,15 +130,16 @@
 /usr/local/share/doc/lttng-ust/examples/gen-tp/sample.c
 /usr/local/share/doc/lttng-ust/examples/gen-tp/sample_tracepoint.tp
 /usr/local/share/doc/lttng-ust/examples/getcpu-override/Makefile
-/usr/local/share/doc/lttng-ust/examples/getcpu-override/README
+/usr/local/share/doc/lttng-ust/examples/getcpu-override/README.md
 /usr/local/share/doc/lttng-ust/examples/getcpu-override/lttng-ust-getcpu-override-example.c
 /usr/local/share/doc/lttng-ust/examples/getcpu-override/run-getcpu-override
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/Makefile
-/usr/local/share/doc/lttng-ust/examples/hello-static-lib/README
+/usr/local/share/doc/lttng-ust/examples/hello-static-lib/README.md
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/hello.c
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/tp.c
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/ust_tests_hello.h
-/usr/local/share/doc/lttng-ust/java-agent.txt
+/usr/local/share/doc/lttng-ust/java-agent.md
+/usr/local/share/doc/lttng-ust/python-agent.md
 /usr/local/share/man/man1/lttng-gen-tp.1.zst
 /usr/local/share/man/man3/do_tracepoint.3.zst
 /usr/local/share/man/man3/lttng-ust-cyg-profile.3.zst

--- a/manifest/x86_64/l/liburcu.filelist
+++ b/manifest/x86_64/l/liburcu.filelist
@@ -1,4 +1,4 @@
-# Total size: 845009
+# Total size: 753379
 /usr/local/include/urcu-bp.h
 /usr/local/include/urcu-call-rcu.h
 /usr/local/include/urcu-defer.h
@@ -6,6 +6,7 @@
 /usr/local/include/urcu-pointer.h
 /usr/local/include/urcu-qsbr.h
 /usr/local/include/urcu.h
+/usr/local/include/urcu/annotate.h
 /usr/local/include/urcu/arch.h
 /usr/local/include/urcu/arch/aarch64.h
 /usr/local/include/urcu/arch/alpha.h
@@ -14,6 +15,7 @@
 /usr/local/include/urcu/arch/generic.h
 /usr/local/include/urcu/arch/hppa.h
 /usr/local/include/urcu/arch/ia64.h
+/usr/local/include/urcu/arch/loongarch.h
 /usr/local/include/urcu/arch/m68k.h
 /usr/local/include/urcu/arch/mips.h
 /usr/local/include/urcu/arch/nios2.h
@@ -40,7 +42,6 @@
 /usr/local/include/urcu/map/urcu-mb.h
 /usr/local/include/urcu/map/urcu-memb.h
 /usr/local/include/urcu/map/urcu-qsbr.h
-/usr/local/include/urcu/map/urcu-signal.h
 /usr/local/include/urcu/map/urcu.h
 /usr/local/include/urcu/pointer.h
 /usr/local/include/urcu/rcuhlist.h
@@ -58,8 +59,6 @@
 /usr/local/include/urcu/static/urcu-mb.h
 /usr/local/include/urcu/static/urcu-memb.h
 /usr/local/include/urcu/static/urcu-qsbr.h
-/usr/local/include/urcu/static/urcu-signal-nr.h
-/usr/local/include/urcu/static/urcu-signal.h
 /usr/local/include/urcu/static/urcu.h
 /usr/local/include/urcu/static/wfcqueue.h
 /usr/local/include/urcu/static/wfqueue.h
@@ -70,11 +69,16 @@
 /usr/local/include/urcu/uatomic.h
 /usr/local/include/urcu/uatomic/aarch64.h
 /usr/local/include/urcu/uatomic/alpha.h
+/usr/local/include/urcu/uatomic/api.h
 /usr/local/include/urcu/uatomic/arm.h
+/usr/local/include/urcu/uatomic/builtins-generic.h
+/usr/local/include/urcu/uatomic/builtins-x86.h
+/usr/local/include/urcu/uatomic/builtins.h
 /usr/local/include/urcu/uatomic/gcc.h
 /usr/local/include/urcu/uatomic/generic.h
 /usr/local/include/urcu/uatomic/hppa.h
 /usr/local/include/urcu/uatomic/ia64.h
+/usr/local/include/urcu/uatomic/loongarch.h
 /usr/local/include/urcu/uatomic/m68k.h
 /usr/local/include/urcu/uatomic/mips.h
 /usr/local/include/urcu/uatomic/nios2.h
@@ -83,6 +87,7 @@
 /usr/local/include/urcu/uatomic/s390.h
 /usr/local/include/urcu/uatomic/sparc64.h
 /usr/local/include/urcu/uatomic/tile.h
+/usr/local/include/urcu/uatomic/uassert.h
 /usr/local/include/urcu/uatomic/x86.h
 /usr/local/include/urcu/uatomic_arch.h
 /usr/local/include/urcu/urcu-bp.h
@@ -91,7 +96,6 @@
 /usr/local/include/urcu/urcu-memb.h
 /usr/local/include/urcu/urcu-poll.h
 /usr/local/include/urcu/urcu-qsbr.h
-/usr/local/include/urcu/urcu-signal.h
 /usr/local/include/urcu/urcu.h
 /usr/local/include/urcu/urcu_ref.h
 /usr/local/include/urcu/wfcqueue.h
@@ -121,10 +125,6 @@
 /usr/local/lib64/liburcu-qsbr.so
 /usr/local/lib64/liburcu-qsbr.so.8
 /usr/local/lib64/liburcu-qsbr.so.8.1.0
-/usr/local/lib64/liburcu-signal.la
-/usr/local/lib64/liburcu-signal.so
-/usr/local/lib64/liburcu-signal.so.8
-/usr/local/lib64/liburcu-signal.so.8.1.0
 /usr/local/lib64/liburcu.la
 /usr/local/lib64/liburcu.so
 /usr/local/lib64/liburcu.so.8
@@ -134,9 +134,8 @@
 /usr/local/lib64/pkgconfig/liburcu-mb.pc
 /usr/local/lib64/pkgconfig/liburcu-memb.pc
 /usr/local/lib64/pkgconfig/liburcu-qsbr.pc
-/usr/local/lib64/pkgconfig/liburcu-signal.pc
 /usr/local/lib64/pkgconfig/liburcu.pc
-/usr/local/share/doc/userspace-rcu/LICENSE
+/usr/local/share/doc/userspace-rcu/LICENSE.md
 /usr/local/share/doc/userspace-rcu/README.md
 /usr/local/share/doc/userspace-rcu/cds-api.md
 /usr/local/share/doc/userspace-rcu/examples/Makefile
@@ -196,12 +195,10 @@
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.mb
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.membarrier
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.qsbr
-/usr/local/share/doc/userspace-rcu/examples/urcu-flavors/Makefile.signal
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/bp.c
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/mb.c
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/membarrier.c
 /usr/local/share/doc/userspace-rcu/examples/urcu-flavors/qsbr.c
-/usr/local/share/doc/userspace-rcu/examples/urcu-flavors/signal.c
 /usr/local/share/doc/userspace-rcu/examples/wfcqueue/Makefile
 /usr/local/share/doc/userspace-rcu/examples/wfcqueue/Makefile.cds_wfcq_dequeue
 /usr/local/share/doc/userspace-rcu/examples/wfcqueue/Makefile.cds_wfcq_enqueue

--- a/manifest/x86_64/l/lttng_ust.filelist
+++ b/manifest/x86_64/l/lttng_ust.filelist
@@ -1,4 +1,4 @@
-# Total size: 1367491
+# Total size: 1942810
 /usr/local/bin/lttng-gen-tp
 /usr/local/include/lttng/tp/lttng-ust-tracef.h
 /usr/local/include/lttng/tp/lttng-ust-tracelog.h
@@ -24,6 +24,7 @@
 /usr/local/include/lttng/ust-endian.h
 /usr/local/include/lttng/ust-error.h
 /usr/local/include/lttng/ust-events.h
+/usr/local/include/lttng/ust-fd.h
 /usr/local/include/lttng/ust-fork.h
 /usr/local/include/lttng/ust-getcpu.h
 /usr/local/include/lttng/ust-libc-wrapper.h
@@ -43,8 +44,8 @@
 /usr/local/lib64/liblttng-ust-common.so.1.0.0
 /usr/local/lib64/liblttng-ust-ctl.la
 /usr/local/lib64/liblttng-ust-ctl.so
-/usr/local/lib64/liblttng-ust-ctl.so.5
-/usr/local/lib64/liblttng-ust-ctl.so.5.0.0
+/usr/local/lib64/liblttng-ust-ctl.so.6
+/usr/local/lib64/liblttng-ust-ctl.so.6.0.0
 /usr/local/lib64/liblttng-ust-cyg-profile-fast.la
 /usr/local/lib64/liblttng-ust-cyg-profile-fast.so
 /usr/local/lib64/liblttng-ust-cyg-profile-fast.so.1
@@ -86,9 +87,9 @@
 /usr/local/share/doc/lttng-ust/ChangeLog
 /usr/local/share/doc/lttng-ust/LICENSE
 /usr/local/share/doc/lttng-ust/README.md
-/usr/local/share/doc/lttng-ust/examples/README
+/usr/local/share/doc/lttng-ust/examples/README.md
 /usr/local/share/doc/lttng-ust/examples/clock-override/Makefile
-/usr/local/share/doc/lttng-ust/examples/clock-override/README
+/usr/local/share/doc/lttng-ust/examples/clock-override/README.md
 /usr/local/share/doc/lttng-ust/examples/clock-override/lttng-ust-clock-override-example.c
 /usr/local/share/doc/lttng-ust/examples/clock-override/run-clock-override
 /usr/local/share/doc/lttng-ust/examples/cmake-multiple-shared-libraries/CMakeLists.txt
@@ -104,15 +105,15 @@
 /usr/local/share/doc/lttng-ust/examples/cmake-multiple-shared-libraries/tracepoint-provider.cpp
 /usr/local/share/doc/lttng-ust/examples/cmake-multiple-shared-libraries/tracepoint-provider.h
 /usr/local/share/doc/lttng-ust/examples/demo-tracef/Makefile
-/usr/local/share/doc/lttng-ust/examples/demo-tracef/README
+/usr/local/share/doc/lttng-ust/examples/demo-tracef/README.md
 /usr/local/share/doc/lttng-ust/examples/demo-tracef/demo-tracef.c
 /usr/local/share/doc/lttng-ust/examples/demo-tracef/demo-vtracef.c
 /usr/local/share/doc/lttng-ust/examples/demo-tracelog/Makefile
-/usr/local/share/doc/lttng-ust/examples/demo-tracelog/README
+/usr/local/share/doc/lttng-ust/examples/demo-tracelog/README.md
 /usr/local/share/doc/lttng-ust/examples/demo-tracelog/demo-tracelog.c
 /usr/local/share/doc/lttng-ust/examples/demo-tracelog/demo-vtracelog.c
 /usr/local/share/doc/lttng-ust/examples/demo/Makefile
-/usr/local/share/doc/lttng-ust/examples/demo/README
+/usr/local/share/doc/lttng-ust/examples/demo/README.md
 /usr/local/share/doc/lttng-ust/examples/demo/demo-trace
 /usr/local/share/doc/lttng-ust/examples/demo/demo.c
 /usr/local/share/doc/lttng-ust/examples/demo/tp.c
@@ -129,15 +130,16 @@
 /usr/local/share/doc/lttng-ust/examples/gen-tp/sample.c
 /usr/local/share/doc/lttng-ust/examples/gen-tp/sample_tracepoint.tp
 /usr/local/share/doc/lttng-ust/examples/getcpu-override/Makefile
-/usr/local/share/doc/lttng-ust/examples/getcpu-override/README
+/usr/local/share/doc/lttng-ust/examples/getcpu-override/README.md
 /usr/local/share/doc/lttng-ust/examples/getcpu-override/lttng-ust-getcpu-override-example.c
 /usr/local/share/doc/lttng-ust/examples/getcpu-override/run-getcpu-override
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/Makefile
-/usr/local/share/doc/lttng-ust/examples/hello-static-lib/README
+/usr/local/share/doc/lttng-ust/examples/hello-static-lib/README.md
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/hello.c
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/tp.c
 /usr/local/share/doc/lttng-ust/examples/hello-static-lib/ust_tests_hello.h
-/usr/local/share/doc/lttng-ust/java-agent.txt
+/usr/local/share/doc/lttng-ust/java-agent.md
+/usr/local/share/doc/lttng-ust/python-agent.md
 /usr/local/share/man/man1/lttng-gen-tp.1.zst
 /usr/local/share/man/man3/do_tracepoint.3.zst
 /usr/local/share/man/man3/lttng-ust-cyg-profile.3.zst

--- a/packages/liburcu.rb
+++ b/packages/liburcu.rb
@@ -3,21 +3,22 @@ require 'buildsystems/autotools'
 class Liburcu < Autotools
   description 'Userspace RCU (read-copy-update) library.'
   homepage 'https://liburcu.org/'
-  version '0.14.0-2'
+  version '0.15.6'
   license 'LGPLv2.1'
   compatibility 'all'
-  source_url "https://lttng.org/files/urcu/userspace-rcu-#{version.split('-').first}.tar.bz2"
-  source_sha256 'ca43bf261d4d392cff20dfae440836603bf009fce24fdc9b2697d837a2239d4f'
+  source_url "https://lttng.org/files/urcu/userspace-rcu-#{version}.tar.bz2"
+  source_sha256 '850b192096eb11ebf2c70e8f97bc7da7479ee41da1bebeb44e3986908bac414f'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2a28e5a8fb742bde0e3177aaee4b59a39cbbc36a4b462897a3e63ca7fa31d5f9',
-     armv7l: '2a28e5a8fb742bde0e3177aaee4b59a39cbbc36a4b462897a3e63ca7fa31d5f9',
-       i686: '7806f53b85628320cf866aafc7c2d3add0b0b42a6afbea1fd5dd15d465ee152f',
-     x86_64: 'c3cfb3686d8d76b611380ac84d2f6c15cffda194a804560413b49ce7998165e5'
+    aarch64: '4fa45616cf52697faa7fc3513ab3d31ecabd61b93ff73ea651e8befda58db4d5',
+     armv7l: '4fa45616cf52697faa7fc3513ab3d31ecabd61b93ff73ea651e8befda58db4d5',
+       i686: 'f61e50171dc9d59d223049468cadc6e14d663c00e1c2501198ecf6e029566f2f',
+     x86_64: '33441ab4a008123e6712d9b8a3b99b4cf1863ff520f853e99afa5b1f3d1ff50e'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
   autotools_configure_options '--disable-static'
 

--- a/packages/lttng_ust.rb
+++ b/packages/lttng_ust.rb
@@ -3,20 +3,22 @@ require 'buildsystems/autotools'
 class Lttng_ust < Autotools
   description 'Linux Trace Toolkit: next generation is a modern toolkit for tracing Linux systems and applications.'
   homepage 'https://lttng.org/'
-  version '2.13.7'
+  version '2.15.1'
   license 'LGPL-2.1-only, MIT, GPL-2.0-only, GPL-3.0-or-later, BSD-2-Clause, BSD-3-Clause'
   compatibility 'all'
-  source_url 'https://lttng.org/files/lttng-ust/lttng-ust-2.13.7.tar.bz2'
-  source_sha256 '5fb4f17c307c8c1b79c68561e89be9562d07e7425bf40e728c4d66755342a5eb'
+  source_url "https://lttng.org/files/lttng-ust/lttng-ust-#{version}.tar.bz2"
+  source_sha256 '37c9b58ea7aa7bc47d6630b52ba1a48ebce095b9a196eab4ddd273d78301792d'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1ac688d427738fbb306c05b2296ba7f3046450ebed75ec237b46cf0b7990aabd',
-     armv7l: '1ac688d427738fbb306c05b2296ba7f3046450ebed75ec237b46cf0b7990aabd',
-       i686: 'd20a9cb55fad688ec847e440a159fcef9654be7004f833dc2b4d0bd80cb54016',
-     x86_64: '569a554f0b8a891430547346f75563d0ba77aacd7a48958d543aad7245f17b1b'
+    aarch64: '8abc564f183bab9aea7b3ac964158a910b618728cdcfea6c02ebc87950d81ab6',
+     armv7l: '8abc564f183bab9aea7b3ac964158a910b618728cdcfea6c02ebc87950d81ab6',
+       i686: 'b5591119e085684594d45fd2ff40c41a876e3f45558565ceea147a29144cf049',
+     x86_64: '38fd7ace2ba041d476337c403f90678ff773c54e359c455a5063d1c396000d31'
   })
 
-  depends_on 'liburcu'
-  depends_on 'numactl'
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'liburcu' => :library
+  depends_on 'numactl' => :library
 end

--- a/tests/package/l/lttng_ust
+++ b/tests/package/l/lttng_ust
@@ -1,0 +1,2 @@
+#!/bin/bash
+lttng-gen-tp --help


### PR DESCRIPTION
Liburcu 0.14.0-2 => 0.15.6

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-lttng_ust crew update \
&& yes | crew upgrade

$ crew check lttng_ust
Checking lttng_ust package ...
Library test for lttng_ust passed.
Checking lttng_ust package ...

 lttng-gen-tp - Generate the LTTng-UST header and source based on a simple template

 usage: lttng-gen-tp TEMPLATE_FILE [-o OUTPUT_FILE][-o OUTPUT_FILE]

 If no OUTPUT_FILE is given, the .h and .c file will be generated.
 (The basename of the template file with be used for the generated file.
  for example sample.tp will generate sample.h, sample.c and sample.o)

 When using the -o option, the OUTPUT_FILE must end with either .h, .c or .o
 The -o option can be repeated multiple times.

 The template file must contains LTTNG_UST_TRACEPOINT_EVENT and LTTNG_UST_TRACEPOINT_LOGLEVEL
 as per defined in the lttng/tracepoint.h file.
 See the lttng-ust(3) man page for more details on the format.

Package tests for lttng_ust passed.
```