### PR TITLE
Mdp 1.0.10 => 1.0.18

### DIFF
--- a/manifest/armv7l/m/mdp.filelist
+++ b/manifest/armv7l/m/mdp.filelist
@@ -1,3 +1,3 @@
-# Total size: 36558
+# Total size: 33686
 /usr/local/bin/mdp
-/usr/local/share/man/man1/mdp.1
+/usr/local/share/man/man1/mdp.1.zst

--- a/manifest/i686/m/mdp.filelist
+++ b/manifest/i686/m/mdp.filelist
@@ -1,3 +1,3 @@
-# Total size: 42866
+# Total size: 44658
 /usr/local/bin/mdp
-/usr/local/share/man/man1/mdp.1
+/usr/local/share/man/man1/mdp.1.zst

--- a/manifest/x86_64/m/mdp.filelist
+++ b/manifest/x86_64/m/mdp.filelist
@@ -1,3 +1,3 @@
-# Total size: 41957
+# Total size: 47166
 /usr/local/bin/mdp
-/usr/local/share/man/man1/mdp.1.gz
+/usr/local/share/man/man1/mdp.1.zst

--- a/packages/mdp.rb
+++ b/packages/mdp.rb
@@ -1,29 +1,26 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Mdp < Package
+class Mdp < Autotools
   description 'A command-line based markdown presentation tool.'
   homepage 'https://github.com/visit1985/mdp'
-  version '1.0.10'
+  version '1.0.18'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://github.com/visit1985/mdp/archive/1.0.10.tar.gz'
-  source_sha256 '7384c1ba32bd8e4b11342570d2144165a60682499b4cb54e50c8eb3164cfabc5'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/visit1985/mdp.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2478dbee17514f83d0340c0ac6eb2ccf957aa000e48a0b0d2c614df523f98315',
-     armv7l: '2478dbee17514f83d0340c0ac6eb2ccf957aa000e48a0b0d2c614df523f98315',
-       i686: 'f3a418a1ab54584b5f6ec1e6ada44075e982c86274edb009ba031199af591984',
-     x86_64: 'a444f58edb9b973d4274e99e31c9e339fe1c88cf0641c55bb7d7f10413f761a4'
+    aarch64: '4e30487f9e37ebc8c5bddc17815e2796789cdfb8a437ef1c4799ed463294f839',
+     armv7l: '4e30487f9e37ebc8c5bddc17815e2796789cdfb8a437ef1c4799ed463294f839',
+       i686: '22b69eb6d4c62a90c545ad0cebd782a82e1a679241364c0ddf42f0aedac53396',
+     x86_64: '8327b998aae1a770f5debfe963389613bef1496650cc5516963bf503ab1a439b'
   })
 
-  depends_on 'ncurses'
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'ncurses' => :executable
 
-  def self.build
-    system "CPPFLAGS=-I#{CREW_PREFIX}/include/ncursesw PREFIX=#{CREW_PREFIX} make"
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_skip_configure
+  autotools_pre_make_options "CPPFLAGS='-I#{CREW_PREFIX}/include/ncursesw'"
 end

--- a/tests/package/m/mdp
+++ b/tests/package/m/mdp
@@ -1,0 +1,3 @@
+#!/bin/bash
+mdp -h 2>&1 | head
+mdp -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-mdp crew update \
&& yes | crew upgrade

$ crew check mdp 
Checking mdp package ...
Library test for mdp passed.
Checking mdp package ...
Usage: mdp [OPTION]... [FILE]
A command-line based markdown presentation tool.

  -c, --nocodebg    don't change the background color of code blocks
  -d, --debug       enable debug messages on STDERR
                    add it multiple times to increases debug level
  -e, --expand      enable character entity expansion
  -f, --nofade      disable color fading in 256 color mode
  -h, --help        display this help and exit
  -i, --invert      swap black and white color
mdp 1.0.18
Copyright (C) 2018 Michael Goehler
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Michael Goehler and others, see <https://github.com/visit1985/mdp/blob/master/AUTHORS>.
Package tests for mdp passed.
```