### PR TITLE
Powerstat 0.02.24 => 0.04.06

### DIFF
--- a/manifest/armv7l/p/powerstat.filelist
+++ b/manifest/armv7l/p/powerstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 69742
+# Total size: 37969
 /usr/local/bin/powerstat
 /usr/local/share/bash-completion/completions/powerstat
-/usr/local/share/man/man8/powerstat.8.gz
+/usr/local/share/man/man8/powerstat.8.zst

--- a/manifest/i686/p/powerstat.filelist
+++ b/manifest/i686/p/powerstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 59330
+# Total size: 50773
 /usr/local/bin/powerstat
 /usr/local/share/bash-completion/completions/powerstat
-/usr/local/share/man/man8/powerstat.8.gz
+/usr/local/share/man/man8/powerstat.8.zst

--- a/manifest/x86_64/p/powerstat.filelist
+++ b/manifest/x86_64/p/powerstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 74866
+# Total size: 49985
 /usr/local/bin/powerstat
 /usr/local/share/bash-completion/completions/powerstat
-/usr/local/share/man/man8/powerstat.8.gz
+/usr/local/share/man/man8/powerstat.8.zst

--- a/packages/powerstat.rb
+++ b/packages/powerstat.rb
@@ -2,20 +2,23 @@ require 'package'
 
 class Powerstat < Package
   description 'Powerstat measures the power consumption of a laptop using the ACPI battery information.'
-  homepage 'https://kernel.ubuntu.com/~cking/powerstat/'
-  version '0.02.24'
+  homepage 'https://github.com/ColinIanKing/powerstat'
+  version '0.04.06'
   license 'GPL-2+'
   compatibility 'all'
-  source_url 'https://kernel.ubuntu.com/~cking/tarballs/powerstat/powerstat-0.02.24.tar.gz'
-  source_sha256 '12781cb108be1fc3be5ec893e6d025bfb40ada060bdc5f7715b65397620f2c7b'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/ColinIanKing/powerstat.git'
+  git_hashtag "V#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '76653569b562862ac42fd13a04a0f89b450da94450b6a25eccb7e1e399267dcb',
-     armv7l: '76653569b562862ac42fd13a04a0f89b450da94450b6a25eccb7e1e399267dcb',
-       i686: '69f76808c40ed957f30738fbb0e76d50a592ec610f8d58ca117e6daceee8e51f',
-     x86_64: '1be1187a936d8e2c0bbe20ad45a350c8b63ce75ef77ee63fd7bbe0b33690c541'
+    aarch64: '1d35badff9788712149a2593a8e5262cc5f60bbebf60ebe754a4dec7ee9c2b54',
+     armv7l: '1d35badff9788712149a2593a8e5262cc5f60bbebf60ebe754a4dec7ee9c2b54',
+       i686: 'd0a2d380c846673a72f0bbe11e1139437a9f857995869567be5a4de299d714cc',
+     x86_64: '1116cc08bc8f783b806fb3b130c1641b790a56fdb0486da23c57557ab19f47f4'
   })
+
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 
   def self.build
     system "sed -i 's,/usr,#{CREW_PREFIX},g' Makefile"

--- a/tests/package/p/powerstat
+++ b/tests/package/p/powerstat
@@ -1,0 +1,2 @@
+#!/bin/bash
+powerstat -h | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-powerstat crew update \
&& yes | crew upgrade

$ crew check powerstat 
Checking powerstat package ...
Library test for powerstat passed.
Checking powerstat package ...
powerstat, version 0.04.06

usage: powerstat [options] [delay [count]]
	-a enable all sampling collection options (-c, -f, -g, -t and -H)
	-b redo a sample if a system is busy, considered less than 98% CPU idle
	-c show C-State statistics at end of the run
	-d specify delay before starting, default is 180 seconds
	-D show RAPL domain power measurements (enables -R option)
	-f show average CPU frequency
	-g show average GPU frequency
Package tests for powerstat passed.
```