### PR TITLE
Netavark 1.0.1 => 2.0.0

### DIFF
--- a/manifest/armv7l/n/netavark.filelist
+++ b/manifest/armv7l/n/netavark.filelist
@@ -1,4 +1,5 @@
-# Total size: 1185995
-/usr/local/lib/podman/netavark
+# Total size: 8688246
+/usr/local/bin/netavark
 /usr/local/share/doc/netavark/README.md
-/usr/local/share/man/man1/netavark.1.gz
+/usr/local/share/man/man1/netavark.1.zst
+/usr/local/share/man/man7/netavark-firewalld.7.zst

--- a/manifest/i686/n/netavark.filelist
+++ b/manifest/i686/n/netavark.filelist
@@ -1,4 +1,5 @@
-# Total size: 1749507
-/usr/local/lib/podman/netavark
+# Total size: 11262558
+/usr/local/bin/netavark
 /usr/local/share/doc/netavark/README.md
-/usr/local/share/man/man1/netavark.1.gz
+/usr/local/share/man/man1/netavark.1.zst
+/usr/local/share/man/man7/netavark-firewalld.7.zst

--- a/manifest/x86_64/n/netavark.filelist
+++ b/manifest/x86_64/n/netavark.filelist
@@ -1,4 +1,5 @@
-# Total size: 6694143
-/usr/local/lib64/podman/netavark
+# Total size: 11093910
+/usr/local/bin/netavark
 /usr/local/share/doc/netavark/README.md
-/usr/local/share/man/man1/netavark.1.gz
+/usr/local/share/man/man1/netavark.1.zst
+/usr/local/share/man/man7/netavark-firewalld.7.zst

--- a/packages/netavark.rb
+++ b/packages/netavark.rb
@@ -6,7 +6,7 @@ require 'package'
 class Netavark < Package
   description 'Container network stack'
   homepage 'https://github.com/containers/netavark'
-  version '1.0.1'
+  version '2.0.0'
   license 'Apache'
   compatibility 'all'
   source_url 'https://github.com/containers/netavark.git'
@@ -14,14 +14,19 @@ class Netavark < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '5278c97de9d0e0d550d74e59bcda1250789a02f111dd2c5ab6ac6661d1a3d8dc',
-     armv7l: '5278c97de9d0e0d550d74e59bcda1250789a02f111dd2c5ab6ac6661d1a3d8dc',
-       i686: 'd6b6e5ae80e4a06f894850f871ffdf57460a605a7ccfc24c8ecab69e667b14b2',
-     x86_64: '78b18d0e1c2271b376b9ed5173185b39e109dd50140d5f8ba71177d4b8f46410'
+    aarch64: 'cc26770ad7c96e2088431bd47fd92bc9bd4fb22ad798bcb2b8e678342964e896',
+     armv7l: 'cc26770ad7c96e2088431bd47fd92bc9bd4fb22ad798bcb2b8e678342964e896',
+       i686: '0d8a370aab601a150d959b2b75af7a4bfd488f37d21c727b9481139f3f57d9ae',
+     x86_64: '32c92aba46076831874528d7ab4be3f5337c0a1a1ec028c5a26596b6b7fd3232'
   })
 
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'go_md2man' => :build
   depends_on 'libgit2' => :build
   depends_on 'mandown' => :build
+  depends_on 'protobuf' => :build
 
   def self.build
     @carch = ARCH == 'aarch64' || ARCH == 'armv7l' ? 'armv7-unknown-linux-gnueabihf' : "#{ARCH}-unknown-linux-gnu"
@@ -31,9 +36,8 @@ class Netavark < Package
   end
 
   def self.install
-    FileUtils.mkdir_p %W[{CREW_DEST_LIB_PREFIX}/podman #{CREW_DEST_PREFIX}/share/doc/netavark]
-    FileUtils.install 'target/release/netavark', "#{CREW_DEST_LIB_PREFIX}/podman/", mode: 0o755
+    FileUtils.install 'target/release/netavark', "#{CREW_DEST_PREFIX}/bin/netavark", mode: 0o755
     system "make DESTDIR=#{CREW_DEST_DIR} PREFIX=#{CREW_PREFIX} install -C docs"
-    FileUtils.install 'README.md', "#{CREW_DEST_PREFIX}/share/doc/netavark/", mode: 0o644
+    FileUtils.install 'README.md', "#{CREW_DEST_PREFIX}/share/doc/netavark/README.md", mode: 0o644
   end
 end

--- a/tests/package/n/netavark
+++ b/tests/package/n/netavark
@@ -1,0 +1,3 @@
+#!/bin/bash
+netavark -h | head
+netavark -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-netavark crew update \
&& yes | crew upgrade

$ crew check netavark 
Checking netavark package ...
Library test for netavark passed.
Checking netavark package ...
Usage: netavark [OPTIONS] <COMMAND>

Commands:
  create            Create a network config
  setup             Configures the given network namespace with the given configuration
  update            Updates network dns servers for an already configured network
  teardown          Undo any configuration applied via setup command
  version           Display info about netavark
  dhcp-proxy        Start dhcp-proxy
  firewalld-reload  Listen for the firewalld reload event and reload fw rules
netavark 2.0.0
Package tests for netavark passed.
```