### PR TITLE
Masscan 1.0.4 => 1.3.2

### DIFF
--- a/manifest/armv7l/m/masscan.filelist
+++ b/manifest/armv7l/m/masscan.filelist
@@ -1,2 +1,3 @@
-# Total size: 1107948
+# Total size: 421416
 /usr/local/bin/masscan
+/usr/local/share/man/man8/masscan.8.zst

--- a/manifest/i686/m/masscan.filelist
+++ b/manifest/i686/m/masscan.filelist
@@ -1,2 +1,3 @@
-# Total size: 1308040
+# Total size: 501920
 /usr/local/bin/masscan
+/usr/local/share/man/man8/masscan.8.zst

--- a/manifest/x86_64/m/masscan.filelist
+++ b/manifest/x86_64/m/masscan.filelist
@@ -1,2 +1,3 @@
-# Total size: 1475800
+# Total size: 444536
 /usr/local/bin/masscan
+/usr/local/share/man/man8/masscan.8.zst

--- a/packages/masscan.rb
+++ b/packages/masscan.rb
@@ -5,26 +5,28 @@ class Masscan < Package
   homepage 'https://github.com/robertdavidgraham/masscan'
   compatibility 'all'
   license 'AGPL-3'
-  version '1.0.4'
-  source_url 'https://github.com/robertdavidgraham/masscan/archive/1.0.4.tar.gz'
-  source_sha256 '51de345f677f46595fc3bd747bfb61bc9ff130adcbec48f3401f8057c8702af9'
-  binary_compression 'tar.xz'
+  version '1.3.2'
+  source_url 'https://github.com/robertdavidgraham/masscan.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd1ca6e9300aa9b9fcc416c3c987844eebf614b7a7c49e77bb780d84f2d4c3030',
-     armv7l: 'd1ca6e9300aa9b9fcc416c3c987844eebf614b7a7c49e77bb780d84f2d4c3030',
-       i686: '2a8c133b95949bb88acd67c3887e23cf8a07f1e81c4ce3d2ec7454ee7268fda8',
-     x86_64: '176e98486ebd547ecc7430bf7bb3763352b48d0422bf95d007f9a9dbf3f15de8'
+    aarch64: '0c6530863a485cb08443373dc9f50ff732ec2ba9ce9fd68ef60b8bde8b19ac37',
+     armv7l: '0c6530863a485cb08443373dc9f50ff732ec2ba9ce9fd68ef60b8bde8b19ac37',
+       i686: '8f34eb82c46d061aab58c96eb1207953400d34a1f7bebf3497fb21f4b8f39bc5',
+     x86_64: 'dd63dbae13a4998ce9cd26743296983406b5762042af54854f4c37db206dd62c'
   })
 
-  depends_on 'libpcap'
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libpcap' => :library
 
   def self.build
     system 'make'
   end
 
   def self.install
-    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
-    system "cp bin/masscan #{CREW_DEST_PREFIX}/bin"
+    FileUtils.install 'bin/masscan', "#{CREW_DEST_PREFIX}/bin/masscan", mode: 0o755
+    FileUtils.install 'doc/masscan.8', "#{CREW_DEST_MAN_PREFIX}/man8/masscan.8", mode: 0o644
   end
 end

--- a/tests/package/m/masscan
+++ b/tests/package/m/masscan
@@ -1,0 +1,3 @@
+#!/bin/bash
+masscan -h
+masscan -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-masscan crew update \
&& yes | crew upgrade

$ crew check masscan 
Checking masscan package ...
Library test for masscan passed.
Checking masscan package ...
usage:
masscan -p80,8000-8100 10.0.0.0/8 --rate=10000
 scan some web ports on 10.x.x.x at 10kpps
masscan --nmap
 list those options that are compatible with nmap
masscan -p80 10.0.0.0/8 --banners -oB <filename>
 save results of scan in binary format to <filename>
masscan --open --banners --readscan <filename> -oX <savefile>
 read binary scan results in <filename> and save them as xml in <savefile>

Masscan version 1.3.2 ( https://github.com/robertdavidgraham/masscan )
Compiled on: Jun 25 2026 22:35:00
Compiler: gcc Clang 22.1.8
OS: Linux
CPU: unknown (64 bits)
GIT version: unknown
Package tests for masscan passed.
```