### PR TITLE
Fix extracting cached git repositories

### DIFF
--- a/commands/download.rb
+++ b/commands/download.rb
@@ -241,8 +241,8 @@ def cached_git_download(pkg, source, filename, extract_dir, verbose: false)
       system "sha256sum -c #{cachefile}.sha256"
     end
       FileUtils.mkdir_p extract_dir
-      system "tar -Izstd -x#{verbose}f #{cachefile} -C #{extract_dir}"
-      return { source:, filename:, extract_dir: }, cachefile
+      system "tar -Izstd -x#{'v' if verbose}f #{cachefile} -C #{extract_dir}"
+      return { source:, filename:, extract_dir: }
     else
       puts 'Cached git repository checksum mismatch. 😔 Will download.'.lightred
     end


### PR DESCRIPTION
## Description
man whaddaya want me to say here

the return fix is an authentic skill issue on my part admittedly that was left over from another idea in an earlier fix pr that i forgot to remove

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=oops3 crew update \
&& yes | crew upgrade
```