### PR TITLE
Oc 3.11.0 => 4.22.0-202605222050

### DIFF
--- a/manifest/armv7l/o/oc.filelist
+++ b/manifest/armv7l/o/oc.filelist
@@ -1,0 +1,2 @@
+# Total size: 128746832
+/usr/local/bin/oc

--- a/manifest/x86_64/o/oc.filelist
+++ b/manifest/x86_64/o/oc.filelist
@@ -1,1 +1,2 @@
+# Total size: 139512040
 /usr/local/bin/oc

--- a/packages/oc.rb
+++ b/packages/oc.rb
@@ -2,14 +2,35 @@ require 'package'
 
 class Oc < Package
   description 'Enterprise Kubernetes for Developers'
-  homepage 'https://github.com/openshift/origin'
-  version '3.11.0'
+  homepage 'https://github.com/openshift/oc'
+  version '4.22.0-202605222050'
   license 'Apache-2.0'
-  compatibility 'x86_64'
-  source_url 'https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz'
-  source_sha256 '4b0f07428ba854174c58d2e38287e5402964c9a9355f6c359d1242efd0990da3'
+  compatibility 'aarch64 armv7l x86_64'
+  source_url 'https://github.com/openshift/oc.git'
+  git_hashtag "openshift-clients-#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '3db6c535c4081c126b63fd87fc50a0ac44fcf714ef5f00fc2cb3ba2116f037ec',
+     armv7l: '3db6c535c4081c126b63fd87fc50a0ac44fcf714ef5f00fc2cb3ba2116f037ec',
+     x86_64: 'e2eb56a4a35cc67c51e9ecbe934d1de2a481605dc35984f28780fc1118b206b5'
+  })
+
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'go' => :build
+  depends_on 'gpgme' => :executable
+
+  def self.patch
+    # Fix /bin/sh: 1: set: Illegal option -o pipefail
+    system "sed -i 's,set -euo pipefail && ,,' vendor/github.com/openshift/build-machinery-go/make/lib/version.mk"
+  end
+
+  def self.build
+    system 'make oc'
+  end
 
   def self.install
-    system "install -Dm755 oc #{CREW_DEST_PREFIX}/bin/oc"
+    FileUtils.install 'oc', "#{CREW_DEST_PREFIX}/bin/oc", mode: 0o755
   end
 end

--- a/tests/package/o/oc
+++ b/tests/package/o/oc
@@ -1,0 +1,3 @@
+#!/bin/bash
+oc help | head
+oc version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-oc crew update \
&& yes | crew upgrade

$ crew check oc 
Checking oc package ...
Library test for oc passed.
Checking oc package ...
OpenShift Client

This client helps you develop, build, deploy, and run your applications on any
OpenShift or Kubernetes cluster. It also includes the administrative
commands for managing a cluster under the 'adm' subcommand.

Basic Commands:
  login             Log in to a server
  new-project       Request a new project
  new-app           Create a new application
Client Version: v0.0.0-unknown-062bc54
Kustomize Version: v5.7.1
Package tests for oc passed.
```