### PR TITLE
Rebuild util_linux with glibc 2.27 on arm. — util_linux: 2.42.2-py3.14 → 2.42.2-1-py3.14

### DIFF
--- a/manifest/armv7l/u/util_linux.filelist
+++ b/manifest/armv7l/u/util_linux.filelist
@@ -1,4 +1,4 @@
-# Total size: 30224744
+# Total size: 30224684
 /usr/local/bin/bits
 /usr/local/bin/cal
 /usr/local/bin/chfn

--- a/manifest/i686/u/util_linux.filelist
+++ b/manifest/i686/u/util_linux.filelist
@@ -1,4 +1,4 @@
-# Total size: 32304030
+# Total size: 32299874
 /usr/local/bin/bits
 /usr/local/bin/cal
 /usr/local/bin/chfn

--- a/manifest/x86_64/u/util_linux.filelist
+++ b/manifest/x86_64/u/util_linux.filelist
@@ -1,4 +1,4 @@
-# Total size: 33599962
+# Total size: 33600882
 /usr/local/bin/bits
 /usr/local/bin/cal
 /usr/local/bin/chfn

--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Util_linux < Meson
   description 'essential linux tools'
   homepage 'https://www.kernel.org/pub/linux/utils/util-linux/'
-  version "2.42.2-#{CREW_PY_VER}"
+  version "2.42.2-1-#{CREW_PY_VER}"
   license 'GPL-2, LGPL-2.1, BSD-4, MIT and public-domain'
   compatibility 'all'
   source_url 'https://github.com/util-linux/util-linux.git'

--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -11,10 +11,10 @@ class Util_linux < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e0907e6cdd3e0547c477963b24ebbdf88077158f474cf13f3fa31a248efa5212',
-     armv7l: 'e0907e6cdd3e0547c477963b24ebbdf88077158f474cf13f3fa31a248efa5212',
-       i686: 'c5e2397101d529d60e25d99dc68768955ea02df0ee8de3900e3e8bf906b2183a',
-     x86_64: 'ab26d552f2a0504f3f1c2a110553163403a20fe146f5a419f62ab7f087bed166'
+    aarch64: 'a1ca9e518abfaa2c06c65015f0b33be8a125cd86ca20081427a3e7feb27ded1b',
+     armv7l: 'a1ca9e518abfaa2c06c65015f0b33be8a125cd86ca20081427a3e7feb27ded1b',
+       i686: '21c5875d2d8d190e64c8e4a28b36f818ddf740287c3ce01abad3c841d7a513ea',
+     x86_64: 'ebbf35eed4460ec4e837c19b6fd1453b0db32f5329c593a0cb4e76a1a9642586'
   })
 
   depends_on 'eudev_header' => :build if ARCH == 'x86_64' # (for libudev.h)


### PR DESCRIPTION
## Description
#### Commits:
-  f1f50df67 Rebuild util_linux with glibc 2.27 on arm.
### Packages with Updated versions or Changed package files:
- `util_linux`: 2.42.2-py3.14 &rarr; 2.42.2-1-py3.14 (current version is 2.42.2)
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=util_linux_fix crew update \
&& yes | crew upgrade
```
