### PR TITLE
Add xwininfo package

### DIFF
--- a/manifest/armv7l/x/xwininfo.filelist
+++ b/manifest/armv7l/x/xwininfo.filelist
@@ -1,0 +1,3 @@
+# Total size: 45458
+/usr/local/bin/xwininfo
+/usr/local/share/man/man1/xwininfo.1.zst

--- a/manifest/x86_64/x/xwininfo.filelist
+++ b/manifest/x86_64/x/xwininfo.filelist
@@ -1,0 +1,3 @@
+# Total size: 61310
+/usr/local/bin/xwininfo
+/usr/local/share/man/man1/xwininfo.1.zst

--- a/packages/xwininfo.rb
+++ b/packages/xwininfo.rb
@@ -1,0 +1,23 @@
+require 'buildsystems/meson'
+
+class Xwininfo < Meson
+  description 'Utility to print information about windows on an X server.'
+  homepage 'https://gitlab.freedesktop.org/xorg/app/xwininfo'
+  version '1.1.7'
+  license 'MIT'
+  compatibility 'aarch64 armv7l x86_64'
+  source_url 'https://gitlab.freedesktop.org/xorg/app/xwininfo.git'
+  git_hashtag "xwininfo-#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: 'cb03cdd01e28ace075f44b720471bbe61ce3a08b5e6ce47b460c550f067472b4',
+     armv7l: 'cb03cdd01e28ace075f44b720471bbe61ce3a08b5e6ce47b460c550f067472b4',
+     x86_64: 'f3db7149ab5b30c79bb4a6fefc839401426820ccef59215484bf6dca8bdd867b'
+  })
+
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libx11' => :executable
+  depends_on 'libxcb' => :executable
+end

--- a/tests/package/x/xwininfo
+++ b/tests/package/x/xwininfo
@@ -1,0 +1,3 @@
+#!/bin/bash
+xwininfo -help 2>&1 | head
+xwininfo -version

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -10860,6 +10860,11 @@ url: https://github.com/freedesktop/xorg-xserver/releases
 activity: medium
 ---
 kind: url
+name: xwininfo
+url: https://gitlab.freedesktop.org/xorg/app/xwininfo/-/tags
+activity: low
+---
+kind: url
 name: xxd_standalone
 url: https://github.com/vim/vim/releases
 activity: high


### PR DESCRIPTION
## Description
Utility to print information about windows on an X server.  See https://gitlab.freedesktop.org/xorg/app/xwininfo.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-xwininfo-package crew update \
&& yes | crew upgrade

$ crew check xwininfo 
Checking xwininfo package ...
Library test for xwininfo passed.
Checking xwininfo package ...
usage:  xwininfo [-options ...]

where options include:
    -help                 print this message
    -version              print version message
    -d[isplay] <host:dpy> X server to contact
    -root                 use the root window
    -id <wdid>            use the window with the specified id
    -name <wdname>        use the window with the specified name
    -int                  print window id in decimal
xwininfo 1.1.7
Package tests for xwininfo passed.
```