### PR TITLE
Sysstat 12.1.5 => 12.7.9

### DIFF
--- a/manifest/armv7l/s/sysstat.filelist
+++ b/manifest/armv7l/s/sysstat.filelist
@@ -1,6 +1,4 @@
-# Total size: 1293577
-/etc/sysconfig/sysstat
-/etc/sysconfig/sysstat.ioconf
+# Total size: 1413004
 /usr/local/bin/cifsiostat
 /usr/local/bin/iostat
 /usr/local/bin/mpstat
@@ -8,27 +6,16 @@
 /usr/local/bin/sadf
 /usr/local/bin/sar
 /usr/local/bin/tapestat
-/usr/local/doc/CHANGES
-/usr/local/doc/COPYING
-/usr/local/doc/CREDITS
-/usr/local/doc/FAQ.md
-/usr/local/doc/README.md
-/usr/local/doc/sysstat-12.1.5.lsm
 /usr/local/lib/sa/sa1
 /usr/local/lib/sa/sa2
 /usr/local/lib/sa/sadc
-/usr/local/man/man1/cifsiostat.1.gz
-/usr/local/man/man1/iostat.1.gz
-/usr/local/man/man1/mpstat.1.gz
-/usr/local/man/man1/pidstat.1.gz
-/usr/local/man/man1/sadf.1.gz
-/usr/local/man/man1/sar.1.gz
-/usr/local/man/man1/tapestat.1.gz
-/usr/local/man/man5/sysstat.5.gz
-/usr/local/man/man8/sa1.8.gz
-/usr/local/man/man8/sa2.8.gz
-/usr/local/man/man8/sadc.8.gz
+/usr/local/share/doc/sysstat-12.7.9/CHANGES
+/usr/local/share/doc/sysstat-12.7.9/COPYING
+/usr/local/share/doc/sysstat-12.7.9/CREDITS
+/usr/local/share/doc/sysstat-12.7.9/FAQ.md
+/usr/local/share/doc/sysstat-12.7.9/README.md
 /usr/local/share/locale/af/LC_MESSAGES/sysstat.mo
+/usr/local/share/locale/be/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/cs/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/da/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/de/LC_MESSAGES/sysstat.mo
@@ -44,6 +31,7 @@
 /usr/local/share/locale/id/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/it/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/ja/LC_MESSAGES/sysstat.mo
+/usr/local/share/locale/ka/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/ko/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/ky/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/lv/LC_MESSAGES/sysstat.mo
@@ -64,3 +52,14 @@
 /usr/local/share/locale/vi/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/sysstat.mo
+/usr/local/share/man/man1/cifsiostat.1.zst
+/usr/local/share/man/man1/iostat.1.zst
+/usr/local/share/man/man1/mpstat.1.zst
+/usr/local/share/man/man1/pidstat.1.zst
+/usr/local/share/man/man1/sadf.1.zst
+/usr/local/share/man/man1/sar.1.zst
+/usr/local/share/man/man1/tapestat.1.zst
+/usr/local/share/man/man5/sysstat.5.zst
+/usr/local/share/man/man8/sa1.8.zst
+/usr/local/share/man/man8/sa2.8.zst
+/usr/local/share/man/man8/sadc.8.zst

--- a/manifest/i686/s/sysstat.filelist
+++ b/manifest/i686/s/sysstat.filelist
@@ -1,6 +1,4 @@
-# Total size: 1488693
-/etc/sysconfig/sysstat
-/etc/sysconfig/sysstat.ioconf
+# Total size: 1675548
 /usr/local/bin/cifsiostat
 /usr/local/bin/iostat
 /usr/local/bin/mpstat
@@ -8,27 +6,16 @@
 /usr/local/bin/sadf
 /usr/local/bin/sar
 /usr/local/bin/tapestat
-/usr/local/doc/CHANGES
-/usr/local/doc/COPYING
-/usr/local/doc/CREDITS
-/usr/local/doc/FAQ.md
-/usr/local/doc/README.md
-/usr/local/doc/sysstat-12.1.5.lsm
 /usr/local/lib/sa/sa1
 /usr/local/lib/sa/sa2
 /usr/local/lib/sa/sadc
-/usr/local/man/man1/cifsiostat.1.gz
-/usr/local/man/man1/iostat.1.gz
-/usr/local/man/man1/mpstat.1.gz
-/usr/local/man/man1/pidstat.1.gz
-/usr/local/man/man1/sadf.1.gz
-/usr/local/man/man1/sar.1.gz
-/usr/local/man/man1/tapestat.1.gz
-/usr/local/man/man5/sysstat.5.gz
-/usr/local/man/man8/sa1.8.gz
-/usr/local/man/man8/sa2.8.gz
-/usr/local/man/man8/sadc.8.gz
+/usr/local/share/doc/sysstat-12.7.9/CHANGES
+/usr/local/share/doc/sysstat-12.7.9/COPYING
+/usr/local/share/doc/sysstat-12.7.9/CREDITS
+/usr/local/share/doc/sysstat-12.7.9/FAQ.md
+/usr/local/share/doc/sysstat-12.7.9/README.md
 /usr/local/share/locale/af/LC_MESSAGES/sysstat.mo
+/usr/local/share/locale/be/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/cs/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/da/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/de/LC_MESSAGES/sysstat.mo
@@ -44,6 +31,7 @@
 /usr/local/share/locale/id/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/it/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/ja/LC_MESSAGES/sysstat.mo
+/usr/local/share/locale/ka/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/ko/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/ky/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/lv/LC_MESSAGES/sysstat.mo
@@ -64,3 +52,14 @@
 /usr/local/share/locale/vi/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/sysstat.mo
+/usr/local/share/man/man1/cifsiostat.1.zst
+/usr/local/share/man/man1/iostat.1.zst
+/usr/local/share/man/man1/mpstat.1.zst
+/usr/local/share/man/man1/pidstat.1.zst
+/usr/local/share/man/man1/sadf.1.zst
+/usr/local/share/man/man1/sar.1.zst
+/usr/local/share/man/man1/tapestat.1.zst
+/usr/local/share/man/man5/sysstat.5.zst
+/usr/local/share/man/man8/sa1.8.zst
+/usr/local/share/man/man8/sa2.8.zst
+/usr/local/share/man/man8/sadc.8.zst

--- a/manifest/x86_64/s/sysstat.filelist
+++ b/manifest/x86_64/s/sysstat.filelist
@@ -1,6 +1,4 @@
-# Total size: 1455474
-/etc/sysconfig/sysstat
-/etc/sysconfig/sysstat.ioconf
+# Total size: 1667915
 /usr/local/bin/cifsiostat
 /usr/local/bin/iostat
 /usr/local/bin/mpstat
@@ -8,27 +6,16 @@
 /usr/local/bin/sadf
 /usr/local/bin/sar
 /usr/local/bin/tapestat
-/usr/local/doc/CHANGES
-/usr/local/doc/COPYING
-/usr/local/doc/CREDITS
-/usr/local/doc/FAQ.md
-/usr/local/doc/README.md
-/usr/local/doc/sysstat-12.1.5.lsm
 /usr/local/lib64/sa/sa1
 /usr/local/lib64/sa/sa2
 /usr/local/lib64/sa/sadc
-/usr/local/man/man1/cifsiostat.1.gz
-/usr/local/man/man1/iostat.1.gz
-/usr/local/man/man1/mpstat.1.gz
-/usr/local/man/man1/pidstat.1.gz
-/usr/local/man/man1/sadf.1.gz
-/usr/local/man/man1/sar.1.gz
-/usr/local/man/man1/tapestat.1.gz
-/usr/local/man/man5/sysstat.5.gz
-/usr/local/man/man8/sa1.8.gz
-/usr/local/man/man8/sa2.8.gz
-/usr/local/man/man8/sadc.8.gz
+/usr/local/share/doc/sysstat-12.7.9/CHANGES
+/usr/local/share/doc/sysstat-12.7.9/COPYING
+/usr/local/share/doc/sysstat-12.7.9/CREDITS
+/usr/local/share/doc/sysstat-12.7.9/FAQ.md
+/usr/local/share/doc/sysstat-12.7.9/README.md
 /usr/local/share/locale/af/LC_MESSAGES/sysstat.mo
+/usr/local/share/locale/be/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/cs/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/da/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/de/LC_MESSAGES/sysstat.mo
@@ -44,6 +31,7 @@
 /usr/local/share/locale/id/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/it/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/ja/LC_MESSAGES/sysstat.mo
+/usr/local/share/locale/ka/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/ko/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/ky/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/lv/LC_MESSAGES/sysstat.mo
@@ -64,3 +52,14 @@
 /usr/local/share/locale/vi/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/sysstat.mo
+/usr/local/share/man/man1/cifsiostat.1.zst
+/usr/local/share/man/man1/iostat.1.zst
+/usr/local/share/man/man1/mpstat.1.zst
+/usr/local/share/man/man1/pidstat.1.zst
+/usr/local/share/man/man1/sadf.1.zst
+/usr/local/share/man/man1/sar.1.zst
+/usr/local/share/man/man1/tapestat.1.zst
+/usr/local/share/man/man5/sysstat.5.zst
+/usr/local/share/man/man8/sa1.8.zst
+/usr/local/share/man/man8/sa2.8.zst
+/usr/local/share/man/man8/sadc.8.zst

--- a/packages/sysstat.rb
+++ b/packages/sysstat.rb
@@ -1,38 +1,29 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Sysstat < Package
+class Sysstat < Autotools
   description 'The sysstat utilities are a collection of performance monitoring tools for Linux. These include sar, sadf, mpstat, iostat, tapestat, pidstat, cifsiostat and sa tools.'
-  homepage 'http://sebastien.godard.pagesperso-orange.fr/'
-  version '12.1.5'
+  homepage 'https://sysstat.github.io/'
+  version '12.7.9'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'http://pagesperso-orange.fr/sebastien.godard/sysstat-12.1.5.tar.xz'
-  source_sha256 'a496936bb3f5093d780a50735f00e39b0b7f3a688eb89051f2ef5f86739522c5'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/sysstat/sysstat.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '88f64d75bf8be7fe4cb8136ec188631a6e504c44951d8f2003f1998167be2df7',
-     armv7l: '88f64d75bf8be7fe4cb8136ec188631a6e504c44951d8f2003f1998167be2df7',
-       i686: 'c33bc10c60d55e2649e62a13b2f666e63035538103d8a81740de1ab0f170685e',
-     x86_64: '5aac1bfb1bdf0a8d3dbeb010f179bbddeac24134768755d9dc3ccad01fb26f24'
+    aarch64: '2bbc4b040c8830a9e1c29c5245aeef718ffeaa0a7a4eba240b3d357e8a4e6743',
+     armv7l: '2bbc4b040c8830a9e1c29c5245aeef718ffeaa0a7a4eba240b3d357e8a4e6743',
+       i686: '8ce65526577737faa583fa9e837bf755ed8ffa4ae07f7c2ff258f34f175d1945',
+     x86_64: '31fda4f33ffb1e7a237e70bb14685e9203b5dbc91652ab9c3afaad5fa373ba0d'
   })
+
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
   def self.patch
     system "sed -i 's/GRP=root/GRP=$(whoami)/' configure"
     system "sed -i 's/\"root\"/\"$(whoami)\"/g' configure"
-    system "sed -i 's/root/$(whoami)/g' configure.in"
+    system "sed -i 's/root/$(whoami)/g' configure.ac"
     system "sed -i 's/root/$(whoami)/g' sysstat-#{version}.spec"
-  end
-
-  def self.build
-    system "./configure \
-            --docdir=#{CREW_PREFIX}/doc \
-            --infodir=#{CREW_PREFIX}/info \
-            --mandir=#{CREW_MAN_PREFIX}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/tests/package/s/sysstat
+++ b/tests/package/s/sysstat
@@ -1,0 +1,2 @@
+#!/bin/bash
+for b in $(crew files sysstat | grep /usr/local/bin); do $b -V; done


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-sysstat crew update \
&& yes | crew upgrade

$ crew check sysstat 
Checking sysstat package ...
Library test for sysstat passed.
Checking sysstat package ...
sysstat version 12.7.9
(C) Sebastien Godard (sysstat <at> orange.fr)
sysstat version 12.7.9
(C) Sebastien Godard (sysstat <at> orange.fr)
sysstat version 12.7.9
(C) Sebastien Godard (sysstat <at> orange.fr)
sysstat version 12.7.9
(C) Sebastien Godard (sysstat <at> orange.fr)
sysstat version 12.7.9
(C) Sebastien Godard (sysstat <at> orange.fr)
sysstat version 12.7.9
(C) Sebastien Godard (sysstat <at> orange.fr)
sysstat version 12.7.9
(C) Sebastien Godard (sysstat <at> orange.fr)
Package tests for sysstat passed.
```