### PR TITLE
Nasm 3.01 => 3.02

### DIFF
--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -4,7 +4,7 @@ require_relative '../require_gem'
 require_relative '../report_buildsystem_methods'
 
 class Autotools < Package
-  boolean_property :autotools_make_j1, :autotools_skip_configure
+  boolean_property :autotools_make_j1, :autotools_skip_configure, :autotools_skip_autoreconf
   property :autotools_build_relative_dir, :autotools_configure_options, :autotools_configure_modifications, :autotools_install_options, :autotools_pre_configure_options, :autotools_build_extras, :autotools_install_extras, :autotools_pre_make_options, :autotools_make_options
 
   def self.prebuild_config_and_report
@@ -27,8 +27,10 @@ class Autotools < Package
         elsif File.executable? './bootstrap'
           system 'NOCONFIGURE=1 ./bootstrap --no-configure || NOCONFIGURE=1 ./bootstrap'
         end
-        # This ensures the correct aclocal and automake versions are configured.
-        system 'autoreconf -fiv' if File.file?('configure.ac')
+        if !@autotools_skip_autoreconf && File.file?('configure.ac')
+          # This ensures the correct aclocal and automake versions are configured.
+          system 'autoreconf -fiv'
+        end
         abort 'configure script not found!'.lightred unless File.file?('configure')
         FileUtils.chmod('+x', 'configure')
         system 'filefix', exception: false unless @no_filefix

--- a/manifest/armv7l/n/nasm.filelist
+++ b/manifest/armv7l/n/nasm.filelist
@@ -1,4 +1,4 @@
-# Total size: 2873091
+# Total size: 2749895
 /usr/local/bin/nasm
 /usr/local/bin/ndisasm
 /usr/local/share/man/man1/nasm.1.zst

--- a/manifest/i686/n/nasm.filelist
+++ b/manifest/i686/n/nasm.filelist
@@ -1,4 +1,4 @@
-# Total size: 2928339
+# Total size: 3023663
 /usr/local/bin/nasm
 /usr/local/bin/ndisasm
 /usr/local/share/man/man1/nasm.1.zst

--- a/manifest/x86_64/n/nasm.filelist
+++ b/manifest/x86_64/n/nasm.filelist
@@ -1,4 +1,4 @@
-# Total size: 3906783
+# Total size: 3968767
 /usr/local/bin/nasm
 /usr/local/bin/ndisasm
 /usr/local/share/man/man1/nasm.1.zst

--- a/packages/nasm.rb
+++ b/packages/nasm.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Nasm < Autotools
   description 'The Netwide Assembler'
   homepage 'https://www.nasm.us/'
-  version '3.01'
+  version '3.02'
   license 'BSD'
   compatibility 'all'
   source_url 'https://github.com/netwide-assembler/nasm.git'
@@ -11,16 +11,19 @@ class Nasm < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '981ea5b6b4422e2ea8474f7826b6dc40b7763c486a673c8e00647c7e67b1d31f',
-     armv7l: '981ea5b6b4422e2ea8474f7826b6dc40b7763c486a673c8e00647c7e67b1d31f',
-       i686: '14374c8074bb89ff97560e275c4b3bfff9bb285dd8041f58747b12dfb98c0b78',
-     x86_64: '907797c0e510b684488ade6f22c80e346352142cc66a5fe98a8559cfbd7812f9'
+    aarch64: '5ffca80369cc4c570cb44969af4456068aa8d8613a949bc9aac12b17ae67d950',
+     armv7l: '5ffca80369cc4c570cb44969af4456068aa8d8613a949bc9aac12b17ae67d950',
+       i686: '2b0c7d6dd11cb97499cb63e13335ee1126be19e5907fa977dcec830ab31dc3a5',
+     x86_64: '92b4f1c5fd25d9868e8108203bc6601a6abe1d2abc2be38e15042eadfab7f7b2'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'py3_asciidoc' => :build
   depends_on 'xmlto' => :build
+  depends_on 'zlib' => :executable
 
+  autotools_skip_autoreconf
   autotools_build_extras do
     system 'make manpages'
   end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-nasm crew update \
&& yes | crew upgrade

$ crew check nasm
Checking nasm package ...
Library test for nasm passed.
Checking nasm package ...
NASM version 3.02 compiled on Jul 15 2026
NDISASM version 3.02 compiled on Jul 15 2026
Package tests for nasm passed.
```