### PR TITLE
Patchutils 0.3.4 => 0.4.5

### DIFF
--- a/manifest/armv7l/p/patchutils.filelist
+++ b/manifest/armv7l/p/patchutils.filelist
@@ -1,4 +1,4 @@
-# Total size: 419818
+# Total size: 143413
 /usr/local/bin/combinediff
 /usr/local/bin/dehtmldiff
 /usr/local/bin/editdiff
@@ -6,10 +6,37 @@
 /usr/local/bin/filterdiff
 /usr/local/bin/fixcvsdiff
 /usr/local/bin/flipdiff
+/usr/local/bin/gitdiff
+/usr/local/bin/gitdiffview
+/usr/local/bin/gitshow
+/usr/local/bin/gitshowview
 /usr/local/bin/grepdiff
 /usr/local/bin/interdiff
 /usr/local/bin/lsdiff
+/usr/local/bin/move-to-front
+/usr/local/bin/patchview
+/usr/local/bin/patchview-wrapper
 /usr/local/bin/recountdiff
 /usr/local/bin/rediff
 /usr/local/bin/splitdiff
+/usr/local/bin/svndiff
+/usr/local/bin/svndiffview
 /usr/local/bin/unwrapdiff
+/usr/local/share/bash-completion/completions/combinediff
+/usr/local/share/bash-completion/completions/dehtmldiff
+/usr/local/share/bash-completion/completions/editdiff
+/usr/local/share/bash-completion/completions/espdiff
+/usr/local/share/bash-completion/completions/filterdiff
+/usr/local/share/bash-completion/completions/fixcvsdiff
+/usr/local/share/bash-completion/completions/flipdiff
+/usr/local/share/bash-completion/completions/gitdiff
+/usr/local/share/bash-completion/completions/gitdiffview
+/usr/local/share/bash-completion/completions/grepdiff
+/usr/local/share/bash-completion/completions/lsdiff
+/usr/local/share/bash-completion/completions/patchview
+/usr/local/share/bash-completion/completions/recountdiff
+/usr/local/share/bash-completion/completions/rediff
+/usr/local/share/bash-completion/completions/splitdiff
+/usr/local/share/bash-completion/completions/svndiff
+/usr/local/share/bash-completion/completions/svndiffview
+/usr/local/share/bash-completion/completions/unwrapdiff

--- a/manifest/i686/p/patchutils.filelist
+++ b/manifest/i686/p/patchutils.filelist
@@ -1,4 +1,4 @@
-# Total size: 418482
+# Total size: 191049
 /usr/local/bin/combinediff
 /usr/local/bin/dehtmldiff
 /usr/local/bin/editdiff
@@ -6,10 +6,37 @@
 /usr/local/bin/filterdiff
 /usr/local/bin/fixcvsdiff
 /usr/local/bin/flipdiff
+/usr/local/bin/gitdiff
+/usr/local/bin/gitdiffview
+/usr/local/bin/gitshow
+/usr/local/bin/gitshowview
 /usr/local/bin/grepdiff
 /usr/local/bin/interdiff
 /usr/local/bin/lsdiff
+/usr/local/bin/move-to-front
+/usr/local/bin/patchview
+/usr/local/bin/patchview-wrapper
 /usr/local/bin/recountdiff
 /usr/local/bin/rediff
 /usr/local/bin/splitdiff
+/usr/local/bin/svndiff
+/usr/local/bin/svndiffview
 /usr/local/bin/unwrapdiff
+/usr/local/share/bash-completion/completions/combinediff
+/usr/local/share/bash-completion/completions/dehtmldiff
+/usr/local/share/bash-completion/completions/editdiff
+/usr/local/share/bash-completion/completions/espdiff
+/usr/local/share/bash-completion/completions/filterdiff
+/usr/local/share/bash-completion/completions/fixcvsdiff
+/usr/local/share/bash-completion/completions/flipdiff
+/usr/local/share/bash-completion/completions/gitdiff
+/usr/local/share/bash-completion/completions/gitdiffview
+/usr/local/share/bash-completion/completions/grepdiff
+/usr/local/share/bash-completion/completions/lsdiff
+/usr/local/share/bash-completion/completions/patchview
+/usr/local/share/bash-completion/completions/recountdiff
+/usr/local/share/bash-completion/completions/rediff
+/usr/local/share/bash-completion/completions/splitdiff
+/usr/local/share/bash-completion/completions/svndiff
+/usr/local/share/bash-completion/completions/svndiffview
+/usr/local/share/bash-completion/completions/unwrapdiff

--- a/manifest/x86_64/p/patchutils.filelist
+++ b/manifest/x86_64/p/patchutils.filelist
@@ -1,4 +1,4 @@
-# Total size: 533990
+# Total size: 185361
 /usr/local/bin/combinediff
 /usr/local/bin/dehtmldiff
 /usr/local/bin/editdiff
@@ -6,10 +6,37 @@
 /usr/local/bin/filterdiff
 /usr/local/bin/fixcvsdiff
 /usr/local/bin/flipdiff
+/usr/local/bin/gitdiff
+/usr/local/bin/gitdiffview
+/usr/local/bin/gitshow
+/usr/local/bin/gitshowview
 /usr/local/bin/grepdiff
 /usr/local/bin/interdiff
 /usr/local/bin/lsdiff
+/usr/local/bin/move-to-front
+/usr/local/bin/patchview
+/usr/local/bin/patchview-wrapper
 /usr/local/bin/recountdiff
 /usr/local/bin/rediff
 /usr/local/bin/splitdiff
+/usr/local/bin/svndiff
+/usr/local/bin/svndiffview
 /usr/local/bin/unwrapdiff
+/usr/local/share/bash-completion/completions/combinediff
+/usr/local/share/bash-completion/completions/dehtmldiff
+/usr/local/share/bash-completion/completions/editdiff
+/usr/local/share/bash-completion/completions/espdiff
+/usr/local/share/bash-completion/completions/filterdiff
+/usr/local/share/bash-completion/completions/fixcvsdiff
+/usr/local/share/bash-completion/completions/flipdiff
+/usr/local/share/bash-completion/completions/gitdiff
+/usr/local/share/bash-completion/completions/gitdiffview
+/usr/local/share/bash-completion/completions/grepdiff
+/usr/local/share/bash-completion/completions/lsdiff
+/usr/local/share/bash-completion/completions/patchview
+/usr/local/share/bash-completion/completions/recountdiff
+/usr/local/share/bash-completion/completions/rediff
+/usr/local/share/bash-completion/completions/splitdiff
+/usr/local/share/bash-completion/completions/svndiff
+/usr/local/share/bash-completion/completions/svndiffview
+/usr/local/share/bash-completion/completions/unwrapdiff

--- a/packages/patchutils.rb
+++ b/packages/patchutils.rb
@@ -1,32 +1,33 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Patchutils < Package
+class Patchutils < Autotools
   description 'Patchutils is a small collection of programs that operate on patch files.'
   homepage 'http://cyberelk.net/tim/software/patchutils/'
-  version '0.3.4'
+  version '0.4.5'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'http://cyberelk.net/tim/data/patchutils/stable/patchutils-0.3.4.tar.xz'
-  source_sha256 'cf55d4db83ead41188f5b6be16f60f6b76a87d5db1c42f5459d596e81dabe876'
-  binary_compression 'tar.xz'
+  source_url "http://cyberelk.net/tim/data/patchutils/stable/patchutils-#{version}.tar.xz"
+  source_sha256 '8386a35a4d2d3cbc28fdcc93c5be007c382c78e3ee079070139f0d822e013325'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a016f2bf4f5cd6711295f46e30563dcbd910b714be964b61f00cb68ef97d0f2c',
-     armv7l: 'a016f2bf4f5cd6711295f46e30563dcbd910b714be964b61f00cb68ef97d0f2c',
-       i686: '3bbc58f6e110e6d7437c0fd7acaf2bd49b7afb51609d577483df3efddbc8e034',
-     x86_64: '47995cc77fbf3bf7dbea906fc2bb7ffd28be265fdf64f970e00cfa85edc55ace'
+    aarch64: '030809998a2de25d0afd81e69b2d6e80172a1c1e9940c2540c1e01d640c0fd67',
+     armv7l: '030809998a2de25d0afd81e69b2d6e80172a1c1e9940c2540c1e01d640c0fd67',
+       i686: '03c0619a5790aea4991abe69f3c6581f2e51078d639be7599cefe502aab301cc',
+     x86_64: '2f6c36e9c6d61fba2452a61fa7c148f698bf1a46038392a1dd6764c92c5fea90'
   })
 
-  def self.build
-    system "./configure --prefix=#{CREW_PREFIX}"
-    system 'make'
-  end
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'pcre2' => :executable
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  run_tests
 
-  def self.check
-    system 'make', 'check'
+  autotools_install_extras do
+    # Remove conflict with bash_completion.
+    FileUtils.rm "#{CREW_DEST_PREFIX}/share/bash-completion/completions/interdiff"
+    %w[gitdiff gitdiffview gitshow gitshowview patchview-wrapper svndiff svndiffview].each do |bin|
+      system "sed -i 's,/usr/bin/python3,#{CREW_PREFIX}/bin/python3,' #{CREW_DEST_PREFIX}/bin/#{bin}"
+    end
   end
 end

--- a/tests/package/p/patchutils
+++ b/tests/package/p/patchutils
@@ -1,0 +1,16 @@
+#!/bin/bash
+combinediff --version
+dehtmldiff --version
+editdiff --version
+espdiff --version
+filterdiff --version
+flipdiff --version
+grepdiff --version
+interdiff --version
+lsdiff --version
+move-to-front --version
+patchview --version
+recountdiff --version
+rediff --version
+splitdiff --version
+unwrapdiff --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-patchutils crew update \
&& yes | crew upgrade

$ crew check patchutils 
Checking patchutils package ...
Library test for patchutils passed.
Checking patchutils package ...
combinediff - patchutils version 0.4.5
dehtmldiff - patchutils version 0.4.5
editdiff - patchutils version 0.4.5
espdiff - patchutils version 0.4.5
filterdiff - patchutils version 0.4.5
flipdiff - patchutils version 0.4.5
grepdiff - patchutils version 0.4.5
interdiff - patchutils version 0.4.5
lsdiff - patchutils version 0.4.5
move-to-front - patchutils version 0.4.5
patchview - patchutils version 0.4.5
recountdiff - patchutils version 0.4.5
rediff - patchutils version 0.4.5
splitdiff - patchutils version 0.4.5
unwrapdiff - patchutils version 0.4.5
Package tests for patchutils passed.
```