### PR TITLE
Screenfetch 3.9.1 => 3.9.9

### DIFF
--- a/manifest/armv7l/s/screenfetch.filelist
+++ b/manifest/armv7l/s/screenfetch.filelist
@@ -1,3 +1,3 @@
-# Total size: 246800
+# Total size: 261453
 /usr/local/bin/screenfetch
-/usr/local/man/man1/screenfetch.1.gz
+/usr/local/share/man/man1/screenfetch.1.zst

--- a/manifest/i686/s/screenfetch.filelist
+++ b/manifest/i686/s/screenfetch.filelist
@@ -1,3 +1,3 @@
-# Total size: 246800
+# Total size: 261453
 /usr/local/bin/screenfetch
-/usr/local/man/man1/screenfetch.1.gz
+/usr/local/share/man/man1/screenfetch.1.zst

--- a/manifest/x86_64/s/screenfetch.filelist
+++ b/manifest/x86_64/s/screenfetch.filelist
@@ -1,3 +1,3 @@
-# Total size: 246800
+# Total size: 261453
 /usr/local/bin/screenfetch
-/usr/local/man/man1/screenfetch.1.gz
+/usr/local/share/man/man1/screenfetch.1.zst

--- a/packages/screenfetch.rb
+++ b/packages/screenfetch.rb
@@ -3,24 +3,24 @@ require 'package'
 class Screenfetch < Package
   description 'Fetches system/theme information in terminal for Linux desktop screenshots.'
   homepage 'https://github.com/KittyKatt/screenFetch'
-  version '3.9.1'
+  version '3.9.9'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://github.com/KittyKatt/screenFetch/archive/v3.9.1.tar.gz'
-  source_sha256 'aa97dcd2a8576ae18de6c16c19744aae1573a3da7541af4b98a91930a30a3178'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/KittyKatt/screenFetch.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '3cd66c744cc13b3527d1b0840a7a2093ac45c1bf2fb10871ccc8a63a3e98c948',
-     armv7l: '3cd66c744cc13b3527d1b0840a7a2093ac45c1bf2fb10871ccc8a63a3e98c948',
-       i686: '8c601b89335b94383480a9fd0e0fe6ac5fe364d27e4a5a8df19319df9b22aacd',
-     x86_64: 'dcadb8b83bf61c17e40f0505dca47f50e7b177a55e79614fdf64a3b78410b404'
+    aarch64: 'af5e7e3afbb1190fac4f190f87ee1f0ba7ea491ccc82b4f60399a9e667d5c9b2',
+     armv7l: 'af5e7e3afbb1190fac4f190f87ee1f0ba7ea491ccc82b4f60399a9e667d5c9b2',
+       i686: '7980f9f1bd43f09b3f7c85b81d13e2fb7bbabe1d0efe3190c4511a8eb5bf1cd9',
+     x86_64: '30d5f73c089280952a8591a23cb1fd4c34b5d0c0ea14eb81edbe25aba849a641'
   })
 
   depends_on 'bc'
 
   def self.install
-    system "install -Dm755 screenfetch-dev #{CREW_DEST_PREFIX}/bin/screenfetch"
-    system "install -D screenfetch.1 #{CREW_DEST_PREFIX}/man/man1/screenfetch.1"
+    FileUtils.install 'screenfetch-dev', "#{CREW_DEST_PREFIX}/bin/screenfetch", mode: 0o755
+    FileUtils.install 'screenfetch.1', "#{CREW_DEST_MAN_PREFIX}/man1/screenfetch.1", mode: 0o644
   end
 end

--- a/tests/package/s/screenfetch
+++ b/tests/package/s/screenfetch
@@ -1,0 +1,3 @@
+#!/bin/bash
+screenfetch -h | head
+screenfetch -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-screenfetch crew update \
&& yes | crew upgrade

$ crew check screenfetch 
Checking screenfetch package ...
Library test for screenfetch passed.
Checking screenfetch package ...
Usage:
  /usr/local/bin/screenfetch [OPTIONAL FLAGS]

screenFetch - a CLI Bash script to show system/theme info in screenshots.

Supported GNU/Linux Distributions:
	ALDOS, Alpine Linux, AlmaLinux, Alter Linux, Amazon Linux, Antergos, Arch Linux 
	(Old and Current Logos), Arch Linux 32, ArcoLinux, Artix Linux, blackPanther 
	OS, BLAG, BunsenLabs, CentOS, Chakra, Chapeau, Chrome OS, Chromium OS, 
	CrunchBang, CRUX, Debian, Deepin, DesaOS,Devuan, Dragora, DraugerOS, elementary 
screenFetch - Version 3.9.9
Created by and licensed to Brett Bohnenkamper <kittykatt@kittykatt.us>
OS X porting done almost solely by shrx (https://github.com/shrx) and John D. Duncan, III (https://github.com/JohnDDuncanIII).

This is free software; see the source for copying conditions.  There is NO warranty; not even MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Package tests for screenfetch passed.
```