### PR TITLE
Fix forced autotools configurations

### DIFF
--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -28,13 +28,7 @@ class Autotools < Package
           system 'NOCONFIGURE=1 ./bootstrap --no-configure || NOCONFIGURE=1 ./bootstrap'
         end
         # This ensures the correct aclocal and automake versions are configured.
-        if File.file?('configure.ac')
-          if File.file?('configure')
-            system 'autoreconf -fiv'
-          else
-            system 'autoconf -fiv'
-          end
-        end
+        system 'autoreconf -fiv' if File.file?('configure.ac')
         abort 'configure script not found!'.lightred unless File.file?('configure')
         FileUtils.chmod('+x', 'configure')
         system 'filefix', exception: false unless @no_filefix


### PR DESCRIPTION
## Description
Some packages with a `configure.ac` file and no `configure` file still require `autoreconf -fiv` to work, including [mutt](https://github.com/chromebrew/chromebrew/actions/runs/28073385652) and [jq](https://github.com/chromebrew/chromebrew/actions/runs/28067445787/job/83095061290).

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=tracts crew update \
&& yes | crew upgrade
```
