### PR TITLE
Squashfuse 0.1.104 => 0.6.2

### DIFF
--- a/manifest/armv7l/s/squashfuse.filelist
+++ b/manifest/armv7l/s/squashfuse.filelist
@@ -1,4 +1,4 @@
-# Total size: 403285
+# Total size: 901776
 /usr/local/bin/squashfuse
 /usr/local/bin/squashfuse_ll
 /usr/local/include/squashfuse/cache.h
@@ -8,6 +8,7 @@
 /usr/local/include/squashfuse/dir.h
 /usr/local/include/squashfuse/file.h
 /usr/local/include/squashfuse/fs.h
+/usr/local/include/squashfuse/ll.h
 /usr/local/include/squashfuse/squashfs_fs.h
 /usr/local/include/squashfuse/squashfuse.h
 /usr/local/include/squashfuse/stack.h
@@ -20,5 +21,12 @@
 /usr/local/lib/libsquashfuse.so
 /usr/local/lib/libsquashfuse.so.0
 /usr/local/lib/libsquashfuse.so.0.0.0
+/usr/local/lib/libsquashfuse_ll.a
+/usr/local/lib/libsquashfuse_ll.la
+/usr/local/lib/libsquashfuse_ll.so
+/usr/local/lib/libsquashfuse_ll.so.0
+/usr/local/lib/libsquashfuse_ll.so.0.0.0
 /usr/local/lib/pkgconfig/squashfuse.pc
-/usr/local/share/man/man1/squashfuse.1.gz
+/usr/local/lib/pkgconfig/squashfuse_ll.pc
+/usr/local/share/man/man1/squashfuse.1.zst
+/usr/local/share/man/man1/squashfuse_ll.1.zst

--- a/manifest/i686/s/squashfuse.filelist
+++ b/manifest/i686/s/squashfuse.filelist
@@ -1,4 +1,4 @@
-# Total size: 418322
+# Total size: 1005898
 /usr/local/bin/squashfuse
 /usr/local/bin/squashfuse_ll
 /usr/local/include/squashfuse/cache.h
@@ -8,16 +8,10 @@
 /usr/local/include/squashfuse/dir.h
 /usr/local/include/squashfuse/file.h
 /usr/local/include/squashfuse/fs.h
-/usr/local/include/squashfuse/fuseprivate.h
-/usr/local/include/squashfuse/hash.h
 /usr/local/include/squashfuse/ll.h
-/usr/local/include/squashfuse/nonstd-internal.h
-/usr/local/include/squashfuse/nonstd.h
 /usr/local/include/squashfuse/squashfs_fs.h
 /usr/local/include/squashfuse/squashfuse.h
 /usr/local/include/squashfuse/stack.h
-/usr/local/include/squashfuse/stat.h
-/usr/local/include/squashfuse/swap.h
 /usr/local/include/squashfuse/table.h
 /usr/local/include/squashfuse/traverse.h
 /usr/local/include/squashfuse/util.h
@@ -27,5 +21,12 @@
 /usr/local/lib/libsquashfuse.so
 /usr/local/lib/libsquashfuse.so.0
 /usr/local/lib/libsquashfuse.so.0.0.0
+/usr/local/lib/libsquashfuse_ll.a
+/usr/local/lib/libsquashfuse_ll.la
+/usr/local/lib/libsquashfuse_ll.so
+/usr/local/lib/libsquashfuse_ll.so.0
+/usr/local/lib/libsquashfuse_ll.so.0.0.0
 /usr/local/lib/pkgconfig/squashfuse.pc
-/usr/local/share/man/man1/squashfuse.1.gz
+/usr/local/lib/pkgconfig/squashfuse_ll.pc
+/usr/local/share/man/man1/squashfuse.1.zst
+/usr/local/share/man/man1/squashfuse_ll.1.zst

--- a/manifest/x86_64/s/squashfuse.filelist
+++ b/manifest/x86_64/s/squashfuse.filelist
@@ -1,4 +1,4 @@
-# Total size: 427536
+# Total size: 1019034
 /usr/local/bin/squashfuse
 /usr/local/bin/squashfuse_ll
 /usr/local/include/squashfuse/cache.h
@@ -8,16 +8,10 @@
 /usr/local/include/squashfuse/dir.h
 /usr/local/include/squashfuse/file.h
 /usr/local/include/squashfuse/fs.h
-/usr/local/include/squashfuse/fuseprivate.h
-/usr/local/include/squashfuse/hash.h
 /usr/local/include/squashfuse/ll.h
-/usr/local/include/squashfuse/nonstd-internal.h
-/usr/local/include/squashfuse/nonstd.h
 /usr/local/include/squashfuse/squashfs_fs.h
 /usr/local/include/squashfuse/squashfuse.h
 /usr/local/include/squashfuse/stack.h
-/usr/local/include/squashfuse/stat.h
-/usr/local/include/squashfuse/swap.h
 /usr/local/include/squashfuse/table.h
 /usr/local/include/squashfuse/traverse.h
 /usr/local/include/squashfuse/util.h
@@ -27,5 +21,12 @@
 /usr/local/lib64/libsquashfuse.so
 /usr/local/lib64/libsquashfuse.so.0
 /usr/local/lib64/libsquashfuse.so.0.0.0
+/usr/local/lib64/libsquashfuse_ll.a
+/usr/local/lib64/libsquashfuse_ll.la
+/usr/local/lib64/libsquashfuse_ll.so
+/usr/local/lib64/libsquashfuse_ll.so.0
+/usr/local/lib64/libsquashfuse_ll.so.0.0.0
 /usr/local/lib64/pkgconfig/squashfuse.pc
-/usr/local/share/man/man1/squashfuse.1.gz
+/usr/local/lib64/pkgconfig/squashfuse_ll.pc
+/usr/local/share/man/man1/squashfuse.1.zst
+/usr/local/share/man/man1/squashfuse_ll.1.zst

--- a/packages/squashfuse.rb
+++ b/packages/squashfuse.rb
@@ -1,37 +1,31 @@
 # Adapted from Arch Linux squashfuse PKGBUILD at:
 # https://github.com/archlinux/svntogit-packages/raw/packages/squashfuse/trunk/PKGBUILD
 
-require 'package'
+require 'buildsystems/autotools'
 
-class Squashfuse < Package
+class Squashfuse < Autotools
   description 'FUSE filesystem to mount squashfs archives'
   homepage 'https://github.com/vasi/squashfuse'
-  version '0.1.104'
+  version '0.6.2'
   license 'custom'
   compatibility 'all'
-  source_url 'https://github.com/vasi/squashfuse/releases/download/0.1.104/squashfuse-0.1.104.tar.gz'
-  source_sha256 'aa52460559e0d0b1753f6b1af5c68cfb777ca5a13913285e93f4f9b7aa894b3a'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/vasi/squashfuse.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '83bad067dece48c952a5fd510fdc2f62d4a790d6134f0015eb1c958bb66a4507',
-     armv7l: '83bad067dece48c952a5fd510fdc2f62d4a790d6134f0015eb1c958bb66a4507',
-       i686: 'afb0d28b2ee43ebc540e6b1d3c4cc56324a3356bd33cea66e47d2ba3797bf5ca',
-     x86_64: 'df130e28a509798c98213a139936e6711b7d6d97b2510f3194820cb47e22631d'
+    aarch64: '9af06b0894554939781f2f02da73eff7e96ebdfe69c2591b8515a60b8762547b',
+     armv7l: '9af06b0894554939781f2f02da73eff7e96ebdfe69c2591b8515a60b8762547b',
+       i686: '66dca481d52e25ebd6ae5be10aa188649ff426b6aa51b961e4ec335dea13ca08',
+     x86_64: 'b624917fef01972cc4d2ac72f15d673535eca1c04ea60994e941e3f822f479f6'
   })
 
-  depends_on 'fuse3'
-  depends_on 'lzo'
-
-  def self.build
-    system "env CFLAGS='-pipe -flto=auto' \
-      CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system "make DESTDIR=#{CREW_DEST_DIR} install"
-  end
+  depends_on 'fuse3' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'lz4' => :library
+  depends_on 'lzo' => :library
+  depends_on 'xzutils' => :library
+  depends_on 'zlib' => :library
+  depends_on 'zstd' => :library
 end

--- a/tests/package/s/squashfuse
+++ b/tests/package/s/squashfuse
@@ -1,0 +1,2 @@
+#!/bin/bash
+squashfuse -h 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-squashfuse crew update \
&& yes | crew upgrade

$ crew check squashfuse
Checking squashfuse package ...
Library test for squashfuse passed.
Checking squashfuse package ...
squashfuse 0.6.2 (c) 2012 Dave Vasilevsky

Usage: squashfuse [options] ARCHIVE MOUNTPOINT

squashfuse options:
    -o offset=N            offset N bytes into ARCHIVE to mount
    -o subdir=PATH         mount subdirectory PATH of ARCHIVE
    -o notify_pipe=PATH    named pipe that will receive 's' (success)
                           or 'f' (failure) when the mountpoint is ready

Selection of FUSE options:
    -h   --help            print help
    -V   --version         print version
    -d   -o debug          enable debug output (implies -f)
    -f                     foreground operation
    -o allow_other         allow access by other users
    -o allow_root          allow access by the superuser
Package tests for squashfuse passed.
```