### PR TITLE
Nedit 5.7 => 5.8

### DIFF
--- a/manifest/armv7l/n/nedit.filelist
+++ b/manifest/armv7l/n/nedit.filelist
@@ -1,5 +1,5 @@
-# Total size: 1358156
+# Total size: 1368359
 /usr/local/bin/nc
 /usr/local/bin/nedit
-/usr/local/share/man/man1/nc.1.gz
-/usr/local/share/man/man1/nedit.1.gz
+/usr/local/share/man/man1/nc.1.zst
+/usr/local/share/man/man1/nedit.1.zst

--- a/manifest/x86_64/n/nedit.filelist
+++ b/manifest/x86_64/n/nedit.filelist
@@ -1,5 +1,5 @@
-# Total size: 1496632
+# Total size: 1613211
 /usr/local/bin/nc
 /usr/local/bin/nedit
-/usr/local/share/man/man1/nc.1.gz
-/usr/local/share/man/man1/nedit.1.gz
+/usr/local/share/man/man1/nc.1.zst
+/usr/local/share/man/man1/nedit.1.zst

--- a/packages/nedit.rb
+++ b/packages/nedit.rb
@@ -3,20 +3,24 @@ require 'package'
 class Nedit < Package
   description 'A fast, compact Motif/X11 plain text editor, for most popular Unix systems.'
   homepage 'https://sourceforge.net/projects/nedit/'
-  version '5.7'
+  version '5.8'
   license 'GPL-2'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://downloads.sourceforge.net/project/nedit/nedit-source/nedit-5.7-src.tar.gz'
-  source_sha256 'add9ac79ff973528ad36c86858238bac4f59896c27dbf285cbe6a4d425fca17a'
-  binary_compression 'tar.xz'
+  source_url "https://downloads.sourceforge.net/project/nedit/nedit-source/nedit-#{version}-src.tar.gz"
+  source_sha256 '5851aa7252dad952084529173640232562dec4a7c440209f196d53d4a5a8074d'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '4fba5943ef167821c201b21a09dece98b6d81cbcb79527c64e95000f4479c3d8',
-     armv7l: '4fba5943ef167821c201b21a09dece98b6d81cbcb79527c64e95000f4479c3d8',
-     x86_64: 'c2db0f40ee914ab92f65814953542ec9e5634415ea155076cf9e67f50e9428ed'
+    aarch64: '53b5407afaa2e90dbb2519d3374bbd3642fb4b38829e8f0025e5d30075c0426c',
+     armv7l: '53b5407afaa2e90dbb2519d3374bbd3642fb4b38829e8f0025e5d30075c0426c',
+     x86_64: '1d007a9473404e669ee0f2312aaa58a72ff6fc4aa9a77d0e636a6226f68588e3'
   })
 
-  depends_on 'motif'
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libx11' => :executable
+  depends_on 'libxt' => :executable
+  depends_on 'motif' => :executable
 
   def self.patch
     system "sed -i 's/\$@/linux/g' Makefile"
@@ -34,9 +38,9 @@ class Nedit < Package
   end
 
   def self.install
-    system "install -Dm755 ./source/nc #{CREW_DEST_PREFIX}/bin/nc"
-    system "install -Dm755 ./source/nedit #{CREW_DEST_PREFIX}/bin/nedit"
-    system "install -Dm644 ./doc/nc.man #{CREW_DEST_MAN_PREFIX}/man1/nc.1"
-    system "install -Dm644 ./doc/nedit.man #{CREW_DEST_MAN_PREFIX}/man1/nedit.1"
+    FileUtils.install 'source/nc', "#{CREW_DEST_PREFIX}/bin/nc", mode: 0o755
+    FileUtils.install 'source/nedit', "#{CREW_DEST_PREFIX}/bin/nedit", mode: 0o755
+    FileUtils.install 'doc/nc.man', "#{CREW_DEST_MAN_PREFIX}/man1/nc.1", mode: 0o644
+    FileUtils.install 'doc/nedit.man', "#{CREW_DEST_MAN_PREFIX}/man1/nedit.1", mode: 0o644
   end
 end

--- a/tests/package/n/nedit
+++ b/tests/package/n/nedit
@@ -1,0 +1,3 @@
+#!/bin/bash
+nedit -h 2>&1
+nedit -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-nedit crew update \
&& yes | crew upgrade

$ crew check nedit 
Checking nedit package ...
Library test for nedit passed.
Checking nedit package ...
nedit: /usr/local/lib64/libuuid.so.1: no version information available (required by /usr/local/lib64/libSM.so.6)
Usage:  nedit [-read] [-create] [-line n | +n] [-server] [-do command]
	      [-tags file] [-tabs n] [-wrap] [-nowrap] [-autowrap]
	      [-autoindent] [-noautoindent] [-autosave] [-noautosave]
	      [-lm languagemode] [-rows n] [-columns n] [-font font]
	      [-geometry geometry] [-iconic] [-noiconic] [-svrname name]
	      [-display [host]:server[.screen] [-xrm resourcestring]
	      [-import file] [-background color] [-foreground color]
	      [-tabbed] [-untabbed] [-group] [-V|-version] [-h|-help]
	      [--] [file...]
NEdit 5.8
Apr 23, 2026

     Built on: Linux, x86-64, GNU C
   With Motif: 2.3.8 [@(#)Motif Version 2.3.8]
Running Motif: 2.3 [unknown]
       Server: The X.Org Foundation 12101007
       Visual: 24-bit TrueColor (ID 0x21, Default)
       Locale: en_US.UTF-8

Package tests for nedit passed.
```