### PR TITLE
Move GitHub Actions to use ruby 4.0.6.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -418,7 +418,7 @@ jobs:
           ref: ${{ inputs.branch || github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0.6'
       - name: Install bin/crew gem dependencies
         run: |
           # Install required gems.

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -485,7 +485,7 @@ jobs:
             fi
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0.6'
       - name: Create Pull Request
         env:
           CHANGED_GITHUB_CONFIG_FILES: ${{ steps.changed-files.outputs.github_all_changed_files }}

--- a/.github/workflows/Package-Dependencies-Updater.yml
+++ b/.github/workflows/Package-Dependencies-Updater.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0.6'
       - name: Install bin/crew gem dependencies
         run: |
           # Install required gems.

--- a/.github/workflows/Repology.yml
+++ b/.github/workflows/Repology.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0.6'
       - name: Install highline
         run: sudo apt install -y ruby-highline
       - name: Install activesupport

--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -14,7 +14,7 @@ jobs:
        - uses: actions/checkout@v7
        - uses: ruby/setup-ruby@v1
          with:
-            ruby-version: '4.0.5'
+            ruby-version: '4.0.6'
        - name: Rubocop
          uses: reviewdog/action-rubocop@v2
          with:

--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -46,7 +46,7 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0.6'
       - name: Install bin/crew gem dependencies
         run: |
           # Install required gems.


### PR DESCRIPTION
## Description
#### Commits:
-  40211b679 Move GitHub Actions to use ruby 4.0.6.
### Updated GitHub configuration files:
- .github/workflows/Build.yml
- .github/workflows/Generate-PR.yml
- .github/workflows/Package-Dependencies-Updater.yml
- .github/workflows/Repology.yml
- .github/workflows/Rubocop.yml
- .github/workflows/Updater-on-Demand.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=actions-ruby-4.0.6 crew update \
&& yes | crew upgrade
```
