### PR TITLE
Seatd 0.7.0 => 0.9.3

### DIFF
--- a/manifest/armv7l/s/seatd.filelist
+++ b/manifest/armv7l/s/seatd.filelist
@@ -1,4 +1,4 @@
-# Total size: 109309
+# Total size: 88565
 /usr/local/bin/seatd
 /usr/local/bin/seatd-launch
 /usr/local/include/libseat.h

--- a/manifest/x86_64/s/seatd.filelist
+++ b/manifest/x86_64/s/seatd.filelist
@@ -1,4 +1,4 @@
-# Total size: 118867
+# Total size: 128523
 /usr/local/bin/seatd
 /usr/local/bin/seatd-launch
 /usr/local/include/libseat.h

--- a/packages/seatd.rb
+++ b/packages/seatd.rb
@@ -1,39 +1,30 @@
 # Adapted from Arch Linux seatd PKGBUILD at:
 # https://github.com/archlinux/svntogit-community/raw/packages/seatd/trunk/PKGBUILD
 
-require 'package'
+require 'buildsystems/meson'
 
-class Seatd < Package
+class Seatd < Meson
   description 'A minimal seat management daemon, and a universal seat management library'
   homepage 'https://sr.ht/~kennylevinsen/seatd/'
-  version '0.7.0'
+  version '0.9.3'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://git.sr.ht/~kennylevinsen/seatd/archive/0.7.0.tar.gz'
-  source_sha256 '210ddf8efa1149cde4dd35908bef8e9e63c2edaa0cdb5435f2e6db277fafff3c'
+  source_url "https://git.sr.ht/~kennylevinsen/seatd/archive/#{version}.tar.gz"
+  source_sha256 '302564d54d8e28191fadfd734f2675ecb0c9e0615a58011b89ef15dfa4dbaa96'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd2517776467070422094fb45abb5e10505b3180b45f913bae61ea016201ce14a',
-     armv7l: 'd2517776467070422094fb45abb5e10505b3180b45f913bae61ea016201ce14a',
-     x86_64: '52baaf5104897a144e2fe4e83057a5ed6ad1b0aa5e471c66cf1945eb7c4be18a'
+    aarch64: '2eac2d212aa0077f01d231d6f4db0ea9e2d2706a9fb78a95498913a7274c9f2c',
+     armv7l: '2eac2d212aa0077f01d231d6f4db0ea9e2d2706a9fb78a95498913a7274c9f2c',
+     x86_64: 'e7b341079c81ba99d7f652b81adfe8ceb8bcaf12931e3ed57280fdfd5f45ae4a'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
-  def self.build
-    system "meson setup #{CREW_MESON_OPTIONS} \
-        -Dlibseat-logind=disabled \
-        -Dlibseat-seatd=enabled \
-        -Dlibseat-builtin=enabled \
-        -Dexamples=disabled \
-        -Dserver=enabled \
-        builddir"
-    system 'meson configure --no-pager builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja install -C builddir"
-  end
+  meson_options '-Dlibseat-logind=disabled \
+    -Dlibseat-seatd=enabled \
+    -Dlibseat-builtin=enabled \
+    -Dexamples=disabled \
+    -Dserver=enabled'
 end

--- a/tests/package/s/seatd
+++ b/tests/package/s/seatd
@@ -1,0 +1,3 @@
+#!/bin/bash
+seatd -h
+seatd -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-seatd crew update \
&& yes | crew upgrade

$ crew check seatd 
Checking seatd package ...
Library test for seatd passed.
Checking seatd package ...
Usage: seatd [options]

  -h		Show this help message
  -n <fd>	FD to notify readiness on
  -u <user>	User to own the seatd socket
  -g <group>	Group to own the seatd socket
  -l <loglevel>	Log-level, one of debug, info, error or silent
  -v		Show the version number

seatd version 0.9.3
Package tests for seatd passed.
```