### PR TITLE
Rav1e 0.5.1-p20220927 => 0.8.1

### DIFF
--- a/manifest/armv7l/r/rav1e.filelist
+++ b/manifest/armv7l/r/rav1e.filelist
@@ -1,8 +1,8 @@
-# Total size: 92770499
+# Total size: 14164308
 /usr/local/bin/rav1e
 /usr/local/include/rav1e/rav1e.h
 /usr/local/lib/librav1e.a
 /usr/local/lib/librav1e.so
-/usr/local/lib/librav1e.so.0
-/usr/local/lib/librav1e.so.0.6.0
+/usr/local/lib/librav1e.so.0.8
+/usr/local/lib/librav1e.so.0.8.1
 /usr/local/lib/pkgconfig/rav1e.pc

--- a/manifest/i686/r/rav1e.filelist
+++ b/manifest/i686/r/rav1e.filelist
@@ -1,8 +1,8 @@
-# Total size: 89614885
+# Total size: 14522996
 /usr/local/bin/rav1e
 /usr/local/include/rav1e/rav1e.h
 /usr/local/lib/librav1e.a
 /usr/local/lib/librav1e.so
-/usr/local/lib/librav1e.so.0
-/usr/local/lib/librav1e.so.0.6.0
+/usr/local/lib/librav1e.so.0.8
+/usr/local/lib/librav1e.so.0.8.1
 /usr/local/lib/pkgconfig/rav1e.pc

--- a/manifest/x86_64/r/rav1e.filelist
+++ b/manifest/x86_64/r/rav1e.filelist
@@ -1,8 +1,8 @@
-# Total size: 101868629
+# Total size: 19353368
 /usr/local/bin/rav1e
 /usr/local/include/rav1e/rav1e.h
 /usr/local/lib64/librav1e.a
 /usr/local/lib64/librav1e.so
-/usr/local/lib64/librav1e.so.0
-/usr/local/lib64/librav1e.so.0.6.0
+/usr/local/lib64/librav1e.so.0.8
+/usr/local/lib64/librav1e.so.0.8.1
 /usr/local/lib64/pkgconfig/rav1e.pc

--- a/packages/rav1e.rb
+++ b/packages/rav1e.rb
@@ -3,26 +3,28 @@ require 'package'
 class Rav1e < Package
   description 'An AV1 encoder focused on speed and safety'
   homepage 'https://github.com/xiph/rav1e/'
-  version '0.5.1-p20220927'
+  version '0.8.1'
   license 'BSD-2, Apache-2.0, MIT and Unlicense'
   compatibility 'all'
   source_url 'https://github.com/xiph/rav1e.git'
-  git_hashtag 'p20220927'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1a25d78f87f3f361cdfd4e1c98c0bea454a96bd73744b2a004d7a58b1ecfb6f0',
-     armv7l: '1a25d78f87f3f361cdfd4e1c98c0bea454a96bd73744b2a004d7a58b1ecfb6f0',
-       i686: 'fdf45f72a79a60b668eb49a80b6d63cb8ea7b3dd0eaa272390b105d20e3aa6a8',
-     x86_64: '8caaa04e32e710632b8d5e465dd323745a2e5d6cd55957b76ddef735487643f2'
+    aarch64: '315ec6326337d5a7f3576c97fd7ecad8197ce9f3c4177692e3f667cb1d00bcef',
+     armv7l: '315ec6326337d5a7f3576c97fd7ecad8197ce9f3c4177692e3f667cb1d00bcef',
+       i686: '1f4a0a3f23fef826301085f9bc615059b56041a2aa9267876978d38fb6f084a1',
+     x86_64: 'c853af1d920d63f20e2a87a2e3f6e4da4762f5b936017a2e9dbc9bf47dd1236c'
   })
 
-  depends_on 'libaom'
-  depends_on 'libgit2'
-  depends_on 'rust' => :build
   depends_on 'cargo_c' => :build
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'libaom' => :library
+  depends_on 'libgit2' => :library
+  depends_on 'nasm' => :build
+  depends_on 'rust' => :build
 
   def self.build
     @rust_flags = ''

--- a/tests/package/r/rav1e
+++ b/tests/package/r/rav1e
@@ -1,0 +1,3 @@
+#!/bin/bash
+rav1e -h | head
+rav1e --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-rav1e crew update \
&& yes | crew upgrade

$ crew check rav1e 
Checking rav1e package ...
Library test for rav1e passed.
Checking rav1e package ...
AV1 video encoder

Usage: 

Commands:
  advanced  Advanced features
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help (see more with '--help')
rav1e 0.8.1 (1fe82de) (release)
rustc 1.97.1 (8bab26f4f 2026-07-14) x86_64-unknown-linux-gnu
Compiled CPU Features: fxsr,sse,sse2
Runtime Assembly Support: Enabled
Runtime Assembly Level: AVX2
Threading: Enabled
Unstable Features: Disabled
Compiler Flags: -Cdebuginfo=0 -Copt-level=3
Package tests for rav1e passed.
```