### PR TITLE
Sed 4.9-b4d01a9 => 4.10

### DIFF
--- a/manifest/armv7l/s/sed.filelist
+++ b/manifest/armv7l/s/sed.filelist
@@ -1,7 +1,8 @@
-# Total size: 770173
+# Total size: 788266
 /usr/local/bin/sed
 /usr/local/share/info/sed.info.zst
 /usr/local/share/locale/af/LC_MESSAGES/sed.mo
+/usr/local/share/locale/ar/LC_MESSAGES/sed.mo
 /usr/local/share/locale/ast/LC_MESSAGES/sed.mo
 /usr/local/share/locale/be/LC_MESSAGES/sed.mo
 /usr/local/share/locale/bg/LC_MESSAGES/sed.mo

--- a/manifest/i686/s/sed.filelist
+++ b/manifest/i686/s/sed.filelist
@@ -1,7 +1,8 @@
-# Total size: 798881
+# Total size: 865062
 /usr/local/bin/sed
 /usr/local/share/info/sed.info.zst
 /usr/local/share/locale/af/LC_MESSAGES/sed.mo
+/usr/local/share/locale/ar/LC_MESSAGES/sed.mo
 /usr/local/share/locale/ast/LC_MESSAGES/sed.mo
 /usr/local/share/locale/be/LC_MESSAGES/sed.mo
 /usr/local/share/locale/bg/LC_MESSAGES/sed.mo

--- a/manifest/x86_64/s/sed.filelist
+++ b/manifest/x86_64/s/sed.filelist
@@ -1,7 +1,8 @@
-# Total size: 799997
+# Total size: 866238
 /usr/local/bin/sed
 /usr/local/share/info/sed.info.zst
 /usr/local/share/locale/af/LC_MESSAGES/sed.mo
+/usr/local/share/locale/ar/LC_MESSAGES/sed.mo
 /usr/local/share/locale/ast/LC_MESSAGES/sed.mo
 /usr/local/share/locale/be/LC_MESSAGES/sed.mo
 /usr/local/share/locale/bg/LC_MESSAGES/sed.mo

--- a/packages/sed.rb
+++ b/packages/sed.rb
@@ -3,27 +3,27 @@ require 'buildsystems/autotools'
 class Sed < Autotools
   description 'sed (stream editor) is a non-interactive command-line text editor.'
   homepage 'https://www.gnu.org/software/sed/'
-  version '4.9-b4d01a9'
+  version '4.10'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://git.savannah.gnu.org/git/sed.git'
-  git_hashtag 'b4d01a9c9174b514fd9ccac50f6e7990a1e86fbe'
-  # source_url "https://ftp.gnu.org/gnu/sed/sed-#{version.split('-').first}.tar.lz"
-  # source_sha256 '6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '95b4f7db1c34826159e39f9d604af322f31c92f37ba9b7ce2967023080eaa61d',
-     armv7l: '95b4f7db1c34826159e39f9d604af322f31c92f37ba9b7ce2967023080eaa61d',
-       i686: 'd86bfd2d533b0f3f47bbf33f5c9d4a24c3f5fae31db4869a4c967964e0b5b17d',
-     x86_64: '545c56168809e37a8c84381ad16905775def14949a09595453fc8ee5ffe7e0fc'
+    aarch64: '4362a8a474cea08d6f9ca254a913334daef865c7a735083d895d09c18faf08e2',
+     armv7l: '4362a8a474cea08d6f9ca254a913334daef865c7a735083d895d09c18faf08e2',
+       i686: '50c33a1f68aab08347f875b2a4441a36a381e01f683eff58bd6f052a6b8c8c89',
+     x86_64: 'efb63f2a8935789bdffc0e37978fd5c878996833e28d177a49716dead83e2382'
   })
 
   depends_on 'acl' => :executable
   depends_on 'attr' => :executable
   depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'wget2' => :build
 
+  autotools_skip_autoreconf
   autotools_configure_options '--without-selinux \
                                --enable-gcc-warnings=no'
 end

--- a/tests/package/s/sed
+++ b/tests/package/s/sed
@@ -1,0 +1,3 @@
+#!/bin/bash
+sed --help | head
+sed --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-sed crew update \
&& yes | crew upgrade

$ crew check sed 
Checking sed package ...
Library test for sed passed.
Checking sed package ...
Usage: sed [OPTION]... {script-only-if-no-other-script} [input-file]...

  -n, --quiet, --silent
                 suppress automatic printing of pattern space
      --debug
                 annotate program execution
  -e script, --expression=script
                 add the script to the commands to be executed
  -f script-file, --file=script-file
                 add the contents of script-file to the commands to be executed
sed (GNU sed) UNKNOWN
Copyright (C) 2026 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jay Fenlason, Tom Lord, Ken Pizzini,
Paolo Bonzini, Jim Meyering, and Assaf Gordon.

This sed program was built without SELinux support.

GNU sed home page: <https://www.gnu.org/software/sed/>.
General help using GNU software: <https://www.gnu.org/gethelp/>.
E-mail bug reports to: <bug-sed@gnu.org>.
Package tests for sed passed.
```