### PR TITLE
Pigz 2.4 => 2.8

### DIFF
--- a/manifest/armv7l/p/pigz.filelist
+++ b/manifest/armv7l/p/pigz.filelist
@@ -1,4 +1,4 @@
-# Total size: 297792
+# Total size: 279389
 /usr/local/bin/pigz
 /usr/local/bin/unpigz
-/usr/local/share/man/man1/pigz.1.gz
+/usr/local/share/man/man1/pigz.1.zst

--- a/manifest/i686/p/pigz.filelist
+++ b/manifest/i686/p/pigz.filelist
@@ -1,4 +1,4 @@
-# Total size: 337832
+# Total size: 324837
 /usr/local/bin/pigz
 /usr/local/bin/unpigz
-/usr/local/share/man/man1/pigz.1.gz
+/usr/local/share/man/man1/pigz.1.zst

--- a/manifest/x86_64/p/pigz.filelist
+++ b/manifest/x86_64/p/pigz.filelist
@@ -1,4 +1,4 @@
-# Total size: 327696
+# Total size: 314365
 /usr/local/bin/pigz
 /usr/local/bin/unpigz
-/usr/local/share/man/man1/pigz.1.gz
+/usr/local/share/man/man1/pigz.1.zst

--- a/packages/pigz.rb
+++ b/packages/pigz.rb
@@ -3,28 +3,31 @@ require 'package'
 class Pigz < Package
   description 'A parallel implementation of gzip for modern multi-processor, multi-core machines'
   homepage 'https://zlib.net/pigz/'
-  version '2.4'
+  version '2.8'
   license 'ZLIB'
   compatibility 'all'
-  source_url 'https://zlib.net/pigz/pigz-2.4.tar.gz'
-  source_sha256 'a4f816222a7b4269bd232680590b579ccc72591f1bb5adafcd7208ca77e14f73'
-  binary_compression 'tar.xz'
+  source_url "https://zlib.net/pigz/pigz-#{version}.tar.gz"
+  source_sha256 'eb872b4f0e1f0ebe59c9f7bd8c506c4204893ba6a8492de31df416f0d5170fd0'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '10aa75b1ea4f2bd9acc84350fa30c0d152391e37517a2487febde4c6a82d329d',
-     armv7l: '10aa75b1ea4f2bd9acc84350fa30c0d152391e37517a2487febde4c6a82d329d',
-       i686: 'a9189537126b568f26aaeb6e8df2f8cb0a6519a47f277c796008be29db0dd87e',
-     x86_64: '7254da818fd1658337f052cf2eaf4ecef66d1932eb3092703f335a847ccf7382'
+    aarch64: '4367672f7ea6833e0098fe4cec1f57ea57e7013c441b03017631def5fc774f19',
+     armv7l: '4367672f7ea6833e0098fe4cec1f57ea57e7013c441b03017631def5fc774f19',
+       i686: '87130e9f6b588e86ef968cc3770df7ca26245ce8a3b287532a9ab871fee62fb2',
+     x86_64: '31bc09206e5584d32ebd36ad3f71199c6673205003145cb07039f2c0579c44a1'
   })
+
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'zlib' => :executable
 
   def self.build
     system 'make'
-    system 'gzip -9 pigz.1'
   end
 
   def self.install
-    system "install -Dm755 pigz #{CREW_DEST_PREFIX}/bin/pigz"
-    system "install -Dm755 unpigz #{CREW_DEST_PREFIX}/bin/unpigz"
-    system "install -Dm644 pigz.1.gz #{CREW_DEST_PREFIX}/share/man/man1/pigz.1.gz"
+    FileUtils.install 'pigz', "#{CREW_DEST_PREFIX}/bin/pigz", mode: 0o755
+    FileUtils.install 'unpigz', "#{CREW_DEST_PREFIX}/bin/unpigz", mode: 0o755
+    FileUtils.install 'pigz.1', "#{CREW_DEST_MAN_PREFIX}/man1/pigz.1", mode: 0o644
   end
 end

--- a/tests/package/p/pigz
+++ b/tests/package/p/pigz
@@ -1,0 +1,5 @@
+#!/bin/bash
+pigz -h 2>&1 | head
+pigz -V
+unpigz -h 2>&1 | head
+unpigz -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-pigz crew update \
&& yes | crew upgrade

$ crew check pigz
Checking pigz package ...
Library test for pigz passed.
Checking pigz package ...
Usage: pigz [options] [files ...]
  will compress files in place, adding the suffix '.gz'. If no files are
  specified, stdin will be compressed to stdout. pigz does what gzip does,
  but spreads the work over multiple processors and cores when compressing.

Options:
  -0 to -9, -11        Compression level (level 11, zopfli, is much slower)
  --fast, --best       Compression levels 1 and 9 respectively
  -A, --alias xxx      Use xxx as the name for any --zip entry from stdin
  -b, --blocksize mmm  Set compression block size to mmmK (default 128K)
pigz 2.8
Usage: pigz [options] [files ...]
  will compress files in place, adding the suffix '.gz'. If no files are
  specified, stdin will be compressed to stdout. pigz does what gzip does,
  but spreads the work over multiple processors and cores when compressing.

Options:
  -0 to -9, -11        Compression level (level 11, zopfli, is much slower)
  --fast, --best       Compression levels 1 and 9 respectively
  -A, --alias xxx      Use xxx as the name for any --zip entry from stdin
  -b, --blocksize mmm  Set compression block size to mmmK (default 128K)
pigz 2.8
Package tests for pigz passed.
```