### PR TITLE
Openjdk25 25.0.2 => 25.0.4

### DIFF
--- a/manifest/x86_64/o/openjdk25.filelist
+++ b/manifest/x86_64/o/openjdk25.filelist
@@ -1,4 +1,4 @@
-# Total size: 414007268
+# Total size: 411111017
 /usr/local/bin/jar
 /usr/local/bin/jarsigner
 /usr/local/bin/java
@@ -195,8 +195,6 @@
 /usr/local/share/openjdk25/include/jvmticmlr.h
 /usr/local/share/openjdk25/include/linux/jawt_md.h
 /usr/local/share/openjdk25/include/linux/jni_md.h
-/usr/local/share/openjdk25/jmods/com.azul.crs.client.jmod
-/usr/local/share/openjdk25/jmods/com.azul.tooling.jmod
 /usr/local/share/openjdk25/jmods/java.base.jmod
 /usr/local/share/openjdk25/jmods/java.compiler.jmod
 /usr/local/share/openjdk25/jmods/java.datatransfer.jmod
@@ -266,19 +264,13 @@
 /usr/local/share/openjdk25/jmods/jdk.unsupported.jmod
 /usr/local/share/openjdk25/jmods/jdk.xml.dom.jmod
 /usr/local/share/openjdk25/jmods/jdk.zipfs.jmod
-/usr/local/share/openjdk25/legal/com.azul.crs.client/ADDITIONAL_LICENSE_INFO
-/usr/local/share/openjdk25/legal/com.azul.crs.client/ASSEMBLY_EXCEPTION
-/usr/local/share/openjdk25/legal/com.azul.crs.client/LICENSE
-/usr/local/share/openjdk25/legal/com.azul.crs.client/crs-asm.md
-/usr/local/share/openjdk25/legal/com.azul.tooling/ADDITIONAL_LICENSE_INFO
-/usr/local/share/openjdk25/legal/com.azul.tooling/ASSEMBLY_EXCEPTION
-/usr/local/share/openjdk25/legal/com.azul.tooling/LICENSE
 /usr/local/share/openjdk25/legal/java.base/ADDITIONAL_LICENSE_INFO
 /usr/local/share/openjdk25/legal/java.base/ASSEMBLY_EXCEPTION
 /usr/local/share/openjdk25/legal/java.base/LICENSE
 /usr/local/share/openjdk25/legal/java.base/aes.md
 /usr/local/share/openjdk25/legal/java.base/c-libutl.md
 /usr/local/share/openjdk25/legal/java.base/cldr.md
+/usr/local/share/openjdk25/legal/java.base/gcc.md
 /usr/local/share/openjdk25/legal/java.base/icu.md
 /usr/local/share/openjdk25/legal/java.base/public_suffix.md
 /usr/local/share/openjdk25/legal/java.base/siphash.md

--- a/packages/openjdk25.rb
+++ b/packages/openjdk25.rb
@@ -3,12 +3,12 @@ require 'package'
 class Openjdk25 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://openjdk.org/'
-  version '25.0.2'
+  version '25.0.4'
   license 'GPL-2'
   compatibility 'x86_64'
   # Visit https://www.azul.com/downloads/?version=java-25-lts&package=jdk#zulu to download the binary.
-  source_url 'https://cdn.azul.com/zulu/bin/zulu25.32.17-ca-jdk25.0.2-linux_x64.tar.gz'
-  source_sha256 'f1752d0051b6ca233625ddb2c18c9170edbe55c5ee6515bfefd8ea0197ee1c20'
+  source_url 'https://cdn.azul.com/zulu/bin/zulu25.36.15-ca-jdk25.0.4-linux_x64.tar.gz'
+  source_sha256 'e476f5c98952cb365ca77a814dbe3c74341e71ae76d1a87d1c0a69c7d2b1b2d0'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-openjdk25 crew update \
&& yes | crew upgrade

$ crew check openjdk25
Checking openjdk25 package ...
Library test for openjdk25 passed.
Checking openjdk25 package ...
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile>.jar [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile>.java [args]
           (to execute a source-file program)

openjdk version "25.0.4" 2026-07-21 LTS
OpenJDK Runtime Environment Zulu25.36+15-CA (build 25.0.4+7-LTS)
OpenJDK 64-Bit Server VM Zulu25.36+15-CA (build 25.0.4+7-LTS, mixed mode, sharing)
javac 25.0.4
Package tests for openjdk25 passed.
```