### PR TITLE
Terminology 1.8.0 => 1.14.0

### DIFF
--- a/manifest/armv7l/t/terminology.filelist
+++ b/manifest/armv7l/t/terminology.filelist
@@ -1,4 +1,4 @@
-# Total size: 29527226
+# Total size: 5757243
 /usr/local/bin/terminology
 /usr/local/bin/tyalpha
 /usr/local/bin/tybg
@@ -17,28 +17,69 @@
 /usr/local/share/locale/es/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/fi/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/fr/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/he/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/hi/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/hr/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/hu/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/id/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/it/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/ja/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/ko/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/lt/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/ms/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/nb_NO/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/nl/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/pl/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/pt/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/ru/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/si/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/sk/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/sl/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/sr/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/sv/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/tr/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/uk/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/vi/LC_MESSAGES/terminology.mo
-/usr/local/share/man/man1/terminology-helpers.1.gz
-/usr/local/share/man/man1/terminology.1.gz
-/usr/local/share/man/man1/tyalpha.1.gz
-/usr/local/share/man/man1/tybg.1.gz
-/usr/local/share/man/man1/tycat.1.gz
-/usr/local/share/man/man1/tyls.1.gz
-/usr/local/share/man/man1/typop.1.gz
-/usr/local/share/man/man1/tyq.1.gz
-/usr/local/share/man/man1/tysend.1.gz
+/usr/local/share/locale/zh_Hans/LC_MESSAGES/terminology.mo
+/usr/local/share/man/man1/terminology-helpers.1.zst
+/usr/local/share/man/man1/terminology.1.zst
+/usr/local/share/man/man1/tyalpha.1.zst
+/usr/local/share/man/man1/tybg.1.zst
+/usr/local/share/man/man1/tycat.1.zst
+/usr/local/share/man/man1/tyls.1.zst
+/usr/local/share/man/man1/typop.1.zst
+/usr/local/share/man/man1/tyq.1.zst
+/usr/local/share/man/man1/tysend.1.zst
 /usr/local/share/terminology/backgrounds/mystic.png
 /usr/local/share/terminology/backgrounds/texture_background.png
+/usr/local/share/terminology/colorschemes/Belafonte Day.eet
+/usr/local/share/terminology/colorschemes/Belafonte Night.eet
+/usr/local/share/terminology/colorschemes/Black.eet
+/usr/local/share/terminology/colorschemes/Cobalt2.eet
+/usr/local/share/terminology/colorschemes/Default.eet
+/usr/local/share/terminology/colorschemes/Dracula.eet
+/usr/local/share/terminology/colorschemes/Fahrenheit.eet
+/usr/local/share/terminology/colorschemes/Fir Dark.eet
+/usr/local/share/terminology/colorschemes/Material.eet
+/usr/local/share/terminology/colorschemes/Mild.eet
+/usr/local/share/terminology/colorschemes/Mustang.eet
+/usr/local/share/terminology/colorschemes/Nord.eet
+/usr/local/share/terminology/colorschemes/Ocean Dark.eet
+/usr/local/share/terminology/colorschemes/One Dark.eet
+/usr/local/share/terminology/colorschemes/PaleNight.eet
+/usr/local/share/terminology/colorschemes/PaperColor.eet
+/usr/local/share/terminology/colorschemes/Selenized Black.eet
+/usr/local/share/terminology/colorschemes/Selenized Dark.eet
+/usr/local/share/terminology/colorschemes/Selenized Light.eet
+/usr/local/share/terminology/colorschemes/Selenized White.eet
+/usr/local/share/terminology/colorschemes/Smyck.eet
+/usr/local/share/terminology/colorschemes/Soft Era.eet
+/usr/local/share/terminology/colorschemes/Solarized Light.eet
+/usr/local/share/terminology/colorschemes/Solarized.eet
+/usr/local/share/terminology/colorschemes/Tango Dark.eet
+/usr/local/share/terminology/colorschemes/Tango Light.eet
+/usr/local/share/terminology/colorschemes/Tomorrow Night Burns.eet
 /usr/local/share/terminology/fonts/10x20.pcf
 /usr/local/share/terminology/fonts/4x6.pcf
 /usr/local/share/terminology/fonts/5x7.pcf
@@ -65,14 +106,5 @@
 /usr/local/share/terminology/fonts/terminus-20-bold.pcf
 /usr/local/share/terminology/fonts/terminus-20.pcf
 /usr/local/share/terminology/images/terminology.png
-/usr/local/share/terminology/themes/base16_ocean_dark.edj
-/usr/local/share/terminology/themes/black.edj
 /usr/local/share/terminology/themes/default.edj
-/usr/local/share/terminology/themes/mild.edj
-/usr/local/share/terminology/themes/mustang.edj
-/usr/local/share/terminology/themes/nord.edj
 /usr/local/share/terminology/themes/nyanology.edj
-/usr/local/share/terminology/themes/papercolor.edj
-/usr/local/share/terminology/themes/smyck.edj
-/usr/local/share/terminology/themes/solarized.edj
-/usr/local/share/terminology/themes/solarized_light.edj

--- a/manifest/x86_64/t/terminology.filelist
+++ b/manifest/x86_64/t/terminology.filelist
@@ -1,4 +1,4 @@
-# Total size: 29661630
+# Total size: 5971535
 /usr/local/bin/terminology
 /usr/local/bin/tyalpha
 /usr/local/bin/tybg
@@ -17,28 +17,69 @@
 /usr/local/share/locale/es/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/fi/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/fr/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/he/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/hi/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/hr/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/hu/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/id/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/it/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/ja/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/ko/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/lt/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/ms/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/nb_NO/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/nl/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/pl/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/pt/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/ru/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/si/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/sk/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/sl/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/sr/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/sv/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/tr/LC_MESSAGES/terminology.mo
+/usr/local/share/locale/uk/LC_MESSAGES/terminology.mo
 /usr/local/share/locale/vi/LC_MESSAGES/terminology.mo
-/usr/local/share/man/man1/terminology-helpers.1.gz
-/usr/local/share/man/man1/terminology.1.gz
-/usr/local/share/man/man1/tyalpha.1.gz
-/usr/local/share/man/man1/tybg.1.gz
-/usr/local/share/man/man1/tycat.1.gz
-/usr/local/share/man/man1/tyls.1.gz
-/usr/local/share/man/man1/typop.1.gz
-/usr/local/share/man/man1/tyq.1.gz
-/usr/local/share/man/man1/tysend.1.gz
+/usr/local/share/locale/zh_Hans/LC_MESSAGES/terminology.mo
+/usr/local/share/man/man1/terminology-helpers.1.zst
+/usr/local/share/man/man1/terminology.1.zst
+/usr/local/share/man/man1/tyalpha.1.zst
+/usr/local/share/man/man1/tybg.1.zst
+/usr/local/share/man/man1/tycat.1.zst
+/usr/local/share/man/man1/tyls.1.zst
+/usr/local/share/man/man1/typop.1.zst
+/usr/local/share/man/man1/tyq.1.zst
+/usr/local/share/man/man1/tysend.1.zst
 /usr/local/share/terminology/backgrounds/mystic.png
 /usr/local/share/terminology/backgrounds/texture_background.png
+/usr/local/share/terminology/colorschemes/Belafonte Day.eet
+/usr/local/share/terminology/colorschemes/Belafonte Night.eet
+/usr/local/share/terminology/colorschemes/Black.eet
+/usr/local/share/terminology/colorschemes/Cobalt2.eet
+/usr/local/share/terminology/colorschemes/Default.eet
+/usr/local/share/terminology/colorschemes/Dracula.eet
+/usr/local/share/terminology/colorschemes/Fahrenheit.eet
+/usr/local/share/terminology/colorschemes/Fir Dark.eet
+/usr/local/share/terminology/colorschemes/Material.eet
+/usr/local/share/terminology/colorschemes/Mild.eet
+/usr/local/share/terminology/colorschemes/Mustang.eet
+/usr/local/share/terminology/colorschemes/Nord.eet
+/usr/local/share/terminology/colorschemes/Ocean Dark.eet
+/usr/local/share/terminology/colorschemes/One Dark.eet
+/usr/local/share/terminology/colorschemes/PaleNight.eet
+/usr/local/share/terminology/colorschemes/PaperColor.eet
+/usr/local/share/terminology/colorschemes/Selenized Black.eet
+/usr/local/share/terminology/colorschemes/Selenized Dark.eet
+/usr/local/share/terminology/colorschemes/Selenized Light.eet
+/usr/local/share/terminology/colorschemes/Selenized White.eet
+/usr/local/share/terminology/colorschemes/Smyck.eet
+/usr/local/share/terminology/colorschemes/Soft Era.eet
+/usr/local/share/terminology/colorschemes/Solarized Light.eet
+/usr/local/share/terminology/colorschemes/Solarized.eet
+/usr/local/share/terminology/colorschemes/Tango Dark.eet
+/usr/local/share/terminology/colorschemes/Tango Light.eet
+/usr/local/share/terminology/colorschemes/Tomorrow Night Burns.eet
 /usr/local/share/terminology/fonts/10x20.pcf
 /usr/local/share/terminology/fonts/4x6.pcf
 /usr/local/share/terminology/fonts/5x7.pcf
@@ -65,14 +106,5 @@
 /usr/local/share/terminology/fonts/terminus-20-bold.pcf
 /usr/local/share/terminology/fonts/terminus-20.pcf
 /usr/local/share/terminology/images/terminology.png
-/usr/local/share/terminology/themes/base16_ocean_dark.edj
-/usr/local/share/terminology/themes/black.edj
 /usr/local/share/terminology/themes/default.edj
-/usr/local/share/terminology/themes/mild.edj
-/usr/local/share/terminology/themes/mustang.edj
-/usr/local/share/terminology/themes/nord.edj
 /usr/local/share/terminology/themes/nyanology.edj
-/usr/local/share/terminology/themes/papercolor.edj
-/usr/local/share/terminology/themes/smyck.edj
-/usr/local/share/terminology/themes/solarized.edj
-/usr/local/share/terminology/themes/solarized_light.edj

--- a/packages/terminology.rb
+++ b/packages/terminology.rb
@@ -1,33 +1,25 @@
-require 'package'
+require 'buildsystems/meson'
 
-class Terminology < Package
+class Terminology < Meson
   description 'Enlightenments terminal emulator'
   homepage 'https://www.enlightenment.org'
-  version '1.8.0'
+  version '1.14.0'
   license 'BSD-2'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://download.enlightenment.org/rel/apps/terminology/terminology-1.8.0.tar.xz'
-  source_sha256 'c6f5b003412f25507277702cabe1a11d7190971343c1d6030aa7d3fe5b45765f'
-  binary_compression 'tar.xz'
+  source_url "https://download.enlightenment.org/rel/apps/terminology/terminology-#{version}.tar.xz"
+  source_sha256 'f354057051b05cffb699e33836a1135db1d4ed8bf954f9b57dc0e93bc307514d'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'be229db30e4c8c423bd89adb118e1e3d7958fe718ca5ecc149bfc395939b0523',
-     armv7l: 'be229db30e4c8c423bd89adb118e1e3d7958fe718ca5ecc149bfc395939b0523',
-       i686: 'd9d03f10e5522feec35fbb4ea2c789eb805a483403ceafacfc0ab6dcda3c36c6',
-     x86_64: '8d975f5df0ff60a90073b858141b042c0b5abe034b84c862b116e4ce0e767fdb'
+    aarch64: '8f3435482057d9d1f8fcb10ff232dadd514e109e51f737c49434cb8ffa993cb7',
+     armv7l: '8f3435482057d9d1f8fcb10ff232dadd514e109e51f737c49434cb8ffa993cb7',
+     x86_64: 'bb0c3c5831b99838c914d05c212c36554bd6bcaba45c29487a56169c182f5da3'
   })
 
-  depends_on 'desktop_file_utilities'
-  depends_on 'libefl'
+  depends_on 'desktop_file_utilities' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libefl' => :executable
   depends_on 'sommelier' => :logical
-  depends_on 'xdg_utils'
-
-  def self.build
-    system "meson --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} _build"
-    system 'ninja -v -C _build'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C _build install"
-  end
+  depends_on 'xdg_utils' => :logical
 end

--- a/tests/package/t/terminology
+++ b/tests/package/t/terminology
@@ -1,0 +1,3 @@
+#!/bin/bash
+terminology -h | head
+terminology -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-terminology crew update \
&& yes | crew upgrade

$ crew check terminology 
Checking terminology package ...
Library test for terminology passed.
Checking terminology package ...
Usage: terminology [options]

Terminal emulator written with Enlightenment Foundation Libraries

Options:
  -b=BACKGROUND, --background=BACKGROUND
                          Use the named file as a background wallpaper
                          Type: STR.
  -d=CURRENT-DIRECTORY, --current-directory=CURRENT-DIRECTORY
                          Change to directory for execution of terminal command
Version: 1.14.0
Package tests for terminology passed.
```