### PR TITLE
Ncdu 1.12 => 2.9.2

### DIFF
--- a/manifest/armv7l/n/ncdu.filelist
+++ b/manifest/armv7l/n/ncdu.filelist
@@ -1,3 +1,3 @@
-# Total size: 198968
+# Total size: 309488
 /usr/local/bin/ncdu
-/usr/local/share/man/man1/ncdu.1.gz
+/usr/local/share/man/man1/ncdu.1.zst

--- a/manifest/i686/n/ncdu.filelist
+++ b/manifest/i686/n/ncdu.filelist
@@ -1,3 +1,0 @@
-# Total size: 195324
-/usr/local/bin/ncdu
-/usr/local/share/man/man1/ncdu.1.gz

--- a/manifest/x86_64/n/ncdu.filelist
+++ b/manifest/x86_64/n/ncdu.filelist
@@ -1,3 +1,3 @@
-# Total size: 223352
+# Total size: 339060
 /usr/local/bin/ncdu
-/usr/local/share/man/man1/ncdu.1.gz
+/usr/local/share/man/man1/ncdu.1.zst

--- a/packages/ncdu.rb
+++ b/packages/ncdu.rb
@@ -1,30 +1,30 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Ncdu < Package
+class Ncdu < Autotools
   description 'Ncdu is a disk usage analyzer with an ncurses interface.'
   homepage 'https://dev.yorhel.nl/ncdu'
-  version '1.12'
+  version '2.9.2'
   license 'MIT'
-  compatibility 'all'
-  source_url 'https://dev.yorhel.nl/download/ncdu-1.12.tar.gz'
-  source_sha256 '820e4e4747a2a2ec7a2e9f06d2f5a353516362c22496a10a9834f871b877499a'
-  binary_compression 'tar.xz'
+  compatibility 'aarch64 armv7l x86_64'
+  source_url "https://dev.yorhel.nl/download/ncdu-#{version}.tar.gz"
+  source_sha256 'e91135281cb66569f2ca4c0bac277246991e7e52524c0ca8cba3de5c8e81cec9'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'ac04b6c7a0c6ac7b9bf75636806e12539631d5617bb85ed9ed9c8536c95062a6',
-     armv7l: 'ac04b6c7a0c6ac7b9bf75636806e12539631d5617bb85ed9ed9c8536c95062a6',
-       i686: '095cd7dc346f99bb9e3e4361f35e034636efb0b68d4b22f9320c72cb0c782164',
-     x86_64: '5b764d5d1f4bc9186384e2aa3d7c51aa84c9c2ed1f6eb78a0ac3ed431d875745'
+    aarch64: '0bdbf0c982ca1c38f96e4a39c419e52607be6f0beb44ce432321fb6573cd1f51',
+     armv7l: '0bdbf0c982ca1c38f96e4a39c419e52607be6f0beb44ce432321fb6573cd1f51',
+     x86_64: '5fe1748ad034063cecc32da6993f19a180879429f64bf4313a4a73570b0d5e34'
   })
 
-  depends_on 'ncurses'
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'llvm_dev' => :build
+  depends_on 'ncurses' => :executable
+  depends_on 'zig' => :build
+  depends_on 'zstd' => :executable
 
-  def self.build
-    system "./configure --prefix=#{CREW_PREFIX} CPPFLAGS=-I#{CREW_PREFIX}/include/ncurses"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_skip_configure
+  autotools_install_options " \
+    PREFIX=#{CREW_DEST_PREFIX} \
+    CPPFLAGS='-I#{CREW_PREFIX}/include/ncurses'"
 end

--- a/tests/package/n/ncdu
+++ b/tests/package/n/ncdu
@@ -1,0 +1,3 @@
+#!/bin/bash
+ncdu -h | head
+ncdu -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-ncdu crew update \
&& yes | crew upgrade

$ crew check ncdu 
Checking ncdu package ...
Library test for ncdu passed.
Checking ncdu package ...
ncdu <options> <directory>

Mode selection:
  -h, --help                 This help message
  -v, -V, --version          Print version
  -f FILE                    Import scanned directory from FILE
  -o FILE                    Export scanned directory to FILE in JSON format
  -O FILE                    Export scanned directory to FILE in binary format
  -e, --extended             Enable extended information
  --ignore-config            Don't load config files
ncdu 2.9.2
Package tests for ncdu passed.
```