### PR TITLE
Pass 1.7.1-1 => 1.7.4

### DIFF
--- a/manifest/armv7l/p/pass.filelist
+++ b/manifest/armv7l/p/pass.filelist
@@ -1,4 +1,6 @@
-# Total size: 46263
+# Total size: 40011
 /usr/local/bin/pass
+/usr/local/etc/env.d/10-pass
 /usr/local/share/bash-completion/completions/pass
-/usr/local/share/man/man1/pass.1
+/usr/local/share/man/man1/pass.1.zst
+/usr/local/share/zsh/site-functions/_pass

--- a/manifest/i686/p/pass.filelist
+++ b/manifest/i686/p/pass.filelist
@@ -1,3 +1,6 @@
-# Total size: 42715
+# Total size: 40011
 /usr/local/bin/pass
-/usr/local/share/man/man1/pass.1
+/usr/local/etc/env.d/10-pass
+/usr/local/share/bash-completion/completions/pass
+/usr/local/share/man/man1/pass.1.zst
+/usr/local/share/zsh/site-functions/_pass

--- a/manifest/x86_64/p/pass.filelist
+++ b/manifest/x86_64/p/pass.filelist
@@ -1,5 +1,6 @@
-# Total size: 38109
+# Total size: 40011
 /usr/local/bin/pass
+/usr/local/etc/env.d/10-pass
 /usr/local/share/bash-completion/completions/pass
-/usr/local/share/man/man1/pass.1.gz
+/usr/local/share/man/man1/pass.1.zst
 /usr/local/share/zsh/site-functions/_pass

--- a/packages/pass.rb
+++ b/packages/pass.rb
@@ -3,24 +3,34 @@ require 'package'
 class Pass < Package
   description 'The standard unix password manager'
   homepage 'https://www.passwordstore.org/'
-  version '1.7.1-1'
+  version '1.7.4'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://git.zx2c4.com/password-store/snapshot/password-store-1.7.1.tar.xz'
-  source_sha256 'f6d2199593398aaefeaa55e21daddfb7f1073e9e096af6d887126141e99d9869'
-  binary_compression 'tar.xz'
+  source_url "https://git.zx2c4.com/password-store/snapshot/password-store-#{version}.tar.xz"
+  source_sha256 '4c2d0a8b99df8915a87099607a8d912fd05d30651b6f014745c14e4ca8dbbfb7'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '0068206d91cb8b9b521456f9019f6a4aaf76d5a90ac55c568a6ee116d0998b65',
-     armv7l: '0068206d91cb8b9b521456f9019f6a4aaf76d5a90ac55c568a6ee116d0998b65',
-       i686: '77fb2f33e609b5df5ca27902e44156ce6e20ab85af9a0c7c754b45a9a8ea44e0',
-     x86_64: '0b111fc35629c26203e3d709b9ec44c51f815d385d8b30fa1e852b5309db4af1'
+    aarch64: '13eaef75e3e5940f93d00bebb4fa2104c90ec542773c1dbbc1b4329f957beb97',
+     armv7l: '13eaef75e3e5940f93d00bebb4fa2104c90ec542773c1dbbc1b4329f957beb97',
+       i686: '2554133a8a18b795e65e91644eec367d854307cef888ee4da0ba3da6d8fa48b1',
+     x86_64: 'a8964951549e340e9ac8ae0e5b21729379c052da83bee07e78198aa9d60b0a2a'
   })
 
   depends_on 'gnupg'
   depends_on 'tree'
 
+  print_source_bashrc
+
+  def self.build
+    File.write '10-pass', <<~EOF
+      #!/bin/bash
+      source #{CREW_PREFIX}/share/bash-completion/completions/pass
+    EOF
+  end
+
   def self.install
     system 'make', "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.install '10-pass', "#{CREW_DEST_PREFIX}/etc/env.d/10-pass", mode: 0o644
   end
 end

--- a/tests/package/p/pass
+++ b/tests/package/p/pass
@@ -1,0 +1,3 @@
+#!/bin/bash
+pass help | head -20
+pass version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-pass crew update \
&& yes | crew upgrade

$ crew check pass 
Checking pass package ...
Library test for pass passed.
Checking pass package ...
============================================
= pass: the standard unix password manager =
=                                          =
=                  v1.7.4                  =
=                                          =
=             Jason A. Donenfeld           =
=               Jason@zx2c4.com            =
=                                          =
=      http://www.passwordstore.org/       =
============================================

Usage:
    pass init [--path=subfolder,-p subfolder] gpg-id...
        Initialize new password storage and use gpg-id for encryption.
        Selectively reencrypt existing passwords using new gpg-id.
    pass [ls] [subfolder]
        List passwords.
    pass find pass-names...
    	List passwords that match pass-names.
    pass [show] [--clip[=line-number],-c[line-number]] pass-name
============================================
= pass: the standard unix password manager =
=                                          =
=                  v1.7.4                  =
=                                          =
=             Jason A. Donenfeld           =
=               Jason@zx2c4.com            =
=                                          =
=      http://www.passwordstore.org/       =
============================================
Package tests for pass passed.
```