### PR TITLE
Rebuild snappy to remove benchmark files (conflict with benchmark package)

### DIFF
--- a/manifest/armv7l/s/snappy.filelist
+++ b/manifest/armv7l/s/snappy.filelist
@@ -1,6 +1,4 @@
-# Total size: 409541
-/usr/local/include/benchmark/benchmark.h
-/usr/local/include/benchmark/export.h
+# Total size: 76566
 /usr/local/include/snappy-c.h
 /usr/local/include/snappy-sinksource.h
 /usr/local/include/snappy-stubs-public.h
@@ -9,29 +7,6 @@
 /usr/local/lib/cmake/Snappy/SnappyConfigVersion.cmake
 /usr/local/lib/cmake/Snappy/SnappyTargets-release.cmake
 /usr/local/lib/cmake/Snappy/SnappyTargets.cmake
-/usr/local/lib/cmake/benchmark/benchmarkConfig.cmake
-/usr/local/lib/cmake/benchmark/benchmarkConfigVersion.cmake
-/usr/local/lib/cmake/benchmark/benchmarkTargets-release.cmake
-/usr/local/lib/cmake/benchmark/benchmarkTargets.cmake
-/usr/local/lib/libbenchmark.so
-/usr/local/lib/libbenchmark.so.1
-/usr/local/lib/libbenchmark.so.1.7.1
-/usr/local/lib/libbenchmark_main.so
-/usr/local/lib/libbenchmark_main.so.1
-/usr/local/lib/libbenchmark_main.so.1.7.1
 /usr/local/lib/libsnappy.so
 /usr/local/lib/libsnappy.so.1
 /usr/local/lib/libsnappy.so.1.2.2
-/usr/local/lib/pkgconfig/benchmark.pc
-/usr/local/share/doc/benchmark/AssemblyTests.md
-/usr/local/share/doc/benchmark/_config.yml
-/usr/local/share/doc/benchmark/dependencies.md
-/usr/local/share/doc/benchmark/index.md
-/usr/local/share/doc/benchmark/perf_counters.md
-/usr/local/share/doc/benchmark/platform_specific_build_instructions.md
-/usr/local/share/doc/benchmark/python_bindings.md
-/usr/local/share/doc/benchmark/random_interleaving.md
-/usr/local/share/doc/benchmark/reducing_variance.md
-/usr/local/share/doc/benchmark/releasing.md
-/usr/local/share/doc/benchmark/tools.md
-/usr/local/share/doc/benchmark/user_guide.md

--- a/manifest/i686/s/snappy.filelist
+++ b/manifest/i686/s/snappy.filelist
@@ -1,6 +1,4 @@
-# Total size: 574493
-/usr/local/include/benchmark/benchmark.h
-/usr/local/include/benchmark/export.h
+# Total size: 94810
 /usr/local/include/snappy-c.h
 /usr/local/include/snappy-sinksource.h
 /usr/local/include/snappy-stubs-public.h
@@ -9,29 +7,6 @@
 /usr/local/lib/cmake/Snappy/SnappyConfigVersion.cmake
 /usr/local/lib/cmake/Snappy/SnappyTargets-release.cmake
 /usr/local/lib/cmake/Snappy/SnappyTargets.cmake
-/usr/local/lib/cmake/benchmark/benchmarkConfig.cmake
-/usr/local/lib/cmake/benchmark/benchmarkConfigVersion.cmake
-/usr/local/lib/cmake/benchmark/benchmarkTargets-release.cmake
-/usr/local/lib/cmake/benchmark/benchmarkTargets.cmake
-/usr/local/lib/libbenchmark.so
-/usr/local/lib/libbenchmark.so.1
-/usr/local/lib/libbenchmark.so.1.7.1
-/usr/local/lib/libbenchmark_main.so
-/usr/local/lib/libbenchmark_main.so.1
-/usr/local/lib/libbenchmark_main.so.1.7.1
 /usr/local/lib/libsnappy.so
 /usr/local/lib/libsnappy.so.1
 /usr/local/lib/libsnappy.so.1.2.2
-/usr/local/lib/pkgconfig/benchmark.pc
-/usr/local/share/doc/benchmark/AssemblyTests.md
-/usr/local/share/doc/benchmark/_config.yml
-/usr/local/share/doc/benchmark/dependencies.md
-/usr/local/share/doc/benchmark/index.md
-/usr/local/share/doc/benchmark/perf_counters.md
-/usr/local/share/doc/benchmark/platform_specific_build_instructions.md
-/usr/local/share/doc/benchmark/python_bindings.md
-/usr/local/share/doc/benchmark/random_interleaving.md
-/usr/local/share/doc/benchmark/reducing_variance.md
-/usr/local/share/doc/benchmark/releasing.md
-/usr/local/share/doc/benchmark/tools.md
-/usr/local/share/doc/benchmark/user_guide.md

--- a/manifest/x86_64/s/snappy.filelist
+++ b/manifest/x86_64/s/snappy.filelist
@@ -1,6 +1,4 @@
-# Total size: 566879
-/usr/local/include/benchmark/benchmark.h
-/usr/local/include/benchmark/export.h
+# Total size: 94802
 /usr/local/include/snappy-c.h
 /usr/local/include/snappy-sinksource.h
 /usr/local/include/snappy-stubs-public.h
@@ -9,29 +7,6 @@
 /usr/local/lib64/cmake/Snappy/SnappyConfigVersion.cmake
 /usr/local/lib64/cmake/Snappy/SnappyTargets-release.cmake
 /usr/local/lib64/cmake/Snappy/SnappyTargets.cmake
-/usr/local/lib64/cmake/benchmark/benchmarkConfig.cmake
-/usr/local/lib64/cmake/benchmark/benchmarkConfigVersion.cmake
-/usr/local/lib64/cmake/benchmark/benchmarkTargets-release.cmake
-/usr/local/lib64/cmake/benchmark/benchmarkTargets.cmake
-/usr/local/lib64/libbenchmark.so
-/usr/local/lib64/libbenchmark.so.1
-/usr/local/lib64/libbenchmark.so.1.7.1
-/usr/local/lib64/libbenchmark_main.so
-/usr/local/lib64/libbenchmark_main.so.1
-/usr/local/lib64/libbenchmark_main.so.1.7.1
 /usr/local/lib64/libsnappy.so
 /usr/local/lib64/libsnappy.so.1
 /usr/local/lib64/libsnappy.so.1.2.2
-/usr/local/lib64/pkgconfig/benchmark.pc
-/usr/local/share/doc/benchmark/AssemblyTests.md
-/usr/local/share/doc/benchmark/_config.yml
-/usr/local/share/doc/benchmark/dependencies.md
-/usr/local/share/doc/benchmark/index.md
-/usr/local/share/doc/benchmark/perf_counters.md
-/usr/local/share/doc/benchmark/platform_specific_build_instructions.md
-/usr/local/share/doc/benchmark/python_bindings.md
-/usr/local/share/doc/benchmark/random_interleaving.md
-/usr/local/share/doc/benchmark/reducing_variance.md
-/usr/local/share/doc/benchmark/releasing.md
-/usr/local/share/doc/benchmark/tools.md
-/usr/local/share/doc/benchmark/user_guide.md

--- a/packages/snappy.rb
+++ b/packages/snappy.rb
@@ -11,10 +11,10 @@ class Snappy < CMake
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '697cff1e0c956c29d65d690a5440aee2f38fe3d9d02bab13396cf3744cb04a66',
-     armv7l: '697cff1e0c956c29d65d690a5440aee2f38fe3d9d02bab13396cf3744cb04a66',
-       i686: 'b9cb1f83e790e0307cbe2e8d51474a76bfb5e77068f2bcc8ca3affbe4b0460c5',
-     x86_64: 'da62465a10ede8e2ce13fc5e4228af137377ef7ebb6e4e219b3031ffe1578872'
+    aarch64: 'fbc02c16f466c8b04025f55c72716d97318de888dfab1151dad3476e3f7dc3a8',
+     armv7l: 'fbc02c16f466c8b04025f55c72716d97318de888dfab1151dad3476e3f7dc3a8',
+       i686: '2c21491abf010a76bdff7092a0071ff16bb116007581e14058e1e75ef04f2972',
+     x86_64: '6a1897e565809ec90eccc647c30486b16bf22b130c5d2f67dd8d6e9941f417b9'
   })
 
   depends_on 'gcc_lib' => :library
@@ -23,5 +23,8 @@ class Snappy < CMake
   depends_on 'llvm_dev' => :build
   depends_on 'lzo' => :library
 
-  cmake_options '-DBUILD_SHARED_LIBS=ON -DSNAPPY_BUILD_TESTS=OFF' # Tests don't work on ARM
+  cmake_options ' \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBENCHMARK_ENABLE_INSTALL=OFF \
+    -DSNAPPY_BUILD_TESTS=OFF' # Tests don't work on ARM
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-snappy crew update \
&& yes | crew upgrade
```