### PR TITLE
Oorexx 5.1.0-12932 => 5.2.0-13156

### DIFF
--- a/manifest/armv7l/o/oorexx.filelist
+++ b/manifest/armv7l/o/oorexx.filelist
@@ -1,7 +1,9 @@
-# Total size: 4342504
+# Total size: 5022926
 /usr/local/bin/csvStream.cls
 /usr/local/bin/dateparser.cls
 /usr/local/bin/json.cls
+/usr/local/bin/json.dtd
+/usr/local/bin/json.xsd
 /usr/local/bin/mime.cls
 /usr/local/bin/ncurses.cls
 /usr/local/bin/rexx
@@ -15,6 +17,11 @@
 /usr/local/bin/smtp.cls
 /usr/local/bin/socket.cls
 /usr/local/bin/streamsocket.cls
+/usr/local/bin/xmlToJson.xsl
+/usr/local/bin/xmlToYaml.xsl
+/usr/local/bin/yaml.cls
+/usr/local/bin/yaml.dtd
+/usr/local/bin/yaml.xsd
 /usr/local/include/oorexxapi.h
 /usr/local/include/oorexxerrors.h
 /usr/local/include/rexx.h

--- a/manifest/x86_64/o/oorexx.filelist
+++ b/manifest/x86_64/o/oorexx.filelist
@@ -1,7 +1,9 @@
-# Total size: 6283368
+# Total size: 7116622
 /usr/local/bin/csvStream.cls
 /usr/local/bin/dateparser.cls
 /usr/local/bin/json.cls
+/usr/local/bin/json.dtd
+/usr/local/bin/json.xsd
 /usr/local/bin/mime.cls
 /usr/local/bin/ncurses.cls
 /usr/local/bin/rexx
@@ -15,6 +17,11 @@
 /usr/local/bin/smtp.cls
 /usr/local/bin/socket.cls
 /usr/local/bin/streamsocket.cls
+/usr/local/bin/xmlToJson.xsl
+/usr/local/bin/xmlToYaml.xsl
+/usr/local/bin/yaml.cls
+/usr/local/bin/yaml.dtd
+/usr/local/bin/yaml.xsd
 /usr/local/include/oorexxapi.h
 /usr/local/include/oorexxerrors.h
 /usr/local/include/rexx.h

--- a/packages/oorexx.rb
+++ b/packages/oorexx.rb
@@ -3,19 +3,23 @@ require 'buildsystems/cmake'
 class Oorexx < CMake
   description 'Free implementation of Object Rexx'
   homepage 'https://www.oorexx.org/'
-  version '5.1.0-12932'
+  version '5.2.0-13156'
   license 'CPL-v1.0'
   compatibility 'aarch64 armv7l x86_64'
-  source_url "https://downloads.sourceforge.net/project/oorexx/oorexx/#{version.split('-')[0]}beta/oorexx-#{version}.tar.gz"
+  source_url "https://downloads.sourceforge.net/project/oorexx/oorexx/#{version.split('-')[0]}/oorexx-#{version}.tar.gz"
   source_sha256 'e69a6d18f49c5097d8cdec628be2c838b890310ca617587630f532349871ea21'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '309106ff3a457124ee1ef2a4b99893fd3f51502a456591b8e5b41ac1e3d6ef3d',
-     armv7l: '309106ff3a457124ee1ef2a4b99893fd3f51502a456591b8e5b41ac1e3d6ef3d',
-     x86_64: '7f74ddab696a9a15e3430cfa8459fdc07d716f7760ef8d9441c910ece658dd7c'
+    aarch64: '2f3d88a35d96652f46fbd66a2694ee372c307bba3a26957e691fe23e842c7342',
+     armv7l: '2f3d88a35d96652f46fbd66a2694ee372c307bba3a26957e691fe23e842c7342',
+     x86_64: '6924c983ef0d13b6d31067c694cd209b460da18f2753ddedb134aa42a847e0a3'
   })
 
-  depends_on 'ncurses'
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'libxcrypt' => :library
+  depends_on 'ncurses' => :library
   depends_on 'subversion' => :build
 end

--- a/tests/package/o/oorexx
+++ b/tests/package/o/oorexx
@@ -1,0 +1,2 @@
+#!/bin/bash
+rexx -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-oorexx crew update \
&& yes | crew upgrade

$ crew check oorexx
Checking oorexx package ...
Library test for oorexx passed.
Checking oorexx package ...
Open Object Rexx Version 5.2.0 r0
Build date: Jul 12 2026
Addressing mode: 64
Copyright (c) 1995, 2004 IBM Corporation. All rights reserved.
Copyright (c) 2005-2026 Rexx Language Association. All rights reserved.
This program and the accompanying materials are made available under the terms
of the Common Public License v1.0 which accompanies this distribution or at
https://www.oorexx.org/license.html
Package tests for oorexx passed.
```