### PR TITLE
Openjdk21 21.0.10 => 21.0.12

### DIFF
--- a/manifest/x86_64/o/openjdk21.filelist
+++ b/manifest/x86_64/o/openjdk21.filelist
@@ -1,4 +1,4 @@
-# Total size: 368161150
+# Total size: 365973690
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java
@@ -192,8 +192,6 @@
 /usr/local/share/openjdk21/include/jvmticmlr.h
 /usr/local/share/openjdk21/include/linux/jawt_md.h
 /usr/local/share/openjdk21/include/linux/jni_md.h
-/usr/local/share/openjdk21/jmods/com.azul.crs.client.jmod
-/usr/local/share/openjdk21/jmods/com.azul.tooling.jmod
 /usr/local/share/openjdk21/jmods/java.base.jmod
 /usr/local/share/openjdk21/jmods/java.compiler.jmod
 /usr/local/share/openjdk21/jmods/java.datatransfer.jmod
@@ -263,13 +261,6 @@
 /usr/local/share/openjdk21/jmods/jdk.unsupported.jmod
 /usr/local/share/openjdk21/jmods/jdk.xml.dom.jmod
 /usr/local/share/openjdk21/jmods/jdk.zipfs.jmod
-/usr/local/share/openjdk21/legal/com.azul.crs.client/ADDITIONAL_LICENSE_INFO
-/usr/local/share/openjdk21/legal/com.azul.crs.client/ASSEMBLY_EXCEPTION
-/usr/local/share/openjdk21/legal/com.azul.crs.client/LICENSE
-/usr/local/share/openjdk21/legal/com.azul.crs.client/crs-asm.md
-/usr/local/share/openjdk21/legal/com.azul.tooling/ADDITIONAL_LICENSE_INFO
-/usr/local/share/openjdk21/legal/com.azul.tooling/ASSEMBLY_EXCEPTION
-/usr/local/share/openjdk21/legal/com.azul.tooling/LICENSE
 /usr/local/share/openjdk21/legal/java.base/ADDITIONAL_LICENSE_INFO
 /usr/local/share/openjdk21/legal/java.base/ASSEMBLY_EXCEPTION
 /usr/local/share/openjdk21/legal/java.base/LICENSE
@@ -277,6 +268,7 @@
 /usr/local/share/openjdk21/legal/java.base/asm.md
 /usr/local/share/openjdk21/legal/java.base/c-libutl.md
 /usr/local/share/openjdk21/legal/java.base/cldr.md
+/usr/local/share/openjdk21/legal/java.base/gcc.md
 /usr/local/share/openjdk21/legal/java.base/icu.md
 /usr/local/share/openjdk21/legal/java.base/public_suffix.md
 /usr/local/share/openjdk21/legal/java.base/siphash.md

--- a/packages/openjdk21.rb
+++ b/packages/openjdk21.rb
@@ -3,12 +3,12 @@ require 'package'
 class Openjdk21 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://openjdk.org/'
-  version '21.0.10'
+  version '21.0.12'
   license 'GPL-2'
   compatibility 'x86_64'
   # Visit https://www.azul.com/downloads/?version=java-21-lts&package=jdk#zulu to download the binary.
-  source_url 'https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz'
-  source_sha256 '7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670'
+  source_url 'https://cdn.azul.com/zulu/bin/zulu21.52.15-ca-jdk21.0.12-linux_x64.tar.gz'
+  source_sha256 'b1a9df12e798770d1b2db43b402a80f1e6080cff6d5d1d1fbe5c768fb4225f6a'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjdk21 crew update \
&& yes | crew upgrade

$ crew check openjdk21 
Checking openjdk21 package ...
Library test for openjdk21 passed.
Checking openjdk21 package ...
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile> [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile> [args]
           (to execute a single source-file program)

openjdk version "21.0.12" 2026-07-21 LTS
OpenJDK Runtime Environment Zulu21.52+15-CA (build 21.0.12+8-LTS)
OpenJDK 64-Bit Server VM Zulu21.52+15-CA (build 21.0.12+8-LTS, mixed mode, sharing)
javac 21.0.12
Package tests for openjdk21 passed.
```