### PR TITLE
Miniupnpc 2.1 => 2.3.3

### DIFF
--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -5,7 +5,7 @@ require_relative '../report_buildsystem_methods'
 
 class Autotools < Package
   boolean_property :autotools_make_j1, :autotools_skip_configure
-  property :autotools_build_relative_dir, :autotools_configure_options, :autotools_configure_modifications, :autotools_install_options, :autotools_pre_configure_options, :autotools_build_extras, :autotools_install_extras, :autotools_pre_make_options
+  property :autotools_build_relative_dir, :autotools_configure_options, :autotools_configure_modifications, :autotools_install_options, :autotools_pre_configure_options, :autotools_build_extras, :autotools_install_extras, :autotools_pre_make_options, :autotools_make_options
 
   def self.prebuild_config_and_report
     @autotools_build_relative_dir ||= '.'
@@ -37,9 +37,9 @@ class Autotools < Package
 
       # Add "-j#" argument to "make" at compile-time, if necessary.
       if @autotools_make_j1
-        system "#{@autotools_pre_make_options} make -j1"
+        system "#{@autotools_pre_make_options} make -j1 #{@autotools_make_options}"
       else
-        system "#{@autotools_pre_make_options} make -j#{CREW_NPROC}"
+        system "#{@autotools_pre_make_options} make -j#{CREW_NPROC} #{@autotools_make_options}"
       end
 
       @autotools_build_extras&.call

--- a/manifest/armv7l/m/miniupnpc.filelist
+++ b/manifest/armv7l/m/miniupnpc.filelist
@@ -1,4 +1,9 @@
-# Total size: 168867
+# Total size: 447371
+/usr/local/bin/external-ip.sh
+/usr/local/bin/upnp-listdevices-shared
+/usr/local/bin/upnp-listdevices-static
+/usr/local/bin/upnpc-shared
+/usr/local/bin/upnpc-static
 /usr/local/include/miniupnpc/igd_desc_parse.h
 /usr/local/include/miniupnpc/miniupnpc.h
 /usr/local/include/miniupnpc/miniupnpc_declspec.h
@@ -9,7 +14,15 @@
 /usr/local/include/miniupnpc/upnpdev.h
 /usr/local/include/miniupnpc/upnperrors.h
 /usr/local/include/miniupnpc/upnpreplyparse.h
+/usr/local/lib/cmake/miniupnpc/libminiupnpc-shared-release.cmake
+/usr/local/lib/cmake/miniupnpc/libminiupnpc-shared.cmake
+/usr/local/lib/cmake/miniupnpc/libminiupnpc-static-release.cmake
+/usr/local/lib/cmake/miniupnpc/libminiupnpc-static.cmake
+/usr/local/lib/cmake/miniupnpc/miniupnpc-config.cmake
+/usr/local/lib/cmake/miniupnpc/miniupnpc-private.cmake
 /usr/local/lib/libminiupnpc.a
 /usr/local/lib/libminiupnpc.so
-/usr/local/lib/libminiupnpc.so.17
-/usr/local/lib/libminiupnpc.so.2.1
+/usr/local/lib/libminiupnpc.so.2.3.3
+/usr/local/lib/libminiupnpc.so.21
+/usr/local/lib/pkgconfig/miniupnpc.pc
+/usr/local/share/man/man3/miniupnpc.3.zst

--- a/manifest/i686/m/miniupnpc.filelist
+++ b/manifest/i686/m/miniupnpc.filelist
@@ -1,4 +1,9 @@
-# Total size: 156593
+# Total size: 500111
+/usr/local/bin/external-ip.sh
+/usr/local/bin/upnp-listdevices-shared
+/usr/local/bin/upnp-listdevices-static
+/usr/local/bin/upnpc-shared
+/usr/local/bin/upnpc-static
 /usr/local/include/miniupnpc/igd_desc_parse.h
 /usr/local/include/miniupnpc/miniupnpc.h
 /usr/local/include/miniupnpc/miniupnpc_declspec.h
@@ -9,7 +14,15 @@
 /usr/local/include/miniupnpc/upnpdev.h
 /usr/local/include/miniupnpc/upnperrors.h
 /usr/local/include/miniupnpc/upnpreplyparse.h
+/usr/local/lib/cmake/miniupnpc/libminiupnpc-shared-release.cmake
+/usr/local/lib/cmake/miniupnpc/libminiupnpc-shared.cmake
+/usr/local/lib/cmake/miniupnpc/libminiupnpc-static-release.cmake
+/usr/local/lib/cmake/miniupnpc/libminiupnpc-static.cmake
+/usr/local/lib/cmake/miniupnpc/miniupnpc-config.cmake
+/usr/local/lib/cmake/miniupnpc/miniupnpc-private.cmake
 /usr/local/lib/libminiupnpc.a
 /usr/local/lib/libminiupnpc.so
-/usr/local/lib/libminiupnpc.so.17
-/usr/local/lib/libminiupnpc.so.2.1
+/usr/local/lib/libminiupnpc.so.2.3.3
+/usr/local/lib/libminiupnpc.so.21
+/usr/local/lib/pkgconfig/miniupnpc.pc
+/usr/local/share/man/man3/miniupnpc.3.zst

--- a/manifest/x86_64/m/miniupnpc.filelist
+++ b/manifest/x86_64/m/miniupnpc.filelist
@@ -1,4 +1,9 @@
-# Total size: 186919
+# Total size: 514439
+/usr/local/bin/external-ip.sh
+/usr/local/bin/upnp-listdevices-shared
+/usr/local/bin/upnp-listdevices-static
+/usr/local/bin/upnpc-shared
+/usr/local/bin/upnpc-static
 /usr/local/include/miniupnpc/igd_desc_parse.h
 /usr/local/include/miniupnpc/miniupnpc.h
 /usr/local/include/miniupnpc/miniupnpc_declspec.h
@@ -9,7 +14,15 @@
 /usr/local/include/miniupnpc/upnpdev.h
 /usr/local/include/miniupnpc/upnperrors.h
 /usr/local/include/miniupnpc/upnpreplyparse.h
+/usr/local/lib64/cmake/miniupnpc/libminiupnpc-shared-release.cmake
+/usr/local/lib64/cmake/miniupnpc/libminiupnpc-shared.cmake
+/usr/local/lib64/cmake/miniupnpc/libminiupnpc-static-release.cmake
+/usr/local/lib64/cmake/miniupnpc/libminiupnpc-static.cmake
+/usr/local/lib64/cmake/miniupnpc/miniupnpc-config.cmake
+/usr/local/lib64/cmake/miniupnpc/miniupnpc-private.cmake
 /usr/local/lib64/libminiupnpc.a
 /usr/local/lib64/libminiupnpc.so
-/usr/local/lib64/libminiupnpc.so.17
-/usr/local/lib64/libminiupnpc.so.2.1
+/usr/local/lib64/libminiupnpc.so.2.3.3
+/usr/local/lib64/libminiupnpc.so.21
+/usr/local/lib64/pkgconfig/miniupnpc.pc
+/usr/local/share/man/man3/miniupnpc.3.zst

--- a/packages/miniupnpc.rb
+++ b/packages/miniupnpc.rb
@@ -1,40 +1,24 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Miniupnpc < Package
+class Miniupnpc < CMake
   description 'UPnP IGD client lightweight library'
   homepage 'http://miniupnp.free.fr/'
-  version '2.1'
+  version '2.3.3'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://github.com/miniupnp/miniupnp/archive/miniupnpc_2_1.tar.gz'
-  source_sha256 '19c5b6cf8f3fc31d5e641c797b36ecca585909c7f3685a5c1a64325340537c94'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/miniupnp/miniupnp.git'
+  git_hashtag "miniupnpc_#{version.gsub('.', '_')}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '312d76ffa9e5f86e7d1556b49a875387455cea3914f359aa2e9b9dee761a6adb',
-     armv7l: '312d76ffa9e5f86e7d1556b49a875387455cea3914f359aa2e9b9dee761a6adb',
-       i686: 'ec9f784b89804522b35d05c62c027ef359c03aa664b885619d942f72418474c5',
-     x86_64: 'cc39583447b82b0599b6fd6807f6df3f728b35089d9d9a99d4c9064f58eb4fa0'
+    aarch64: 'bf163ac0912951443577a91ed6c89e3f269e129b1b7860a2145e6620bdac07e0',
+     armv7l: 'bf163ac0912951443577a91ed6c89e3f269e129b1b7860a2145e6620bdac07e0',
+       i686: 'af826ef511ea524d0a8245f4d668254c50588676f261411033607388c6814ce6',
+     x86_64: '491990bc8083e746f871521fd42b91f66f0673f0b7d66bb3610dec6848050c0f'
   })
 
-  def self.patch
-    # system "sed -i '139s,/usr,,' Makefile"
-  end
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
-  def self.build
-    Dir.chdir 'miniupnpc' do
-      if ARCH == 'x86_64'
-        system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DLIB_SUFFIX=64"
-      else
-        system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}"
-      end
-      system 'make'
-    end
-  end
-
-  def self.install
-    Dir.chdir 'miniupnpc' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
-  end
+  cmake_build_relative_dir 'miniupnpc'
 end

--- a/tests/package/m/miniupnpc
+++ b/tests/package/m/miniupnpc
@@ -1,0 +1,2 @@
+#!/bin/bash
+upnpc-shared -h | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-miniupnpc crew update \
&& yes | crew upgrade

$ crew check miniupnpc
Checking miniupnpc package ...
Library test for miniupnpc passed.
Checking miniupnpc package ...
upnpc: miniupnpc library test client, version 2.3.3.
 (c) 2005-2025 Thomas Bernard.
More information at https://miniupnp.tuxfamily.org/ or http://miniupnp.free.fr/

Usage:
  upnpc [options] -a ip port external_port protocol [duration] [remote host]
    Add port mapping
  upnpc [options] -r port1 [external_port1] protocol1 [port2 [external_port2] protocol2] [...]
    Add multiple port mappings to the current host
  upnpc [options] -d external_port protocol [remote host]
Package tests for miniupnpc passed.
```