### PR TITLE
Add json output option to crew version.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -189,7 +189,7 @@ def search(pkg_name, pkg_path: File.join(CREW_PACKAGES_PATH, "#{pkg_name}.rb"), 
     return check_load_package(pkg_path)
   else
     @pkg = nil
-    abort "Package #{pkg_name} not found. 😞".lightred unless silent
+    abort "Package #{pkg_name} not found. 😞".lightred unless silent || CREW_OUTPUT_JSON
   end
 rescue StandardError => e
   abort "Error with #{pkg_name}.rb: #{e}".lightred unless silent
@@ -1849,11 +1849,12 @@ end
 def version_command(args)
   args = { '<name>' => args.split } if args.is_a? String
   if args['<name>'].empty?
-    puts CREW_VERSION
+    puts CREW_OUTPUT_JSON ? [{ package: 'Chromebrew', version: CREW_VERSION }].to_json : CREW_VERSION
   else
     args['<name>'].each do |name|
       search name
-      puts @pkg.version
+      version_array = @pkg.nil? ? [{ package: name, version: '' }] : [{ package: name, version: @pkg.version }]
+      puts CREW_OUTPUT_JSON ? version_array.to_json : @pkg.version
     end
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.75.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.75.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]
@@ -430,7 +430,7 @@ CREW_DOCOPT = <<~DOCOPT
     crew upgrade [options] [-f|--force] [-k|--keep] [--regenerate-filelist] [-s|--source] [-v|--verbose] [<name> ...]
     crew upload [options] [-f|--force] [-v|--verbose] [<name> ...]
     crew upstream [options] [-a|--all|-f|--force|-j|--json|-u|--update-package-files|-v|--verbose|-vv] <name> ...
-    crew version [options] [<name>]
+    crew version [options] [-j|--json] [<name>]
     crew whatdepends [options] [-j|--json] <name> ...
     crew whatprovides [options] [-j|--json] <pattern> ...
 


### PR DESCRIPTION
## Description
- This matches the json output format from tools/version.rb.
```
ruby bin/crew version
1.75.6
ruby bin/crew version -j
[{"package":"Chromebrew","version":"1.75.6"}]
ruby bin/crew version bash
5.3
ruby bin/crew version bash -j
[{"package":"bash","version":"5.3"}]
ruby tools/version.rb -j bash
[{"package":"bash","updatable":"Yes","update_status":"Up to date.","version":"5.3","upstream_version":"5.3"}]
```
#### Commits:
-  2a0d76c10 Add json output option to crew version.
### Other changed files:
- bin/crew
- lib/const.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=crew_json_version crew update \
&& yes | crew upgrade
```
