### PR TITLE
Prohibit downloading fake packages and add tests for `commands/download.rb`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ task default: %w[command_test lib_test]
 # Command tests
 task :command_test do
   ruby 'tests/commands/const.rb'
+  ruby 'tests/commands/download.rb'
   ruby 'tests/commands/help.rb'
   ruby 'tests/commands/list.rb'
   ruby 'tests/commands/prop.rb'

--- a/bin/crew
+++ b/bin/crew
@@ -1708,34 +1708,7 @@ def download_command(args)
     search @pkg_name
     @pkg.build_from_source = true if @opt_source
     print_current_package extra: CREW_VERBOSE
-    meta = {}
-    # rubocop:disable Style/ArrayIntersectWithSingleElement
-    if ARGV.intersect?(%w[download]) && @pkg.is_fake?
-      # rubocop:enable Style/ArrayIntersectWithSingleElement
-      fake_pkg_deplist = @pkg.get_deps_list(return_attr: true).flat_map(&:keys).uniq
-      until fake_pkg_deplist.blank?
-        puts "Will download the following packages: #{fake_pkg_deplist.join(' ')}".orange
-        fake_pkg_deplist.each_with_index do |fake_pkg_dep, index|
-          @pkg_name = fake_pkg_dep
-          search @pkg_name
-          @pkg.build_from_source = true if @opt_source
-          if @pkg.is_fake?
-            puts "Expanding #{fake_pkg_dep}...".lightpurple
-            expanded_pkg_list = @pkg.get_deps_list(return_attr: true).flat_map(&:keys).uniq
-            fake_pkg_deplist.push(*expanded_pkg_list)
-            fake_pkg_deplist.delete(@pkg_name)
-            next fake_pkg_dep
-          end
-          total_files_to_check = fake_pkg_deplist.length
-          numlength = total_files_to_check.to_s.length
-          puts "[#{(index + 1).to_s.rjust(numlength)}/#{total_files_to_check}] Downloading #{fake_pkg_dep}...".blue
-          meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: @opt_source)
-          fake_pkg_deplist.delete(@pkg_name)
-        end
-      end
-    else
-      meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: @opt_source)
-    end
+    meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: @opt_source)
     # Clean up remnant meta[:extract_dir] folders.
     FileUtils.rm_rf File.join(CREW_BREW_DIR, meta[:extract_dir]) unless meta[:extract_dir].nil?
   end

--- a/bin/crew
+++ b/bin/crew
@@ -1082,7 +1082,7 @@ def install(skip_postinstall: false)
     # use CREW_DEST_DIR
     dest_dir = CREW_DEST_DIR
   elsif @pkg.superclass.to_s == 'RUBY'
-    meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: @opt_source)
+    meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: @opt_source || @opt_recursive || CREW_BUILD_FROM_SOURCE)
     target_dir = unpack meta
     ruby_gem_name, ruby_gem_version, _upstream_version, _gem_installed_version, _gem_latest_version_installed, _gem_deps = PackageUtils.get_gem_vars(@pkg.name, @pkg.version, @pkg.upstream_name)
     gem_file = "#{ruby_gem_name}-#{ruby_gem_version}-#{GEM_ARCH}.gem"
@@ -1093,7 +1093,7 @@ def install(skip_postinstall: false)
     end
     dest_dir = CREW_DEST_DIR
   else
-    meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: @opt_source)
+    meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: @opt_source || @opt_recursive || CREW_BUILD_FROM_SOURCE)
     target_dir = unpack meta
     if meta[:source]
       # build from source and place binaries at CREW_DEST_DIR
@@ -1239,7 +1239,7 @@ end
 
 def build_package(crew_archive_dest)
   # Download source code and unpack it.
-  meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: @opt_source)
+  meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: true)
   target_dir = unpack meta
 
   # Build from source and place binaries in CREW_DEST_DIR.
@@ -1706,7 +1706,6 @@ def download_command(args)
   args['<name>'].each do |name|
     @pkg_name = name
     search @pkg_name
-    @pkg.build_from_source = true if @opt_source
     print_current_package extra: CREW_VERBOSE
     meta = Command.download(@pkg, verbose: CREW_VERBOSE, opt_source: @opt_source)
     # Clean up remnant meta[:extract_dir] folders.

--- a/commands/download.rb
+++ b/commands/download.rb
@@ -6,10 +6,10 @@ require_relative '../lib/package_utils'
 
 class Command
   def self.download(pkg, verbose: false, opt_source: false)
-    url = PackageUtils.get_url(pkg, build_from_source: opt_source || pkg.build_from_source)
-    sha256sum = PackageUtils.get_sha256(pkg, build_from_source: opt_source || pkg.build_from_source)
+    url = PackageUtils.get_url(pkg, build_from_source: opt_source)
+    sha256sum = PackageUtils.get_sha256(pkg, build_from_source: opt_source)
 
-    source = pkg.source?(ARCH.to_sym)
+    source = pkg.source?(ARCH.to_sym) || opt_source
     # Check for a missing binary package and if so rebuild.
     if !source && pkg.superclass.to_s == 'Pip' && !(`curl -sI #{url}`.lines.first.split[1] == '200' && PackageUtils.get_gitlab_pkginfo(pkg.name, pkg.version, ARCH, false, false)[:pkg_sha256] == sha256sum)
       url = 'SKIP'
@@ -29,7 +29,7 @@ class Command
       abort "No precompiled binary or source is available for #{ARCH}.".lightred
     elsif url.casecmp?('SKIP') || (pkg.no_source_build? || pkg.gem_compile_needed?)
       puts 'Skipping source download...'
-    elsif pkg.build_from_source
+    elsif opt_source
       puts 'Downloading source...'
     elsif !source
       puts 'Precompiled binary available, downloading...'

--- a/commands/download.rb
+++ b/commands/download.rb
@@ -6,6 +6,8 @@ require_relative '../lib/package_utils'
 
 class Command
   def self.download(pkg, verbose: false, opt_source: false)
+    abort 'Unable to download fake package.'.lightred if pkg.is_fake?
+
     url = PackageUtils.get_url(pkg, build_from_source: opt_source)
     sha256sum = PackageUtils.get_sha256(pkg, build_from_source: opt_source)
 

--- a/tests/commands/download.rb
+++ b/tests/commands/download.rb
@@ -1,0 +1,39 @@
+require 'digest/sha2'
+require 'minitest/autorun'
+require_relative '../../commands/download'
+require_relative '../../lib/const'
+require_relative '../../lib/package'
+require_relative '../../lib/package_utils'
+
+# Add lib to LOAD_PATH
+$LOAD_PATH << File.join(CREW_LIB_PATH, 'lib')
+
+class DownloadCommandTest < Minitest::Test
+  def test_precompiled_download
+    pkg = Package.load_package('gnome_common.rb')
+    meta = Command.download(pkg)
+    refute(meta[:source])
+    assert_equal(PackageUtils.get_sha256(pkg), Digest::SHA256.hexdigest(File.read(File.join(CREW_BREW_DIR, meta[:filename]))))
+  end
+
+  def test_regular_source_download
+    pkg = Package.load_package('ctorrent.rb')
+    meta = Command.download(pkg, opt_source: true)
+    assert(meta[:source])
+    assert_equal(PackageUtils.get_sha256(pkg, build_from_source: true), Digest::SHA256.hexdigest(File.read(File.join(CREW_BREW_DIR, meta[:filename]))))
+  end
+
+  def test_skip_source_download
+    pkg = Package.load_package('json2csv.rb')
+    meta = Command.download(pkg, opt_source: true)
+    assert(meta[:source])
+    assert_equal('SKIP', meta[:filename])
+  end
+
+  def test_unusual_source_download
+    pkg = Package.load_package('nmon.rb')
+    meta = Command.download(pkg, opt_source: true)
+    assert(meta[:source])
+    assert_equal(PackageUtils.get_sha256(pkg, build_from_source: true), Digest::SHA256.hexdigest(File.read(File.join(CREW_BREW_DIR, meta[:extract_dir], meta[:filename]))))
+  end
+end

--- a/tests/commands/download.rb
+++ b/tests/commands/download.rb
@@ -36,4 +36,8 @@ class DownloadCommandTest < Minitest::Test
     assert(meta[:source])
     assert_equal(PackageUtils.get_sha256(pkg, build_from_source: true), Digest::SHA256.hexdigest(File.read(File.join(CREW_BREW_DIR, meta[:extract_dir], meta[:filename]))))
   end
+
+  def test_fake_download
+    assert_raises(SystemExit) { Command.download(Package.load_package('buildessential.rb')) }
+  end
 end


### PR DESCRIPTION
## Description
I'd like to disentangle the whole `pkg.build_from_source` situation at some point, but this is a start.

also add some basic tests to avoid regressions and whatnot

although given that `tests/commands/prop.rb` is currently broken it seems our tests arent being run enough

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=untuned crew update \
&& yes | crew upgrade
```