### PR TITLE
Pciutils 3.6.2 => 3.15.0

### DIFF
--- a/manifest/armv7l/p/pciutils.filelist
+++ b/manifest/armv7l/p/pciutils.filelist
@@ -1,17 +1,20 @@
-# Total size: 497738
+# Total size: 768725
 /usr/local/bin/lspci
-/usr/local/bin/setpci
-/usr/local/bin/update-pciids
 /usr/local/include/pci/config.h
 /usr/local/include/pci/header.h
 /usr/local/include/pci/pci.h
 /usr/local/include/pci/types.h
 /usr/local/lib/libpci.so
 /usr/local/lib/libpci.so.3
-/usr/local/lib/libpci.so.3.6.2
+/usr/local/lib/libpci.so.3.15.0
 /usr/local/lib/pkgconfig/libpci.pc
-/usr/local/share/man/man7/pcilib.7.gz
-/usr/local/share/man/man8/lspci.8.gz
-/usr/local/share/man/man8/setpci.8.gz
-/usr/local/share/man/man8/update-pciids.8.gz
+/usr/local/sbin/pcilmr
+/usr/local/sbin/setpci
+/usr/local/sbin/update-pciids
+/usr/local/share/man/man5/pci.ids.5.zst
+/usr/local/share/man/man7/pcilib.7.zst
+/usr/local/share/man/man8/lspci.8.zst
+/usr/local/share/man/man8/pcilmr.8.zst
+/usr/local/share/man/man8/setpci.8.zst
+/usr/local/share/man/man8/update-pciids.8.zst
 /usr/local/share/pci.ids.gz

--- a/manifest/i686/p/pciutils.filelist
+++ b/manifest/i686/p/pciutils.filelist
@@ -1,17 +1,20 @@
-# Total size: 537655
+# Total size: 817234
 /usr/local/bin/lspci
-/usr/local/bin/setpci
-/usr/local/bin/update-pciids
 /usr/local/include/pci/config.h
 /usr/local/include/pci/header.h
 /usr/local/include/pci/pci.h
 /usr/local/include/pci/types.h
 /usr/local/lib/libpci.so
 /usr/local/lib/libpci.so.3
-/usr/local/lib/libpci.so.3.6.2
+/usr/local/lib/libpci.so.3.15.0
 /usr/local/lib/pkgconfig/libpci.pc
-/usr/local/share/man/man7/pcilib.7.gz
-/usr/local/share/man/man8/lspci.8.gz
-/usr/local/share/man/man8/setpci.8.gz
-/usr/local/share/man/man8/update-pciids.8.gz
+/usr/local/sbin/pcilmr
+/usr/local/sbin/setpci
+/usr/local/sbin/update-pciids
+/usr/local/share/man/man5/pci.ids.5.zst
+/usr/local/share/man/man7/pcilib.7.zst
+/usr/local/share/man/man8/lspci.8.zst
+/usr/local/share/man/man8/pcilmr.8.zst
+/usr/local/share/man/man8/setpci.8.zst
+/usr/local/share/man/man8/update-pciids.8.zst
 /usr/local/share/pci.ids.gz

--- a/manifest/x86_64/p/pciutils.filelist
+++ b/manifest/x86_64/p/pciutils.filelist
@@ -1,17 +1,20 @@
-# Total size: 534459
+# Total size: 807090
 /usr/local/bin/lspci
-/usr/local/bin/setpci
-/usr/local/bin/update-pciids
 /usr/local/include/pci/config.h
 /usr/local/include/pci/header.h
 /usr/local/include/pci/pci.h
 /usr/local/include/pci/types.h
 /usr/local/lib64/libpci.so
 /usr/local/lib64/libpci.so.3
-/usr/local/lib64/libpci.so.3.6.2
+/usr/local/lib64/libpci.so.3.15.0
 /usr/local/lib64/pkgconfig/libpci.pc
-/usr/local/share/man/man7/pcilib.7.gz
-/usr/local/share/man/man8/lspci.8.gz
-/usr/local/share/man/man8/setpci.8.gz
-/usr/local/share/man/man8/update-pciids.8.gz
+/usr/local/sbin/pcilmr
+/usr/local/sbin/setpci
+/usr/local/sbin/update-pciids
+/usr/local/share/man/man5/pci.ids.5.zst
+/usr/local/share/man/man7/pcilib.7.zst
+/usr/local/share/man/man8/lspci.8.zst
+/usr/local/share/man/man8/pcilmr.8.zst
+/usr/local/share/man/man8/setpci.8.zst
+/usr/local/share/man/man8/update-pciids.8.zst
 /usr/local/share/pci.ids.gz

--- a/packages/pciutils.rb
+++ b/packages/pciutils.rb
@@ -3,26 +3,28 @@ require 'package'
 class Pciutils < Package
   description 'The PCI Utilities are a collection of programs for inspecting and manipulating configuration of PCI devices, all based on a common portable library libpci which offers access to the PCI configuration space on a variety of operating systems.'
   homepage 'https://mj.ucw.cz/sw/pciutils/'
-  version '3.6.2'
+  version '3.15.0'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.6.2.tar.xz'
-  source_sha256 'db452ec986edefd88af0d222d22f6102f8030a8633fdfe846c3ae4bde9bb93f3'
-  binary_compression 'tar.xz'
+  source_url "https://www.kernel.org/pub/software/utils/pciutils/pciutils-#{version}.tar.xz"
+  source_sha256 'c02940f430841ecf158d5d9a50007afc4d5353c8678a2455003ca0b2c4e9f5ff'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f6e98ae7fdd796945dfc130eb256ee9d1aafe9c7e6a15bcc63a2ba4d77640b62',
-     armv7l: 'f6e98ae7fdd796945dfc130eb256ee9d1aafe9c7e6a15bcc63a2ba4d77640b62',
-       i686: '5e3c1391e1780632c7e71c0863528e17ff65bceef211e13d486ab672e373b3c6',
-     x86_64: '1aae1bf10b5fdbbdcdf5e5d04bdbab5e8e683486a8d7a569e79eee336fbb0755'
+    aarch64: '40dc809f5d705270bc0fa95981f57da5434a8b480cec590fbe131b56b85f9a1b',
+     armv7l: '40dc809f5d705270bc0fa95981f57da5434a8b480cec590fbe131b56b85f9a1b',
+       i686: '50057aad169f658270b2af8f1469c2730ca4889fa6a5b58bc432f1debb0798a4',
+     x86_64: '9351bf6326f63e282987d071416a33e980455cb9b1b40e6ae14e75cbcede937b'
   })
 
-  depends_on 'eudev'
+  depends_on 'eudev' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'zlib' => :library
 
   def self.build
     system 'make',
            "LIBDIR=#{CREW_LIB_PREFIX}",
-           'SBINDIR=$(PREFIX)/bin',
            "PREFIX=#{CREW_PREFIX}",
            'SHARED=yes',
            'ZLIB=yes',
@@ -33,7 +35,6 @@ class Pciutils < Package
     system 'make',
            "LIBDIR=#{CREW_LIB_PREFIX}",
            "DESTDIR=#{CREW_DEST_DIR}",
-           'SBINDIR=$(PREFIX)/bin',
            "PREFIX=#{CREW_PREFIX}",
            'install-lib',
            'SHARED=yes',

--- a/tests/package/p/pciutils
+++ b/tests/package/p/pciutils
@@ -1,0 +1,3 @@
+#!/bin/bash
+lspci --help 2>&1 | head
+lspci --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-pciutils crew update \
&& yes | crew upgrade

$ crew check pciutils 
Checking pciutils package ...
Library test for pciutils passed.
Checking pciutils package ...
lspci: invalid option -- '-'
Usage: lspci [<switches>]

Basic display modes:
-mm		Produce machine-readable output (single -m for an obsolete format)
-t		Show bus tree

Display options:
-v		Be verbose (-vv or -vvv for higher verbosity)
-k		Show kernel drivers handling each device
lspci version 3.15.0
Package tests for pciutils passed.
```