### PR TITLE
Stunnel 5.78 => 5.80

### DIFF
--- a/manifest/armv7l/s/stunnel.filelist
+++ b/manifest/armv7l/s/stunnel.filelist
@@ -1,4 +1,4 @@
-# Total size: 543819
+# Total size: 559130
 /usr/local/bin/stunnel
 /usr/local/bin/stunnel3
 /usr/local/etc/stunnel/stunnel.conf-sample

--- a/manifest/i686/s/stunnel.filelist
+++ b/manifest/i686/s/stunnel.filelist
@@ -1,4 +1,4 @@
-# Total size: 631751
+# Total size: 657848
 /usr/local/bin/stunnel
 /usr/local/bin/stunnel3
 /usr/local/etc/stunnel/stunnel.conf-sample

--- a/manifest/x86_64/s/stunnel.filelist
+++ b/manifest/x86_64/s/stunnel.filelist
@@ -1,4 +1,4 @@
-# Total size: 610433
+# Total size: 633632
 /usr/local/bin/stunnel
 /usr/local/bin/stunnel3
 /usr/local/etc/stunnel/stunnel.conf-sample

--- a/packages/stunnel.rb
+++ b/packages/stunnel.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Stunnel < Autotools
   description "Stunnel is a proxy designed to add TLS encryption functionality to existing clients and servers without any changes in the programs' code."
   homepage 'https://www.stunnel.org/index.html'
-  version '5.78'
+  version '5.80'
   license 'GPL-2+'
   compatibility 'all'
   source_url 'https://github.com/mtrojnar/stunnel.git'
@@ -11,16 +11,19 @@ class Stunnel < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '9a80a9dd3a7f31a740ed926adaf41867f01175218417e5c5e37d989dfcfde0dd',
-     armv7l: '9a80a9dd3a7f31a740ed926adaf41867f01175218417e5c5e37d989dfcfde0dd',
-       i686: '45e5a3b88201859af59e8fb9f2334e890ad0d76e3e3944f3a73f7c7776144aa1',
-     x86_64: '2a1faf8c8a4e10a4fa483b9116a8462747d6983cc2ae097aca4d2b63400a4d57'
+    aarch64: '877e2fe163c0215bc262eb8cd80f6f27db5952c7388cb8ed9abee762ce568dcf',
+     armv7l: '877e2fe163c0215bc262eb8cd80f6f27db5952c7388cb8ed9abee762ce568dcf',
+       i686: '7a00118302234de0a24f1706b9d342c76031ca3f8304719985b4210fafe03568',
+     x86_64: '4ada48f543baef427c34560031391b83ecad9d0048d28593c68cf2e8d4502072'
   })
 
   depends_on 'glibc' => :library
   depends_on 'glibc_lib' => :library
   depends_on 'openssl' => :executable
+  depends_on 'pandoc' => :build
   depends_on 'tcpwrappers' => :library
+
+  autotools_skip_autoreconf
 
   def self.patch
     # The aclocal & automake versions are hardcoded.


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-stunnel crew update \
&& yes | crew upgrade

$ crew check stunnel
Checking stunnel package ...
Library test for stunnel passed.
Checking stunnel package ...
Initializing inetd mode configuration
stunnel 5.80 on x86_64-pc-linux-gnu platform
Compiled/running with OpenSSL 3.5.7 9 Jun 2026
Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI,DTLS Auth:LIBWRAP
 
Global options:
chroot                 = directory to chroot stunnel process
compression            = compression type
EGD                    = path to Entropy Gathering Daemon socket
engine                 = auto|engine_id
Initializing inetd mode configuration
stunnel 5.80 on x86_64-pc-linux-gnu platform
Compiled/running with OpenSSL 3.5.7 9 Jun 2026
Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI,DTLS Auth:LIBWRAP
 
Global options:
RNDbytes               = 1024
RNDfile                = /dev/urandom
RNDoverwrite           = yes
 
Service-level options:
ciphers                = HIGH:!aNULL:!SSLv2:!DH:!kDHEPSK
ciphersuites           = TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256 (with TLSv1.3)
curves                 = X25519MLKEM768:X25519:P-256:X448:P-521:P-384
debug                  = daemon.notice
logId                  = sequential
options                = NO_SSLv2
options                = NO_SSLv3
securityLevel          = 2
sessionCacheSize       = 1000
sessionCacheTimeout    = 300 seconds
stack                  = 131072 bytes
TIMEOUTbusy            = 300 seconds
TIMEOUTclose           = 60 seconds
TIMEOUTconnect         = 10 seconds
TIMEOUTidle            = 43200 seconds
TIMEOUTocsp            = 5 seconds
verify                 = none
Package tests for stunnel passed.
```