### PR TITLE
Sshrc 0.6.1 => 0.6.2

### DIFF
--- a/manifest/armv7l/s/sshrc.filelist
+++ b/manifest/armv7l/s/sshrc.filelist
@@ -1,2 +1,3 @@
-# Total size: 2477
+# Total size: 5922
+/usr/local/bin/moshrc
 /usr/local/bin/sshrc

--- a/manifest/i686/s/sshrc.filelist
+++ b/manifest/i686/s/sshrc.filelist
@@ -1,2 +1,3 @@
-# Total size: 2477
+# Total size: 5922
+/usr/local/bin/moshrc
 /usr/local/bin/sshrc

--- a/manifest/x86_64/s/sshrc.filelist
+++ b/manifest/x86_64/s/sshrc.filelist
@@ -1,2 +1,3 @@
-# Total size: 2477
+# Total size: 5922
+/usr/local/bin/moshrc
 /usr/local/bin/sshrc

--- a/packages/sshrc.rb
+++ b/packages/sshrc.rb
@@ -2,22 +2,17 @@ require 'package'
 
 class Sshrc < Package
   description 'bring your .bashrc, .vimrc, etc. with you when you ssh'
-  homepage 'https://github.com/Russell91/sshrc'
-  version '0.6.1'
+  homepage 'https://github.com/cdown/sshrc'
+  version '0.6.2'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/Russell91/sshrc/archive/0.6.1.tar.gz'
-  source_sha256 'e849ff19319381548011a9bdf1e33abc6eba3dc6a910c4226e6981d75d5564dd'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/cdown/sshrc.git'
+  git_hashtag version
 
-  binary_sha256({
-    aarch64: 'e52ec8b2ea9be7d694bcc676059a8f5bfd35a9a05dbde317eff1bfb992ed9d37',
-     armv7l: 'e52ec8b2ea9be7d694bcc676059a8f5bfd35a9a05dbde317eff1bfb992ed9d37',
-       i686: 'c75c2b8cdd3996299d91195ed16fe727a72add0c718df10baf9aa6b009737f31',
-     x86_64: '7d940b4d6e59da0868081379314f31a923bb37ca9cfc934c23e62892a24750b9'
-  })
+  no_compile_needed
 
   def self.install
-    system "install -Dm755 sshrc #{CREW_DEST_PREFIX}/bin/sshrc"
+    FileUtils.install 'sshrc', "#{CREW_DEST_PREFIX}/bin/sshrc", mode: 0o755
+    FileUtils.install 'moshrc', "#{CREW_DEST_PREFIX}/bin/moshrc", mode: 0o755
   end
 end

--- a/tests/package/s/sshrc
+++ b/tests/package/s/sshrc
@@ -1,0 +1,2 @@
+#!/bin/bash
+sshrc 2>&1


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-sshrc crew update \
&& yes | crew upgrade

$ crew check sshrc 
Checking sshrc package ...
Library test for sshrc passed.
Checking sshrc package ...
usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] [-B bind_interface]
           [-b bind_address] [-c cipher_spec] [-D [bind_address:]port]
           [-E log_file] [-e escape_char] [-F configfile] [-I pkcs11]
           [-i identity_file] [-J [user@]host[:port]] [-L address]
           [-l login_name] [-m mac_spec] [-O ctl_cmd] [-o option] [-p port]
           [-Q query_option] [-R address] [-S ctl_path] [-W host:port]
           [-w local_tun[:remote_tun]] destination [command]
Package tests for sshrc passed.
```