### PR TITLE
Nanomsg 1.1.5 => 1.2.2

### DIFF
--- a/manifest/armv7l/n/nanomsg.filelist
+++ b/manifest/armv7l/n/nanomsg.filelist
@@ -1,4 +1,4 @@
-# Total size: 468628
+# Total size: 264799
 /usr/local/bin/nanocat
 /usr/local/include/nanomsg/bus.h
 /usr/local/include/nanomsg/inproc.h
@@ -11,11 +11,11 @@
 /usr/local/include/nanomsg/survey.h
 /usr/local/include/nanomsg/tcp.h
 /usr/local/include/nanomsg/ws.h
-/usr/local/lib/cmake/nanomsg-1.1.5/nanomsg-config-version.cmake
-/usr/local/lib/cmake/nanomsg-1.1.5/nanomsg-config.cmake
-/usr/local/lib/cmake/nanomsg-1.1.5/nanomsg-target-noconfig.cmake
-/usr/local/lib/cmake/nanomsg-1.1.5/nanomsg-target.cmake
+/usr/local/lib/cmake/nanomsg-ccd7f20/nanomsg-config-version.cmake
+/usr/local/lib/cmake/nanomsg-ccd7f20/nanomsg-config.cmake
+/usr/local/lib/cmake/nanomsg-ccd7f20/nanomsg-target-release.cmake
+/usr/local/lib/cmake/nanomsg-ccd7f20/nanomsg-target.cmake
 /usr/local/lib/libnanomsg.so
-/usr/local/lib/libnanomsg.so.5
-/usr/local/lib/libnanomsg.so.5.1.0
+/usr/local/lib/libnanomsg.so.6
+/usr/local/lib/libnanomsg.so.6.0.1
 /usr/local/lib/pkgconfig/nanomsg.pc

--- a/manifest/i686/n/nanomsg.filelist
+++ b/manifest/i686/n/nanomsg.filelist
@@ -1,4 +1,4 @@
-# Total size: 431810
+# Total size: 374015
 /usr/local/bin/nanocat
 /usr/local/include/nanomsg/bus.h
 /usr/local/include/nanomsg/inproc.h
@@ -11,11 +11,11 @@
 /usr/local/include/nanomsg/survey.h
 /usr/local/include/nanomsg/tcp.h
 /usr/local/include/nanomsg/ws.h
-/usr/local/lib/cmake/nanomsg-1.1.5/nanomsg-config-version.cmake
-/usr/local/lib/cmake/nanomsg-1.1.5/nanomsg-config.cmake
-/usr/local/lib/cmake/nanomsg-1.1.5/nanomsg-target-noconfig.cmake
-/usr/local/lib/cmake/nanomsg-1.1.5/nanomsg-target.cmake
+/usr/local/lib/cmake/nanomsg-ccd7f20/nanomsg-config-version.cmake
+/usr/local/lib/cmake/nanomsg-ccd7f20/nanomsg-config.cmake
+/usr/local/lib/cmake/nanomsg-ccd7f20/nanomsg-target-release.cmake
+/usr/local/lib/cmake/nanomsg-ccd7f20/nanomsg-target.cmake
 /usr/local/lib/libnanomsg.so
-/usr/local/lib/libnanomsg.so.5
-/usr/local/lib/libnanomsg.so.5.1.0
+/usr/local/lib/libnanomsg.so.6
+/usr/local/lib/libnanomsg.so.6.0.1
 /usr/local/lib/pkgconfig/nanomsg.pc

--- a/manifest/x86_64/n/nanomsg.filelist
+++ b/manifest/x86_64/n/nanomsg.filelist
@@ -1,4 +1,4 @@
-# Total size: 481286
+# Total size: 365909
 /usr/local/bin/nanocat
 /usr/local/include/nanomsg/bus.h
 /usr/local/include/nanomsg/inproc.h
@@ -11,11 +11,11 @@
 /usr/local/include/nanomsg/survey.h
 /usr/local/include/nanomsg/tcp.h
 /usr/local/include/nanomsg/ws.h
-/usr/local/lib64/cmake/nanomsg-1.1.5/nanomsg-config-version.cmake
-/usr/local/lib64/cmake/nanomsg-1.1.5/nanomsg-config.cmake
-/usr/local/lib64/cmake/nanomsg-1.1.5/nanomsg-target-noconfig.cmake
-/usr/local/lib64/cmake/nanomsg-1.1.5/nanomsg-target.cmake
+/usr/local/lib64/cmake/nanomsg-ccd7f20/nanomsg-config-version.cmake
+/usr/local/lib64/cmake/nanomsg-ccd7f20/nanomsg-config.cmake
+/usr/local/lib64/cmake/nanomsg-ccd7f20/nanomsg-target-release.cmake
+/usr/local/lib64/cmake/nanomsg-ccd7f20/nanomsg-target.cmake
 /usr/local/lib64/libnanomsg.so
-/usr/local/lib64/libnanomsg.so.5
-/usr/local/lib64/libnanomsg.so.5.1.0
+/usr/local/lib64/libnanomsg.so.6
+/usr/local/lib64/libnanomsg.so.6.0.1
 /usr/local/lib64/pkgconfig/nanomsg.pc

--- a/packages/nanomsg.rb
+++ b/packages/nanomsg.rb
@@ -1,40 +1,24 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Nanomsg < Package
+class Nanomsg < CMake
   description 'nanomsg is a socket library that provides several common communication patterns.'
   homepage 'https://nanomsg.org/'
-  version '1.1.5'
+  version '1.2.2'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/nanomsg/nanomsg/archive/1.1.5.tar.gz'
-  source_sha256 '218b31ae1534ab897cb5c419973603de9ca1a5f54df2e724ab4a188eb416df5a'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/nanomsg/nanomsg.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '70871fc6e26bbb62ed2924c9f368f9dae4395a7c03306ccfd00d01fcae196c03',
-     armv7l: '70871fc6e26bbb62ed2924c9f368f9dae4395a7c03306ccfd00d01fcae196c03',
-       i686: 'fed0e57269bae6898436d906b38cc36751aa1abd3c786810168ad9f673d002c8',
-     x86_64: 'fbe6018ba37354fb102a78ec63c0aef7a36f0e1e34b0bf19355e3e912df498c2'
+    aarch64: '3ae948550c1e89b5f7428206ba532762866cbd0d4846b473cb7d04faa33e40f6',
+     armv7l: '3ae948550c1e89b5f7428206ba532762866cbd0d4846b473cb7d04faa33e40f6',
+       i686: 'a83453df24247af3c5556eb97c2d4f9e8e89cc8cec450c77e34937609947a13f',
+     x86_64: '04175387ed5c0882622f512794aec327cc4cc41094d2ca3a4c74c5565e1c5968'
   })
 
-  def self.build
-    FileUtils.mkdir('build')
-    FileUtils.cd('build') do
-      system "cmake .. -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
-                       -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX}"
-      system 'make'
-    end
-  end
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
-  def self.install
-    FileUtils.cd('build') do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
-  end
-
-  def self.check
-    FileUtils.cd('build') do
-      system 'ctest .'
-    end
-  end
+  run_tests
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-nanomsg crew update \
&& yes | crew upgrade

$ crew check nanomsg 
Checking nanomsg package ...
Library test for nanomsg passed.
Checking nanomsg package ...
Usage:
    nanocat {--push|--pull|--pub|--sub|--req|--rep|--surveyor|--respondent|--bus|--pair|--bind|--connect|--bind-ipc|--connect-ipc|--bind-local|--connect-local} [-vqhAQ] [-i SEC] [-d SEC] [-D DATA] [-F PATH] [options] 

A command-line interface to nanomsg

Generic:
 --verbose,-v           Increase verbosity of the nanocat
 --silent,-q            Decrease verbosity of the nanocat
 --help,-h              This help text

Package tests for nanomsg passed.
```