### PR TITLE
Onevpl 2023.1.0 => 2023.4.0

### DIFF
--- a/manifest/x86_64/o/onevpl.filelist
+++ b/manifest/x86_64/o/onevpl.filelist
@@ -1,11 +1,10 @@
-# Total size: 4325980
+# Total size: 4231355
 /usr/local/bin/sample_decode
 /usr/local/bin/sample_encode
 /usr/local/bin/sample_multi_transcode
 /usr/local/bin/sample_vpp
 /usr/local/bin/system_analyzer
 /usr/local/bin/vpl-inspect
-/usr/local/etc/modulefiles/vpl
 /usr/local/etc/vpl/vars.sh
 /usr/local/include/vpl/mfx.h
 /usr/local/include/vpl/mfxadapter.h
@@ -18,6 +17,7 @@
 /usr/local/include/vpl/mfxencodestats.h
 /usr/local/include/vpl/mfximplcaps.h
 /usr/local/include/vpl/mfxjpeg.h
+/usr/local/include/vpl/mfxmemory.h
 /usr/local/include/vpl/mfxmvc.h
 /usr/local/include/vpl/mfxpcp.h
 /usr/local/include/vpl/mfxsession.h
@@ -33,7 +33,7 @@
 /usr/local/lib64/cmake/vpl/VPLConfigVersion.cmake
 /usr/local/lib64/libvpl.so
 /usr/local/lib64/libvpl.so.2
-/usr/local/lib64/libvpl.so.2.8
+/usr/local/lib64/libvpl.so.2.10
 /usr/local/lib64/pkgconfig/vpl.pc
 /usr/local/lib64/vpl/libvpl_wayland.so
 /usr/local/share/vpl/licensing/license.txt

--- a/packages/onevpl.rb
+++ b/packages/onevpl.rb
@@ -1,46 +1,34 @@
-# Adapted from Arch Linux onevpl PKGBUILD at:
-# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=onevpl
+require 'buildsystems/cmake'
 
-require 'package'
-
-class Onevpl < Package
+class Onevpl < CMake
   description 'oneAPI Video Processing Library'
   homepage 'https://www.intel.com/content/www/us/en/developer/tools/vpl/overview.html'
-  version '2023.1.0'
+  version '2023.4.0'
   license 'MIT'
   compatibility 'x86_64'
-  source_url 'https://github.com/oneapi-src/oneVPL/archive/refs/tags/v2023.1.0.tar.gz'
-  source_sha256 '0a1991278c64849f471e4b307a7c01f465a308674f359054886c32352e887b60'
+  source_url 'https://github.com/oneapi-src/oneVPL.git'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-     x86_64: 'ad119dc97568f728a42b909a6c3980d9245fc10fa81bab64a261e3c8c6e6d634'
+     x86_64: '23a79ff8af0ce111b4bff1839d64b08835d599a0c7f23afb63dcdf6f4b909643'
   })
 
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
-  depends_on 'intel_media_sdk' # R
-  depends_on 'libdrm' # R
-  depends_on 'libva' # R
-  depends_on 'libx11' # R
-  depends_on 'libxcb' # R
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'intel_media_sdk' => :library
+  depends_on 'libdrm' => :library
+  depends_on 'libva' => :library
+  depends_on 'libx11' => :library
+  depends_on 'libxcb' => :library
+  depends_on 'wayland' => :library
   depends_on 'wayland_protocols' => :build
-  depends_on 'wayland' # R
 
-  def self.build
-    FileUtils.mkdir_p 'builddir'
-    Dir.chdir 'builddir' do
-      system "cmake -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        -DBUILD_TESTS:BOOL='OFF' \
-        -DINSTALL_EXAMPLE_CODE:BOOL='OFF' \
-        -Wno-dev \
-        .."
-    end
-    system 'ninja -C builddir'
-  end
+  cmake_options '-DBUILD_TESTS=OFF -DINSTALL_EXAMPLE_CODE=OFF'
 
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  def self.patch
+    # Fix error: ‘uint64_t’ was not declared in this scope
+    system "sed -i '11i#include <cstdint>' tools/legacy/sample_vpp/src/sample_vpp_frc_adv.cpp"
   end
 end

--- a/tests/package/o/onevpl
+++ b/tests/package/o/onevpl
@@ -1,0 +1,6 @@
+#!/bin/bash
+sample_decode -? | head
+sample_encode -? | head
+sample_multi_transcode -? | head
+sample_vpp -? | head
+vpl-inspect -? | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-onevpl crew update \
&& yes | crew upgrade

$ crew check onevpl 
Checking onevpl package ...
Library test for onevpl passed.
Checking onevpl package ...
Decoding Sample Version 8.4.27.0

Error: 
Usage: sample_decode <codecid> [<options>] -i InputBitstream
   or: sample_decode <codecid> [<options>] -i InputBitstream -r
   or: sample_decode <codecid> [<options>] -i InputBitstream -o OutputYUVFile

Supported codecs (<codecid>):
   <codecid>=h264|mpeg2|vc1|mvc|jpeg|vp9|av1 - built-in Media SDK codecs
   <codecid>=h265|vp9|capture            - in-box Media SDK plugins (may require separate downloading and installation)
Encoding Sample Version 8.4.27.0

Usage: sample_encode <msdk-codecid> [<options>] -i InputYUVFile -o OutputEncodedFile -w width -h height

Supported codecs, <msdk-codecid>:
   <codecid>=h264|mpeg2|vc1|mvc|jpeg|av1 - built-in Media SDK codecs
   <codecid>=h265|vp9                    - in-box Media SDK plugins (may require separate downloading and installation)
   If codecid is jpeg, -q option is mandatory.)
Options: 
   [-device /path/to/device] - set graphics device for processing
Multi Transcoding Sample Version 8.4.27.0

Command line parameters

Usage: sample_multi_transcode [options] [--] pipeline-description
   or: sample_multi_transcode [options] -par ParFile


  -stat <N>
                Output statistic every N transcoding cycles
Intel(R) Media SDK VPP Sample version 8.4.27.0
Error: Not enough parameters
Usage: sample_vpp [Options] -i InputFile -o OutputFile
Options: 
   [-lib  type]                - type of used library. sw, hw (def: sw)

   [-device /path/to/device]   - set graphics device for processing
                                  For example: '-device /dev/dri/card0'
                                               '-device /dev/dri/renderD128'
                                  If not specified, defaults to the first Intel device found on the system

Usage: vpl-inspect [options]

If no options are specified, print default capabilities report (MFX_IMPLCAPS_IMPLDESCSTRUCTURE)

Options:
   -?, -help ...... print help message
   -b ............. print brief output (do not print decoder, encoder, and VPP capabilities)
   -ex ............ print extended device ID info (MFX_IMPLCAPS_DEVICE_ID_EXTENDED)
   -f ............. print list of implemented functions (MFX_IMPLCAPS_IMPLEMENTEDFUNCTIONS)
Package tests for onevpl passed.
```