### PR TITLE
Luit 2_0_20230201 => 20250912

### DIFF
--- a/manifest/armv7l/l/luit.filelist
+++ b/manifest/armv7l/l/luit.filelist
@@ -1,3 +1,3 @@
-# Total size: 29593
+# Total size: 48740
 /usr/local/bin/luit
 /usr/local/share/man/man1/luit.1.zst

--- a/manifest/x86_64/l/luit.filelist
+++ b/manifest/x86_64/l/luit.filelist
@@ -1,3 +1,3 @@
-# Total size: 68146
+# Total size: 69490
 /usr/local/bin/luit
 /usr/local/share/man/man1/luit.1.zst

--- a/packages/luit.rb
+++ b/packages/luit.rb
@@ -1,34 +1,28 @@
 # Adapted from Arch Linux luit PKGBUILD at:
 # https://github.com/archlinux/svntogit-packages/raw/packages/luit/trunk/PKGBUILD
 
-require 'package'
+require 'buildsystems/autotools'
 
-class Luit < Package
+class Luit < Autotools
   description 'Filter that can be run between an arbitrary application and a UTF-8 terminal emulator'
   homepage 'https://invisible-island.net/luit/luit.html'
-  version '2_0_20230201'
+  version '20250912'
   license 'custom'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/ThomasDickey/luit-snapshots.git'
-  git_hashtag "v#{version}"
+  git_hashtag "t#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '04d87e98277c2b522ea8f088b11a79a46abb15700dc44db9cd85e17e4c37d111',
-     armv7l: '04d87e98277c2b522ea8f088b11a79a46abb15700dc44db9cd85e17e4c37d111',
-     x86_64: '038cf6925d94fdb7ab7f9982c998eadeedd254e6e0a13c5e7db4b4ef6dc0a094'
+    aarch64: '5e0646cd5144876dbab261938a5b25a8ef5326290e85c3d998706b0327264869',
+     armv7l: '5e0646cd5144876dbab261938a5b25a8ef5326290e85c3d998706b0327264869',
+     x86_64: 'bdba06704ca949d6ce72e88655cf48f96dcbee2ae1f28f0b2e28db9d04b757f7'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'libfontenc' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libfontenc' => :executable
   depends_on 'libx11' => ':build'
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS} --enable-fontenc"
-    system 'make'
-  end
-
-  def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
-  end
+  autotools_configure_options '--enable-fontenc'
 end

--- a/tests/package/l/luit
+++ b/tests/package/l/luit
@@ -1,0 +1,3 @@
+#!/bin/bash
+luit -h | head
+luit -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-luit crew update \
&& yes | crew upgrade

$ crew check luit 
Checking luit package ...
Library test for luit passed.
Checking luit package ...
Usage: luit [options] [ program [ args ] ]

Options:
  -V                  show version
  -alias filename     location of the locale alias file
  -argv0 name         set child's name
  -c                  simple converter stdin/stdout
  -encoding encoding  use this encoding rather than current locale's encoding
  -fill-fontenc       fill in one-one mapping in -show-fontenc report
  -g0 set             set output G0 charset (default ASCII)
luit - 2.0-20250912
Package tests for luit passed.
```