### PR TITLE
Minerd 2.5.0 => 2.5.1

### DIFF
--- a/manifest/armv7l/m/minerd.filelist
+++ b/manifest/armv7l/m/minerd.filelist
@@ -1,3 +1,3 @@
-# Total size: 331444
+# Total size: 82062
 /usr/local/bin/minerd
-/usr/local/share/man/man1/minerd.1.gz
+/usr/local/share/man/man1/minerd.1.zst

--- a/manifest/i686/m/minerd.filelist
+++ b/manifest/i686/m/minerd.filelist
@@ -1,3 +1,3 @@
-# Total size: 363956
+# Total size: 147158
 /usr/local/bin/minerd
-/usr/local/share/man/man1/minerd.1.gz
+/usr/local/share/man/man1/minerd.1.zst

--- a/manifest/x86_64/m/minerd.filelist
+++ b/manifest/x86_64/m/minerd.filelist
@@ -1,3 +1,3 @@
-# Total size: 552192
+# Total size: 315730
 /usr/local/bin/minerd
-/usr/local/share/man/man1/minerd.1.gz
+/usr/local/share/man/man1/minerd.1.zst

--- a/packages/minerd.rb
+++ b/packages/minerd.rb
@@ -1,33 +1,24 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Minerd < Package
+class Minerd < Autotools
   description 'CPU miner for Litecoin and Bitcoin'
   homepage 'https://github.com/pooler/cpuminer'
-  version '2.5.0'
+  version '2.5.1'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://github.com/pooler/cpuminer/releases/download/v2.5.0/pooler-cpuminer-2.5.0.tar.gz'
-  source_sha256 'ea16761a952b8f0fbba22fd16d48bb5e20abc48a10af99a00c70c332b3cb54f5'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/pooler/cpuminer.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '37f961088b95729020863d96f4718eee45159fbbdc829e23e89f3f5c8c87dade',
-     armv7l: '37f961088b95729020863d96f4718eee45159fbbdc829e23e89f3f5c8c87dade',
-       i686: '668b081bac76e9e239b0df9b30d39b32d97e1cd7b0c18a9b118025e7c0dbdace',
-     x86_64: 'a4101c3804f18fa55f93ea0516c5deca35093064f47146ef1f398b8b1e10f343'
+    aarch64: 'a6be8bbbd7b0bbddf383ddd7eb280a7cf5099b2183ba5c67eec06bfabcc62f63',
+     armv7l: 'a6be8bbbd7b0bbddf383ddd7eb280a7cf5099b2183ba5c67eec06bfabcc62f63',
+       i686: 'd194f08920ad6a668027fa42b9bca49bd302ddf8d46b406993e1f38c9474f044',
+     x86_64: '4f109da12beed9cf7054b5bb31432e79d6c2d88aebe9861405ead57a583f4ca5'
   })
 
-  depends_on 'curl'
-  depends_on 'jansson'
-
-  def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    system "gzip -9 #{CREW_DEST_PREFIX}/share/man/man1/minerd.1"
-  end
+  depends_on 'curl' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'jansson' => :executable
 end

--- a/tests/package/m/minerd
+++ b/tests/package/m/minerd
@@ -1,0 +1,3 @@
+#!/bin/bash
+minerd -h | head
+minerd -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-minerd crew update \
&& yes | crew upgrade

$ crew check minerd 
Checking minerd package ...
Library test for minerd passed.
Checking minerd package ...
Usage: minerd [OPTIONS]
Options:
  -a, --algo=ALGO       specify the algorithm to use
                          scrypt    scrypt(1024, 1, 1) (default)
                          scrypt:N  scrypt(N, 1, 1)
                          sha256d   SHA-256d
  -o, --url=URL         URL of mining server
  -O, --userpass=U:P    username:password pair for mining server
  -u, --user=USERNAME   username for mining server
  -p, --pass=PASSWORD   password for mining server
cpuminer 2.5.1
 built on Jun 28 2026
 features: x86_64 PHE SSE2 AVX AVX2 XOP
libcurl/8.21.0 OpenSSL/3.5.7 zlib/1.3.2 brotli/1.2.0 zstd/1.5.7 c-ares/1.34.6 libidn2/2.3.8 libpsl/0.22.0 libssh/0.12.0/openssl/zlib nghttp2/1.69.0 ngtcp2/1.23.0 nghttp3/1.17.0 OpenLDAP/2.6.13
libjansson 2.15.0
```