### PR TITLE
Openjpeg 2.5.0 => 2.5.4

### DIFF
--- a/manifest/armv7l/o/openjpeg.filelist
+++ b/manifest/armv7l/o/openjpeg.filelist
@@ -1,15 +1,15 @@
-# Total size: 2583958
+# Total size: 2268214
 /usr/local/bin/opj_compress
 /usr/local/bin/opj_decompress
 /usr/local/bin/opj_dump
 /usr/local/include/openjpeg-2.5/openjpeg.h
 /usr/local/include/openjpeg-2.5/opj_config.h
-/usr/local/include/openjpeg-2.5/opj_stdint.h
+/usr/local/lib/cmake/openjpeg-2.5/OpenJPEGConfig.cmake
+/usr/local/lib/cmake/openjpeg-2.5/OpenJPEGConfigVersion.cmake
+/usr/local/lib/cmake/openjpeg-2.5/OpenJPEGTargets-release.cmake
+/usr/local/lib/cmake/openjpeg-2.5/OpenJPEGTargets.cmake
 /usr/local/lib/libopenjp2.a
 /usr/local/lib/libopenjp2.so
-/usr/local/lib/libopenjp2.so.2.5.0
+/usr/local/lib/libopenjp2.so.2.5.4
 /usr/local/lib/libopenjp2.so.7
-/usr/local/lib/openjpeg-2.5/OpenJPEGConfig.cmake
-/usr/local/lib/openjpeg-2.5/OpenJPEGTargets-release.cmake
-/usr/local/lib/openjpeg-2.5/OpenJPEGTargets.cmake
 /usr/local/lib/pkgconfig/libopenjp2.pc

--- a/manifest/x86_64/o/openjpeg.filelist
+++ b/manifest/x86_64/o/openjpeg.filelist
@@ -1,15 +1,15 @@
-# Total size: 2999204
+# Total size: 2560754
 /usr/local/bin/opj_compress
 /usr/local/bin/opj_decompress
 /usr/local/bin/opj_dump
 /usr/local/include/openjpeg-2.5/openjpeg.h
 /usr/local/include/openjpeg-2.5/opj_config.h
-/usr/local/include/openjpeg-2.5/opj_stdint.h
+/usr/local/lib64/cmake/openjpeg-2.5/OpenJPEGConfig.cmake
+/usr/local/lib64/cmake/openjpeg-2.5/OpenJPEGConfigVersion.cmake
+/usr/local/lib64/cmake/openjpeg-2.5/OpenJPEGTargets-release.cmake
+/usr/local/lib64/cmake/openjpeg-2.5/OpenJPEGTargets.cmake
 /usr/local/lib64/libopenjp2.a
 /usr/local/lib64/libopenjp2.so
-/usr/local/lib64/libopenjp2.so.2.5.0
+/usr/local/lib64/libopenjp2.so.2.5.4
 /usr/local/lib64/libopenjp2.so.7
-/usr/local/lib64/openjpeg-2.5/OpenJPEGConfig.cmake
-/usr/local/lib64/openjpeg-2.5/OpenJPEGTargets-release.cmake
-/usr/local/lib64/openjpeg-2.5/OpenJPEGTargets.cmake
 /usr/local/lib64/pkgconfig/libopenjp2.pc

--- a/packages/openjpeg.rb
+++ b/packages/openjpeg.rb
@@ -3,29 +3,31 @@ require 'buildsystems/cmake'
 class Openjpeg < CMake
   description 'An open source JPEG 2000 codec, written in C.'
   homepage 'https://github.com/uclouvain/openjpeg'
-  version '2.5.0'
+  version '2.5.4'
   license 'BSD-2'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://github.com/uclouvain/openjpeg/archive/v2.5.0.tar.gz'
-  source_sha256 '0333806d6adecc6f7a91243b2b839ff4d2053823634d4f6ed7a59bc87409122a'
+  source_url 'https://github.com/uclouvain/openjpeg.git'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a7af46fa74fd908fafa8c9ba3761a5f3167159e7e0776d72892b342d130db604',
-     armv7l: 'a7af46fa74fd908fafa8c9ba3761a5f3167159e7e0776d72892b342d130db604',
-     x86_64: 'cad4bc6d4f0784d9f0871c51d36c5c96ff5becff4d43ed52eefda13c89ea5eeb'
+    aarch64: 'e22a565ed03f1d81c9794c01a1e17b5610aac01a3f0942f61d55605ce631f0f1',
+     armv7l: 'e22a565ed03f1d81c9794c01a1e17b5610aac01a3f0942f61d55605ce631f0f1',
+     x86_64: '3f5122ee391a746dc4c0108968f8cafcc7cd507dd0f4eb1348b83b321d1e08d6'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'jbigkit' # R
-  depends_on 'libdeflate' # R
-  depends_on 'libjpeg_turbo' # R
-  depends_on 'libpng' # R
-  depends_on 'libtiff' # R
-  depends_on 'libwebp' # R
-  depends_on 'xzutils' # R
-  depends_on 'zlib' # R
-  depends_on 'zstd' # R
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'jbigkit' => :library
+  depends_on 'lcms' => :executable
+  depends_on 'libdeflate' => :library
+  depends_on 'libjpeg_turbo' => :library
+  depends_on 'libpng' => :executable
+  depends_on 'libtiff' => :executable
+  depends_on 'libwebp' => :executable
+  depends_on 'xzutils' => :executable
+  depends_on 'zlib' => :executable
+  depends_on 'zstd' => :executable
 
   cmake_options "-DOPENJPEG_INSTALL_LIB_DIR='lib#{CREW_LIB_SUFFIX}'"
 end

--- a/tests/package/o/openjpeg
+++ b/tests/package/o/openjpeg
@@ -1,0 +1,4 @@
+#!/bin/bash
+opj_compress -h | head
+opj_decompress -h | head
+opj_dump -h | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjpeg crew update \
&& yes | crew upgrade

$ crew check openjpeg
Checking openjpeg package ...
Library test for openjpeg passed.
Checking openjpeg package ...

This is the opj_compress utility from the OpenJPEG project.
It compresses various image formats with the JPEG 2000 algorithm.
It has been compiled against openjp2 library v2.5.4.

Default encoding options:
-------------------------

 * Lossless
 * 1 tile

This is the opj_decompress utility from the OpenJPEG project.
It decompresses JPEG 2000 codestreams to various image formats.
It has been compiled against openjp2 library v2.5.4.

Parameters:
-----------

  -ImgDir <directory> 
	Image file Directory path 

This is the opj_dump utility from the OpenJPEG project.
It dumps JPEG 2000 codestream info to stdout or a given file.
It has been compiled against openjp2 library v2.5.4.

Parameters:
-----------

  -ImgDir <directory>
	Image file Directory path 
Package tests for openjpeg passed.
```
