### PR TITLE
Asmc 2.38 => 2.39

### DIFF
--- a/manifest/armv7l/a/asmc.filelist
+++ b/manifest/armv7l/a/asmc.filelist
@@ -1,2 +1,2 @@
-# Total size: 389884
+# Total size: 415104
 /usr/local/bin/asmc

--- a/manifest/i686/a/asmc.filelist
+++ b/manifest/i686/a/asmc.filelist
@@ -1,2 +1,2 @@
-# Total size: 389884
+# Total size: 415104
 /usr/local/bin/asmc

--- a/manifest/x86_64/a/asmc.filelist
+++ b/manifest/x86_64/a/asmc.filelist
@@ -1,2 +1,2 @@
-# Total size: 393784
+# Total size: 419472
 /usr/local/bin/asmc

--- a/packages/asmc.rb
+++ b/packages/asmc.rb
@@ -4,17 +4,17 @@ class Asmc < Package
   description 'Asmc Macro Assembler'
   homepage 'https://github.com/nidud/asmc'
   license 'GPL-2.0'
-  version '2.38'
+  version '2.39'
   compatibility 'all'
   source_url 'https://github.com/nidud/asmc.git'
   git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a2916448cb69f6e19dccd24e50b4418db76aab39f657b0b3d62be042a6371476',
-     armv7l: 'a2916448cb69f6e19dccd24e50b4418db76aab39f657b0b3d62be042a6371476',
-       i686: 'b9ed1b02d45dad14a9e013a0177f436ffce15844a2d8588afd895bb002126cbd',
-     x86_64: '54473d9215b5e13215f7221e2692dd8d071b51d40926e301cc3cb2effb81c505'
+    aarch64: 'e4e66ec418d389c19ce28c740d083e41d16ee3f7bea90d31b89b964758f75614',
+     armv7l: 'e4e66ec418d389c19ce28c740d083e41d16ee3f7bea90d31b89b964758f75614',
+       i686: 'f9ab49087ea87467a9b30b8c49dedf049d44798dd1480bbb7b980f5028bb6ee8',
+     x86_64: '344903c084b24ea8df7a58428bd5ba580d5cde9fa216a40a8a598371fbb0dcfc'
   })
 
   def self.build


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-asmc crew update \
&& yes | crew upgrade

$ crew check asmc 
Checking asmc package ...
Library test for asmc passed.
Checking asmc package ...
Asmc Macro Assembler (x64) Version 2.39
Copyright (C) The Asmc Contributors. All Rights Reserved.

        asmc64 [ options ] filelist [ -link link_options]

-assert Generate .assert() code           -auto Auto stack space for arguments
-bin Generate plain binary file           -Bl<linker> Use alternate linker
-c Assemble without linking               -Cs No USES registers inside frame
-coff Generate COFF format object file    -Cp Preserve case of user identifiers
-Cu Map all identifiers to upper case     -Cx Preserve case in publics, externs
Package tests for asmc passed.
```