### PR TITLE
Rarian 0.8.1 => 0.8.6

### DIFF
--- a/manifest/armv7l/r/rarian.filelist
+++ b/manifest/armv7l/r/rarian.filelist
@@ -1,7 +1,6 @@
-# Total size: 2082361
+# Total size: 503315
 /usr/local/bin/rarian-example
 /usr/local/bin/rarian-sk-config
-/usr/local/bin/rarian-sk-extract
 /usr/local/bin/rarian-sk-gen-uuid
 /usr/local/bin/rarian-sk-get-cl
 /usr/local/bin/rarian-sk-get-content-list
@@ -13,7 +12,6 @@
 /usr/local/bin/rarian-sk-rebuild
 /usr/local/bin/rarian-sk-update
 /usr/local/bin/scrollkeeper-config
-/usr/local/bin/scrollkeeper-extract
 /usr/local/bin/scrollkeeper-gen-seriesid
 /usr/local/bin/scrollkeeper-get-cl
 /usr/local/bin/scrollkeeper-get-content-list

--- a/manifest/i686/r/rarian.filelist
+++ b/manifest/i686/r/rarian.filelist
@@ -1,7 +1,6 @@
-# Total size: 1748365
+# Total size: 570553
 /usr/local/bin/rarian-example
 /usr/local/bin/rarian-sk-config
-/usr/local/bin/rarian-sk-extract
 /usr/local/bin/rarian-sk-gen-uuid
 /usr/local/bin/rarian-sk-get-cl
 /usr/local/bin/rarian-sk-get-content-list
@@ -13,7 +12,6 @@
 /usr/local/bin/rarian-sk-rebuild
 /usr/local/bin/rarian-sk-update
 /usr/local/bin/scrollkeeper-config
-/usr/local/bin/scrollkeeper-extract
 /usr/local/bin/scrollkeeper-gen-seriesid
 /usr/local/bin/scrollkeeper-get-cl
 /usr/local/bin/scrollkeeper-get-content-list

--- a/manifest/x86_64/r/rarian.filelist
+++ b/manifest/x86_64/r/rarian.filelist
@@ -1,7 +1,6 @@
-# Total size: 2465605
+# Total size: 582682
 /usr/local/bin/rarian-example
 /usr/local/bin/rarian-sk-config
-/usr/local/bin/rarian-sk-extract
 /usr/local/bin/rarian-sk-gen-uuid
 /usr/local/bin/rarian-sk-get-cl
 /usr/local/bin/rarian-sk-get-content-list
@@ -13,7 +12,6 @@
 /usr/local/bin/rarian-sk-rebuild
 /usr/local/bin/rarian-sk-update
 /usr/local/bin/scrollkeeper-config
-/usr/local/bin/scrollkeeper-extract
 /usr/local/bin/scrollkeeper-gen-seriesid
 /usr/local/bin/scrollkeeper-get-cl
 /usr/local/bin/scrollkeeper-get-content-list

--- a/packages/rarian.rb
+++ b/packages/rarian.rb
@@ -3,17 +3,22 @@ require 'buildsystems/autotools'
 class Rarian < Autotools
   description 'Documentation metadata library based on the proposed Freedesktop.org spec.'
   homepage 'https://rarian.freedesktop.org/'
-  version '0.8.1'
+  version '0.8.6'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url 'https://ftp.gnome.org/pub/gnome/sources/rarian/0.8/rarian-0.8.1.tar.bz2'
-  source_sha256 'aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577'
-  binary_compression 'tar.xz'
+  source_url "https://gitlab.freedesktop.org/rarian/rarian/-/archive/#{version}/rarian-#{version}.tar.bz2"
+  source_sha256 '2dcb9a421e084511d654aa8803807ddd56560747ac37ab2fe7d84270b94084ed'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '0432d2e342be1d21b788bd906d12312faae65f9badef502c9cbcfe74c56aabf3',
-     armv7l: '0432d2e342be1d21b788bd906d12312faae65f9badef502c9cbcfe74c56aabf3',
-       i686: 'f8feef1bf91eb6fc6c503f8b088dcb23da53de683809d941e793fbeaaf87bb00',
-     x86_64: '3ececd8ac3dce371c40d1b32c10b538821a2b74edff336d9c041f8fcab4ac09c'
+    aarch64: '4e61c8edc87cdfbdbead29dfc360bcdbf46b804c4bc630068ae7b1ebf0c24ed4',
+     armv7l: '4e61c8edc87cdfbdbead29dfc360bcdbf46b804c4bc630068ae7b1ebf0c24ed4',
+       i686: '779fb792378b1c694c3f358cca9489d403b110837e65811feb2381ce5d267f0d',
+     x86_64: '9e1533e82cffb9fc5eb937de733125b6e3c17aa1d99642edf972b7b555636622'
   })
+
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'tinyxml2' => :library
 end

--- a/tests/package/r/rarian
+++ b/tests/package/r/rarian
@@ -1,0 +1,5 @@
+#!/bin/bash
+rarian-sk-config --help
+rarian-sk-config --version
+scrollkeeper-config --help
+scrollkeeper-config --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-rarian crew update \
&& yes | crew upgrade

$ crew check rarian
Checking rarian package ...
Library test for rarian passed.
Checking rarian package ...
Usage: rarian-sk-config [OPTION]
(Rarian replacement for scrollkeeper-config)

OPTION is one of:

 --help		Display this message and exit
 --version		Display version for this package
 --prefix		Print install directory
 --localstatedir		print localstatedir used at package build time
 --pkglocalstatedir		printscrollkeeper data directory
 --pkgdatadir		print scrollkeeper home directory
 --omfdir		 print OMF files directories (one per line)
UNKNOWN (Rarian replacement for scrollkeeper-config)
Usage: scrollkeeper-config [OPTION]
(Rarian replacement for scrollkeeper-config)

OPTION is one of:

 --help		Display this message and exit
 --version		Display version for this package
 --prefix		Print install directory
 --localstatedir		print localstatedir used at package build time
 --pkglocalstatedir		printscrollkeeper data directory
 --pkgdatadir		print scrollkeeper home directory
 --omfdir		 print OMF files directories (one per line)
UNKNOWN (Rarian replacement for scrollkeeper-config)
Package tests for rarian passed.
```