### PR TITLE
Sysfsutils 2.1.0 => 2.1.1

### DIFF
--- a/manifest/armv7l/s/sysfsutils.filelist
+++ b/manifest/armv7l/s/sysfsutils.filelist
@@ -1,8 +1,4 @@
-# Total size: 441133
-/usr/local/bin/dlist_test
-/usr/local/bin/get_device
-/usr/local/bin/get_driver
-/usr/local/bin/get_module
+# Total size: 331461
 /usr/local/bin/systool
 /usr/local/include/sysfs/dlist.h
 /usr/local/include/sysfs/libsysfs.h
@@ -11,4 +7,5 @@
 /usr/local/lib/libsysfs.so
 /usr/local/lib/libsysfs.so.2
 /usr/local/lib/libsysfs.so.2.0.1
-/usr/local/man/man1/systool.1.gz
+/usr/local/lib/pkgconfig/libsysfs.pc
+/usr/local/share/man/man1/systool.1.zst

--- a/manifest/i686/s/sysfsutils.filelist
+++ b/manifest/i686/s/sysfsutils.filelist
@@ -1,8 +1,4 @@
-# Total size: 408425
-/usr/local/bin/dlist_test
-/usr/local/bin/get_device
-/usr/local/bin/get_driver
-/usr/local/bin/get_module
+# Total size: 383237
 /usr/local/bin/systool
 /usr/local/include/sysfs/dlist.h
 /usr/local/include/sysfs/libsysfs.h
@@ -11,4 +7,5 @@
 /usr/local/lib/libsysfs.so
 /usr/local/lib/libsysfs.so.2
 /usr/local/lib/libsysfs.so.2.0.1
-/usr/local/man/man1/systool.1.gz
+/usr/local/lib/pkgconfig/libsysfs.pc
+/usr/local/share/man/man1/systool.1.zst

--- a/manifest/x86_64/s/sysfsutils.filelist
+++ b/manifest/x86_64/s/sysfsutils.filelist
@@ -1,8 +1,4 @@
-# Total size: 512375
-/usr/local/bin/dlist_test
-/usr/local/bin/get_device
-/usr/local/bin/get_driver
-/usr/local/bin/get_module
+# Total size: 391169
 /usr/local/bin/systool
 /usr/local/include/sysfs/dlist.h
 /usr/local/include/sysfs/libsysfs.h
@@ -11,4 +7,5 @@
 /usr/local/lib64/libsysfs.so
 /usr/local/lib64/libsysfs.so.2
 /usr/local/lib64/libsysfs.so.2.0.1
-/usr/local/man/man1/systool.1.gz
+/usr/local/lib64/pkgconfig/libsysfs.pc
+/usr/local/share/man/man1/systool.1.zst

--- a/packages/sysfsutils.rb
+++ b/packages/sysfsutils.rb
@@ -1,28 +1,22 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Sysfsutils < Package
+class Sysfsutils < Autotools
   description 'These are a set of utilities built upon sysfs, a new virtual filesystem in Linux kernel versions 2.5+ that exposes a system\'s device tree. The current version of sysfsutils includes libsysfs and systool.'
   homepage 'https://linux-diag.sourceforge.net/Sysfsutils.html'
-  version '2.1.0'
+  version '2.1.1'
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
-  source_url 'https://sourceforge.net/projects/linux-diag/files/sysfsutils/2.1.0/sysfsutils-2.1.0.tar.gz'
-  source_sha256 'e865de2c1f559fff0d3fc936e660c0efaf7afe662064f2fb97ccad1ec28d208a'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/linux-ras/sysfsutils.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f5cce4169a5647744a583823b0ea095f531574a0fcb11a584207dd871bfef43e',
-     armv7l: 'f5cce4169a5647744a583823b0ea095f531574a0fcb11a584207dd871bfef43e',
-       i686: '6f7d32bd3a199f8febb2101b368c36da43c5c6363570e020dd66774386ab0288',
-     x86_64: '81876c5c17b99ad08b662f0b560021a419c3a441be485963fab688e7fbde6a0b'
+    aarch64: '08ea5ac3b4c6cfa2cefa71fc16fe7011f7bcfc223fdf0013f5fec8a558164739',
+     armv7l: '08ea5ac3b4c6cfa2cefa71fc16fe7011f7bcfc223fdf0013f5fec8a558164739',
+       i686: 'a9ab189f5843e8cca18017ec7e0fe48acdc68bf77ecc18bff7ed08ab88bf3b85',
+     x86_64: '9ca3180951bfc976230861af19532ea87e7b62dcbcbc4c5061f5c07439b5cced'
   })
 
-  def self.build
-    system './configure', "--prefix=#{CREW_PREFIX}", "--libdir=#{CREW_LIB_PREFIX}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 end

--- a/tests/package/s/sysfsutils
+++ b/tests/package/s/sysfsutils
@@ -1,0 +1,2 @@
+#!/bin/bash
+systool -h


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-sysfsutils crew update \
&& yes | crew upgrade

$ crew check sysfsutils 
Checking sysfsutils package ...
Library test for sysfsutils passed.
Checking sysfsutils package ...
Usage: systool [<options> [device]]
	-a			Show attributes
	-b <bus_name>		Show a specific bus
	-c <class_name>		Show a specific class
	-d			Show only devices
	-h			Show usage
	-m <module_name>	Show a specific module
	-p			Show path to device/driver
	-v			Show all attributes with values
	-A <attribute_name>	Show attribute value
	-D			Show only drivers
	-P			Show device's parent
Package tests for sysfsutils passed.
```