### PR TITLE
Pagemon 0.02.05 => 0.02.06

### DIFF
--- a/manifest/armv7l/p/pagemon.filelist
+++ b/manifest/armv7l/p/pagemon.filelist
@@ -1,4 +1,4 @@
-# Total size: 31111
+# Total size: 31157
 /usr/local/etc/bash.d/10-pagemon
 /usr/local/sbin/pagemon
 /usr/local/share/bash-completion/completions/pagemon

--- a/manifest/i686/p/pagemon.filelist
+++ b/manifest/i686/p/pagemon.filelist
@@ -1,4 +1,4 @@
-# Total size: 36619
+# Total size: 36681
 /usr/local/etc/bash.d/10-pagemon
 /usr/local/sbin/pagemon
 /usr/local/share/bash-completion/completions/pagemon

--- a/manifest/x86_64/p/pagemon.filelist
+++ b/manifest/x86_64/p/pagemon.filelist
@@ -1,4 +1,4 @@
-# Total size: 34795
+# Total size: 34825
 /usr/local/etc/bash.d/10-pagemon
 /usr/local/sbin/pagemon
 /usr/local/share/bash-completion/completions/pagemon

--- a/packages/pagemon.rb
+++ b/packages/pagemon.rb
@@ -3,7 +3,7 @@ require 'package'
 class Pagemon < Package
   description 'Pagemon is an interactive memory/page monitoring tool allowing one to browse the memory map of an active running process.'
   homepage 'https://github.com/ColinIanKing/pagemon'
-  version '0.02.05'
+  version '0.02.06'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/ColinIanKing/pagemon.git'
@@ -11,10 +11,10 @@ class Pagemon < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '03bc0311994ece280d5511d97847503c2e2793c037cc9225367fe9d5eca5c00e',
-     armv7l: '03bc0311994ece280d5511d97847503c2e2793c037cc9225367fe9d5eca5c00e',
-       i686: '80cef6fd289eaf68c841491cd76dae1a4b7e043484fdef66860ca1e3f5433670',
-     x86_64: '9efa248be2e4d1be3d420051ea17c17aaafa3232b63efa4ee6e98cb89499acab'
+    aarch64: '7090fa3616ffe16dec3ea81277531d2062a60374f2cd34467f69fe81ef86a924',
+     armv7l: '7090fa3616ffe16dec3ea81277531d2062a60374f2cd34467f69fe81ef86a924',
+       i686: 'c0ef52b6e2604f3e13de266c0cb1e6f1c8970eb61093080cd8040d24ea226d32',
+     x86_64: 'c42726dffc0d91e416fd3de87a696912b6e375873108db02dc36f9aeb1b341c9'
   })
 
   depends_on 'glibc' => :executable


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-pagemon crew update \
&& yes | crew upgrade

$ crew check pagemon 
Checking pagemon package ...
Library test for pagemon passed.
Checking pagemon package ...
pagemon, version 0.02.06

Usage: pagemon [options]
 -a        enable automatic zoom mode
 -d        delay in microseconds between refreshes, default 15000
 -h        help
 -p pid    process ID to monitor
 -r        read (page back in) pages at start
 -t ticks  ticks between dirty page checks
 -v        enable VM view
 -z zoom   set page zoom scale
Package tests for pagemon passed.
```