### PR TITLE
Ncdc 1.20 => 1.25

### DIFF
--- a/manifest/armv7l/n/ncdc.filelist
+++ b/manifest/armv7l/n/ncdc.filelist
@@ -1,3 +1,3 @@
-# Total size: 1286027
+# Total size: 405459
 /usr/local/bin/ncdc
-/usr/local/share/man/man1/ncdc.1.gz
+/usr/local/share/man/man1/ncdc.1.zst

--- a/manifest/i686/n/ncdc.filelist
+++ b/manifest/i686/n/ncdc.filelist
@@ -1,3 +1,3 @@
-# Total size: 1203699
+# Total size: 600999
 /usr/local/bin/ncdc
-/usr/local/share/man/man1/ncdc.1.gz
+/usr/local/share/man/man1/ncdc.1.zst

--- a/manifest/x86_64/n/ncdc.filelist
+++ b/manifest/x86_64/n/ncdc.filelist
@@ -1,3 +1,3 @@
-# Total size: 1508719
+# Total size: 544847
 /usr/local/bin/ncdc
-/usr/local/share/man/man1/ncdc.1.gz
+/usr/local/share/man/man1/ncdc.1.zst

--- a/packages/ncdc.rb
+++ b/packages/ncdc.rb
@@ -1,39 +1,33 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Ncdc < Package
+class Ncdc < Autotools
   description 'Ncdc is a modern and lightweight direct connect client with a friendly ncurses interface.'
   homepage 'https://dev.yorhel.nl/ncdc'
-  version '1.20'
+  version '1.25'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://dev.yorhel.nl/download/ncdc-1.20.tar.gz'
-  source_sha256 '8a998857df6289b6bd44287fc06f705b662098189f2a8fe95b1a5fbc703b9631'
-  binary_compression 'tar.xz'
+  source_url "https://dev.yorhel.nl/download/ncdc-#{version}.tar.gz"
+  source_sha256 'b9be58e7dbe677f2ac1c472f6e76fad618a65e2f8bf1c7b9d3d97bc169feb740'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '29c39214a120bd002a78b118a53daa085530e837a6b67f1cf10bbaa7d1991524',
-     armv7l: '29c39214a120bd002a78b118a53daa085530e837a6b67f1cf10bbaa7d1991524',
-       i686: 'f28d8e26a29f6c2d555f591e5b3552aa1231fc843f52b827950ab67293443f2f',
-     x86_64: '7d72e59960fa27fef99a6f45c0fc9fc86b62931851c811d192e60d1376829452'
+    aarch64: '99096c1af84e886ea58f55f68132a375016825d87b8b483e533a53f1b197e14f',
+     armv7l: '99096c1af84e886ea58f55f68132a375016825d87b8b483e533a53f1b197e14f',
+       i686: '76f487fe4a0130551563328e9ea0886309bbaab13b5666b7bec6c6963ea3e28a',
+     x86_64: '59c4c5834ed95e77cc1b4a1ca7dcb1ec89472df025e3584fcf5e3696f450137c'
   })
 
-  depends_on 'ncurses'
-  depends_on 'zlib'
-  depends_on 'bzip2'
-  depends_on 'sqlite'
-  depends_on 'glib'
-  depends_on 'gnutls'
-  depends_on 'geoip'
+  depends_on 'bzip2' => :executable
+  depends_on 'geoip' => :executable
+  depends_on 'glib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'gnutls' => :executable
+  depends_on 'libmaxminddb' => :executable
+  depends_on 'ncurses' => :executable
+  depends_on 'sqlite' => :executable
+  depends_on 'zlib' => :executable
 
-  def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "CPPFLAGS=-I#{CREW_PREFIX}/include/ncursesw",
-           '--with-geoip'
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_pre_configure_options "CPPFLAGS='-I#{CREW_PREFIX}/include/ncursesw'"
+  autotools_configure_options '--with-geoip'
 end

--- a/tests/package/n/ncdc
+++ b/tests/package/n/ncdc
@@ -1,0 +1,3 @@
+#!/bin/bash
+ncdc -h
+ncdc -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-ncdc crew update \
&& yes | crew upgrade

$ crew check ncdc 
Checking ncdc package ...
Library test for ncdc passed.
Checking ncdc package ...
Usage:
  ncdc [OPTION…] - NCurses Direct Connect

Help Options:
  -h, --help                  Show help options

Application Options:
  -v, --version               Print version and compilation information.
  -c, --session-dir=<dir>     Use a different session directory. Default: `$NCDC_DIR' or `$HOME/.ncdc'.
  -n, --no-autoconnect        Don't automatically connect to hubs with the `autoconnect' option set.
  --no-bracketed-paste        Disable bracketed pasting.

ncdc 1.25 (built Jul  4 2026 06:09:40)
Sendfile support: yes (Linux)
GeoIP support: yes (libmaxminddb)
Libraries:
  GLib 2.88.2 (2.88.2)
  GnuTLS 3.8.13 (3.8.13)
  SQLite 3.53.3 (3.53.3)
  ncurses 6.6
  libmaxminddb 1.12.2
Package tests for ncdc passed.
```