### PR TITLE
Putty 0.83 => 0.84

### DIFF
--- a/manifest/armv7l/p/putty.filelist
+++ b/manifest/armv7l/p/putty.filelist
@@ -1,4 +1,4 @@
-# Total size: 3756414
+# Total size: 4895885
 /usr/local/bin/pageant
 /usr/local/bin/plink
 /usr/local/bin/pscp

--- a/manifest/x86_64/p/putty.filelist
+++ b/manifest/x86_64/p/putty.filelist
@@ -1,4 +1,4 @@
-# Total size: 5224838
+# Total size: 7446177
 /usr/local/bin/pageant
 /usr/local/bin/plink
 /usr/local/bin/pscp

--- a/packages/putty.rb
+++ b/packages/putty.rb
@@ -3,30 +3,32 @@ require 'buildsystems/cmake'
 class Putty < CMake
   description 'Free Telnet, SSH, and Rlogin clients plus a terminal emulator'
   homepage 'https://www.chiark.greenend.org.uk/~sgtatham/putty/'
-  version '0.83'
+  version '0.84'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://the.earth.li/~sgtatham/putty/latest/putty-#{version}.tar.gz"
-  source_sha256 '195621638bb6b33784b4e96cdc296f332991b5244968dc623521c3703097b5d9'
+  source_sha256 '06057862ae198f1dbd219d0c7493080d59f606194bb5056c549e342aa01b69fe'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'ecfe1d617d11768e210ecded8185711b57747c5e20408306090fd0d88b972364',
-     armv7l: 'ecfe1d617d11768e210ecded8185711b57747c5e20408306090fd0d88b972364',
-     x86_64: 'b66f3a1691b04d7ff87bad0f5c119bf754b1a64a07c914122d3ca33f5d8cbe25'
+    aarch64: '0eb7c7cef781a2a7b1f0fc0f9e47a3e58b86609698c048049483fe9527516a5e',
+     armv7l: '0eb7c7cef781a2a7b1f0fc0f9e47a3e58b86609698c048049483fe9527516a5e',
+     x86_64: '580c0439c5767e8e79a5d88b9bdfb0b6ce30b77f562eddf70994ac976c65a8d8'
   })
 
-  depends_on 'at_spi2_core' # R
-  depends_on 'cairo' # R
-  depends_on 'gdk_pixbuf' # R
-  depends_on 'glib' # R
-  depends_on 'glibc' # R
-  depends_on 'gtk3' # R
-  depends_on 'harfbuzz' # R
-  depends_on 'libice' # R
-  depends_on 'libsm' # R
-  depends_on 'libx11' # R
-  depends_on 'libxext' # R
-  depends_on 'pango' # R
-  depends_on 'zlib' # R
+  depends_on 'at_spi2_core' => :executable
+  depends_on 'cairo' => :executable
+  depends_on 'gdk_pixbuf' => :executable
+  depends_on 'glib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'gtk3' => :executable
+  depends_on 'harfbuzz' => :executable
+  depends_on 'libice' => :executable
+  depends_on 'libsm' => :executable
+  depends_on 'libx11' => :executable
+  depends_on 'libxext' => :executable
+  depends_on 'libxrender' => :executable
+  depends_on 'pango' => :executable
+  depends_on 'zlib' => :executable
 end

--- a/tests/package/p/putty
+++ b/tests/package/p/putty
@@ -1,0 +1,3 @@
+#!/bin/bash
+putty --help 2>&1 | head
+putty --version 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-putty crew update \
&& yes | crew upgrade

$ crew check putty 
Checking putty package ...
Library test for putty passed.
Checking putty package ...
putty: /usr/local/lib64/libuuid.so.1: no version information available (required by /usr/local/lib64/libSM.so.6)

(putty:10414): dbind-WARNING **: 08:41:49.307: Couldn't connect to accessibility bus: Failed to connect to socket /run/user/1000/at-spi/bus_0: No such file or directory
pterm option summary:

  --display DISPLAY         Specify X display to use (note '--')
  -name PREFIX              Prefix when looking up resources (default: pterm)
  -fn FONT                  Normal text font
  -fb FONT                  Bold text font
  -geometry GEOMETRY        Position and size of window (size in characters)
putty: /usr/local/lib64/libuuid.so.1: no version information available (required by /usr/local/lib64/libSM.so.6)

(putty:10417): dbind-WARNING **: 08:41:49.319: Couldn't connect to accessibility bus: Failed to connect to socket /run/user/1000/at-spi/bus_0: No such file or directory
PuTTY: Release 0.84
Build platform: 64-bit Unix (GTK + X11)
Compiler: gcc 16.1.0
Compiled against GTK version 3.24.52
Source commit: cda57ec785f52a9092f529b206059355646caab6
Package tests for putty passed.
```