### PR TITLE
Rdfind 1.7.0-1ed3036 => 1.8.0

### DIFF
--- a/manifest/armv7l/r/rdfind.filelist
+++ b/manifest/armv7l/r/rdfind.filelist
@@ -1,3 +1,3 @@
-# Total size: 80719
+# Total size: 81182
 /usr/local/bin/rdfind
 /usr/local/share/man/man1/rdfind.1.zst

--- a/manifest/i686/r/rdfind.filelist
+++ b/manifest/i686/r/rdfind.filelist
@@ -1,3 +1,3 @@
-# Total size: 127755
+# Total size: 135606
 /usr/local/bin/rdfind
 /usr/local/share/man/man1/rdfind.1.zst

--- a/manifest/x86_64/r/rdfind.filelist
+++ b/manifest/x86_64/r/rdfind.filelist
@@ -1,3 +1,3 @@
-# Total size: 120459
+# Total size: 122874
 /usr/local/bin/rdfind
 /usr/local/share/man/man1/rdfind.1.zst

--- a/packages/rdfind.rb
+++ b/packages/rdfind.rb
@@ -1,29 +1,26 @@
-# Adapted from Arch Linux rdfind PKGBUILD at:
-# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=rdfind
-
 require 'buildsystems/autotools'
 
 class Rdfind < Autotools
   description 'Redundant data find - a program that finds duplicate files.'
   homepage 'https://rdfind.pauldreik.se/'
-  version '1.7.0-1ed3036'
+  version '1.8.0'
   license 'GPL2'
   compatibility 'all'
   source_url 'https://github.com/pauldreik/rdfind.git'
-  git_hashtag '1ed3036a133037c4a32b99f960177f9774495f74'
-  # git_hashtag "releases/#{version.split('-').first}"
+  git_hashtag "releases/#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '0ae9197eb83e4b11cb03fefc8dd8dc4cc8f8ec1186821874b10ddc456416befa',
-     armv7l: '0ae9197eb83e4b11cb03fefc8dd8dc4cc8f8ec1186821874b10ddc456416befa',
-       i686: '8906db22f0dcca36ca4938cedcb4374c0e9f3402bad72f46a93082e28fc6ac4d',
-     x86_64: 'e4782a1446cbf734a3794e0ceb88b842c708e177c1128724576f03611e3b68ce'
+    aarch64: 'cf6870de60995f62b36a96baa20868901ac3bf75faf976f0dfcc36a22db1a8f4',
+     armv7l: 'cf6870de60995f62b36a96baa20868901ac3bf75faf976f0dfcc36a22db1a8f4',
+       i686: 'cfb0177d2c3de2b880c802b1bf057f889328a4b4b03e36dd2e8565164b88b0fb',
+     x86_64: '7aaeadaf82cd766f26c1dbcb79f5471cf6ce16e4d4576c44ed1c6ae032f40c24'
   })
 
   depends_on 'autoconf_archive' => :build
   depends_on 'gcc_lib' => :executable
   depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'nettle' => :executable
   depends_on 'xxhash' => :executable
 

--- a/tests/package/r/rdfind
+++ b/tests/package/r/rdfind
@@ -1,0 +1,3 @@
+#!/bin/bash
+rdfind -h | head
+rdfind -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-rdfind crew update \
&& yes | crew upgrade

$ crew check rdfind 
Checking rdfind package ...
Library test for rdfind passed.
Checking rdfind package ...
Usage: rdfind [options] FILE ...

Finds duplicate files recursively in the given FILEs (directories), and takes
appropriate action (by default, nothing). Directories listed first are ranked
higher, meaning that if a file is found on several places, the file found in
the directory first encountered on the command line is kept, and the others are
considered duplicate.

options are (default choice within parentheses)

This is rdfind version 1.8.0
Package tests for rdfind passed.
```