### PR TITLE
Rubberband 3.3.0 => 4.0.0

### DIFF
--- a/manifest/armv7l/r/rubberband.filelist
+++ b/manifest/armv7l/r/rubberband.filelist
@@ -1,14 +1,15 @@
-# Total size: 4405360
+# Total size: 5682518
 /usr/local/bin/rubberband
 /usr/local/bin/rubberband-r3
+/usr/local/include/rubberband/RubberBandLiveShifter.h
 /usr/local/include/rubberband/RubberBandStretcher.h
 /usr/local/include/rubberband/rubberband-c.h
 /usr/local/lib/ladspa/ladspa-rubberband.cat
 /usr/local/lib/ladspa/ladspa-rubberband.so
 /usr/local/lib/librubberband.a
 /usr/local/lib/librubberband.so
-/usr/local/lib/librubberband.so.2
-/usr/local/lib/librubberband.so.2.3.0
+/usr/local/lib/librubberband.so.3
+/usr/local/lib/librubberband.so.3.0.0
 /usr/local/lib/lv2/rubberband.lv2/lv2-rubberband.so
 /usr/local/lib/lv2/rubberband.lv2/lv2-rubberband.ttl
 /usr/local/lib/lv2/rubberband.lv2/manifest.ttl

--- a/manifest/x86_64/r/rubberband.filelist
+++ b/manifest/x86_64/r/rubberband.filelist
@@ -1,14 +1,15 @@
-# Total size: 5102820
+# Total size: 7228234
 /usr/local/bin/rubberband
 /usr/local/bin/rubberband-r3
+/usr/local/include/rubberband/RubberBandLiveShifter.h
 /usr/local/include/rubberband/RubberBandStretcher.h
 /usr/local/include/rubberband/rubberband-c.h
 /usr/local/lib64/ladspa/ladspa-rubberband.cat
 /usr/local/lib64/ladspa/ladspa-rubberband.so
 /usr/local/lib64/librubberband.a
 /usr/local/lib64/librubberband.so
-/usr/local/lib64/librubberband.so.2
-/usr/local/lib64/librubberband.so.2.3.0
+/usr/local/lib64/librubberband.so.3
+/usr/local/lib64/librubberband.so.3.0.0
 /usr/local/lib64/lv2/rubberband.lv2/lv2-rubberband.so
 /usr/local/lib64/lv2/rubberband.lv2/lv2-rubberband.ttl
 /usr/local/lib64/lv2/rubberband.lv2/manifest.ttl

--- a/packages/rubberband.rb
+++ b/packages/rubberband.rb
@@ -3,23 +3,24 @@ require 'buildsystems/meson'
 class Rubberband < Meson
   description 'Rubber Band Library is a high quality software library for audio time-stretching and pitch-shifting.'
   homepage 'https://breakfastquay.com/rubberband/'
-  version '3.3.0'
+  version '4.0.0'
   license 'GPL-2'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://breakfastquay.com/files/releases/rubberband-3.3.0.tar.bz2'
-  source_sha256 'd9ef89e2b8ef9f85b13ac3c2faec30e20acf2c9f3a9c8c45ce637f2bc95e576c'
+  source_url "https://breakfastquay.com/files/releases/rubberband-#{version}.tar.bz2"
+  source_sha256 'af050313ee63bc18b35b2e064e5dce05b276aaf6d1aa2b8a82ced1fe2f8028e9'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '30db5404665bb687280f3a90748260dcc4fe78abdb591dfdb1a713ef444f7ec6',
-     armv7l: '30db5404665bb687280f3a90748260dcc4fe78abdb591dfdb1a713ef444f7ec6',
-     x86_64: 'd280cbc2f5f677b739dfc6ba1fa5739f0342635eb629bf7848d654dd9bbda667'
+    aarch64: '7794865a06c44c6c5404ab90b1788672ed205b7a6f5e0490255e26a574b4dc64',
+     armv7l: '7794865a06c44c6c5404ab90b1788672ed205b7a6f5e0490255e26a574b4dc64',
+     x86_64: '8cf64e3fa806fd38358820d710c409a217ac3079b976fe7f62b33be72fe24d20'
   })
 
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'ladspa' => :build
   depends_on 'libsamplerate' => :build
-  depends_on 'libsndfile' # R
-  depends_on 'vamp_sdk' # R
+  depends_on 'libsndfile' => :executable
+  depends_on 'vamp_sdk' => :library
 end

--- a/tests/package/r/rubberband
+++ b/tests/package/r/rubberband
@@ -1,0 +1,3 @@
+#!/bin/bash
+rubberband -h 2>&1 | head
+rubberband -V 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-rubberband crew update \
&& yes | crew upgrade

$ crew check rubberband 
Checking rubberband package ...
Library test for rubberband passed.
Checking rubberband package ...

Rubber Band
An audio time-stretching and pitch-shifting library and utility program.
Copyright 2007-2024 Particular Programs Ltd.

   Usage: rubberband [options] <infile.wav> <outfile.wav>

You must specify at least one of the following time and pitch ratio options:

  -t<X>, --time <X>       Stretch to X times original duration, or
4.0.0
Package tests for rubberband passed.
```