### PR TITLE
Mpg123 1.32.3 => 1.33.6

### DIFF
--- a/manifest/armv7l/m/mpg123.filelist
+++ b/manifest/armv7l/m/mpg123.filelist
@@ -1,4 +1,4 @@
-# Total size: 845580
+# Total size: 969050
 /usr/local/bin/mpg123
 /usr/local/bin/mpg123-id3dump
 /usr/local/bin/mpg123-strip
@@ -10,15 +10,15 @@
 /usr/local/lib/libmpg123.la
 /usr/local/lib/libmpg123.so
 /usr/local/lib/libmpg123.so.0
-/usr/local/lib/libmpg123.so.0.48.1
+/usr/local/lib/libmpg123.so.0.49.4
 /usr/local/lib/libout123.la
 /usr/local/lib/libout123.so
 /usr/local/lib/libout123.so.0
-/usr/local/lib/libout123.so.0.5.0
+/usr/local/lib/libout123.so.0.5.2
 /usr/local/lib/libsyn123.la
 /usr/local/lib/libsyn123.so
 /usr/local/lib/libsyn123.so.0
-/usr/local/lib/libsyn123.so.0.2.2
+/usr/local/lib/libsyn123.so.0.2.3
 /usr/local/lib/mpg123/output_alsa.so
 /usr/local/lib/mpg123/output_dummy.so
 /usr/local/lib/pkgconfig/libmpg123.pc

--- a/manifest/i686/m/mpg123.filelist
+++ b/manifest/i686/m/mpg123.filelist
@@ -1,4 +1,4 @@
-# Total size: 1112240
+# Total size: 1215914
 /usr/local/bin/mpg123
 /usr/local/bin/mpg123-id3dump
 /usr/local/bin/mpg123-strip
@@ -10,15 +10,15 @@
 /usr/local/lib/libmpg123.la
 /usr/local/lib/libmpg123.so
 /usr/local/lib/libmpg123.so.0
-/usr/local/lib/libmpg123.so.0.48.1
+/usr/local/lib/libmpg123.so.0.49.4
 /usr/local/lib/libout123.la
 /usr/local/lib/libout123.so
 /usr/local/lib/libout123.so.0
-/usr/local/lib/libout123.so.0.5.0
+/usr/local/lib/libout123.so.0.5.2
 /usr/local/lib/libsyn123.la
 /usr/local/lib/libsyn123.so
 /usr/local/lib/libsyn123.so.0
-/usr/local/lib/libsyn123.so.0.2.2
+/usr/local/lib/libsyn123.so.0.2.3
 /usr/local/lib/mpg123/output_alsa.so
 /usr/local/lib/mpg123/output_dummy.so
 /usr/local/lib/pkgconfig/libmpg123.pc

--- a/manifest/x86_64/m/mpg123.filelist
+++ b/manifest/x86_64/m/mpg123.filelist
@@ -1,4 +1,4 @@
-# Total size: 1027472
+# Total size: 1386214
 /usr/local/bin/mpg123
 /usr/local/bin/mpg123-id3dump
 /usr/local/bin/mpg123-strip
@@ -10,15 +10,15 @@
 /usr/local/lib64/libmpg123.la
 /usr/local/lib64/libmpg123.so
 /usr/local/lib64/libmpg123.so.0
-/usr/local/lib64/libmpg123.so.0.48.1
+/usr/local/lib64/libmpg123.so.0.49.4
 /usr/local/lib64/libout123.la
 /usr/local/lib64/libout123.so
 /usr/local/lib64/libout123.so.0
-/usr/local/lib64/libout123.so.0.5.0
+/usr/local/lib64/libout123.so.0.5.2
 /usr/local/lib64/libsyn123.la
 /usr/local/lib64/libsyn123.so
 /usr/local/lib64/libsyn123.so.0
-/usr/local/lib64/libsyn123.so.0.2.2
+/usr/local/lib64/libsyn123.so.0.2.3
 /usr/local/lib64/mpg123/output_alsa.so
 /usr/local/lib64/mpg123/output_dummy.so
 /usr/local/lib64/pkgconfig/libmpg123.pc

--- a/packages/mpg123.rb
+++ b/packages/mpg123.rb
@@ -3,28 +3,23 @@ require 'buildsystems/autotools'
 class Mpg123 < Autotools
   description 'Fast console MPEG Audio Player and decoder library.'
   homepage 'http://www.mpg123.org/'
-  version '1.32.3'
+  version '1.33.6'
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
-  source_url 'https://sourceforge.net/projects/mpg123/files/mpg123/1.32.3/mpg123-1.32.3.tar.bz2'
-  source_sha256 '2d9913a57d4ee8f497a182c6e82582602409782a4fb481e989feebf4435867b4'
+  source_url "https://sourceforge.net/projects/mpg123/files/mpg123/#{version}/mpg123-#{version}.tar.bz2"
+  source_sha256 '929a7c18ba662b8927aed4de229ad9ae8ab2b4806dd0f30b90113eb1b4e2195a'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1ee23b78dee236ceea6eb9b8ea8b73121054e78fbbf3e5eec2ccda354a46a0aa',
-     armv7l: '1ee23b78dee236ceea6eb9b8ea8b73121054e78fbbf3e5eec2ccda354a46a0aa',
-       i686: 'b5d513cd57c46d1b5b563bb663d733696f5c521f3f4cd3349b3125a4d52b0391',
-     x86_64: '190163428312dc5dd4f5ac4c076753f7b43c563f1e702d6c508467d850e0cc11'
+    aarch64: 'a553b6184906f57c17b0783c780882b643ddee8ccfffe9fe9788cd0d3592597c',
+     armv7l: 'a553b6184906f57c17b0783c780882b643ddee8ccfffe9fe9788cd0d3592597c',
+       i686: '471e4c0bec3bc22faeceab652ed794f50b3c33d303a44e503dd5bc285fd63c0a',
+     x86_64: '84f446be131d1a27fd61429f435a11ba515a6ebcd8b0e5fca14025338dcd40aa'
   })
 
-  depends_on 'alsa_lib'
-  # depends_on 'cras'
-  depends_on 'glibc' # R
+  depends_on 'alsa_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
-  case ARCH
-  when 'i686'
-    autotools_configure_options '--with-audio=alsa --with-cpu=i386'
-  else
-    autotools_configure_options '--with-audio=alsa'
-  end
+  autotools_configure_options "--with-audio=alsa #{'--with-cpu=i386' if ARCH.eql?('i686')}"
 end

--- a/tests/package/m/mpg123
+++ b/tests/package/m/mpg123
@@ -1,0 +1,3 @@
+#!/bin/bash
+mpg123 -? | head
+mpg123 --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-mpg123 crew update \
&& yes | crew upgrade

$ crew check mpg123 
Checking mpg123 package ...
Library test for mpg123 passed.
Checking mpg123 package ...
High Performance MPEG 1.0/2.0/2.5 Audio Player for Layers 1, 2 and 3
	version 1.33.6; written and copyright by Michael Hipp and others
	free software (LGPL) without any warranty but with best wishes

usage: mpg123 [option(s)] [file(s) | URL(s) | -]
supported options [defaults in brackets]:
   -v    increase verbosity level       -q    quiet (don't print title)
   -t    testmode (no output)           -s    write to stdout
   -w f  write output as WAV file
   -k n  skip first n frames [0]        -n n  decode only n frames [all]
mpg123 1.33.6
Package tests for mpg123 passed.
```