### PR TITLE
Patchelf 0.18.0-523f401-1 => 0.19.1

### DIFF
--- a/manifest/armv7l/p/patchelf.filelist
+++ b/manifest/armv7l/p/patchelf.filelist
@@ -1,4 +1,4 @@
-# Total size: 1765487
+# Total size: 1803588
 /usr/local/bin/patchelf
 /usr/local/share/doc/patchelf/README.md
 /usr/local/share/man/man1/patchelf.1.zst

--- a/manifest/i686/p/patchelf.filelist
+++ b/manifest/i686/p/patchelf.filelist
@@ -1,4 +1,4 @@
-# Total size: 2197931
+# Total size: 2292720
 /usr/local/bin/patchelf
 /usr/local/share/doc/patchelf/README.md
 /usr/local/share/man/man1/patchelf.1.zst

--- a/manifest/x86_64/p/patchelf.filelist
+++ b/manifest/x86_64/p/patchelf.filelist
@@ -1,4 +1,4 @@
-# Total size: 2136319
+# Total size: 2246208
 /usr/local/bin/patchelf
 /usr/local/share/doc/patchelf/README.md
 /usr/local/share/man/man1/patchelf.1.zst

--- a/packages/patchelf.rb
+++ b/packages/patchelf.rb
@@ -3,25 +3,21 @@ require 'buildsystems/autotools'
 class Patchelf < Autotools
   description 'PatchELF is a small utility to modify the dynamic linker and RPATH of ELF executables.'
   homepage 'https://github.com/NixOS/patchelf'
-  version '0.18.0-523f401-1'
+  version '0.19.1'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://github.com/NixOS/patchelf.git'
-  git_hashtag '523f401584d9584e76c9c77004e7abeb9e6c4551'
+  git_hashtag version
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2abcfc0a51ed852ca1ca469a32866204c806110f6a7b3c6bef785edd01507703',
-     armv7l: '2abcfc0a51ed852ca1ca469a32866204c806110f6a7b3c6bef785edd01507703',
-       i686: 'ef3052e4bd59d6bddbb5b9a0ae0498429a17edacb662613ff1b3b0528fb0e78d',
-     x86_64: '313c3dffbec9404b609999f8e5adf71cdd601025b9dda7afb81caf500225f8bf'
+    aarch64: '857991f1169648215918eed884356fe5579ba4aed34c23c430ad39af236389c4',
+     armv7l: '857991f1169648215918eed884356fe5579ba4aed34c23c430ad39af236389c4',
+       i686: '392f4e9a578ed695ec754d3aefb1ddb253f41c3928e274de2c6f67644053655a',
+     x86_64: '10214c09c0d594110732b67f27fa51fd80c20544be08898ed0194d8f2248dc45'
   })
 
   no_env_options
 
   autotools_pre_configure_options "LDFLAGS='#{CREW_LINKER_FLAGS} -static'"
-
-  def self.check
-    system "#{CREW_DEST_PREFIX}/bin/patchelf --version"
-  end
 end

--- a/tests/package/p/patchelf
+++ b/tests/package/p/patchelf
@@ -1,0 +1,3 @@
+#!/bin/bash
+patchelf -h 2>&1 | head
+patchelf --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-patchelf crew update \
&& yes | crew upgrade

$ crew check patchelf 
Checking patchelf package ...
Library test for patchelf passed.
Checking patchelf package ...
syntax: patchelf
  [--set-interpreter FILENAME]
  [--page-size SIZE]
  [--print-interpreter]
  [--print-os-abi]		Prints 'EI_OSABI' field of ELF header
  [--set-os-abi ABI]		Sets 'EI_OSABI' field of ELF header to ABI.
  [--print-soname]		Prints 'DT_SONAME' entry of .dynamic section. Raises an error if DT_SONAME doesn't exist
  [--set-soname SONAME]		Sets 'DT_SONAME' entry to SONAME.
  [--set-rpath RPATH]
  [--add-rpath RPATH]
patchelf 0.19.1
Package tests for patchelf passed.
```