### PR TITLE
Replace -Wno-dev with -Wno-author in cmake packages alongside https://github.com/chromebrew/chromebrew/pull/18165. — intel_media_sdk: 20.5.1 → 20.5.1,jellyfin_media_player: 1.9.1-1 → 1.9.1-1,libaom: 3.6.1 → 3.6.1,libclc: 22.1.8 → 22.1.8,lib...

### DIFF
--- a/packages/intel_media_sdk.rb
+++ b/packages/intel_media_sdk.rb
@@ -35,7 +35,7 @@ class Intel_media_sdk < Package
         -DENABLE_OPENCL:BOOL='ON' \
         -DENABLE_WAYLAND:BOOL='ON' \
         -DENABLE_X11_DRI3:BOOL='ON' \
-        -Wno-dev \
+        -Wno-author \
         .."
     end
     system 'ninja -C builddir'

--- a/packages/jellyfin_media_player.rb
+++ b/packages/jellyfin_media_player.rb
@@ -57,7 +57,7 @@ class Jellyfin_media_player < Package
       -DLINUX_X11POWER=ON \
       -DQTROOT=./qt \
       -DCMAKE_SKIP_RPATH=1 \
-      -Wno-dev"
+      -Wno-author"
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/libaom.rb
+++ b/packages/libaom.rb
@@ -40,7 +40,7 @@ class Libaom < Package
       -DENABLE_WERROR:BOOL='OFF' \
       -DINCLUDE_INSTALL_DIR:PATH='#{CREW_PREFIX}/include' \
       -DLIB_INSTALL_DIR:PATH='#{CREW_LIB_PREFIX}' \
-      -Wno-dev"
+      -Wno-author"
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/libclc.rb
+++ b/packages/libclc.rb
@@ -70,7 +70,7 @@ class Libclc < Package
       -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
       -DCMAKE_LIBRARY_PATH='#{CREW_GLIBC_INTERPRETER.nil? ? CREW_LIB_PREFIX : "#{CREW_GLIBC_PREFIX};#{CREW_LIB_PREFIX}"}' \
       -D_CMAKE_TOOLCHAIN_PREFIX=llvm- \
-      -Wno-dev"
+      -Wno-author"
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/libde265.rb
+++ b/packages/libde265.rb
@@ -26,7 +26,7 @@ class Libde265 < Package
       -B builddir -G Ninja \
       #{CREW_CMAKE_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} \
       -DENABLE_ENCODER=ON \
-      -Wno-dev"
+      -Wno-author"
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/libvncserver.rb
+++ b/packages/libvncserver.rb
@@ -31,7 +31,7 @@ class Libvncserver < Package
   def self.build
     system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
         -DWITH_SYSTEMD=OFF \
-        -Wno-dev \
+        -Wno-author \
         -G Ninja"
     system "#{CREW_NINJA} -C builddir"
   end

--- a/packages/libx265.rb
+++ b/packages/libx265.rb
@@ -36,7 +36,7 @@ class Libx265 < Package
           -DEXPORT_C_API=FALSE \
           -DENABLE_CLI=FALSE \
           -DENABLE_SHARED=FALSE \
-          -Wno-dev \
+          -Wno-author \
           ../source"
       end
       system 'ninja -C build-12'
@@ -53,7 +53,7 @@ class Libx265 < Package
           -DEXPORT_C_API=FALSE \
           -DENABLE_CLI=FALSE \
           -DENABLE_SHARED=FALSE \
-          -Wno-dev \
+          -Wno-author \
           ../source"
       end
       system 'ninja -C build-10'
@@ -72,7 +72,7 @@ class Libx265 < Package
           -DEXTRA_LINK_FLAGS='-L .' \
           -DLINKED_10BIT=TRUE \
           -DLINKED_12BIT=TRUE \
-          -Wno-dev \
+          -Wno-author \
           ../source"
       end
       FileUtils.ln_s '../build-10/libx265.a', 'builddir/libx265_main10.a'
@@ -88,7 +88,7 @@ class Libx265 < Package
         #{CREW_CMAKE_OPTIONS} \
         -DENABLE_SHARED=TRUE \
         -DLIB_INSTALL_DIR=lib#{CREW_LIB_SUFFIX} \
-        -Wno-dev \
+        -Wno-author \
         ../source"
       end
     end

--- a/packages/llvm16_build.rb
+++ b/packages/llvm16_build.rb
@@ -163,7 +163,7 @@ class Llvm16_build < Package
             -DLLVM_TARGETS_TO_BUILD='#{LLVM_TARGETS_TO_BUILD}' \
             -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
             -DPYTHON_EXECUTABLE=$(which python3) \
-            -Wno-dev"
+            -Wno-author"
     end
     @counter = 1
     @counter_max = 20

--- a/packages/llvm17_build.rb
+++ b/packages/llvm17_build.rb
@@ -164,7 +164,7 @@ class Llvm17_build < Package
             -DLLVM_TARGETS_TO_BUILD='#{LLVM_TARGETS_TO_BUILD}' \
             -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
             -DPYTHON_EXECUTABLE=$(which python3) \
-            -Wno-dev"
+            -Wno-author"
     end
     @counter = 1
     @counter_max = 20

--- a/packages/llvm18_build.rb
+++ b/packages/llvm18_build.rb
@@ -167,7 +167,7 @@ class Llvm18_build < Package
             -DLLVM_TARGETS_TO_BUILD='#{LLVM_TARGETS_TO_BUILD}' \
             -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
             -DPYTHON_EXECUTABLE=$(which python3) \
-            -Wno-dev"
+            -Wno-author"
     end
     @counter = 1
     @counter_max = 20

--- a/packages/llvm19_build.rb
+++ b/packages/llvm19_build.rb
@@ -152,7 +152,7 @@ class Llvm19_build < Package
             -DLLVM_LINK_LLVM_DYLIB=ON \
             -DLLVM_OPTIMIZED_TABLEGEN=ON \
             -DLLVM_TARGETS_TO_BUILD='#{LLVM_TARGETS_TO_BUILD}' \
-            -Wno-dev"
+            -Wno-author"
     end
     @counter = 1
     @counter_max = 20

--- a/packages/llvm20_build.rb
+++ b/packages/llvm20_build.rb
@@ -149,7 +149,7 @@ class Llvm20_build < Package
             -DLLVM_LINK_LLVM_DYLIB=ON \
             -DLLVM_OPTIMIZED_TABLEGEN=ON \
             -DLLVM_TARGETS_TO_BUILD='#{LLVM_TARGETS_TO_BUILD}' \
-            -Wno-dev"
+            -Wno-author"
     end
     system "#{CREW_NINJA} -C builddir -j #{CREW_NPROC}"
   end

--- a/packages/llvm21_build.rb
+++ b/packages/llvm21_build.rb
@@ -149,7 +149,7 @@ class Llvm21_build < Package
             -DLLVM_LINK_LLVM_DYLIB=ON \
             -DLLVM_OPTIMIZED_TABLEGEN=ON \
             -DLLVM_TARGETS_TO_BUILD='#{LLVM_TARGETS_TO_BUILD}' \
-            -Wno-dev"
+            -Wno-author"
     end
     system "#{CREW_NINJA} -C builddir -j #{CREW_NPROC}"
   end

--- a/packages/llvm22_build.rb
+++ b/packages/llvm22_build.rb
@@ -154,7 +154,7 @@ class Llvm22_build < Package
             -DLLVM_LINK_LLVM_DYLIB=ON \
             -DLLVM_OPTIMIZED_TABLEGEN=ON \
             -DLLVM_TARGETS_TO_BUILD='#{@llvm_targets_to_build}' \
-            -Wno-dev"
+            -Wno-author"
     end
     system "#{CREW_NINJA} -C builddir -j #{CREW_NPROC}"
   end

--- a/packages/llvm_stage1.rb
+++ b/packages/llvm_stage1.rb
@@ -102,7 +102,7 @@ clang++ -fPIC  -rtlib=compiler-rt -stdlib=libc++ -cxx-isystem \${cxx_sys} -I \${
             -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
             -DCOMPILER_RT_BUILD_BUILTINS=ON \
             -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
-            -Wno-dev \
+            -Wno-author \
             ../llvm"
       system 'ninja'
     end

--- a/packages/openmp.rb
+++ b/packages/openmp.rb
@@ -77,7 +77,7 @@ class Openmp < Package
       -DLLVM_INCLUDE_BENCHMARKS=OFF \
       -DOPENMP_LIBDIR_SUFFIX=#{CREW_LIB_SUFFIX} \
       -DPYTHON_EXECUTABLE=$(which python3) \
-      -Wno-dev"
+      -Wno-author"
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/poppler.rb
+++ b/packages/poppler.rb
@@ -39,7 +39,7 @@ class Poppler < Package
   def self.build
     system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
         -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
-        -Wno-dev \
+        -Wno-author \
         -G Ninja"
     system "#{CREW_NINJA} -C builddir"
   end

--- a/packages/zlib.rb
+++ b/packages/zlib.rb
@@ -22,7 +22,7 @@ class Zlib < CMake
 
   depends_on 'glibc' => :library
 
-  cmake_options "#{CREW_CMAKE_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} -Wno-dev"
+  cmake_options "#{CREW_CMAKE_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} -Wno-author"
 
   run_tests
 


### PR DESCRIPTION
## Description
#### Commits:
-  353ba2e16 Replace -Wno-dev with -Wno-author in cmake packages alongside https://github.com/chromebrew/chromebrew/pull/18165.
### Packages with Updated versions or Changed package files:
- `intel_media_sdk`: 20.5.1 &rarr; 20.5.1 (current version is 23.2.2)
- `jellyfin_media_player`: 1.9.1-1 &rarr; 1.9.1-1 (current version is 2.0.0)
- `libaom`: 3.6.1 &rarr; 3.6.1 (current version is 3.14.1)
- `libclc`: 22.1.8 &rarr; 22.1.8
- `libde265`: 1.0.16 &rarr; 1.0.16 (current version is 1.1.1)
- `libvncserver`: 0.9.14 &rarr; 0.9.14 (current version is 0.9.15)
- `libx265`: 3.4 &rarr; 3.4
- `llvm16_build`: 16.0.6 &rarr; 16.0.6 (current version is 22.1.8)
- `llvm17_build`: 17.0.6 &rarr; 17.0.6 (current version is 22.1.8)
- `llvm18_build`: 18.1.8 &rarr; 18.1.8 (current version is 22.1.8)
- `llvm19_build`: 19.1.7 &rarr; 19.1.7 (current version is 22.1.8)
- `llvm20_build`: 20.1.8 &rarr; 20.1.8 (current version is 22.1.8)
- `llvm21_build`: 21.1.8 &rarr; 21.1.8 (current version is 22.1.8)
- `llvm22_build`: 22.1.8 &rarr; 22.1.8
- `llvm_stage1`: 13.0.0 &rarr; 13.0.0 (current version is 22.1.8)
- `openmp`: 22.1.8 &rarr; 22.1.8
- `poppler`: 23.07.0 &rarr; 23.07.0 (current version is 26.08.0)
- `zlib`: 1.3.2 &rarr; 1.3.2
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=cmake_no_author2 crew update \
&& yes | crew upgrade
```
