### PR TITLE
Smemstat 0.02.07 => 0.02.10

### DIFF
--- a/manifest/armv7l/s/smemstat.filelist
+++ b/manifest/armv7l/s/smemstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 56896
+# Total size: 25463
 /usr/local/bin/smemstat
 /usr/local/share/bash-completion/completions/smemstat
-/usr/local/share/man/man8/smemstat.8.gz
+/usr/local/share/man/man8/smemstat.8.zst

--- a/manifest/i686/s/smemstat.filelist
+++ b/manifest/i686/s/smemstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 47252
+# Total size: 30451
 /usr/local/bin/smemstat
 /usr/local/share/bash-completion/completions/smemstat
-/usr/local/share/man/man8/smemstat.8.gz
+/usr/local/share/man/man8/smemstat.8.zst

--- a/manifest/x86_64/s/smemstat.filelist
+++ b/manifest/x86_64/s/smemstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 57836
+# Total size: 30815
 /usr/local/bin/smemstat
 /usr/local/share/bash-completion/completions/smemstat
-/usr/local/share/man/man8/smemstat.8.gz
+/usr/local/share/man/man8/smemstat.8.zst

--- a/packages/smemstat.rb
+++ b/packages/smemstat.rb
@@ -1,31 +1,30 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Smemstat < Package
+class Smemstat < Autotools
   description 'Smemstat reports the physical memory usage taking into consideration shared memory.'
-  homepage 'https://kernel.ubuntu.com/~cking/smemstat/'
-  version '0.02.07'
+  homepage 'https://github.com/ColinIanKing/smemstat'
+  version '0.02.10'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://kernel.ubuntu.com/~cking/tarballs/smemstat/smemstat-0.02.07.tar.xz'
-  source_sha256 'acc17fdd6da92571e73a58bf1512b398cb307b80f46dc196cbb8102e7fb02526'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/ColinIanKing/smemstat.git'
+  git_hashtag "V#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '80549cd181fd79bd9c58462ea5e9b87d5f0c0657093a892803ae3db77980b7cb',
-     armv7l: '80549cd181fd79bd9c58462ea5e9b87d5f0c0657093a892803ae3db77980b7cb',
-       i686: 'b015b51fa07cbaeb7f3f2ae2abcef9a8c425a3f52a3c87c9ad51a4477c5fcf92',
-     x86_64: '80884214345553902dd3bef26011b1381c6f16382df34bbd473ee506ddf81e83'
+    aarch64: '32de67cf01fa86ca7ac325ae46b1a23774bd080e939dd864e9b5b2d66d42db10',
+     armv7l: '32de67cf01fa86ca7ac325ae46b1a23774bd080e939dd864e9b5b2d66d42db10',
+       i686: '66452ce0828149c8af7ba5bdbaf805628c35463cd1aa470f00d7fc5d1a50ba69',
+     x86_64: '441dcdd891898b730436d84a5454ea0bd8916c47c13920c621dc8548ba36f543'
   })
 
-  depends_on 'ncurses'
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'ncurses' => :executable
 
-  def self.build
+  def self.patch
     system "sed -i 's,/usr,#{CREW_PREFIX},g' Makefile"
     system "sed -i '/^CFLAGS += -Wall/s/$/ -I\\/usr\\/local\\/include\\/ncurses/' Makefile"
-    system 'make'
   end
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_skip_configure
 end

--- a/tests/package/s/smemstat
+++ b/tests/package/s/smemstat
@@ -1,0 +1,2 @@
+#!/bin/bash
+smemstat -h


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-smemstat crew update \
&& yes | crew upgrade

$ crew check smemstat 
Checking smemstat package ...
Library test for smemstat passed.
Checking smemstat package ...
smemstat, version 0.02.10

Usage: smemstat [options] [duration] [count]
Options are:
  -a		show memory change with up/down arrows
  -c		get command name from processes comm field
  -d		strip directory basename off command information
  -g		report memory in gigabytes
  -h		show this help information
  -k		report memory in kilobytes
  -l		show long (full) command information
  -m		report memory in megabytes
  -o file	dump data to json formatted file
  -p proclist	specify comma separated list of processes to monitor
  -q		run quietly, useful for -o output only
  -s		show short command information
  -t		top mode, show only changes in memory
  -T		top mode, show top memory hoggers
Package tests for smemstat passed.
```