### PR TITLE
Add drill package

### DIFF
--- a/manifest/armv7l/d/drill.filelist
+++ b/manifest/armv7l/d/drill.filelist
@@ -1,0 +1,2 @@
+# Total size: 7697476
+/usr/local/bin/drill

--- a/manifest/i686/d/drill.filelist
+++ b/manifest/i686/d/drill.filelist
@@ -1,0 +1,2 @@
+# Total size: 10203380
+/usr/local/bin/drill

--- a/manifest/x86_64/d/drill.filelist
+++ b/manifest/x86_64/d/drill.filelist
@@ -1,0 +1,2 @@
+# Total size: 11143488
+/usr/local/bin/drill

--- a/packages/drill.rb
+++ b/packages/drill.rb
@@ -1,0 +1,29 @@
+require 'package'
+
+class Drill < Package
+  description 'Drill is an HTTP load testing application written in Rust'
+  homepage 'https://github.com/fcsonline/drill'
+  version '0.9.1'
+  license 'GPL-3.0'
+  compatibility 'all'
+  source_url 'https://github.com/fcsonline/drill.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '5429409f4dd049f22ed19733c96b5d8502a1f5ca2abf5582e5a52d286d9ea68b',
+     armv7l: '5429409f4dd049f22ed19733c96b5d8502a1f5ca2abf5582e5a52d286d9ea68b',
+       i686: '7e20ccefd49488b41d379b61cd5dc7fa85dffb58ee0d9877c6088b8a9911a188',
+     x86_64: 'ffbbb9c11f934bda6c03ca23ef62432f650909beb0dec3b719edc1a6ed784f80'
+  })
+
+  depends_on 'gcc_lib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'rust' => :build
+
+  def self.install
+    system 'cargo build --release'
+    FileUtils.install 'target/release/drill', "#{CREW_DEST_PREFIX}/bin/drill", mode: 0o755
+  end
+end

--- a/tests/package/d/drill
+++ b/tests/package/d/drill
@@ -1,0 +1,3 @@
+#!/bin/bash
+drill -h | head
+drill -V

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1655,6 +1655,11 @@ url: https://github.com/doxygen/doxygen/releases
 activity: low
 ---
 kind: url
+name: drill
+url: https://github.com/fcsonline/drill/releases
+activity: low
+---
+kind: url
 name: dropbox
 url: https://www.dropbox.com/
 activity: high


### PR DESCRIPTION
## Description
Drill is an HTTP load testing application written in Rust.  See https://github.com/fcsonline/drill.
Needed for #17731.
#
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-drill-package crew update \
&& yes | crew upgrade

$ crew check drill 
Checking drill package ...
Library test for drill passed.
Checking drill package ...
HTTP load testing application written in Rust inspired by Ansible syntax

Usage: drill [OPTIONS] --benchmark <benchmark>

Options:
  -b, --benchmark <benchmark>   Sets the benchmark file
  -s, --stats                   Shows request statistics
  -r, --report <report>         Sets a report file
  -c, --compare <compare>       Sets a compare file
  -t, --threshold <threshold>   Sets a threshold value in ms amongst the compared file
drill 0.9.1
Package tests for drill passed.
```