### PR TITLE
Nethogs 0.8.8 => 0.9.0

### DIFF
--- a/manifest/armv7l/n/nethogs.filelist
+++ b/manifest/armv7l/n/nethogs.filelist
@@ -1,3 +1,3 @@
-# Total size: 64164
+# Total size: 53840
 /usr/local/sbin/nethogs
 /usr/local/share/man/man8/nethogs.8.zst

--- a/manifest/i686/n/nethogs.filelist
+++ b/manifest/i686/n/nethogs.filelist
@@ -1,3 +1,3 @@
-# Total size: 73768
+# Total size: 79344
 /usr/local/sbin/nethogs
 /usr/local/share/man/man8/nethogs.8.zst

--- a/manifest/x86_64/n/nethogs.filelist
+++ b/manifest/x86_64/n/nethogs.filelist
@@ -1,3 +1,3 @@
-# Total size: 71068
+# Total size: 77324
 /usr/local/sbin/nethogs
 /usr/local/share/man/man8/nethogs.8.zst

--- a/packages/nethogs.rb
+++ b/packages/nethogs.rb
@@ -1,9 +1,9 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Nethogs < Package
+class Nethogs < Autotools
   description "Linux 'net top' tool"
   homepage 'https://github.com/raboof/nethogs'
-  version '0.8.8'
+  version '0.9.0'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/raboof/nethogs.git'
@@ -11,20 +11,18 @@ class Nethogs < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'c123320353c55444546c61c75116f8d9225f72f82bf315fc641801f85b416320',
-     armv7l: 'c123320353c55444546c61c75116f8d9225f72f82bf315fc641801f85b416320',
-       i686: '0a8f67fc63b3e607344fa7d48581279d3caeb726a8baa466513f5ca4cd3d308f',
-     x86_64: '7772c37491162fd7a40b41f090b2bc5bd63570708f55e5c0e891f6c20589537a'
+    aarch64: '922510114f373f3f985b791b07c6b4399ee037277b9ad8d71ef596c441e0d73c',
+     armv7l: '922510114f373f3f985b791b07c6b4399ee037277b9ad8d71ef596c441e0d73c',
+       i686: 'a31ad6b573a9dd490447680c142e5d059a3b9b5fd06474d6ca82cba0b367e4f4',
+     x86_64: '34b4322abac56ca8f23d250e71f875e1b0d8707e2337bcf128d7f939fdfbc8b7'
   })
 
-  depends_on 'ncurses'
-  depends_on 'libpcap'
+  depends_on 'gcc_lib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libpcap' => :executable
+  depends_on 'ncurses' => :executable
 
-  def self.build
-    system "PREFIX=#{CREW_PREFIX} CPPFLAGS='-I#{CREW_PREFIX}/include/ncursesw' make"
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_skip_configure
+  autotools_pre_make_options "CPPFLAGS='-I#{CREW_PREFIX}/include/ncursesw'"
 end

--- a/tests/package/n/nethogs
+++ b/tests/package/n/nethogs
@@ -1,0 +1,3 @@
+#!/bin/bash
+nethogs -h | head
+nethogs -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-nethogs crew update \
&& yes | crew upgrade

$ crew check nethogs
Checking nethogs package ...
Library test for nethogs passed.
Checking nethogs package ...
usage: nethogs [-V] [-h] [-x] [-d seconds] [-v mode] [-c count] [-t] [-p] [-s] [-a] [-l] [-f filter] [-C] [-b] [-P pid] [device [device [device ...]]]
		-V : prints version.
		-h : prints this help.
		-x : bughunt mode - implies tracemode.
		-d : delay for update refresh rate in seconds. default is 1.
		-v : view mode (0 = kB/s, 1 = total kB, 2 = total bytes, 3 = total MB, 4 = MB/s, 5 = GB/s). default is 0.
		-c : number of updates. default is 0 (unlimited).
		-t : tracemode.
		-p : sniff in promiscious mode (not recommended).
		-s : sort output by sent column.
 version 
Package tests for nethogs passed.
```