### PR TITLE
Openjdk17 17.0.18 => 17.0.20

### DIFF
--- a/manifest/armv7l/o/openjdk17.filelist
+++ b/manifest/armv7l/o/openjdk17.filelist
@@ -1,4 +1,4 @@
-# Total size: 290007614
+# Total size: 290429746
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java
@@ -300,6 +300,7 @@
 /usr/local/share/openjdk17/legal/java.base/asm.md
 /usr/local/share/openjdk17/legal/java.base/c-libutl.md
 /usr/local/share/openjdk17/legal/java.base/cldr.md
+/usr/local/share/openjdk17/legal/java.base/gcc.md
 /usr/local/share/openjdk17/legal/java.base/icu.md
 /usr/local/share/openjdk17/legal/java.base/public_suffix.md
 /usr/local/share/openjdk17/legal/java.base/siphash.md

--- a/manifest/i686/o/openjdk17.filelist
+++ b/manifest/i686/o/openjdk17.filelist
@@ -1,4 +1,4 @@
-# Total size: 310536873
+# Total size: 311031207
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java
@@ -300,6 +300,7 @@
 /usr/local/share/openjdk17/legal/java.base/asm.md
 /usr/local/share/openjdk17/legal/java.base/c-libutl.md
 /usr/local/share/openjdk17/legal/java.base/cldr.md
+/usr/local/share/openjdk17/legal/java.base/gcc.md
 /usr/local/share/openjdk17/legal/java.base/icu.md
 /usr/local/share/openjdk17/legal/java.base/public_suffix.md
 /usr/local/share/openjdk17/legal/java.base/siphash.md

--- a/manifest/x86_64/o/openjdk17.filelist
+++ b/manifest/x86_64/o/openjdk17.filelist
@@ -1,4 +1,4 @@
-# Total size: 338868716
+# Total size: 336987024
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java
@@ -226,8 +226,6 @@
 /usr/local/share/openjdk17/include/jvmticmlr.h
 /usr/local/share/openjdk17/include/linux/jawt_md.h
 /usr/local/share/openjdk17/include/linux/jni_md.h
-/usr/local/share/openjdk17/jmods/com.azul.crs.client.jmod
-/usr/local/share/openjdk17/jmods/com.azul.tooling.jmod
 /usr/local/share/openjdk17/jmods/java.base.jmod
 /usr/local/share/openjdk17/jmods/java.compiler.jmod
 /usr/local/share/openjdk17/jmods/java.datatransfer.jmod
@@ -298,13 +296,6 @@
 /usr/local/share/openjdk17/jmods/jdk.unsupported.jmod
 /usr/local/share/openjdk17/jmods/jdk.xml.dom.jmod
 /usr/local/share/openjdk17/jmods/jdk.zipfs.jmod
-/usr/local/share/openjdk17/legal/com.azul.crs.client/ADDITIONAL_LICENSE_INFO
-/usr/local/share/openjdk17/legal/com.azul.crs.client/ASSEMBLY_EXCEPTION
-/usr/local/share/openjdk17/legal/com.azul.crs.client/LICENSE
-/usr/local/share/openjdk17/legal/com.azul.crs.client/crs-asm.md
-/usr/local/share/openjdk17/legal/com.azul.tooling/ADDITIONAL_LICENSE_INFO
-/usr/local/share/openjdk17/legal/com.azul.tooling/ASSEMBLY_EXCEPTION
-/usr/local/share/openjdk17/legal/com.azul.tooling/LICENSE
 /usr/local/share/openjdk17/legal/java.base/ADDITIONAL_LICENSE_INFO
 /usr/local/share/openjdk17/legal/java.base/ASSEMBLY_EXCEPTION
 /usr/local/share/openjdk17/legal/java.base/LICENSE
@@ -312,6 +303,7 @@
 /usr/local/share/openjdk17/legal/java.base/asm.md
 /usr/local/share/openjdk17/legal/java.base/c-libutl.md
 /usr/local/share/openjdk17/legal/java.base/cldr.md
+/usr/local/share/openjdk17/legal/java.base/gcc.md
 /usr/local/share/openjdk17/legal/java.base/icu.md
 /usr/local/share/openjdk17/legal/java.base/public_suffix.md
 /usr/local/share/openjdk17/legal/java.base/siphash.md

--- a/packages/openjdk17.rb
+++ b/packages/openjdk17.rb
@@ -3,21 +3,22 @@ require 'package'
 class Openjdk17 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://openjdk.org/'
-  version '17.0.18'
+  version %w[i686 x86_64].include?(ARCH) ? '17.0.20' : '17.0.19'
   license 'GPL-2'
   compatibility 'all'
   # Visit https://www.azul.com/downloads/?version=java-17-lts&package=jdk#zulu to download the binaries.
+  # The project stopped supporting arm 32-bit with version 17.0.19.
   source_url({
-    aarch64: 'https://cdn.azul.com/zulu/bin/zulu17.64.17-ca-jdk17.0.18-c2-linux_aarch32hf.tar.gz',
-     armv7l: 'https://cdn.azul.com/zulu/bin/zulu17.64.17-ca-jdk17.0.18-c2-linux_aarch32hf.tar.gz',
-       i686: 'https://cdn.azul.com/zulu/bin/zulu17.64.15-ca-jdk17.0.18-linux_i686.tar.gz',
-     x86_64: 'https://cdn.azul.com/zulu/bin/zulu17.64.15-ca-jdk17.0.18-linux_x64.tar.gz'
+    aarch64: 'https://cdn.azul.com/zulu/bin/zulu17.66.19-ca-jdk17.0.19-c2-linux_aarch32hf.tar.gz',
+     armv7l: 'https://cdn.azul.com/zulu/bin/zulu17.66.19-ca-jdk17.0.19-c2-linux_aarch32hf.tar.gz',
+       i686: 'https://cdn.azul.com/zulu/bin/zulu17.68.17-ca-jdk17.0.20-linux_i686.tar.gz',
+     x86_64: 'https://cdn.azul.com/zulu/bin/zulu17.68.17-ca-jdk17.0.20-linux_x64.tar.gz'
   })
   source_sha256({
-    aarch64: 'a8ef931ae3c5c6ee563b385b9f92a445bff382753437a4014bce3b3e311f3709',
-     armv7l: 'a8ef931ae3c5c6ee563b385b9f92a445bff382753437a4014bce3b3e311f3709',
-       i686: '473f89250a27f55d3490140565d881a1a3e5911d624bd4f791cf79e3c95d2f8c',
-     x86_64: '48dcbcb09f9802b144347b164080df762ddbd0077966e273116c973edb3020ef'
+    aarch64: 'bda6b8fbeb63d4be15f4d98604502fc9f08671e2ffd0c1b838f1ad1a053535dc',
+     armv7l: 'bda6b8fbeb63d4be15f4d98604502fc9f08671e2ffd0c1b838f1ad1a053535dc',
+       i686: 'fc51a5a4551c697a56324bf63052e76302d9491407a6bbf48a43f57a1e4f2e88',
+     x86_64: '32c5efedf69f4a95635ea2923f6a6ee90ce6ca83df0bd43ba55dd662d5af429a'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjdk17 crew update \
&& yes | crew upgrade

$ crew check openjdk17 
Checking openjdk17 package ...
Library test for openjdk17 passed.
Checking openjdk17 package ...
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile> [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile> [args]
           (to execute a single source-file program)

openjdk version "17.0.20" 2026-07-21 LTS
OpenJDK Runtime Environment Zulu17.68+17-CA (build 17.0.20+8-LTS)
OpenJDK Server VM Zulu17.68+17-CA (build 17.0.20+8-LTS, mixed mode, sharing)
javac 17.0.20
Package tests for openjdk17 passed.
```