### PR TITLE
Pacparser 1.3.7-1 => 1.5.1

### DIFF
--- a/manifest/armv7l/p/pacparser.filelist
+++ b/manifest/armv7l/p/pacparser.filelist
@@ -1,4 +1,4 @@
-# Total size: 2394932
+# Total size: 2273800
 /usr/local/bin/pactester
 /usr/local/include/pacparser.h
 /usr/local/lib/libpacparser.so
@@ -10,17 +10,17 @@
 /usr/local/share/doc/pacparser/html/doxygen.css
 /usr/local/share/doc/pacparser/html/pacparser.html
 /usr/local/share/doc/pacparser/html/pactester.1.html
-/usr/local/share/man/man1/pactester.1
-/usr/local/share/man/man3/pacparser.3
-/usr/local/share/man/man3/pacparser_cleanup.3
-/usr/local/share/man/man3/pacparser_enable_microsoft_extensions.3
-/usr/local/share/man/man3/pacparser_error_printer.3
-/usr/local/share/man/man3/pacparser_find_proxy.3
-/usr/local/share/man/man3/pacparser_init.3
-/usr/local/share/man/man3/pacparser_just_find_proxy.3
-/usr/local/share/man/man3/pacparser_parse_pac.3
-/usr/local/share/man/man3/pacparser_parse_pac_file.3
-/usr/local/share/man/man3/pacparser_parse_pac_string.3
-/usr/local/share/man/man3/pacparser_set_error_printer.3
-/usr/local/share/man/man3/pacparser_setmyip.3
-/usr/local/share/man/man3/pacparser_version.3
+/usr/local/share/man/man1/pactester.1.zst
+/usr/local/share/man/man3/pacparser.3.zst
+/usr/local/share/man/man3/pacparser_cleanup.3.zst
+/usr/local/share/man/man3/pacparser_enable_microsoft_extensions.3.zst
+/usr/local/share/man/man3/pacparser_error_printer.3.zst
+/usr/local/share/man/man3/pacparser_find_proxy.3.zst
+/usr/local/share/man/man3/pacparser_init.3.zst
+/usr/local/share/man/man3/pacparser_just_find_proxy.3.zst
+/usr/local/share/man/man3/pacparser_parse_pac.3.zst
+/usr/local/share/man/man3/pacparser_parse_pac_file.3.zst
+/usr/local/share/man/man3/pacparser_parse_pac_string.3.zst
+/usr/local/share/man/man3/pacparser_set_error_printer.3.zst
+/usr/local/share/man/man3/pacparser_setmyip.3.zst
+/usr/local/share/man/man3/pacparser_version.3.zst

--- a/manifest/i686/p/pacparser.filelist
+++ b/manifest/i686/p/pacparser.filelist
@@ -1,4 +1,4 @@
-# Total size: 2118005
+# Total size: 2115340
 /usr/local/bin/pactester
 /usr/local/include/pacparser.h
 /usr/local/lib/libpacparser.so
@@ -10,17 +10,17 @@
 /usr/local/share/doc/pacparser/html/doxygen.css
 /usr/local/share/doc/pacparser/html/pacparser.html
 /usr/local/share/doc/pacparser/html/pactester.1.html
-/usr/local/share/man/man1/pactester.1.gz
-/usr/local/share/man/man3/pacparser.3.gz
-/usr/local/share/man/man3/pacparser_cleanup.3.gz
-/usr/local/share/man/man3/pacparser_enable_microsoft_extensions.3.gz
-/usr/local/share/man/man3/pacparser_error_printer.3.gz
-/usr/local/share/man/man3/pacparser_find_proxy.3.gz
-/usr/local/share/man/man3/pacparser_init.3.gz
-/usr/local/share/man/man3/pacparser_just_find_proxy.3.gz
-/usr/local/share/man/man3/pacparser_parse_pac.3.gz
-/usr/local/share/man/man3/pacparser_parse_pac_file.3.gz
-/usr/local/share/man/man3/pacparser_parse_pac_string.3.gz
-/usr/local/share/man/man3/pacparser_set_error_printer.3.gz
-/usr/local/share/man/man3/pacparser_setmyip.3.gz
-/usr/local/share/man/man3/pacparser_version.3.gz
+/usr/local/share/man/man1/pactester.1.zst
+/usr/local/share/man/man3/pacparser.3.zst
+/usr/local/share/man/man3/pacparser_cleanup.3.zst
+/usr/local/share/man/man3/pacparser_enable_microsoft_extensions.3.zst
+/usr/local/share/man/man3/pacparser_error_printer.3.zst
+/usr/local/share/man/man3/pacparser_find_proxy.3.zst
+/usr/local/share/man/man3/pacparser_init.3.zst
+/usr/local/share/man/man3/pacparser_just_find_proxy.3.zst
+/usr/local/share/man/man3/pacparser_parse_pac.3.zst
+/usr/local/share/man/man3/pacparser_parse_pac_file.3.zst
+/usr/local/share/man/man3/pacparser_parse_pac_string.3.zst
+/usr/local/share/man/man3/pacparser_set_error_printer.3.zst
+/usr/local/share/man/man3/pacparser_setmyip.3.zst
+/usr/local/share/man/man3/pacparser_version.3.zst

--- a/manifest/x86_64/p/pacparser.filelist
+++ b/manifest/x86_64/p/pacparser.filelist
@@ -1,8 +1,8 @@
-# Total size: 2358637
+# Total size: 2485996
 /usr/local/bin/pactester
 /usr/local/include/pacparser.h
-/usr/local/lib/libpacparser.so
-/usr/local/lib/libpacparser.so.1
+/usr/local/lib64/libpacparser.so
+/usr/local/lib64/libpacparser.so.1
 /usr/local/share/doc/pacparser/examples/fetchurl.py
 /usr/local/share/doc/pacparser/examples/pactest.c
 /usr/local/share/doc/pacparser/examples/pactest.py
@@ -10,17 +10,17 @@
 /usr/local/share/doc/pacparser/html/doxygen.css
 /usr/local/share/doc/pacparser/html/pacparser.html
 /usr/local/share/doc/pacparser/html/pactester.1.html
-/usr/local/share/man/man1/pactester.1.gz
-/usr/local/share/man/man3/pacparser.3.gz
-/usr/local/share/man/man3/pacparser_cleanup.3.gz
-/usr/local/share/man/man3/pacparser_enable_microsoft_extensions.3.gz
-/usr/local/share/man/man3/pacparser_error_printer.3.gz
-/usr/local/share/man/man3/pacparser_find_proxy.3.gz
-/usr/local/share/man/man3/pacparser_init.3.gz
-/usr/local/share/man/man3/pacparser_just_find_proxy.3.gz
-/usr/local/share/man/man3/pacparser_parse_pac.3.gz
-/usr/local/share/man/man3/pacparser_parse_pac_file.3.gz
-/usr/local/share/man/man3/pacparser_parse_pac_string.3.gz
-/usr/local/share/man/man3/pacparser_set_error_printer.3.gz
-/usr/local/share/man/man3/pacparser_setmyip.3.gz
-/usr/local/share/man/man3/pacparser_version.3.gz
+/usr/local/share/man/man1/pactester.1.zst
+/usr/local/share/man/man3/pacparser.3.zst
+/usr/local/share/man/man3/pacparser_cleanup.3.zst
+/usr/local/share/man/man3/pacparser_enable_microsoft_extensions.3.zst
+/usr/local/share/man/man3/pacparser_error_printer.3.zst
+/usr/local/share/man/man3/pacparser_find_proxy.3.zst
+/usr/local/share/man/man3/pacparser_init.3.zst
+/usr/local/share/man/man3/pacparser_just_find_proxy.3.zst
+/usr/local/share/man/man3/pacparser_parse_pac.3.zst
+/usr/local/share/man/man3/pacparser_parse_pac_file.3.zst
+/usr/local/share/man/man3/pacparser_parse_pac_string.3.zst
+/usr/local/share/man/man3/pacparser_set_error_printer.3.zst
+/usr/local/share/man/man3/pacparser_setmyip.3.zst
+/usr/local/share/man/man3/pacparser_version.3.zst

--- a/packages/pacparser.rb
+++ b/packages/pacparser.rb
@@ -3,25 +3,29 @@ require 'package'
 class Pacparser < Package
   description 'pacparser is a library to parse proxy auto-config (PAC) files.'
   homepage 'https://pacparser.manugarg.com/'
-  version '1.3.7-1'
+  version '1.5.1'
   license 'LGPL-3'
   compatibility 'all'
-  source_url 'https://github.com/pacparser/pacparser/archive/1.3.7.tar.gz'
-  source_sha256 '575c5d8096b4c842b2af852bbb8bcfde96170b28b49f33249dbe2057a8beea13'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/pacparser/pacparser.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b5552a187ea7fdc2bdf7038e9af576b5dab3beb31e10be7f9fcf87345cad3269',
-     armv7l: 'b5552a187ea7fdc2bdf7038e9af576b5dab3beb31e10be7f9fcf87345cad3269',
-       i686: 'e19682f29ee5ee1671ede739a231a273e24f1d4e589c97db1661b38b02674145',
-     x86_64: '19fba2248fd1de821160e42a66c01d5e9543e20996e4d6c4795a35d7325e3a65'
+    aarch64: 'dba823a01d88db2af7e68015fbaadae2eb601cd1346a0a6aa387a7461f45c1b2',
+     armv7l: 'dba823a01d88db2af7e68015fbaadae2eb601cd1346a0a6aa387a7461f45c1b2',
+       i686: 'dd7339aa274690f26ebf100df056a2c04ddda1fc478c4c4b63f74f7745296944',
+     x86_64: '86853d02df16871221d2c0f5637115fbf6dd7add392f8e289e412a7b8849d812'
   })
 
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+
   def self.build
-    system 'make -j1 -C src'
+    system "CFLAGS='-lpthread' make -j1 -C src"
   end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} PREFIX=#{CREW_PREFIX} make -C src install"
+    FileUtils.mv "#{CREW_DEST_PREFIX}/lib", CREW_DEST_LIB_PREFIX if ARCH.eql?('x86_64')
   end
 end

--- a/tests/package/p/pacparser
+++ b/tests/package/p/pacparser
@@ -1,0 +1,3 @@
+#!/bin/bash
+pactester --help 2>&1
+pactester -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-pacparser crew update \
&& yes | crew upgrade

$ crew check pacparser 
Checking pacparser package ...
Library test for pacparser passed.
Checking pacparser package ...

Usage:  pactester <-p pacfile> <-u url> [-h host] [-c client_ip] [-e]
        pactester <-p pacfile> <-f urlslist> [-c client_ip] [-e]

Options:
  -p pacfile   : PAC file to test (specify '-' to read from standard input)
  -u url       : URL to test for
  -h host      : Host part of the URL
  -c client_ip : client IP address (as returned by myIpAddres() function
                 in PAC files), defaults to IP address on which it is running.
  -e           : Deprecated: IPv6 extensions are enabledby default now.
  -f urlslist  : a file containing list of URLs to be tested.
  -v           : print version and exit
a040312
Package tests for pacparser passed.
```