### PR TITLE
Tcsh 6.22.03 => 6.24.16

### DIFF
--- a/manifest/armv7l/t/tcsh.filelist
+++ b/manifest/armv7l/t/tcsh.filelist
@@ -1,15 +1,15 @@
-# Total size: 2159268
+# Total size: 1082405
 /usr/local/bin/tcsh
 /usr/local/share/locale/C/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/de/LC_MESSAGES/tcsh.cat
+/usr/local/share/locale/el/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/es/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/et/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/fi/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/fr/LC_MESSAGES/tcsh.cat
-/usr/local/share/locale/gr/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/it/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/ja/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/pl/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/ru/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/ru_UA/LC_MESSAGES/tcsh.cat
-/usr/local/share/man/man1/tcsh.1.gz
+/usr/local/share/man/man1/tcsh.1.zst

--- a/manifest/i686/t/tcsh.filelist
+++ b/manifest/i686/t/tcsh.filelist
@@ -1,15 +1,15 @@
-# Total size: 2107868
+# Total size: 1275865
 /usr/local/bin/tcsh
 /usr/local/share/locale/C/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/de/LC_MESSAGES/tcsh.cat
+/usr/local/share/locale/el/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/es/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/et/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/fi/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/fr/LC_MESSAGES/tcsh.cat
-/usr/local/share/locale/gr/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/it/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/ja/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/pl/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/ru/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/ru_UA/LC_MESSAGES/tcsh.cat
-/usr/local/share/man/man1/tcsh.1.gz
+/usr/local/share/man/man1/tcsh.1.zst

--- a/manifest/x86_64/t/tcsh.filelist
+++ b/manifest/x86_64/t/tcsh.filelist
@@ -1,15 +1,15 @@
-# Total size: 2413028
+# Total size: 1273945
 /usr/local/bin/tcsh
 /usr/local/share/locale/C/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/de/LC_MESSAGES/tcsh.cat
+/usr/local/share/locale/el/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/es/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/et/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/fi/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/fr/LC_MESSAGES/tcsh.cat
-/usr/local/share/locale/gr/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/it/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/ja/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/pl/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/ru/LC_MESSAGES/tcsh.cat
 /usr/local/share/locale/ru_UA/LC_MESSAGES/tcsh.cat
-/usr/local/share/man/man1/tcsh.1.gz
+/usr/local/share/man/man1/tcsh.1.zst

--- a/packages/tcsh.rb
+++ b/packages/tcsh.rb
@@ -1,32 +1,24 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Tcsh < Package
+class Tcsh < Autotools
   description 'tcsh is a csh compatible shell with file name completion and command line editing.'
   homepage 'https://www.tcsh.org/'
-  version '6.22.03'
+  version '6.24.16'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://astron.com/pub/tcsh/tcsh-6.22.03.tar.gz'
-  source_sha256 'be2cfd653d2a0c7f506d2dd14c12324ba749bd484037be6df44a3973f52262b7'
-  binary_compression 'tar.xz'
+  source_url "https://astron.com/pub/tcsh/tcsh-#{version}.tar.gz"
+  source_sha256 '4208cf4630fb64d91d81987f854f9570a5a0e8a001a92827def37d0ed8f37364'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'caf87524b2701545318ba80f96c45c616ea2bbd98aab84bc7039c80142393943',
-     armv7l: 'caf87524b2701545318ba80f96c45c616ea2bbd98aab84bc7039c80142393943',
-       i686: '18d29203257ca85a42b31c4968207543efd38cbc89d12d0127bdc2bc7f30fcae',
-     x86_64: 'a84996be2c9b34a339695bfdb04e51a5ad98aff123c95ad35e9fcca18ed0d54f'
+    aarch64: '358b1c3ba4a502ba79edaf40231d7d82dac41aef570d19aa9f6f040ed2ade807',
+     armv7l: '358b1c3ba4a502ba79edaf40231d7d82dac41aef570d19aa9f6f040ed2ade807',
+       i686: '67afc7cb104549ff3862cd660a9610c6d3cc4cde11520e083647aa0c6490d9ab',
+     x86_64: '57d4afb56cbeacc60e2d1a594c6f0a072f3e3bab71440bd2333d5f3f4076bb45'
   })
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
-  def self.check
-    system 'make', 'check'
-  end
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libxcrypt' => :executable
+  depends_on 'ncurses' => :executable
 end

--- a/tests/package/t/tcsh
+++ b/tests/package/t/tcsh
@@ -1,0 +1,3 @@
+#!/bin/bash
+tcsh --help | head
+tcsh --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-tcsh crew update \
&& yes | crew upgrade

$ crew check tcsh 
Checking tcsh package ...
Library test for tcsh passed.
Checking tcsh package ...
tcsh 6.24.16 (Astron) 2025-07-09 (x86_64-unknown-linux) options wide,nls,dl,al,kan,sm,rh,color,filec

-b file		batch mode, read and execute commands from `file' 
-c command	run `command' from next argument 
-d		load directory stack from `~/.cshdirs' 
-Dname[=value]	define environment variable `name' to `value' (DomainOS only) 
-e		exit on any error 
-f		start faster by ignoring the start-up file 
-F		use fork() instead of vfork() when spawning (ConvexOS only) 
-i		interactive, even when input is not from a terminal 
tcsh 6.24.16 (Astron) 2025-07-09 (x86_64-unknown-linux) options wide,nls,dl,al,kan,sm,rh,color,filec
Package tests for tcsh passed.
```