### PR TITLE
Pivy 0.6.10-26b38e0 => 0.6.11

### DIFF
--- a/manifest/armv7l/p/pivy.filelist
+++ b/manifest/armv7l/p/pivy.filelist
@@ -1,4 +1,4 @@
-# Total size: 10245137
+# Total size: 10271505
 /usr/local/lib/python3.14/site-packages/pivy/__init__.py
 /usr/local/lib/python3.14/site-packages/pivy/_coin.so
 /usr/local/lib/python3.14/site-packages/pivy/coin.py

--- a/manifest/x86_64/p/pivy.filelist
+++ b/manifest/x86_64/p/pivy.filelist
@@ -1,4 +1,4 @@
-# Total size: 13117313
+# Total size: 13741633
 /usr/local/lib64/python3.14/site-packages/pivy/__init__.py
 /usr/local/lib64/python3.14/site-packages/pivy/_coin.so
 /usr/local/lib64/python3.14/site-packages/pivy/coin.py

--- a/packages/pivy.rb
+++ b/packages/pivy.rb
@@ -3,21 +3,22 @@ require 'buildsystems/cmake'
 class Pivy < CMake
   description 'python bindings to coin3d'
   homepage 'https://github.com/coin3d/pivy'
-  version '0.6.10-26b38e0'
+  version '0.6.11'
   license 'ISC'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/coin3d/pivy.git'
-  git_hashtag '26b38e0766d99b82e9541bb3975a154fbb176264'
+  git_hashtag version
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'ff5abf8dfc63ebb94f229079823308eb10e7c065c9f420f3ecbf2e462ae941c2',
-     armv7l: 'ff5abf8dfc63ebb94f229079823308eb10e7c065c9f420f3ecbf2e462ae941c2',
-     x86_64: 'b79c2a980bf590e31d30037774888bbd2aee3f65e3506cb62870f87d19870f5b'
+    aarch64: 'aae1bfe84b71b451be6a1c0ec0b392592e6e0eeb4aaa82dbdf69272ec846b053',
+     armv7l: 'aae1bfe84b71b451be6a1c0ec0b392592e6e0eeb4aaa82dbdf69272ec846b053',
+     x86_64: '40f5bd10bd037ac0707be2c5fc1e2f973389573fa95d802580c26bc0dbb24aad'
   })
 
   depends_on 'coin' => :library
   depends_on 'gcc_lib' => :library
   depends_on 'glibc' => :library
-  depends_on 'swig'
+  depends_on 'glibc_lib' => :library
+  depends_on 'swig' => :library
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-pivy crew update \
&& yes | crew upgrade
```