### PR TITLE
Squashfs_tools 1.1.0 => 1.3.2

### DIFF
--- a/manifest/armv7l/s/squashfs_tools_ng.filelist
+++ b/manifest/armv7l/s/squashfs_tools_ng.filelist
@@ -1,4 +1,4 @@
-# Total size: 1350757
+# Total size: 1270531
 /usr/local/bin/gensquashfs
 /usr/local/bin/rdsquashfs
 /usr/local/bin/sqfs2tar
@@ -29,10 +29,10 @@
 /usr/local/lib/libsquashfs.la
 /usr/local/lib/libsquashfs.so
 /usr/local/lib/libsquashfs.so.1
-/usr/local/lib/libsquashfs.so.1.1.1
+/usr/local/lib/libsquashfs.so.1.4.1
 /usr/local/lib/pkgconfig/libsquashfs1.pc
-/usr/local/share/man/man1/gensquashfs.1.gz
-/usr/local/share/man/man1/rdsquashfs.1.gz
-/usr/local/share/man/man1/sqfs2tar.1.gz
-/usr/local/share/man/man1/sqfsdiff.1.gz
-/usr/local/share/man/man1/tar2sqfs.1.gz
+/usr/local/share/man/man1/gensquashfs.1.zst
+/usr/local/share/man/man1/rdsquashfs.1.zst
+/usr/local/share/man/man1/sqfs2tar.1.zst
+/usr/local/share/man/man1/sqfsdiff.1.zst
+/usr/local/share/man/man1/tar2sqfs.1.zst

--- a/manifest/i686/s/squashfs_tools_ng.filelist
+++ b/manifest/i686/s/squashfs_tools_ng.filelist
@@ -1,4 +1,4 @@
-# Total size: 1269829
+# Total size: 1426645
 /usr/local/bin/gensquashfs
 /usr/local/bin/rdsquashfs
 /usr/local/bin/sqfs2tar
@@ -29,10 +29,10 @@
 /usr/local/lib/libsquashfs.la
 /usr/local/lib/libsquashfs.so
 /usr/local/lib/libsquashfs.so.1
-/usr/local/lib/libsquashfs.so.1.1.1
+/usr/local/lib/libsquashfs.so.1.4.1
 /usr/local/lib/pkgconfig/libsquashfs1.pc
-/usr/local/share/man/man1/gensquashfs.1.gz
-/usr/local/share/man/man1/rdsquashfs.1.gz
-/usr/local/share/man/man1/sqfs2tar.1.gz
-/usr/local/share/man/man1/sqfsdiff.1.gz
-/usr/local/share/man/man1/tar2sqfs.1.gz
+/usr/local/share/man/man1/gensquashfs.1.zst
+/usr/local/share/man/man1/rdsquashfs.1.zst
+/usr/local/share/man/man1/sqfs2tar.1.zst
+/usr/local/share/man/man1/sqfsdiff.1.zst
+/usr/local/share/man/man1/tar2sqfs.1.zst

--- a/manifest/x86_64/s/squashfs_tools_ng.filelist
+++ b/manifest/x86_64/s/squashfs_tools_ng.filelist
@@ -1,4 +1,4 @@
-# Total size: 1373917
+# Total size: 1464785
 /usr/local/bin/gensquashfs
 /usr/local/bin/rdsquashfs
 /usr/local/bin/sqfs2tar
@@ -29,10 +29,10 @@
 /usr/local/lib64/libsquashfs.la
 /usr/local/lib64/libsquashfs.so
 /usr/local/lib64/libsquashfs.so.1
-/usr/local/lib64/libsquashfs.so.1.1.1
+/usr/local/lib64/libsquashfs.so.1.4.1
 /usr/local/lib64/pkgconfig/libsquashfs1.pc
-/usr/local/share/man/man1/gensquashfs.1.gz
-/usr/local/share/man/man1/rdsquashfs.1.gz
-/usr/local/share/man/man1/sqfs2tar.1.gz
-/usr/local/share/man/man1/sqfsdiff.1.gz
-/usr/local/share/man/man1/tar2sqfs.1.gz
+/usr/local/share/man/man1/gensquashfs.1.zst
+/usr/local/share/man/man1/rdsquashfs.1.zst
+/usr/local/share/man/man1/sqfs2tar.1.zst
+/usr/local/share/man/man1/sqfsdiff.1.zst
+/usr/local/share/man/man1/tar2sqfs.1.zst

--- a/packages/squashfs_tools_ng.rb
+++ b/packages/squashfs_tools_ng.rb
@@ -1,38 +1,35 @@
 # Adapted from Arch Linux squashfs-tools-ng PKGBUILD at:
 # https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=squashfs-tools-ng
 
-require 'package'
+require 'buildsystems/autotools'
 
-class Squashfs_tools_ng < Package
+class Squashfs_tools_ng < Autotools
   description 'A new set of tools and libraries for working with SquashFS images'
   homepage 'https://infraroot.at/projects/squashfs-tools-ng/index.html'
-  version '1.1.0'
+  version '1.3.2'
   license 'GPLv3'
   compatibility 'all'
-  source_url 'https://infraroot.at/pub/squashfs/squashfs-tools-ng-1.1.0.tar.xz'
-  source_sha256 '110794124b268e92e28e6a95f0781d1338f48c338434ef746f5de68c64e19aeb'
-  binary_compression 'tar.xz'
+  source_url "https://infraroot.at/pub/squashfs/squashfs-tools-ng-#{version}.tar.xz"
+  source_sha256 '0d907ac3e735c351e47c867fb51d94bffa3b05fb95bec01f31e848b7c44215a9'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '60048d2dd13cc62c08437afd9ef009977d4d40e5ebd3bb8e60dc8a1de0766b2f',
-     armv7l: '60048d2dd13cc62c08437afd9ef009977d4d40e5ebd3bb8e60dc8a1de0766b2f',
-       i686: '92926e16bd5f9607e35e1b0ef3b3d10ad6a2d9e6b2cedc19cbd431f1f881c4ff',
-     x86_64: '5a3c9173fe96e8f9f3a0e0a6f764c4f88e0871c10140a7d2caf966a9956687c4'
+    aarch64: 'c3d5831a23e4d35cd41e335bb60dac7af83ac025e60933944234aaca12b35843',
+     armv7l: 'c3d5831a23e4d35cd41e335bb60dac7af83ac025e60933944234aaca12b35843',
+       i686: '64b8ebf3f07647106bcc97b730fdccf0e6c900c1f2937c87f69eb0e84f7b6a9c',
+     x86_64: '1fc538c1984aa003dbcd05b1613c09fe2f05cd91fb0b059e729c4960394fda48'
   })
 
-  depends_on 'lzo'
+  depends_on 'bzip2' => :executable
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'lz4' => :library
+  depends_on 'lzo' => :executable
+  depends_on 'xzutils' => :library
+  depends_on 'zlib' => :library
+  depends_on 'zstd' => :library
 
-  def self.build
-    system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "env CFLAGS='-pipe -flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
+  autotools_build_extras do
     system 'make doxygen-doc'
-  end
-
-  def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/tests/package/s/squashfs_tools_ng
+++ b/tests/package/s/squashfs_tools_ng
@@ -1,0 +1,2 @@
+#!/bin/bash
+for b in $(crew files squashfs_tools_ng | grep /usr/local/bin); do $b -V; done


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-squashfs_tools crew update \
&& yes | crew upgrade

$ crew check squashfs_tools_ng 
Checking squashfs_tools_ng package ...
Library test for squashfs_tools_ng passed.
Checking squashfs_tools_ng package ...
gensquashfs (squashfs-tools-ng) 1.3.2
Copyright (c) 2019 David Oberhollenzer et al
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
rdsquashfs (squashfs-tools-ng) 1.3.2
Copyright (c) 2019 David Oberhollenzer et al
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
sqfs2tar (squashfs-tools-ng) 1.3.2
Copyright (c) 2019 David Oberhollenzer et al
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
sqfsdiff (squashfs-tools-ng) 1.3.2
Copyright (c) 2019 David Oberhollenzer et al
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
tar2sqfs (squashfs-tools-ng) 1.3.2
Copyright (c) 2019 David Oberhollenzer et al
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Package tests for squashfs_tools_ng passed.
```