### PR TITLE
Ntfs_3g 2022.10.3 => 2026.2.25

### DIFF
--- a/manifest/armv7l/n/ntfs_3g.filelist
+++ b/manifest/armv7l/n/ntfs_3g.filelist
@@ -1,4 +1,4 @@
-# Total size: 2938373
+# Total size: 3067544
 /usr/local/bin/ntfscat
 /usr/local/bin/ntfscluster
 /usr/local/bin/ntfscmp
@@ -72,10 +72,5 @@
 /usr/local/share/man/man8/ntfslabel.8.zst
 /usr/local/share/man/man8/ntfsls.8.zst
 /usr/local/share/man/man8/ntfsprogs.8.zst
-/usr/local/share/man/man8/ntfsrecover.8.zst
 /usr/local/share/man/man8/ntfsresize.8.zst
-/usr/local/share/man/man8/ntfssecaudit.8.zst
-/usr/local/share/man/man8/ntfstruncate.8.zst
 /usr/local/share/man/man8/ntfsundelete.8.zst
-/usr/local/share/man/man8/ntfsusermap.8.zst
-/usr/local/share/man/man8/ntfswipe.8.zst

--- a/manifest/i686/n/ntfs_3g.filelist
+++ b/manifest/i686/n/ntfs_3g.filelist
@@ -1,4 +1,4 @@
-# Total size: 3197781
+# Total size: 3450802
 /usr/local/bin/ntfscat
 /usr/local/bin/ntfscluster
 /usr/local/bin/ntfscmp
@@ -72,10 +72,5 @@
 /usr/local/share/man/man8/ntfslabel.8.zst
 /usr/local/share/man/man8/ntfsls.8.zst
 /usr/local/share/man/man8/ntfsprogs.8.zst
-/usr/local/share/man/man8/ntfsrecover.8.zst
 /usr/local/share/man/man8/ntfsresize.8.zst
-/usr/local/share/man/man8/ntfssecaudit.8.zst
-/usr/local/share/man/man8/ntfstruncate.8.zst
 /usr/local/share/man/man8/ntfsundelete.8.zst
-/usr/local/share/man/man8/ntfsusermap.8.zst
-/usr/local/share/man/man8/ntfswipe.8.zst

--- a/manifest/x86_64/n/ntfs_3g.filelist
+++ b/manifest/x86_64/n/ntfs_3g.filelist
@@ -1,4 +1,4 @@
-# Total size: 3165573
+# Total size: 3470084
 /usr/local/bin/ntfscat
 /usr/local/bin/ntfscluster
 /usr/local/bin/ntfscmp
@@ -72,10 +72,5 @@
 /usr/local/share/man/man8/ntfslabel.8.zst
 /usr/local/share/man/man8/ntfsls.8.zst
 /usr/local/share/man/man8/ntfsprogs.8.zst
-/usr/local/share/man/man8/ntfsrecover.8.zst
 /usr/local/share/man/man8/ntfsresize.8.zst
-/usr/local/share/man/man8/ntfssecaudit.8.zst
-/usr/local/share/man/man8/ntfstruncate.8.zst
 /usr/local/share/man/man8/ntfsundelete.8.zst
-/usr/local/share/man/man8/ntfsusermap.8.zst
-/usr/local/share/man/man8/ntfswipe.8.zst

--- a/packages/ntfs_3g.rb
+++ b/packages/ntfs_3g.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Ntfs_3g < Autotools
   description 'NTFS-3G Safe Read/Write NTFS Driver'
   homepage 'https://github.com/tuxera/ntfs-3g'
-  version '2022.10.3'
+  version '2026.2.25'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/tuxera/ntfs-3g.git'
@@ -11,14 +11,15 @@ class Ntfs_3g < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '20a7ab1f3292de6dd70298bfd1939d09ee1326a2bd6b83da0134bd9142297e53',
-     armv7l: '20a7ab1f3292de6dd70298bfd1939d09ee1326a2bd6b83da0134bd9142297e53',
-       i686: '03b6d129a013d7f219d3ddd29ece882c6b6821fd4e163d9cef6373970c3a5aa7',
-     x86_64: '24498aee82923066f076c889d1df019477797fc6f682d0d49426cd0c31875db2'
+    aarch64: '6a0945e41b06452ba9b4e7e2b46c45d87a47b0287dd201e94c234d16243bdd92',
+     armv7l: '6a0945e41b06452ba9b4e7e2b46c45d87a47b0287dd201e94c234d16243bdd92',
+       i686: '075120ba32bbf1b1b4b0cacccb88981f3d0a7981385afbccce56e23f2721ab31',
+     x86_64: '7b7ef5e12c8f9d0856575b3dcf0c25ca184a04eb5b65f8416c76b87b1844532b'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'util_linux' # R
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'util_linux' => :executable
 
   autotools_configure_options "--exec-prefix=#{CREW_PREFIX} --disable-ntfs-3g"
 end

--- a/tests/package/n/ntfs_3g
+++ b/tests/package/n/ntfs_3g
@@ -1,0 +1,13 @@
+#!/bin/bash
+mkntfs -h | head
+mkntfs -V
+ntfsclone -h | head
+ntfsclone -V
+ntfscp -h | head
+ntfscp -V
+ntfslabel -h | head
+ntfslabel -V
+ntfsresize -h | head
+ntfsresize -V
+ntfsundelete -h | head
+ntfsundelete -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-ntfs_3g crew update \
&& yes | crew upgrade

$ crew check ntfs_3g 
Checking ntfs_3g package ...
Library test for ntfs_3g passed.
Checking ntfs_3g package ...

Usage: mkntfs [options] device [number-of-sectors]

Basic options:
    -f, --fast                      Perform a quick format
    -Q, --quick                     Perform a quick format
    -L, --label STRING              Set the volume label
    -C, --enable-compression        Enable compression on the volume
    -I, --no-indexing               Disable indexing on the volume
    -n, --no-action                 Do not write to disk

mkntfs v2026.2.25 (libntfs-3g)

Create an NTFS volume on a user specified (block) device.

Copyright (c) 2000-2007 Anton Altaparmakov
Copyright (c) 2001-2005 Richard Russon
Copyright (c) 2002-2006 Szabolcs Szakacsits
Copyright (c) 2005      Erik Sornes
Copyright (c) 2007      Yura Pakhuchiy
Copyright (c) 2010-2018 Jean-Pierre Andre

This program is free software, released under the GNU General Public License
and you are welcome to redistribute it under certain conditions.  It comes with
ABSOLUTELY NO WARRANTY; for details read the GNU General Public License to be
found in the file "COPYING" distributed with this program, or online at:
http://www.gnu.org/copyleft/gpl.html

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/


Usage: ntfslabel [options] device [label]
    -n, --no-action    Do not write to disk
    -f, --force        Use less caution
        --new-serial   Set a new serial number
        --new-half-serial Set a partial new serial number
    -q, --quiet        Less output
    -v, --verbose      More output
    -V, --version      Display version information
    -h, --help         Display this help

ntfslabel v2026.2.25 (libntfs-3g) - Display, or set, the label for an NTFS Volume.

Copyright (c)
    2002      Matthew J. Fanto
    2002-2005 Anton Altaparmakov
    2002-2003 Richard Russon
    2012-2014 Jean-Pierre Andre

This program is free software, released under the GNU General Public License
and you are welcome to redistribute it under certain conditions.  It comes with
ABSOLUTELY NO WARRANTY; for details read the GNU General Public License to be
found in the file "COPYING" distributed with this program, or online at:
http://www.gnu.org/copyleft/gpl.html

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/

ntfsresize v2026.2.25 (libntfs-3g)

Usage: ntfsresize [OPTIONS] DEVICE
    Resize an NTFS volume non-destructively, safely move any data if needed.

    -c, --check            Check to ensure that the device is ready for resize
    -i, --info             Estimate the smallest shrunken size or the smallest
                                expansion size
    -m, --info-mb-only     Estimate the smallest shrunken size possible,
                                output size in MB only
ntfsresize v2026.2.25 (libntfs-3g)

Resize an NTFS Volume, without data loss.

Copyright (c) 2002-2006  Szabolcs Szakacsits
Copyright (c) 2002-2005  Anton Altaparmakov
Copyright (c) 2002-2003  Richard Russon
Copyright (c) 2007       Yura Pakhuchiy
Copyright (c) 2011-2018  Jean-Pierre Andre

This program is free software, released under the GNU General Public License
and you are welcome to redistribute it under certain conditions.  It comes with
ABSOLUTELY NO WARRANTY; for details read the GNU General Public License to be
found in the file "COPYING" distributed with this program, or online at:
http://www.gnu.org/copyleft/gpl.html

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/

Usage: ntfsundelete [options] device
    -s, --scan             Scan for files (default)
    -p, --percentage NUM   Minimum percentage recoverable
    -m, --match PATTERN    Only work on files with matching names
    -C, --case             Case sensitive matching
    -S, --size RANGE       Match files of this size
    -t, --time SINCE       Last referenced since this time

    -u, --undelete         Undelete mode

ntfsundelete v2026.2.25 (libntfs-3g) - Recover deleted files from an NTFS Volume.

Copyright (c) 2002-2005 Richard Russon
Copyright (c) 2004-2005 Holger Ohmacht
Copyright (c) 2005      Anton Altaparmakov
Copyright (c) 2007      Yura Pakhuchiy
Copyright (c) 2013-2018 Jean-Pierre Andre

This program is free software, released under the GNU General Public License
and you are welcome to redistribute it under certain conditions.  It comes with
ABSOLUTELY NO WARRANTY; for details read the GNU General Public License to be
found in the file "COPYING" distributed with this program, or online at:
http://www.gnu.org/copyleft/gpl.html

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/

Package tests for ntfs_3g passed.
```