### PR TITLE
Uwsgi 2.0.17 => 2.0.31

### DIFF
--- a/manifest/armv7l/u/uwsgi.filelist
+++ b/manifest/armv7l/u/uwsgi.filelist
@@ -1,0 +1,2 @@
+# Total size: 1157584
+/usr/local/bin/uwsgi

--- a/manifest/i686/u/uwsgi.filelist
+++ b/manifest/i686/u/uwsgi.filelist
@@ -1,0 +1,2 @@
+# Total size: 1800336
+/usr/local/bin/uwsgi

--- a/manifest/x86_64/u/uwsgi.filelist
+++ b/manifest/x86_64/u/uwsgi.filelist
@@ -1,0 +1,2 @@
+# Total size: 1341872
+/usr/local/bin/uwsgi

--- a/packages/uwsgi.rb
+++ b/packages/uwsgi.rb
@@ -3,13 +3,31 @@ require 'package'
 class Uwsgi < Package
   description 'uWSGI application server container'
   homepage 'https://uwsgi-docs.readthedocs.io/'
-  version '2.0.17'
+  version '2.0.31'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://github.com/unbit/uwsgi/archive/2.0.17.tar.gz'
-  source_sha256 '3dc2e9b48db92b67bfec1badec0d3fdcc0771316486c5efa3217569da3528bf2'
+  source_url 'https://github.com/unbit/uwsgi.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
-  depends_on 'pcre'
+  binary_sha256({
+    aarch64: 'a8b6047057a3ffff0726325ae3cf0ebe830655ef92c78a4f8b282668b8e28f65',
+     armv7l: 'a8b6047057a3ffff0726325ae3cf0ebe830655ef92c78a4f8b282668b8e28f65',
+       i686: 'bb7c677a15901b9252021548938ec7f7eadf654128fcc1c13256afdff2babda6',
+     x86_64: 'be2d84db95ed5ff9ad4a7c74bcd05dc6909b7a24c60429e729245c64aca67776'
+  })
+
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libcap' => :executable
+  depends_on 'libxcrypt' => :executable
+  depends_on 'libxml2' => :executable
+  depends_on 'openssl' => :executable
+  depends_on 'pcre' => :executable
+  depends_on 'pcre2' => :executable
+  depends_on 'python3' => :executable
+  depends_on 'util_linux' => :executable
+  depends_on 'zlib' => :executable
 
   def self.build
     puts
@@ -22,6 +40,6 @@ class Uwsgi < Package
   end
 
   def self.install
-    system "install -Dm755 uwsgi #{CREW_DEST_PREFIX}/bin/uwsgi"
+    FileUtils.install 'uwsgi', "#{CREW_DEST_PREFIX}/bin/uwsgi", mode: 0o755
   end
 end

--- a/tests/package/u/uwsgi
+++ b/tests/package/u/uwsgi
@@ -1,0 +1,3 @@
+#!/bin/bash
+uwsgi -h | head
+uwsgi --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-uwsgi crew update \
&& yes | crew upgrade

$ crew check uwsgi
Checking uwsgi package ...
Library test for uwsgi passed.
Checking uwsgi package ...
Usage: /usr/local/bin/uwsgi [options...]
    -s|--socket                             bind to the specified UNIX/TCP socket using default protocol
    -s|--uwsgi-socket                       bind to the specified UNIX/TCP socket using uwsgi protocol
    --suwsgi-socket                         bind to the specified UNIX/TCP socket using uwsgi protocol over SSL
    --ssl-socket                            bind to the specified UNIX/TCP socket using uwsgi protocol over SSL
    --http-socket                           bind to the specified UNIX/TCP socket using HTTP protocol
    --http-socket-modifier1                 force the specified modifier1 when using HTTP protocol
    --http-socket-modifier2                 force the specified modifier2 when using HTTP protocol
    --http11-socket                         bind to the specified UNIX/TCP socket using HTTP 1.1 (Keep-Alive) protocol
    --https-socket                          bind to the specified UNIX/TCP socket using HTTPS protocol
2.0.31
Package tests for uwsgi passed.
```