### PR TITLE
Sbc 2.0 => 2.2

### DIFF
--- a/manifest/armv7l/s/sbc.filelist
+++ b/manifest/armv7l/s/sbc.filelist
@@ -1,4 +1,4 @@
-# Total size: 128796
+# Total size: 142761
 /usr/local/bin/sbcdec
 /usr/local/bin/sbcenc
 /usr/local/bin/sbcinfo
@@ -6,5 +6,5 @@
 /usr/local/lib/libsbc.la
 /usr/local/lib/libsbc.so
 /usr/local/lib/libsbc.so.1
-/usr/local/lib/libsbc.so.1.3.1
+/usr/local/lib/libsbc.so.1.3.2
 /usr/local/lib/pkgconfig/sbc.pc

--- a/manifest/i686/s/sbc.filelist
+++ b/manifest/i686/s/sbc.filelist
@@ -1,4 +1,4 @@
-# Total size: 129824
+# Total size: 209497
 /usr/local/bin/sbcdec
 /usr/local/bin/sbcenc
 /usr/local/bin/sbcinfo
@@ -6,5 +6,5 @@
 /usr/local/lib/libsbc.la
 /usr/local/lib/libsbc.so
 /usr/local/lib/libsbc.so.1
-/usr/local/lib/libsbc.so.1.3.1
+/usr/local/lib/libsbc.so.1.3.2
 /usr/local/lib/pkgconfig/sbc.pc

--- a/manifest/x86_64/s/sbc.filelist
+++ b/manifest/x86_64/s/sbc.filelist
@@ -1,4 +1,4 @@
-# Total size: 136408
+# Total size: 226437
 /usr/local/bin/sbcdec
 /usr/local/bin/sbcenc
 /usr/local/bin/sbcinfo
@@ -6,5 +6,5 @@
 /usr/local/lib64/libsbc.la
 /usr/local/lib64/libsbc.so
 /usr/local/lib64/libsbc.so.1
-/usr/local/lib64/libsbc.so.1.3.1
+/usr/local/lib64/libsbc.so.1.3.2
 /usr/local/lib64/pkgconfig/sbc.pc

--- a/packages/sbc.rb
+++ b/packages/sbc.rb
@@ -3,21 +3,22 @@ require 'buildsystems/autotools'
 class Sbc < Autotools
   description 'SBC is a digital audio encoder and decoder used to transfer data to Bluetooth audio output devices.'
   homepage 'https://www.linuxfromscratch.org/blfs/view/svn/multimedia/sbc.html'
-  version '2.0'
+  version '2.2'
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
-  source_url 'https://www.kernel.org/pub/linux/bluetooth/sbc-2.0.tar.xz'
-  source_sha256 '8f12368e1dbbf55e14536520473cfb338c84b392939cc9b64298360fd4a07992'
+  source_url "https://www.kernel.org/pub/linux/bluetooth/sbc-#{version}.tar.xz"
+  source_sha256 'a1ada76ef35e5af9c2fbd063754dc9e37a8d989417c6eb1ecebb089b1383ae9e'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '94eb507ecb737f856ab6fd64d6fffbb56fa06fa17c3c9fd89b7f168dbd3836c0',
-     armv7l: '94eb507ecb737f856ab6fd64d6fffbb56fa06fa17c3c9fd89b7f168dbd3836c0',
-       i686: '7d910e200cf5edf6654369a94e6652b5af9989977ea3ec636fb2f900b72189e5',
-     x86_64: '5fd600e8ab31ea0668acb2679787a99c94fef58cb222e843a7781a820636c3bd'
+    aarch64: '57287efd1e700d01de2cdf1864df60770e141b8e34f35b99f50098c9e69e521c',
+     armv7l: '57287efd1e700d01de2cdf1864df60770e141b8e34f35b99f50098c9e69e521c',
+       i686: '712f5585af3360d502207aa806fd43da99f5ebfb09785c3349b2fcef97972402',
+     x86_64: '7fe4781bac996f63a148cec3fbc864dd6e0592f9e1d68f7d627f815133c68649'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'libsndfile' => :build
 
   autotools_configure_options '--enable-high-precision \

--- a/tests/package/s/sbc
+++ b/tests/package/s/sbc
@@ -1,0 +1,3 @@
+#!/bin/bash
+sbcenc -h
+sbcdec -h


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-sbc crew update \
&& yes | crew upgrade

$ crew check sbc
Checking sbc package ...
Library test for sbc passed.
Checking sbc package ...
SBC encoder utility ver 2.2
Copyright (c) 2004-2010  Marcel Holtmann

Usage:
	sbcenc [options] file(s)

Options:
	-h, --help           Display help
	-v, --verbose        Verbose mode
	-m, --msbc           mSBC codec
	-s, --subbands       Number of subbands to use (4 or 8)
	-b, --bitpool        Bitpool value (default is 32)
	-j, --joint          Joint stereo
	-d, --dualchannel    Dual channel
	-S, --snr            Use SNR mode (default is loudness)
	-B, --blocks         Number of blocks (4, 8, 12 or 16)

SBC decoder utility ver 2.2
Copyright (c) 2004-2010  Marcel Holtmann

Usage:
	sbcdec [options] file(s)

Options:
	-h, --help           Display help
	-d, --device <dsp>   Sound device
	-v, --verbose        Verbose mode
	-m, --msbc           mSBC codec
	-f, --file <file>    Decode to a file

Package tests for sbc passed.
```