### PR TITLE
Split out determining updatable packages into separate method within commands/update.rb

### DIFF
--- a/commands/update.rb
+++ b/commands/update.rb
@@ -6,95 +6,93 @@ require_relative '../lib/package_utils'
 
 class Command
   def self.update(last_update_check)
-    unless CREW_NO_GIT
-      unless Dir.exist?(File.join(CREW_LIB_PATH, '.git'))
-        puts 'Fixing Chromebrew system git repo clone...'.orange
-        system(<<~GIT_REPAIR_COMMANDS, chdir: CREW_LIB_PATH, %i[out err] => File::NULL)
-          ## Run the git setup commands used in install.sh.
-          # Make the git default branch error messages go away.
-          git config --global init.defaultBranch main
-          # Setup the dir with git information.
-          git init --ref-format=reftable
-          git remote add origin #{CREW_REPO}
-          # Help handle situations where GitHub is down.
-          git config --local http.lowSpeedLimit 1000
-          git config --local http.lowSpeedTime 5
-          # Checkout, overwriting local files.
-          git fetch --all
-          git checkout -f master
-          git reset --hard origin/#{CREW_BRANCH}
-        GIT_REPAIR_COMMANDS
-      end
-
-      ## Update crew from git.
-      # Set sparse-checkout folders.
-      silent = CREW_UNATTENDED ? '&>/dev/null' : ''
-      system "git sparse-checkout set packages manifest/#{ARCH} lib commands bin crew tests tools #{silent}", chdir: CREW_LIB_PATH, exception: true
-      system "git sparse-checkout reapply  #{silent}", chdir: CREW_LIB_PATH, exception: true
-      system "git fetch #{CREW_REPO} #{CREW_BRANCH}  #{silent}", chdir: CREW_LIB_PATH, exception: true
-      # Now that we've fetched all the new changes, see if lib/const.rb was changed.
-      # We do this before resetting to FETCH_HEAD because we lose the original HEAD when doing so.
-      to_update = `cd #{CREW_LIB_PATH} && git show --name-only HEAD..FETCH_HEAD`.include?('lib/const.rb')
-      system("git reset --hard FETCH_HEAD  #{silent}", chdir: CREW_LIB_PATH, exception: true)
-
-      if Time.now.to_i - last_update_check > (CREW_UPDATE_CHECK_INTERVAL * 3600 * 24)
-        puts 'Updating RubyGems.'.orange
-        system "gem update -N --system  #{silent}"
-        system "gem cleanup  #{silent}"
-      end
-
-      puts 'Package lists, crew, and library updated.' unless CREW_UNATTENDED
-
-      # If lib/const.rb was changed, CREW_VERSION was bumped, so we re-run crew update.
-      if to_update
-        puts 'Restarting crew update since there is an updated crew version.'.lightcyan unless CREW_UNATTENDED
-        puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange if CREW_VERBOSE
-        exec "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update"
-      end
-
-      # Do any fixups necessary after crew has updated from git.
-      system "#{CREW_LIB_PATH}/lib/fixup.rb"
+    unless Dir.exist?(File.join(CREW_LIB_PATH, '.git'))
+      puts 'Fixing Chromebrew system git repo clone...'.orange
+      system(<<~GIT_REPAIR_COMMANDS, chdir: CREW_LIB_PATH, %i[out err] => File::NULL)
+        ## Run the git setup commands used in install.sh.
+        # Make the git default branch error messages go away.
+        git config --global init.defaultBranch main
+        # Setup the dir with git information.
+        git init --ref-format=reftable
+        git remote add origin #{CREW_REPO}
+        # Help handle situations where GitHub is down.
+        git config --local http.lowSpeedLimit 1000
+        git config --local http.lowSpeedTime 5
+        # Checkout, overwriting local files.
+        git fetch --all
+        git checkout -f master
+        git reset --hard origin/#{CREW_BRANCH}
+      GIT_REPAIR_COMMANDS
     end
+
+    # Update crew from git.
+    # Set sparse-checkout folders.
+    system "git sparse-checkout set packages manifest/#{ARCH} lib commands bin crew tests tools", chdir: CREW_LIB_PATH, exception: true
+    system 'git sparse-checkout reapply', chdir: CREW_LIB_PATH, exception: true
+    system "git fetch #{CREW_REPO} #{CREW_BRANCH}", chdir: CREW_LIB_PATH, exception: true
+    # Now that we've fetched all the new changes, see if lib/const.rb was changed.
+    # We do this before resetting to FETCH_HEAD because we lose the original HEAD when doing so.
+    to_update = `cd #{CREW_LIB_PATH} && git show --name-only HEAD..FETCH_HEAD`.include?('lib/const.rb')
+    system('git reset --hard FETCH_HEAD', chdir: CREW_LIB_PATH, exception: true)
+
+    if Time.now.to_i - last_update_check > (CREW_UPDATE_CHECK_INTERVAL * 3600 * 24)
+      puts 'Updating RubyGems.'.orange
+      system 'gem update -N --system'
+      system 'gem cleanup'
+    end
+
+    puts 'Package lists, crew, and library updated.'
+
+    # If lib/const.rb was changed, CREW_VERSION was bumped, so we re-run crew update.
+    if to_update
+      puts 'Restarting crew update since there is an updated crew version.'.lightcyan
+      puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange if CREW_VERBOSE
+      exec "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update"
+    end
+
+    # Do any fixups necessary after crew has updated from git.
+    system "#{CREW_LIB_PATH}/lib/fixup.rb"
 
     # check for outdated installed packages
-    puts 'Checking for package updates...' unless CREW_UNATTENDED
+    puts 'Checking for package updates...'
+    can_be_updated = determine_updatable_packages
 
-    can_be_updated = 0
-    updatable_packages = []
-    device_json = JSON.load_file(File.join(CREW_CONFIG_PATH, 'device.json'))
-    device_json['installed_packages'].each do |installed_package|
-      updated_package = Package.load_package(File.join(CREW_PACKAGES_PATH, "#{installed_package['name']}.rb"))
-
-      different_version = (installed_package['version'] != updated_package.version)
-      has_sha = !(PackageUtils.get_sha256(updated_package).to_s.empty? || installed_package['sha256'].to_s.empty?)
-      different_sha = has_sha && installed_package['sha256'] != PackageUtils.get_sha256(updated_package)
-
-      can_be_updated += 1 if different_version || different_sha
-
-      if different_version && !different_sha && has_sha
-        unless updated_package.no_compile_needed?
-          can_be_updated -= 1
-          updatable_packages.push(updated_package.name)
-          puts "#{updated_package.name} has a version change but does not have updated binaries".yellow unless CREW_UNATTENDED
-        end
-      elsif different_version
-        updatable_packages.push(updated_package.name)
-        puts "#{updated_package.name} could be updated from #{installed_package['version']} to #{updated_package.version}" unless CREW_UNATTENDED
-      elsif !different_version && different_sha
-        updatable_packages.push(updated_package.name)
-        puts "#{updated_package.name} could be updated (rebuild)" unless CREW_UNATTENDED
-      end
-    end
-
-    # Don't be clever about checking to see if updatable packages can be
-    # updated here. Let tools/build_updated_packages.rb handle that.
-    if CREW_UNATTENDED && updatable_packages.length.positive?
-      puts updatable_packages.to_json
-    elsif can_be_updated.positive?
+    if can_be_updated.positive?
       puts "\n#{can_be_updated} packages can be updated."
       puts 'Run `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages.'
     else
-      puts 'Your software is up to date.'.lightgreen unless CREW_UNATTENDED
+      puts 'Your software is up to date.'.lightgreen
     end
   end
+end
+
+def determine_updatable_packages(json: false)
+  can_be_updated = 0
+  updatable_packages = []
+  device_json = JSON.load_file(File.join(CREW_CONFIG_PATH, 'device.json'))
+  device_json['installed_packages'].each do |installed_package|
+    updated_package = Package.load_package(File.join(CREW_PACKAGES_PATH, "#{installed_package['name']}.rb"))
+
+    different_version = (installed_package['version'] != updated_package.version)
+    has_sha = !(PackageUtils.get_sha256(updated_package).to_s.empty? || installed_package['sha256'].to_s.empty?)
+    different_sha = has_sha && installed_package['sha256'] != PackageUtils.get_sha256(updated_package)
+
+    can_be_updated += 1 if different_version || different_sha
+
+    if different_version && !different_sha && has_sha
+      unless updated_package.no_compile_needed?
+        can_be_updated -= 1
+        updatable_packages.push(updated_package.name)
+        puts "#{updated_package.name} has a version change but does not have updated binaries".yellow unless json
+      end
+    elsif different_version
+      updatable_packages.push(updated_package.name)
+      puts "#{updated_package.name} could be updated from #{installed_package['version']} to #{updated_package.version}" unless json
+    elsif !different_version && different_sha
+      updatable_packages.push(updated_package.name)
+      puts "#{updated_package.name} could be updated (rebuild)" unless json
+    end
+  end
+
+  return json ? updatable_packages : can_be_updated
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.74.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.74.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]
@@ -137,9 +137,7 @@ CREW_MUSL_PREFIX      = File.join(CREW_PREFIX, '/share/musl/')
 CREW_DEST_MUSL_PREFIX = File.join(CREW_DEST_DIR, CREW_MUSL_PREFIX)
 MUSL_LIBC_VERSION     = File.executable?("#{CREW_MUSL_PREFIX}/lib/libc.so") ? `#{CREW_MUSL_PREFIX}/lib/libc.so 2>&1`[/\bVersion\s+\K\S+/] : nil unless defined?(MUSL_LIBC_VERSION)
 
-CREW_DEST_HOME  = File.join(CREW_DEST_DIR, HOME)
-CREW_NO_GIT     = ENV.fetch('CREW_NO_GIT', false)
-CREW_UNATTENDED = ENV.fetch('CREW_UNATTENDED', false)
+CREW_DEST_HOME = File.join(CREW_DEST_DIR, HOME)
 
 CREW_STANDALONE_UPGRADE_ORDER = %w[libxcrypt crew_preload glibc openssl ruby python3 perl icu4c sommelier]
 

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -263,7 +263,7 @@ if File.exist?("#{CREW_PREFIX}/bin/upx") && File.exist?("#{CREW_PREFIX}/bin/patc
   # errors on arm.
   # Running find twice because it involves less ruby overhead than saving
   # the output in memory, and also doing that in ruby is VERY SLOW.
-  puts 'Please wait while upx is run to uncompress binaries...'.lightblue unless CREW_UNATTENDED
+  puts 'Please wait while upx is run to uncompress binaries...'.lightblue
   Kernel.system "#{CREW_PREFIX}/bin/find #{CREW_PREFIX}/bin -type f -print0 | xargs -0 -P#{CREW_NPROC} -n1 -r bash -c 'header=$(head -c4 ${0}); elfheader='$(printf '\\\177ELF')' ; arheader=\\!\\<ar ; case $header in $elfheader|$arheader) upx -qq -d ${0} ;; esac'", %i[err] => File::NULL, exception: false
 
   unless CREW_GLIBC_INTERPRETER.blank?

--- a/tools/build_updated_packages.rb
+++ b/tools/build_updated_packages.rb
@@ -21,6 +21,7 @@ crew_local_repo_root = `git rev-parse --show-toplevel 2> /dev/null`.chomp
 # When invoked from crew, pwd is CREW_DEST_DIR, so crew_local_repo_root
 # is empty.
 crew_local_repo_root = '../' if crew_local_repo_root.to_s.empty?
+require File.join(crew_local_repo_root, 'commands/update')
 require File.join(crew_local_repo_root, 'lib/color')
 require File.join(crew_local_repo_root, 'lib/const')
 require File.join(crew_local_repo_root, 'lib/package')
@@ -274,7 +275,7 @@ else
 end
 
 unless ONLY_SPECIFIED_PACKAGES
-  crew_update_packages = `CREW_NO_GIT=1 CREW_UNATTENDED=1 crew update | grep "\\[\\""  | jq -r '.[]'`.chomp.split.map(&'packages/'.method(:+)).map { it.concat('.rb') }
+  crew_update_packages = determine_updatable_packages(json: true).map { "packages/#{it}.rb" }
   if CHECK_ALL_PYTHON
     py_packages = `grep -l CREW_PY_VER packages/*`.chomp.split
     updated_packages.push(*py_packages)


### PR DESCRIPTION
## Description
This way `tools/build_updated_packages.rb` can just use the method, and we don't need all the extra constants and hacks for extracting json out of what `crew update` prints.

Vaguely tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=borough crew update \
&& yes | crew upgrade
```