### PR TITLE
Openjdk11 11.0.30 => 11.0.32

### DIFF
--- a/manifest/armv7l/o/openjdk11.filelist
+++ b/manifest/armv7l/o/openjdk11.filelist
@@ -1,4 +1,4 @@
-# Total size: 283358225
+# Total size: 283487389
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java

--- a/manifest/i686/o/openjdk11.filelist
+++ b/manifest/i686/o/openjdk11.filelist
@@ -1,4 +1,4 @@
-# Total size: 293765928
+# Total size: 294000279
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java

--- a/manifest/x86_64/o/openjdk11.filelist
+++ b/manifest/x86_64/o/openjdk11.filelist
@@ -1,4 +1,4 @@
-# Total size: 330183049
+# Total size: 328508432
 /usr/local/bin/jaotc
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
@@ -284,8 +284,6 @@
 /usr/local/share/openjdk11/include/jvmticmlr.h
 /usr/local/share/openjdk11/include/linux/jawt_md.h
 /usr/local/share/openjdk11/include/linux/jni_md.h
-/usr/local/share/openjdk11/jmods/com.azul.crs.client.jmod
-/usr/local/share/openjdk11/jmods/com.azul.tooling.jmod
 /usr/local/share/openjdk11/jmods/java.base.jmod
 /usr/local/share/openjdk11/jmods/java.compiler.jmod
 /usr/local/share/openjdk11/jmods/java.datatransfer.jmod
@@ -357,13 +355,6 @@
 /usr/local/share/openjdk11/jmods/jdk.unsupported.jmod
 /usr/local/share/openjdk11/jmods/jdk.xml.dom.jmod
 /usr/local/share/openjdk11/jmods/jdk.zipfs.jmod
-/usr/local/share/openjdk11/legal/com.azul.crs.client/ADDITIONAL_LICENSE_INFO
-/usr/local/share/openjdk11/legal/com.azul.crs.client/ASSEMBLY_EXCEPTION
-/usr/local/share/openjdk11/legal/com.azul.crs.client/LICENSE
-/usr/local/share/openjdk11/legal/com.azul.crs.client/crs-asm.md
-/usr/local/share/openjdk11/legal/com.azul.tooling/ADDITIONAL_LICENSE_INFO
-/usr/local/share/openjdk11/legal/com.azul.tooling/ASSEMBLY_EXCEPTION
-/usr/local/share/openjdk11/legal/com.azul.tooling/LICENSE
 /usr/local/share/openjdk11/legal/java.base/ADDITIONAL_LICENSE_INFO
 /usr/local/share/openjdk11/legal/java.base/ASSEMBLY_EXCEPTION
 /usr/local/share/openjdk11/legal/java.base/LICENSE

--- a/packages/openjdk11.rb
+++ b/packages/openjdk11.rb
@@ -3,21 +3,22 @@ require 'package'
 class Openjdk11 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://openjdk.org/'
-  version %w[i686 x86_64].include?(ARCH) ? '11.0.30' : '11.0.29'
+  version %w[i686 x86_64].include?(ARCH) ? '11.0.32' : '11.0.31'
   license 'GPL-2'
   compatibility 'all'
   # Visit https://www.azul.com/downloads/?version=java-11-lts&package=jdk#zulu to download the binaries.
+  # The project stopped supporting arm 32-bit with version 11.0.31.
   source_url({
-    aarch64: 'https://cdn.azul.com/zulu-embedded/bin/zulu11.84.17-ca-jdk11.0.29-linux_aarch32hf.tar.gz',
-     armv7l: 'https://cdn.azul.com/zulu-embedded/bin/zulu11.84.17-ca-jdk11.0.29-linux_aarch32hf.tar.gz',
-       i686: 'https://cdn.azul.com/zulu/bin/zulu11.86.19-ca-jdk11.0.30-linux_i686.tar.gz',
-     x86_64: 'https://cdn.azul.com/zulu/bin/zulu11.86.19-ca-jdk11.0.30-linux_x64.tar.gz'
+    aarch64: 'https://cdn.azul.com/zulu/bin/zulu11.88.17-ca-jdk11.0.31-linux_aarch32hf.tar.gz',
+     armv7l: 'https://cdn.azul.com/zulu/bin/zulu11.88.17-ca-jdk11.0.31-linux_aarch32hf.tar.gz',
+       i686: 'https://cdn.azul.com/zulu/bin/zulu11.90.19-ca-jdk11.0.32-linux_i686.tar.gz',
+     x86_64: 'https://cdn.azul.com/zulu/bin/zulu11.90.19-ca-jdk11.0.32-linux_x64.tar.gz'
   })
   source_sha256({
-    aarch64: '2b1e9764868f2f20678390b86a2c7527afc008bf53f3440788b9c1dc9b0f729e',
-     armv7l: '2b1e9764868f2f20678390b86a2c7527afc008bf53f3440788b9c1dc9b0f729e',
-       i686: '4a87875925a64b640f18ca9cc70baf7054d8c2642e3f749102b1ba139cb1c25c',
-     x86_64: 'ac3ae99b3bedd81b672467279656a91bf34d1887ebd244e1cedcf2498a78d1c8'
+    aarch64: '5cae41fea1dd1378250a12e103a236171c33f88b9b7e9cbc57e508b30a1f0e36',
+     armv7l: '5cae41fea1dd1378250a12e103a236171c33f88b9b7e9cbc57e508b30a1f0e36',
+       i686: 'ae6de7be808501d85e1adb2f7e93d22ad05eb4028ee26502d274ec2eff7f1aa5',
+     x86_64: 'd4832d97886444346ed75fd1059c68c5e38795098e3273e4a0929fe2eb2abf76'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjdk11 crew update \
&& yes | crew upgrade

$ crew check openjdk11 
Checking openjdk11 package ...
Library test for openjdk11 passed.
Checking openjdk11 package ...
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile> [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile> [args]
           (to execute a single source-file program)

openjdk version "11.0.32" 2026-07-21 LTS
OpenJDK Runtime Environment Zulu11.90+19-CA (build 11.0.32+9-LTS)
OpenJDK Server VM Zulu11.90+19-CA (build 11.0.32+9-LTS, mixed mode)
javac 11.0.32
Package tests for openjdk11 passed.
```