### PR TITLE
Pavucontrol 4.0-381b-1 => 6.2

### DIFF
--- a/manifest/armv7l/p/pavucontrol.filelist
+++ b/manifest/armv7l/p/pavucontrol.filelist
@@ -1,8 +1,12 @@
-# Total size: 1245883
+# Total size: 964021
 /usr/local/bin/pavucontrol
-/usr/local/share/applications/pavucontrol.desktop
+/usr/local/share/applications/org.pulseaudio.pavucontrol.desktop
 /usr/local/share/doc/pavucontrol/README.html
 /usr/local/share/doc/pavucontrol/style.css
+/usr/local/share/icons/hicolor/scalable/apps/org.pulseaudio.pavucontrol.svg
+/usr/local/share/icons/hicolor/symbolic/apps/org.pulseaudio.pavucontrol-symbolic.svg
+/usr/local/share/locale/af/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/ar/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/as/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/ast/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/be/LC_MESSAGES/pavucontrol.mo
@@ -19,11 +23,14 @@
 /usr/local/share/locale/fr/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/gl/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/gu/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/he/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/hi/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/hr/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/hu/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/id/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/it/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/ja/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/ka/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/kk/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/kn/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/ko/LC_MESSAGES/pavucontrol.mo
@@ -38,7 +45,9 @@
 /usr/local/share/locale/pl/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/pt/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/pt_BR/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/ro/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/ru/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/si/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/sk/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/sl/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/sr/LC_MESSAGES/pavucontrol.mo
@@ -51,4 +60,4 @@
 /usr/local/share/locale/uk/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/pavucontrol.mo
-/usr/local/share/pavucontrol/pavucontrol.glade
+/usr/local/share/metainfo/org.pulseaudio.pavucontrol.metainfo.xml

--- a/manifest/x86_64/p/pavucontrol.filelist
+++ b/manifest/x86_64/p/pavucontrol.filelist
@@ -1,8 +1,12 @@
-# Total size: 1341771
+# Total size: 1118801
 /usr/local/bin/pavucontrol
-/usr/local/share/applications/pavucontrol.desktop
+/usr/local/share/applications/org.pulseaudio.pavucontrol.desktop
 /usr/local/share/doc/pavucontrol/README.html
 /usr/local/share/doc/pavucontrol/style.css
+/usr/local/share/icons/hicolor/scalable/apps/org.pulseaudio.pavucontrol.svg
+/usr/local/share/icons/hicolor/symbolic/apps/org.pulseaudio.pavucontrol-symbolic.svg
+/usr/local/share/locale/af/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/ar/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/as/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/ast/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/be/LC_MESSAGES/pavucontrol.mo
@@ -19,11 +23,14 @@
 /usr/local/share/locale/fr/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/gl/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/gu/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/he/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/hi/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/hr/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/hu/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/id/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/it/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/ja/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/ka/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/kk/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/kn/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/ko/LC_MESSAGES/pavucontrol.mo
@@ -38,7 +45,9 @@
 /usr/local/share/locale/pl/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/pt/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/pt_BR/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/ro/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/ru/LC_MESSAGES/pavucontrol.mo
+/usr/local/share/locale/si/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/sk/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/sl/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/sr/LC_MESSAGES/pavucontrol.mo
@@ -51,4 +60,4 @@
 /usr/local/share/locale/uk/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/pavucontrol.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/pavucontrol.mo
-/usr/local/share/pavucontrol/pavucontrol.glade
+/usr/local/share/metainfo/org.pulseaudio.pavucontrol.metainfo.xml

--- a/packages/pavucontrol.rb
+++ b/packages/pavucontrol.rb
@@ -1,38 +1,33 @@
-require 'package'
+require 'buildsystems/meson'
 
-class Pavucontrol < Package
+class Pavucontrol < Meson
   description 'PulseAudio Volume Control'
   homepage 'https://freedesktop.org/software/pulseaudio/pavucontrol/'
-  version '4.0-381b-1'
+  version '6.2'
   license 'GPL-2'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://github.com/pulseaudio/pavucontrol/archive/381b708202e87e40347a57f8a627014199cde266.zip'
-  source_sha256 'aa6c5814e77a8f36d8ed50b70381fbfbab2ebbf0fb62548ec8b8b935527d527e'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/pulseaudio/pavucontrol.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2773e569e8fef5cbc3d2adadf9d94abdbb7122393baff840e6f743ebe669f1b9',
-     armv7l: '2773e569e8fef5cbc3d2adadf9d94abdbb7122393baff840e6f743ebe669f1b9',
-     x86_64: '01f0d27fac88490d8d4b149a3396e8e0fd85e2c5763a08f4367245e10b6ea303'
+    aarch64: '211e496463f621889f9c73b9646c28c8c741a0cfc96c8348c00e0560c1711d98',
+     armv7l: '211e496463f621889f9c73b9646c28c8c741a0cfc96c8348c00e0560c1711d98',
+     x86_64: '1a279ee44dffa2d32571e81dde1a102cd0dcd9ecc0bcfee5a02aafabca39688b'
   })
 
-  depends_on 'libcanberra'
-  depends_on 'gtkmm3'
-  depends_on 'libsigcplusplus'
-  depends_on 'pulseaudio'
-  depends_on 'pygtk'
-  depends_on 'glibmm'
-
-  def self.build
-    system 'NOCONFIGURE=1 ./bootstrap.sh'
-    system "env #{CREW_ENV_OPTIONS} \
-    ./configure \
-    #{CREW_CONFIGURE_OPTIONS} \
-    --disable-lynx"
-    system 'make'
-  end
-
-  def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
-  end
+  depends_on 'gcc_lib' => :executable
+  depends_on 'glib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'glibmm' => :executable
+  depends_on 'glibmm_2_68' => :executable
+  depends_on 'gtk4' => :executable
+  depends_on 'gtkmm4' => :executable
+  depends_on 'json_glib' => :executable
+  depends_on 'libcanberra' => :executable
+  depends_on 'libsigcplusplus' => :executable
+  depends_on 'libsigcplusplus3' => :executable
+  depends_on 'pulseaudio' => :executable
+  depends_on 'pygtk' => :executable
 end

--- a/tests/package/p/pavucontrol
+++ b/tests/package/p/pavucontrol
@@ -1,0 +1,2 @@
+#!/bin/bash
+pavucontrol -h 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-pavucontrol crew update \
&& yes | crew upgrade

$ crew check pavucontrol 
Checking pavucontrol package ...
Library test for pavucontrol passed.
Checking pavucontrol package ...
_amdgpu_device_initialize: amdgpu_get_auth (1) failed (-1)
MESA: error: amdgpu: amdgpu_device_initialize failed.
libEGL warning: egl: failed to create dri2 screen
Usage:
  pavucontrol [OPTION…]

Help Options:
  -h, --help                Show help options
  --help-all                Show all help options
  --help-gapplication       Show GApplication options

Application Options:
  -t, --tab=number          Select a specific tab on load.
  -r, --retry               Retry forever if pa quits (every 5 seconds).
  -m, --maximize            Maximize the window.
  -v, --version             Show version.

Package tests for pavucontrol passed.
```