### PR TITLE
Samurai 1.2-1 => 1.3

### DIFF
--- a/manifest/armv7l/s/samurai.filelist
+++ b/manifest/armv7l/s/samurai.filelist
@@ -1,3 +1,3 @@
-# Total size: 27682
+# Total size: 68975
 /usr/local/bin/samu
-/usr/local/share/man/man1/samu.1.gz
+/usr/local/share/man/man1/samu.1.zst

--- a/manifest/i686/s/samurai.filelist
+++ b/manifest/i686/s/samurai.filelist
@@ -1,3 +1,3 @@
-# Total size: 31458
+# Total size: 108435
 /usr/local/bin/samu
-/usr/local/share/man/man1/samu.1.gz
+/usr/local/share/man/man1/samu.1.zst

--- a/manifest/x86_64/s/samurai.filelist
+++ b/manifest/x86_64/s/samurai.filelist
@@ -1,3 +1,3 @@
-# Total size: 29286
+# Total size: 94651
 /usr/local/bin/samu
-/usr/local/share/man/man1/samu.1.gz
+/usr/local/share/man/man1/samu.1.zst

--- a/packages/samurai.rb
+++ b/packages/samurai.rb
@@ -1,37 +1,30 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Samurai < Package
+class Samurai < Autotools
   description 'Samurai is a ninja compatible build tool written in C.'
   homepage 'https://github.com/michaelforney/samurai/'
-  @_ver = '1.2'
-  version "#{@_ver}-1"
+  version '1.3'
   license 'Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'https://github.com/michaelforney/samurai.git'
-  git_hashtag @_ver
+  git_hashtag version
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'ec57080a9deeee698094cb87f0976168e0dae2ac5685deaf2e68fd1f3d8a7bb3',
-     armv7l: 'ec57080a9deeee698094cb87f0976168e0dae2ac5685deaf2e68fd1f3d8a7bb3',
-       i686: 'e84c2886040bbc549bb9aebc17fdad87218d4a83371c7f42999dd54b48bde36f',
-     x86_64: '292fd418d6db6cd9d2f67a92f1f2fdcbd784f5d4bc5abeee002dbe5f2bd7205d'
+    aarch64: '784aed466b5f55b5f5ebe4f30ac3f0d2988fb3ccc4bdaecf7d63bf19bc2400c2',
+     armv7l: '784aed466b5f55b5f5ebe4f30ac3f0d2988fb3ccc4bdaecf7d63bf19bc2400c2',
+       i686: '225f294eeb5763d264213e3d96c3891418b0a6aa8ec327ddfcd379e2e0f8a450',
+     x86_64: 'b06bc0918e3d16ed85c4bec818dc8613e8116eaab5d92b4ff4df127148552473'
   })
+
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 
   def self.patch
     system "sed -i 's:PREFIX=/usr/local:PREFIX=#{CREW_PREFIX}:' Makefile"
     system "sed -i 's:MANDIR=\$(PREFIX)/share/man:MANDIR=#{CREW_MAN_PREFIX}:g' Makefile"
   end
 
-  def self.build
-    system "make CFLAGS='#{CREW_COMMON_FLAGS}' LDFLAGS='#{CREW_LINKER_FLAGS}'"
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.check
-    # no checks
-  end
+  autotools_skip_configure
+  autotools_make_options "CFLAGS='#{CREW_COMMON_FLAGS}' LDFLAGS='#{CREW_LINKER_FLAGS}'"
 end

--- a/tests/package/s/samurai
+++ b/tests/package/s/samurai
@@ -1,0 +1,3 @@
+#!/bin/bash
+samu -h 2>&1
+samu --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-samurai crew update \
&& yes | crew upgrade

$ crew check samurai
Checking samurai package ...
Library test for samurai passed.
Checking samurai package ...
usage: samu [-C dir] [-f buildfile] [-j maxjobs] [-k maxfail] [-l maxload] [-n]
1.9.0
Package tests for samurai passed.
```