### PR TITLE
Ripgrep 12.1.0 => 15.2.0

### DIFF
--- a/manifest/armv7l/r/ripgrep.filelist
+++ b/manifest/armv7l/r/ripgrep.filelist
@@ -1,2 +1,2 @@
-# Total size: 4190808
+# Total size: 4201088
 /usr/local/bin/rg

--- a/manifest/armv7l/r/ripgrep.filelist
+++ b/manifest/armv7l/r/ripgrep.filelist
@@ -1,2 +1,2 @@
-# Total size: 30728608
+# Total size: 4190808
 /usr/local/bin/rg

--- a/manifest/i686/r/ripgrep.filelist
+++ b/manifest/i686/r/ripgrep.filelist
@@ -1,2 +1,2 @@
-# Total size: 5275600
+# Total size: 5289592
 /usr/local/bin/rg

--- a/manifest/i686/r/ripgrep.filelist
+++ b/manifest/i686/r/ripgrep.filelist
@@ -1,0 +1,2 @@
+# Total size: 5275600
+/usr/local/bin/rg

--- a/manifest/x86_64/r/ripgrep.filelist
+++ b/manifest/x86_64/r/ripgrep.filelist
@@ -1,2 +1,2 @@
-# Total size: 5173384
+# Total size: 5195104
 /usr/local/bin/rg

--- a/manifest/x86_64/r/ripgrep.filelist
+++ b/manifest/x86_64/r/ripgrep.filelist
@@ -1,2 +1,2 @@
-# Total size: 31610720
+# Total size: 5173384
 /usr/local/bin/rg

--- a/packages/ripgrep.rb
+++ b/packages/ripgrep.rb
@@ -1,6 +1,6 @@
-require 'package'
+require 'buildsystems/rust'
 
-class Ripgrep < Package
+class Ripgrep < RUST
   description 'ripgrep recursively searches directories for a regex pattern'
   homepage 'https://github.com/BurntSushi/ripgrep'
   version '15.2.0'
@@ -11,36 +11,16 @@ class Ripgrep < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'cdff508de644154a18a1636ab681c6d9255d7551d19f2f35a92c42db04006ea0',
-     armv7l: 'cdff508de644154a18a1636ab681c6d9255d7551d19f2f35a92c42db04006ea0',
-       i686: 'bad92325e65b9950933b7e3ddfce7e3a6bbc2b91a10b2333251dd3b213d08c39',
-     x86_64: 'd22b1ddd15dafa60399cabba67f30d29d526488411aa741dcdae48e2b63693cf'
+    aarch64: '5b7a8062fd9cb4bedd1b52394b4f7423d4f0a82915d77cba7029c805ae8452ab',
+     armv7l: '5b7a8062fd9cb4bedd1b52394b4f7423d4f0a82915d77cba7029c805ae8452ab',
+       i686: 'b1ff66a6f8b683e8e63640efb6b6a48af0791677c2fa6dea61e8ac2a45950bb8',
+     x86_64: '5039e808a0542c47dca18dad9000e095616e2943031f4ad495c4a897d7d3b4b7'
   })
 
   depends_on 'gcc_lib' => :executable
   depends_on 'glibc' => :executable
   depends_on 'glibc_lib' => :executable
   depends_on 'rust' => :build
-
-  def self.build
-    case ARCH
-    when 'aarch64', 'armv7l'
-      system 'rustup toolchain install 1.43.1-armv7-unknown-linux-gnueabihf'
-      system 'rustup default 1.43.1-armv7-unknown-linux-gnueabihf'
-    else
-      system 'rustup toolchain install stable'
-      system 'rustup default stable'
-    end
-    system 'cargo build --release'
-  end
-
-  def self.check
-    system 'cargo test --all'
-  end
-
-  def self.install
-    FileUtils.install 'target/release/rg', "#{CREW_DEST_PREFIX}/bin/rg", mode: 0o755
-  end
 
   def self.postinstall
     ExitMessage.add "\nType 'rg' to get started.\n"

--- a/packages/ripgrep.rb
+++ b/packages/ripgrep.rb
@@ -3,19 +3,23 @@ require 'package'
 class Ripgrep < Package
   description 'ripgrep recursively searches directories for a regex pattern'
   homepage 'https://github.com/BurntSushi/ripgrep'
-  version '12.1.0'
+  version '15.2.0'
   license 'Apache-2.0, BSD-2, Boost-1.0 and MIT or Unlicense'
   compatibility 'all'
-  source_url 'https://github.com/BurntSushi/ripgrep/archive/12.1.0.tar.gz'
-  source_sha256 'ca2d11dd7b7346734d47ad8073468e9c409fbe85842a608d372b8d4fb36be291'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/BurntSushi/ripgrep.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '3a258a81559b077d04cf3d9912731da26d2f8398538e9a9faa3fb3e0a15aa6cd',
-     armv7l: '3a258a81559b077d04cf3d9912731da26d2f8398538e9a9faa3fb3e0a15aa6cd',
-     x86_64: '1e1b614726be5ad7de8e35921d8ea73c0fd72f4cd3d245b5dae78e356055e17b'
+    aarch64: 'cdff508de644154a18a1636ab681c6d9255d7551d19f2f35a92c42db04006ea0',
+     armv7l: 'cdff508de644154a18a1636ab681c6d9255d7551d19f2f35a92c42db04006ea0',
+       i686: 'bad92325e65b9950933b7e3ddfce7e3a6bbc2b91a10b2333251dd3b213d08c39',
+     x86_64: 'd22b1ddd15dafa60399cabba67f30d29d526488411aa741dcdae48e2b63693cf'
   })
 
+  depends_on 'gcc_lib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'rust' => :build
 
   def self.build
@@ -35,12 +39,10 @@ class Ripgrep < Package
   end
 
   def self.install
-    system "install -Dm755 target/release/rg #{CREW_DEST_PREFIX}/bin/rg"
+    FileUtils.install 'target/release/rg', "#{CREW_DEST_PREFIX}/bin/rg", mode: 0o755
   end
 
   def self.postinstall
-    puts
-    puts "Type 'rg' to get started.".lightblue
-    puts
+    ExitMessage.add "\nType 'rg' to get started.\n"
   end
 end

--- a/tests/package/r/ripgrep
+++ b/tests/package/r/ripgrep
@@ -1,0 +1,3 @@
+#!/bin/bash
+rg -h | head
+rg -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-ripgrep crew update \
&& yes | crew upgrade

$ crew check ripgrep 
Checking ripgrep package ...
Library test for ripgrep passed.
Checking ripgrep package ...
ripgrep 15.2.0 (rev e89fff89ac)
Andrew Gallant <jamslam@gmail.com>

ripgrep (rg) recursively searches the current directory for lines matching
a regex pattern. By default, ripgrep will respect gitignore rules and
automatically skip hidden files/directories and binary files.

Use -h for short descriptions and --help for more details.

Project home page: https://github.com/BurntSushi/ripgrep
ripgrep 15.2.0 (rev e89fff89ac)
Package tests for ripgrep passed.
```