### PR TITLE
Screen 5.0.1 => 5.0.2

### DIFF
--- a/manifest/armv7l/s/screen.filelist
+++ b/manifest/armv7l/s/screen.filelist
@@ -1,6 +1,7 @@
-# Total size: 987405
+# Total size: 1070309
 /usr/local/bin/screen
-/usr/local/bin/screen-5.0.1
+/usr/local/bin/screen-5.0.2
+/usr/local/share/info/screen.info.zst
 /usr/local/share/man/man1/screen.1.zst
 /usr/local/share/screen/utf8encodings/01
 /usr/local/share/screen/utf8encodings/02

--- a/manifest/i686/s/screen.filelist
+++ b/manifest/i686/s/screen.filelist
@@ -1,6 +1,7 @@
-# Total size: 839613
+# Total size: 913217
 /usr/local/bin/screen
-/usr/local/bin/screen-5.0.1
+/usr/local/bin/screen-5.0.2
+/usr/local/share/info/screen.info.zst
 /usr/local/share/man/man1/screen.1.zst
 /usr/local/share/screen/utf8encodings/01
 /usr/local/share/screen/utf8encodings/02

--- a/manifest/x86_64/s/screen.filelist
+++ b/manifest/x86_64/s/screen.filelist
@@ -1,6 +1,7 @@
-# Total size: 887129
+# Total size: 962737
 /usr/local/bin/screen
-/usr/local/bin/screen-5.0.1
+/usr/local/bin/screen-5.0.2
+/usr/local/share/info/screen.info.zst
 /usr/local/share/man/man1/screen.1.zst
 /usr/local/share/screen/utf8encodings/01
 /usr/local/share/screen/utf8encodings/02

--- a/packages/screen.rb
+++ b/packages/screen.rb
@@ -3,24 +3,25 @@ require 'buildsystems/autotools'
 class Screen < Autotools
   description 'Screen is a full-screen window manager that multiplexes a physical terminal between several processes, typically interactive shells.'
   homepage 'https://www.gnu.org/software/screen/'
-  version '5.0.1'
+  version '5.0.2'
   license 'GPL-3+'
   compatibility 'all'
-  source_url "https://git.savannah.gnu.org/cgit/screen.git/snapshot/screen-v.#{version}.tar.gz"
-  source_sha256 'e90c84930a439b005cce01f76f13e30a4947efe4f4421acd37f02951c6bcab9d'
+  source_url 'https://git.savannah.gnu.org/git/screen.git'
+  git_hashtag "v.#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '6f8ba1f3091dfc7707505637d29f0babb5666bc2b3efb276c70da4323e6bc301',
-     armv7l: '6f8ba1f3091dfc7707505637d29f0babb5666bc2b3efb276c70da4323e6bc301',
-       i686: 'e5ebb986ea1e1d1ba5b4e36da6b8948e3f697cee109e870564a472d4e1ade607',
-     x86_64: '7c3d258a354d407120a67e8a075c1365e48cce382ea5581b7b3ae9fbba0cad79'
+    aarch64: 'b4e9708194cb19cad6082e6d2e34e9d378638ba6aa379d35924f8834742fbf6d',
+     armv7l: 'b4e9708194cb19cad6082e6d2e34e9d378638ba6aa379d35924f8834742fbf6d',
+       i686: '7742eae113ef5f0991c0a6792c12a0f8c4a307407e4ef4def4ddd1d085053e62',
+     x86_64: '661ab943c92c456b3427e8e2bf484b19a46d6d9283ac54f4f63713017f91f643'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'libxcrypt' # R
-  depends_on 'linux_pam' # R
-  depends_on 'ncurses' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libxcrypt' => :executable
+  depends_on 'linux_pam' => :executable
+  depends_on 'ncurses' => :executable
 
   autotools_configure_options "--enable-colors256 CFLAGS='-I#{CREW_PREFIX}/include/ncursesw'"
 

--- a/tests/package/s/screen
+++ b/tests/package/s/screen
@@ -1,0 +1,3 @@
+#!/bin/bash
+screen -h | head
+screen -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-screen crew update \
&& yes | crew upgrade

$ crew check screen 
Checking screen package ...
Library test for screen passed.
Checking screen package ...
Use: screen [-opts] [cmd [args]]
 or: screen -r [host.tty]

Options:
-a            Force all capabilities into each window's termcap.
-A -[r|R]     Adapt all windows to the new display width & height.
-c file       Read configuration file instead of '.screenrc'.
-d (-r)       Detach the elsewhere running screen (and reattach here).
-dmS name     Start as daemon: Screen session in detached mode.
-D (-r)       Detach and logout remote (and reattach here).
Screen version 5.0.2 (build on 2026-08-02 23:40:50) 
Package tests for screen passed.
```