### PR TITLE
Mkfontscale 1.2.1-1 => 1.2.4

### DIFF
--- a/manifest/armv7l/m/mkfontscale.filelist
+++ b/manifest/armv7l/m/mkfontscale.filelist
@@ -1,5 +1,5 @@
-# Total size: 56717
+# Total size: 31248
 /usr/local/bin/mkfontdir
 /usr/local/bin/mkfontscale
-/usr/local/share/man/man1/mkfontdir.1.gz
-/usr/local/share/man/man1/mkfontscale.1.gz
+/usr/local/share/man/man1/mkfontdir.1.zst
+/usr/local/share/man/man1/mkfontscale.1.zst

--- a/manifest/x86_64/m/mkfontscale.filelist
+++ b/manifest/x86_64/m/mkfontscale.filelist
@@ -1,5 +1,5 @@
-# Total size: 62993
+# Total size: 44532
 /usr/local/bin/mkfontdir
 /usr/local/bin/mkfontscale
-/usr/local/share/man/man1/mkfontdir.1.gz
-/usr/local/share/man/man1/mkfontscale.1.gz
+/usr/local/share/man/man1/mkfontdir.1.zst
+/usr/local/share/man/man1/mkfontscale.1.zst

--- a/packages/mkfontscale.rb
+++ b/packages/mkfontscale.rb
@@ -1,31 +1,25 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Mkfontscale < Package
+class Mkfontscale < Autotools
   description 'X11 Scalable Font Index Generator'
   homepage 'https://www.x.org/wiki/'
-  version '1.2.1-1'
+  version '1.2.4'
   license 'custom'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://www.x.org/releases/individual/app/mkfontscale-1.2.1.tar.bz2'
-  source_sha256 'ca0495eb974a179dd742bfa6199d561bda1c8da4a0c5a667f21fd82aaab6bac7'
-  binary_compression 'tar.xz'
+  source_url "https://xorg.freedesktop.org/archive/individual/app/mkfontscale-#{version}.tar.xz"
+  source_sha256 'a01492a17a9b6c0ee3f92ee578850e305315b9f298da5f006a1cd4b51db01a5e'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '6dc86c623685bdc66affcdf10ddf98f0c3d0a1426e68556eb5b3eb88a238c868',
-     armv7l: '6dc86c623685bdc66affcdf10ddf98f0c3d0a1426e68556eb5b3eb88a238c868',
-     x86_64: '3c30b109c94cba6d833ad87644e01daba2a78a6954cea5d9b7749f569cd5bcac'
+    aarch64: '901addea13358a97378dd55c3bc6d6cb41855190b3c5e08c48c4829b0dc2db40',
+     armv7l: '901addea13358a97378dd55c3bc6d6cb41855190b3c5e08c48c4829b0dc2db40',
+     x86_64: '1bae144c8961d56ae7f0200fe121c8f0764afc4502e891c78f1d85498ce69baa'
   })
 
-  depends_on 'xorg_proto'
-  depends_on 'freetype'
-  depends_on 'libfontenc'
-
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system "make install DESTDIR=#{CREW_DEST_DIR}"
-  end
+  depends_on 'freetype' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libfontenc' => :executable
+  depends_on 'xorg_proto' => :executable
+  depends_on 'zlib' => :executable
 end

--- a/tests/package/m/mkfontscale
+++ b/tests/package/m/mkfontscale
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkfontscale --help 2>&1
+mkfontscale --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-mkfontscale crew update \
&& yes | crew upgrade

$ crew check mkfontscale 
Checking mkfontscale package ...
Library test for mkfontscale passed.
Checking mkfontscale package ...
Usage:
mkfontscale [ -b ] [ -s ] [ -o filename ] [-x suffix ]
            [ -a encoding ] [ -f fuzz ] [ -l ]
            [ -e directory ] [ -p prefix ] [ -n ] [ -r ] 
            [-u] [-U] [-v] [ directory ]...
mkfontscale 1.2.4
Package tests for mkfontscale passed.
```