### PR TITLE
Mysqltuner 2.7.0 => 2.8.45

### DIFF
--- a/manifest/armv7l/m/mysqltuner.filelist
+++ b/manifest/armv7l/m/mysqltuner.filelist
@@ -1,4 +1,4 @@
-# Total size: 2634814
+# Total size: 881838
 /usr/local/bin/mysqltuner
 /usr/local/share/mysqltuner/basic_passwords.txt
 /usr/local/share/mysqltuner/mysqltuner.pl

--- a/manifest/i686/m/mysqltuner.filelist
+++ b/manifest/i686/m/mysqltuner.filelist
@@ -1,4 +1,4 @@
-# Total size: 2634814
+# Total size: 881838
 /usr/local/bin/mysqltuner
 /usr/local/share/mysqltuner/basic_passwords.txt
 /usr/local/share/mysqltuner/mysqltuner.pl

--- a/manifest/x86_64/m/mysqltuner.filelist
+++ b/manifest/x86_64/m/mysqltuner.filelist
@@ -1,4 +1,4 @@
-# Total size: 2634814
+# Total size: 881838
 /usr/local/bin/mysqltuner
 /usr/local/share/mysqltuner/basic_passwords.txt
 /usr/local/share/mysqltuner/mysqltuner.pl

--- a/packages/mysqltuner.rb
+++ b/packages/mysqltuner.rb
@@ -3,13 +3,13 @@ require 'package'
 class Mysqltuner < Package
   description 'MySQLTuner is a script written in Perl that allows you to review a MySQL installation quickly and make adjustments to increase performance and stability.'
   homepage 'https://github.com/major/MySQLTuner-perl'
-  version '2.7.0'
+  version '2.8.45'
   license 'GPL-3+'
   compatibility 'all'
   source_url 'https://github.com/major/MySQLTuner-perl.git'
   git_hashtag "v#{version}"
 
-  depends_on 'perl'
+  depends_on 'perl' => :logical
 
   no_compile_needed
 

--- a/tests/package/m/mysqltuner
+++ b/tests/package/m/mysqltuner
@@ -1,0 +1,2 @@
+#!/bin/bash
+mysqltuner --help | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-mysqltuner crew update \
&& yes | crew upgrade

$ crew check mysqltuner 
Checking mysqltuner package ...
Library test for mysqltuner passed.
Checking mysqltuner package ...
MySQLTuner 2.8.45 - MySQL High Performance Tuning Script

Usage: ./mysqltuner.pl [options]

CONNECTION AND AUTHENTICATION:
  --defaults-extra-file <path>     Path to an extra custom config file
  --defaults-file <path>           Path to a custom .my.cnf
  --host <host>                    Connect to a remote host to perform tests
  --login-path <path>              Read options from the specified login path
  --mysqladmin <path>              Path to a custom mysqladmin executable
Package tests for mysqltuner passed.
```